### PR TITLE
Meet and join for the standard finite types

### DIFF
--- a/src/elementary-number-theory/inequality-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/inequality-standard-finite-types.lagda.md
@@ -14,6 +14,7 @@ open import elementary-number-theory.natural-numbers using (ℕ; zero-ℕ; succ-
 open import foundation.coproduct-types using (inl; inr)
 open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2)
 open import foundation.empty-types using (empty; ex-falso; is-prop-empty)
+open import foundation.decidable-types
 open import foundation.identity-types using (_＝_; refl; ap)
 open import foundation.propositions using (is-prop; UU-Prop)
 open import foundation.unit-type using (unit; star; is-prop-unit)
@@ -113,4 +114,14 @@ pr1 (pr2 (fin-Poset k)) = leq-fin-Prop
 pr1 (pr1 (pr2 (pr2 (fin-Poset k)))) = refl-leq-Fin
 pr2 (pr1 (pr2 (pr2 (fin-Poset k)))) = transitive-leq-Fin
 pr2 (pr2 (pr2 (fin-Poset k))) = antisymmetric-leq-Fin
+```
+
+### Ordering on the standard finite types is decidable
+
+```agda
+decide-leq-Fin : {k : ℕ} (x y : Fin k) → is-decidable (leq-Fin x y)
+decide-leq-Fin {k = succ-ℕ k} (inl x) (inl y) = decide-leq-Fin x y
+decide-leq-Fin {k = succ-ℕ k} (inl x) (inr y) = inl star
+decide-leq-Fin {k = succ-ℕ k} (inr x) (inl y) = inr (λ x → x)
+decide-leq-Fin {k = succ-ℕ k} (inr x) (inr y) = inl star
 ```

--- a/src/elementary-number-theory/inequality-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/inequality-standard-finite-types.lagda.md
@@ -119,9 +119,9 @@ pr2 (pr2 (pr2 (fin-Poset k))) = antisymmetric-leq-Fin
 ### Ordering on the standard finite types is decidable
 
 ```agda
-decide-leq-Fin : {k : ℕ} (x y : Fin k) → is-decidable (leq-Fin x y)
-decide-leq-Fin {k = succ-ℕ k} (inl x) (inl y) = decide-leq-Fin x y
-decide-leq-Fin {k = succ-ℕ k} (inl x) (inr y) = inl star
-decide-leq-Fin {k = succ-ℕ k} (inr x) (inl y) = inr (λ x → x)
-decide-leq-Fin {k = succ-ℕ k} (inr x) (inr y) = inl star
+is-decidable-leq-Fin : {k : ℕ} (x y : Fin k) → is-decidable (leq-Fin x y)
+is-decidable-leq-Fin {k = succ-ℕ k} (inl x) (inl y) = is-decidable-leq-Fin x y
+is-decidable-leq-Fin {k = succ-ℕ k} (inl x) (inr y) = inl star
+is-decidable-leq-Fin {k = succ-ℕ k} (inr x) (inl y) = inr (λ x → x)
+is-decidable-leq-Fin {k = succ-ℕ k} (inr x) (inr y) = inl star
 ```

--- a/src/elementary-number-theory/maximum-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/maximum-natural-numbers.lagda.md
@@ -7,16 +7,23 @@ title: Maximum on the natural numbers
 
 module elementary-number-theory.maximum-natural-numbers where
 
-open import elementary-number-theory.inequality-natural-numbers using (_≤-ℕ_)
+open import elementary-number-theory.inequality-natural-numbers
 open import elementary-number-theory.natural-numbers using (ℕ; zero-ℕ; succ-ℕ)
 
+open import foundation.dependent-pair-types using (_,_)
 open import foundation.coproduct-types using (inl; inr)
 open import foundation.unit-type using (star)
+
+open import order-theory.least-upper-bounds-posets
 
 open import univalent-combinatorics.standard-finite-types using (Fin)
 ```
 
-# Maximum on the natural numbers
+## Idea
+
+We define the operation of maximum (least upper bound) for the natural numbers.
+
+## Definition
 
 ```agda
 max-ℕ : ℕ → (ℕ → ℕ)
@@ -24,6 +31,16 @@ max-ℕ 0 n = n
 max-ℕ (succ-ℕ m) 0 = succ-ℕ m
 max-ℕ (succ-ℕ m) (succ-ℕ n) = succ-ℕ (max-ℕ m n)
 
+max-Fin-ℕ : (n : ℕ) → (Fin n → ℕ) → ℕ
+max-Fin-ℕ zero-ℕ f = zero-ℕ
+max-Fin-ℕ (succ-ℕ n) f = max-ℕ (f (inr star)) (max-Fin-ℕ n (λ k → f (inl k)))
+```
+
+## Properties
+
+### Maximum is a least upper bound
+
+```agda
 leq-max-ℕ :
   (k m n : ℕ) → m ≤-ℕ k → n ≤-ℕ k → (max-ℕ m n) ≤-ℕ k
 leq-max-ℕ zero-ℕ zero-ℕ zero-ℕ H K = star
@@ -48,7 +65,10 @@ leq-right-leq-max-ℕ k (succ-ℕ m) zero-ℕ H = star
 leq-right-leq-max-ℕ (succ-ℕ k) (succ-ℕ m) (succ-ℕ n) H =
   leq-right-leq-max-ℕ k m n H
 
-max-Fin-ℕ : (n : ℕ) → (Fin n → ℕ) → ℕ
-max-Fin-ℕ zero-ℕ f = zero-ℕ
-max-Fin-ℕ (succ-ℕ n) f = max-ℕ (f (inr star)) (max-Fin-ℕ n (λ k → f (inl k)))
+is-least-upper-bound-max-ℕ :
+  (m n : ℕ) → is-least-binary-upper-bound-Poset ℕ-Poset m n (max-ℕ m n)
+is-least-upper-bound-max-ℕ m n =
+  ( leq-left-leq-max-ℕ (max-ℕ m n) m n (refl-leq-ℕ (max-ℕ m n)),
+    leq-right-leq-max-ℕ (max-ℕ m n) m n (refl-leq-ℕ (max-ℕ m n))),
+  λ x (m≤x , n≤x) → leq-max-ℕ x m n m≤x n≤x
 ```

--- a/src/elementary-number-theory/maximum-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/maximum-standard-finite-types.lagda.md
@@ -7,16 +7,23 @@ title: Maximum on the standard finite types
 
 module elementary-number-theory.maximum-standard-finite-types where
 
-open import elementary-number-theory.inequality-standard-finite-types using (leq-Fin)
+open import elementary-number-theory.inequality-standard-finite-types
 open import elementary-number-theory.natural-numbers using (ℕ; zero-ℕ; succ-ℕ)
 
+open import foundation.dependent-pair-types using (_,_)
 open import foundation.coproduct-types using (inl; inr)
 open import foundation.unit-type using (star)
+
+open import order-theory.least-upper-bounds-posets
 
 open import univalent-combinatorics.standard-finite-types using (Fin)
 ```
 
-# Maximum on the standard finite types
+## Idea
+
+We define the operation of maximum (least upper bound) for the standard finite types.
+
+## Definition
 
 ```agda
 max-Fin : ∀ {k} → Fin k → Fin k → Fin k
@@ -25,6 +32,16 @@ max-Fin {k = succ-ℕ k} (inl x) (inr _) = inr star
 max-Fin {k = succ-ℕ k} (inr _) (inl x) = inr star
 max-Fin {k = succ-ℕ k} (inr _) (inr _) = inr star
 
+max-Fin-Fin : {k : ℕ} (n : ℕ) → (Fin (succ-ℕ n) → Fin k) → Fin k
+max-Fin-Fin zero-ℕ f     = f (inr star)
+max-Fin-Fin (succ-ℕ n) f = max-Fin (f (inr star)) (max-Fin-Fin n (λ k → f (inl k)))
+```
+
+## Properties
+
+### Maximum is greatest lower bound
+
+```agda
 leq-max-Fin :
   ∀ {k} (l m n : Fin k) → leq-Fin m l → leq-Fin n l → leq-Fin (max-Fin m n) l
 leq-max-Fin {k = succ-ℕ k} (inl x) (inl y) (inl z) p q = leq-max-Fin x y z p q
@@ -51,7 +68,11 @@ leq-right-leq-max-Fin {succ-ℕ k} (inr x) (inr y) (inl z) p = star
 leq-right-leq-max-Fin {succ-ℕ k} (inr x) (inr y) (inr z) p = star
 leq-right-leq-max-Fin {succ-ℕ k} (inl x) (inl y) (inr z) p = p
 
-max-Fin-Fin : {k : ℕ} (n : ℕ) → (Fin (succ-ℕ n) → Fin k) → Fin k
-max-Fin-Fin zero-ℕ f     = f (inr star)
-max-Fin-Fin (succ-ℕ n) f = max-Fin (f (inr star)) (max-Fin-Fin n (λ k → f (inl k)))
+is-least-upper-bound-max-Fin :
+  ∀ {k} (m n : Fin k) →
+  is-least-binary-upper-bound-Poset (fin-Poset k) m n (max-Fin m n)
+is-least-upper-bound-max-Fin m n =
+  ( leq-left-leq-max-Fin (max-Fin m n) m n (refl-leq-Fin (max-Fin m n)),
+    leq-right-leq-max-Fin (max-Fin m n) m n (refl-leq-Fin (max-Fin m n))),
+  λ x (m≤x , n≤x) → leq-max-Fin x m n m≤x n≤x
 ```

--- a/src/elementary-number-theory/maximum-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/maximum-standard-finite-types.lagda.md
@@ -1,0 +1,57 @@
+---
+title: Maximum on the standard finite types
+---
+
+```agda
+{-# OPTIONS --without-K --exact-split #-}
+
+module elementary-number-theory.maximum-standard-finite-types where
+
+open import elementary-number-theory.inequality-standard-finite-types using (leq-Fin)
+open import elementary-number-theory.natural-numbers using (ℕ; zero-ℕ; succ-ℕ)
+
+open import foundation.coproduct-types using (inl; inr)
+open import foundation.unit-type using (star)
+
+open import univalent-combinatorics.standard-finite-types using (Fin)
+```
+
+# Maximum on the standard finite types
+
+```agda
+max-Fin : ∀ {k} → Fin k → Fin k → Fin k
+max-Fin {k = succ-ℕ k} (inl x) (inl y) = inl (max-Fin x y)
+max-Fin {k = succ-ℕ k} (inl x) (inr _) = inr star
+max-Fin {k = succ-ℕ k} (inr _) (inl x) = inr star
+max-Fin {k = succ-ℕ k} (inr _) (inr _) = inr star
+
+leq-max-Fin :
+  ∀ {k} (l m n : Fin k) → leq-Fin m l → leq-Fin n l → leq-Fin (max-Fin m n) l
+leq-max-Fin {k = succ-ℕ k} (inl x) (inl y) (inl z) p q = leq-max-Fin x y z p q
+leq-max-Fin {k = succ-ℕ k} (inr x) (inl y) (inl z) p q = star
+leq-max-Fin {k = succ-ℕ k} (inr x) (inl y) (inr z) p q = star
+leq-max-Fin {k = succ-ℕ k} (inr x) (inr y) (inl z) p q = star
+leq-max-Fin {k = succ-ℕ k} (inr x) (inr y) (inr z) p q = star
+
+leq-left-leq-max-Fin :
+  ∀ {k} (l m n : Fin k) → leq-Fin (max-Fin m n) l → leq-Fin m l
+leq-left-leq-max-Fin {succ-ℕ k} (inl x) (inl y) (inl z) p = leq-left-leq-max-Fin x y z p
+leq-left-leq-max-Fin {succ-ℕ k} (inr x) (inl y) (inl z) p = star
+leq-left-leq-max-Fin {succ-ℕ k} (inr x) (inl y) (inr z) p = star
+leq-left-leq-max-Fin {succ-ℕ k} (inr x) (inr y) (inl z) p = star
+leq-left-leq-max-Fin {succ-ℕ k} (inr x) (inr y) (inr z) p = star
+leq-left-leq-max-Fin {succ-ℕ k} (inl x) (inr y) (inr z) p = p
+
+leq-right-leq-max-Fin :
+  ∀ {k} (l m n : Fin k) → leq-Fin (max-Fin m n) l → leq-Fin n l
+leq-right-leq-max-Fin {succ-ℕ k} (inl x) (inl y) (inl z) p = leq-right-leq-max-Fin x y z p
+leq-right-leq-max-Fin {succ-ℕ k} (inr x) (inl y) (inl z) p = star
+leq-right-leq-max-Fin {succ-ℕ k} (inr x) (inl y) (inr z) p = star
+leq-right-leq-max-Fin {succ-ℕ k} (inr x) (inr y) (inl z) p = star
+leq-right-leq-max-Fin {succ-ℕ k} (inr x) (inr y) (inr z) p = star
+leq-right-leq-max-Fin {succ-ℕ k} (inl x) (inl y) (inr z) p = p
+
+max-Fin-Fin : {k : ℕ} (n : ℕ) → (Fin (succ-ℕ n) → Fin k) → Fin k
+max-Fin-Fin zero-ℕ f     = f (inr star)
+max-Fin-Fin (succ-ℕ n) f = max-Fin (f (inr star)) (max-Fin-Fin n (λ k → f (inl k)))
+```

--- a/src/elementary-number-theory/minimum-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/minimum-natural-numbers.lagda.md
@@ -7,16 +7,23 @@ title: Minimum on the natural numbers
 
 module elementary-number-theory.minimum-natural-numbers where
 
-open import elementary-number-theory.inequality-natural-numbers using (_≤-ℕ_)
+open import elementary-number-theory.inequality-natural-numbers
 open import elementary-number-theory.natural-numbers using (ℕ; zero-ℕ; succ-ℕ)
 
+open import foundation.dependent-pair-types using (_,_)
 open import foundation.coproduct-types using (inl; inr)
 open import foundation.unit-type using (star)
+
+open import order-theory.greatest-lower-bounds-posets
 
 open import univalent-combinatorics.standard-finite-types using (Fin)
 ```
 
-# Minimum on the natural numbers
+## Idea
+
+We define the operation of minimum (greatest lower bound) for the natural numbers.
+
+## Definition
 
 ```agda
 min-ℕ : ℕ → (ℕ → ℕ)
@@ -24,6 +31,16 @@ min-ℕ 0 n = 0
 min-ℕ (succ-ℕ m) 0 = 0
 min-ℕ (succ-ℕ m) (succ-ℕ n) = succ-ℕ (min-ℕ m n)
 
+min-Fin-ℕ : (n : ℕ) → (Fin (succ-ℕ n) → ℕ) → ℕ
+min-Fin-ℕ zero-ℕ f = f (inr star)
+min-Fin-ℕ (succ-ℕ n) f = min-ℕ (f (inr star)) (min-Fin-ℕ n (λ k → f (inl k)))
+```
+
+## Properties
+
+### Minimum is a greatest lower bound
+
+```agda
 leq-min-ℕ :
   (k m n : ℕ) → k ≤-ℕ m → k ≤-ℕ n → k ≤-ℕ (min-ℕ m n)
 leq-min-ℕ zero-ℕ zero-ℕ zero-ℕ H K = star
@@ -50,7 +67,10 @@ leq-right-leq-min-ℕ zero-ℕ (succ-ℕ m) (succ-ℕ n) H = star
 leq-right-leq-min-ℕ (succ-ℕ k) (succ-ℕ m) (succ-ℕ n) H =
   leq-right-leq-min-ℕ k m n H
 
-min-Fin-ℕ : (n : ℕ) → (Fin (succ-ℕ n) → ℕ) → ℕ
-min-Fin-ℕ zero-ℕ f = f (inr star)
-min-Fin-ℕ (succ-ℕ n) f = min-ℕ (f (inr star)) (min-Fin-ℕ n (λ k → f (inl k)))
+is-greatest-lower-bound-min-ℕ :
+  (l m : ℕ) → is-greatest-binary-lower-bound-Poset ℕ-Poset l m (min-ℕ l m)
+is-greatest-lower-bound-min-ℕ l m =
+  ( leq-left-leq-min-ℕ (min-ℕ l m) l m (refl-leq-ℕ (min-ℕ l m)),
+    leq-right-leq-min-ℕ (min-ℕ l m) l m (refl-leq-ℕ (min-ℕ l m))),
+  λ x (x≤l , x≤m) → leq-min-ℕ x l m x≤l x≤m
 ```

--- a/src/elementary-number-theory/minimum-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/minimum-standard-finite-types.lagda.md
@@ -7,16 +7,23 @@ title: Minimum on the standard finite types
 
 module elementary-number-theory.minimum-standard-finite-types where
 
-open import elementary-number-theory.inequality-standard-finite-types using (leq-Fin)
+open import elementary-number-theory.inequality-standard-finite-types
 open import elementary-number-theory.natural-numbers using (ℕ; zero-ℕ; succ-ℕ)
 
+open import foundation.dependent-pair-types using (_,_)
 open import foundation.coproduct-types using (inl; inr)
 open import foundation.unit-type using (star)
+
+open import order-theory.greatest-lower-bounds-posets
 
 open import univalent-combinatorics.standard-finite-types using (Fin)
 ```
 
-# Minimum on the standard finite types
+## Idea
+
+We define the operation of minimum (greatest lower bound) for the standard finite types.
+
+## Definition
 
 ```agda
 min-Fin : ∀ {k} → Fin k → Fin k → Fin k
@@ -25,6 +32,18 @@ min-Fin {k = succ-ℕ k} (inl x) (inr _) = inl x
 min-Fin {k = succ-ℕ k} (inr _) (inl x) = inl x
 min-Fin {k = succ-ℕ k} (inr _) (inr _) = inr star
 
+min-Fin-Fin : {k : ℕ} (n : ℕ) → (Fin (succ-ℕ n) → Fin k) → Fin k
+min-Fin-Fin zero-ℕ f     = f (inr star)
+min-Fin-Fin (succ-ℕ n) f = min-Fin (f (inr star)) (min-Fin-Fin n (λ k → f (inl k)))
+```
+
+## Properties
+
+### Minimum is a greatest lower bound
+
+We prove that `min-Fin` is a greatest lower bound of its two arguments by showing that `min(m,n) ≤ x` is equivalent to `(m ≤ x) ∧ (n ≤ x)`, in components. By reflexivity of `≤`, we compute that `min(m,n) ≤ m` (and correspondingly for `n`).
+
+```agda
 leq-min-Fin :
   ∀ {k} (l m n : Fin k) → leq-Fin l m → leq-Fin l n → leq-Fin l (min-Fin m n)
 leq-min-Fin {k = succ-ℕ k} (inl x) (inl y) (inl z) p q = leq-min-Fin x y z p q
@@ -53,7 +72,11 @@ leq-right-leq-min-Fin {succ-ℕ k} (inr x) (inr x₁) (inr x₂) p = star
 leq-right-leq-min-Fin {succ-ℕ k} (inr x) (inl x₁) (inl x₂) p = p
 leq-right-leq-min-Fin {succ-ℕ k} (inr x) (inr x₁) (inl x₂) p = p
 
-min-Fin-Fin : {k : ℕ} (n : ℕ) → (Fin (succ-ℕ n) → Fin k) → Fin k
-min-Fin-Fin zero-ℕ f     = f (inr star)
-min-Fin-Fin (succ-ℕ n) f = min-Fin (f (inr star)) (min-Fin-Fin n (λ k → f (inl k)))
+is-greatest-lower-bound-min-Fin :
+  ∀ {k} (l m : Fin k)
+  → is-greatest-binary-lower-bound-Poset (fin-Poset k) l m (min-Fin l m)
+is-greatest-lower-bound-min-Fin l m =
+  ( leq-left-leq-min-Fin (min-Fin l m) l m (refl-leq-Fin (min-Fin l m)),
+    leq-right-leq-min-Fin (min-Fin l m) l m (refl-leq-Fin (min-Fin l m))),
+  λ x (x≤l , x≤m) → leq-min-Fin x l m x≤l x≤m
 ```

--- a/src/elementary-number-theory/minimum-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/minimum-standard-finite-types.lagda.md
@@ -1,0 +1,59 @@
+---
+title: Minimum on the standard finite types
+---
+
+```agda
+{-# OPTIONS --without-K --exact-split #-}
+
+module elementary-number-theory.minimum-standard-finite-types where
+
+open import elementary-number-theory.inequality-standard-finite-types using (leq-Fin)
+open import elementary-number-theory.natural-numbers using (ℕ; zero-ℕ; succ-ℕ)
+
+open import foundation.coproduct-types using (inl; inr)
+open import foundation.unit-type using (star)
+
+open import univalent-combinatorics.standard-finite-types using (Fin)
+```
+
+# Minimum on the standard finite types
+
+```agda
+min-Fin : ∀ {k} → Fin k → Fin k → Fin k
+min-Fin {k = succ-ℕ k} (inl x) (inl y) = inl (min-Fin x y)
+min-Fin {k = succ-ℕ k} (inl x) (inr _) = inl x
+min-Fin {k = succ-ℕ k} (inr _) (inl x) = inl x
+min-Fin {k = succ-ℕ k} (inr _) (inr _) = inr star
+
+leq-min-Fin :
+  ∀ {k} (l m n : Fin k) → leq-Fin l m → leq-Fin l n → leq-Fin l (min-Fin m n)
+leq-min-Fin {k = succ-ℕ k} (inl x) (inl y) (inl z) p q = leq-min-Fin x y z p q
+leq-min-Fin {k = succ-ℕ k} (inl x) (inl y) (inr z) p q = p
+leq-min-Fin {k = succ-ℕ k} (inl x) (inr y) (inl z) p q = q
+leq-min-Fin {k = succ-ℕ k} (inl x) (inr y) (inr z) p q = star
+leq-min-Fin {k = succ-ℕ k} (inr x) (inr y) (inr z) p q = star
+
+leq-left-leq-min-Fin :
+  ∀ {k} (l m n : Fin k) → leq-Fin l (min-Fin m n) → leq-Fin l m
+leq-left-leq-min-Fin {succ-ℕ k} (inl x) (inl y) (inl z) p = leq-left-leq-min-Fin x y z p
+leq-left-leq-min-Fin {succ-ℕ k} (inl x) (inl y) (inr _) p = p
+leq-left-leq-min-Fin {succ-ℕ k} (inl x) (inr _) (inl _) p = star
+leq-left-leq-min-Fin {succ-ℕ k} (inl x) (inr _) (inr _) p = star
+leq-left-leq-min-Fin {succ-ℕ k} (inr _) (inl y) (inr _) p = p
+leq-left-leq-min-Fin {succ-ℕ k} (inr _) (inr _) (inl _) p = star
+leq-left-leq-min-Fin {succ-ℕ k} (inr _) (inr _) (inr _) p = star
+
+leq-right-leq-min-Fin :
+  ∀ {k} (l m n : Fin k) → leq-Fin l (min-Fin m n) → leq-Fin l n
+leq-right-leq-min-Fin {succ-ℕ k} (inl x) (inl x₁) (inl x₂) p = leq-right-leq-min-Fin x x₁ x₂ p
+leq-right-leq-min-Fin {succ-ℕ k} (inl x) (inl x₁) (inr x₂) p = star
+leq-right-leq-min-Fin {succ-ℕ k} (inl x) (inr x₁) (inl x₂) p = p
+leq-right-leq-min-Fin {succ-ℕ k} (inl x) (inr x₁) (inr x₂) p = star
+leq-right-leq-min-Fin {succ-ℕ k} (inr x) (inr x₁) (inr x₂) p = star
+leq-right-leq-min-Fin {succ-ℕ k} (inr x) (inl x₁) (inl x₂) p = p
+leq-right-leq-min-Fin {succ-ℕ k} (inr x) (inr x₁) (inl x₂) p = p
+
+min-Fin-Fin : {k : ℕ} (n : ℕ) → (Fin (succ-ℕ n) → Fin k) → Fin k
+min-Fin-Fin zero-ℕ f     = f (inr star)
+min-Fin-Fin (succ-ℕ n) f = min-Fin (f (inr star)) (min-Fin-Fin n (λ k → f (inl k)))
+```

--- a/src/univalent-combinatorics/standard-finite-types.lagda.md
+++ b/src/univalent-combinatorics/standard-finite-types.lagda.md
@@ -43,7 +43,7 @@ open import structured-types.types-equipped-with-endomorphisms
 
 ## Idea
 
-The standard finite types are defined inductively by `Fin 0 := empty` and `Fin (n+1) := (Fin n) + 1`.
+The standard finite types are defined inductively by `Fin 0 := empty` and `Fin (n+1) := (Fin n) + 1`. **Note** that the outermost coproduct (i.e. the `inr` injection) is the _top_ element, when `Fin n` is considered as an initial segment of `n`.
 
 ## Definition
 


### PR DESCRIPTION
Needed these for my idea about how to prove the standard polygon graphs are connected: Order the vertices and then compare them — the resulting difference will tell you exactly what path to build. Also to match the natural numbers.

I added a small note on the definition of `Fin` because `inr` being the top element caught me off-guard: hopefully nobody else trips on this!

To be honest I can't ever see a need for `min-Fin-Fin` and `max-Fin-Fin` but `min-Fin-Fin` has such great prosody that I just _had_ to include it.