### PR TITLE
refactoring for performance

### DIFF
--- a/src/README.lagda.md
+++ b/src/README.lagda.md
@@ -179,6 +179,7 @@ open import finite-group-theory.groups-of-order-2
 open import finite-group-theory.orbits-permutations
 open import finite-group-theory.permutations
 open import finite-group-theory.sign-homomorphism
+open import finite-group-theory.simpson-delooping-sign-homomorphism
 open import finite-group-theory.tetrahedra-in-3-space
 open import finite-group-theory.transpositions
 ```

--- a/src/elementary-number-theory/catalan-numbers.lagda.md
+++ b/src/elementary-number-theory/catalan-numbers.lagda.md
@@ -35,18 +35,18 @@ catalan-numbers : ℕ → ℕ
 catalan-numbers =
   strong-ind-ℕ (λ _ → ℕ) (succ-ℕ zero-ℕ)
     ( λ k C →
-      sum-Fin-ℕ {k = k}
+      sum-Fin-ℕ k
         ( λ i →
           mul-ℕ
-            ( C ( nat-Fin i)
-                ( leq-le-ℕ {x = nat-Fin i} (strict-upper-bound-nat-Fin i)))
-            ( C ( dist-ℕ (nat-Fin i) k)
+            ( C ( nat-Fin k i)
+                ( leq-le-ℕ {x = nat-Fin k i} (strict-upper-bound-nat-Fin k i)))
+            ( C ( dist-ℕ (nat-Fin k i) k)
                 ( leq-dist-ℕ
-                  ( nat-Fin i)
+                  ( nat-Fin k i)
                   ( k)
                   ( leq-le-ℕ
-                    { x = nat-Fin i}
-                    ( strict-upper-bound-nat-Fin i))))))
+                    { x = nat-Fin k i}
+                    ( strict-upper-bound-nat-Fin k i))))))
 
 catalan-numbers-binomial : ℕ → ℕ
 catalan-numbers-binomial n =

--- a/src/elementary-number-theory/congruence-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/congruence-natural-numbers.lagda.md
@@ -137,18 +137,18 @@ eq-cong-le-ℕ k x y H K =
 
 ```agda
 eq-cong-nat-Fin :
-  (k : ℕ) (x y : Fin k) → cong-ℕ k (nat-Fin x) (nat-Fin y) → x ＝ y
+  (k : ℕ) (x y : Fin k) → cong-ℕ k (nat-Fin k x) (nat-Fin k y) → x ＝ y
 eq-cong-nat-Fin (succ-ℕ k) x y H =
-  is-injective-nat-Fin
-    ( eq-cong-le-ℕ (succ-ℕ k) (nat-Fin x) (nat-Fin y)
-      ( strict-upper-bound-nat-Fin x)
-      ( strict-upper-bound-nat-Fin y)
+  is-injective-nat-Fin (succ-ℕ k)
+    ( eq-cong-le-ℕ (succ-ℕ k) (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y)
+      ( strict-upper-bound-nat-Fin (succ-ℕ k) x)
+      ( strict-upper-bound-nat-Fin (succ-ℕ k) y)
       ( H))
 ```
 
 ```agda
 cong-is-zero-nat-zero-Fin :
-  {k : ℕ} → cong-ℕ (succ-ℕ k) (nat-Fin (zero-Fin {k})) zero-ℕ
+  {k : ℕ} → cong-ℕ (succ-ℕ k) (nat-Fin (succ-ℕ k) (zero-Fin k)) zero-ℕ
 cong-is-zero-nat-zero-Fin {k} =
   cong-identification-ℕ (succ-ℕ k) (is-zero-nat-zero-Fin {k})
 ```

--- a/src/elementary-number-theory/divisibility-modular-arithmetic.lagda.md
+++ b/src/elementary-number-theory/divisibility-modular-arithmetic.lagda.md
@@ -13,7 +13,7 @@ open import elementary-number-theory.divisibility-standard-finite-types using
   ( refl-div-Fin; trans-div-Fin)
 open import elementary-number-theory.modular-arithmetic using
   ( ℤ-Mod; mul-ℤ-Mod)
-open import elementary-number-theory.natural-numbers using (ℕ)
+open import elementary-number-theory.natural-numbers using (ℕ; zero-ℕ; succ-ℕ)
 
 open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2)
 open import foundation.identity-types using (_＝_)
@@ -47,6 +47,6 @@ refl-div-ℤ-Mod {ℕ.succ-ℕ k} = refl-div-Fin
 trans-div-ℤ-Mod :
   {k : ℕ} (x y z : ℤ-Mod k) →
   div-ℤ-Mod k x y → div-ℤ-Mod k y z → div-ℤ-Mod k x z
-trans-div-ℤ-Mod {ℕ.zero-ℕ} = trans-div-ℤ
-trans-div-ℤ-Mod {ℕ.succ-ℕ k} = trans-div-Fin
+trans-div-ℤ-Mod {zero-ℕ} = trans-div-ℤ
+trans-div-ℤ-Mod {succ-ℕ k} = trans-div-Fin (succ-ℕ k)
 ```

--- a/src/elementary-number-theory/divisibility-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/divisibility-standard-finite-types.lagda.md
@@ -33,8 +33,8 @@ Given two elements `x y : Fin k`, we say that `x` divides `y` if there is an ele
 ## Definition
 
 ```agda
-div-Fin : {k : ℕ} → Fin k → Fin k → UU lzero
-div-Fin {k} x y = Σ (Fin k) (λ u → mul-Fin u x ＝ y)
+div-Fin : (k : ℕ) → Fin k → Fin k → UU lzero
+div-Fin k x y = Σ (Fin k) (λ u → mul-Fin k u x ＝ y)
 ```
 
 ## Properties
@@ -42,49 +42,50 @@ div-Fin {k} x y = Σ (Fin k) (λ u → mul-Fin u x ＝ y)
 ### The divisibility relation is reflexive
 
 ```agda
-refl-div-Fin : {k : ℕ} (x : Fin k) → div-Fin x x
-pr1 (refl-div-Fin {succ-ℕ k} x) = one-Fin
-pr2 (refl-div-Fin {succ-ℕ k} x) = left-unit-law-mul-Fin x
+refl-div-Fin : {k : ℕ} (x : Fin k) → div-Fin k x x
+pr1 (refl-div-Fin {succ-ℕ k} x) = one-Fin k
+pr2 (refl-div-Fin {succ-ℕ k} x) = left-unit-law-mul-Fin k x
 ```
 
 ### The divisibility relation is transitive
 
 ```agda
 trans-div-Fin :
-  {k : ℕ} (x y z : Fin k) → div-Fin x y → div-Fin y z → div-Fin x z
-pr1 (trans-div-Fin x y z (pair u p) (pair v q)) = mul-Fin v u
-pr2 (trans-div-Fin x y z (pair u p) (pair v q)) =
-  associative-mul-Fin v u x ∙ (ap (mul-Fin v) p ∙ q)
+  (k : ℕ) (x y z : Fin k) → div-Fin k x y → div-Fin k y z → div-Fin k x z
+pr1 (trans-div-Fin k x y z (pair u p) (pair v q)) = mul-Fin k v u
+pr2 (trans-div-Fin k x y z (pair u p) (pair v q)) =
+  associative-mul-Fin k v u x ∙ (ap (mul-Fin k v) p ∙ q)
 ```
 
 ### Every element divides zero
 
 ```agda
-div-zero-Fin : {k : ℕ} (x : Fin (succ-ℕ k)) → div-Fin x zero-Fin
-pr1 (div-zero-Fin x) = zero-Fin
-pr2 (div-zero-Fin x) = left-zero-law-mul-Fin x
+div-zero-Fin : (k : ℕ) (x : Fin (succ-ℕ k)) → div-Fin (succ-ℕ k) x (zero-Fin k)
+pr1 (div-zero-Fin k x) = zero-Fin k
+pr2 (div-zero-Fin k x) = left-zero-law-mul-Fin k x
 ```
 
 ### Every element is divisible by one
 
 ```agda
-div-one-Fin : {k : ℕ} (x : Fin (succ-ℕ k)) → div-Fin one-Fin x
-pr1 (div-one-Fin x) = x
-pr2 (div-one-Fin x) = right-unit-law-mul-Fin x
+div-one-Fin : (k : ℕ) (x : Fin (succ-ℕ k)) → div-Fin (succ-ℕ k) (one-Fin k) x
+pr1 (div-one-Fin k x) = x
+pr2 (div-one-Fin k x) = right-unit-law-mul-Fin k x
 ```
 
 ### The only element that is divisible by zero is zero itself
 
 ```agda
 is-zero-div-zero-Fin :
-  {k : ℕ} (x : Fin (succ-ℕ k)) → div-Fin zero-Fin x → is-zero-Fin x
-is-zero-div-zero-Fin {k} x (pair u p) = inv p ∙ right-zero-law-mul-Fin u
+  {k : ℕ} (x : Fin (succ-ℕ k)) →
+  div-Fin (succ-ℕ k) (zero-Fin k) x → is-zero-Fin (succ-ℕ k) x
+is-zero-div-zero-Fin {k} x (pair u p) = inv p ∙ right-zero-law-mul-Fin k u
 ```
 
 ### The divisibility relation is decidable
 
 ```agda
-is-decidable-div-Fin : {k : ℕ} (x y : Fin k) → is-decidable (div-Fin x y)
-is-decidable-div-Fin x y =
-  is-decidable-Σ-Fin (λ u → has-decidable-equality-Fin (mul-Fin u x) y)
+is-decidable-div-Fin : (k : ℕ) (x y : Fin k) → is-decidable (div-Fin k x y)
+is-decidable-div-Fin k x y =
+  is-decidable-Σ-Fin k (λ u → has-decidable-equality-Fin k (mul-Fin k u x) y)
 ```

--- a/src/elementary-number-theory/euclidean-division-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/euclidean-division-natural-numbers.lagda.md
@@ -38,15 +38,15 @@ euclidean-division-ℕ :
 pr1 (euclidean-division-ℕ zero-ℕ x) = x
 pr1 (pr2 (euclidean-division-ℕ zero-ℕ x)) = refl-cong-ℕ zero-ℕ x
 pr2 (pr2 (euclidean-division-ℕ zero-ℕ x)) f = ex-falso (f refl)
-pr1 (euclidean-division-ℕ (succ-ℕ k) x) = nat-Fin (mod-succ-ℕ k x)
+pr1 (euclidean-division-ℕ (succ-ℕ k) x) = nat-Fin (succ-ℕ k) (mod-succ-ℕ k x)
 pr1 (pr2 (euclidean-division-ℕ (succ-ℕ k) x)) =
   symm-cong-ℕ
     ( succ-ℕ k)
-    ( nat-Fin (mod-succ-ℕ k x))
+    ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k x))
     ( x)
     ( cong-nat-mod-succ-ℕ k x)
 pr2 (pr2 (euclidean-division-ℕ (succ-ℕ k) x)) f =
-  strict-upper-bound-nat-Fin (mod-succ-ℕ k x)
+  strict-upper-bound-nat-Fin (succ-ℕ k) (mod-succ-ℕ k x)
 
 remainder-euclidean-division-ℕ : ℕ → ℕ → ℕ
 remainder-euclidean-division-ℕ k x =

--- a/src/elementary-number-theory/finitary-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/finitary-natural-numbers.lagda.md
@@ -45,10 +45,10 @@ data based-ℕ : ℕ → UU lzero where
 {- Converting a k-ary natural number to a natural number -}
 
 constant-ℕ : (k : ℕ) → Fin k → ℕ
-constant-ℕ k x = nat-Fin x
+constant-ℕ k x = nat-Fin k x
 
 unary-op-ℕ : (k : ℕ) → Fin k → ℕ → ℕ
-unary-op-ℕ k x n = add-ℕ (mul-ℕ k (succ-ℕ n)) (nat-Fin x)
+unary-op-ℕ k x n = add-ℕ (mul-ℕ k (succ-ℕ n)) (nat-Fin k x)
 
 convert-based-ℕ : (k : ℕ) → based-ℕ k → ℕ
 convert-based-ℕ k (constant-based-ℕ .k x) =
@@ -69,7 +69,7 @@ is-empty-based-zero-ℕ (unary-op-based-ℕ .zero-ℕ () n)
 
 cong-unary-op-ℕ :
   (k : ℕ) (x : Fin k) (n : ℕ) →
-  cong-ℕ k (unary-op-ℕ k x n) (nat-Fin x)
+  cong-ℕ k (unary-op-ℕ k x n) (nat-Fin k x)
 cong-unary-op-ℕ (succ-ℕ k) x n =
   concatenate-cong-eq-ℕ
     ( succ-ℕ k)
@@ -78,9 +78,9 @@ cong-unary-op-ℕ (succ-ℕ k) x n =
       ( succ-ℕ k)
       ( mul-ℕ (succ-ℕ k) (succ-ℕ n))
       ( zero-ℕ)
-      ( nat-Fin x)
+      ( nat-Fin (succ-ℕ k) x)
       ( pair (succ-ℕ n) (commutative-mul-ℕ (succ-ℕ n) (succ-ℕ k))))
-    ( left-unit-law-add-ℕ (nat-Fin x))
+    ( left-unit-law-add-ℕ (nat-Fin (succ-ℕ k) x))
 
 {- Any natural number of the form constant-ℕ k x is strictly less than any
    natural number of the form unary-op-ℕ k y m -}
@@ -88,13 +88,13 @@ cong-unary-op-ℕ (succ-ℕ k) x n =
 le-constant-unary-op-ℕ :
   (k : ℕ) (x y : Fin k) (m : ℕ) → le-ℕ (constant-ℕ k x) (unary-op-ℕ k y m)
 le-constant-unary-op-ℕ k x y m =
-  concatenate-le-leq-ℕ {nat-Fin x} {k} {unary-op-ℕ k y m}
-    ( strict-upper-bound-nat-Fin x)
+  concatenate-le-leq-ℕ {nat-Fin k x} {k} {unary-op-ℕ k y m}
+    ( strict-upper-bound-nat-Fin k x)
     ( transitive-leq-ℕ
       ( k)
       ( mul-ℕ k (succ-ℕ m))
       ( unary-op-ℕ k y m)
-      ( leq-add-ℕ (mul-ℕ k (succ-ℕ m)) (nat-Fin y))
+      ( leq-add-ℕ (mul-ℕ k (succ-ℕ m)) (nat-Fin k y))
       ( leq-mul-ℕ m k))
 
 is-injective-convert-based-ℕ :
@@ -103,7 +103,7 @@ is-injective-convert-based-ℕ
   ( succ-ℕ k)
   { constant-based-ℕ .(succ-ℕ k) x}
   { constant-based-ℕ .(succ-ℕ k) y} p =
-  ap (constant-based-ℕ (succ-ℕ k)) (is-injective-nat-Fin p)
+  ap (constant-based-ℕ (succ-ℕ k)) (is-injective-nat-Fin (succ-ℕ k) p)
 is-injective-convert-based-ℕ
   ( succ-ℕ k)
   { constant-based-ℕ .(succ-ℕ k) x}
@@ -125,23 +125,23 @@ is-injective-convert-based-ℕ
   { unary-op-based-ℕ .(succ-ℕ k) x n}
   { unary-op-based-ℕ .(succ-ℕ k) y m} p with
   -- the following term has type Id x y
-  is-injective-nat-Fin {succ-ℕ k} {x} {y}
+  is-injective-nat-Fin (succ-ℕ k) {x} {y}
     ( eq-cong-le-ℕ
       ( succ-ℕ k)
-      ( nat-Fin x)
-      ( nat-Fin y)
-      ( strict-upper-bound-nat-Fin x)
-      ( strict-upper-bound-nat-Fin y)
+      ( nat-Fin (succ-ℕ k) x)
+      ( nat-Fin (succ-ℕ k) y)
+      ( strict-upper-bound-nat-Fin (succ-ℕ k) x)
+      ( strict-upper-bound-nat-Fin (succ-ℕ k) y)
       ( concatenate-cong-eq-cong-ℕ
         { succ-ℕ k}
-        { nat-Fin x}
+        { nat-Fin (succ-ℕ k) x}
         { unary-op-ℕ (succ-ℕ k) x (convert-based-ℕ (succ-ℕ k) n)}
         { unary-op-ℕ (succ-ℕ k) y (convert-based-ℕ (succ-ℕ k) m)}
-        { nat-Fin y}
+        { nat-Fin (succ-ℕ k) y}
         ( symm-cong-ℕ
           ( succ-ℕ k)
           ( unary-op-ℕ (succ-ℕ k) x (convert-based-ℕ (succ-ℕ k) n))
-          ( nat-Fin x)
+          ( nat-Fin (succ-ℕ k) x)
           ( cong-unary-op-ℕ (succ-ℕ k) x (convert-based-ℕ (succ-ℕ k) n)))
         ( p)
         ( cong-unary-op-ℕ (succ-ℕ k) y (convert-based-ℕ (succ-ℕ k) m))))
@@ -150,7 +150,7 @@ is-injective-convert-based-ℕ
      ( is-injective-convert-based-ℕ (succ-ℕ k)
        ( is-injective-succ-ℕ
          ( is-injective-mul-succ-ℕ k
-           ( is-injective-add-ℕ' (nat-Fin x) p))))
+           ( is-injective-add-ℕ' (nat-Fin (succ-ℕ k) x) p))))
 
 -- Exercise 7.10 (c)
 
@@ -158,18 +158,18 @@ is-injective-convert-based-ℕ
 
 -- The zero-element of the (k+1)-ary natural numbers
 zero-based-ℕ : (k : ℕ) → based-ℕ (succ-ℕ k)
-zero-based-ℕ k = constant-based-ℕ (succ-ℕ k) zero-Fin
+zero-based-ℕ k = constant-based-ℕ (succ-ℕ k) (zero-Fin k)
 
 -- The successor function on the k-ary natural numbers
 succ-based-ℕ : (k : ℕ) → based-ℕ k → based-ℕ k
 succ-based-ℕ (succ-ℕ k) (constant-based-ℕ .(succ-ℕ k) (inl x)) =
-  constant-based-ℕ (succ-ℕ k) (succ-Fin (inl x))
+  constant-based-ℕ (succ-ℕ k) (succ-Fin (succ-ℕ k) (inl x))
 succ-based-ℕ (succ-ℕ k) (constant-based-ℕ .(succ-ℕ k) (inr star)) =
-  unary-op-based-ℕ (succ-ℕ k) zero-Fin (constant-based-ℕ (succ-ℕ k) zero-Fin)
+  unary-op-based-ℕ (succ-ℕ k) (zero-Fin k) (constant-based-ℕ (succ-ℕ k) (zero-Fin k))
 succ-based-ℕ (succ-ℕ k) (unary-op-based-ℕ .(succ-ℕ k) (inl x) n) =
-  unary-op-based-ℕ (succ-ℕ k) (succ-Fin (inl x)) n
+  unary-op-based-ℕ (succ-ℕ k) (succ-Fin (succ-ℕ k) (inl x)) n
 succ-based-ℕ (succ-ℕ k) (unary-op-based-ℕ .(succ-ℕ k) (inr x) n) =
-  unary-op-based-ℕ (succ-ℕ k) zero-Fin (succ-based-ℕ (succ-ℕ k) n)
+  unary-op-based-ℕ (succ-ℕ k) (zero-Fin k) (succ-based-ℕ (succ-ℕ k) n)
 
 -- The inverse map of convert-based-ℕ
 inv-convert-based-ℕ : (k : ℕ) → ℕ → based-ℕ (succ-ℕ k)
@@ -182,7 +182,7 @@ convert-based-succ-based-ℕ :
   (k : ℕ) (x : based-ℕ k) →
   convert-based-ℕ k (succ-based-ℕ k x) ＝ succ-ℕ (convert-based-ℕ k x)
 convert-based-succ-based-ℕ (succ-ℕ k) (constant-based-ℕ .(succ-ℕ k) (inl x)) =
-  nat-succ-Fin x
+  nat-succ-Fin k x
 convert-based-succ-based-ℕ
   ( succ-ℕ k) (constant-based-ℕ .(succ-ℕ k) (inr star)) =
   ( ap
@@ -191,7 +191,7 @@ convert-based-succ-based-ℕ
   ( right-unit-law-mul-ℕ (succ-ℕ k))
 convert-based-succ-based-ℕ (succ-ℕ k) (unary-op-based-ℕ .(succ-ℕ k) (inl x) n) =
   ap ( add-ℕ (mul-ℕ (succ-ℕ k) (succ-ℕ (convert-based-ℕ (succ-ℕ k) n))))
-     ( nat-succ-Fin {k} x)
+     ( nat-succ-Fin k x)
 convert-based-succ-based-ℕ
   (succ-ℕ k) (unary-op-based-ℕ .(succ-ℕ k) (inr star) n) =
   ( ap ( add-ℕ

--- a/src/elementary-number-theory/finitely-cyclic-maps.lagda.md
+++ b/src/elementary-number-theory/finitely-cyclic-maps.lagda.md
@@ -88,20 +88,27 @@ module _
 ```agda
 compute-iterate-succ-Fin :
   {k : ℕ} (n : ℕ) (x : Fin (succ-ℕ k)) →
-  iterate n succ-Fin x ＝ add-Fin x (mod-succ-ℕ k n)
-compute-iterate-succ-Fin zero-ℕ x = inv (right-unit-law-add-Fin x)
+  iterate n (succ-Fin (succ-ℕ k)) x ＝ add-Fin (succ-ℕ k) x (mod-succ-ℕ k n)
+compute-iterate-succ-Fin {k} zero-ℕ x = inv (right-unit-law-add-Fin k x)
 compute-iterate-succ-Fin {k} (succ-ℕ n) x =
-  ( ap succ-Fin (compute-iterate-succ-Fin n x)) ∙
-  ( inv (right-successor-law-add-Fin x (mod-succ-ℕ k n)))
+  ( ap (succ-Fin (succ-ℕ k)) (compute-iterate-succ-Fin n x)) ∙
+  ( inv (right-successor-law-add-Fin (succ-ℕ k) x (mod-succ-ℕ k n)))
 
-is-finitely-cyclic-succ-Fin : {k : ℕ} → is-finitely-cyclic-map (succ-Fin {k})
+is-finitely-cyclic-succ-Fin : {k : ℕ} → is-finitely-cyclic-map (succ-Fin k)
 pr1 (is-finitely-cyclic-succ-Fin {succ-ℕ k} x y) =
-  nat-Fin (add-Fin y (neg-Fin x))
+  nat-Fin (succ-ℕ k) (add-Fin (succ-ℕ k) y (neg-Fin (succ-ℕ k) x))
 pr2 (is-finitely-cyclic-succ-Fin {succ-ℕ k} x y) =
-  ( compute-iterate-succ-Fin (nat-Fin (add-Fin y (neg-Fin x))) x) ∙
-    ( ( ap (add-Fin x) (issec-nat-Fin (add-Fin y (neg-Fin x)))) ∙
-      ( ( commutative-add-Fin x (add-Fin y (neg-Fin x))) ∙
-        ( ( associative-add-Fin y (neg-Fin x) x) ∙
-          ( ( ap (add-Fin y) (left-inverse-law-add-Fin x)) ∙
-            ( right-unit-law-add-Fin y)))))
+  ( compute-iterate-succ-Fin
+    ( nat-Fin (succ-ℕ k) (add-Fin (succ-ℕ k) y (neg-Fin (succ-ℕ k) x)))
+    ( x)) ∙
+    ( ( ap
+        ( add-Fin (succ-ℕ k) x)
+        ( issec-nat-Fin k (add-Fin (succ-ℕ k) y (neg-Fin (succ-ℕ k) x)))) ∙
+      ( ( commutative-add-Fin
+          ( succ-ℕ k)
+          ( x)
+          ( add-Fin (succ-ℕ k) y (neg-Fin (succ-ℕ k) x))) ∙
+        ( ( associative-add-Fin (succ-ℕ k) y (neg-Fin (succ-ℕ k) x) x) ∙
+          ( ( ap (add-Fin (succ-ℕ k) y) (left-inverse-law-add-Fin k x)) ∙
+            ( right-unit-law-add-Fin k y)))))
 ```

--- a/src/elementary-number-theory/inequality-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/inequality-standard-finite-types.lagda.md
@@ -12,9 +12,10 @@ open import elementary-number-theory.inequality-natural-numbers using
 open import elementary-number-theory.natural-numbers using (ℕ; zero-ℕ; succ-ℕ)
 
 open import foundation.coproduct-types using (inl; inr)
+open import foundation.decidable-propositions
+open import foundation.decidable-types
 open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2)
 open import foundation.empty-types using (empty; ex-falso; is-prop-empty)
-open import foundation.decidable-types
 open import foundation.identity-types using (_＝_; refl; ap)
 open import foundation.propositions using (is-prop; UU-Prop)
 open import foundation.unit-type using (unit; star; is-prop-unit)
@@ -30,71 +31,74 @@ open import univalent-combinatorics.standard-finite-types using
 # Inequality on the standard finite types
 
 ```agda
-leq-Fin : {k : ℕ} → Fin k → Fin k → UU lzero
-leq-Fin {succ-ℕ k} x (inr y) = unit
-leq-Fin {succ-ℕ k} (inl x) (inl y) = leq-Fin x y
-leq-Fin {succ-ℕ k} (inr x) (inl y) = empty
+leq-Fin : (k : ℕ) → Fin k → Fin k → UU lzero
+leq-Fin (succ-ℕ k) x (inr y) = unit
+leq-Fin (succ-ℕ k) (inl x) (inl y) = leq-Fin k x y
+leq-Fin (succ-ℕ k) (inr x) (inl y) = empty
 
 abstract
   is-prop-leq-Fin :
-    {k : ℕ} (x y : Fin k) → is-prop (leq-Fin x y)
-  is-prop-leq-Fin {succ-ℕ k} (inl x) (inl y) = is-prop-leq-Fin x y
-  is-prop-leq-Fin {succ-ℕ k} (inl x) (inr star) = is-prop-unit
-  is-prop-leq-Fin {succ-ℕ k} (inr star) (inl y) = is-prop-empty
-  is-prop-leq-Fin {succ-ℕ k} (inr star) (inr star) = is-prop-unit
+    (k : ℕ) (x y : Fin k) → is-prop (leq-Fin k x y)
+  is-prop-leq-Fin (succ-ℕ k) (inl x) (inl y) = is-prop-leq-Fin k x y
+  is-prop-leq-Fin (succ-ℕ k) (inl x) (inr star) = is-prop-unit
+  is-prop-leq-Fin (succ-ℕ k) (inr star) (inl y) = is-prop-empty
+  is-prop-leq-Fin (succ-ℕ k) (inr star) (inr star) = is-prop-unit
 
-leq-fin-Prop : {k : ℕ} → Fin k → Fin k → UU-Prop lzero
-pr1 (leq-fin-Prop x y) = leq-Fin x y
-pr2 (leq-fin-Prop x y) = is-prop-leq-Fin x y
+leq-fin-Prop : (k : ℕ) → Fin k → Fin k → UU-Prop lzero
+pr1 (leq-fin-Prop k x y) = leq-Fin k x y
+pr2 (leq-fin-Prop k x y) = is-prop-leq-Fin k x y
 
-leq-neg-one-Fin : {k : ℕ} (x : Fin (succ-ℕ k)) → leq-Fin x neg-one-Fin
-leq-neg-one-Fin x = star
+leq-neg-one-Fin :
+  (k : ℕ) (x : Fin (succ-ℕ k)) → leq-Fin (succ-ℕ k) x (neg-one-Fin k)
+leq-neg-one-Fin k x = star
 
-refl-leq-Fin : {k : ℕ} (x : Fin k) → leq-Fin x x
-refl-leq-Fin {succ-ℕ k} (inl x) = refl-leq-Fin x
-refl-leq-Fin {succ-ℕ k} (inr star) = star
+refl-leq-Fin : (k : ℕ) (x : Fin k) → leq-Fin k x x
+refl-leq-Fin (succ-ℕ k) (inl x) = refl-leq-Fin k x
+refl-leq-Fin (succ-ℕ k) (inr star) = star
 
 antisymmetric-leq-Fin :
-  {k : ℕ} (x y : Fin k) → leq-Fin x y → leq-Fin y x → x ＝ y
-antisymmetric-leq-Fin {succ-ℕ k} (inl x) (inl y) H K =
-  ap inl (antisymmetric-leq-Fin x y H K)
-antisymmetric-leq-Fin {succ-ℕ k} (inr star) (inr star) H K = refl
+  (k : ℕ) (x y : Fin k) → leq-Fin k x y → leq-Fin k y x → x ＝ y
+antisymmetric-leq-Fin (succ-ℕ k) (inl x) (inl y) H K =
+  ap inl (antisymmetric-leq-Fin k x y H K)
+antisymmetric-leq-Fin (succ-ℕ k) (inr star) (inr star) H K = refl
 
 transitive-leq-Fin :
-  {k : ℕ} (x y z : Fin k) → leq-Fin y z → leq-Fin {k} x y → leq-Fin {k} x z
-transitive-leq-Fin {succ-ℕ k} (inl x) (inl y) (inl z) H K =
-  transitive-leq-Fin {k} x y z H K
-transitive-leq-Fin {succ-ℕ k} (inl x) (inl y) (inr star) H K = star
-transitive-leq-Fin {succ-ℕ k} (inl x) (inr star) (inr star) H K = star
-transitive-leq-Fin {succ-ℕ k} (inr star) (inr star) (inr star) H K = star
+  (k : ℕ) (x y z : Fin k) → leq-Fin k y z → leq-Fin k x y → leq-Fin k x z
+transitive-leq-Fin (succ-ℕ k) (inl x) (inl y) (inl z) H K =
+  transitive-leq-Fin k x y z H K
+transitive-leq-Fin (succ-ℕ k) (inl x) (inl y) (inr star) H K = star
+transitive-leq-Fin (succ-ℕ k) (inl x) (inr star) (inr star) H K = star
+transitive-leq-Fin (succ-ℕ k) (inr star) (inr star) (inr star) H K = star
 
 concatenate-eq-leq-eq-Fin :
-  {k : ℕ} {x1 x2 x3 x4 : Fin k} →
-  x1 ＝ x2 → leq-Fin x2 x3 → x3 ＝ x4 → leq-Fin x1 x4
-concatenate-eq-leq-eq-Fin refl H refl = H
+  (k : ℕ) {x1 x2 x3 x4 : Fin k} →
+  x1 ＝ x2 → leq-Fin k x2 x3 → x3 ＝ x4 → leq-Fin k x1 x4
+concatenate-eq-leq-eq-Fin k refl H refl = H
 
 leq-succ-Fin :
-  {k : ℕ} (x : Fin k) → leq-Fin (inl-Fin k x) (succ-Fin (inl-Fin k x))
-leq-succ-Fin {succ-ℕ k} (inl x) = leq-succ-Fin x
-leq-succ-Fin {succ-ℕ k} (inr star) = star
+  (k : ℕ) (x : Fin k) →
+  leq-Fin (succ-ℕ k) (inl-Fin k x) (succ-Fin (succ-ℕ k) (inl-Fin k x))
+leq-succ-Fin (succ-ℕ k) (inl x) = leq-succ-Fin k x
+leq-succ-Fin (succ-ℕ k) (inr star) = star
 
 preserves-leq-nat-Fin :
-  {k : ℕ} {x y : Fin k} → leq-Fin x y → leq-ℕ (nat-Fin x) (nat-Fin y)
-preserves-leq-nat-Fin {succ-ℕ k} {inl x} {inl y} H =
-  preserves-leq-nat-Fin {k} H
-preserves-leq-nat-Fin {succ-ℕ k} {inl x} {inr star} H =
-  leq-le-ℕ {nat-Fin x} {k} (strict-upper-bound-nat-Fin x)
-preserves-leq-nat-Fin {succ-ℕ k} {inr star} {inr star} H =
+  (k : ℕ) {x y : Fin k} → leq-Fin k x y → leq-ℕ (nat-Fin k x) (nat-Fin k y)
+preserves-leq-nat-Fin (succ-ℕ k) {inl x} {inl y} H =
+  preserves-leq-nat-Fin k H
+preserves-leq-nat-Fin (succ-ℕ k) {inl x} {inr star} H =
+  leq-le-ℕ {nat-Fin k x} {k} (strict-upper-bound-nat-Fin k x)
+preserves-leq-nat-Fin (succ-ℕ k) {inr star} {inr star} H =
   refl-leq-ℕ k
 
 reflects-leq-nat-Fin :
-  {k : ℕ} {x y : Fin k} → leq-ℕ (nat-Fin x) (nat-Fin y) → leq-Fin x y
-reflects-leq-nat-Fin {succ-ℕ k} {inl x} {inl y} H =
-  reflects-leq-nat-Fin {k} H
-reflects-leq-nat-Fin {succ-ℕ k} {inr star} {inl y} H =
-  ex-falso (contradiction-le-ℕ (nat-Fin y) k (strict-upper-bound-nat-Fin y) H)
-reflects-leq-nat-Fin {succ-ℕ k} {inl x} {inr star} H = star
-reflects-leq-nat-Fin {succ-ℕ k} {inr star} {inr star} H = star
+  (k : ℕ) {x y : Fin k} → leq-ℕ (nat-Fin k x) (nat-Fin k y) → leq-Fin k x y
+reflects-leq-nat-Fin (succ-ℕ k) {inl x} {inl y} H =
+  reflects-leq-nat-Fin k H
+reflects-leq-nat-Fin (succ-ℕ k) {inr star} {inl y} H =
+  ex-falso
+    ( contradiction-le-ℕ (nat-Fin k y) k (strict-upper-bound-nat-Fin k y) H)
+reflects-leq-nat-Fin (succ-ℕ k) {inl x} {inr star} H = star
+reflects-leq-nat-Fin (succ-ℕ k) {inr star} {inr star} H = star
 ```
 
 ## Properties
@@ -104,24 +108,29 @@ reflects-leq-nat-Fin {succ-ℕ k} {inr star} {inr star} H = star
 ```agda
 fin-Preorder : ℕ → Preorder lzero lzero
 pr1 (fin-Preorder k) = Fin k
-pr1 (pr2 (fin-Preorder k)) = leq-fin-Prop
-pr1 (pr2 (pr2 (fin-Preorder k))) = refl-leq-Fin
-pr2 (pr2 (pr2 (fin-Preorder k))) = transitive-leq-Fin
+pr1 (pr2 (fin-Preorder k)) = leq-fin-Prop k
+pr1 (pr2 (pr2 (fin-Preorder k))) = refl-leq-Fin k
+pr2 (pr2 (pr2 (fin-Preorder k))) = transitive-leq-Fin k
 
 fin-Poset : ℕ → Poset lzero lzero
 pr1 (fin-Poset k) = Fin k
-pr1 (pr2 (fin-Poset k)) = leq-fin-Prop
-pr1 (pr1 (pr2 (pr2 (fin-Poset k)))) = refl-leq-Fin
-pr2 (pr1 (pr2 (pr2 (fin-Poset k)))) = transitive-leq-Fin
-pr2 (pr2 (pr2 (fin-Poset k))) = antisymmetric-leq-Fin
+pr1 (pr2 (fin-Poset k)) = leq-fin-Prop k
+pr1 (pr1 (pr2 (pr2 (fin-Poset k)))) = refl-leq-Fin k
+pr2 (pr1 (pr2 (pr2 (fin-Poset k)))) = transitive-leq-Fin k
+pr2 (pr2 (pr2 (fin-Poset k))) = antisymmetric-leq-Fin k
 ```
 
 ### Ordering on the standard finite types is decidable
 
 ```agda
-is-decidable-leq-Fin : {k : ℕ} (x y : Fin k) → is-decidable (leq-Fin x y)
-is-decidable-leq-Fin {k = succ-ℕ k} (inl x) (inl y) = is-decidable-leq-Fin x y
-is-decidable-leq-Fin {k = succ-ℕ k} (inl x) (inr y) = inl star
-is-decidable-leq-Fin {k = succ-ℕ k} (inr x) (inl y) = inr (λ x → x)
-is-decidable-leq-Fin {k = succ-ℕ k} (inr x) (inr y) = inl star
+is-decidable-leq-Fin : (k : ℕ) (x y : Fin k) → is-decidable (leq-Fin k x y)
+is-decidable-leq-Fin (succ-ℕ k) (inl x) (inl y) = is-decidable-leq-Fin k x y
+is-decidable-leq-Fin (succ-ℕ k) (inl x) (inr y) = inl star
+is-decidable-leq-Fin (succ-ℕ k) (inr x) (inl y) = inr (λ x → x)
+is-decidable-leq-Fin (succ-ℕ k) (inr x) (inr y) = inl star
+
+leq-Fin-decidable-Prop : (k : ℕ) → Fin k → Fin k → decidable-Prop lzero
+pr1 (leq-Fin-decidable-Prop k x y) = leq-Fin k x y
+pr1 (pr2 (leq-Fin-decidable-Prop k x y)) = is-prop-leq-Fin k x y
+pr2 (pr2 (leq-Fin-decidable-Prop k x y)) = is-decidable-leq-Fin k x y
 ```

--- a/src/elementary-number-theory/maximum-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/maximum-standard-finite-types.lagda.md
@@ -10,7 +10,7 @@ module elementary-number-theory.maximum-standard-finite-types where
 open import elementary-number-theory.inequality-standard-finite-types
 open import elementary-number-theory.natural-numbers using (ℕ; zero-ℕ; succ-ℕ)
 
-open import foundation.dependent-pair-types using (_,_)
+open import foundation.dependent-pair-types using (pair; pr1; pr2)
 open import foundation.coproduct-types using (inl; inr)
 open import foundation.unit-type using (star)
 
@@ -26,15 +26,15 @@ We define the operation of maximum (least upper bound) for the standard finite t
 ## Definition
 
 ```agda
-max-Fin : ∀ {k} → Fin k → Fin k → Fin k
-max-Fin {k = succ-ℕ k} (inl x) (inl y) = inl (max-Fin x y)
-max-Fin {k = succ-ℕ k} (inl x) (inr _) = inr star
-max-Fin {k = succ-ℕ k} (inr _) (inl x) = inr star
-max-Fin {k = succ-ℕ k} (inr _) (inr _) = inr star
+max-Fin : (k : ℕ) → Fin k → Fin k → Fin k
+max-Fin (succ-ℕ k) (inl x) (inl y) = inl (max-Fin k x y)
+max-Fin (succ-ℕ k) (inl x) (inr _) = inr star
+max-Fin (succ-ℕ k) (inr _) (inl x) = inr star
+max-Fin (succ-ℕ k) (inr _) (inr _) = inr star
 
-max-Fin-Fin : {k : ℕ} (n : ℕ) → (Fin (succ-ℕ n) → Fin k) → Fin k
-max-Fin-Fin zero-ℕ f     = f (inr star)
-max-Fin-Fin (succ-ℕ n) f = max-Fin (f (inr star)) (max-Fin-Fin n (λ k → f (inl k)))
+max-Fin-Fin : (n k : ℕ) → (Fin (succ-ℕ n) → Fin k) → Fin k
+max-Fin-Fin zero-ℕ k f     = f (inr star)
+max-Fin-Fin (succ-ℕ n) k f = max-Fin k (f (inr star)) (max-Fin-Fin n k (λ k → f (inl k)))
 ```
 
 ## Properties
@@ -43,36 +43,38 @@ max-Fin-Fin (succ-ℕ n) f = max-Fin (f (inr star)) (max-Fin-Fin n (λ k → f (
 
 ```agda
 leq-max-Fin :
-  ∀ {k} (l m n : Fin k) → leq-Fin m l → leq-Fin n l → leq-Fin (max-Fin m n) l
-leq-max-Fin {k = succ-ℕ k} (inl x) (inl y) (inl z) p q = leq-max-Fin x y z p q
-leq-max-Fin {k = succ-ℕ k} (inr x) (inl y) (inl z) p q = star
-leq-max-Fin {k = succ-ℕ k} (inr x) (inl y) (inr z) p q = star
-leq-max-Fin {k = succ-ℕ k} (inr x) (inr y) (inl z) p q = star
-leq-max-Fin {k = succ-ℕ k} (inr x) (inr y) (inr z) p q = star
+  (k : ℕ) (l m n : Fin k) → leq-Fin k m l → leq-Fin k n l → leq-Fin k (max-Fin k m n) l
+leq-max-Fin (succ-ℕ k) (inl x) (inl y) (inl z) p q = leq-max-Fin k x y z p q
+leq-max-Fin (succ-ℕ k) (inr x) (inl y) (inl z) p q = star
+leq-max-Fin (succ-ℕ k) (inr x) (inl y) (inr z) p q = star
+leq-max-Fin (succ-ℕ k) (inr x) (inr y) (inl z) p q = star
+leq-max-Fin (succ-ℕ k) (inr x) (inr y) (inr z) p q = star
 
 leq-left-leq-max-Fin :
-  ∀ {k} (l m n : Fin k) → leq-Fin (max-Fin m n) l → leq-Fin m l
-leq-left-leq-max-Fin {succ-ℕ k} (inl x) (inl y) (inl z) p = leq-left-leq-max-Fin x y z p
-leq-left-leq-max-Fin {succ-ℕ k} (inr x) (inl y) (inl z) p = star
-leq-left-leq-max-Fin {succ-ℕ k} (inr x) (inl y) (inr z) p = star
-leq-left-leq-max-Fin {succ-ℕ k} (inr x) (inr y) (inl z) p = star
-leq-left-leq-max-Fin {succ-ℕ k} (inr x) (inr y) (inr z) p = star
-leq-left-leq-max-Fin {succ-ℕ k} (inl x) (inr y) (inr z) p = p
+  (k : ℕ) (l m n : Fin k) → leq-Fin k (max-Fin k m n) l → leq-Fin k m l
+leq-left-leq-max-Fin (succ-ℕ k) (inl x) (inl y) (inl z) p = leq-left-leq-max-Fin k x y z p
+leq-left-leq-max-Fin (succ-ℕ k) (inr x) (inl y) (inl z) p = star
+leq-left-leq-max-Fin (succ-ℕ k) (inr x) (inl y) (inr z) p = star
+leq-left-leq-max-Fin (succ-ℕ k) (inr x) (inr y) (inl z) p = star
+leq-left-leq-max-Fin (succ-ℕ k) (inr x) (inr y) (inr z) p = star
+leq-left-leq-max-Fin (succ-ℕ k) (inl x) (inr y) (inr z) p = p
 
 leq-right-leq-max-Fin :
-  ∀ {k} (l m n : Fin k) → leq-Fin (max-Fin m n) l → leq-Fin n l
-leq-right-leq-max-Fin {succ-ℕ k} (inl x) (inl y) (inl z) p = leq-right-leq-max-Fin x y z p
-leq-right-leq-max-Fin {succ-ℕ k} (inr x) (inl y) (inl z) p = star
-leq-right-leq-max-Fin {succ-ℕ k} (inr x) (inl y) (inr z) p = star
-leq-right-leq-max-Fin {succ-ℕ k} (inr x) (inr y) (inl z) p = star
-leq-right-leq-max-Fin {succ-ℕ k} (inr x) (inr y) (inr z) p = star
-leq-right-leq-max-Fin {succ-ℕ k} (inl x) (inl y) (inr z) p = p
+  (k : ℕ) (l m n : Fin k) → leq-Fin k (max-Fin k m n) l → leq-Fin k n l
+leq-right-leq-max-Fin (succ-ℕ k) (inl x) (inl y) (inl z) p = leq-right-leq-max-Fin k x y z p
+leq-right-leq-max-Fin (succ-ℕ k) (inr x) (inl y) (inl z) p = star
+leq-right-leq-max-Fin (succ-ℕ k) (inr x) (inl y) (inr z) p = star
+leq-right-leq-max-Fin (succ-ℕ k) (inr x) (inr y) (inl z) p = star
+leq-right-leq-max-Fin (succ-ℕ k) (inr x) (inr y) (inr z) p = star
+leq-right-leq-max-Fin (succ-ℕ k) (inl x) (inl y) (inr z) p = p
 
 is-least-upper-bound-max-Fin :
-  ∀ {k} (m n : Fin k) →
-  is-least-binary-upper-bound-Poset (fin-Poset k) m n (max-Fin m n)
-is-least-upper-bound-max-Fin m n =
-  ( leq-left-leq-max-Fin (max-Fin m n) m n (refl-leq-Fin (max-Fin m n)),
-    leq-right-leq-max-Fin (max-Fin m n) m n (refl-leq-Fin (max-Fin m n))),
-  λ x (m≤x , n≤x) → leq-max-Fin x m n m≤x n≤x
+  (k : ℕ) (m n : Fin k) →
+  is-least-binary-upper-bound-Poset (fin-Poset k) m n (max-Fin k m n)
+pr1 (pr1 (is-least-upper-bound-max-Fin k m n)) =
+  leq-left-leq-max-Fin k (max-Fin k m n) m n (refl-leq-Fin k (max-Fin k m n))
+pr2 (pr1 (is-least-upper-bound-max-Fin k m n)) =
+  leq-right-leq-max-Fin k (max-Fin k m n) m n (refl-leq-Fin k (max-Fin k m n))
+pr2 (is-least-upper-bound-max-Fin k m n) x (pair H K) =
+  leq-max-Fin k x m n H K
 ```

--- a/src/elementary-number-theory/minimum-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/minimum-standard-finite-types.lagda.md
@@ -10,7 +10,7 @@ module elementary-number-theory.minimum-standard-finite-types where
 open import elementary-number-theory.inequality-standard-finite-types
 open import elementary-number-theory.natural-numbers using (ℕ; zero-ℕ; succ-ℕ)
 
-open import foundation.dependent-pair-types using (_,_)
+open import foundation.dependent-pair-types using (pair; pr1; pr2)
 open import foundation.coproduct-types using (inl; inr)
 open import foundation.unit-type using (star)
 
@@ -26,15 +26,15 @@ We define the operation of minimum (greatest lower bound) for the standard finit
 ## Definition
 
 ```agda
-min-Fin : ∀ {k} → Fin k → Fin k → Fin k
-min-Fin {k = succ-ℕ k} (inl x) (inl y) = inl (min-Fin x y)
-min-Fin {k = succ-ℕ k} (inl x) (inr _) = inl x
-min-Fin {k = succ-ℕ k} (inr _) (inl x) = inl x
-min-Fin {k = succ-ℕ k} (inr _) (inr _) = inr star
+min-Fin : (k : ℕ) → Fin k → Fin k → Fin k
+min-Fin (succ-ℕ k) (inl x) (inl y) = inl (min-Fin k x y)
+min-Fin (succ-ℕ k) (inl x) (inr _) = inl x
+min-Fin (succ-ℕ k) (inr _) (inl x) = inl x
+min-Fin (succ-ℕ k) (inr _) (inr _) = inr star
 
-min-Fin-Fin : {k : ℕ} (n : ℕ) → (Fin (succ-ℕ n) → Fin k) → Fin k
-min-Fin-Fin zero-ℕ f     = f (inr star)
-min-Fin-Fin (succ-ℕ n) f = min-Fin (f (inr star)) (min-Fin-Fin n (λ k → f (inl k)))
+min-Fin-Fin : (n k : ℕ) → (Fin (succ-ℕ n) → Fin k) → Fin k
+min-Fin-Fin zero-ℕ k f     = f (inr star)
+min-Fin-Fin (succ-ℕ n) k f = min-Fin k (f (inr star)) (min-Fin-Fin n k (λ k → f (inl k)))
 ```
 
 ## Properties
@@ -45,38 +45,40 @@ We prove that `min-Fin` is a greatest lower bound of its two arguments by showin
 
 ```agda
 leq-min-Fin :
-  ∀ {k} (l m n : Fin k) → leq-Fin l m → leq-Fin l n → leq-Fin l (min-Fin m n)
-leq-min-Fin {k = succ-ℕ k} (inl x) (inl y) (inl z) p q = leq-min-Fin x y z p q
-leq-min-Fin {k = succ-ℕ k} (inl x) (inl y) (inr z) p q = p
-leq-min-Fin {k = succ-ℕ k} (inl x) (inr y) (inl z) p q = q
-leq-min-Fin {k = succ-ℕ k} (inl x) (inr y) (inr z) p q = star
-leq-min-Fin {k = succ-ℕ k} (inr x) (inr y) (inr z) p q = star
+  (k : ℕ) (l m n : Fin k) →
+  leq-Fin k l m → leq-Fin k l n → leq-Fin k l (min-Fin k m n)
+leq-min-Fin (succ-ℕ k) (inl x) (inl y) (inl z) p q = leq-min-Fin k x y z p q
+leq-min-Fin (succ-ℕ k) (inl x) (inl y) (inr z) p q = p
+leq-min-Fin (succ-ℕ k) (inl x) (inr y) (inl z) p q = q
+leq-min-Fin (succ-ℕ k) (inl x) (inr y) (inr z) p q = star
+leq-min-Fin (succ-ℕ k) (inr x) (inr y) (inr z) p q = star
 
 leq-left-leq-min-Fin :
-  ∀ {k} (l m n : Fin k) → leq-Fin l (min-Fin m n) → leq-Fin l m
-leq-left-leq-min-Fin {succ-ℕ k} (inl x) (inl y) (inl z) p = leq-left-leq-min-Fin x y z p
-leq-left-leq-min-Fin {succ-ℕ k} (inl x) (inl y) (inr _) p = p
-leq-left-leq-min-Fin {succ-ℕ k} (inl x) (inr _) (inl _) p = star
-leq-left-leq-min-Fin {succ-ℕ k} (inl x) (inr _) (inr _) p = star
-leq-left-leq-min-Fin {succ-ℕ k} (inr _) (inl y) (inr _) p = p
-leq-left-leq-min-Fin {succ-ℕ k} (inr _) (inr _) (inl _) p = star
-leq-left-leq-min-Fin {succ-ℕ k} (inr _) (inr _) (inr _) p = star
+  (k : ℕ) (l m n : Fin k) → leq-Fin k l (min-Fin k m n) → leq-Fin k l m
+leq-left-leq-min-Fin (succ-ℕ k) (inl x) (inl y) (inl z) p = leq-left-leq-min-Fin k x y z p
+leq-left-leq-min-Fin (succ-ℕ k) (inl x) (inl y) (inr _) p = p
+leq-left-leq-min-Fin (succ-ℕ k) (inl x) (inr _) (inl _) p = star
+leq-left-leq-min-Fin (succ-ℕ k) (inl x) (inr _) (inr _) p = star
+leq-left-leq-min-Fin (succ-ℕ k) (inr _) (inl y) (inr _) p = p
+leq-left-leq-min-Fin (succ-ℕ k) (inr _) (inr _) (inl _) p = star
+leq-left-leq-min-Fin (succ-ℕ k) (inr _) (inr _) (inr _) p = star
 
 leq-right-leq-min-Fin :
-  ∀ {k} (l m n : Fin k) → leq-Fin l (min-Fin m n) → leq-Fin l n
-leq-right-leq-min-Fin {succ-ℕ k} (inl x) (inl x₁) (inl x₂) p = leq-right-leq-min-Fin x x₁ x₂ p
-leq-right-leq-min-Fin {succ-ℕ k} (inl x) (inl x₁) (inr x₂) p = star
-leq-right-leq-min-Fin {succ-ℕ k} (inl x) (inr x₁) (inl x₂) p = p
-leq-right-leq-min-Fin {succ-ℕ k} (inl x) (inr x₁) (inr x₂) p = star
-leq-right-leq-min-Fin {succ-ℕ k} (inr x) (inr x₁) (inr x₂) p = star
-leq-right-leq-min-Fin {succ-ℕ k} (inr x) (inl x₁) (inl x₂) p = p
-leq-right-leq-min-Fin {succ-ℕ k} (inr x) (inr x₁) (inl x₂) p = p
+  (k : ℕ) (l m n : Fin k) → leq-Fin k l (min-Fin k m n) → leq-Fin k l n
+leq-right-leq-min-Fin (succ-ℕ k) (inl x) (inl x₁) (inl x₂) p = leq-right-leq-min-Fin k x x₁ x₂ p
+leq-right-leq-min-Fin (succ-ℕ k) (inl x) (inl x₁) (inr x₂) p = star
+leq-right-leq-min-Fin (succ-ℕ k) (inl x) (inr x₁) (inl x₂) p = p
+leq-right-leq-min-Fin (succ-ℕ k) (inl x) (inr x₁) (inr x₂) p = star
+leq-right-leq-min-Fin (succ-ℕ k) (inr x) (inr x₁) (inr x₂) p = star
+leq-right-leq-min-Fin (succ-ℕ k) (inr x) (inl x₁) (inl x₂) p = p
+leq-right-leq-min-Fin (succ-ℕ k) (inr x) (inr x₁) (inl x₂) p = p
 
 is-greatest-lower-bound-min-Fin :
-  ∀ {k} (l m : Fin k)
-  → is-greatest-binary-lower-bound-Poset (fin-Poset k) l m (min-Fin l m)
-is-greatest-lower-bound-min-Fin l m =
-  ( leq-left-leq-min-Fin (min-Fin l m) l m (refl-leq-Fin (min-Fin l m)),
-    leq-right-leq-min-Fin (min-Fin l m) l m (refl-leq-Fin (min-Fin l m))),
-  λ x (x≤l , x≤m) → leq-min-Fin x l m x≤l x≤m
+  (k : ℕ) (l m : Fin k)
+  → is-greatest-binary-lower-bound-Poset (fin-Poset k) l m (min-Fin k l m)
+pr1 (pr1 (is-greatest-lower-bound-min-Fin k l m)) =
+  leq-left-leq-min-Fin k (min-Fin k l m) l m (refl-leq-Fin k (min-Fin k l m))
+pr2 (pr1 (is-greatest-lower-bound-min-Fin k l m)) =
+  leq-right-leq-min-Fin k (min-Fin k l m) l m (refl-leq-Fin k (min-Fin k l m))
+pr2 (is-greatest-lower-bound-min-Fin k l m) x (pair H K) = leq-min-Fin k x l m H K 
 ```

--- a/src/elementary-number-theory/modular-arithmetic-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/modular-arithmetic-standard-finite-types.lagda.md
@@ -60,8 +60,8 @@ open import univalent-combinatorics.standard-finite-types using
 
 ```agda
 mod-succ-ℕ : (k : ℕ) → ℕ → Fin (succ-ℕ k)
-mod-succ-ℕ k zero-ℕ = zero-Fin
-mod-succ-ℕ k (succ-ℕ n) = succ-Fin (mod-succ-ℕ k n)
+mod-succ-ℕ k zero-ℕ = zero-Fin k
+mod-succ-ℕ k (succ-ℕ n) = succ-Fin (succ-ℕ k) (mod-succ-ℕ k n)
 
 mod-two-ℕ : ℕ → Fin 2
 mod-two-ℕ = mod-succ-ℕ 1
@@ -72,30 +72,31 @@ mod-three-ℕ = mod-succ-ℕ 2
 
 ```agda
 cong-nat-succ-Fin :
-  (k : ℕ) (x : Fin k) → cong-ℕ k (nat-Fin (succ-Fin x)) (succ-ℕ (nat-Fin x))
+  (k : ℕ) (x : Fin k) →
+  cong-ℕ k (nat-Fin k (succ-Fin k x)) (succ-ℕ (nat-Fin k x))
 cong-nat-succ-Fin (succ-ℕ k) (inl x) =
   cong-identification-ℕ
     ( succ-ℕ k)
-    { nat-Fin (succ-Fin (inl x))}
-    { succ-ℕ (nat-Fin x)}
-    ( nat-succ-Fin x)
+    { nat-Fin (succ-ℕ k) (succ-Fin (succ-ℕ k) (inl x))}
+    { succ-ℕ (nat-Fin k x)}
+    ( nat-succ-Fin k x)
 cong-nat-succ-Fin (succ-ℕ k) (inr star) =
   concatenate-eq-cong-ℕ
     ( succ-ℕ k)
-    { nat-Fin {succ-ℕ k} zero-Fin}
+    { nat-Fin (succ-ℕ k) (zero-Fin k)}
     { zero-ℕ}
     { succ-ℕ k}
     ( is-zero-nat-zero-Fin {k})
     ( cong-zero-ℕ' (succ-ℕ k))
 
 cong-nat-mod-succ-ℕ :
-  (k x : ℕ) → cong-ℕ (succ-ℕ k) (nat-Fin (mod-succ-ℕ k x)) x
+  (k x : ℕ) → cong-ℕ (succ-ℕ k) (nat-Fin (succ-ℕ k) (mod-succ-ℕ k x)) x
 cong-nat-mod-succ-ℕ k zero-ℕ = cong-is-zero-nat-zero-Fin
 cong-nat-mod-succ-ℕ k (succ-ℕ x) =
   trans-cong-ℕ
     ( succ-ℕ k)
-    ( nat-Fin (mod-succ-ℕ k (succ-ℕ x)))
-    ( succ-ℕ (nat-Fin (mod-succ-ℕ k x)))
+    ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k (succ-ℕ x)))
+    ( succ-ℕ (nat-Fin (succ-ℕ k) (mod-succ-ℕ k x)))
     ( succ-ℕ x)
     ( cong-nat-succ-Fin (succ-ℕ k) (mod-succ-ℕ k x) )
     ( cong-nat-mod-succ-ℕ k x)
@@ -108,9 +109,9 @@ cong-eq-mod-succ-ℕ :
   (k x y : ℕ) → mod-succ-ℕ k x ＝ mod-succ-ℕ k y → cong-ℕ (succ-ℕ k) x y
 cong-eq-mod-succ-ℕ k x y p =
   concatenate-cong-eq-cong-ℕ {succ-ℕ k} {x}
-    ( symm-cong-ℕ (succ-ℕ k) (nat-Fin (mod-succ-ℕ k x)) x
+    ( symm-cong-ℕ (succ-ℕ k) (nat-Fin (succ-ℕ k) (mod-succ-ℕ k x)) x
       ( cong-nat-mod-succ-ℕ k x))
-    ( ap nat-Fin p)
+    ( ap (nat-Fin (succ-ℕ k)) p)
     ( cong-nat-mod-succ-ℕ k y)
 ```
 
@@ -124,24 +125,24 @@ eq-mod-succ-cong-ℕ k x y H =
     ( mod-succ-ℕ k y)
     ( trans-cong-ℕ
       ( succ-ℕ k)
-      ( nat-Fin (mod-succ-ℕ k x))
+      ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k x))
       ( x)
-      ( nat-Fin (mod-succ-ℕ k y))
+      ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k y))
       ( cong-nat-mod-succ-ℕ k x)
-      ( trans-cong-ℕ (succ-ℕ k) x y (nat-Fin (mod-succ-ℕ k y)) H
-        ( symm-cong-ℕ (succ-ℕ k) (nat-Fin (mod-succ-ℕ k y)) y
+      ( trans-cong-ℕ (succ-ℕ k) x y (nat-Fin (succ-ℕ k) (mod-succ-ℕ k y)) H
+        ( symm-cong-ℕ (succ-ℕ k) (nat-Fin (succ-ℕ k) (mod-succ-ℕ k y)) y
           ( cong-nat-mod-succ-ℕ k y))))
 ```          
 
 ```agda
 is-zero-mod-succ-ℕ :
-  (k x : ℕ) → div-ℕ (succ-ℕ k) x → is-zero-Fin (mod-succ-ℕ k x)
+  (k x : ℕ) → div-ℕ (succ-ℕ k) x → is-zero-Fin (succ-ℕ k) (mod-succ-ℕ k x)
 is-zero-mod-succ-ℕ k x d =
   eq-mod-succ-cong-ℕ k x zero-ℕ
     ( concatenate-div-eq-ℕ d (inv (right-unit-law-dist-ℕ x)))
 
 div-is-zero-mod-succ-ℕ :
-  (k x : ℕ) → is-zero-Fin (mod-succ-ℕ k x) → div-ℕ (succ-ℕ k) x
+  (k x : ℕ) → is-zero-Fin (succ-ℕ k) (mod-succ-ℕ k x) → div-ℕ (succ-ℕ k) x
 div-is-zero-mod-succ-ℕ k x p =
   concatenate-div-eq-ℕ
     ( cong-eq-mod-succ-ℕ k x zero-ℕ p)
@@ -152,21 +153,23 @@ div-is-zero-mod-succ-ℕ k x p =
 
 ```agda
 issec-nat-Fin :
-  {k : ℕ} (x : Fin (succ-ℕ k)) → mod-succ-ℕ k (nat-Fin x) ＝ x
-issec-nat-Fin {k} x =
-  is-injective-nat-Fin
+  (k : ℕ) (x : Fin (succ-ℕ k)) → mod-succ-ℕ k (nat-Fin (succ-ℕ k) x) ＝ x
+issec-nat-Fin k x =
+  is-injective-nat-Fin (succ-ℕ k)
     ( eq-cong-le-ℕ
       ( succ-ℕ k)
-      ( nat-Fin (mod-succ-ℕ k (nat-Fin x)))
-      ( nat-Fin x)
-      ( strict-upper-bound-nat-Fin (mod-succ-ℕ k (nat-Fin x)))
-      ( strict-upper-bound-nat-Fin x)
-      ( cong-nat-mod-succ-ℕ k (nat-Fin x)))
+      ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k (nat-Fin (succ-ℕ k) x)))
+      ( nat-Fin (succ-ℕ k) x)
+      ( strict-upper-bound-nat-Fin
+        ( succ-ℕ k)
+        ( mod-succ-ℕ k (nat-Fin (succ-ℕ k) x)))
+      ( strict-upper-bound-nat-Fin (succ-ℕ k) x)
+      ( cong-nat-mod-succ-ℕ k (nat-Fin (succ-ℕ k) x)))
 
 is-split-surjective-mod-succ-ℕ :
   {k : ℕ} → is-split-surjective (mod-succ-ℕ k)
-pr1 (is-split-surjective-mod-succ-ℕ {k} x) = nat-Fin x
-pr2 (is-split-surjective-mod-succ-ℕ {k} x) = issec-nat-Fin x
+pr1 (is-split-surjective-mod-succ-ℕ {k} x) = nat-Fin (succ-ℕ k) x
+pr2 (is-split-surjective-mod-succ-ℕ {k} x) = issec-nat-Fin k x
 ```
 
 ## The group structure on the standard finite types
@@ -174,42 +177,47 @@ pr2 (is-split-surjective-mod-succ-ℕ {k} x) = issec-nat-Fin x
 ### Addition on finite sets
 
 ```agda
-add-Fin : {k : ℕ} → Fin k → Fin k → Fin k
-add-Fin {succ-ℕ k} x y = mod-succ-ℕ k (add-ℕ (nat-Fin x) (nat-Fin y))
+add-Fin : (k : ℕ) → Fin k → Fin k → Fin k
+add-Fin (succ-ℕ k) x y =
+  mod-succ-ℕ k (add-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y))
 
-add-Fin' : {k : ℕ} → Fin k → Fin k → Fin k
-add-Fin' x y = add-Fin y x
+add-Fin' : (k : ℕ) → Fin k → Fin k → Fin k
+add-Fin' k x y = add-Fin k y x
 
 ap-add-Fin :
-  {k : ℕ} {x y x' y' : Fin k} →
-  x ＝ x' → y ＝ y' → add-Fin x y ＝ add-Fin x' y'
-ap-add-Fin p q = ap-binary add-Fin p q
+  (k : ℕ) {x y x' y' : Fin k} →
+  x ＝ x' → y ＝ y' → add-Fin k x y ＝ add-Fin k x' y'
+ap-add-Fin k p q = ap-binary (add-Fin k) p q
 
 cong-add-Fin :
   {k : ℕ} (x y : Fin k) →
-  cong-ℕ k (nat-Fin (add-Fin x y)) (add-ℕ (nat-Fin x) (nat-Fin y))
+  cong-ℕ k (nat-Fin k (add-Fin k x y)) (add-ℕ (nat-Fin k x) (nat-Fin k y))
 cong-add-Fin {succ-ℕ k} x y =
-  cong-nat-mod-succ-ℕ k (add-ℕ (nat-Fin x) (nat-Fin y))
+  cong-nat-mod-succ-ℕ k (add-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y))
 
 cong-add-ℕ : {k : ℕ} (x y : ℕ) →
   cong-ℕ
     ( succ-ℕ k)
-    ( add-ℕ (nat-Fin (mod-succ-ℕ k x)) (nat-Fin (mod-succ-ℕ k y)))
+    ( add-ℕ
+      ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k x))
+      ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k y)))
     ( add-ℕ x y)
 cong-add-ℕ {k} x y =
   trans-cong-ℕ (succ-ℕ k)
-    ( add-ℕ (nat-Fin (mod-succ-ℕ k x)) (nat-Fin (mod-succ-ℕ k y)))
-    ( add-ℕ x (nat-Fin (mod-succ-ℕ k y)))
+    ( add-ℕ
+      ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k x))
+      ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k y)))
+    ( add-ℕ x (nat-Fin (succ-ℕ k) (mod-succ-ℕ k y)))
     ( add-ℕ x y)
     ( translation-invariant-cong-ℕ'
       ( succ-ℕ k)
-      ( nat-Fin (mod-succ-ℕ k x))
+      ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k x))
       ( x)
-      ( nat-Fin (mod-succ-ℕ k y))
+      ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k y))
       ( cong-nat-mod-succ-ℕ k x))
     ( translation-invariant-cong-ℕ
       ( succ-ℕ k)
-      ( nat-Fin (mod-succ-ℕ k y))
+      ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k y))
       ( y)
       ( x)
       ( cong-nat-mod-succ-ℕ k y))
@@ -218,37 +226,38 @@ cong-add-ℕ {k} x y =
 ### Distance on finite sets
 
 ```agda
-dist-Fin : {k : ℕ} → Fin k → Fin k → Fin k
-dist-Fin {succ-ℕ k} x y = mod-succ-ℕ k (dist-ℕ (nat-Fin x) (nat-Fin y))
+dist-Fin : (k : ℕ) → Fin k → Fin k → Fin k
+dist-Fin (succ-ℕ k) x y =
+  mod-succ-ℕ k (dist-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y))
 
-dist-Fin' : {k : ℕ} → Fin k → Fin k → Fin k
-dist-Fin' x y = dist-Fin y x
+dist-Fin' : (k : ℕ) → Fin k → Fin k → Fin k
+dist-Fin' k x y = dist-Fin k y x
 
 ap-dist-Fin :
-  {k : ℕ} {x y x' y' : Fin k} →
-  x ＝ x' → y ＝ y' → dist-Fin x y ＝ dist-Fin x' y'
-ap-dist-Fin p q = ap-binary dist-Fin p q
+  (k : ℕ) {x y x' y' : Fin k} →
+  x ＝ x' → y ＝ y' → dist-Fin k x y ＝ dist-Fin k x' y'
+ap-dist-Fin k p q = ap-binary (dist-Fin k) p q
 
 cong-dist-Fin :
   {k : ℕ} (x y : Fin k) →
-  cong-ℕ k (nat-Fin (dist-Fin x y)) (dist-ℕ (nat-Fin x) (nat-Fin y))
+  cong-ℕ k (nat-Fin k (dist-Fin k x y)) (dist-ℕ (nat-Fin k x) (nat-Fin k y))
 cong-dist-Fin {succ-ℕ k} x y =
-  cong-nat-mod-succ-ℕ k (dist-ℕ (nat-Fin x) (nat-Fin y))
+  cong-nat-mod-succ-ℕ k (dist-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y))
 ```
 
 ### The negative of an element of Fin k
 
 ```agda
 neg-Fin :
-  {k : ℕ} → Fin k → Fin k
-neg-Fin {succ-ℕ k} x =
-  mod-succ-ℕ k (dist-ℕ (nat-Fin x) (succ-ℕ k))
+  (k : ℕ) → Fin k → Fin k
+neg-Fin (succ-ℕ k) x =
+  mod-succ-ℕ k (dist-ℕ (nat-Fin (succ-ℕ k) x) (succ-ℕ k))
 
 cong-neg-Fin :
   {k : ℕ} (x : Fin k) →
-  cong-ℕ k (nat-Fin (neg-Fin x)) (dist-ℕ (nat-Fin x) k)
+  cong-ℕ k (nat-Fin k (neg-Fin k x)) (dist-ℕ (nat-Fin k x) k)
 cong-neg-Fin {succ-ℕ k} x =
-  cong-nat-mod-succ-ℕ k (dist-ℕ (nat-Fin x) (succ-ℕ k))
+  cong-nat-mod-succ-ℕ k (dist-ℕ (nat-Fin (succ-ℕ k) x) (succ-ℕ k))
 ```
 
 ```agda
@@ -262,141 +271,180 @@ congruence-add-ℕ k {x} {y} {x'} {y'} H K =
 
 mod-succ-add-ℕ :
   (k x y : ℕ) →
-  mod-succ-ℕ k (add-ℕ x y) ＝ add-Fin (mod-succ-ℕ k x) (mod-succ-ℕ k y)
+  mod-succ-ℕ k (add-ℕ x y) ＝
+  add-Fin (succ-ℕ k) (mod-succ-ℕ k x) (mod-succ-ℕ k y)
 mod-succ-add-ℕ k x y =
   eq-mod-succ-cong-ℕ k
     ( add-ℕ x y)
-    ( add-ℕ (nat-Fin (mod-succ-ℕ k x)) (nat-Fin (mod-succ-ℕ k y)))
+    ( add-ℕ
+      ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k x))
+      ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k y)))
     ( congruence-add-ℕ
       ( succ-ℕ k)
       { x}
       { y}
-      { nat-Fin (mod-succ-ℕ k x)}
-      { nat-Fin (mod-succ-ℕ k y)}
-      ( symm-cong-ℕ (succ-ℕ k) (nat-Fin (mod-succ-ℕ k x)) x
+      { nat-Fin (succ-ℕ k) (mod-succ-ℕ k x)}
+      { nat-Fin (succ-ℕ k) (mod-succ-ℕ k y)}
+      ( symm-cong-ℕ (succ-ℕ k) (nat-Fin (succ-ℕ k) (mod-succ-ℕ k x)) x
         ( cong-nat-mod-succ-ℕ k x))
-      ( symm-cong-ℕ (succ-ℕ k) (nat-Fin (mod-succ-ℕ k y)) y
+      ( symm-cong-ℕ (succ-ℕ k) (nat-Fin (succ-ℕ k) (mod-succ-ℕ k y)) y
         ( cong-nat-mod-succ-ℕ k y)))
 ```
 
 ## Laws for addition on Fin k
 
 ```agda
-commutative-add-Fin : {k : ℕ} (x y : Fin k) → add-Fin x y ＝ add-Fin y x
-commutative-add-Fin {succ-ℕ k} x y =
-  ap (mod-succ-ℕ k) (commutative-add-ℕ (nat-Fin x) (nat-Fin y))
+commutative-add-Fin : (k : ℕ) (x y : Fin k) → add-Fin k x y ＝ add-Fin k y x
+commutative-add-Fin (succ-ℕ k) x y =
+  ap
+    ( mod-succ-ℕ k)
+    ( commutative-add-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y))
 
 associative-add-Fin :
-  {k : ℕ} (x y z : Fin k) →
-  add-Fin (add-Fin x y) z ＝ add-Fin x (add-Fin y z)
-associative-add-Fin {succ-ℕ k} x y z =
+  (k : ℕ) (x y z : Fin k) →
+  add-Fin k (add-Fin k x y) z ＝ add-Fin k x (add-Fin k y z)
+associative-add-Fin (succ-ℕ k) x y z =
   eq-mod-succ-cong-ℕ k
-    ( add-ℕ (nat-Fin (add-Fin x y)) (nat-Fin z))
-    ( add-ℕ (nat-Fin x) (nat-Fin (add-Fin y z)))
+    ( add-ℕ
+      ( nat-Fin (succ-ℕ k) (add-Fin (succ-ℕ k) x y))
+      ( nat-Fin (succ-ℕ k) z))
+    ( add-ℕ
+      ( nat-Fin (succ-ℕ k) x)
+      ( nat-Fin (succ-ℕ k) (add-Fin (succ-ℕ k) y z)))
     ( concatenate-cong-eq-cong-ℕ
-      { x1 = add-ℕ (nat-Fin (add-Fin x y)) (nat-Fin z)}
-      { x2 = add-ℕ (add-ℕ (nat-Fin x) (nat-Fin y)) (nat-Fin z)}
-      { x3 = add-ℕ (nat-Fin x) (add-ℕ (nat-Fin y) (nat-Fin z))}
-      { x4 = add-ℕ (nat-Fin x) (nat-Fin (add-Fin y z))}
+      { x1 =
+        add-ℕ
+          ( nat-Fin (succ-ℕ k) (add-Fin (succ-ℕ k) x y))
+          ( nat-Fin (succ-ℕ k) z)}
+      { x2 =
+        add-ℕ
+          ( add-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y))
+          ( nat-Fin (succ-ℕ k) z)}
+      { x3 =
+        add-ℕ
+          ( nat-Fin (succ-ℕ k) x)
+          ( add-ℕ (nat-Fin (succ-ℕ k) y) (nat-Fin (succ-ℕ k) z))}
+      { x4 =
+        add-ℕ
+          ( nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k)
+          ( add-Fin (succ-ℕ k) y z))}
       ( congruence-add-ℕ
         ( succ-ℕ k)
-        { x = nat-Fin (add-Fin x y)}
-        { y = nat-Fin z}
-        { x' = add-ℕ (nat-Fin x) (nat-Fin y)}
-        { y' = nat-Fin z}
+        { x = nat-Fin (succ-ℕ k) (add-Fin (succ-ℕ k) x y)}
+        { y = nat-Fin (succ-ℕ k) z}
+        { x' = add-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y)}
+        { y' = nat-Fin (succ-ℕ k) z}
         ( cong-add-Fin x y)
-        ( refl-cong-ℕ (succ-ℕ k) (nat-Fin z)))
-      ( associative-add-ℕ (nat-Fin x) (nat-Fin y) (nat-Fin z))
+        ( refl-cong-ℕ (succ-ℕ k) (nat-Fin (succ-ℕ k) z)))
+      ( associative-add-ℕ
+        ( nat-Fin (succ-ℕ k) x)
+        ( nat-Fin (succ-ℕ k) y)
+        ( nat-Fin (succ-ℕ k) z))
       ( congruence-add-ℕ
         ( succ-ℕ k)
-        { x = nat-Fin x}
-        { y = add-ℕ (nat-Fin y) (nat-Fin z)}
-        { x' = nat-Fin x}
-        { y' = nat-Fin (add-Fin y z)}
-        ( refl-cong-ℕ (succ-ℕ k) (nat-Fin x))
+        { x = nat-Fin (succ-ℕ k) x}
+        { y = add-ℕ (nat-Fin (succ-ℕ k) y) (nat-Fin (succ-ℕ k) z)}
+        { x' = nat-Fin (succ-ℕ k) x}
+        { y' = nat-Fin (succ-ℕ k) (add-Fin (succ-ℕ k) y z)}
+        ( refl-cong-ℕ (succ-ℕ k) (nat-Fin (succ-ℕ k) x))
         ( symm-cong-ℕ
           ( succ-ℕ k)
-          ( nat-Fin (add-Fin y z))
-          ( add-ℕ (nat-Fin y) (nat-Fin z))
+          ( nat-Fin (succ-ℕ k) (add-Fin (succ-ℕ k) y z))
+          ( add-ℕ (nat-Fin (succ-ℕ k) y) (nat-Fin (succ-ℕ k) z))
           ( cong-add-Fin y z))))
 
 right-unit-law-add-Fin :
-  {k : ℕ} (x : Fin (succ-ℕ k)) → add-Fin x zero-Fin ＝ x
-right-unit-law-add-Fin {k} x =
+  (k : ℕ) (x : Fin (succ-ℕ k)) → add-Fin (succ-ℕ k) x (zero-Fin k) ＝ x
+right-unit-law-add-Fin k x =
   ( eq-mod-succ-cong-ℕ k
-    ( add-ℕ (nat-Fin x) (nat-Fin {succ-ℕ k} zero-Fin))
-    ( add-ℕ (nat-Fin x) zero-ℕ)
+    ( add-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) (zero-Fin k)))
+    ( add-ℕ (nat-Fin (succ-ℕ k) x) zero-ℕ)
     ( congruence-add-ℕ
       ( succ-ℕ k)
-      { x = nat-Fin {succ-ℕ k} x}
-      { y = nat-Fin {succ-ℕ k} zero-Fin}
-      { x' = nat-Fin x}
+      { x = nat-Fin (succ-ℕ k) x}
+      { y = nat-Fin (succ-ℕ k) (zero-Fin k)}
+      { x' = nat-Fin (succ-ℕ k) x}
       { y' = zero-ℕ}
-      ( refl-cong-ℕ (succ-ℕ k) (nat-Fin {succ-ℕ k} x))
+      ( refl-cong-ℕ (succ-ℕ k) (nat-Fin (succ-ℕ k) x))
       ( cong-is-zero-nat-zero-Fin {k}))) ∙
-  ( issec-nat-Fin x)
+  ( issec-nat-Fin k x)
 
 left-unit-law-add-Fin :
-  {k : ℕ} (x : Fin (succ-ℕ k)) → add-Fin zero-Fin x ＝ x
-left-unit-law-add-Fin {k} x =
-  ( commutative-add-Fin zero-Fin x) ∙
-  ( right-unit-law-add-Fin x)
+  (k : ℕ) (x : Fin (succ-ℕ k)) → add-Fin (succ-ℕ k) (zero-Fin k) x ＝ x
+left-unit-law-add-Fin k x =
+  ( commutative-add-Fin (succ-ℕ k) (zero-Fin k) x) ∙
+  ( right-unit-law-add-Fin k x)
 
 left-inverse-law-add-Fin :
-  {k : ℕ} (x : Fin (succ-ℕ k)) → is-zero-Fin (add-Fin (neg-Fin x) x)
-left-inverse-law-add-Fin {k} x =
+  (k : ℕ) (x : Fin (succ-ℕ k)) →
+  is-zero-Fin (succ-ℕ k) (add-Fin (succ-ℕ k) (neg-Fin (succ-ℕ k) x) x)
+left-inverse-law-add-Fin k x =
   eq-mod-succ-cong-ℕ k
-    ( add-ℕ (nat-Fin (neg-Fin x)) (nat-Fin x))
+    ( add-ℕ (nat-Fin (succ-ℕ k) (neg-Fin (succ-ℕ k) x)) (nat-Fin (succ-ℕ k) x))
     ( zero-ℕ)
     ( concatenate-cong-eq-cong-ℕ
       { succ-ℕ k}
-      { x1 = add-ℕ (nat-Fin (neg-Fin x)) (nat-Fin x)}
-      { x2 = add-ℕ (dist-ℕ (nat-Fin x) (succ-ℕ k)) (nat-Fin x)}
+      { x1 =
+        add-ℕ
+          ( nat-Fin (succ-ℕ k) (neg-Fin (succ-ℕ k) x))
+          ( nat-Fin (succ-ℕ k) x)}
+      { x2 =
+        add-ℕ (dist-ℕ (nat-Fin (succ-ℕ k) x) (succ-ℕ k)) (nat-Fin (succ-ℕ k) x)}
       { x3 = succ-ℕ k}
       { x4 = zero-ℕ}
       ( translation-invariant-cong-ℕ' (succ-ℕ k)
-        ( nat-Fin (neg-Fin x))
-        ( dist-ℕ (nat-Fin x) (succ-ℕ k))
-        ( nat-Fin x)
+        ( nat-Fin (succ-ℕ k) (neg-Fin (succ-ℕ k) x))
+        ( dist-ℕ (nat-Fin (succ-ℕ k) x) (succ-ℕ k))
+        ( nat-Fin (succ-ℕ k) x)
         ( cong-neg-Fin x))
-      ( is-difference-dist-ℕ' (nat-Fin x) (succ-ℕ k)
-        ( upper-bound-nat-Fin (inl x)))
+      ( is-difference-dist-ℕ' (nat-Fin (succ-ℕ k) x) (succ-ℕ k)
+        ( upper-bound-nat-Fin (succ-ℕ k) (inl x)))
       ( cong-zero-ℕ' (succ-ℕ k)))
 
 right-inverse-law-add-Fin :
-  {k : ℕ} (x : Fin (succ-ℕ k)) → is-zero-Fin (add-Fin x (neg-Fin x))
-right-inverse-law-add-Fin x =
-  ( commutative-add-Fin x (neg-Fin x)) ∙ (left-inverse-law-add-Fin x)
+  (k : ℕ) (x : Fin (succ-ℕ k)) →
+  is-zero-Fin (succ-ℕ k) (add-Fin (succ-ℕ k) x (neg-Fin (succ-ℕ k) x))
+right-inverse-law-add-Fin k x =
+  ( commutative-add-Fin (succ-ℕ k) x (neg-Fin (succ-ℕ k) x)) ∙
+  ( left-inverse-law-add-Fin k x)
 ```
 
 ```agda
 is-add-one-succ-Fin' :
-  {k : ℕ} (x : Fin (succ-ℕ k)) → succ-Fin x ＝ add-Fin x one-Fin
-is-add-one-succ-Fin' {zero-ℕ} (inr star) = refl
-is-add-one-succ-Fin' {succ-ℕ k} x =
-  ( ap succ-Fin (inv (issec-nat-Fin x))) ∙
+  (k : ℕ) (x : Fin (succ-ℕ k)) →
+  succ-Fin (succ-ℕ k) x ＝ add-Fin (succ-ℕ k) x (one-Fin k)
+is-add-one-succ-Fin' zero-ℕ (inr star) = refl
+is-add-one-succ-Fin' (succ-ℕ k) x =
+  ( ap (succ-Fin (succ-ℕ (succ-ℕ k))) (inv (issec-nat-Fin (succ-ℕ k) x))) ∙
   ( ap ( mod-succ-ℕ  (succ-ℕ k))
-       ( ap (add-ℕ (nat-Fin x)) (inv (is-one-nat-one-Fin (succ-ℕ k)))))
+       ( ap
+         ( add-ℕ (nat-Fin (succ-ℕ (succ-ℕ k)) x))
+         ( inv (is-one-nat-one-Fin (succ-ℕ k)))))
 
 is-add-one-succ-Fin :
-  {k : ℕ} (x : Fin (succ-ℕ k)) → succ-Fin x ＝ add-Fin one-Fin x
-is-add-one-succ-Fin x = is-add-one-succ-Fin' x ∙ commutative-add-Fin x one-Fin
+  (k : ℕ) (x : Fin (succ-ℕ k)) →
+  succ-Fin (succ-ℕ k) x ＝ add-Fin (succ-ℕ k) (one-Fin k) x
+is-add-one-succ-Fin k x =
+  ( is-add-one-succ-Fin' k x) ∙
+  ( commutative-add-Fin (succ-ℕ k) x (one-Fin k))
 
 -- We conclude the successor laws for addition on Fin k
 
 right-successor-law-add-Fin :
-  {k : ℕ} (x y : Fin k) → add-Fin x (succ-Fin y) ＝ succ-Fin (add-Fin x y)
-right-successor-law-add-Fin {succ-ℕ k} x y =
-  ( ap (add-Fin x) (is-add-one-succ-Fin' y)) ∙
-  ( ( inv (associative-add-Fin x y one-Fin)) ∙
-    ( inv (is-add-one-succ-Fin' (add-Fin x y))))
+  (k : ℕ) (x y : Fin k) →
+  add-Fin k x (succ-Fin k y) ＝ succ-Fin k (add-Fin k x y)
+right-successor-law-add-Fin (succ-ℕ k) x y =
+  ( ap (add-Fin (succ-ℕ k) x) (is-add-one-succ-Fin' k y)) ∙
+  ( ( inv (associative-add-Fin (succ-ℕ k) x y (one-Fin k))) ∙
+    ( inv (is-add-one-succ-Fin' k (add-Fin (succ-ℕ k) x y))))
 
 left-successor-law-add-Fin :
-  {k : ℕ} (x y : Fin k) → add-Fin (succ-Fin x) y ＝ succ-Fin (add-Fin x y)
-left-successor-law-add-Fin x y =
-  commutative-add-Fin (succ-Fin x) y ∙
-  ( ( right-successor-law-add-Fin y x) ∙
-    ( ap succ-Fin (commutative-add-Fin y x)))
+  (k : ℕ) (x y : Fin k) →
+  add-Fin k (succ-Fin k x) y ＝ succ-Fin k (add-Fin k x y)
+left-successor-law-add-Fin k x y =
+  commutative-add-Fin k (succ-Fin k x) y ∙
+  ( ( right-successor-law-add-Fin k y x) ∙
+    ( ap (succ-Fin k) (commutative-add-Fin k y x)))
 ```
 
 ## Multiplication on Fin k
@@ -405,238 +453,297 @@ left-successor-law-add-Fin x y =
 {- We define the multiplication on the types Fin k. -}
 
 mul-Fin :
-  {k : ℕ} → Fin k → Fin k → Fin k
-mul-Fin {succ-ℕ k} x y = mod-succ-ℕ k (mul-ℕ (nat-Fin x) (nat-Fin y))
+  (k : ℕ) → Fin k → Fin k → Fin k
+mul-Fin (succ-ℕ k) x y =
+  mod-succ-ℕ k (mul-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y))
 
 mul-Fin' :
-  {k : ℕ} → Fin k → Fin k → Fin k
-mul-Fin' {k} x y = mul-Fin y x
+  (k : ℕ) → Fin k → Fin k → Fin k
+mul-Fin' k x y = mul-Fin k y x
 
 ap-mul-Fin :
-  {k : ℕ} {x y x' y' : Fin k} → x ＝ x' → y ＝ y' → mul-Fin x y ＝ mul-Fin x' y'
-ap-mul-Fin p q = ap-binary mul-Fin p q
+  (k : ℕ) {x y x' y' : Fin k} →
+  x ＝ x' → y ＝ y' → mul-Fin k x y ＝ mul-Fin k x' y'
+ap-mul-Fin k p q = ap-binary (mul-Fin k) p q
 
 cong-mul-Fin :
   {k : ℕ} (x y : Fin k) →
-  cong-ℕ k (nat-Fin (mul-Fin x y)) (mul-ℕ (nat-Fin x) (nat-Fin y))
+  cong-ℕ k (nat-Fin k (mul-Fin k x y)) (mul-ℕ (nat-Fin k x) (nat-Fin k y))
 cong-mul-Fin {succ-ℕ k} x y =
-  cong-nat-mod-succ-ℕ k (mul-ℕ (nat-Fin x) (nat-Fin y))
+  cong-nat-mod-succ-ℕ k (mul-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y))
 ```
 
 ## Laws for multiplication on the standard finite types
 
 ```agda
 associative-mul-Fin :
-  {k : ℕ} (x y z : Fin k) →
-  mul-Fin (mul-Fin x y) z ＝ mul-Fin x (mul-Fin y z)
-associative-mul-Fin {succ-ℕ k} x y z =
+  (k : ℕ) (x y z : Fin k) →
+  mul-Fin k (mul-Fin k x y) z ＝ mul-Fin k x (mul-Fin k y z)
+associative-mul-Fin (succ-ℕ k) x y z =
   eq-mod-succ-cong-ℕ k
-    ( mul-ℕ (nat-Fin (mul-Fin x y)) (nat-Fin z))
-    ( mul-ℕ (nat-Fin x) (nat-Fin (mul-Fin y z)))
+    ( mul-ℕ
+      ( nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) x y))
+      ( nat-Fin (succ-ℕ k) z))
+    ( mul-ℕ
+      ( nat-Fin (succ-ℕ k) x)
+      ( nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) y z)))
     ( concatenate-cong-eq-cong-ℕ
-      { x1 = mul-ℕ (nat-Fin (mul-Fin x y)) (nat-Fin z)}
-      { x2 = mul-ℕ (mul-ℕ (nat-Fin x) (nat-Fin y)) (nat-Fin z)}
-      { x3 = mul-ℕ (nat-Fin x) (mul-ℕ (nat-Fin y) (nat-Fin z))}
-      { x4 = mul-ℕ (nat-Fin x) (nat-Fin (mul-Fin y z))}
+      { x1 =
+        mul-ℕ
+          ( nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) x y))
+          ( nat-Fin (succ-ℕ k) z)}
+      { x2 =
+        mul-ℕ
+          ( mul-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y))
+          ( nat-Fin (succ-ℕ k) z)}
+      { x3 =
+        mul-ℕ
+          ( nat-Fin (succ-ℕ k) x)
+          ( mul-ℕ (nat-Fin (succ-ℕ k) y) (nat-Fin (succ-ℕ k) z))}
+      { x4 =
+        mul-ℕ
+          ( nat-Fin (succ-ℕ k) x)
+          ( nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) y z))}
       ( congruence-mul-ℕ
         ( succ-ℕ k)
-        { x = nat-Fin (mul-Fin x y)}
-        { y = nat-Fin z}
+        { x = nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) x y)}
+        { y = nat-Fin (succ-ℕ k) z}
         ( cong-mul-Fin x y)
-        ( refl-cong-ℕ (succ-ℕ k) (nat-Fin z)))
-      ( associative-mul-ℕ (nat-Fin x) (nat-Fin y) (nat-Fin z))
+        ( refl-cong-ℕ (succ-ℕ k) (nat-Fin (succ-ℕ k) z)))
+      ( associative-mul-ℕ
+        ( nat-Fin (succ-ℕ k) x)
+        ( nat-Fin (succ-ℕ k) y)
+        ( nat-Fin (succ-ℕ k) z))
       ( symm-cong-ℕ
         ( succ-ℕ k)
-        ( mul-ℕ (nat-Fin x) (nat-Fin (mul-Fin y z)))
-        ( mul-ℕ (nat-Fin x) (mul-ℕ (nat-Fin y) (nat-Fin z)))
+        ( mul-ℕ
+          ( nat-Fin (succ-ℕ k) x)
+          ( nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) y z)))
+        ( mul-ℕ
+          ( nat-Fin (succ-ℕ k) x)
+          ( mul-ℕ (nat-Fin (succ-ℕ k) y) (nat-Fin (succ-ℕ k) z)))
         ( congruence-mul-ℕ
           ( succ-ℕ k)
-          { x = nat-Fin x}
-          { y = nat-Fin (mul-Fin y z)}
-          ( refl-cong-ℕ (succ-ℕ k) (nat-Fin x))
+          { x = nat-Fin (succ-ℕ k) x}
+          { y = nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) y z)}
+          ( refl-cong-ℕ (succ-ℕ k) (nat-Fin (succ-ℕ k) x))
           ( cong-mul-Fin y z))))
 
 commutative-mul-Fin :
-  {k : ℕ} (x y : Fin k) → mul-Fin x y ＝ mul-Fin y x
-commutative-mul-Fin {succ-ℕ k} x y =
+  (k : ℕ) (x y : Fin k) → mul-Fin k x y ＝ mul-Fin k y x
+commutative-mul-Fin (succ-ℕ k) x y =
   eq-mod-succ-cong-ℕ k
-    ( mul-ℕ (nat-Fin x) (nat-Fin y))
-    ( mul-ℕ (nat-Fin y) (nat-Fin x))
+    ( mul-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y))
+    ( mul-ℕ (nat-Fin (succ-ℕ k) y) (nat-Fin (succ-ℕ k) x))
     ( cong-identification-ℕ
       ( succ-ℕ k)
-      ( commutative-mul-ℕ (nat-Fin x) (nat-Fin y)))
+      ( commutative-mul-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y)))
 
 left-unit-law-mul-Fin :
-  {k : ℕ} (x : Fin (succ-ℕ k)) → mul-Fin one-Fin x ＝ x
-left-unit-law-mul-Fin {zero-ℕ} (inr star) = refl
-left-unit-law-mul-Fin {succ-ℕ k} x =
+  (k : ℕ) (x : Fin (succ-ℕ k)) → mul-Fin (succ-ℕ k) (one-Fin k) x ＝ x
+left-unit-law-mul-Fin zero-ℕ (inr star) = refl
+left-unit-law-mul-Fin (succ-ℕ k) x =
   ( eq-mod-succ-cong-ℕ (succ-ℕ k)
-    ( mul-ℕ (nat-Fin (one-Fin {succ-ℕ k})) (nat-Fin x))
-    ( nat-Fin x)
+    ( mul-ℕ
+      ( nat-Fin (succ-ℕ (succ-ℕ k)) (one-Fin (succ-ℕ k)))
+      ( nat-Fin (succ-ℕ (succ-ℕ k)) x))
+    ( nat-Fin (succ-ℕ (succ-ℕ k)) x)
     ( cong-identification-ℕ
       ( succ-ℕ (succ-ℕ k))
-      ( ( ap ( mul-ℕ' (nat-Fin x))
+      ( ( ap ( mul-ℕ' (nat-Fin (succ-ℕ (succ-ℕ k)) x))
              ( is-one-nat-one-Fin k)) ∙
-        ( left-unit-law-mul-ℕ (nat-Fin x))))) ∙
-  ( issec-nat-Fin x)
+        ( left-unit-law-mul-ℕ (nat-Fin (succ-ℕ (succ-ℕ k)) x))))) ∙
+  ( issec-nat-Fin (succ-ℕ k) x)
 
 right-unit-law-mul-Fin :
-  {k : ℕ} (x : Fin (succ-ℕ k)) → mul-Fin x one-Fin ＝ x
-right-unit-law-mul-Fin x =
-  ( commutative-mul-Fin x one-Fin) ∙
-  ( left-unit-law-mul-Fin x)
+  (k : ℕ) (x : Fin (succ-ℕ k)) → mul-Fin (succ-ℕ k) x (one-Fin k) ＝ x
+right-unit-law-mul-Fin k x =
+  ( commutative-mul-Fin (succ-ℕ k) x (one-Fin k)) ∙
+  ( left-unit-law-mul-Fin k x)
 
 left-zero-law-mul-Fin :
-  {k : ℕ} (x : Fin (succ-ℕ k)) → mul-Fin zero-Fin x ＝ zero-Fin
-left-zero-law-mul-Fin {k} x =
+  (k : ℕ) (x : Fin (succ-ℕ k)) → mul-Fin (succ-ℕ k) (zero-Fin k) x ＝ zero-Fin k
+left-zero-law-mul-Fin k x =
   ( eq-mod-succ-cong-ℕ k
-    ( mul-ℕ (nat-Fin (zero-Fin {k})) (nat-Fin x))
-    ( nat-Fin (zero-Fin {k}))
+    ( mul-ℕ (nat-Fin (succ-ℕ k) (zero-Fin k)) (nat-Fin (succ-ℕ k) x))
+    ( nat-Fin (succ-ℕ k) (zero-Fin k))
     ( cong-identification-ℕ
       ( succ-ℕ k)
-      { mul-ℕ (nat-Fin (zero-Fin {k})) (nat-Fin x)}
-      { nat-Fin (zero-Fin {k})}
-      ( ( ap (mul-ℕ' (nat-Fin x)) (is-zero-nat-zero-Fin {k})) ∙
+      { mul-ℕ (nat-Fin (succ-ℕ k) (zero-Fin k)) (nat-Fin (succ-ℕ k) x)}
+      { nat-Fin (succ-ℕ k) (zero-Fin k)}
+      ( ( ap (mul-ℕ' (nat-Fin (succ-ℕ k) x)) (is-zero-nat-zero-Fin {k})) ∙
         ( inv (is-zero-nat-zero-Fin {k}))))) ∙
-  ( issec-nat-Fin (zero-Fin {k}))
+  ( issec-nat-Fin k (zero-Fin k))
 
 right-zero-law-mul-Fin :
-  {k : ℕ} (x : Fin (succ-ℕ k)) → mul-Fin x zero-Fin ＝ zero-Fin
-right-zero-law-mul-Fin x =
-  ( commutative-mul-Fin x zero-Fin) ∙
-  ( left-zero-law-mul-Fin x)
+  (k : ℕ) (x : Fin (succ-ℕ k)) → mul-Fin (succ-ℕ k) x (zero-Fin k) ＝ zero-Fin k
+right-zero-law-mul-Fin k x =
+  ( commutative-mul-Fin (succ-ℕ k) x (zero-Fin k)) ∙
+  ( left-zero-law-mul-Fin k x)
 
 left-distributive-mul-add-Fin :
-  {k : ℕ} (x y z : Fin k) →
-  mul-Fin x (add-Fin y z) ＝ add-Fin (mul-Fin x y) (mul-Fin x z)
-left-distributive-mul-add-Fin {succ-ℕ k} x y z =
+  (k : ℕ) (x y z : Fin k) →
+  mul-Fin k x (add-Fin k y z) ＝ add-Fin k (mul-Fin k x y) (mul-Fin k x z)
+left-distributive-mul-add-Fin (succ-ℕ k) x y z =
   eq-mod-succ-cong-ℕ k
-    ( mul-ℕ (nat-Fin x) (nat-Fin (add-Fin y z)))
-    ( add-ℕ (nat-Fin (mul-Fin x y)) (nat-Fin (mul-Fin x z)))
+    ( mul-ℕ
+      ( nat-Fin (succ-ℕ k) x)
+      ( nat-Fin (succ-ℕ k) (add-Fin (succ-ℕ k) y z)))
+    ( add-ℕ
+      ( nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) x y))
+      ( nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) x z)))
     ( concatenate-cong-eq-cong-ℕ
       { k = succ-ℕ k}
-      { x1 = mul-ℕ ( nat-Fin x) (nat-Fin (add-Fin y z))}
-      { x2 = mul-ℕ ( nat-Fin x) (add-ℕ (nat-Fin y) (nat-Fin z))}
-      { x3 = add-ℕ ( mul-ℕ (nat-Fin x) (nat-Fin y))
-                   ( mul-ℕ (nat-Fin x) (nat-Fin z))}
-      { x4 = add-ℕ (nat-Fin (mul-Fin x y)) (nat-Fin (mul-Fin x z))}
+      { x1 =
+        mul-ℕ
+          ( nat-Fin (succ-ℕ k) x)
+          ( nat-Fin (succ-ℕ k) (add-Fin (succ-ℕ k) y z))}
+      { x2 =
+        mul-ℕ
+          ( nat-Fin (succ-ℕ k) x)
+          ( add-ℕ (nat-Fin (succ-ℕ k) y) (nat-Fin (succ-ℕ k) z))}
+      { x3 =
+        add-ℕ
+          ( mul-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y))
+          ( mul-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) z))}
+      { x4 =
+        add-ℕ
+          ( nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) x y))
+          ( nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) x z))}
       ( congruence-mul-ℕ
         ( succ-ℕ k)
-        { x = nat-Fin x}
-        { y = nat-Fin (add-Fin y z)}
-        { x' = nat-Fin x}
-        { y' = add-ℕ (nat-Fin y) (nat-Fin z)}
-        ( refl-cong-ℕ (succ-ℕ k) (nat-Fin x))
+        { x = nat-Fin (succ-ℕ k) x}
+        { y = nat-Fin (succ-ℕ k) (add-Fin (succ-ℕ k) y z)}
+        { x' = nat-Fin (succ-ℕ k) x}
+        { y' = add-ℕ (nat-Fin (succ-ℕ k) y) (nat-Fin (succ-ℕ k) z)}
+        ( refl-cong-ℕ (succ-ℕ k) (nat-Fin (succ-ℕ k) x))
         ( cong-add-Fin y z))
-      ( left-distributive-mul-add-ℕ (nat-Fin x) (nat-Fin y) (nat-Fin z))
+      ( left-distributive-mul-add-ℕ
+        ( nat-Fin (succ-ℕ k) x)
+        ( nat-Fin (succ-ℕ k) y)
+        ( nat-Fin (succ-ℕ k) z))
       ( symm-cong-ℕ (succ-ℕ k)
-        ( add-ℕ ( nat-Fin (mul-Fin x y))
-                ( nat-Fin (mul-Fin x z)))
-        ( add-ℕ ( mul-ℕ (nat-Fin x) (nat-Fin y))
-                ( mul-ℕ (nat-Fin x) (nat-Fin z)))
+        ( add-ℕ
+          ( nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) x y))
+          ( nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) x z)))
+        ( add-ℕ
+          ( mul-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y))
+          ( mul-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) z)))
         ( congruence-add-ℕ
           ( succ-ℕ k)
-          { x = nat-Fin (mul-Fin x y)}
-          { y = nat-Fin (mul-Fin x z)}
-          { x' = mul-ℕ (nat-Fin x) (nat-Fin y)}
-          { y' = mul-ℕ (nat-Fin x) (nat-Fin z)}
+          { x = nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) x y)}
+          { y = nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) x z)}
+          { x' = mul-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y)}
+          { y' = mul-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) z)}
           ( cong-mul-Fin x y)
           ( cong-mul-Fin x z))))
 
 right-distributive-mul-add-Fin :
-  {k : ℕ} (x y z : Fin k) →
-  mul-Fin (add-Fin x y) z ＝ add-Fin (mul-Fin x z) (mul-Fin y z)
-right-distributive-mul-add-Fin {k} x y z =
-  ( commutative-mul-Fin (add-Fin x y) z) ∙
-  ( ( left-distributive-mul-add-Fin z x y) ∙
-    ( ap-add-Fin (commutative-mul-Fin z x) (commutative-mul-Fin z y)))
+  (k : ℕ) (x y z : Fin k) →
+  mul-Fin k (add-Fin k x y) z ＝ add-Fin k (mul-Fin k x z) (mul-Fin k y z)
+right-distributive-mul-add-Fin k x y z =
+  ( commutative-mul-Fin k (add-Fin k x y) z) ∙
+  ( ( left-distributive-mul-add-Fin k z x y) ∙
+    ( ap-add-Fin k (commutative-mul-Fin k z x) (commutative-mul-Fin k z y)))
 ```
+
+### Addition on `Fin k` is a binary equivalence
 
 ```agda
 add-add-neg-Fin :
-  {k : ℕ} (x y : Fin k) → add-Fin x (add-Fin (neg-Fin x) y) ＝ y
-add-add-neg-Fin {succ-ℕ k} x y =
-  ( inv (associative-add-Fin x (neg-Fin x) y)) ∙
-  ( ( ap (add-Fin' y) (right-inverse-law-add-Fin x)) ∙
-    ( left-unit-law-add-Fin y))
+  (k : ℕ) (x y : Fin k) → add-Fin k x (add-Fin k (neg-Fin k x) y) ＝ y
+add-add-neg-Fin (succ-ℕ k) x y =
+  ( inv (associative-add-Fin (succ-ℕ k) x (neg-Fin (succ-ℕ k) x) y)) ∙
+  ( ( ap (add-Fin' (succ-ℕ k) y) (right-inverse-law-add-Fin k x)) ∙
+    ( left-unit-law-add-Fin k y))
 
 add-neg-add-Fin :
-  {k : ℕ} (x y : Fin k) → add-Fin (neg-Fin x) (add-Fin x y) ＝ y
-add-neg-add-Fin {succ-ℕ k} x y =
-  ( inv (associative-add-Fin (neg-Fin x) x y)) ∙
-  ( ( ap (add-Fin' y) (left-inverse-law-add-Fin x)) ∙
-    ( left-unit-law-add-Fin y))
+  (k : ℕ) (x y : Fin k) → add-Fin k (neg-Fin k x) (add-Fin k x y) ＝ y
+add-neg-add-Fin (succ-ℕ k) x y =
+  ( inv (associative-add-Fin (succ-ℕ k) (neg-Fin (succ-ℕ k) x) x y)) ∙
+  ( ( ap (add-Fin' (succ-ℕ k) y) (left-inverse-law-add-Fin k x)) ∙
+    ( left-unit-law-add-Fin k y))
 
 is-equiv-add-Fin :
-  {k : ℕ} (x : Fin k) → is-equiv (add-Fin x)
-pr1 (pr1 (is-equiv-add-Fin x)) = add-Fin (neg-Fin x)
-pr2 (pr1 (is-equiv-add-Fin x)) = add-add-neg-Fin x
-pr1 (pr2 (is-equiv-add-Fin x)) = add-Fin (neg-Fin x)
-pr2 (pr2 (is-equiv-add-Fin x)) = add-neg-add-Fin x
+  (k : ℕ) (x : Fin k) → is-equiv (add-Fin k x)
+pr1 (pr1 (is-equiv-add-Fin k x)) = add-Fin k (neg-Fin k x)
+pr2 (pr1 (is-equiv-add-Fin k x)) = add-add-neg-Fin k x
+pr1 (pr2 (is-equiv-add-Fin k x)) = add-Fin k (neg-Fin k x)
+pr2 (pr2 (is-equiv-add-Fin k x)) = add-neg-add-Fin k x
 
 equiv-add-Fin :
-  {k : ℕ} (x : Fin k) → Fin k ≃ Fin k
-pr1 (equiv-add-Fin x) = add-Fin x
-pr2 (equiv-add-Fin x) = is-equiv-add-Fin x
+  (k : ℕ) (x : Fin k) → Fin k ≃ Fin k
+pr1 (equiv-add-Fin k x) = add-Fin k x
+pr2 (equiv-add-Fin k x) = is-equiv-add-Fin k x
 
 add-add-neg-Fin' :
-  {k : ℕ} (x y : Fin k) → add-Fin' x (add-Fin' (neg-Fin x) y) ＝ y
-add-add-neg-Fin' {succ-ℕ k} x y =
-  ( associative-add-Fin y (neg-Fin x) x) ∙
-  ( ( ap (add-Fin y) (left-inverse-law-add-Fin x)) ∙
-    ( right-unit-law-add-Fin y))
+  (k : ℕ) (x y : Fin k) → add-Fin' k x (add-Fin' k (neg-Fin k x) y) ＝ y
+add-add-neg-Fin' (succ-ℕ k) x y =
+  ( associative-add-Fin (succ-ℕ k) y (neg-Fin (succ-ℕ k) x) x) ∙
+  ( ( ap (add-Fin (succ-ℕ k) y) (left-inverse-law-add-Fin k x)) ∙
+    ( right-unit-law-add-Fin k y))
 
 add-neg-add-Fin' :
-  {k : ℕ} (x y : Fin k) → add-Fin' (neg-Fin x) (add-Fin' x y) ＝ y
-add-neg-add-Fin' {succ-ℕ k} x y =
-  ( associative-add-Fin y x (neg-Fin x)) ∙
-  ( ( ap (add-Fin y) (right-inverse-law-add-Fin x)) ∙
-    ( right-unit-law-add-Fin y))
+  (k : ℕ) (x y : Fin k) → add-Fin' k (neg-Fin k x) (add-Fin' k x y) ＝ y
+add-neg-add-Fin' (succ-ℕ k) x y =
+  ( associative-add-Fin (succ-ℕ k) y x (neg-Fin (succ-ℕ k) x)) ∙
+  ( ( ap (add-Fin (succ-ℕ k) y) (right-inverse-law-add-Fin k x)) ∙
+    ( right-unit-law-add-Fin k y))
 
 is-equiv-add-Fin' :
-  {k : ℕ} (x : Fin k) → is-equiv (add-Fin' x)
-pr1 (pr1 (is-equiv-add-Fin' x)) = add-Fin' (neg-Fin x)
-pr2 (pr1 (is-equiv-add-Fin' x)) = add-add-neg-Fin' x
-pr1 (pr2 (is-equiv-add-Fin' x)) = add-Fin' (neg-Fin x)
-pr2 (pr2 (is-equiv-add-Fin' x)) = add-neg-add-Fin' x
+  (k : ℕ) (x : Fin k) → is-equiv (add-Fin' k x)
+pr1 (pr1 (is-equiv-add-Fin' k x)) = add-Fin' k (neg-Fin k x)
+pr2 (pr1 (is-equiv-add-Fin' k x)) = add-add-neg-Fin' k x
+pr1 (pr2 (is-equiv-add-Fin' k x)) = add-Fin' k (neg-Fin k x)
+pr2 (pr2 (is-equiv-add-Fin' k x)) = add-neg-add-Fin' k x
 
 equiv-add-Fin' :
-  {k : ℕ} (x : Fin k) → Fin k ≃ Fin k
-pr1 (equiv-add-Fin' x) = add-Fin' x
-pr2 (equiv-add-Fin' x) = is-equiv-add-Fin' x
+  (k : ℕ) (x : Fin k) → Fin k ≃ Fin k
+pr1 (equiv-add-Fin' k x) = add-Fin' k x
+pr2 (equiv-add-Fin' k x) = is-equiv-add-Fin' k x
 
 is-injective-add-Fin :
-  {k : ℕ} (x : Fin k) → is-injective (add-Fin x)
-is-injective-add-Fin {k} x {y} {z} p =
-  ( inv (add-neg-add-Fin x y)) ∙
-  ( ( ap (add-Fin (neg-Fin x)) p) ∙
-    ( add-neg-add-Fin x z))
+  (k : ℕ) (x : Fin k) → is-injective (add-Fin k x)
+is-injective-add-Fin k x {y} {z} p =
+  ( inv (add-neg-add-Fin k x y)) ∙
+  ( ( ap (add-Fin k (neg-Fin k x)) p) ∙
+    ( add-neg-add-Fin k x z))
 
 is-injective-add-Fin' :
-  {k : ℕ} (x : Fin k) → is-injective (add-Fin' x)
-is-injective-add-Fin' {k} x {y} {z} p =
-  is-injective-add-Fin x
-    (commutative-add-Fin x y ∙ (p ∙ commutative-add-Fin z x))
+  (k : ℕ) (x : Fin k) → is-injective (add-Fin' k x)
+is-injective-add-Fin' k x {y} {z} p =
+  is-injective-add-Fin k x
+    ( commutative-add-Fin k x y ∙ (p ∙ commutative-add-Fin k z x))
 ```
 
 ```agda
 mul-neg-one-Fin :
-  {k : ℕ} (x : Fin (succ-ℕ k)) → mul-Fin neg-one-Fin x ＝ neg-Fin x
+  {k : ℕ} (x : Fin (succ-ℕ k)) →
+  mul-Fin (succ-ℕ k) (neg-one-Fin k) x ＝ neg-Fin (succ-ℕ k) x
 mul-neg-one-Fin {k} x =
-  is-injective-add-Fin x
+  is-injective-add-Fin
+    ( succ-ℕ k)
+    ( x)
     ( ( ( ap
-          ( add-Fin' (mul-Fin neg-one-Fin x))
-          ( inv (left-unit-law-mul-Fin x))) ∙
-        ( ( inv (right-distributive-mul-add-Fin one-Fin neg-one-Fin x)) ∙
-          ( ( ap (mul-Fin' x) (inv (is-add-one-succ-Fin neg-one-Fin))) ∙
-            ( left-zero-law-mul-Fin x)))) ∙
-      ( inv (right-inverse-law-add-Fin x)))
+          ( add-Fin' (succ-ℕ k) (mul-Fin (succ-ℕ k) (neg-one-Fin k) x))
+          ( inv (left-unit-law-mul-Fin k x))) ∙
+        ( ( inv
+            ( right-distributive-mul-add-Fin
+              ( succ-ℕ k)
+              ( one-Fin k)
+              ( neg-one-Fin k)
+              ( x))) ∙
+          ( ( ap
+              ( mul-Fin' (succ-ℕ k) x)
+              ( inv (is-add-one-succ-Fin k (neg-one-Fin k)))) ∙
+            ( left-zero-law-mul-Fin k x)))) ∙
+      ( inv (right-inverse-law-add-Fin k x)))
 ```
 
 ```agda
 is-one-neg-neg-one-Fin :
-  {k : ℕ} → is-one-Fin {succ-ℕ k} (neg-Fin neg-one-Fin)
-is-one-neg-neg-one-Fin {k} =
+  (k : ℕ) → is-one-Fin (succ-ℕ k) (neg-Fin (succ-ℕ k) (neg-one-Fin k))
+is-one-neg-neg-one-Fin k =
   eq-mod-succ-cong-ℕ k
     ( dist-ℕ k (succ-ℕ k))
     ( 1)
@@ -645,159 +752,203 @@ is-one-neg-neg-one-Fin {k} =
       ( is-one-dist-succ-ℕ k))
 
 is-neg-one-neg-one-Fin :
-  {k : ℕ} → neg-Fin {succ-ℕ k} one-Fin ＝ neg-one-Fin
-is-neg-one-neg-one-Fin {k} =
-  is-injective-add-Fin one-Fin
-    ( ( right-inverse-law-add-Fin one-Fin) ∙
-      ( ( inv (left-inverse-law-add-Fin neg-one-Fin)) ∙
-        ( ap (add-Fin' neg-one-Fin) is-one-neg-neg-one-Fin)))
+  (k : ℕ) → neg-Fin (succ-ℕ k) (one-Fin k) ＝ (neg-one-Fin k)
+is-neg-one-neg-one-Fin k =
+  is-injective-add-Fin (succ-ℕ k) (one-Fin k)
+    ( ( right-inverse-law-add-Fin k (one-Fin k)) ∙
+      ( ( inv (left-inverse-law-add-Fin k (neg-one-Fin k))) ∙
+        ( ap (add-Fin' (succ-ℕ k) (neg-one-Fin k)) (is-one-neg-neg-one-Fin k))))
 
 is-add-neg-one-pred-Fin' :
-  {k : ℕ} (x : Fin (succ-ℕ k)) → pred-Fin x ＝ add-Fin x neg-one-Fin
-is-add-neg-one-pred-Fin' {k} x =
+  (k : ℕ) (x : Fin (succ-ℕ k)) →
+  pred-Fin (succ-ℕ k) x ＝ add-Fin (succ-ℕ k) x (neg-one-Fin k)
+is-add-neg-one-pred-Fin' k x =
   is-injective-succ-Fin
-    ( ( issec-pred-Fin x) ∙
-      ( ( ( ( inv (right-unit-law-add-Fin x)) ∙
+    ( succ-ℕ k)
+    ( ( issec-pred-Fin (succ-ℕ k) x) ∙
+      ( ( ( ( inv (right-unit-law-add-Fin k x)) ∙
             ( ap
-              ( add-Fin x)
+              ( add-Fin (succ-ℕ k) x)
               ( inv
-                ( ( ap (add-Fin' one-Fin) (inv is-neg-one-neg-one-Fin)) ∙
-                  ( left-inverse-law-add-Fin one-Fin))))) ∙
-          ( inv (associative-add-Fin x neg-one-Fin one-Fin))) ∙
-        ( inv (is-add-one-succ-Fin' (add-Fin x neg-one-Fin)))))
+                ( ( ap
+                    ( add-Fin' (succ-ℕ k) (one-Fin k))
+                    ( inv (is-neg-one-neg-one-Fin k))) ∙
+                  ( left-inverse-law-add-Fin k (one-Fin k)))))) ∙
+          ( inv
+            ( associative-add-Fin (succ-ℕ k) x (neg-one-Fin k) (one-Fin k)))) ∙
+        ( inv (is-add-one-succ-Fin' k (add-Fin (succ-ℕ k) x (neg-one-Fin k))))))
 
 is-add-neg-one-pred-Fin :
-  {k : ℕ} (x : Fin (succ-ℕ k)) → pred-Fin x ＝ add-Fin neg-one-Fin x
-is-add-neg-one-pred-Fin x =
-  is-add-neg-one-pred-Fin' x ∙ commutative-add-Fin x neg-one-Fin
+  (k : ℕ) (x : Fin (succ-ℕ k)) →
+  pred-Fin (succ-ℕ k) x ＝ add-Fin (succ-ℕ k) (neg-one-Fin k) x
+is-add-neg-one-pred-Fin k x =
+  ( is-add-neg-one-pred-Fin' k x) ∙
+  ( commutative-add-Fin (succ-ℕ k) x (neg-one-Fin k))
 
 is-mul-neg-one-neg-Fin :
-  {k : ℕ} (x : Fin (succ-ℕ k)) → neg-Fin x ＝ mul-Fin neg-one-Fin x
-is-mul-neg-one-neg-Fin x =
-  is-injective-add-Fin x
-    ( ( right-inverse-law-add-Fin x) ∙
-      ( ( ( ( inv (left-zero-law-mul-Fin x)) ∙
+  (k : ℕ) (x : Fin (succ-ℕ k)) →
+  neg-Fin (succ-ℕ k) x ＝ mul-Fin (succ-ℕ k) (neg-one-Fin k) x
+is-mul-neg-one-neg-Fin k x =
+  is-injective-add-Fin (succ-ℕ k) x
+    ( ( right-inverse-law-add-Fin k x) ∙
+      ( ( ( ( inv (left-zero-law-mul-Fin k x)) ∙
             ( ap
-              ( mul-Fin' x)
+              ( mul-Fin' (succ-ℕ k) x)
               ( inv
-                ( ( ap (add-Fin one-Fin) (inv is-neg-one-neg-one-Fin)) ∙
-                  ( right-inverse-law-add-Fin one-Fin))))) ∙
-          ( right-distributive-mul-add-Fin one-Fin neg-one-Fin x)) ∙
-        ( ap (add-Fin' (mul-Fin neg-one-Fin x)) (left-unit-law-mul-Fin x))))
+                ( ( ap
+                  ( add-Fin (succ-ℕ k) (one-Fin k))
+                  ( inv (is-neg-one-neg-one-Fin k))) ∙
+                  ( right-inverse-law-add-Fin k (one-Fin k)))))) ∙
+          ( right-distributive-mul-add-Fin
+            ( succ-ℕ k)
+            ( one-Fin k)
+            ( neg-one-Fin k)
+            ( x))) ∙
+        ( ap
+          ( add-Fin'
+            ( succ-ℕ k)
+            ( mul-Fin (succ-ℕ k) (neg-one-Fin k) x))
+          ( left-unit-law-mul-Fin k x))))
 
 is-mul-neg-one-neg-Fin' :
-  {k : ℕ} (x : Fin (succ-ℕ k)) → neg-Fin x ＝ mul-Fin x neg-one-Fin
-is-mul-neg-one-neg-Fin' x =
-  is-mul-neg-one-neg-Fin x ∙ commutative-mul-Fin neg-one-Fin x
+  (k : ℕ) (x : Fin (succ-ℕ k)) →
+  neg-Fin (succ-ℕ k) x ＝ mul-Fin (succ-ℕ k) x (neg-one-Fin k)
+is-mul-neg-one-neg-Fin' k x =
+  is-mul-neg-one-neg-Fin k x ∙ commutative-mul-Fin (succ-ℕ k) (neg-one-Fin k) x
 
-neg-zero-Fin : {k : ℕ} → neg-Fin (zero-Fin {k}) ＝ zero-Fin
-neg-zero-Fin {k} =
-  ( inv (left-unit-law-add-Fin (neg-Fin zero-Fin))) ∙
-  ( right-inverse-law-add-Fin zero-Fin)
+neg-zero-Fin : (k : ℕ) → neg-Fin (succ-ℕ k) (zero-Fin k) ＝ zero-Fin k
+neg-zero-Fin k =
+  ( inv (left-unit-law-add-Fin k (neg-Fin (succ-ℕ k) (zero-Fin k)))) ∙
+  ( right-inverse-law-add-Fin k (zero-Fin k))
 
 neg-succ-Fin :
-  {k : ℕ} (x : Fin k) → neg-Fin (succ-Fin x) ＝ pred-Fin (neg-Fin x)
-neg-succ-Fin {succ-ℕ k} x =
-  ( ap neg-Fin (is-add-one-succ-Fin' x)) ∙
-  ( ( is-mul-neg-one-neg-Fin (add-Fin x one-Fin)) ∙
-    ( ( left-distributive-mul-add-Fin neg-one-Fin x one-Fin) ∙
+  (k : ℕ) (x : Fin k) → neg-Fin k (succ-Fin k x) ＝ pred-Fin k (neg-Fin k x)
+neg-succ-Fin (succ-ℕ k) x =
+  ( ap (neg-Fin (succ-ℕ k)) (is-add-one-succ-Fin' k x)) ∙
+  ( ( is-mul-neg-one-neg-Fin k (add-Fin (succ-ℕ k) x (one-Fin k))) ∙
+    ( ( left-distributive-mul-add-Fin
+        ( succ-ℕ k)
+        ( neg-one-Fin k)
+        ( x)
+        ( one-Fin k)) ∙
       ( ( ap-add-Fin
-          ( inv (is-mul-neg-one-neg-Fin x))
-          ( inv (is-mul-neg-one-neg-Fin one-Fin) ∙ is-neg-one-neg-one-Fin)) ∙
-        ( inv (is-add-neg-one-pred-Fin' (neg-Fin x))))))
+          ( succ-ℕ k) 
+          ( inv (is-mul-neg-one-neg-Fin k x))
+          ( ( inv (is-mul-neg-one-neg-Fin k (one-Fin k))) ∙
+            ( is-neg-one-neg-one-Fin k))) ∙
+        ( inv (is-add-neg-one-pred-Fin' k (neg-Fin (succ-ℕ k) x))))))
 
 neg-pred-Fin :
-  {k : ℕ} (x : Fin k) → neg-Fin (pred-Fin x) ＝ succ-Fin (neg-Fin x)
-neg-pred-Fin {succ-ℕ k} x =
-  ( ap neg-Fin (is-add-neg-one-pred-Fin' x)) ∙
-  ( ( is-mul-neg-one-neg-Fin (add-Fin x neg-one-Fin)) ∙
-    ( ( left-distributive-mul-add-Fin neg-one-Fin x neg-one-Fin) ∙
+  (k : ℕ) (x : Fin k) → neg-Fin k (pred-Fin k x) ＝ succ-Fin k (neg-Fin k x)
+neg-pred-Fin (succ-ℕ k) x =
+  ( ap (neg-Fin (succ-ℕ k)) (is-add-neg-one-pred-Fin' k x)) ∙
+  ( ( is-mul-neg-one-neg-Fin k (add-Fin (succ-ℕ k) x (neg-one-Fin k))) ∙
+    ( ( left-distributive-mul-add-Fin
+        ( succ-ℕ k)
+        ( neg-one-Fin k)
+        ( x)
+        ( neg-one-Fin k)) ∙
       ( ( ap-add-Fin
-          ( inv (is-mul-neg-one-neg-Fin x))
-          ( ( inv (is-mul-neg-one-neg-Fin neg-one-Fin)) ∙
-            ( is-one-neg-neg-one-Fin))) ∙
-        ( inv (is-add-one-succ-Fin' (neg-Fin x))))))
+          ( succ-ℕ k) 
+          ( inv (is-mul-neg-one-neg-Fin k x))
+          ( ( inv (is-mul-neg-one-neg-Fin k (neg-one-Fin k))) ∙
+            ( is-one-neg-neg-one-Fin k))) ∙
+        ( inv (is-add-one-succ-Fin' k (neg-Fin (succ-ℕ k) x))))))
 
 distributive-neg-add-Fin :
-  {k : ℕ} (x y : Fin k) →
-  neg-Fin (add-Fin x y) ＝ add-Fin (neg-Fin x) (neg-Fin y)
-distributive-neg-add-Fin {succ-ℕ k} x y =
-  ( is-mul-neg-one-neg-Fin (add-Fin x y)) ∙
-  ( ( left-distributive-mul-add-Fin neg-one-Fin x y) ∙
-    ( inv (ap-add-Fin (is-mul-neg-one-neg-Fin x) (is-mul-neg-one-neg-Fin y))))
+  (k : ℕ) (x y : Fin k) →
+  neg-Fin k (add-Fin k x y) ＝ add-Fin k (neg-Fin k x) (neg-Fin k y)
+distributive-neg-add-Fin (succ-ℕ k) x y =
+  ( is-mul-neg-one-neg-Fin k (add-Fin (succ-ℕ k) x y)) ∙
+  ( ( left-distributive-mul-add-Fin (succ-ℕ k) (neg-one-Fin k) x y) ∙
+    ( inv
+      ( ap-add-Fin
+        ( succ-ℕ k)
+        ( is-mul-neg-one-neg-Fin k x)
+        ( is-mul-neg-one-neg-Fin k y))))
 
 left-predecessor-law-add-Fin :
-  {k : ℕ} (x y : Fin k) → add-Fin (pred-Fin x) y ＝ pred-Fin (add-Fin x y)
-left-predecessor-law-add-Fin {succ-ℕ k} x y =
-  ( ap (add-Fin' y) (is-add-neg-one-pred-Fin x)) ∙
-  ( ( associative-add-Fin neg-one-Fin x y) ∙
-    ( inv (is-add-neg-one-pred-Fin (add-Fin x y))))
+  (k : ℕ) (x y : Fin k) →
+  add-Fin k (pred-Fin k x) y ＝ pred-Fin k (add-Fin k x y)
+left-predecessor-law-add-Fin (succ-ℕ k) x y =
+  ( ap (add-Fin' (succ-ℕ k) y) (is-add-neg-one-pred-Fin k x)) ∙
+  ( ( associative-add-Fin (succ-ℕ k) (neg-one-Fin k) x y) ∙
+    ( inv (is-add-neg-one-pred-Fin k (add-Fin (succ-ℕ k) x y))))
 
 right-predecessor-law-add-Fin :
-  {k : ℕ} (x y : Fin k) → add-Fin x (pred-Fin y) ＝ pred-Fin (add-Fin x y)
-right-predecessor-law-add-Fin {succ-ℕ k} x y =
-  ( ap (add-Fin x) (is-add-neg-one-pred-Fin' y)) ∙
-  ( ( inv (associative-add-Fin x y neg-one-Fin)) ∙
-    ( inv (is-add-neg-one-pred-Fin' (add-Fin x y))))
+  (k : ℕ) (x y : Fin k) →
+  add-Fin k x (pred-Fin k y) ＝ pred-Fin k (add-Fin k x y)
+right-predecessor-law-add-Fin (succ-ℕ k) x y =
+  ( ap (add-Fin (succ-ℕ k) x) (is-add-neg-one-pred-Fin' k y)) ∙
+  ( ( inv (associative-add-Fin (succ-ℕ k) x y (neg-one-Fin k))) ∙
+    ( inv (is-add-neg-one-pred-Fin' k (add-Fin (succ-ℕ k) x y))))
 
 left-negative-law-mul-Fin :
-  {k : ℕ} (x y : Fin k) →
-  mul-Fin (neg-Fin x) y ＝ neg-Fin (mul-Fin x y)
-left-negative-law-mul-Fin {succ-ℕ k} x y =
-  ( ap (mul-Fin' y) (is-mul-neg-one-neg-Fin x)) ∙
-  ( ( associative-mul-Fin neg-one-Fin x y) ∙
-    ( inv (is-mul-neg-one-neg-Fin (mul-Fin x y))))
+  (k : ℕ) (x y : Fin k) →
+  mul-Fin k (neg-Fin k x) y ＝ neg-Fin k (mul-Fin k x y)
+left-negative-law-mul-Fin (succ-ℕ k) x y =
+  ( ap (mul-Fin' (succ-ℕ k) y) (is-mul-neg-one-neg-Fin k x)) ∙
+  ( ( associative-mul-Fin (succ-ℕ k) (neg-one-Fin k) x y) ∙
+    ( inv (is-mul-neg-one-neg-Fin k (mul-Fin (succ-ℕ k) x y))))
 
 right-negative-law-mul-Fin :
-  {k : ℕ} (x y : Fin k) →
-  mul-Fin x (neg-Fin y) ＝ neg-Fin (mul-Fin x y)
-right-negative-law-mul-Fin {succ-ℕ k} x y =
-  ( commutative-mul-Fin x (neg-Fin y)) ∙
-  ( ( left-negative-law-mul-Fin y x) ∙
-    ( ap neg-Fin (commutative-mul-Fin y x)))
+  (k : ℕ) (x y : Fin k) →
+  mul-Fin k x (neg-Fin k y) ＝ neg-Fin k (mul-Fin k x y)
+right-negative-law-mul-Fin (succ-ℕ k) x y =
+  ( commutative-mul-Fin (succ-ℕ k) x (neg-Fin (succ-ℕ k) y)) ∙
+  ( ( left-negative-law-mul-Fin (succ-ℕ k) y x) ∙
+    ( ap (neg-Fin (succ-ℕ k)) (commutative-mul-Fin (succ-ℕ k) y x)))
 
 left-successor-law-mul-Fin :
-  {k : ℕ} (x y : Fin k) →
-  mul-Fin (succ-Fin x) y ＝ add-Fin y (mul-Fin x y)
-left-successor-law-mul-Fin {succ-ℕ k} x y =
-  ( ap (mul-Fin' y) (is-add-one-succ-Fin x)) ∙
-  ( ( right-distributive-mul-add-Fin one-Fin x y) ∙
-    ( ap (add-Fin' (mul-Fin x y)) (left-unit-law-mul-Fin y)))
+  (k : ℕ) (x y : Fin k) →
+  mul-Fin k (succ-Fin k x) y ＝ add-Fin k y (mul-Fin k x y)
+left-successor-law-mul-Fin (succ-ℕ k) x y =
+  ( ap (mul-Fin' (succ-ℕ k) y) (is-add-one-succ-Fin k x)) ∙
+  ( ( right-distributive-mul-add-Fin (succ-ℕ k) (one-Fin k) x y) ∙
+    ( ap
+      ( add-Fin' (succ-ℕ k) (mul-Fin (succ-ℕ k) x y))
+      ( left-unit-law-mul-Fin k y)))
 
 right-successor-law-mul-Fin :
-  {k : ℕ} (x y : Fin k) →
-  mul-Fin x (succ-Fin y) ＝ add-Fin x (mul-Fin x y)
-right-successor-law-mul-Fin {succ-ℕ k} x y =
-  ( ap (mul-Fin x) (is-add-one-succ-Fin y)) ∙
-  ( ( left-distributive-mul-add-Fin x one-Fin y) ∙
-    ( ap (add-Fin' (mul-Fin x y)) (right-unit-law-mul-Fin x)))
+  (k : ℕ) (x y : Fin k) →
+  mul-Fin k x (succ-Fin k y) ＝ add-Fin k x (mul-Fin k x y)
+right-successor-law-mul-Fin (succ-ℕ k) x y =
+  ( ap (mul-Fin (succ-ℕ k) x) (is-add-one-succ-Fin k y)) ∙
+  ( ( left-distributive-mul-add-Fin (succ-ℕ k) x (one-Fin k) y) ∙
+    ( ap
+      ( add-Fin' (succ-ℕ k) (mul-Fin (succ-ℕ k) x y))
+      ( right-unit-law-mul-Fin k x)))
 
 left-predecessor-law-mul-Fin :
-  {k : ℕ} (x y : Fin k) →
-  mul-Fin (pred-Fin x) y ＝ add-Fin (neg-Fin y) (mul-Fin x y)
-left-predecessor-law-mul-Fin {succ-ℕ k} x y =
-  ( ap (mul-Fin' y) (is-add-neg-one-pred-Fin x)) ∙
-  ( ( right-distributive-mul-add-Fin neg-one-Fin x y) ∙
-    ( ap (add-Fin' (mul-Fin x y)) (inv (is-mul-neg-one-neg-Fin y))))
+  (k : ℕ) (x y : Fin k) →
+  mul-Fin k (pred-Fin k x) y ＝ add-Fin k (neg-Fin k y) (mul-Fin k x y)
+left-predecessor-law-mul-Fin (succ-ℕ k) x y =
+  ( ap (mul-Fin' (succ-ℕ k) y) (is-add-neg-one-pred-Fin k x)) ∙
+  ( ( right-distributive-mul-add-Fin (succ-ℕ k) (neg-one-Fin k) x y) ∙
+    ( ap
+      ( add-Fin' (succ-ℕ k) (mul-Fin (succ-ℕ k) x y))
+      ( inv (is-mul-neg-one-neg-Fin k y))))
 
 right-predecessor-law-mul-Fin :
-  {k : ℕ} (x y : Fin k) →
-  mul-Fin x (pred-Fin y) ＝ add-Fin (neg-Fin x) (mul-Fin x y)
-right-predecessor-law-mul-Fin {succ-ℕ k} x y =
-  ( ap (mul-Fin x) (is-add-neg-one-pred-Fin y)) ∙
-  ( ( left-distributive-mul-add-Fin x neg-one-Fin y) ∙
-    ( ap (add-Fin' (mul-Fin x y)) (inv (is-mul-neg-one-neg-Fin' x))))
+  (k : ℕ) (x y : Fin k) →
+  mul-Fin k x (pred-Fin k y) ＝ add-Fin k (neg-Fin k x) (mul-Fin k x y)
+right-predecessor-law-mul-Fin (succ-ℕ k) x y =
+  ( ap (mul-Fin (succ-ℕ k) x) (is-add-neg-one-pred-Fin k y)) ∙
+  ( ( left-distributive-mul-add-Fin (succ-ℕ k) x (neg-one-Fin k) y) ∙
+    ( ap
+      ( add-Fin' (succ-ℕ k) (mul-Fin (succ-ℕ k) x y))
+      ( inv (is-mul-neg-one-neg-Fin' k x))))
 ```
 
 ```agda
 leq-nat-mod-succ-ℕ :
-  (k x : ℕ) → leq-ℕ (nat-Fin (mod-succ-ℕ k x)) x
+  (k x : ℕ) → leq-ℕ (nat-Fin (succ-ℕ k) (mod-succ-ℕ k x)) x
 leq-nat-mod-succ-ℕ k zero-ℕ =
   concatenate-eq-leq-ℕ zero-ℕ (is-zero-nat-zero-Fin {k}) (refl-leq-ℕ zero-ℕ)
 leq-nat-mod-succ-ℕ k (succ-ℕ x) =
   transitive-leq-ℕ
-    ( nat-Fin (mod-succ-ℕ k (succ-ℕ x)))
-    ( succ-ℕ (nat-Fin (mod-succ-ℕ k x)))
+    ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k (succ-ℕ x)))
+    ( succ-ℕ (nat-Fin (succ-ℕ k) (mod-succ-ℕ k x)))
     ( succ-ℕ x)
     ( leq-nat-mod-succ-ℕ k x)
     ( leq-nat-succ-Fin (succ-ℕ k) (mod-succ-ℕ k x))
@@ -832,23 +983,33 @@ is-decidable-is-odd-ℕ x = is-decidable-neg (is-decidable-is-even-ℕ x)
 
 ```agda
 neg-neg-Fin :
-  {k : ℕ} (x : Fin k) → neg-Fin (neg-Fin x) ＝ x
-neg-neg-Fin {succ-ℕ k} x =
-  ( inv (right-unit-law-add-Fin (neg-Fin (neg-Fin x)))) ∙
-  ( ( ap (add-Fin (neg-Fin (neg-Fin x))) (inv (left-inverse-law-add-Fin x))) ∙
-    ( ( inv (associative-add-Fin (neg-Fin (neg-Fin x)) (neg-Fin x) x)) ∙
-      ( ( ap (add-Fin' x) (left-inverse-law-add-Fin (neg-Fin x))) ∙
-        ( left-unit-law-add-Fin x))))
+  (k : ℕ) (x : Fin k) → neg-Fin k (neg-Fin k x) ＝ x
+neg-neg-Fin (succ-ℕ k) x =
+  ( inv
+    ( right-unit-law-add-Fin k (neg-Fin (succ-ℕ k) (neg-Fin (succ-ℕ k) x)))) ∙
+  ( ( ap
+      ( add-Fin (succ-ℕ k) (neg-Fin (succ-ℕ k) (neg-Fin (succ-ℕ k) x)))
+      ( inv (left-inverse-law-add-Fin k x))) ∙
+    ( ( inv
+        ( associative-add-Fin
+          ( succ-ℕ k)
+          ( neg-Fin (succ-ℕ k) (neg-Fin (succ-ℕ k) x))
+          ( neg-Fin (succ-ℕ k) x)
+          ( x))) ∙
+      ( ( ap
+          ( add-Fin' (succ-ℕ k) x)
+          ( left-inverse-law-add-Fin k (neg-Fin (succ-ℕ k) x))) ∙
+        ( left-unit-law-add-Fin k x))))
 
 is-equiv-neg-Fin :
-  {k : ℕ} → is-equiv (neg-Fin {k})
-pr1 (pr1 is-equiv-neg-Fin) = neg-Fin
-pr2 (pr1 is-equiv-neg-Fin) = neg-neg-Fin
-pr1 (pr2 is-equiv-neg-Fin) = neg-Fin
-pr2 (pr2 is-equiv-neg-Fin) = neg-neg-Fin
+  (k : ℕ) → is-equiv (neg-Fin k)
+pr1 (pr1 (is-equiv-neg-Fin k)) = neg-Fin k
+pr2 (pr1 (is-equiv-neg-Fin k)) = neg-neg-Fin k
+pr1 (pr2 (is-equiv-neg-Fin k)) = neg-Fin k
+pr2 (pr2 (is-equiv-neg-Fin k)) = neg-neg-Fin k
 
 equiv-neg-Fin :
-  {k : ℕ} → Fin k ≃ Fin k
-pr1 equiv-neg-Fin = neg-Fin
-pr2 equiv-neg-Fin = is-equiv-neg-Fin
+  (k : ℕ) → Fin k ≃ Fin k
+pr1 (equiv-neg-Fin k) = neg-Fin k
+pr2 (equiv-neg-Fin k) = is-equiv-neg-Fin k
 ```

--- a/src/elementary-number-theory/modular-arithmetic.lagda.md
+++ b/src/elementary-number-theory/modular-arithmetic.lagda.md
@@ -39,11 +39,12 @@ open import elementary-number-theory.multiplication-integers using
 open import elementary-number-theory.multiplication-natural-numbers using
   ( mul-ℕ)
 open import elementary-number-theory.natural-numbers using
-  ( ℕ; zero-ℕ; succ-ℕ; is-one-ℕ; is-not-one-ℕ)
+  ( ℕ; zero-ℕ; succ-ℕ; is-one-ℕ; is-not-one-ℕ; is-nonzero-ℕ)
 
 open import foundation.coproduct-types using (inl; inr)
 open import foundation.decidable-equality using (has-decidable-equality)
 open import foundation.dependent-pair-types using (pair; pr1; pr2)
+open import foundation.empty-types using (ex-falso)
 open import foundation.equivalences using (is-equiv; _≃_)
 open import foundation.identity-types using
   ( _＝_; refl; _∙_; inv; ap; ap-binary)
@@ -57,11 +58,13 @@ open import foundation.universe-levels using (UU; lzero)
 open import structured-types.types-equipped-with-endomorphisms using (Endo)
 
 open import univalent-combinatorics.equality-standard-finite-types using
-  ( has-decidable-equality-Fin; is-set-Fin)
+  ( has-decidable-equality-Fin)
+open import univalent-combinatorics.finite-types using
+  ( is-finite; is-finite-Fin; 𝔽)
 open import univalent-combinatorics.standard-finite-types using
   ( Fin; zero-Fin; neg-one-Fin; one-Fin; nat-Fin; is-injective-nat-Fin;
     is-zero-nat-zero-Fin; succ-Fin; pred-Fin; issec-pred-Fin; isretr-pred-Fin;
-    is-equiv-succ-Fin; is-equiv-pred-Fin)
+    is-equiv-succ-Fin; is-equiv-pred-Fin; is-set-Fin)
 ```
 
 Some modular arithmetic was already defined in `modular-arithmetic-standard-finite-types`. Here we package those results together in a more convenient package that also allows congruence modulo 0.
@@ -77,7 +80,7 @@ Some modular arithmetic was already defined in `modular-arithmetic-standard-fini
 ```agda
 zero-ℤ-Mod : (k : ℕ) → ℤ-Mod k
 zero-ℤ-Mod zero-ℕ = zero-ℤ
-zero-ℤ-Mod (succ-ℕ k) = zero-Fin
+zero-ℤ-Mod (succ-ℕ k) = zero-Fin k
 
 is-zero-ℤ-Mod : (k : ℕ) → ℤ-Mod k → UU lzero
 is-zero-ℤ-Mod k x = (x ＝ zero-ℤ-Mod k)
@@ -87,11 +90,11 @@ is-nonzero-ℤ-Mod k x = ¬ (is-zero-ℤ-Mod k x)
 
 neg-one-ℤ-Mod : (k : ℕ) → ℤ-Mod k
 neg-one-ℤ-Mod zero-ℕ = neg-one-ℤ
-neg-one-ℤ-Mod (succ-ℕ k) = neg-one-Fin
+neg-one-ℤ-Mod (succ-ℕ k) = neg-one-Fin k
 
 one-ℤ-Mod : (k : ℕ) → ℤ-Mod k
 one-ℤ-Mod zero-ℕ = one-ℤ
-one-ℤ-Mod (succ-ℕ k) = one-Fin
+one-ℤ-Mod (succ-ℕ k) = one-Fin k
 ```
 
 ## The integers modulo k have decidable equality
@@ -99,7 +102,7 @@ one-ℤ-Mod (succ-ℕ k) = one-Fin
 ```agda
 has-decidable-equality-ℤ-Mod : (k : ℕ) → has-decidable-equality (ℤ-Mod k)
 has-decidable-equality-ℤ-Mod zero-ℕ = has-decidable-equality-ℤ
-has-decidable-equality-ℤ-Mod (succ-ℕ k) = has-decidable-equality-Fin
+has-decidable-equality-ℤ-Mod (succ-ℕ k) = has-decidable-equality-Fin (succ-ℕ k)
 ```
 
 ### The integers modulo k form a set
@@ -115,17 +118,30 @@ pr1 (ℤ-Mod-Set k) = ℤ-Mod k
 pr2 (ℤ-Mod-Set k) = is-set-ℤ-Mod k
 ```
 
+### The types `ℤ-Mod k` are finite for nonzero natural numbers `k`
+
+```agda
+abstract
+  is-finite-ℤ-Mod : {k : ℕ} → is-nonzero-ℕ k → is-finite (ℤ-Mod k)
+  is-finite-ℤ-Mod {zero-ℕ} H = ex-falso (H refl)
+  is-finite-ℤ-Mod {succ-ℕ k} H = is-finite-Fin (succ-ℕ k)
+
+ℤ-Mod-𝔽 : (k : ℕ) → is-nonzero-ℕ k → 𝔽
+pr1 (ℤ-Mod-𝔽 k H) = ℤ-Mod k
+pr2 (ℤ-Mod-𝔽 k H) = is-finite-ℤ-Mod H
+```
+
 ## The inclusion of the integers modulo k into ℤ
 
 ```agda
 int-ℤ-Mod : (k : ℕ) → ℤ-Mod k → ℤ
 int-ℤ-Mod zero-ℕ x = x
-int-ℤ-Mod (succ-ℕ k) x = int-ℕ (nat-Fin x)
+int-ℤ-Mod (succ-ℕ k) x = int-ℕ (nat-Fin (succ-ℕ k) x)
 
 is-injective-int-ℤ-Mod : (k : ℕ) → is-injective (int-ℤ-Mod k)
 is-injective-int-ℤ-Mod zero-ℕ = is-injective-id
 is-injective-int-ℤ-Mod (succ-ℕ k) =
-  is-injective-comp' is-injective-nat-Fin is-injective-int-ℕ
+  is-injective-comp' (is-injective-nat-Fin (succ-ℕ k)) is-injective-int-ℕ
 
 is-zero-int-zero-ℤ-Mod : (k : ℕ) → is-zero-ℤ (int-ℤ-Mod k (zero-ℤ-Mod k))
 is-zero-int-zero-ℤ-Mod (zero-ℕ) = refl
@@ -137,7 +153,7 @@ is-zero-int-zero-ℤ-Mod (succ-ℕ k) = ap int-ℕ (is-zero-nat-zero-Fin {k})
 ```agda
 succ-ℤ-Mod : (k : ℕ) → ℤ-Mod k → ℤ-Mod k
 succ-ℤ-Mod zero-ℕ = succ-ℤ
-succ-ℤ-Mod (succ-ℕ k) = succ-Fin
+succ-ℤ-Mod (succ-ℕ k) = succ-Fin (succ-ℕ k)
 
 ℤ-Mod-Endo : (k : ℕ) → Endo lzero
 pr1 (ℤ-Mod-Endo k) = ℤ-Mod k
@@ -146,7 +162,7 @@ pr2 (ℤ-Mod-Endo k) = succ-ℤ-Mod k
 abstract
   is-equiv-succ-ℤ-Mod : (k : ℕ) → is-equiv (succ-ℤ-Mod k)
   is-equiv-succ-ℤ-Mod zero-ℕ = is-equiv-succ-ℤ
-  is-equiv-succ-ℤ-Mod (succ-ℕ k) = is-equiv-succ-Fin
+  is-equiv-succ-ℤ-Mod (succ-ℕ k) = is-equiv-succ-Fin (succ-ℕ k)
 
 equiv-succ-ℤ-Mod : (k : ℕ) → ℤ-Mod k ≃ ℤ-Mod k
 pr1 (equiv-succ-ℤ-Mod k) = succ-ℤ-Mod k
@@ -154,20 +170,20 @@ pr2 (equiv-succ-ℤ-Mod k) = is-equiv-succ-ℤ-Mod k
 
 pred-ℤ-Mod : (k : ℕ) → ℤ-Mod k → ℤ-Mod k
 pred-ℤ-Mod zero-ℕ = pred-ℤ
-pred-ℤ-Mod (succ-ℕ k) = pred-Fin
+pred-ℤ-Mod (succ-ℕ k) = pred-Fin (succ-ℕ k)
 
 issec-pred-ℤ-Mod : (k : ℕ) (x : ℤ-Mod k) → succ-ℤ-Mod k (pred-ℤ-Mod k x) ＝ x
 issec-pred-ℤ-Mod zero-ℕ = issec-pred-ℤ
-issec-pred-ℤ-Mod (succ-ℕ k) = issec-pred-Fin
+issec-pred-ℤ-Mod (succ-ℕ k) = issec-pred-Fin (succ-ℕ k)
 
 isretr-pred-ℤ-Mod : (k : ℕ) (x : ℤ-Mod k) → pred-ℤ-Mod k (succ-ℤ-Mod k x) ＝ x
 isretr-pred-ℤ-Mod zero-ℕ = isretr-pred-ℤ
-isretr-pred-ℤ-Mod (succ-ℕ k) = isretr-pred-Fin
+isretr-pred-ℤ-Mod (succ-ℕ k) = isretr-pred-Fin (succ-ℕ k)
 
 abstract
   is-equiv-pred-ℤ-Mod : (k : ℕ) → is-equiv (pred-ℤ-Mod k)
   is-equiv-pred-ℤ-Mod zero-ℕ = is-equiv-pred-ℤ
-  is-equiv-pred-ℤ-Mod (succ-ℕ k) = is-equiv-pred-Fin
+  is-equiv-pred-ℤ-Mod (succ-ℕ k) = is-equiv-pred-Fin (succ-ℕ k)
 
 equiv-pred-ℤ-Mod : (k : ℕ) → ℤ-Mod k ≃ ℤ-Mod k
 pr1 (equiv-pred-ℤ-Mod k) = pred-ℤ-Mod k
@@ -179,7 +195,7 @@ pr2 (equiv-pred-ℤ-Mod k) = is-equiv-pred-ℤ-Mod k
 ```
 add-ℤ-Mod : (k : ℕ) → ℤ-Mod k → ℤ-Mod k → ℤ-Mod k
 add-ℤ-Mod zero-ℕ = add-ℤ
-add-ℤ-Mod (succ-ℕ k) = add-Fin
+add-ℤ-Mod (succ-ℕ k) = add-Fin (succ-ℕ k)
 
 add-ℤ-Mod' : (k : ℕ) → ℤ-Mod k → ℤ-Mod k → ℤ-Mod k
 add-ℤ-Mod' k x y = add-ℤ-Mod k y x
@@ -192,7 +208,7 @@ ap-add-ℤ-Mod k p q = ap-binary (add-ℤ-Mod k) p q
 abstract
   is-equiv-add-ℤ-Mod : (k : ℕ) (x : ℤ-Mod k) → is-equiv (add-ℤ-Mod k x)
   is-equiv-add-ℤ-Mod zero-ℕ = is-equiv-add-ℤ
-  is-equiv-add-ℤ-Mod (succ-ℕ k) = is-equiv-add-Fin
+  is-equiv-add-ℤ-Mod (succ-ℕ k) = is-equiv-add-Fin (succ-ℕ k)
 
 equiv-add-ℤ-Mod : (k : ℕ) (x : ℤ-Mod k) → ℤ-Mod k ≃ ℤ-Mod k
 pr1 (equiv-add-ℤ-Mod k x) = add-ℤ-Mod k x
@@ -201,7 +217,7 @@ pr2 (equiv-add-ℤ-Mod k x) = is-equiv-add-ℤ-Mod k x
 abstract
   is-equiv-add-ℤ-Mod' : (k : ℕ) (x : ℤ-Mod k) → is-equiv (add-ℤ-Mod' k x)
   is-equiv-add-ℤ-Mod' zero-ℕ = is-equiv-add-ℤ'
-  is-equiv-add-ℤ-Mod' (succ-ℕ k) = is-equiv-add-Fin'
+  is-equiv-add-ℤ-Mod' (succ-ℕ k) = is-equiv-add-Fin' (succ-ℕ k)
 
 equiv-add-ℤ-Mod' : (k : ℕ) (x : ℤ-Mod k) → ℤ-Mod k ≃ ℤ-Mod k
 pr1 (equiv-add-ℤ-Mod' k x) = add-ℤ-Mod' k x
@@ -209,11 +225,11 @@ pr2 (equiv-add-ℤ-Mod' k x) = is-equiv-add-ℤ-Mod' k x
 
 is-injective-add-ℤ-Mod : (k : ℕ) (x : ℤ-Mod k) → is-injective (add-ℤ-Mod k x)
 is-injective-add-ℤ-Mod zero-ℕ = is-injective-add-ℤ
-is-injective-add-ℤ-Mod (succ-ℕ k) = is-injective-add-Fin
+is-injective-add-ℤ-Mod (succ-ℕ k) = is-injective-add-Fin (succ-ℕ k)
 
 is-injective-add-ℤ-Mod' : (k : ℕ) (x : ℤ-Mod k) → is-injective (add-ℤ-Mod' k x)
 is-injective-add-ℤ-Mod' zero-ℕ = is-injective-add-ℤ'
-is-injective-add-ℤ-Mod' (succ-ℕ k) = is-injective-add-Fin'
+is-injective-add-ℤ-Mod' (succ-ℕ k) = is-injective-add-Fin' (succ-ℕ k)
 ```
 
 ## The negative of an integer modulo k
@@ -221,12 +237,12 @@ is-injective-add-ℤ-Mod' (succ-ℕ k) = is-injective-add-Fin'
 ```agda
 neg-ℤ-Mod : (k : ℕ) → ℤ-Mod k → ℤ-Mod k
 neg-ℤ-Mod zero-ℕ = neg-ℤ
-neg-ℤ-Mod (succ-ℕ k) = neg-Fin
+neg-ℤ-Mod (succ-ℕ k) = neg-Fin (succ-ℕ k)
 
 abstract
   is-equiv-neg-ℤ-Mod : (k : ℕ) → is-equiv (neg-ℤ-Mod k)
   is-equiv-neg-ℤ-Mod zero-ℕ = is-equiv-neg-ℤ
-  is-equiv-neg-ℤ-Mod (succ-ℕ k) = is-equiv-neg-Fin
+  is-equiv-neg-ℤ-Mod (succ-ℕ k) = is-equiv-neg-Fin (succ-ℕ k)
 
 equiv-neg-ℤ-Mod : (k : ℕ) → ℤ-Mod k ≃ ℤ-Mod k
 pr1 (equiv-neg-ℤ-Mod k) = neg-ℤ-Mod k
@@ -240,76 +256,79 @@ associative-add-ℤ-Mod :
   (k : ℕ) (x y z : ℤ-Mod k) →
   add-ℤ-Mod k (add-ℤ-Mod k x y) z ＝ add-ℤ-Mod k x (add-ℤ-Mod k y z)
 associative-add-ℤ-Mod zero-ℕ = associative-add-ℤ
-associative-add-ℤ-Mod (succ-ℕ k) = associative-add-Fin
+associative-add-ℤ-Mod (succ-ℕ k) = associative-add-Fin (succ-ℕ k)
 
 commutative-add-ℤ-Mod :
   (k : ℕ) (x y : ℤ-Mod k) → add-ℤ-Mod k x y ＝ add-ℤ-Mod k y x
 commutative-add-ℤ-Mod zero-ℕ = commutative-add-ℤ
-commutative-add-ℤ-Mod (succ-ℕ k) = commutative-add-Fin
+commutative-add-ℤ-Mod (succ-ℕ k) = commutative-add-Fin (succ-ℕ k)
 
 left-unit-law-add-ℤ-Mod :
   (k : ℕ) (x : ℤ-Mod k) → add-ℤ-Mod k (zero-ℤ-Mod k) x ＝ x
 left-unit-law-add-ℤ-Mod zero-ℕ = left-unit-law-add-ℤ
-left-unit-law-add-ℤ-Mod (succ-ℕ k) = left-unit-law-add-Fin
+left-unit-law-add-ℤ-Mod (succ-ℕ k) = left-unit-law-add-Fin k
 
 right-unit-law-add-ℤ-Mod :
   (k : ℕ) (x : ℤ-Mod k) → add-ℤ-Mod k x (zero-ℤ-Mod k) ＝ x
 right-unit-law-add-ℤ-Mod zero-ℕ = right-unit-law-add-ℤ
-right-unit-law-add-ℤ-Mod (succ-ℕ k) = right-unit-law-add-Fin
+right-unit-law-add-ℤ-Mod (succ-ℕ k) = right-unit-law-add-Fin k
 
 left-inverse-law-add-ℤ-Mod :
   (k : ℕ) (x : ℤ-Mod k) → add-ℤ-Mod k (neg-ℤ-Mod k x) x ＝ zero-ℤ-Mod k
 left-inverse-law-add-ℤ-Mod zero-ℕ = left-inverse-law-add-ℤ
-left-inverse-law-add-ℤ-Mod (succ-ℕ k) = left-inverse-law-add-Fin
+left-inverse-law-add-ℤ-Mod (succ-ℕ k) = left-inverse-law-add-Fin k
 
 right-inverse-law-add-ℤ-Mod :
   (k : ℕ) (x : ℤ-Mod k) → add-ℤ-Mod k x (neg-ℤ-Mod k x) ＝ zero-ℤ-Mod k
 right-inverse-law-add-ℤ-Mod zero-ℕ = right-inverse-law-add-ℤ
-right-inverse-law-add-ℤ-Mod (succ-ℕ k) = right-inverse-law-add-Fin
+right-inverse-law-add-ℤ-Mod (succ-ℕ k) = right-inverse-law-add-Fin k
 
 left-successor-law-add-ℤ-Mod :
   (k : ℕ) (x y : ℤ-Mod k) →
   add-ℤ-Mod k (succ-ℤ-Mod k x) y ＝ succ-ℤ-Mod k (add-ℤ-Mod k x y)
 left-successor-law-add-ℤ-Mod zero-ℕ = left-successor-law-add-ℤ
-left-successor-law-add-ℤ-Mod (succ-ℕ k) = left-successor-law-add-Fin
+left-successor-law-add-ℤ-Mod (succ-ℕ k) = left-successor-law-add-Fin (succ-ℕ k)
 
 right-successor-law-add-ℤ-Mod :
   (k : ℕ) (x y : ℤ-Mod k) →
   add-ℤ-Mod k x (succ-ℤ-Mod k y) ＝ succ-ℤ-Mod k (add-ℤ-Mod k x y)
 right-successor-law-add-ℤ-Mod zero-ℕ = right-successor-law-add-ℤ
-right-successor-law-add-ℤ-Mod (succ-ℕ k) = right-successor-law-add-Fin
+right-successor-law-add-ℤ-Mod (succ-ℕ k) =
+  right-successor-law-add-Fin (succ-ℕ k)
 
 left-predecessor-law-add-ℤ-Mod :
   (k : ℕ) (x y : ℤ-Mod k) →
   add-ℤ-Mod k (pred-ℤ-Mod k x) y ＝ pred-ℤ-Mod k (add-ℤ-Mod k x y)
 left-predecessor-law-add-ℤ-Mod zero-ℕ = left-predecessor-law-add-ℤ
-left-predecessor-law-add-ℤ-Mod (succ-ℕ k) = left-predecessor-law-add-Fin
+left-predecessor-law-add-ℤ-Mod (succ-ℕ k) =
+  left-predecessor-law-add-Fin (succ-ℕ k)
 
 right-predecessor-law-add-ℤ-Mod :
   (k : ℕ) (x y : ℤ-Mod k) →
   add-ℤ-Mod k x (pred-ℤ-Mod k y) ＝ pred-ℤ-Mod k (add-ℤ-Mod k x y)
 right-predecessor-law-add-ℤ-Mod zero-ℕ = right-predecessor-law-add-ℤ
-right-predecessor-law-add-ℤ-Mod (succ-ℕ k) = right-predecessor-law-add-Fin
+right-predecessor-law-add-ℤ-Mod (succ-ℕ k) =
+  right-predecessor-law-add-Fin (succ-ℕ k)
 
 is-add-one-succ-ℤ-Mod :
   (k : ℕ) (x : ℤ-Mod k) → succ-ℤ-Mod k x ＝ add-ℤ-Mod k (one-ℤ-Mod k) x
 is-add-one-succ-ℤ-Mod zero-ℕ = is-add-one-succ-ℤ
-is-add-one-succ-ℤ-Mod (succ-ℕ k) = is-add-one-succ-Fin
+is-add-one-succ-ℤ-Mod (succ-ℕ k) = is-add-one-succ-Fin k
 
 is-add-one-succ-ℤ-Mod' :
   (k : ℕ) (x : ℤ-Mod k) → succ-ℤ-Mod k x ＝ add-ℤ-Mod k x (one-ℤ-Mod k)
 is-add-one-succ-ℤ-Mod' zero-ℕ = is-add-one-succ-ℤ'
-is-add-one-succ-ℤ-Mod' (succ-ℕ k) = is-add-one-succ-Fin'
+is-add-one-succ-ℤ-Mod' (succ-ℕ k) = is-add-one-succ-Fin' k
 
 is-add-neg-one-pred-ℤ-Mod :
   (k : ℕ) (x : ℤ-Mod k) → pred-ℤ-Mod k x ＝ add-ℤ-Mod k (neg-one-ℤ-Mod k) x
 is-add-neg-one-pred-ℤ-Mod zero-ℕ = is-add-neg-one-pred-ℤ
-is-add-neg-one-pred-ℤ-Mod (succ-ℕ k) = is-add-neg-one-pred-Fin
+is-add-neg-one-pred-ℤ-Mod (succ-ℕ k) = is-add-neg-one-pred-Fin k
 
 is-add-neg-one-pred-ℤ-Mod' :
   (k : ℕ) (x : ℤ-Mod k) → pred-ℤ-Mod k x ＝ add-ℤ-Mod k x (neg-one-ℤ-Mod k)
 is-add-neg-one-pred-ℤ-Mod' zero-ℕ = is-add-neg-one-pred-ℤ'
-is-add-neg-one-pred-ℤ-Mod' (succ-ℕ k) = is-add-neg-one-pred-Fin'
+is-add-neg-one-pred-ℤ-Mod' (succ-ℕ k) = is-add-neg-one-pred-Fin' k
 ```
 
 ## Multiplication modulo k
@@ -317,7 +336,7 @@ is-add-neg-one-pred-ℤ-Mod' (succ-ℕ k) = is-add-neg-one-pred-Fin'
 ```agda
 mul-ℤ-Mod : (k : ℕ) → ℤ-Mod k → ℤ-Mod k → ℤ-Mod k
 mul-ℤ-Mod zero-ℕ = mul-ℤ
-mul-ℤ-Mod (succ-ℕ k) = mul-Fin
+mul-ℤ-Mod (succ-ℕ k) = mul-Fin (succ-ℕ k)
 
 mul-ℤ-Mod' : (k : ℕ) → ℤ-Mod k → ℤ-Mod k → ℤ-Mod k
 mul-ℤ-Mod' k x y = mul-ℤ-Mod k y x
@@ -335,46 +354,48 @@ associative-mul-ℤ-Mod :
   (k : ℕ) (x y z : ℤ-Mod k) →
   mul-ℤ-Mod k (mul-ℤ-Mod k x y) z ＝ mul-ℤ-Mod k x (mul-ℤ-Mod k y z)
 associative-mul-ℤ-Mod zero-ℕ = associative-mul-ℤ
-associative-mul-ℤ-Mod (succ-ℕ k) = associative-mul-Fin
+associative-mul-ℤ-Mod (succ-ℕ k) = associative-mul-Fin (succ-ℕ k)
 
 commutative-mul-ℤ-Mod :
   (k : ℕ) (x y : ℤ-Mod k) → mul-ℤ-Mod k x y ＝ mul-ℤ-Mod k y x
 commutative-mul-ℤ-Mod zero-ℕ = commutative-mul-ℤ
-commutative-mul-ℤ-Mod (succ-ℕ k) = commutative-mul-Fin
+commutative-mul-ℤ-Mod (succ-ℕ k) = commutative-mul-Fin (succ-ℕ k)
 
 left-unit-law-mul-ℤ-Mod :
   (k : ℕ) (x : ℤ-Mod k) → mul-ℤ-Mod k (one-ℤ-Mod k) x ＝ x
 left-unit-law-mul-ℤ-Mod zero-ℕ = left-unit-law-mul-ℤ
-left-unit-law-mul-ℤ-Mod (succ-ℕ k) = left-unit-law-mul-Fin
+left-unit-law-mul-ℤ-Mod (succ-ℕ k) = left-unit-law-mul-Fin k
 
 right-unit-law-mul-ℤ-Mod :
   (k : ℕ) (x : ℤ-Mod k) → mul-ℤ-Mod k x (one-ℤ-Mod k) ＝ x
 right-unit-law-mul-ℤ-Mod zero-ℕ = right-unit-law-mul-ℤ
-right-unit-law-mul-ℤ-Mod (succ-ℕ k) = right-unit-law-mul-Fin
+right-unit-law-mul-ℤ-Mod (succ-ℕ k) = right-unit-law-mul-Fin k
 
 left-distributive-mul-add-ℤ-Mod :
   (k : ℕ) (x y z : ℤ-Mod k) →
   ( mul-ℤ-Mod k x (add-ℤ-Mod k y z)) ＝
   ( add-ℤ-Mod k (mul-ℤ-Mod k x y) (mul-ℤ-Mod k x z))
 left-distributive-mul-add-ℤ-Mod zero-ℕ = left-distributive-mul-add-ℤ
-left-distributive-mul-add-ℤ-Mod (succ-ℕ k) = left-distributive-mul-add-Fin
+left-distributive-mul-add-ℤ-Mod (succ-ℕ k) =
+  left-distributive-mul-add-Fin (succ-ℕ k)
 
 right-distributive-mul-add-ℤ-Mod :
   (k : ℕ) (x y z : ℤ-Mod k) →
   ( mul-ℤ-Mod k (add-ℤ-Mod k x y) z) ＝
   ( add-ℤ-Mod k (mul-ℤ-Mod k x z) (mul-ℤ-Mod k y z))
 right-distributive-mul-add-ℤ-Mod zero-ℕ = right-distributive-mul-add-ℤ
-right-distributive-mul-add-ℤ-Mod (succ-ℕ k) = right-distributive-mul-add-Fin
+right-distributive-mul-add-ℤ-Mod (succ-ℕ k) =
+  right-distributive-mul-add-Fin (succ-ℕ k)
 
 is-mul-neg-one-neg-ℤ-Mod :
   (k : ℕ) (x : ℤ-Mod k) → neg-ℤ-Mod k x ＝ mul-ℤ-Mod k (neg-one-ℤ-Mod k) x
 is-mul-neg-one-neg-ℤ-Mod zero-ℕ = is-mul-neg-one-neg-ℤ
-is-mul-neg-one-neg-ℤ-Mod (succ-ℕ k) = is-mul-neg-one-neg-Fin
+is-mul-neg-one-neg-ℤ-Mod (succ-ℕ k) = is-mul-neg-one-neg-Fin k
 
 is-mul-neg-one-neg-ℤ-Mod' :
   (k : ℕ) (x : ℤ-Mod k) → neg-ℤ-Mod k x ＝ mul-ℤ-Mod k x (neg-one-ℤ-Mod k)
 is-mul-neg-one-neg-ℤ-Mod' zero-ℕ = is-mul-neg-one-neg-ℤ'
-is-mul-neg-one-neg-ℤ-Mod' (succ-ℕ k) = is-mul-neg-one-neg-Fin'
+is-mul-neg-one-neg-ℤ-Mod' (succ-ℕ k) = is-mul-neg-one-neg-Fin' k
 ```
 
 ## Congruence classes of integers modulo k
@@ -386,8 +407,8 @@ mod-ℕ (succ-ℕ k) x = mod-succ-ℕ k x
 
 mod-ℤ : (k : ℕ) → ℤ → ℤ-Mod k
 mod-ℤ zero-ℕ x = x
-mod-ℤ (succ-ℕ k) (inl x) = neg-Fin (mod-succ-ℕ k (succ-ℕ x))
-mod-ℤ (succ-ℕ k) (inr (inl x)) = zero-Fin
+mod-ℤ (succ-ℕ k) (inl x) = neg-Fin (succ-ℕ k) (mod-succ-ℕ k (succ-ℕ x))
+mod-ℤ (succ-ℕ k) (inr (inl x)) = zero-Fin k
 mod-ℤ (succ-ℕ k) (inr (inr x)) = mod-succ-ℕ k (succ-ℕ x)
 ```
 
@@ -415,19 +436,24 @@ mod-one-ℤ (succ-ℕ k) = refl
 mod-neg-one-ℤ : (k : ℕ) → mod-ℤ k neg-one-ℤ ＝ neg-one-ℤ-Mod k
 mod-neg-one-ℤ zero-ℕ = refl
 mod-neg-one-ℤ (succ-ℕ k) =
-  ( neg-succ-Fin zero-Fin) ∙
-  ( ( ap pred-Fin neg-zero-Fin) ∙
-    ( ( is-add-neg-one-pred-Fin' zero-Fin) ∙
-      ( left-unit-law-add-Fin neg-one-Fin)))
+  ( neg-succ-Fin (succ-ℕ k) (zero-Fin k)) ∙
+  ( ( ap (pred-Fin (succ-ℕ k)) (neg-zero-Fin k)) ∙
+    ( ( is-add-neg-one-pred-Fin' k (zero-Fin k)) ∙
+      ( left-unit-law-add-Fin k (neg-one-Fin k))))
 
 preserves-successor-mod-ℤ :
   (k : ℕ) (x : ℤ) → mod-ℤ k (succ-ℤ x) ＝ succ-ℤ-Mod k (mod-ℤ k x)
 preserves-successor-mod-ℤ zero-ℕ x = refl
 preserves-successor-mod-ℤ (succ-ℕ k) (inl zero-ℕ) =
-  inv (ap succ-Fin is-neg-one-neg-one-Fin)
+  inv (ap (succ-Fin (succ-ℕ k)) (is-neg-one-neg-one-Fin k))
 preserves-successor-mod-ℤ (succ-ℕ k) (inl (succ-ℕ x)) =
-  ( ap neg-Fin (inv (isretr-pred-Fin (succ-Fin (mod-succ-ℕ k x))))) ∙
-  ( neg-pred-Fin (succ-Fin (succ-Fin (mod-succ-ℕ k x))))
+  ( ap
+    ( neg-Fin (succ-ℕ k))
+    ( inv
+      ( isretr-pred-Fin (succ-ℕ k) (succ-Fin (succ-ℕ k) (mod-succ-ℕ k x))))) ∙
+  ( neg-pred-Fin
+    ( succ-ℕ k)
+    ( succ-Fin (succ-ℕ k) (succ-Fin (succ-ℕ k) (mod-succ-ℕ k x))))
 preserves-successor-mod-ℤ (succ-ℕ k) (inr (inl star)) = refl
 preserves-successor-mod-ℤ (succ-ℕ k) (inr (inr x)) = refl
 
@@ -435,17 +461,19 @@ preserves-predecessor-mod-ℤ :
   (k : ℕ) (x : ℤ) → mod-ℤ k (pred-ℤ x) ＝ pred-ℤ-Mod k (mod-ℤ k x)
 preserves-predecessor-mod-ℤ zero-ℕ x = refl
 preserves-predecessor-mod-ℤ (succ-ℕ k) (inl x) =
-  neg-succ-Fin (succ-Fin (mod-succ-ℕ k x))
+  neg-succ-Fin (succ-ℕ k) (succ-Fin (succ-ℕ k) (mod-succ-ℕ k x))
 preserves-predecessor-mod-ℤ (succ-ℕ k) (inr (inl star)) =
-  ( is-neg-one-neg-one-Fin) ∙
-  ( ( inv (left-unit-law-add-Fin neg-one-Fin)) ∙
-    ( inv (is-add-neg-one-pred-Fin' zero-Fin)))
+  ( is-neg-one-neg-one-Fin k) ∙
+  ( ( inv (left-unit-law-add-Fin k (neg-one-Fin k))) ∙
+    ( inv (is-add-neg-one-pred-Fin' k (zero-Fin k))))
 preserves-predecessor-mod-ℤ (succ-ℕ k) (inr (inr zero-ℕ)) =
   inv
-    ( ( ap pred-Fin (preserves-successor-mod-ℤ (succ-ℕ k) zero-ℤ)) ∙
-      ( isretr-pred-Fin zero-Fin))
+    ( ( ap
+        ( pred-Fin (succ-ℕ k))
+        ( preserves-successor-mod-ℤ (succ-ℕ k) zero-ℤ)) ∙
+      ( isretr-pred-Fin (succ-ℕ k) (zero-Fin k)))
 preserves-predecessor-mod-ℤ (succ-ℕ k) (inr (inr (succ-ℕ x))) =
-  inv (isretr-pred-Fin (succ-Fin (mod-succ-ℕ k x)))
+  inv (isretr-pred-Fin (succ-ℕ k) (succ-Fin (succ-ℕ k) (mod-succ-ℕ k x)))
 
 preserves-add-mod-ℤ :
   (k : ℕ) (x y : ℤ) →
@@ -453,29 +481,39 @@ preserves-add-mod-ℤ :
 preserves-add-mod-ℤ zero-ℕ x y = refl
 preserves-add-mod-ℤ (succ-ℕ k) (inl zero-ℕ) y =
   ( preserves-predecessor-mod-ℤ (succ-ℕ k) y) ∙
-  ( ( is-add-neg-one-pred-Fin (mod-ℤ (succ-ℕ k) y)) ∙
-    ( ap (add-Fin' (mod-ℤ (succ-ℕ k) y)) (inv (mod-neg-one-ℤ (succ-ℕ k)))))
+  ( ( is-add-neg-one-pred-Fin k (mod-ℤ (succ-ℕ k) y)) ∙
+    ( ap
+      ( add-Fin' (succ-ℕ k) (mod-ℤ (succ-ℕ k) y))
+      ( inv (mod-neg-one-ℤ (succ-ℕ k)))))
 preserves-add-mod-ℤ (succ-ℕ k) (inl (succ-ℕ x)) y =
   ( preserves-predecessor-mod-ℤ (succ-ℕ k) (add-ℤ (inl x) y)) ∙
-  ( ( ap pred-Fin (preserves-add-mod-ℤ (succ-ℕ k) (inl x) y)) ∙
+  ( ( ap (pred-Fin (succ-ℕ k)) (preserves-add-mod-ℤ (succ-ℕ k) (inl x) y)) ∙
     ( ( inv
-        ( left-predecessor-law-add-Fin
+        ( left-predecessor-law-add-Fin (succ-ℕ k)
           ( mod-ℤ (succ-ℕ k) (inl x))
           ( mod-ℤ (succ-ℕ k) y))) ∙
       ( ap
-        ( add-Fin' (mod-ℤ (succ-ℕ k) y))
+        ( add-Fin' (succ-ℕ k) (mod-ℤ (succ-ℕ k) y))
         ( inv (preserves-predecessor-mod-ℤ (succ-ℕ k) (inl x))))))
 preserves-add-mod-ℤ (succ-ℕ k) (inr (inl star)) y =
-  inv (left-unit-law-add-Fin (mod-ℤ (succ-ℕ k) y))
+  inv (left-unit-law-add-Fin k (mod-ℤ (succ-ℕ k) y))
 preserves-add-mod-ℤ (succ-ℕ k) (inr (inr zero-ℕ)) y =
   ( preserves-successor-mod-ℤ (succ-ℕ k) y) ∙
-  ( ( ap succ-Fin (inv (left-unit-law-add-Fin (mod-ℤ (succ-ℕ k) y)))) ∙
-    ( inv (left-successor-law-add-Fin zero-Fin (mod-ℤ (succ-ℕ k) y))))
-preserves-add-mod-ℤ (succ-ℕ k) (inr (inr (succ-ℕ x))) y =
-  ( preserves-successor-mod-ℤ (succ-ℕ k) (add-ℤ (inr (inr x)) y)) ∙
-  ( ( ap succ-Fin (preserves-add-mod-ℤ (succ-ℕ k) (inr (inr x)) y)) ∙
+  ( ( ap
+      ( succ-Fin (succ-ℕ k))
+      ( inv (left-unit-law-add-Fin k (mod-ℤ (succ-ℕ k) y)))) ∙
     ( inv
       ( left-successor-law-add-Fin
+        ( succ-ℕ k)
+        ( zero-Fin k)
+        ( mod-ℤ (succ-ℕ k) y))))
+preserves-add-mod-ℤ (succ-ℕ k) (inr (inr (succ-ℕ x))) y =
+  ( preserves-successor-mod-ℤ (succ-ℕ k) (add-ℤ (inr (inr x)) y)) ∙
+  ( ( ap
+      ( succ-Fin (succ-ℕ k))
+      ( preserves-add-mod-ℤ (succ-ℕ k) (inr (inr x)) y)) ∙
+    ( inv
+      ( left-successor-law-add-Fin (succ-ℕ k)
         ( mod-ℤ (succ-ℕ k) (inr (inr x)))
         ( mod-ℤ (succ-ℕ k) y))))
 
@@ -483,7 +521,7 @@ preserves-neg-mod-ℤ :
   (k : ℕ) (x : ℤ) → mod-ℤ k (neg-ℤ x) ＝ neg-ℤ-Mod k (mod-ℤ k x)
 preserves-neg-mod-ℤ zero-ℕ x = refl
 preserves-neg-mod-ℤ (succ-ℕ k) x =
-  is-injective-add-Fin
+  is-injective-add-Fin (succ-ℕ k)
     ( mod-ℤ (succ-ℕ k) x)
     ( ( inv (preserves-add-mod-ℤ (succ-ℕ k) x (neg-ℤ x))) ∙
       ( ( ap (mod-ℤ (succ-ℕ k)) (right-inverse-law-add-ℤ x)) ∙
@@ -495,7 +533,7 @@ preserves-mul-mod-ℤ :
 preserves-mul-mod-ℤ zero-ℕ x y = refl
 preserves-mul-mod-ℤ (succ-ℕ k) (inl zero-ℕ) y =
   ( preserves-neg-mod-ℤ (succ-ℕ k) y) ∙
-  ( ( is-mul-neg-one-neg-Fin (mod-ℤ (succ-ℕ k) y)) ∙
+  ( ( is-mul-neg-one-neg-Fin k (mod-ℤ (succ-ℕ k) y)) ∙
     ( ap
       ( mul-ℤ-Mod' (succ-ℕ k) (mod-ℤ (succ-ℕ k) y))
       ( inv (mod-neg-one-ℤ (succ-ℕ k)))))
@@ -506,23 +544,23 @@ preserves-mul-mod-ℤ (succ-ℕ k) (inl (succ-ℕ x)) y =
       ( preserves-neg-mod-ℤ (succ-ℕ k) y)
       ( preserves-mul-mod-ℤ (succ-ℕ k) (inl x) y)) ∙
     ( ( inv
-        ( left-predecessor-law-mul-Fin
+        ( left-predecessor-law-mul-Fin (succ-ℕ k)
           ( mod-ℤ (succ-ℕ k) (inl x))
           ( mod-ℤ (succ-ℕ k) y))) ∙
       ( ap
-        ( mul-Fin' (mod-ℤ (succ-ℕ k) y))
+        ( mul-Fin' (succ-ℕ k) (mod-ℤ (succ-ℕ k) y))
         ( inv (preserves-predecessor-mod-ℤ (succ-ℕ k) (inl x))))))
 preserves-mul-mod-ℤ (succ-ℕ k) (inr (inl star)) y =
-  inv (left-zero-law-mul-Fin (mod-ℤ (succ-ℕ k) y))
+  inv (left-zero-law-mul-Fin k (mod-ℤ (succ-ℕ k) y))
 preserves-mul-mod-ℤ (succ-ℕ k) (inr (inr zero-ℕ)) y =
-  inv (left-unit-law-mul-Fin (mod-ℤ (succ-ℕ k) y))
+  inv (left-unit-law-mul-Fin k (mod-ℤ (succ-ℕ k) y))
 preserves-mul-mod-ℤ (succ-ℕ k) (inr (inr (succ-ℕ x))) y =
   ( preserves-add-mod-ℤ (succ-ℕ k) y (mul-ℤ (inr (inr x)) y)) ∙
   ( ( ap
       ( add-ℤ-Mod (succ-ℕ k) (mod-ℤ (succ-ℕ k) y))
       ( preserves-mul-mod-ℤ (succ-ℕ k) (inr (inr x)) y)) ∙
     ( inv
-      ( left-successor-law-mul-Fin
+      ( left-successor-law-mul-Fin (succ-ℕ k)
         ( mod-ℤ (succ-ℕ k) (inr (inr x)))
         ( mod-ℤ (succ-ℕ k) y))))
 ```
@@ -534,7 +572,7 @@ cong-int-mod-ℕ zero-ℕ x = refl-cong-ℤ zero-ℤ (int-ℕ x)
 cong-int-mod-ℕ (succ-ℕ k) x =
   cong-int-cong-ℕ
     ( succ-ℕ k)
-    ( nat-Fin (mod-succ-ℕ k x))
+    ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k x))
     ( x)
     ( cong-nat-mod-succ-ℕ k x)
 
@@ -545,34 +583,46 @@ cong-int-mod-ℤ (succ-ℕ k) (inl x) =
   concatenate-eq-cong-ℤ
     ( int-ℕ (succ-ℕ k))
     ( int-ℤ-Mod (succ-ℕ k) (mod-ℤ (succ-ℕ k) (inl x)))
-    ( int-ℕ (nat-Fin (mul-Fin neg-one-Fin (mod-succ-ℕ k (succ-ℕ x)))))
+    ( int-ℕ
+      ( nat-Fin
+        ( succ-ℕ k)
+        ( mul-Fin (succ-ℕ k) (neg-one-Fin k) (mod-succ-ℕ k (succ-ℕ x)))))
     ( inl x)
     ( ap
       ( int-ℤ-Mod (succ-ℕ k))
       ( preserves-mul-mod-ℤ (succ-ℕ k) neg-one-ℤ (inr (inr x)) ∙
-        ap (mul-Fin' (mod-succ-ℕ k (succ-ℕ x))) (mod-neg-one-ℤ (succ-ℕ k))))
+        ap
+        ( mul-Fin'
+          ( succ-ℕ k)
+          ( mod-succ-ℕ k (succ-ℕ x)))
+          ( mod-neg-one-ℤ (succ-ℕ k))))
     ( transitive-cong-ℤ
       ( int-ℕ (succ-ℕ k))
-      ( int-ℕ (nat-Fin (mul-Fin neg-one-Fin (mod-succ-ℕ k (succ-ℕ x)))))
-      ( int-ℕ (mul-ℕ k (nat-Fin (mod-succ-ℕ k (succ-ℕ x)))))
+      ( int-ℕ
+        ( nat-Fin
+          ( succ-ℕ k)
+          ( mul-Fin (succ-ℕ k) (neg-one-Fin k) (mod-succ-ℕ k (succ-ℕ x)))))
+      ( int-ℕ (mul-ℕ k (nat-Fin (succ-ℕ k) (mod-succ-ℕ k (succ-ℕ x)))))
       ( inl x)
       ( cong-int-cong-ℕ
         ( succ-ℕ k)
-        ( nat-Fin (mul-Fin neg-one-Fin (mod-succ-ℕ k (succ-ℕ x))))
-        ( mul-ℕ k (nat-Fin (mod-succ-ℕ k (succ-ℕ x))))
-        ( cong-mul-Fin neg-one-Fin (mod-succ-ℕ k (succ-ℕ x))))
+        ( nat-Fin
+          ( succ-ℕ k)
+          ( mul-Fin (succ-ℕ k) (neg-one-Fin k) (mod-succ-ℕ k (succ-ℕ x))))
+        ( mul-ℕ k (nat-Fin (succ-ℕ k) (mod-succ-ℕ k (succ-ℕ x))))
+        ( cong-mul-Fin (neg-one-Fin k) (mod-succ-ℕ k (succ-ℕ x))))
       ( transitive-cong-ℤ
         ( int-ℕ (succ-ℕ k))
-        ( int-ℕ (mul-ℕ k (nat-Fin (mod-succ-ℕ k (succ-ℕ x)))))
+        ( int-ℕ (mul-ℕ k (nat-Fin (succ-ℕ k) (mod-succ-ℕ k (succ-ℕ x)))))
         ( int-ℕ (mul-ℕ k (succ-ℕ x)))
         ( inl x)
         ( cong-int-cong-ℕ
           ( succ-ℕ k)
-          ( mul-ℕ k (nat-Fin (mod-succ-ℕ k (succ-ℕ x))))
+          ( mul-ℕ k (nat-Fin (succ-ℕ k) (mod-succ-ℕ k (succ-ℕ x))))
           ( mul-ℕ k (succ-ℕ x))
           ( congruence-mul-ℕ
             ( succ-ℕ k)
-            {k} {nat-Fin (mod-succ-ℕ k (succ-ℕ x))} {k} {succ-ℕ x}
+            {k} {nat-Fin (succ-ℕ k) (mod-succ-ℕ k (succ-ℕ x))} {k} {succ-ℕ x}
             ( refl-cong-ℕ (succ-ℕ k) k)
             ( cong-nat-mod-succ-ℕ k (succ-ℕ x))))
         ( pair
@@ -588,13 +638,13 @@ cong-int-mod-ℤ (succ-ℕ k) (inl x) =
 cong-int-mod-ℤ (succ-ℕ k) (inr (inl star)) =
   cong-int-cong-ℕ
     ( succ-ℕ k)
-    ( nat-Fin (mod-succ-ℕ k zero-ℕ))
+    ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k zero-ℕ))
     ( zero-ℕ)
     ( cong-nat-mod-succ-ℕ k zero-ℕ)
 cong-int-mod-ℤ (succ-ℕ k) (inr (inr x)) = 
   cong-int-cong-ℕ
     ( succ-ℕ k)
-    ( nat-Fin (mod-succ-ℕ k (succ-ℕ x)))
+    ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k (succ-ℕ x)))
     ( succ-ℕ x)
     ( cong-nat-mod-succ-ℕ k (succ-ℕ x))
 
@@ -621,7 +671,11 @@ eq-cong-int-ℤ-Mod :
 eq-cong-int-ℤ-Mod zero-ℕ = is-discrete-cong-ℤ zero-ℤ refl
 eq-cong-int-ℤ-Mod (succ-ℕ k) x y H =
   eq-cong-nat-Fin (succ-ℕ k) x y
-    ( cong-cong-int-ℕ (succ-ℕ k) (nat-Fin x) (nat-Fin y) H)
+    ( cong-cong-int-ℕ
+      ( succ-ℕ k)
+      ( nat-Fin (succ-ℕ k) x)
+      ( nat-Fin (succ-ℕ k) y)
+      ( H))
 
 eq-mod-cong-ℤ :
   (k : ℕ) (x y : ℤ) → cong-ℤ (int-ℕ k) x y → mod-ℤ k x ＝ mod-ℤ k y
@@ -691,7 +745,7 @@ has-no-fixed-points-succ-ℤ-Mod k x =
   map-neg (is-one-is-fixed-point-succ-ℤ-Mod k x)
 
 has-no-fixed-points-succ-Fin :
-  {k : ℕ} (x : Fin k) → is-not-one-ℕ k → ¬ (succ-Fin x ＝ x)
+  {k : ℕ} (x : Fin k) → is-not-one-ℕ k → ¬ (succ-Fin k x ＝ x)
 has-no-fixed-points-succ-Fin {succ-ℕ k} x =
   has-no-fixed-points-succ-ℤ-Mod (succ-ℕ k) x
 ```

--- a/src/elementary-number-theory/repeating-element-standard-finite-type.lagda.md
+++ b/src/elementary-number-theory/repeating-element-standard-finite-type.lagda.md
@@ -23,37 +23,38 @@ open import univalent-combinatorics.standard-finite-types using (Fin)
 
 ```agda
 repeat-Fin :
-  {k : ℕ} (x : Fin k) → Fin (succ-ℕ k) → Fin k
-repeat-Fin {succ-ℕ k} (inl x) (inl y) = inl (repeat-Fin x y)
-repeat-Fin {succ-ℕ k} (inl x) (inr star) = inr star
-repeat-Fin {succ-ℕ k} (inr star) (inl y) = y
-repeat-Fin {succ-ℕ k} (inr star) (inr star) = inr star
+  (k : ℕ) (x : Fin k) → Fin (succ-ℕ k) → Fin k
+repeat-Fin (succ-ℕ k) (inl x) (inl y) = inl (repeat-Fin k x y)
+repeat-Fin (succ-ℕ k) (inl x) (inr star) = inr star
+repeat-Fin (succ-ℕ k) (inr star) (inl y) = y
+repeat-Fin (succ-ℕ k) (inr star) (inr star) = inr star
 
 abstract
   is-almost-injective-repeat-Fin :
-    {k : ℕ} (x : Fin k) {y z : Fin (succ-ℕ k)} →
-    ¬ (inl x ＝ y) → ¬ (inl x ＝ z) → repeat-Fin x y ＝ repeat-Fin x z → y ＝ z
-  is-almost-injective-repeat-Fin {succ-ℕ k} (inl x) {inl y} {inl z} f g p =
+    (k : ℕ) (x : Fin k) {y z : Fin (succ-ℕ k)} →
+    ¬ (inl x ＝ y) → ¬ (inl x ＝ z) →
+    repeat-Fin k x y ＝ repeat-Fin k x z → y ＝ z
+  is-almost-injective-repeat-Fin (succ-ℕ k) (inl x) {inl y} {inl z} f g p =
     ap ( inl)
-       ( is-almost-injective-repeat-Fin x
+       ( is-almost-injective-repeat-Fin k x
          ( λ q → f (ap inl q))
          ( λ q → g (ap inl q))
          ( is-injective-inl p))
-  is-almost-injective-repeat-Fin {succ-ℕ k} (inl x) {inl y} {inr star} f g p =
-    ex-falso (Eq-Fin-eq p)
-  is-almost-injective-repeat-Fin {succ-ℕ k} (inl x) {inr star} {inl z} f g p =
-    ex-falso (Eq-Fin-eq p)
+  is-almost-injective-repeat-Fin (succ-ℕ k) (inl x) {inl y} {inr star} f g p =
+    ex-falso (Eq-Fin-eq (succ-ℕ k) p)
+  is-almost-injective-repeat-Fin (succ-ℕ k) (inl x) {inr star} {inl z} f g p =
+    ex-falso (Eq-Fin-eq (succ-ℕ k) p)
   is-almost-injective-repeat-Fin
-    {succ-ℕ k} (inl x) {inr star} {inr star} f g p =
+    (succ-ℕ k) (inl x) {inr star} {inr star} f g p =
     refl
-  is-almost-injective-repeat-Fin {succ-ℕ k} (inr star) {inl y} {inl z} f g p =
+  is-almost-injective-repeat-Fin (succ-ℕ k) (inr star) {inl y} {inl z} f g p =
     ap inl p
   is-almost-injective-repeat-Fin
-    {succ-ℕ k} (inr star) {inl y} {inr star} f g p =
+    (succ-ℕ k) (inr star) {inl y} {inr star} f g p =
     ex-falso (f (ap inl (inv p)))
   is-almost-injective-repeat-Fin
-    {succ-ℕ k} (inr star) {inr star} {inl z} f g p =
+    (succ-ℕ k) (inr star) {inr star} {inl z} f g p =
     ex-falso (g (ap inl p))
   is-almost-injective-repeat-Fin
-    {succ-ℕ k} (inr star) {inr star} {inr star} f g p = refl
+    (succ-ℕ k) (inr star) {inr star} {inr star} f g p = refl
 ```

--- a/src/elementary-number-theory/sums-of-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/sums-of-natural-numbers.lagda.md
@@ -41,16 +41,16 @@ The values of a map `f : X → ℕ` out of a finite type `X` can be summed up.
 ### Sums of natural numbers indexed by a standard finite type
 
 ```agda
-sum-Fin-ℕ : {k : ℕ} → (Fin k → ℕ) → ℕ
-sum-Fin-ℕ {zero-ℕ} f = zero-ℕ
-sum-Fin-ℕ {succ-ℕ k} f = add-ℕ (sum-Fin-ℕ (λ x → f (inl x))) (f (inr star))
+sum-Fin-ℕ : (k : ℕ) → (Fin k → ℕ) → ℕ
+sum-Fin-ℕ zero-ℕ f = zero-ℕ
+sum-Fin-ℕ (succ-ℕ k) f = add-ℕ (sum-Fin-ℕ k (λ x → f (inl x))) (f (inr star))
 ```
 
 ### Sums of natural numbers indexed by a type equipped with a counting
 
 ```agda
 sum-count-ℕ : {l : Level} {A : UU l} (e : count A) → (f : A → ℕ) → ℕ
-sum-count-ℕ (pair k e) f = sum-Fin-ℕ (f ∘ (map-equiv e))
+sum-count-ℕ (pair k e) f = sum-Fin-ℕ k (f ∘ (map-equiv e))
 ```
 
 ### Bounded sums of natural numbers
@@ -71,18 +71,18 @@ bounded-sum-ℕ (succ-ℕ u) f =
 ```agda
 abstract
   htpy-sum-Fin-ℕ :
-    {k : ℕ} {f g : Fin k → ℕ} (H : f ~ g) → sum-Fin-ℕ f ＝ sum-Fin-ℕ g
-  htpy-sum-Fin-ℕ {zero-ℕ} H = refl
-  htpy-sum-Fin-ℕ {succ-ℕ k} H =
+    (k : ℕ) {f g : Fin k → ℕ} (H : f ~ g) → sum-Fin-ℕ k f ＝ sum-Fin-ℕ k g
+  htpy-sum-Fin-ℕ zero-ℕ H = refl
+  htpy-sum-Fin-ℕ (succ-ℕ k) H =
     ap-add-ℕ
-      ( htpy-sum-Fin-ℕ (λ x → H (inl x)))
+      ( htpy-sum-Fin-ℕ k (λ x → H (inl x)))
       ( H (inr star))
 
 abstract
   htpy-sum-count-ℕ :
     {l : Level} {A : UU l} (e : count A) {f g : A → ℕ} (H : f ~ g) →
     sum-count-ℕ e f ＝ sum-count-ℕ e g
-  htpy-sum-count-ℕ (pair k e) H = htpy-sum-Fin-ℕ (H ·r (map-equiv e))
+  htpy-sum-count-ℕ (pair k e) H = htpy-sum-Fin-ℕ k (H ·r (map-equiv e))
 ```
 
 ### Summing up the same value `m` times is multiplication by `m`.
@@ -90,7 +90,7 @@ abstract
 ```agda
 abstract
   constant-sum-Fin-ℕ :
-    (m n : ℕ) → sum-Fin-ℕ (const (Fin m) ℕ n) ＝ mul-ℕ m n
+    (m n : ℕ) → sum-Fin-ℕ m (const (Fin m) ℕ n) ＝ mul-ℕ m n
   constant-sum-Fin-ℕ zero-ℕ n = refl
   constant-sum-Fin-ℕ (succ-ℕ m) n = ap (add-ℕ' n) (constant-sum-Fin-ℕ m n)
 

--- a/src/elementary-number-theory/unit-elements-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/unit-elements-standard-finite-types.lagda.md
@@ -36,11 +36,11 @@ A unit element in a standard finite type is a divisor of one
 ## Definition
 
 ```agda
-is-unit-Fin : {k : ℕ} → Fin k → UU lzero
-is-unit-Fin {succ-ℕ k} x = div-Fin x one-Fin
+is-unit-Fin : (k : ℕ) → Fin k → UU lzero
+is-unit-Fin (succ-ℕ k) x = div-Fin (succ-ℕ k) x (one-Fin k)
 
 unit-Fin : ℕ → UU lzero
-unit-Fin k = Σ (Fin k) is-unit-Fin
+unit-Fin k = Σ (Fin k) (is-unit-Fin k)
 ```
 
 ## Properties
@@ -48,20 +48,20 @@ unit-Fin k = Σ (Fin k) is-unit-Fin
 ### One is a unit
 
 ```agda
-is-unit-one-Fin : {k : ℕ} → is-unit-Fin (one-Fin {k})
-is-unit-one-Fin {k} = refl-div-Fin one-Fin
+is-unit-one-Fin : {k : ℕ} → is-unit-Fin (succ-ℕ k) (one-Fin k)
+is-unit-one-Fin {k} = refl-div-Fin (one-Fin k)
 
 one-unit-Fin : {k : ℕ} → unit-Fin (succ-ℕ k)
-pr1 (one-unit-Fin {k}) = one-Fin
+pr1 (one-unit-Fin {k}) = one-Fin k
 pr2 (one-unit-Fin {k}) = is-unit-one-Fin
 ```
 
 ### Negative one is a unit
 
 ```agda
-is-unit-neg-one-Fin : {k : ℕ} → is-unit-Fin (neg-one-Fin {k})
-is-unit-neg-one-Fin {zero-ℕ} = refl-div-Fin neg-one-Fin
-pr1 (is-unit-neg-one-Fin {succ-ℕ k}) = neg-one-Fin
+is-unit-neg-one-Fin : {k : ℕ} → is-unit-Fin (succ-ℕ k) (neg-one-Fin k)
+is-unit-neg-one-Fin {zero-ℕ} = refl-div-Fin (neg-one-Fin 0)
+pr1 (is-unit-neg-one-Fin {succ-ℕ k}) = neg-one-Fin (succ-ℕ k)
 pr2 (is-unit-neg-one-Fin {succ-ℕ k}) =
   eq-mod-succ-cong-ℕ
     ( succ-ℕ k)
@@ -75,9 +75,9 @@ pr2 (is-unit-neg-one-Fin {succ-ℕ k}) =
         ( ( commutative-mul-ℕ k (succ-ℕ (succ-ℕ k))) ∙
           ( inv (right-unit-law-dist-ℕ (mul-ℕ (succ-ℕ (succ-ℕ k)) k))))))
 
-neg-one-unit-Fin : {k : ℕ} → unit-Fin (succ-ℕ k)
-pr1 neg-one-unit-Fin = neg-one-Fin
-pr2 neg-one-unit-Fin = is-unit-neg-one-Fin
+neg-one-unit-Fin : (k : ℕ) → unit-Fin (succ-ℕ k)
+pr1 (neg-one-unit-Fin k) = neg-one-Fin k
+pr2 (neg-one-unit-Fin k) = is-unit-neg-one-Fin
 ```
 
 ### Units are closed under multiplication
@@ -85,19 +85,19 @@ pr2 neg-one-unit-Fin = is-unit-neg-one-Fin
 ```agda
 is-unit-mul-Fin :
   {k : ℕ} {x y : Fin k} →
-  is-unit-Fin x → is-unit-Fin y → is-unit-Fin (mul-Fin x y)
-pr1 (is-unit-mul-Fin {succ-ℕ k} {x} {y} (pair d p) (pair e q)) = mul-Fin e d
+  is-unit-Fin k x → is-unit-Fin k y → is-unit-Fin k (mul-Fin k x y)
+pr1 (is-unit-mul-Fin {succ-ℕ k} {x} {y} (pair d p) (pair e q)) = mul-Fin (succ-ℕ k) e d
 pr2 (is-unit-mul-Fin {succ-ℕ k} {x} {y} (pair d p) (pair e q)) =
-  ( associative-mul-Fin e d (mul-Fin x y)) ∙
+  ( associative-mul-Fin (succ-ℕ k) e d (mul-Fin (succ-ℕ k) x y)) ∙
     ( ( ap
-        ( mul-Fin e)
-        ( ( inv (associative-mul-Fin d x y)) ∙
-          ( ap (mul-Fin' y) p ∙ left-unit-law-mul-Fin y))) ∙
+        ( mul-Fin (succ-ℕ k) e)
+        ( ( inv (associative-mul-Fin (succ-ℕ k) d x y)) ∙
+          ( ap (mul-Fin' (succ-ℕ k) y) p ∙ left-unit-law-mul-Fin k y))) ∙
       ( q))
 
-mul-unit-Fin : {k : ℕ} → unit-Fin k → unit-Fin k → unit-Fin k
-pr1 (mul-unit-Fin u v) = mul-Fin (pr1 u) (pr1 v)
-pr2 (mul-unit-Fin u v) = is-unit-mul-Fin (pr2 u) (pr2 v)
+mul-unit-Fin : (k : ℕ) → unit-Fin k → unit-Fin k → unit-Fin k
+pr1 (mul-unit-Fin k u v) = mul-Fin k (pr1 u) (pr1 v)
+pr2 (mul-unit-Fin k u v) = is-unit-mul-Fin (pr2 u) (pr2 v)
 ```
 
 ### The multiplicative inverse of a unit
@@ -107,5 +107,5 @@ inv-unit-Fin : {k : ℕ} → unit-Fin k → unit-Fin k
 pr1 (inv-unit-Fin {succ-ℕ k} (pair u (pair v p))) = v
 pr1 (pr2 (inv-unit-Fin {succ-ℕ k} (pair u (pair v p)))) = u
 pr2 (pr2 (inv-unit-Fin {succ-ℕ k} (pair u (pair v p)))) =
-  commutative-mul-Fin u v ∙ p
+  commutative-mul-Fin (succ-ℕ k) u v ∙ p
 ```

--- a/src/elementary-number-theory/unit-similarity-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/unit-similarity-standard-finite-types.lagda.md
@@ -35,54 +35,56 @@ Two elements `x y : Fin k` are said to be unit similar if there is a unit elemen
 
 ```agda
 sim-unit-Fin :
-  {k : ℕ} → Fin k → Fin k → UU lzero
-sim-unit-Fin {k} x y = Σ (unit-Fin k) (λ u → mul-Fin (pr1 u) x ＝ y)
+  (k : ℕ) → Fin k → Fin k → UU lzero
+sim-unit-Fin k x y = Σ (unit-Fin k) (λ u → mul-Fin k (pr1 u) x ＝ y)
 
 refl-sim-unit-Fin :
-  {k : ℕ} (x : Fin k) → sim-unit-Fin x x
+  {k : ℕ} (x : Fin k) → sim-unit-Fin k x x
 pr1 (refl-sim-unit-Fin {succ-ℕ k} x) = one-unit-Fin
-pr2 (refl-sim-unit-Fin {succ-ℕ k} x) = left-unit-law-mul-Fin x
+pr2 (refl-sim-unit-Fin {succ-ℕ k} x) = left-unit-law-mul-Fin k x
 
 symm-sim-unit-Fin :
-  {k : ℕ} (x y : Fin k) → sim-unit-Fin x y → sim-unit-Fin y x
+  {k : ℕ} (x y : Fin k) → sim-unit-Fin k x y → sim-unit-Fin k y x
 pr1 (symm-sim-unit-Fin {succ-ℕ k} x y (pair (pair u (pair v q)) p)) =
   inv-unit-Fin (pair u (pair v q))
 pr2 (symm-sim-unit-Fin {succ-ℕ k} x y (pair (pair u (pair v q)) p)) =
-  ( ( ( ap (mul-Fin v) (inv p)) ∙
-        ( inv (associative-mul-Fin v u x))) ∙
-      ( ap (mul-Fin' x) q)) ∙
-    ( left-unit-law-mul-Fin x)
+  ( ( ( ap (mul-Fin (succ-ℕ k) v) (inv p)) ∙
+        ( inv (associative-mul-Fin (succ-ℕ k) v u x))) ∙
+      ( ap (mul-Fin' (succ-ℕ k) x) q)) ∙
+    ( left-unit-law-mul-Fin k x)
 
 trans-sim-unit-Fin :
-  {k : ℕ} (x y z : Fin k) → sim-unit-Fin x y → sim-unit-Fin y z →
-  sim-unit-Fin x z
+  {k : ℕ} (x y z : Fin k) → sim-unit-Fin k x y → sim-unit-Fin k y z →
+  sim-unit-Fin k x z
 pr1 (trans-sim-unit-Fin {succ-ℕ k} x y z (pair u p) (pair v q)) =
-  mul-unit-Fin v u
+  mul-unit-Fin (succ-ℕ k) v u
 pr2 (trans-sim-unit-Fin {succ-ℕ k} x y z (pair u p) (pair v q)) =
-  associative-mul-Fin (pr1 v) (pr1 u) x ∙ (ap (mul-Fin (pr1 v)) p ∙ q)
+  ( associative-mul-Fin (succ-ℕ k) (pr1 v) (pr1 u) x) ∙
+  ( ap (mul-Fin (succ-ℕ k) (pr1 v)) p ∙ q)
 
 is-mod-unit-ℕ : (k x : ℕ) → UU lzero
 is-mod-unit-ℕ k x = Σ ℕ (λ l → cong-ℕ k (mul-ℕ l x) 1)
 
 is-mod-unit-sim-unit-mod-succ-ℕ :
-  (k x : ℕ) → sim-unit-Fin (mod-succ-ℕ k x) one-Fin → is-mod-unit-ℕ (succ-ℕ k) x
+  (k x : ℕ) → sim-unit-Fin (succ-ℕ k) (mod-succ-ℕ k x) (one-Fin k) →
+  is-mod-unit-ℕ (succ-ℕ k) x
 pr1 (is-mod-unit-sim-unit-mod-succ-ℕ k x (pair u p)) =
-  nat-Fin (pr1 u)
+  nat-Fin (succ-ℕ k) (pr1 u)
 pr2 (is-mod-unit-sim-unit-mod-succ-ℕ k x (pair u p)) =
   cong-eq-mod-succ-ℕ k
-    ( mul-ℕ (nat-Fin (pr1 u)) x)
+    ( mul-ℕ (nat-Fin (succ-ℕ k) (pr1 u)) x)
     ( 1)
     ( ( eq-mod-succ-cong-ℕ k
-        ( mul-ℕ (nat-Fin (pr1 u)) x)
-        ( mul-ℕ (nat-Fin (pr1 u)) (nat-Fin (mod-succ-ℕ k x)))
+        ( mul-ℕ (nat-Fin (succ-ℕ k) (pr1 u)) x)
+        ( mul-ℕ (nat-Fin (succ-ℕ k) (pr1 u)) (nat-Fin (succ-ℕ k) (mod-succ-ℕ k x)))
         ( scalar-invariant-cong-ℕ
           ( succ-ℕ k)
           ( x)
-          ( nat-Fin (mod-succ-ℕ k x))
-          ( nat-Fin (pr1 u))
+          ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k x))
+          ( nat-Fin (succ-ℕ k) (pr1 u))
           ( symm-cong-ℕ
             ( succ-ℕ k)
-            ( nat-Fin (mod-succ-ℕ k x))
+            ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k x))
             ( x)
             ( cong-nat-mod-succ-ℕ k x)))) ∙
       ( p))

--- a/src/elementary-number-theory/well-ordering-principle-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/well-ordering-principle-standard-finite-types.lagda.md
@@ -57,11 +57,12 @@ open import foundation.type-arithmetic-unit-type using (left-unit-law-Σ)
 open import foundation.unit-type using (unit; star; ind-unit)
 open import foundation.universe-levels using (Level; UU)
 
+open import univalent-combinatorics.counting using
+  ( count; number-of-elements-count; map-equiv-count)
 open import univalent-combinatorics.decidable-dependent-pair-types using
   ( is-decidable-Σ-Fin)
 open import univalent-combinatorics.standard-finite-types using
   ( Fin; inl-Fin; neg-one-Fin; nat-Fin)
-open import univalent-combinatorics.counting using (count; number-of-elements-count)
 ```
 
 ## Idea
@@ -74,12 +75,12 @@ The standard finite types inherit a well-ordering principle from the natural num
 
 ```agda
 exists-not-not-forall-Fin :
-  {l : Level} {k : ℕ} {P : Fin k → UU l} → (is-decidable-fam P) →
+  {l : Level} (k : ℕ) {P : Fin k → UU l} → (is-decidable-fam P) →
   ¬ ((x : Fin k) → P x) → Σ (Fin k) (λ x → ¬ (P x))
-exists-not-not-forall-Fin {l} {zero-ℕ} d H = ex-falso (H ind-empty)
-exists-not-not-forall-Fin {l} {succ-ℕ k} {P} d H with d (inr star)
+exists-not-not-forall-Fin {l} zero-ℕ d H = ex-falso (H ind-empty)
+exists-not-not-forall-Fin {l} (succ-ℕ k) {P} d H with d (inr star)
 ... | inl p =
-  T ( exists-not-not-forall-Fin
+  T ( exists-not-not-forall-Fin k
       ( λ x → d (inl x))
       ( λ f → H (ind-coprod P f (ind-unit p))))
   where
@@ -92,7 +93,10 @@ exists-not-not-forall-count :
   (is-decidable-fam P) → count X →
   ¬ ((x : X) → P x) → Σ X (λ x → ¬ (P x))
 exists-not-not-forall-count {l1} {l2} {X} P p e =
-  g ∘ ((exists-not-not-forall-Fin (p ∘ (map-equiv (pr2 e)) )) ∘ f)
+  ( g) ∘
+  ( ( exists-not-not-forall-Fin
+      ( number-of-elements-count e)
+      ( p ∘ map-equiv-count e)) ∘ f)
   where
   k : ℕ
   k = number-of-elements-count e
@@ -110,93 +114,93 @@ exists-not-not-forall-count {l1} {l2} {X} P p e =
 
 ```agda
 is-lower-bound-Fin :
-  {l : Level} {k : ℕ} (P : Fin k → UU l) → Fin k → UU l
-is-lower-bound-Fin {l} {k} P x =
-  (y : Fin k) → P y → leq-Fin x y
+  {l : Level} (k : ℕ) (P : Fin k → UU l) → Fin k → UU l
+is-lower-bound-Fin k P x = (y : Fin k) → P y → leq-Fin k x y
 
 abstract
   is-prop-is-lower-bound-Fin :
-    {l : Level} {k : ℕ} {P : Fin k → UU l} (x : Fin k) →
-    is-prop (is-lower-bound-Fin P x)
-  is-prop-is-lower-bound-Fin x =
-    is-prop-Π (λ y → is-prop-function-type (is-prop-leq-Fin x y))
+    {l : Level} (k : ℕ) {P : Fin k → UU l} (x : Fin k) →
+    is-prop (is-lower-bound-Fin k P x)
+  is-prop-is-lower-bound-Fin k x =
+    is-prop-Π (λ y → is-prop-function-type (is-prop-leq-Fin k x y))
 
   is-lower-bound-fin-Prop :
-    {l : Level} {k : ℕ} (P : Fin k → UU l) (x : Fin k) → UU-Prop l
-  pr1 (is-lower-bound-fin-Prop P x) = is-lower-bound-Fin P x
-  pr2 (is-lower-bound-fin-Prop P x) = is-prop-is-lower-bound-Fin x
+    {l : Level} (k : ℕ) (P : Fin k → UU l) (x : Fin k) → UU-Prop l
+  pr1 (is-lower-bound-fin-Prop k P x) = is-lower-bound-Fin k P x
+  pr2 (is-lower-bound-fin-Prop k P x) = is-prop-is-lower-bound-Fin k x
 
 minimal-element-Fin :
-  {l : Level} {k : ℕ} (P : Fin k → UU l) → UU l
-minimal-element-Fin {l} {k} P =
-  Σ (Fin k) (λ x → (P x) × is-lower-bound-Fin P x)
+  {l : Level} (k : ℕ) (P : Fin k → UU l) → UU l
+minimal-element-Fin k P =
+  Σ (Fin k) (λ x → (P x) × is-lower-bound-Fin k P x)
 
 abstract
   all-elements-equal-minimal-element-Fin :
-    {l : Level} {k : ℕ} (P : subtype l (Fin k)) →
-    all-elements-equal (minimal-element-Fin (is-in-subtype P))
-  all-elements-equal-minimal-element-Fin P
+    {l : Level} (k : ℕ) (P : subtype l (Fin k)) →
+    all-elements-equal (minimal-element-Fin k (is-in-subtype P))
+  all-elements-equal-minimal-element-Fin k P
     (pair x (pair p l)) (pair y (pair q m)) =
     eq-subtype
-      ( λ t → prod-Prop (P t) (is-lower-bound-fin-Prop (is-in-subtype P) t))
-      ( antisymmetric-leq-Fin x y (l y q) (m x p))
+      ( λ t → prod-Prop (P t) (is-lower-bound-fin-Prop k (is-in-subtype P) t))
+      ( antisymmetric-leq-Fin k x y (l y q) (m x p))
 
 abstract
   is-prop-minimal-element-Fin :
-    {l : Level} {k : ℕ} (P : subtype l (Fin k)) →
-    is-prop (minimal-element-Fin (is-in-subtype P))
-  is-prop-minimal-element-Fin P =
-    is-prop-all-elements-equal (all-elements-equal-minimal-element-Fin P)
+    {l : Level} (k : ℕ) (P : subtype l (Fin k)) →
+    is-prop (minimal-element-Fin k (is-in-subtype P))
+  is-prop-minimal-element-Fin k P =
+    is-prop-all-elements-equal (all-elements-equal-minimal-element-Fin k P)
 
 minimal-element-Fin-Prop :
-  {l : Level} {k : ℕ} (P : subtype l (Fin k)) → UU-Prop l
-pr1 (minimal-element-Fin-Prop P) = minimal-element-Fin (is-in-subtype P)
-pr2 (minimal-element-Fin-Prop P) = is-prop-minimal-element-Fin P
+  {l : Level} (k : ℕ) (P : subtype l (Fin k)) → UU-Prop l
+pr1 (minimal-element-Fin-Prop k P) = minimal-element-Fin k (is-in-subtype P)
+pr2 (minimal-element-Fin-Prop k P) = is-prop-minimal-element-Fin k P
 
 is-lower-bound-inl-Fin :
-  {l : Level} {k : ℕ} {P : Fin (succ-ℕ k) → UU l} {x : Fin k} →
-  is-lower-bound-Fin (P ∘ inl) x → is-lower-bound-Fin P (inl-Fin k x)
-is-lower-bound-inl-Fin H (inl y) p = H y p
-is-lower-bound-inl-Fin {l} {k} {P} {x} H (inr star) p =
-  ( leq-neg-one-Fin (inl x))
+  {l : Level} (k : ℕ) {P : Fin (succ-ℕ k) → UU l} {x : Fin k} →
+  is-lower-bound-Fin k (P ∘ inl) x →
+  is-lower-bound-Fin (succ-ℕ k) P (inl-Fin k x)
+is-lower-bound-inl-Fin k H (inl y) p = H y p
+is-lower-bound-inl-Fin k {P} {x} H (inr star) p =
+  ( leq-neg-one-Fin k (inl x))
 
 well-ordering-principle-Σ-Fin :
-  {l : Level} {k : ℕ} {P : Fin k → UU l} → ((x : Fin k) → is-decidable (P x)) →
-  Σ (Fin k) P → minimal-element-Fin P
-pr1 (well-ordering-principle-Σ-Fin {l} {succ-ℕ k} d (pair (inl x) p)) =
-  inl (pr1 (well-ordering-principle-Σ-Fin (λ x' → d (inl x')) (pair x p)))
-pr1 (pr2 (well-ordering-principle-Σ-Fin {l} {succ-ℕ k} d (pair (inl x) p))) =
-  pr1 (pr2 (well-ordering-principle-Σ-Fin (λ x' → d (inl x')) (pair x p)))
-pr2 (pr2 (well-ordering-principle-Σ-Fin {l} {succ-ℕ k} d (pair (inl x) p))) =
-  is-lower-bound-inl-Fin (pr2 (pr2 m))
+  {l : Level} (k : ℕ) {P : Fin k → UU l} → ((x : Fin k) → is-decidable (P x)) →
+  Σ (Fin k) P → minimal-element-Fin k P
+pr1 (well-ordering-principle-Σ-Fin (succ-ℕ k) d (pair (inl x) p)) =
+  inl (pr1 (well-ordering-principle-Σ-Fin k (λ x' → d (inl x')) (pair x p)))
+pr1 (pr2 (well-ordering-principle-Σ-Fin (succ-ℕ k) d (pair (inl x) p))) =
+  pr1 (pr2 (well-ordering-principle-Σ-Fin k (λ x' → d (inl x')) (pair x p)))
+pr2 (pr2 (well-ordering-principle-Σ-Fin (succ-ℕ k) d (pair (inl x) p))) =
+  is-lower-bound-inl-Fin k (pr2 (pr2 m))
   where
-  m = well-ordering-principle-Σ-Fin (λ x' → d (inl x')) (pair x p)
-well-ordering-principle-Σ-Fin {l} {succ-ℕ k} {P} d (pair (inr star) p)
+  m = well-ordering-principle-Σ-Fin k (λ x' → d (inl x')) (pair x p)
+well-ordering-principle-Σ-Fin (succ-ℕ k) {P} d (pair (inr star) p)
   with
-  is-decidable-Σ-Fin (λ t → d (inl t))
+  is-decidable-Σ-Fin k (λ t → d (inl t))
 ... | inl t =
   pair
     ( inl (pr1 m))
-    ( pair (pr1 (pr2 m)) (is-lower-bound-inl-Fin (pr2 (pr2 m))))
+    ( pair (pr1 (pr2 m)) (is-lower-bound-inl-Fin k (pr2 (pr2 m))))
   where
-  m = well-ordering-principle-Σ-Fin (λ x' → d (inl x')) t
+  m = well-ordering-principle-Σ-Fin k (λ x' → d (inl x')) t
 ... | inr f =
   pair
     ( inr star)
     ( pair p g)
   where
-  g : (y : Fin (succ-ℕ k)) → P y → leq-Fin (neg-one-Fin {k}) y
+  g : (y : Fin (succ-ℕ k)) → P y → leq-Fin (succ-ℕ k) (neg-one-Fin k) y
   g (inl y) q = ex-falso (f (pair y q))
-  g (inr star) q = refl-leq-Fin (neg-one-Fin {k})
+  g (inr star) q = refl-leq-Fin (succ-ℕ k) (neg-one-Fin k)
 
 well-ordering-principle-∃-Fin :
-  {l : Level} {k : ℕ} (P : decidable-subtype l (Fin k)) →
+  {l : Level} (k : ℕ) (P : decidable-subtype l (Fin k)) →
   ∃ (Fin k) (is-in-decidable-subtype P) →
-  minimal-element-Fin (is-in-decidable-subtype P)
-well-ordering-principle-∃-Fin P H =
+  minimal-element-Fin k (is-in-decidable-subtype P)
+well-ordering-principle-∃-Fin k P H =
   apply-universal-property-trunc-Prop H
-    ( minimal-element-Fin-Prop (subtype-decidable-subtype P))
-    ( well-ordering-principle-Σ-Fin
+    ( minimal-element-Fin-Prop k (subtype-decidable-subtype P))
+    ( well-ordering-principle-Σ-Fin k
       ( is-decidable-subtype-subtype-decidable-subtype P))
 ```
 
@@ -204,11 +208,11 @@ well-ordering-principle-∃-Fin P H =
 
 ```agda
 ε-operator-decidable-subtype-Fin :
-  {l : Level} {k : ℕ} (P : decidable-subtype l (Fin k)) →
+  {l : Level} (k : ℕ) (P : decidable-subtype l (Fin k)) →
   ε-operator-Hilbert (type-decidable-subtype P)
-ε-operator-decidable-subtype-Fin {l} {zero-ℕ} P t =
+ε-operator-decidable-subtype-Fin {l} zero-ℕ P t =
   ex-falso (apply-universal-property-trunc-Prop t empty-Prop pr1)
-ε-operator-decidable-subtype-Fin {l} {succ-ℕ k} P t =
+ε-operator-decidable-subtype-Fin {l} (succ-ℕ k) P t =
   map-Σ
     ( is-in-decidable-subtype P)
     ( mod-succ-ℕ k)
@@ -217,8 +221,8 @@ well-ordering-principle-∃-Fin P H =
       ( map-trunc-Prop
         ( map-Σ
           ( type-Prop ∘ Q)
-          ( nat-Fin)
-          ( λ x → tr (is-in-decidable-subtype P) (inv (issec-nat-Fin x))))
+          ( nat-Fin (succ-ℕ k))
+          ( λ x → tr (is-in-decidable-subtype P) (inv (issec-nat-Fin k x))))
         ( t)))
   where
   Q : ℕ → UU-Prop l

--- a/src/finite-group-theory.lagda.md
+++ b/src/finite-group-theory.lagda.md
@@ -16,6 +16,7 @@ open import finite-group-theory.groups-of-order-2 public
 open import finite-group-theory.orbits-permutations public
 open import finite-group-theory.permutations public
 open import finite-group-theory.sign-homomorphism public
+open import finite-group-theory.simpson-delooping-sign-homomorphism public
 open import finite-group-theory.tetrahedra-in-3-space public
 open import finite-group-theory.transpositions public
 ```

--- a/src/finite-group-theory/cartier-delooping-sign-homomorphism.lagda.md
+++ b/src/finite-group-theory/cartier-delooping-sign-homomorphism.lagda.md
@@ -115,7 +115,7 @@ open import univalent-combinatorics.counting using
 open import univalent-combinatorics.equality-finite-types using
   ( set-UU-Fin-Level)
 open import univalent-combinatorics.equality-standard-finite-types using
-  ( Fin-Set; has-decidable-equality-Fin; two-distinct-elements-leq-2-Fin; is-set-Fin)
+  ( has-decidable-equality-Fin; two-distinct-elements-leq-2-Fin)
 open import univalent-combinatorics.finite-types using
   ( UU-Fin-Level; type-UU-Fin-Level; has-cardinality; has-cardinality-type-UU-Fin-Level)
 open import univalent-combinatorics.lists using
@@ -128,10 +128,11 @@ open import univalent-combinatorics.orientations-complete-undirected-graph using
     preserves-even-difference-orientation-complete-undirected-graph-equiv;
     preserves-id-equiv-orientation-complete-undirected-graph-equiv;
     equiv-fin-2-quotient-sign-count; orientation-complete-undirected-graph-equiv;
-    orientation-aut-count; is-decidable-even-difference-orientation-Complete-Undirected-Graph;
+    orientation-aut-count;
+    is-decidable-even-difference-orientation-Complete-Undirected-Graph;
     not-even-difference-orientation-aut-transposition-count)
 open import univalent-combinatorics.standard-finite-types using
-  ( Fin; equiv-succ-Fin; zero-Fin; nat-Fin; is-zero-nat-zero-Fin)
+  ( Fin; equiv-succ-Fin; zero-Fin; nat-Fin; is-zero-nat-zero-Fin; Fin-Set; is-set-Fin)
 ```
 
 ## Idea
@@ -542,7 +543,7 @@ module _
       ( raise-UU-Fin-Fin (succ-ℕ (succ-ℕ n)))
       ( star)
       ( equiv-raise l (Fin (succ-ℕ (succ-ℕ n))))) ∘e
-      ( equiv-succ-Fin ∘e
+      ( ( equiv-succ-Fin 2) ∘e
         ( inv-equiv
           ( equiv-fin-2-quotient-sign-equiv-Fin
             ( succ-ℕ (succ-ℕ n))
@@ -574,7 +575,7 @@ module _
         ( raise-UU-Fin-Fin (succ-ℕ (succ-ℕ n)))
         ( star)
         ( equiv-raise l (Fin (succ-ℕ (succ-ℕ n))))) ∘e
-        ( equiv-succ-Fin ∘e
+        ( ( equiv-succ-Fin 2) ∘e
           ( inv-equiv
             ( equiv-fin-2-quotient-sign-equiv-Fin
               ( succ-ℕ (succ-ℕ n))
@@ -731,7 +732,7 @@ module _
           ( star)
           ( equiv-raise l (Fin (succ-ℕ (succ-ℕ n))))))
       ( ( ap
-        ( map-equiv equiv-succ-Fin)
+        ( map-equiv (equiv-succ-Fin 2))
         ( q)) ∙
         ( inv r))) ∙
        ap
@@ -759,7 +760,7 @@ module _
           ( star)
           ( equiv-raise l (Fin (succ-ℕ (succ-ℕ n))))))
       ( ( ap
-        ( map-equiv equiv-succ-Fin)
+        ( map-equiv (equiv-succ-Fin 2))
         ( q)) ∙
         ( inv r))) ∙
        ap
@@ -1201,7 +1202,7 @@ module _
                                 ( ap
                                   ( map-hom-Group
                                     ( symmetric-Group
-                                      ( set-UU-Fin-Level
+                                      ( set-UU-Fin-Level (succ-ℕ (succ-ℕ n))
                                        ( pair (Fin (succ-ℕ (succ-ℕ n))) (unit-trunc-Prop id-equiv))))
                                     ( symmetric-Group (Fin-Set 2))
                                     ( sign-homomorphism

--- a/src/finite-group-theory/concrete-quaternion-group.lagda.md
+++ b/src/finite-group-theory/concrete-quaternion-group.lagda.md
@@ -35,55 +35,65 @@ equiv-face-standard-cube {succ-ℕ k} d a = {!!}
 -}
 
 equiv-face-cube :
-  {k : ℕ} (X Y : cube (succ-ℕ k)) (e : equiv-cube X Y) (d : dim-cube X)
-  (a : axis-cube X d) →
-  equiv-cube
-    ( face-cube X d a)
-    ( face-cube Y (map-dim-equiv-cube X Y e d) (map-axis-equiv-cube X Y e d a))
-equiv-face-cube X Y e d a =
+  (k : ℕ) (X Y : cube (succ-ℕ k)) (e : equiv-cube (succ-ℕ k) X Y)
+  (d : dim-cube (succ-ℕ k) X) (a : axis-cube (succ-ℕ k) X d) →
+  equiv-cube k
+    ( face-cube k X d a)
+    ( face-cube k Y
+      ( map-dim-equiv-cube (succ-ℕ k) X Y e d)
+      ( map-axis-equiv-cube (succ-ℕ k) X Y e d a))
+equiv-face-cube k X Y e d a =
   pair
-    ( equiv-complement-point-UU-Fin
-      ( pair (dim-cube-UU-Fin X) d)
-      ( pair (dim-cube-UU-Fin Y) (map-dim-equiv-cube X Y e d))
-      ( dim-equiv-cube X Y e)
+    ( equiv-complement-point-UU-Fin k
+      ( pair (dim-cube-UU-Fin (succ-ℕ k) X) d)
+      ( pair (dim-cube-UU-Fin (succ-ℕ k) Y) (map-dim-equiv-cube (succ-ℕ k) X Y e d))
+      ( dim-equiv-cube (succ-ℕ k) X Y e)
       ( refl))
     ( λ d' →
       ( equiv-tr
-        ( axis-cube Y)
+        ( axis-cube (succ-ℕ k) Y)
         ( inv
           ( natural-inclusion-equiv-complement-isolated-point
-            ( dim-equiv-cube X Y e)
-            ( pair d (λ z → has-decidable-equality-has-cardinality
-                            ( has-cardinality-dim-cube X) d z))
-            ( pair
-              ( map-dim-equiv-cube X Y e d)
+            ( dim-equiv-cube (succ-ℕ k) X Y e)
+            ( pair d
               ( λ z →
                 has-decidable-equality-has-cardinality
-                  ( has-cardinality-dim-cube Y)
-                  ( map-dim-equiv-cube X Y e d)
+                  ( succ-ℕ k)
+                  ( has-cardinality-dim-cube (succ-ℕ k) X)
+                  ( d)
+                  ( z)))
+            ( pair
+              ( map-dim-equiv-cube (succ-ℕ k) X Y e d)
+              ( λ z →
+                has-decidable-equality-has-cardinality
+                  ( succ-ℕ k)
+                  ( has-cardinality-dim-cube (succ-ℕ k) Y)
+                  ( map-dim-equiv-cube (succ-ℕ k) X Y e d)
                   ( z)))
             ( refl)
             ( d')))) ∘e
-      ( axis-equiv-cube X Y e
-        ( inclusion-complement-point-UU-Fin (pair (dim-cube-UU-Fin X) d) d')))
+      ( axis-equiv-cube (succ-ℕ k) X Y e
+        ( inclusion-complement-point-UU-Fin k
+          ( pair (dim-cube-UU-Fin (succ-ℕ k) X) d) d')))
 
 cube-with-labelled-faces :
   (k : ℕ) → UU (lsuc lzero)
 cube-with-labelled-faces k =
   Σ ( cube (succ-ℕ k))
-    ( λ X → (d : dim-cube X) (a : axis-cube X d) →
-            labelling-cube (face-cube X d a))
+    ( λ X →
+      (d : dim-cube (succ-ℕ k) X) (a : axis-cube (succ-ℕ k) X d) →
+      labelling-cube k (face-cube k X d a))
 
 cube-cube-with-labelled-faces :
-  {k : ℕ} → cube-with-labelled-faces k → cube (succ-ℕ k)
-cube-cube-with-labelled-faces X = pr1 X
+  (k : ℕ) → cube-with-labelled-faces k → cube (succ-ℕ k)
+cube-cube-with-labelled-faces k X = pr1 X
 
 labelling-faces-cube-with-labelled-faces :
-  {k : ℕ} (X : cube-with-labelled-faces k)
-  (d : dim-cube (cube-cube-with-labelled-faces X))
-  (a : axis-cube (cube-cube-with-labelled-faces X) d) →
-  labelling-cube (face-cube (cube-cube-with-labelled-faces X) d a)
-labelling-faces-cube-with-labelled-faces X = pr2 X
+  (k : ℕ) (X : cube-with-labelled-faces k)
+  (d : dim-cube (succ-ℕ k) (cube-cube-with-labelled-faces k X))
+  (a : axis-cube (succ-ℕ k) (cube-cube-with-labelled-faces k X) d) →
+  labelling-cube k (face-cube k (cube-cube-with-labelled-faces k X) d a)
+labelling-faces-cube-with-labelled-faces k X = pr2 X
 
 {-
 standard-cube-with-labelled-faces :
@@ -96,37 +106,39 @@ standard-cube-with-labelled-faces k =
 equiv-cube-with-labelled-faces :
   {k : ℕ} (X Y : cube-with-labelled-faces k) → UU lzero
 equiv-cube-with-labelled-faces {k} X Y =
-  Σ ( equiv-cube ( cube-cube-with-labelled-faces X)
-                 ( cube-cube-with-labelled-faces Y))
-    ( λ e → ( d : dim-cube (cube-cube-with-labelled-faces X))
-            ( a : axis-cube (cube-cube-with-labelled-faces X) d) →
-            htpy-equiv-cube
+  Σ ( equiv-cube (succ-ℕ k)
+      ( cube-cube-with-labelled-faces k X)
+      ( cube-cube-with-labelled-faces k Y))
+    ( λ e → ( d : dim-cube (succ-ℕ k) (cube-cube-with-labelled-faces k X))
+            ( a : axis-cube (succ-ℕ k) (cube-cube-with-labelled-faces k X) d) →
+            htpy-equiv-cube k
               ( standard-cube k)
-              ( face-cube
-                ( cube-cube-with-labelled-faces Y)
-                ( map-dim-equiv-cube
-                  ( cube-cube-with-labelled-faces X)
-                  ( cube-cube-with-labelled-faces Y)
-                  e d)
-                ( map-axis-equiv-cube
-                  ( cube-cube-with-labelled-faces X)
-                  ( cube-cube-with-labelled-faces Y)
+              ( face-cube k
+                ( cube-cube-with-labelled-faces k Y)
+                ( map-dim-equiv-cube (succ-ℕ k)
+                  ( cube-cube-with-labelled-faces k X)
+                  ( cube-cube-with-labelled-faces k Y)
+                  ( e)
+                  ( d))
+                ( map-axis-equiv-cube (succ-ℕ k)
+                  ( cube-cube-with-labelled-faces k X)
+                  ( cube-cube-with-labelled-faces k Y)
                   e d a))
-              ( comp-equiv-cube
+              ( comp-equiv-cube k
                 ( standard-cube k)
-                ( face-cube (pr1 X) d a)
-                ( face-cube (pr1 Y)
-                  ( map-dim-equiv-cube (pr1 X) (pr1 Y) e d)
-                  ( map-axis-equiv-cube (pr1 X) (pr1 Y) e d a))
-                ( equiv-face-cube (pr1 X) (pr1 Y) e d a)
-                ( labelling-faces-cube-with-labelled-faces X d a))
-              ( labelling-faces-cube-with-labelled-faces Y
-                ( map-dim-equiv-cube
-                  ( cube-cube-with-labelled-faces X)
-                  ( cube-cube-with-labelled-faces Y)
+                ( face-cube k (pr1 X) d a)
+                ( face-cube k (pr1 Y)
+                  ( map-dim-equiv-cube (succ-ℕ k) (pr1 X) (pr1 Y) e d)
+                  ( map-axis-equiv-cube (succ-ℕ k) (pr1 X) (pr1 Y) e d a))
+                ( equiv-face-cube k (pr1 X) (pr1 Y) e d a)
+                ( labelling-faces-cube-with-labelled-faces k X d a))
+              ( labelling-faces-cube-with-labelled-faces k Y
+                ( map-dim-equiv-cube (succ-ℕ k)
+                  ( cube-cube-with-labelled-faces k X)
+                  ( cube-cube-with-labelled-faces k Y)
                   e d)
-                ( map-axis-equiv-cube
-                  ( cube-cube-with-labelled-faces X)
-                  ( cube-cube-with-labelled-faces Y)
+                ( map-axis-equiv-cube (succ-ℕ k)
+                  ( cube-cube-with-labelled-faces k X)
+                  ( cube-cube-with-labelled-faces k Y)
                   e d a)))
 ```

--- a/src/finite-group-theory/finite-groups.lagda.md
+++ b/src/finite-group-theory/finite-groups.lagda.md
@@ -52,9 +52,9 @@ Group-of-Order : (l : Level) (n : ℕ) → UU (lsuc l)
 Group-of-Order l n = Σ (Group l) (λ G → mere-equiv (Fin n) (type-Group G))
 
 is-finite-is-group :
-  {l : Level} {n : ℕ} (G : Semigroup-of-Order l n) →
+  {l : Level} (n : ℕ) (G : Semigroup-of-Order l n) →
   is-finite {l} (is-group (pr1 G))
-is-finite-is-group {l} {n} G =
+is-finite-is-group {l} n G =
   apply-universal-property-trunc-Prop
     ( pr2 G)
     ( is-finite-Prop _)
@@ -108,7 +108,7 @@ is-π-finite-Group-of-Order {l} k n =
       ( is-π-finite-Semigroup-of-Order (succ-ℕ k) n)
       ( λ X →
         is-π-finite-is-finite k
-          ( is-finite-is-group X)))
+          ( is-finite-is-group n X)))
   where
   e : Group-of-Order l n ≃
       Σ (Semigroup-of-Order l n) (λ X → is-group (pr1 X))

--- a/src/finite-group-theory/finite-monoids.lagda.md
+++ b/src/finite-group-theory/finite-monoids.lagda.md
@@ -58,9 +58,9 @@ Monoid-of-Order l n = Σ (Monoid l) (λ M → mere-equiv (Fin n) (type-Monoid M)
 
 ```agda
 is-finite-is-unital-Semigroup :
-  {l : Level} {n : ℕ} (X : Semigroup-of-Order l n) →
+  {l : Level} (n : ℕ) (X : Semigroup-of-Order l n) →
   is-finite (is-unital-Semigroup (pr1 X))
-is-finite-is-unital-Semigroup {l} {n} X =
+is-finite-is-unital-Semigroup {l} n X =
   apply-universal-property-trunc-Prop
     ( pr2 X)
     ( is-finite-Prop _)
@@ -98,7 +98,7 @@ is-π-finite-Monoid-of-Order {l} k n =
       ( is-π-finite-Semigroup-of-Order (succ-ℕ k) n)
       ( λ X →
         is-π-finite-is-finite k
-          ( is-finite-is-unital-Semigroup X)))
+          ( is-finite-is-unital-Semigroup n X)))
   where
   e : Monoid-of-Order l n ≃
       Σ (Semigroup-of-Order l n) (λ X → is-unital-Semigroup (pr1 X))

--- a/src/finite-group-theory/finite-semigroups.lagda.md
+++ b/src/finite-group-theory/finite-semigroups.lagda.md
@@ -52,7 +52,7 @@ Finite semigroups are semigroups of which the underlying type is finite.
 Semigroup-of-Order' : (l : Level) (n : ℕ) → UU (lsuc l)
 Semigroup-of-Order' l n =
   Σ ( UU-Fin-Level l n)
-    ( λ X → has-associative-mul (type-UU-Fin-Level X))
+    ( λ X → has-associative-mul (type-UU-Fin-Level n X))
 
 Semigroup-of-Order : (l : Level) (n : ℕ) → UU (lsuc l)
 Semigroup-of-Order l n =
@@ -90,7 +90,7 @@ is-π-finite-Semigroup-of-Order' k n =
     ( λ x →
       is-π-finite-is-finite k
         ( is-finite-has-associative-mul
-          ( is-finite-type-UU-Fin-Level x)))
+          ( is-finite-type-UU-Fin-Level n x)))
 
 is-π-finite-Semigroup-of-Order :
   {l : Level} (k n : ℕ) → is-π-finite k (Semigroup-of-Order l n)
@@ -100,13 +100,13 @@ is-π-finite-Semigroup-of-Order {l} k n =
   where
   e : Semigroup-of-Order l n ≃ Semigroup-of-Order' l n
   e = ( equiv-Σ
-        ( has-associative-mul ∘ type-UU-Fin-Level)
+        ( has-associative-mul ∘ type-UU-Fin-Level n)
         ( ( right-unit-law-Σ-is-contr
             ( λ X →
               is-proof-irrelevant-is-prop
                 ( is-prop-is-set _)
                 ( is-set-is-finite
-                  ( is-finite-has-cardinality (pr2 X))))) ∘e
+                  ( is-finite-has-cardinality n (pr2 X))))) ∘e
           ( equiv-right-swap-Σ))
         ( λ X → id-equiv)) ∘e
       ( equiv-right-swap-Σ

--- a/src/finite-group-theory/orbits-permutations.lagda.md
+++ b/src/finite-group-theory/orbits-permutations.lagda.md
@@ -175,23 +175,33 @@ module _
   -- The map `i ↦ eⁱ a` repeats itself
   
   repetition-iterate-automorphism-Fin :
-    repetition (λ k → iterate (nat-Fin k) (map-equiv f) a)
+    repetition
+      ( λ (k : Fin (succ-ℕ (number-of-elements-count eX))) →
+        iterate (nat-Fin (succ-ℕ (number-of-elements-count eX)) k) (map-equiv f) a)
   repetition-iterate-automorphism-Fin =
     repetition-le-count
       ( count-Fin (succ-ℕ (number-of-elements-count eX)))
       ( eX)
-      ( λ k → iterate (nat-Fin k) (map-equiv f) a)
+      ( λ k → iterate (nat-Fin (succ-ℕ (number-of-elements-count eX)) k) (map-equiv f) a)
       ( succ-le-ℕ (number-of-elements-count eX))
 
   point1-iterate-ℕ : ℕ
-  point1-iterate-ℕ = nat-Fin (pr1 (pr1 repetition-iterate-automorphism-Fin))
+  point1-iterate-ℕ =
+    nat-Fin
+      ( succ-ℕ (number-of-elements-count eX))
+      ( pr1 (pr1 repetition-iterate-automorphism-Fin))
 
   point2-iterate-ℕ : ℕ
-  point2-iterate-ℕ = nat-Fin (pr1 (pr2 (pr1 repetition-iterate-automorphism-Fin)))
+  point2-iterate-ℕ =
+    nat-Fin
+      ( succ-ℕ (number-of-elements-count eX))
+      ( pr1 (pr2 (pr1 repetition-iterate-automorphism-Fin)))
 
   neq-points-iterate-ℕ : ¬ (Id point1-iterate-ℕ point2-iterate-ℕ)
   neq-points-iterate-ℕ p =
-    pr2 (pr2 (pr1 repetition-iterate-automorphism-Fin)) (is-injective-nat-Fin p)
+    pr2
+      ( pr2 (pr1 repetition-iterate-automorphism-Fin))
+      ( is-injective-nat-Fin (succ-ℕ (number-of-elements-count eX)) p)
  
   two-points-iterate-ordered-ℕ :
     coprod
@@ -223,9 +233,13 @@ module _
         ( point2-iterate-ℕ ≤-ℕ point1-iterate-ℕ)) →
     pr1 (two-points-iterate-ordered-ℕ p) ≤-ℕ number-of-elements-count eX
   leq-greater-point-number-elements (inl p) =
-    ( upper-bound-nat-Fin (pr1 (pr2 (pr1 repetition-iterate-automorphism-Fin))))
+    ( upper-bound-nat-Fin
+      ( number-of-elements-count eX)
+      ( pr1 (pr2 (pr1 repetition-iterate-automorphism-Fin))))
   leq-greater-point-number-elements (inr p) =
-    ( upper-bound-nat-Fin (pr1 (pr1 repetition-iterate-automorphism-Fin)))
+    ( upper-bound-nat-Fin
+      ( number-of-elements-count eX)
+      ( pr1 (pr1 repetition-iterate-automorphism-Fin)))
 
   abstract
     min-repeating :
@@ -443,10 +457,10 @@ module _
 
 ```agda
 module _
-  {l : Level} (n : ℕ) (X : UU-Fin-Level l n) (f : Aut (type-UU-Fin-Level X)) 
+  {l : Level} (n : ℕ) (X : UU-Fin-Level l n) (f : Aut (type-UU-Fin-Level n X)) 
   where
 
-  same-orbits-permutation : Eq-Rel l (type-UU-Fin-Level X)
+  same-orbits-permutation : Eq-Rel l (type-UU-Fin-Level n X)
   (pr1 same-orbits-permutation) a b =
     trunc-Prop (Σ ℕ (λ k → Id (iterate k (map-equiv f) a) b))
   pr1 (pr2 same-orbits-permutation) = unit-trunc-Prop (pair 0 refl)
@@ -456,7 +470,7 @@ module _
       ( pr1 same-orbits-permutation b a)
       ( λ (pair k p) →
         apply-universal-property-trunc-Prop
-          ( has-cardinality-type-UU-Fin-Level X)
+          ( has-cardinality-type-UU-Fin-Level n X)
           ( pr1 same-orbits-permutation b a)
           ( λ h →
             unit-trunc-Prop
@@ -468,18 +482,18 @@ module _
                         ( λ x → iterate x (map-equiv f) a)
                         ( pr2 (lemma h k))) ∙
                       ( mult-has-finite-orbits-permutation
-                        ( type-UU-Fin-Level X)
+                        ( type-UU-Fin-Level n X)
                         ( pair n h)
                         ( f)
                         ( a)
                         ( k))))))))
     where
     has-finite-orbits-permutation-a :
-      (h : Fin n ≃ type-UU-Fin-Level X) →
+      (h : Fin n ≃ type-UU-Fin-Level n X) →
       Σ ℕ (λ l → (is-nonzero-ℕ l) × Id (iterate l (map-equiv f) a) a)
     has-finite-orbits-permutation-a h =
-      has-finite-orbits-permutation (type-UU-Fin-Level X) (pair n h) f a
-    lemma : (h : Fin n ≃ type-UU-Fin-Level X) (k : ℕ) →
+      has-finite-orbits-permutation (type-UU-Fin-Level n X) (pair n h) f a
+    lemma : (h : Fin n ≃ type-UU-Fin-Level n X) (k : ℕ) →
       Σ ( ℕ)
         ( λ j →
           Id (add-ℕ j k) (mul-ℕ k (pr1 (has-finite-orbits-permutation-a h))))
@@ -508,11 +522,11 @@ module _
 
   abstract
     is-decidable-same-orbits-permutation :
-      ( a b : type-UU-Fin-Level X) →
+      ( a b : type-UU-Fin-Level n X) →
       is-decidable (sim-Eq-Rel same-orbits-permutation a b) 
     is-decidable-same-orbits-permutation a b =
       apply-universal-property-trunc-Prop
-        ( has-cardinality-type-UU-Fin-Level X)
+        ( has-cardinality-type-UU-Fin-Level n X)
         ( is-decidable-Prop (prop-Eq-Rel same-orbits-permutation a b))
         ( λ h →
           is-decidable-trunc-Prop-is-merely-decidable
@@ -526,13 +540,13 @@ module _
                   ( λ z →
                     has-decidable-equality-equiv
                       ( inv-equiv h)
-                      ( has-decidable-equality-Fin)
+                      ( has-decidable-equality-Fin n)
                       ( iterate z (map-equiv f) a)
                       ( b))
                   ( λ m p → p)))))
       where
       is-decidable-iterate-is-decidable-bounded :
-        ( h : Fin n ≃ type-UU-Fin-Level X) (a b : type-UU-Fin-Level X) →
+        ( h : Fin n ≃ type-UU-Fin-Level n X) (a b : type-UU-Fin-Level n X) →
         is-decidable
           ( Σ ℕ (λ m → (m ≤-ℕ n) × (Id (iterate m (map-equiv f) a) b))) →
         is-decidable (Σ ℕ (λ m → Id (iterate m (map-equiv f) a) b))
@@ -554,12 +568,12 @@ module _
                          ( pr1
                            ( pr2
                              ( has-finite-orbits-permutation
-                               ( type-UU-Fin-Level X)
+                               ( type-UU-Fin-Level n X)
                                ( pair n h)
                                ( f)
                                ( a)))))
                        ( leq-has-finite-orbits-permutation-number-elements
-                         ( type-UU-Fin-Level X)
+                         ( type-UU-Fin-Level n X)
                          ( pair n h)
                          ( f)
                          ( a))))
@@ -569,7 +583,7 @@ module _
                          ( map-equiv f))
                        ( inv
                          ( mult-has-finite-orbits-permutation
-                           ( type-UU-Fin-Level X)
+                           ( type-UU-Fin-Level n X)
                            ( pair n h)
                            ( f)
                            ( a)
@@ -593,7 +607,7 @@ module _
         m : ℕ
         m = pr1
             ( has-finite-orbits-permutation
-              ( type-UU-Fin-Level X)
+              ( type-UU-Fin-Level n X)
               ( pair n h)
               ( f)
               ( a))
@@ -601,7 +615,7 @@ module _
   abstract
     is-decidable-is-in-subtype-equivalence-class-same-orbits-permutation :
       (T : equivalence-class same-orbits-permutation) →
-      (a : type-UU-Fin-Level X) →
+      (a : type-UU-Fin-Level n X) →
       is-decidable (is-in-subtype-equivalence-class same-orbits-permutation T a)
     is-decidable-is-in-subtype-equivalence-class-same-orbits-permutation T a =
       is-decidable-is-in-subtype-equivalence-class-is-decidable
@@ -615,10 +629,10 @@ module _
       is-finite (equivalence-class same-orbits-permutation)
     has-finite-number-orbits-permutation =
       is-finite-codomain
-        ( is-finite-type-UU-Fin-Level X)
+        ( is-finite-type-UU-Fin-Level n X)
         ( is-surjective-class same-orbits-permutation)
         ( apply-universal-property-trunc-Prop
-          ( has-cardinality-type-UU-Fin-Level X)
+          ( has-cardinality-type-UU-Fin-Level n X)
           ( pair
             ( has-decidable-equality
               ( equivalence-class same-orbits-permutation))
@@ -631,11 +645,12 @@ module _
           ( λ (pair t1 p1) →
             cases-decidable-equality T1 T2 t1
               ( eq-pair-Σ (inv p1) (all-elements-equal-type-trunc-Prop _ _))
-              ( is-decidable-is-in-subtype-equivalence-class-same-orbits-permutation T2 t1))))
+              ( is-decidable-is-in-subtype-equivalence-class-same-orbits-permutation
+                T2 t1))))
       where
       cases-decidable-equality :
         (T1 T2 : equivalence-class same-orbits-permutation)
-        (t1 : type-UU-Fin-Level X) →
+        (t1 : type-UU-Fin-Level n X) →
         Id T1 (class same-orbits-permutation t1) →
         is-decidable
           ( is-in-subtype-equivalence-class same-orbits-permutation T2 t1) →
@@ -656,7 +671,7 @@ module _
 
   sign-permutation-orbit : Fin 2
   sign-permutation-orbit =
-    iterate (add-ℕ n number-of-orbits-permutation) (succ-Fin {k = 2}) zero-Fin
+    iterate (add-ℕ n number-of-orbits-permutation) (succ-Fin 2) (zero-Fin 1)
 ```
 
 ```agda
@@ -1622,7 +1637,7 @@ module _
     opposite-sign-composition-transposition-count : (g : X ≃ X) →
       Id
         (sign-permutation-orbit (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX))) g)
-        (succ-Fin (sign-permutation-orbit (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX)))
+        (succ-Fin 2 (sign-permutation-orbit (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX)))
           (composition-transposition-a-b g)))
     opposite-sign-composition-transposition-count g =
       cases-opposite-sign-composition-transposition
@@ -1631,15 +1646,15 @@ module _
       cases-opposite-sign-composition-transposition : is-decidable (sim-Eq-Rel (same-orbits-permutation-count g) a b) →
         Id
           (sign-permutation-orbit (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX))) g)
-          (succ-Fin (sign-permutation-orbit (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX)))
+          (succ-Fin 2 (sign-permutation-orbit (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX)))
             (composition-transposition-a-b g)))
       cases-opposite-sign-composition-transposition (inl P) =
-        inv (is-involution-aut-Fin-two-ℕ equiv-succ-Fin
+        inv (is-involution-aut-Fin-two-ℕ (equiv-succ-Fin 2)
           (sign-permutation-orbit (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX))) g)) ∙
-          ap (λ k → succ-Fin (iterate (add-ℕ (number-of-elements-count eX) k) succ-Fin zero-Fin))
+          ap (λ k → succ-Fin 2 (iterate (add-ℕ (number-of-elements-count eX) k) (succ-Fin 2) (zero-Fin 1)))
             (number-orbits-composition-transposition g P)
       cases-opposite-sign-composition-transposition (inr NP) =
-        ap (λ k → iterate (add-ℕ (number-of-elements-count eX) k) succ-Fin zero-Fin)
+        ap (λ k → iterate (add-ℕ (number-of-elements-count eX) k) (succ-Fin 2) (zero-Fin 1))
           ( number-orbits-composition-transposition' g NP)
 
 module _
@@ -1650,17 +1665,17 @@ module _
     sign-list-transpositions-count :
       ( li : list (Σ (X → decidable-Prop l) (λ P → has-cardinality 2 (Σ X (λ x → type-decidable-Prop (P x)))))) →
       Id
-        ( iterate (length-list li) succ-Fin
+        ( iterate (length-list li) (succ-Fin 2)
           ( sign-permutation-orbit (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX))) id-equiv))
         ( sign-permutation-orbit (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX)))
           ( permutation-list-transpositions li))
     sign-list-transpositions-count nil = refl
     sign-list-transpositions-count (cons t li) =
-      ap succ-Fin
+      ap (succ-Fin 2)
         ( (sign-list-transpositions-count li) ∙
           opposite-sign-composition-transposition-count X eX (pr1 two-elements-t) (pr1 (pr2 two-elements-t))
             ( pr1 (pr2 (pr2 two-elements-t))) (permutation-list-transpositions li )) ∙
-        ( is-involution-aut-Fin-two-ℕ equiv-succ-Fin
+        ( is-involution-aut-Fin-two-ℕ (equiv-succ-Fin 2)
           (sign-permutation-orbit (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX)))
             (permutation-list-transpositions
               (cons (standard-2-Element-Decidable-Subtype (has-decidable-equality-count eX)

--- a/src/finite-group-theory/permutations.lagda.md
+++ b/src/finite-group-theory/permutations.lagda.md
@@ -89,14 +89,14 @@ open import univalent-combinatorics.counting using
 open import univalent-combinatorics.equality-finite-types using
   ( set-UU-Fin-Level)
 open import univalent-combinatorics.equality-standard-finite-types using
-  ( has-decidable-equality-Fin; Fin-Set)
+  ( has-decidable-equality-Fin)
 open import univalent-combinatorics.finite-types using
   ( has-cardinality; UU-Fin-Level; type-UU-Fin-Level; has-cardinality-type-UU-Fin-Level)
 open import univalent-combinatorics.lists using
   ( cons; list; fold-list; map-list; nil; length-list; concat-list;
     length-concat-list)
 open import univalent-combinatorics.standard-finite-types using
-  ( Fin; nat-Fin; succ-Fin; equiv-succ-Fin; zero-Fin)
+  ( Fin; nat-Fin; succ-Fin; equiv-succ-Fin; zero-Fin; Fin-Set)
 ```
 
 ## Properties
@@ -126,7 +126,11 @@ list-transpositions-permutation-Fin' (succ-ℕ n) f (inl x) p =
     ( λ P →
       has-cardinality 2
         ( Σ (Fin (succ-ℕ (succ-ℕ n))) (λ x → type-decidable-Prop (P x)))))
-  t = standard-2-Element-Decidable-Subtype has-decidable-equality-Fin {inr star} {inl x} neq-inr-inl 
+  t = standard-2-Element-Decidable-Subtype
+      ( has-decidable-equality-Fin (succ-ℕ (succ-ℕ n)))
+      { inr star}
+      { inl x}
+      ( neq-inr-inl)
   f' : (Fin (succ-ℕ n) ≃ Fin (succ-ℕ n))
   f' =
     map-inv-equiv
@@ -134,7 +138,11 @@ list-transpositions-permutation-Fin' (succ-ℕ n) f (inl x) p =
       ( pair
         ( transposition t ∘e f)
         ( ( ap (λ y → map-transposition t y) p) ∙
-          right-computation-standard-transposition has-decidable-equality-Fin {inr star} {inl x} neq-inr-inl))
+          ( right-computation-standard-transposition
+            ( has-decidable-equality-Fin (succ-ℕ (succ-ℕ n)))
+            { inr star}
+            { inl x}
+            ( neq-inr-inl))))
 list-transpositions-permutation-Fin' (succ-ℕ n) f (inr star) p =
   map-list
     ( Fin-succ-Fin-transposition (succ-ℕ n))
@@ -194,29 +202,46 @@ abstract
       ( λ P →
         has-cardinality 2
           ( Σ (Fin (succ-ℕ (succ-ℕ n))) (λ x → type-decidable-Prop (P x)))))
-    t = standard-2-Element-Decidable-Subtype has-decidable-equality-Fin {inr star} {inl x} neq-inr-inl 
-    P : Σ (Fin (succ-ℕ (succ-ℕ n)) ≃ Fin (succ-ℕ (succ-ℕ n))) (λ g → Id (map-equiv g (inr star)) (inr star))
-    P = pair
-      ( transposition t ∘e f)
-      ( ( ap (λ y → map-transposition t y) p) ∙
-        right-computation-standard-transposition has-decidable-equality-Fin {inr star} {inl x} neq-inr-inl)
+    t =
+      standard-2-Element-Decidable-Subtype
+        ( has-decidable-equality-Fin (succ-ℕ (succ-ℕ n)))
+        { inr star}
+        { inl x}
+        ( neq-inr-inl)
+    P :
+      Σ ( Fin (succ-ℕ (succ-ℕ n)) ≃ Fin (succ-ℕ (succ-ℕ n)))
+        ( λ g → Id (map-equiv g (inr star)) (inr star))
+    P =
+      pair
+        ( transposition t ∘e f)
+        ( ( ap (λ y → map-transposition t y) p) ∙
+          ( right-computation-standard-transposition
+            ( has-decidable-equality-Fin (succ-ℕ (succ-ℕ n)))
+            { inr star}
+            { inl x}
+            ( neq-inr-inl)))
     F' : (Fin (succ-ℕ n) ≃ Fin (succ-ℕ n))
     F' = map-inv-equiv (extend-equiv-Maybe (Fin-Set (succ-ℕ n))) P
     lemma2 : Id
       (map-equiv
       (transposition t) (inl z))
       (inl z)
-    lemma2 = is-fixed-point-standard-transposition
-            ( has-decidable-equality-Fin)
-            { inr star}
-            { inl x}
-            ( neq-inr-inl)
-            ( inl z)
-            ( neq-inr-inl)
-            ( λ r →
-              neq-inr-inl
-                ( is-injective-map-equiv f (p ∙ (r ∙ inv q))))
-    lemma : Id (map-equiv (pr1 (map-equiv (extend-equiv-Maybe (Fin-Set (succ-ℕ n))) F')) (inl y)) (inl z)
+    lemma2 =
+      is-fixed-point-standard-transposition
+        ( has-decidable-equality-Fin (succ-ℕ (succ-ℕ n)))
+        { inr star}
+        { inl x}
+        ( neq-inr-inl)
+        ( inl z)
+        ( neq-inr-inl)
+        ( λ r →
+          neq-inr-inl
+            ( is-injective-map-equiv f (p ∙ (r ∙ inv q))))
+    lemma :
+      Id ( map-equiv
+           ( pr1 (map-equiv (extend-equiv-Maybe (Fin-Set (succ-ℕ n))) F'))
+           ( inl y))
+         ( inl z)
     lemma =
       ( ap (λ e → map-equiv (pr1 (map-equiv e P)) (inl y)) (right-inverse-law-equiv (extend-equiv-Maybe (Fin-Set (succ-ℕ n))))) ∙
         ( ap (map-equiv (transposition t)) q ∙ lemma2)
@@ -248,7 +273,7 @@ abstract
             ( λ w → retr-permutation-list-transpositions-Fin' n _ (map-equiv F' (inr star)) refl w (map-equiv F' w) refl)) ∙
           ( (ap (map-equiv (transposition t)) lemma) ∙
             ( (right-computation-standard-transposition
-              ( has-decidable-equality-Fin)
+              ( has-decidable-equality-Fin (succ-ℕ (succ-ℕ n)))
               { inr star}
               { inl x}
               ( neq-inr-inl)) ∙
@@ -259,19 +284,19 @@ abstract
       ( λ P →
         has-cardinality 2
           ( Σ (Fin (succ-ℕ (succ-ℕ n))) (λ x → type-decidable-Prop (P x)))))
-    t = standard-2-Element-Decidable-Subtype has-decidable-equality-Fin {inr star} {inl x} neq-inr-inl 
+    t = standard-2-Element-Decidable-Subtype (has-decidable-equality-Fin (succ-ℕ (succ-ℕ n))) {inr star} {inl x} neq-inr-inl 
     P : Σ (Fin (succ-ℕ (succ-ℕ n)) ≃ Fin (succ-ℕ (succ-ℕ n))) (λ g → Id (map-equiv g (inr star)) (inr star))
     P = pair
       ( transposition t ∘e f)
       ( ( ap (λ y → map-transposition t y) p) ∙
-        right-computation-standard-transposition has-decidable-equality-Fin {inr star} {inl x} neq-inr-inl)
+        right-computation-standard-transposition (has-decidable-equality-Fin (succ-ℕ (succ-ℕ n))) {inr star} {inl x} neq-inr-inl)
     F' : (Fin (succ-ℕ n) ≃ Fin (succ-ℕ n))
     F' = map-inv-equiv (extend-equiv-Maybe (Fin-Set (succ-ℕ n))) P
     lemma : Id (map-equiv (pr1 (map-equiv (extend-equiv-Maybe (Fin-Set (succ-ℕ n))) F')) (inl y)) (inl x)
     lemma =
       ( ap (λ e → map-equiv (pr1 (map-equiv e P)) (inl y)) (right-inverse-law-equiv (extend-equiv-Maybe (Fin-Set (succ-ℕ n))))) ∙
         ( ap (map-equiv (transposition t)) q ∙
-          ( left-computation-standard-transposition has-decidable-equality-Fin {inr star} {inl x} neq-inr-inl))
+          ( left-computation-standard-transposition (has-decidable-equality-Fin (succ-ℕ (succ-ℕ n))) {inr star} {inl x} neq-inr-inl))
   retr-permutation-list-transpositions-Fin' (succ-ℕ n) f (inl x) p (inr star) z q =
     ap 
       (λ w →
@@ -289,7 +314,7 @@ abstract
         ( ap
           ( map-equiv (transposition t))
           ( pr2 (map-equiv (extend-equiv-Maybe (Fin-Set (succ-ℕ n))) F')) ∙
-          ( left-computation-standard-transposition has-decidable-equality-Fin {inr star} {inl x} neq-inr-inl ∙
+          ( left-computation-standard-transposition (has-decidable-equality-Fin (succ-ℕ (succ-ℕ n))) {inr star} {inl x} neq-inr-inl ∙
             inv p)))
     where
     t : ( Σ
@@ -297,7 +322,7 @@ abstract
       ( λ P →
         has-cardinality 2
           ( Σ (Fin (succ-ℕ (succ-ℕ n))) (λ x → type-decidable-Prop (P x)))))
-    t = standard-2-Element-Decidable-Subtype has-decidable-equality-Fin {inr star} {inl x} neq-inr-inl 
+    t = standard-2-Element-Decidable-Subtype (has-decidable-equality-Fin (succ-ℕ (succ-ℕ n))) {inr star} {inl x} neq-inr-inl 
     F' : (Fin (succ-ℕ n) ≃ Fin (succ-ℕ n))
     F' =
       map-inv-equiv
@@ -305,7 +330,7 @@ abstract
         ( pair
           ( transposition t ∘e f)
           ( ( ap (λ y → map-transposition t y) p) ∙
-            right-computation-standard-transposition has-decidable-equality-Fin {inr star} {inl x} neq-inr-inl))
+            right-computation-standard-transposition (has-decidable-equality-Fin (succ-ℕ (succ-ℕ n))) {inr star} {inl x} neq-inr-inl))
   retr-permutation-list-transpositions-Fin' (succ-ℕ n) f (inr star) p (inl y) (inl z) q =
     ap 
       (λ w →
@@ -398,13 +423,13 @@ module _
 
   is-generated-transposition-symmetric-Fin-Level :
     is-generating-subset-Group
-      ( symmetric-Group (set-UU-Fin-Level X))
+      ( symmetric-Group (set-UU-Fin-Level n X))
       ( is-transposition-permutation-Prop)
   is-generated-transposition-symmetric-Fin-Level f _ =
     apply-universal-property-trunc-Prop
-      ( has-cardinality-type-UU-Fin-Level X)
+      ( has-cardinality-type-UU-Fin-Level n X)
       ( subset-subgroup-subset-Group
-        ( symmetric-Group (set-UU-Fin-Level X))
+        ( symmetric-Group (set-UU-Fin-Level n X))
         ( is-transposition-permutation-Prop)
         ( f))
       ( λ h →
@@ -412,14 +437,14 @@ module _
           ( pair
             ( map-list
               ( λ x → pair (inr star) (pair (transposition x) (unit-trunc-Prop (pair x refl))))
-              ( list-transpositions-permutation-count (type-UU-Fin-Level X) (pair n h) f))
-            ( ( lemma (list-transpositions-permutation-count (type-UU-Fin-Level X) (pair n h) f)) ∙
-              ( eq-htpy-equiv (retr-permutation-list-transpositions-count (type-UU-Fin-Level X) (pair n h) f)))))
+              ( list-transpositions-permutation-count (type-UU-Fin-Level n X) (pair n h) f))
+            ( ( lemma (list-transpositions-permutation-count (type-UU-Fin-Level n X) (pair n h) f)) ∙
+              ( eq-htpy-equiv (retr-permutation-list-transpositions-count (type-UU-Fin-Level n X) (pair n h) f)))))
     where
-    lemma : (l : list (2-Element-Decidable-Subtype l2 (type-UU-Fin-Level X))) →
+    lemma : (l : list (2-Element-Decidable-Subtype l2 (type-UU-Fin-Level n X))) →
       Id
         ( ev-formal-combination-subset-Group
-          ( symmetric-Group (set-UU-Fin-Level X))
+          ( symmetric-Group (set-UU-Fin-Level n X))
           ( is-transposition-permutation-Prop)
           ( map-list
             ( λ x →
@@ -438,7 +463,7 @@ module _
   where
 
   module _
-    (f : (type-UU-Fin-Level X) ≃ (type-UU-Fin-Level X))
+    (f : (type-UU-Fin-Level n X) ≃ (type-UU-Fin-Level n X))
     where
     
     parity-transposition-permutation : UU (lsuc l)
@@ -447,15 +472,15 @@ module _
         type-trunc-Prop
           (Σ
             ( list
-              ( Σ ((type-UU-Fin-Level X) → decidable-Prop l)
-                ( λ P → has-cardinality 2 (Σ (type-UU-Fin-Level X) (λ x → type-decidable-Prop (P x))))))
+              ( Σ ((type-UU-Fin-Level n X) → decidable-Prop l)
+                ( λ P → has-cardinality 2 (Σ (type-UU-Fin-Level n X) (λ x → type-decidable-Prop (P x))))))
             ( λ li → Id k (mod-two-ℕ (length-list li)) × Id f (permutation-list-transpositions li))))
 
     abstract
       is-contr-parity-transposition-permutation : is-contr parity-transposition-permutation
       is-contr-parity-transposition-permutation =
         apply-universal-property-trunc-Prop
-          ( has-cardinality-type-UU-Fin-Level X)
+          ( has-cardinality-type-UU-Fin-Level n X)
           ( is-trunc-Prop neg-two-𝕋 parity-transposition-permutation)
           ( λ h →
             pair
@@ -465,41 +490,41 @@ module _
                   ( pair (list-transposition-f h)
                     ( pair refl
                       ( inv
-                        ( eq-htpy-equiv (retr-permutation-list-transpositions-count (type-UU-Fin-Level X) (pair n h) f)))))))
+                        ( eq-htpy-equiv (retr-permutation-list-transpositions-count (type-UU-Fin-Level n X) (pair n h) f)))))))
               ( λ (pair k u) →
                 eq-pair-Σ
                   ( apply-universal-property-trunc-Prop u
                     ( Id-Prop (Fin-Set 2) (mod-two-ℕ (length-list (list-transposition-f h))) k)
                     ( λ (pair li (pair q r)) →
                       is-injective-iterate-involution (mod-two-ℕ (length-list (list-transposition-f h))) k
-                        ( sign-permutation-orbit n (pair (type-UU-Fin-Level X) (unit-trunc-Prop h)) id-equiv)
+                        ( sign-permutation-orbit n (pair (type-UU-Fin-Level n X) (unit-trunc-Prop h)) id-equiv)
                         ( inv
-                          ( iterate-involution succ-Fin (is-involution-aut-Fin-two-ℕ equiv-succ-Fin)
+                          ( iterate-involution (succ-Fin 2) (is-involution-aut-Fin-two-ℕ (equiv-succ-Fin 2))
                             (length-list (list-transposition-f h))
-                            (sign-permutation-orbit n (pair (type-UU-Fin-Level X) (unit-trunc-Prop h)) id-equiv)) ∙
-                          ( sign-list-transpositions-count (type-UU-Fin-Level X) (pair n h) (list-transposition-f h) ∙
+                            (sign-permutation-orbit n (pair (type-UU-Fin-Level n X) (unit-trunc-Prop h)) id-equiv)) ∙
+                          ( sign-list-transpositions-count (type-UU-Fin-Level n X) (pair n h) (list-transposition-f h) ∙
                             ( ap
-                              ( sign-permutation-orbit n (pair (type-UU-Fin-Level X) (unit-trunc-Prop h)))
+                              ( sign-permutation-orbit n (pair (type-UU-Fin-Level n X) (unit-trunc-Prop h)))
                               { x = permutation-list-transpositions (list-transposition-f h)}
                               { y = permutation-list-transpositions li}
                               ( (eq-htpy-equiv (retr-permutation-list-transpositions-count
-                                (type-UU-Fin-Level X) (pair n h) f)) ∙ r) ∙
-                              ( inv (sign-list-transpositions-count (type-UU-Fin-Level X) (pair n h) li) ∙
-                                ( (iterate-involution succ-Fin (is-involution-aut-Fin-two-ℕ equiv-succ-Fin) (length-list li)
-                                  ( sign-permutation-orbit n (pair (type-UU-Fin-Level X) (unit-trunc-Prop h)) id-equiv)) ∙
+                                (type-UU-Fin-Level n X) (pair n h) f)) ∙ r) ∙
+                              ( inv (sign-list-transpositions-count (type-UU-Fin-Level n X) (pair n h) li) ∙
+                                ( (iterate-involution (succ-Fin 2) (is-involution-aut-Fin-two-ℕ (equiv-succ-Fin 2)) (length-list li)
+                                  ( sign-permutation-orbit n (pair (type-UU-Fin-Level n X) (unit-trunc-Prop h)) id-equiv)) ∙
                                   ( ap
-                                    ( λ k → iterate (nat-Fin k) succ-Fin
-                                      ( sign-permutation-orbit n (pair (type-UU-Fin-Level X) (unit-trunc-Prop h)) id-equiv))
+                                    ( λ k → iterate (nat-Fin 2 k) (succ-Fin 2)
+                                      ( sign-permutation-orbit n (pair (type-UU-Fin-Level n X) (unit-trunc-Prop h)) id-equiv))
                                     ( inv q)))))))))
                   ( eq-is-prop is-prop-type-trunc-Prop)))
         where
-        list-transposition-f : (h : Fin n ≃ (type-UU-Fin-Level X)) →
+        list-transposition-f : (h : Fin n ≃ (type-UU-Fin-Level n X)) →
           list
-            (Σ (type-UU-Fin-Level X → decidable-Prop l)
-            (λ P → has-cardinality 2 (Σ (type-UU-Fin-Level X) (λ x → type-decidable-Prop (P x)))))
-        list-transposition-f h = list-transpositions-permutation-count (type-UU-Fin-Level X) (pair n h) f
+            (Σ (type-UU-Fin-Level n X → decidable-Prop l)
+            (λ P → has-cardinality 2 (Σ (type-UU-Fin-Level n X) (λ x → type-decidable-Prop (P x)))))
+        list-transposition-f h = list-transpositions-permutation-count (type-UU-Fin-Level n X) (pair n h) f
         is-injective-iterate-involution : (k k' x : Fin 2) →
-          Id (iterate (nat-Fin k) succ-Fin x) (iterate (nat-Fin k') succ-Fin x) → Id k k'
+          Id (iterate (nat-Fin 2 k) (succ-Fin 2) x) (iterate (nat-Fin 2 k') (succ-Fin 2) x) → Id k k'
         is-injective-iterate-involution (inl (inr star)) (inl (inr star)) x p = refl
         is-injective-iterate-involution (inl (inr star)) (inr star) (inl (inr star)) p = ex-falso (neq-inl-inr p)
         is-injective-iterate-involution (inl (inr star)) (inr star) (inr star) p = ex-falso (neq-inr-inl p)

--- a/src/finite-group-theory/sign-homomorphism.lagda.md
+++ b/src/finite-group-theory/sign-homomorphism.lagda.md
@@ -88,13 +88,13 @@ open import univalent-combinatorics.counting using
 open import univalent-combinatorics.equality-finite-types using
   ( set-UU-Fin-Level)
 open import univalent-combinatorics.equality-standard-finite-types using
-  ( Fin-Set; has-decidable-equality-Fin; two-distinct-elements-leq-2-Fin)
+  ( has-decidable-equality-Fin; two-distinct-elements-leq-2-Fin)
 open import univalent-combinatorics.finite-types using
   ( UU-Fin-Level; type-UU-Fin-Level; has-cardinality; has-cardinality-type-UU-Fin-Level)
 open import univalent-combinatorics.lists using
   ( list; cons; nil; concat-list; length-list; length-concat-list; reverse-list; in-list)
 open import univalent-combinatorics.standard-finite-types using
-  ( Fin; equiv-succ-Fin; zero-Fin; nat-Fin; is-zero-nat-zero-Fin)
+  ( Fin; equiv-succ-Fin; zero-Fin; nat-Fin; is-zero-nat-zero-Fin; Fin-Set)
 ```
 
 ## Idea
@@ -110,21 +110,21 @@ module _
   {l : Level} (n : ℕ) (X : UU-Fin-Level l n) 
   where
 
-  sign-homomorphism-Fin-two : Aut (type-UU-Fin-Level X) → Fin 2
+  sign-homomorphism-Fin-two : Aut (type-UU-Fin-Level n X) → Fin 2
   sign-homomorphism-Fin-two f =
     pr1 (center (is-contr-parity-transposition-permutation n X f))
 
   preserves-add-sign-homomorphism-Fin-two :
-    (f g : (type-UU-Fin-Level X) ≃ (type-UU-Fin-Level X)) →
+    (f g : (type-UU-Fin-Level n X) ≃ (type-UU-Fin-Level n X)) →
     Id ( sign-homomorphism-Fin-two (f ∘e g))
-       ( add-Fin (sign-homomorphism-Fin-two f) (sign-homomorphism-Fin-two g))
+       ( add-Fin 2 (sign-homomorphism-Fin-two f) (sign-homomorphism-Fin-two g))
   preserves-add-sign-homomorphism-Fin-two f g =
     apply-universal-property-trunc-Prop
-      ( has-cardinality-type-UU-Fin-Level X)
+      ( has-cardinality-type-UU-Fin-Level n X)
       ( Id-Prop
         ( Fin-Set 2)
         ( sign-homomorphism-Fin-two (f ∘e g))
-        ( add-Fin (sign-homomorphism-Fin-two f) (sign-homomorphism-Fin-two g)))
+        ( add-Fin 2 (sign-homomorphism-Fin-two f) (sign-homomorphism-Fin-two g)))
       ( λ h →
         ( ap
           ( pr1)
@@ -147,7 +147,7 @@ module _
               ( length-list (list-trans g h))) ∙
             ( ( ap
                 ( λ P →
-                  add-Fin (pr1 P) (mod-two-ℕ (length-list (list-trans g h))))
+                  add-Fin 2 (pr1 P) (mod-two-ℕ (length-list (list-trans g h))))
                 { x =
                   pair
                     ( mod-two-ℕ (length-list (list-trans f h)))
@@ -159,14 +159,14 @@ module _
                           ( inv
                             ( eq-htpy-equiv
                               ( retr-permutation-list-transpositions-count
-                                ( type-UU-Fin-Level X)
+                                ( type-UU-Fin-Level n X)
                                 ( pair n h)
                                 ( f)))))))}
                 { y = center (is-contr-parity-transposition-permutation n X f)}
                 ( eq-is-contr
                   ( is-contr-parity-transposition-permutation n X f))) ∙
               ( ap
-                ( λ P → add-Fin (sign-homomorphism-Fin-two f) (pr1 P))
+                ( λ P → add-Fin 2 (sign-homomorphism-Fin-two f) (pr1 P))
                 { x =
                   pair
                     ( mod-two-ℕ (length-list (list-trans g h)))
@@ -178,7 +178,7 @@ module _
                           ( inv
                             ( eq-htpy-equiv
                               ( retr-permutation-list-transpositions-count
-                                ( type-UU-Fin-Level X)
+                                ( type-UU-Fin-Level n X)
                                 ( pair n h)
                                 ( g)))))))}
                 { y = center (is-contr-parity-transposition-permutation n X g)}
@@ -186,25 +186,25 @@ module _
                   ( is-contr-parity-transposition-permutation n X g)))))))
     where
     list-trans :
-      ( f' : (type-UU-Fin-Level X) ≃ (type-UU-Fin-Level X))
-      ( h : Fin n ≃ type-UU-Fin-Level X) →
+      ( f' : (type-UU-Fin-Level n X) ≃ (type-UU-Fin-Level n X))
+      ( h : Fin n ≃ type-UU-Fin-Level n X) →
       list
-        ( Σ ( type-UU-Fin-Level X → decidable-Prop l)
+        ( Σ ( type-UU-Fin-Level n X → decidable-Prop l)
             ( λ P →
               has-cardinality 2
-                ( Σ (type-UU-Fin-Level X) (λ x → type-decidable-Prop (P x)))))
+                ( Σ (type-UU-Fin-Level n X) (λ x → type-decidable-Prop (P x)))))
     list-trans f' h =
-      list-transpositions-permutation-count (type-UU-Fin-Level X) (pair n h) f'
+      list-transpositions-permutation-count (type-UU-Fin-Level n X) (pair n h) f'
     list-comp-f-g :
-      ( h : Fin n ≃ type-UU-Fin-Level X) →
+      ( h : Fin n ≃ type-UU-Fin-Level n X) →
       list
-        ( Σ ( (type-UU-Fin-Level X) → decidable-Prop l)
+        ( Σ ( (type-UU-Fin-Level n X) → decidable-Prop l)
             ( λ P →
               has-cardinality 2
-                ( Σ (type-UU-Fin-Level X) (λ x → type-decidable-Prop (P x)))))
+                ( Σ (type-UU-Fin-Level n X) (λ x → type-decidable-Prop (P x)))))
     list-comp-f-g h = concat-list (list-trans f h) (list-trans g h)
     eq-list-comp-f-g :
-      ( h : Fin n ≃ type-UU-Fin-Level X) →
+      ( h : Fin n ≃ type-UU-Fin-Level n X) →
       Id ( f ∘e g)
          ( permutation-list-transpositions
            ( list-comp-f-g h))
@@ -213,7 +213,7 @@ module _
         ( λ x →
           ( inv
             ( retr-permutation-list-transpositions-count
-              ( type-UU-Fin-Level X)
+              ( type-UU-Fin-Level n X)
               ( pair n h)
               ( f)
               ( map-equiv g x))) ∙
@@ -223,7 +223,7 @@ module _
                 ( list-trans f h)))
             ( inv
               ( retr-permutation-list-transpositions-count
-                ( type-UU-Fin-Level X)
+                ( type-UU-Fin-Level n X)
                 ( pair n h)
                 ( g)
                 ( x))))) ∙
@@ -239,7 +239,7 @@ module _
   {l : Level} (n : ℕ) (X : UU-Fin-Level l n)
   where
 
-  map-sign-homomorphism : Aut (type-UU-Fin-Level X) → Aut (Fin 2)
+  map-sign-homomorphism : Aut (type-UU-Fin-Level n X) → Aut (Fin 2)
   map-sign-homomorphism f =
     aut-point-Fin-two-ℕ (sign-homomorphism-Fin-two n X f)
 
@@ -255,20 +255,20 @@ module _
   
   sign-homomorphism :
     type-hom-Group
-      ( symmetric-Group (set-UU-Fin-Level X))
+      ( symmetric-Group (set-UU-Fin-Level n X))
       ( symmetric-Group (Fin-Set 2))
   pr1 sign-homomorphism = map-sign-homomorphism
   pr2 sign-homomorphism = preserves-comp-map-sign-homomorphism
 
   eq-sign-homomorphism-transposition :
-    ( Y : 2-Element-Decidable-Subtype l (type-UU-Fin-Level X)) →
+    ( Y : 2-Element-Decidable-Subtype l (type-UU-Fin-Level n X)) →
     Id
       ( map-hom-Group
-        ( symmetric-Group (set-UU-Fin-Level X))
+        ( symmetric-Group (set-UU-Fin-Level n X))
         ( symmetric-Group (Fin-Set 2))
         ( sign-homomorphism)
         ( transposition Y))
-      equiv-succ-Fin
+      ( equiv-succ-Fin 2)
   eq-sign-homomorphism-transposition Y =
     ap aut-point-Fin-two-ℕ
       ( ap pr1
@@ -283,528 +283,4 @@ module _
         ( eq-is-contr
           ( is-contr-parity-transposition-permutation n X (transposition Y))))
     
-```
-
-## Deloopings of the sign homomorphism
-
-### Simpson's delooping of the sign homomorphism
-
-```agda
-module _
-  {l : Level} (n : ℕ) (X : UU-Fin-Level l n)
-  where
-
-  sign-comp-Eq-Rel : Eq-Rel lzero (Fin n ≃ type-UU-Fin-Level X)
-  pr1 sign-comp-Eq-Rel f g =
-    Id-Prop (Fin-Set 2) zero-Fin (sign-homomorphism-Fin-two n X (f ∘e inv-equiv g))
-  pr1 (pr2 sign-comp-Eq-Rel) {f} =
-    ap pr1
-      { x = pair zero-Fin (unit-trunc-Prop (pair nil (pair refl (right-inverse-law-equiv f))))}
-      { y = center (is-contr-parity-transposition-permutation n X (f ∘e inv-equiv f))}
-      ( eq-is-contr (is-contr-parity-transposition-permutation n X (f ∘e inv-equiv f)))
-  pr1 (pr2 (pr2 sign-comp-Eq-Rel)) {f} {g} P =
-    ap pr1
-      { x = pair zero-Fin (unit-trunc-Prop (pair nil (pair refl (left-inverse-law-equiv (f ∘e inv-equiv g)))))}
-      { y = center (is-contr-parity-transposition-permutation n X (inv-equiv (f ∘e inv-equiv g) ∘e (f ∘e inv-equiv g)))}
-      ( eq-is-contr
-        ( is-contr-parity-transposition-permutation n X
-          ( inv-equiv (f ∘e inv-equiv g) ∘e (f ∘e inv-equiv g)))) ∙
-      ( ( preserves-add-sign-homomorphism-Fin-two n X (inv-equiv (f ∘e inv-equiv g)) (f ∘e inv-equiv g)) ∙
-        ( ( ap
-          ( add-Fin (sign-homomorphism-Fin-two n X (inv-equiv (f ∘e inv-equiv g))))
-          ( inv P)) ∙
-          ( ( ap
-            ( λ k →
-              mod-two-ℕ (add-ℕ (nat-Fin (sign-homomorphism-Fin-two n X (inv-equiv (f ∘e inv-equiv g)))) k))
-            ( is-zero-nat-zero-Fin {k = 1})) ∙
-            ( ( issec-nat-Fin (sign-homomorphism-Fin-two n X (inv-equiv (f ∘e inv-equiv g)))) ∙
-              ( ap
-                ( sign-homomorphism-Fin-two n X)
-                ( ( distributive-inv-comp-equiv (inv-equiv g) f) ∙
-                  ap (λ h → h ∘e inv-equiv f) (inv-inv-equiv g)))))))
-  pr2 (pr2 (pr2 sign-comp-Eq-Rel)) {f} {g} {h} P Q =
-    ( ap mod-two-ℕ
-      ( ( ap (add-ℕ zero-ℕ) (inv (is-zero-nat-zero-Fin {k = 1}) ∙ ap nat-Fin Q)) ∙
-        ( ap
-          ( λ k → add-ℕ k (nat-Fin (sign-homomorphism-Fin-two n X (g ∘e inv-equiv h))))
-          ( inv (is-zero-nat-zero-Fin {k = 1}) ∙ ap nat-Fin P)))) ∙
-      ( ( inv
-        ( preserves-add-sign-homomorphism-Fin-two n X (f ∘e inv-equiv g) (g ∘e inv-equiv h))) ∙
-        ( ap
-          ( sign-homomorphism-Fin-two n X)
-          ( ( eq-htpy-equiv refl-htpy) ∙
-            ( ap (λ h' → f ∘e (h' ∘e inv-equiv h)) (left-inverse-law-equiv g) ∙
-              ( eq-htpy-equiv refl-htpy)))))
-
-  quotient-sign-comp : UU (lsuc lzero ⊔ l)
-  quotient-sign-comp = equivalence-class sign-comp-Eq-Rel
-
-  quotient-sign-comp-Set : UU-Set (lsuc lzero ⊔ l)
-  quotient-sign-comp-Set = equivalence-class-Set sign-comp-Eq-Rel
-
-module _
-  {l : Level} {X : UU l} (eX : count X) (ineq : leq-ℕ 2 (number-of-elements-count eX))
-  where
-
-  private abstract
-    lemma :
-      Id
-        ( inr star)
-        ( pr1
-          ( center
-            ( is-contr-parity-transposition-permutation
-              ( number-of-elements-count eX)
-              ( pair X (unit-trunc-Prop (equiv-count eX)))
-              ( equiv-count eX ∘e
-                inv-equiv
-                  (equiv-count eX ∘e
-                    transposition
-                      ( standard-2-Element-Decidable-Subtype
-                        ( has-decidable-equality-Fin)
-                          ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))))))
-    lemma =
-      ap pr1
-        { x =
-          pair
-            ( inr star)
-            ( unit-trunc-Prop
-              ( pair
-                ( in-list
-                  ( transposition-conjugation-equiv
-                    ( Fin (number-of-elements-count eX))
-                    ( X)
-                    ( equiv-count eX)
-                    ( standard-2-Element-Decidable-Subtype
-                      ( has-decidable-equality-Fin)
-                      ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq))))))
-                ( pair
-                  ( refl)
-                  ( ( ap
-                    ( λ e → equiv-count eX ∘e e)
-                    ( distributive-inv-comp-equiv
-                      ( transposition
-                        ( standard-2-Element-Decidable-Subtype
-                          ( has-decidable-equality-Fin)
-                          ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))
-                      ( equiv-count eX))) ∙
-                      ( ( ap
-                        ( λ e → equiv-count eX ∘e (e ∘e inv-equiv (equiv-count eX)))
-                        ( ( own-inverse-is-involution
-                          ( is-involution-map-transposition
-                            ( standard-2-Element-Decidable-Subtype
-                              ( has-decidable-equality-Fin)
-                              ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))) ∙
-                          ( inv
-                            ( right-unit-law-equiv
-                              ( transposition
-                                ( standard-2-Element-Decidable-Subtype
-                                  ( has-decidable-equality-Fin)
-                                  ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq))))))))) ∙
-                          ( inv
-                            ( eq-htpy-equiv
-                              ( correct-transposition-conjugation-equiv-list
-                                ( Fin (number-of-elements-count eX))
-                                ( X)
-                                ( equiv-count eX)
-                                ( in-list
-                                  ( standard-2-Element-Decidable-Subtype
-                                    ( has-decidable-equality-Fin)
-                                    ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))))))))))}
-        { y =
-          center
-            ( is-contr-parity-transposition-permutation
-              ( number-of-elements-count eX)
-              ( pair X (unit-trunc-Prop (equiv-count eX)))
-              ( equiv-count eX ∘e
-                inv-equiv
-                  ( equiv-count eX ∘e
-                    transposition
-                      ( standard-2-Element-Decidable-Subtype
-                        ( has-decidable-equality-Fin)
-                        ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))))}
-        ( eq-is-contr
-          ( is-contr-parity-transposition-permutation
-            ( number-of-elements-count eX)
-            ( pair X (unit-trunc-Prop (equiv-count eX)))
-            ( equiv-count eX ∘e
-              inv-equiv
-                ( equiv-count eX ∘e
-                  transposition
-                    ( standard-2-Element-Decidable-Subtype
-                      ( has-decidable-equality-Fin)
-                      ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq))))))))
-
-  inv-Fin-2-quotient-sign-comp-count :
-    ( T : quotient-sign-comp (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX)))) →
-    is-decidable
-      ( is-in-subtype-equivalence-class
-        ( sign-comp-Eq-Rel (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX))))
-        ( T)
-        ( equiv-count eX)) →
-    Fin 2
-  inv-Fin-2-quotient-sign-comp-count T (inl P) = inl (inr star)
-  inv-Fin-2-quotient-sign-comp-count T (inr NP) = inr star
-
-  equiv-Fin-2-quotient-sign-comp-count : Fin 2 ≃
-    quotient-sign-comp (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX)))
-  pr1 equiv-Fin-2-quotient-sign-comp-count (inl (inr star)) =
-    class
-      ( sign-comp-Eq-Rel (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX))))
-      ( equiv-count eX)
-  pr1 equiv-Fin-2-quotient-sign-comp-count (inr star) =
-    class
-      ( sign-comp-Eq-Rel (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX))))
-      ( equiv-count eX ∘e
-        transposition
-          ( standard-2-Element-Decidable-Subtype
-            ( has-decidable-equality-Fin)
-            ( pr2 (pr2 ( two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))
-  pr2 equiv-Fin-2-quotient-sign-comp-count =
-    is-equiv-has-inverse
-      (λ T →
-        inv-Fin-2-quotient-sign-comp-count T
-          ( is-decidable-is-in-subtype-equivalence-class-is-decidable
-            ( sign-comp-Eq-Rel (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX))))
-            ( λ a b →
-              has-decidable-equality-Fin
-                ( zero-Fin)
-                ( sign-homomorphism-Fin-two
-                  ( number-of-elements-count eX)
-                  ( pair X (unit-trunc-Prop (equiv-count eX))) (a ∘e inv-equiv b)))
-            ( T)
-            ( equiv-count eX)))
-      ( λ T →
-        retr-Fin-2-quotient-sign-comp-count T
-          ( is-decidable-is-in-subtype-equivalence-class-is-decidable
-            ( sign-comp-Eq-Rel
-              ( number-of-elements-count eX)
-              ( pair X (unit-trunc-Prop (equiv-count eX))))
-            ( λ a b →
-              has-decidable-equality-Fin zero-Fin
-                ( sign-homomorphism-Fin-two
-                  ( number-of-elements-count eX)
-                  ( pair X (unit-trunc-Prop (equiv-count eX))) (a ∘e inv-equiv b)))
-            ( T)
-            ( equiv-count eX)))
-      ( λ k →
-        sec-Fin-2-quotient-sign-comp-count k
-          ( is-decidable-is-in-subtype-equivalence-class-is-decidable
-            ( sign-comp-Eq-Rel
-              ( number-of-elements-count eX)
-              ( pair X (unit-trunc-Prop (equiv-count eX))))
-            ( λ a b →
-              has-decidable-equality-Fin zero-Fin
-                ( sign-homomorphism-Fin-two
-                  ( number-of-elements-count eX)
-                  ( pair X (unit-trunc-Prop (equiv-count eX))) (a ∘e inv-equiv b)))
-            ( pr1 equiv-Fin-2-quotient-sign-comp-count k)
-            ( equiv-count eX)))
-    where
-    cases-retr-Fin-2-quotient-sign-comp-count :
-      ( T : quotient-sign-comp
-        ( number-of-elements-count eX)
-        ( pair X (unit-trunc-Prop (equiv-count eX)))) →
-      ¬ ( is-in-subtype-equivalence-class
-        ( sign-comp-Eq-Rel (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX))))
-        ( T)
-        ( equiv-count eX)) →
-      ( f : Fin (number-of-elements-count eX) ≃ X) →
-      Id
-        ( class
-          ( sign-comp-Eq-Rel (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX))))
-          ( f))
-        ( T) →
-      ( k : Fin 2) →
-      Id
-        ( k)
-        ( sign-homomorphism-Fin-two
-          ( number-of-elements-count eX)
-          ( pair X (unit-trunc-Prop (equiv-count eX)))
-          ( f ∘e inv-equiv (equiv-count eX))) →
-      is-in-subtype-equivalence-class
-        ( sign-comp-Eq-Rel
-          ( number-of-elements-count eX)
-          ( pair X (unit-trunc-Prop (equiv-count eX))))
-        ( T)
-        ( equiv-count eX ∘e
-          transposition
-            ( standard-2-Element-Decidable-Subtype
-              ( has-decidable-equality-Fin)
-              ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))    
-    cases-retr-Fin-2-quotient-sign-comp-count T NP f p (inl (inr star)) q =
-      ex-falso
-        ( NP
-          ( tr
-            ( λ x →
-              is-in-subtype-equivalence-class
-                ( sign-comp-Eq-Rel
-                  ( number-of-elements-count eX)
-                  ( pair X (unit-trunc-Prop (equiv-count eX))))
-                ( x)
-                ( equiv-count eX))
-            ( p)
-            ( q)))
-    cases-retr-Fin-2-quotient-sign-comp-count T NP f p (inr star) q =
-      tr
-        ( λ x →
-          is-in-subtype-equivalence-class
-            ( sign-comp-Eq-Rel
-              ( number-of-elements-count eX)
-              ( pair X (unit-trunc-Prop (equiv-count eX))))
-            ( x)
-            ( equiv-count eX ∘e
-              transposition
-                ( standard-2-Element-Decidable-Subtype
-                  ( has-decidable-equality-Fin)
-                  ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq))))))
-        ( p)
-        ( ( eq-mod-succ-cong-ℕ 1 0 2 (cong-zero-ℕ' 2)) ∙
-          ( ( ap-add-Fin
-            ( q)
-            ( lemma)) ∙
-            ( ( inv
-              ( preserves-add-sign-homomorphism-Fin-two
-                ( number-of-elements-count eX)
-                ( pair X (unit-trunc-Prop (equiv-count eX)))
-                ( f ∘e inv-equiv (equiv-count eX))
-                ( equiv-count eX ∘e
-                  inv-equiv
-                    ( equiv-count eX ∘e
-                      transposition
-                        ( standard-2-Element-Decidable-Subtype has-decidable-equality-Fin
-                        ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))))) ∙
-              ( ap
-                ( sign-homomorphism-Fin-two
-                  ( number-of-elements-count eX)
-                  ( pair X (unit-trunc-Prop (equiv-count eX))))
-                ( ( eq-htpy-equiv refl-htpy) ∙
-                  ( ap
-                    ( λ h →
-                      f ∘e
-                        ( h ∘e
-                          inv-equiv
-                            ( equiv-count eX ∘e
-                              transposition
-                                ( standard-2-Element-Decidable-Subtype
-                                  ( has-decidable-equality-Fin)
-                                  ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))))
-                    (left-inverse-law-equiv (equiv-count eX)) ∙
-                    ( eq-htpy-equiv refl-htpy)))))))
-    retr-Fin-2-quotient-sign-comp-count :
-      ( T : quotient-sign-comp
-        ( number-of-elements-count eX)
-        ( pair X (unit-trunc-Prop (equiv-count eX)))) →
-      ( H : is-decidable
-        (is-in-subtype-equivalence-class
-          ( sign-comp-Eq-Rel (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX))))
-          ( T)
-          ( equiv-count eX))) →
-      Id
-        ( pr1 equiv-Fin-2-quotient-sign-comp-count (inv-Fin-2-quotient-sign-comp-count T H))
-        ( T)
-    retr-Fin-2-quotient-sign-comp-count T (inl P) =
-      eq-effective-quotient'
-        ( sign-comp-Eq-Rel (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX))))
-        ( equiv-count eX)
-        ( T)
-        ( P)
-    retr-Fin-2-quotient-sign-comp-count T (inr NP) =
-      eq-effective-quotient'
-        ( sign-comp-Eq-Rel (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX))))
-        ( equiv-count eX ∘e
-          transposition
-            ( standard-2-Element-Decidable-Subtype
-              ( has-decidable-equality-Fin)
-              ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))
-        ( T)
-        ( apply-universal-property-trunc-Prop
-          ( pr2 T)
-          ( pair
-            ( is-in-subtype-equivalence-class
-              ( sign-comp-Eq-Rel
-                ( number-of-elements-count eX)
-                ( pair X (unit-trunc-Prop (equiv-count eX))))
-              ( T)
-              ( equiv-count eX ∘e
-                transposition
-                  ( standard-2-Element-Decidable-Subtype
-                    ( has-decidable-equality-Fin)
-                    ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq))))))
-            ( is-prop-is-in-subtype-equivalence-class
-              ( sign-comp-Eq-Rel
-                ( number-of-elements-count eX)
-                ( pair X (unit-trunc-Prop (equiv-count eX))))
-              ( T)
-              ( equiv-count eX ∘e
-                transposition
-                  (standard-2-Element-Decidable-Subtype
-                    ( has-decidable-equality-Fin)
-                    ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))))
-          ( λ (pair t p) →
-            cases-retr-Fin-2-quotient-sign-comp-count
-              ( T)
-              ( NP)
-              ( t)
-              ( eq-pair-Σ
-                ( p)
-                ( all-elements-equal-type-trunc-Prop _ (pr2 T)))
-              ( sign-homomorphism-Fin-two (number-of-elements-count eX)
-                ( pair X (unit-trunc-Prop (equiv-count eX)))
-                ( t ∘e inv-equiv (equiv-count eX)))
-              ( refl)))
-    sec-Fin-2-quotient-sign-comp-count : (k : Fin 2) →
-      ( D : is-decidable
-        ( is-in-subtype-equivalence-class
-          ( sign-comp-Eq-Rel
-            ( number-of-elements-count eX)
-            ( pair X (unit-trunc-Prop (equiv-count eX))))
-          ( pr1 equiv-Fin-2-quotient-sign-comp-count k)
-          ( equiv-count eX))) →
-      Id
-        ( inv-Fin-2-quotient-sign-comp-count
-          ( pr1 equiv-Fin-2-quotient-sign-comp-count k)
-          ( D))
-        ( k)
-    sec-Fin-2-quotient-sign-comp-count (inl (inr star)) (inl D) = refl
-    sec-Fin-2-quotient-sign-comp-count (inl (inr star)) (inr ND) =
-      ex-falso
-        ( ND
-          ( refl-Eq-Rel
-            ( sign-comp-Eq-Rel
-              ( number-of-elements-count eX)
-              ( pair X (unit-trunc-Prop (equiv-count eX))))))
-    sec-Fin-2-quotient-sign-comp-count (inr star) (inl D) =
-      ex-falso
-        ( neq-inr-inl
-          (lemma ∙
-            ( inv
-              ( D ∙
-                ( ap
-                  ( sign-homomorphism-Fin-two
-                    ( number-of-elements-count eX)
-                    ( pair X (unit-trunc-Prop (equiv-count eX))))
-                  ( eq-htpy-equiv refl-htpy ∙
-                    ( ( ap
-                      ( λ h → equiv-count eX ∘e h)
-                      ( ( ap
-                        ( λ h → h ∘e inv-equiv (equiv-count eX))
-                        { x =
-                          transposition
-                            (standard-2-Element-Decidable-Subtype
-                              has-decidable-equality-Fin
-                              (pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq))))}
-                        ( inv
-                          ( own-inverse-is-involution
-                            ( is-involution-map-transposition
-                              ( standard-2-Element-Decidable-Subtype
-                                ( has-decidable-equality-Fin)
-                                ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))))) ∙
-                        ( inv
-                          ( distributive-inv-comp-equiv
-                            ( transposition
-                              ( standard-2-Element-Decidable-Subtype
-                                ( has-decidable-equality-Fin)
-                                ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))
-                            ( equiv-count eX))))) ∙
-                      ( eq-htpy-equiv refl-htpy))))))))
-    sec-Fin-2-quotient-sign-comp-count (inr star) (inr ND) = refl
-
-module _
-  {l : Level} (n : ℕ) (X : UU-Fin-Level l n) (ineq : leq-ℕ 2 n)
-  where
-  
-  equiv-Fin-2-quotient-sign-comp-equiv-Fin-n : (h : Fin n ≃ type-UU-Fin-Level X) →
-    ( Fin 2 ≃ quotient-sign-comp n X)
-  equiv-Fin-2-quotient-sign-comp-equiv-Fin-n h =
-    tr
-      ( λ e → Fin 2 ≃ quotient-sign-comp n (pair (type-UU-Fin-Level X) e))
-      ( all-elements-equal-type-trunc-Prop (unit-trunc-Prop (equiv-count (pair n h))) (pr2 X))
-      ( equiv-Fin-2-quotient-sign-comp-count (pair n h) ineq)
-    
-  abstract
-    mere-equiv-Fin-2-quotient-sign-comp :
-      mere-equiv (Fin 2) (quotient-sign-comp n X)
-    mere-equiv-Fin-2-quotient-sign-comp =
-      map-trunc-Prop
-        ( equiv-Fin-2-quotient-sign-comp-equiv-Fin-n)
-        ( has-cardinality-type-UU-Fin-Level X)
-
-module _
-  { l : Level}
-  where
-  
-  map-simpson-delooping-sign : (n : ℕ) →
-    classifying-type-Concrete-Group
-      ( Automorphism-Group
-        ( UU-Set l)
-        ( raise-Set l (Fin-Set n))
-        ( is-one-type-UU-Set l)) →
-    classifying-type-Concrete-Group
-      ( Automorphism-Group
-        ( UU-Set (lsuc lzero ⊔ l))
-        ( raise-Set (lsuc lzero ⊔ l) (Fin-Set 2))
-        ( is-one-type-UU-Set (lsuc lzero ⊔ l)))
-  pr1 (map-simpson-delooping-sign zero-ℕ X) = raise-Set (lsuc lzero ⊔ l) (Fin-Set 2)
-  pr2 (map-simpson-delooping-sign zero-ℕ X) = unit-trunc-Prop refl
-  pr1 (map-simpson-delooping-sign (succ-ℕ zero-ℕ) X) = raise-Set (lsuc lzero ⊔ l) (Fin-Set 2)
-  pr2 (map-simpson-delooping-sign (succ-ℕ zero-ℕ) X) = unit-trunc-Prop refl
-  pr1 (map-simpson-delooping-sign (succ-ℕ (succ-ℕ n)) (pair X p)) =
-    quotient-sign-comp-Set
-      ( succ-ℕ (succ-ℕ n))
-      ( pair
-        ( type-Set X)
-        ( map-trunc-Prop (λ p' → equiv-eq (inv (pr1 (pair-eq-Σ p'))) ∘e equiv-raise l (Fin (succ-ℕ (succ-ℕ n)))) p))
-  pr2 (map-simpson-delooping-sign (succ-ℕ (succ-ℕ n)) (pair X p)) =
-    map-trunc-Prop
-      ( λ e →
-        eq-pair-Σ
-          ( eq-equiv
-            ( type-Set (pr1 (map-simpson-delooping-sign (succ-ℕ (succ-ℕ n)) (pair X p))))
-            ( type-Set (raise-Set (lsuc lzero ⊔ l) (Fin-Set 2)))
-            ( equiv-raise (lsuc lzero ⊔ l) (Fin 2) ∘e inv-equiv e))
-          ( eq-is-prop (is-prop-is-set (raise (lsuc lzero ⊔ l) (type-Set (Fin-Set 2))))))
-      ( mere-equiv-Fin-2-quotient-sign-comp
-        ( succ-ℕ (succ-ℕ n))
-        ( pair
-          ( type-Set X)
-          ( map-trunc-Prop (λ p' → equiv-eq (inv (pr1 (pair-eq-Σ p'))) ∘e equiv-raise l (Fin (succ-ℕ (succ-ℕ n)))) p))
-        ( star))
-
-  simpson-delooping-sign : (n : ℕ) →
-    hom-Concrete-Group
-      ( Automorphism-Group (UU-Set l) (raise-Set l (Fin-Set n)) (is-one-type-UU-Set l))
-      ( Automorphism-Group
-        ( UU-Set (lsuc lzero ⊔ l))
-        ( raise-Set (lsuc lzero ⊔ l) (Fin-Set 2))
-        ( is-one-type-UU-Set (lsuc lzero ⊔ l)))
-  pr1 (simpson-delooping-sign n) = map-simpson-delooping-sign n
-  pr2 (simpson-delooping-sign zero-ℕ) = refl
-  pr2 (simpson-delooping-sign (succ-ℕ zero-ℕ)) = refl
-  pr2 (simpson-delooping-sign (succ-ℕ (succ-ℕ n))) =
-    eq-pair-Σ
-      ( eq-pair-Σ
-        ( eq-equiv
-          ( type-Set
-            ( pr1
-              ( map-simpson-delooping-sign
-                ( succ-ℕ (succ-ℕ n))
-                ( pair
-                  ( raise-Set l (Fin-Set (succ-ℕ (succ-ℕ n))))
-                  ( unit-trunc-Prop refl)))))
-          ( type-Set (raise-Set (lsuc lzero ⊔ l) (Fin-Set 2)))
-          ( equiv-raise (lsuc lzero ⊔ l) (Fin 2) ∘e
-            inv-equiv
-              ( equiv-Fin-2-quotient-sign-comp-equiv-Fin-n
-                ( succ-ℕ (succ-ℕ n))
-                ( pair
-                  ( raise l (Fin (succ-ℕ (succ-ℕ n))))
-                  ( map-trunc-Prop
-                    ( λ p' →
-                      ( equiv-eq (inv (pr1 (pair-eq-Σ p')))) ∘e
-                        ( equiv-raise l (Fin (succ-ℕ (succ-ℕ n)))))
-                    ( unit-trunc-Prop refl)))
-                ( star)
-                ( equiv-raise l (Fin (succ-ℕ (succ-ℕ n)))))))
-        ( eq-is-prop (is-prop-is-set _)))
-      ( eq-is-prop is-prop-type-trunc-Prop)
 ```

--- a/src/finite-group-theory/simpson-delooping-sign-homomorphism.lagda.md
+++ b/src/finite-group-theory/simpson-delooping-sign-homomorphism.lagda.md
@@ -1,0 +1,588 @@
+---
+title: Simpson's delooping of the sign homomorphism
+---
+
+```agda
+{-# OPTIONS --without-K #-}
+
+module finite-group-theory.simpson-delooping-sign-homomorphism where
+
+open import elementary-number-theory.addition-natural-numbers
+open import elementary-number-theory.congruence-natural-numbers
+open import elementary-number-theory.inequality-natural-numbers
+open import elementary-number-theory.modular-arithmetic-standard-finite-types
+open import elementary-number-theory.natural-numbers
+
+open import finite-group-theory.permutations
+open import finite-group-theory.sign-homomorphism
+open import finite-group-theory.transpositions
+
+open import foundation.contractible-types
+open import foundation.coproduct-types
+open import foundation.decidable-types
+open import foundation.dependent-pair-types
+open import foundation.empty-types
+open import foundation.equality-dependent-pair-types
+open import foundation.equivalence-classes
+open import foundation.equivalence-relations
+open import foundation.equivalences
+open import foundation.functoriality-propositional-truncation
+open import foundation.homotopies
+open import foundation.identity-types
+open import foundation.involutions
+open import foundation.mere-equivalences
+open import foundation.negation
+open import foundation.propositional-truncations
+open import foundation.propositions
+open import foundation.raising-universe-levels
+open import foundation.sets
+open import foundation.subuniverses
+open import foundation.unit-type
+open import foundation.univalence
+open import foundation.universe-levels
+
+open import group-theory.automorphism-groups
+open import group-theory.concrete-groups
+
+open import univalent-combinatorics.2-element-decidable-subtypes
+open import univalent-combinatorics.counting
+open import univalent-combinatorics.equality-standard-finite-types
+open import univalent-combinatorics.finite-types
+open import univalent-combinatorics.lists
+open import univalent-combinatorics.standard-finite-types
+```
+
+### Simpson's delooping of the sign homomorphism
+
+```agda
+module _
+  {l : Level} (n : ℕ) (X : UU-Fin-Level l n)
+  where
+
+  sign-comp-Eq-Rel : Eq-Rel lzero (Fin n ≃ type-UU-Fin-Level n X)
+  pr1 sign-comp-Eq-Rel f g =
+    Id-Prop (Fin-Set 2) (zero-Fin 1) (sign-homomorphism-Fin-two n X (f ∘e inv-equiv g))
+  pr1 (pr2 sign-comp-Eq-Rel) {f} =
+    ap pr1
+      { x = pair (zero-Fin 1) (unit-trunc-Prop (pair nil (pair refl (right-inverse-law-equiv f))))}
+      { y = center (is-contr-parity-transposition-permutation n X (f ∘e inv-equiv f))}
+      ( eq-is-contr (is-contr-parity-transposition-permutation n X (f ∘e inv-equiv f)))
+  pr1 (pr2 (pr2 sign-comp-Eq-Rel)) {f} {g} P =
+    ap pr1
+      { x = pair (zero-Fin 1) (unit-trunc-Prop (pair nil (pair refl (left-inverse-law-equiv (f ∘e inv-equiv g)))))}
+      { y = center (is-contr-parity-transposition-permutation n X (inv-equiv (f ∘e inv-equiv g) ∘e (f ∘e inv-equiv g)))}
+      ( eq-is-contr
+        ( is-contr-parity-transposition-permutation n X
+          ( inv-equiv (f ∘e inv-equiv g) ∘e (f ∘e inv-equiv g)))) ∙
+      ( ( preserves-add-sign-homomorphism-Fin-two n X (inv-equiv (f ∘e inv-equiv g)) (f ∘e inv-equiv g)) ∙
+        ( ( ap
+          ( add-Fin 2 (sign-homomorphism-Fin-two n X (inv-equiv (f ∘e inv-equiv g))))
+          ( inv P)) ∙
+          ( ( ap
+            ( λ k →
+              mod-two-ℕ (add-ℕ (nat-Fin 2 (sign-homomorphism-Fin-two n X (inv-equiv (f ∘e inv-equiv g)))) k))
+            ( is-zero-nat-zero-Fin {k = 1})) ∙
+            ( ( issec-nat-Fin 1 (sign-homomorphism-Fin-two n X (inv-equiv (f ∘e inv-equiv g)))) ∙
+              ( ap
+                ( sign-homomorphism-Fin-two n X)
+                ( ( distributive-inv-comp-equiv (inv-equiv g) f) ∙
+                  ap (λ h → h ∘e inv-equiv f) (inv-inv-equiv g)))))))
+  pr2 (pr2 (pr2 sign-comp-Eq-Rel)) {f} {g} {h} P Q =
+    ( ap mod-two-ℕ
+      ( ( ap (add-ℕ zero-ℕ) (inv (is-zero-nat-zero-Fin {k = 1}) ∙ ap (nat-Fin 2) Q)) ∙
+        ( ap
+          ( λ k → add-ℕ k (nat-Fin 2 (sign-homomorphism-Fin-two n X (g ∘e inv-equiv h))))
+          ( inv (is-zero-nat-zero-Fin {k = 1}) ∙ ap (nat-Fin 2) P)))) ∙
+      ( ( inv
+        ( preserves-add-sign-homomorphism-Fin-two n X (f ∘e inv-equiv g) (g ∘e inv-equiv h))) ∙
+        ( ap
+          ( sign-homomorphism-Fin-two n X)
+          ( ( eq-htpy-equiv refl-htpy) ∙
+            ( ap (λ h' → f ∘e (h' ∘e inv-equiv h)) (left-inverse-law-equiv g) ∙
+              ( eq-htpy-equiv refl-htpy)))))
+
+  quotient-sign-comp : UU (lsuc lzero ⊔ l)
+  quotient-sign-comp = equivalence-class sign-comp-Eq-Rel
+
+  quotient-sign-comp-Set : UU-Set (lsuc lzero ⊔ l)
+  quotient-sign-comp-Set = equivalence-class-Set sign-comp-Eq-Rel
+
+module _
+  {l : Level} {X : UU l} (eX : count X) (ineq : leq-ℕ 2 (number-of-elements-count eX))
+  where
+
+  private abstract
+    lemma :
+      Id
+        ( inr star)
+        ( pr1
+          ( center
+            ( is-contr-parity-transposition-permutation
+              ( number-of-elements-count eX)
+              ( pair X (unit-trunc-Prop (equiv-count eX)))
+              ( equiv-count eX ∘e
+                inv-equiv
+                  (equiv-count eX ∘e
+                    transposition
+                      ( standard-2-Element-Decidable-Subtype
+                        ( has-decidable-equality-Fin (number-of-elements-count eX))
+                          ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))))))
+    lemma =
+      ap pr1
+        { x =
+          pair
+            ( inr star)
+            ( unit-trunc-Prop
+              ( pair
+                ( in-list
+                  ( transposition-conjugation-equiv
+                    ( Fin (number-of-elements-count eX))
+                    ( X)
+                    ( equiv-count eX)
+                    ( standard-2-Element-Decidable-Subtype
+                      ( has-decidable-equality-Fin (number-of-elements-count eX))
+                      ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq))))))
+                ( pair
+                  ( refl)
+                  ( ( ap
+                    ( λ e → equiv-count eX ∘e e)
+                    ( distributive-inv-comp-equiv
+                      ( transposition
+                        ( standard-2-Element-Decidable-Subtype
+                          ( has-decidable-equality-Fin (number-of-elements-count eX))
+                          ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))
+                      ( equiv-count eX))) ∙
+                      ( ( ap
+                        ( λ e → equiv-count eX ∘e (e ∘e inv-equiv (equiv-count eX)))
+                        ( ( own-inverse-is-involution
+                          ( is-involution-map-transposition
+                            ( standard-2-Element-Decidable-Subtype
+                              ( has-decidable-equality-Fin (number-of-elements-count eX))
+                              ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))) ∙
+                          ( inv
+                            ( right-unit-law-equiv
+                              ( transposition
+                                ( standard-2-Element-Decidable-Subtype
+                                  ( has-decidable-equality-Fin (number-of-elements-count eX))
+                                  ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq))))))))) ∙
+                          ( inv
+                            ( eq-htpy-equiv
+                              ( correct-transposition-conjugation-equiv-list
+                                ( Fin (number-of-elements-count eX))
+                                ( X)
+                                ( equiv-count eX)
+                                ( in-list
+                                  ( standard-2-Element-Decidable-Subtype
+                                    ( has-decidable-equality-Fin (number-of-elements-count eX))
+                                    ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))))))))))}
+        { y =
+          center
+            ( is-contr-parity-transposition-permutation
+              ( number-of-elements-count eX)
+              ( pair X (unit-trunc-Prop (equiv-count eX)))
+              ( equiv-count eX ∘e
+                inv-equiv
+                  ( equiv-count eX ∘e
+                    transposition
+                      ( standard-2-Element-Decidable-Subtype
+                        ( has-decidable-equality-Fin (number-of-elements-count eX))
+                        ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))))}
+        ( eq-is-contr
+          ( is-contr-parity-transposition-permutation
+            ( number-of-elements-count eX)
+            ( pair X (unit-trunc-Prop (equiv-count eX)))
+            ( equiv-count eX ∘e
+              inv-equiv
+                ( equiv-count eX ∘e
+                  transposition
+                    ( standard-2-Element-Decidable-Subtype
+                      ( has-decidable-equality-Fin (number-of-elements-count eX))
+                      ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq))))))))
+
+  inv-Fin-2-quotient-sign-comp-count :
+    ( T : quotient-sign-comp (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX)))) →
+    is-decidable
+      ( is-in-subtype-equivalence-class
+        ( sign-comp-Eq-Rel (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX))))
+        ( T)
+        ( equiv-count eX)) →
+    Fin 2
+  inv-Fin-2-quotient-sign-comp-count T (inl P) = inl (inr star)
+  inv-Fin-2-quotient-sign-comp-count T (inr NP) = inr star
+
+  equiv-Fin-2-quotient-sign-comp-count : Fin 2 ≃
+    quotient-sign-comp (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX)))
+  pr1 equiv-Fin-2-quotient-sign-comp-count (inl (inr star)) =
+    class
+      ( sign-comp-Eq-Rel (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX))))
+      ( equiv-count eX)
+  pr1 equiv-Fin-2-quotient-sign-comp-count (inr star) =
+    class
+      ( sign-comp-Eq-Rel (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX))))
+      ( equiv-count eX ∘e
+        transposition
+          ( standard-2-Element-Decidable-Subtype
+            ( has-decidable-equality-Fin (number-of-elements-count eX))
+            ( pr2 (pr2 ( two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))
+  pr2 equiv-Fin-2-quotient-sign-comp-count =
+    is-equiv-has-inverse
+      (λ T →
+        inv-Fin-2-quotient-sign-comp-count T
+          ( is-decidable-is-in-subtype-equivalence-class-is-decidable
+            ( sign-comp-Eq-Rel (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX))))
+            ( λ a b →
+              has-decidable-equality-Fin 2
+                ( zero-Fin 1)
+                ( sign-homomorphism-Fin-two
+                  ( number-of-elements-count eX)
+                  ( pair X (unit-trunc-Prop (equiv-count eX))) (a ∘e inv-equiv b)))
+            ( T)
+            ( equiv-count eX)))
+      ( λ T →
+        retr-Fin-2-quotient-sign-comp-count T
+          ( is-decidable-is-in-subtype-equivalence-class-is-decidable
+            ( sign-comp-Eq-Rel
+              ( number-of-elements-count eX)
+              ( pair X (unit-trunc-Prop (equiv-count eX))))
+            ( λ a b →
+              has-decidable-equality-Fin 2
+                ( zero-Fin 1)
+                ( sign-homomorphism-Fin-two
+                  ( number-of-elements-count eX)
+                  ( pair X (unit-trunc-Prop (equiv-count eX))) (a ∘e inv-equiv b)))
+            ( T)
+            ( equiv-count eX)))
+      ( λ k →
+        sec-Fin-2-quotient-sign-comp-count k
+          ( is-decidable-is-in-subtype-equivalence-class-is-decidable
+            ( sign-comp-Eq-Rel
+              ( number-of-elements-count eX)
+              ( pair X (unit-trunc-Prop (equiv-count eX))))
+            ( λ a b →
+              has-decidable-equality-Fin 2
+                ( zero-Fin 1)
+                ( sign-homomorphism-Fin-two
+                  ( number-of-elements-count eX)
+                  ( pair X (unit-trunc-Prop (equiv-count eX))) (a ∘e inv-equiv b)))
+            ( pr1 equiv-Fin-2-quotient-sign-comp-count k)
+            ( equiv-count eX)))
+    where
+    cases-retr-Fin-2-quotient-sign-comp-count :
+      ( T : quotient-sign-comp
+        ( number-of-elements-count eX)
+        ( pair X (unit-trunc-Prop (equiv-count eX)))) →
+      ¬ ( is-in-subtype-equivalence-class
+        ( sign-comp-Eq-Rel (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX))))
+        ( T)
+        ( equiv-count eX)) →
+      ( f : Fin (number-of-elements-count eX) ≃ X) →
+      Id
+        ( class
+          ( sign-comp-Eq-Rel (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX))))
+          ( f))
+        ( T) →
+      ( k : Fin 2) →
+      Id
+        ( k)
+        ( sign-homomorphism-Fin-two
+          ( number-of-elements-count eX)
+          ( pair X (unit-trunc-Prop (equiv-count eX)))
+          ( f ∘e inv-equiv (equiv-count eX))) →
+      is-in-subtype-equivalence-class
+        ( sign-comp-Eq-Rel
+          ( number-of-elements-count eX)
+          ( pair X (unit-trunc-Prop (equiv-count eX))))
+        ( T)
+        ( equiv-count eX ∘e
+          transposition
+            ( standard-2-Element-Decidable-Subtype
+              ( has-decidable-equality-Fin
+                (number-of-elements-count eX))
+              ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))    
+    cases-retr-Fin-2-quotient-sign-comp-count T NP f p (inl (inr star)) q =
+      ex-falso
+        ( NP
+          ( tr
+            ( λ x →
+              is-in-subtype-equivalence-class
+                ( sign-comp-Eq-Rel
+                  ( number-of-elements-count eX)
+                  ( pair X (unit-trunc-Prop (equiv-count eX))))
+                ( x)
+                ( equiv-count eX))
+            ( p)
+            ( q)))
+    cases-retr-Fin-2-quotient-sign-comp-count T NP f p (inr star) q =
+      tr
+        ( λ x →
+          is-in-subtype-equivalence-class
+            ( sign-comp-Eq-Rel
+              ( number-of-elements-count eX)
+              ( pair X (unit-trunc-Prop (equiv-count eX))))
+            ( x)
+            ( equiv-count eX ∘e
+              transposition
+                ( standard-2-Element-Decidable-Subtype
+                  ( has-decidable-equality-Fin
+                    (number-of-elements-count eX))
+                  ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq))))))
+        ( p)
+        ( ( eq-mod-succ-cong-ℕ 1 0 2 (cong-zero-ℕ' 2)) ∙
+          ( ( ap-add-Fin 2
+            ( q)
+            ( lemma)) ∙
+            ( ( inv
+              ( preserves-add-sign-homomorphism-Fin-two
+                ( number-of-elements-count eX)
+                ( pair X (unit-trunc-Prop (equiv-count eX)))
+                ( f ∘e inv-equiv (equiv-count eX))
+                ( equiv-count eX ∘e
+                  inv-equiv
+                    ( equiv-count eX ∘e
+                      transposition
+                        ( standard-2-Element-Decidable-Subtype
+                          ( has-decidable-equality-Fin
+                            ( number-of-elements-count eX))
+                            ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))))) ∙
+              ( ap
+                ( sign-homomorphism-Fin-two
+                  ( number-of-elements-count eX)
+                  ( pair X (unit-trunc-Prop (equiv-count eX))))
+                ( ( eq-htpy-equiv refl-htpy) ∙
+                  ( ap
+                    ( λ h →
+                      f ∘e
+                        ( h ∘e
+                          inv-equiv
+                            ( equiv-count eX ∘e
+                              transposition
+                                ( standard-2-Element-Decidable-Subtype
+                                  ( has-decidable-equality-Fin
+                                    ( number-of-elements-count eX))
+                                    ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))))
+                    (left-inverse-law-equiv (equiv-count eX)) ∙
+                    ( eq-htpy-equiv refl-htpy)))))))
+    retr-Fin-2-quotient-sign-comp-count :
+      ( T : quotient-sign-comp
+        ( number-of-elements-count eX)
+        ( pair X (unit-trunc-Prop (equiv-count eX)))) →
+      ( H : is-decidable
+        (is-in-subtype-equivalence-class
+          ( sign-comp-Eq-Rel (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX))))
+          ( T)
+          ( equiv-count eX))) →
+      Id
+        ( pr1 equiv-Fin-2-quotient-sign-comp-count (inv-Fin-2-quotient-sign-comp-count T H))
+        ( T)
+    retr-Fin-2-quotient-sign-comp-count T (inl P) =
+      eq-effective-quotient'
+        ( sign-comp-Eq-Rel (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX))))
+        ( equiv-count eX)
+        ( T)
+        ( P)
+    retr-Fin-2-quotient-sign-comp-count T (inr NP) =
+      eq-effective-quotient'
+        ( sign-comp-Eq-Rel (number-of-elements-count eX) (pair X (unit-trunc-Prop (equiv-count eX))))
+        ( equiv-count eX ∘e
+          transposition
+            ( standard-2-Element-Decidable-Subtype
+              ( has-decidable-equality-Fin
+                ( number-of-elements-count eX))
+                ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))
+        ( T)
+        ( apply-universal-property-trunc-Prop
+          ( pr2 T)
+          ( pair
+            ( is-in-subtype-equivalence-class
+              ( sign-comp-Eq-Rel
+                ( number-of-elements-count eX)
+                ( pair X (unit-trunc-Prop (equiv-count eX))))
+              ( T)
+              ( equiv-count eX ∘e
+                transposition
+                  ( standard-2-Element-Decidable-Subtype
+                    ( has-decidable-equality-Fin
+                      ( number-of-elements-count eX))
+                      ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq))))))
+            ( is-prop-is-in-subtype-equivalence-class
+              ( sign-comp-Eq-Rel
+                ( number-of-elements-count eX)
+                ( pair X (unit-trunc-Prop (equiv-count eX))))
+              ( T)
+              ( equiv-count eX ∘e
+                transposition
+                  (standard-2-Element-Decidable-Subtype
+                    ( has-decidable-equality-Fin
+                      ( number-of-elements-count eX))
+                      ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))))
+          ( λ (pair t p) →
+            cases-retr-Fin-2-quotient-sign-comp-count
+              ( T)
+              ( NP)
+              ( t)
+              ( eq-pair-Σ
+                ( p)
+                ( all-elements-equal-type-trunc-Prop _ (pr2 T)))
+              ( sign-homomorphism-Fin-two (number-of-elements-count eX)
+                ( pair X (unit-trunc-Prop (equiv-count eX)))
+                ( t ∘e inv-equiv (equiv-count eX)))
+              ( refl)))
+    sec-Fin-2-quotient-sign-comp-count : (k : Fin 2) →
+      ( D : is-decidable
+        ( is-in-subtype-equivalence-class
+          ( sign-comp-Eq-Rel
+            ( number-of-elements-count eX)
+            ( pair X (unit-trunc-Prop (equiv-count eX))))
+          ( pr1 equiv-Fin-2-quotient-sign-comp-count k)
+          ( equiv-count eX))) →
+      Id
+        ( inv-Fin-2-quotient-sign-comp-count
+          ( pr1 equiv-Fin-2-quotient-sign-comp-count k)
+          ( D))
+        ( k)
+    sec-Fin-2-quotient-sign-comp-count (inl (inr star)) (inl D) = refl
+    sec-Fin-2-quotient-sign-comp-count (inl (inr star)) (inr ND) =
+      ex-falso
+        ( ND
+          ( refl-Eq-Rel
+            ( sign-comp-Eq-Rel
+              ( number-of-elements-count eX)
+              ( pair X (unit-trunc-Prop (equiv-count eX))))))
+    sec-Fin-2-quotient-sign-comp-count (inr star) (inl D) =
+      ex-falso
+        ( neq-inr-inl
+          (lemma ∙
+            ( inv
+              ( D ∙
+                ( ap
+                  ( sign-homomorphism-Fin-two
+                    ( number-of-elements-count eX)
+                    ( pair X (unit-trunc-Prop (equiv-count eX))))
+                  ( eq-htpy-equiv refl-htpy ∙
+                    ( ( ap
+                      ( λ h → equiv-count eX ∘e h)
+                      ( ( ap
+                        ( λ h → h ∘e inv-equiv (equiv-count eX))
+                        { x =
+                          transposition
+                            (standard-2-Element-Decidable-Subtype
+                              ( has-decidable-equality-Fin
+                                ( number-of-elements-count eX))
+                                ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq))))}
+                        ( inv
+                          ( own-inverse-is-involution
+                            ( is-involution-map-transposition
+                              ( standard-2-Element-Decidable-Subtype
+                                ( has-decidable-equality-Fin
+                                  ( number-of-elements-count eX))
+                                  ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))))) ∙
+                        ( inv
+                          ( distributive-inv-comp-equiv
+                            ( transposition
+                              ( standard-2-Element-Decidable-Subtype
+                                ( has-decidable-equality-Fin
+                                  ( number-of-elements-count eX))
+                                  ( pr2 (pr2 (two-distinct-elements-leq-2-Fin (number-of-elements-count eX) ineq)))))
+                            ( equiv-count eX))))) ∙
+                      ( eq-htpy-equiv refl-htpy))))))))
+    sec-Fin-2-quotient-sign-comp-count (inr star) (inr ND) = refl
+
+module _
+  {l : Level} (n : ℕ) (X : UU-Fin-Level l n) (ineq : leq-ℕ 2 n)
+  where
+  
+  equiv-Fin-2-quotient-sign-comp-equiv-Fin-n : (h : Fin n ≃ type-UU-Fin-Level n X) →
+    ( Fin 2 ≃ quotient-sign-comp n X)
+  equiv-Fin-2-quotient-sign-comp-equiv-Fin-n h =
+    tr
+      ( λ e → Fin 2 ≃ quotient-sign-comp n (pair (type-UU-Fin-Level n X) e))
+      ( all-elements-equal-type-trunc-Prop (unit-trunc-Prop (equiv-count (pair n h))) (pr2 X))
+      ( equiv-Fin-2-quotient-sign-comp-count (pair n h) ineq)
+    
+  abstract
+    mere-equiv-Fin-2-quotient-sign-comp :
+      mere-equiv (Fin 2) (quotient-sign-comp n X)
+    mere-equiv-Fin-2-quotient-sign-comp =
+      map-trunc-Prop
+        ( equiv-Fin-2-quotient-sign-comp-equiv-Fin-n)
+        ( has-cardinality-type-UU-Fin-Level n X)
+
+module _
+  { l : Level}
+  where
+  
+  map-simpson-delooping-sign : (n : ℕ) →
+    classifying-type-Concrete-Group
+      ( Automorphism-Group
+        ( UU-Set l)
+        ( raise-Set l (Fin-Set n))
+        ( is-one-type-UU-Set l)) →
+    classifying-type-Concrete-Group
+      ( Automorphism-Group
+        ( UU-Set (lsuc lzero ⊔ l))
+        ( raise-Set (lsuc lzero ⊔ l) (Fin-Set 2))
+        ( is-one-type-UU-Set (lsuc lzero ⊔ l)))
+  pr1 (map-simpson-delooping-sign zero-ℕ X) = raise-Set (lsuc lzero ⊔ l) (Fin-Set 2)
+  pr2 (map-simpson-delooping-sign zero-ℕ X) = unit-trunc-Prop refl
+  pr1 (map-simpson-delooping-sign (succ-ℕ zero-ℕ) X) = raise-Set (lsuc lzero ⊔ l) (Fin-Set 2)
+  pr2 (map-simpson-delooping-sign (succ-ℕ zero-ℕ) X) = unit-trunc-Prop refl
+  pr1 (map-simpson-delooping-sign (succ-ℕ (succ-ℕ n)) (pair X p)) =
+    quotient-sign-comp-Set
+      ( succ-ℕ (succ-ℕ n))
+      ( pair
+        ( type-Set X)
+        ( map-trunc-Prop (λ p' → equiv-eq (inv (pr1 (pair-eq-Σ p'))) ∘e equiv-raise l (Fin (succ-ℕ (succ-ℕ n)))) p))
+  pr2 (map-simpson-delooping-sign (succ-ℕ (succ-ℕ n)) (pair X p)) =
+    map-trunc-Prop
+      ( λ e →
+        eq-pair-Σ
+          ( eq-equiv
+            ( type-Set (pr1 (map-simpson-delooping-sign (succ-ℕ (succ-ℕ n)) (pair X p))))
+            ( type-Set (raise-Set (lsuc lzero ⊔ l) (Fin-Set 2)))
+            ( equiv-raise (lsuc lzero ⊔ l) (Fin 2) ∘e inv-equiv e))
+          ( eq-is-prop (is-prop-is-set (raise (lsuc lzero ⊔ l) (type-Set (Fin-Set 2))))))
+      ( mere-equiv-Fin-2-quotient-sign-comp
+        ( succ-ℕ (succ-ℕ n))
+        ( pair
+          ( type-Set X)
+          ( map-trunc-Prop (λ p' → equiv-eq (inv (pr1 (pair-eq-Σ p'))) ∘e equiv-raise l (Fin (succ-ℕ (succ-ℕ n)))) p))
+        ( star))
+
+  simpson-delooping-sign : (n : ℕ) →
+    hom-Concrete-Group
+      ( Automorphism-Group (UU-Set l) (raise-Set l (Fin-Set n)) (is-one-type-UU-Set l))
+      ( Automorphism-Group
+        ( UU-Set (lsuc lzero ⊔ l))
+        ( raise-Set (lsuc lzero ⊔ l) (Fin-Set 2))
+        ( is-one-type-UU-Set (lsuc lzero ⊔ l)))
+  pr1 (simpson-delooping-sign n) = map-simpson-delooping-sign n
+  pr2 (simpson-delooping-sign zero-ℕ) = refl
+  pr2 (simpson-delooping-sign (succ-ℕ zero-ℕ)) = refl
+  pr2 (simpson-delooping-sign (succ-ℕ (succ-ℕ n))) =
+    eq-pair-Σ
+      ( eq-pair-Σ
+        ( eq-equiv
+          ( type-Set
+            ( pr1
+              ( map-simpson-delooping-sign
+                ( succ-ℕ (succ-ℕ n))
+                ( pair
+                  ( raise-Set l (Fin-Set (succ-ℕ (succ-ℕ n))))
+                  ( unit-trunc-Prop refl)))))
+          ( type-Set (raise-Set (lsuc lzero ⊔ l) (Fin-Set 2)))
+          ( equiv-raise (lsuc lzero ⊔ l) (Fin 2) ∘e
+            inv-equiv
+              ( equiv-Fin-2-quotient-sign-comp-equiv-Fin-n
+                ( succ-ℕ (succ-ℕ n))
+                ( pair
+                  ( raise l (Fin (succ-ℕ (succ-ℕ n))))
+                  ( map-trunc-Prop
+                    ( λ p' →
+                      ( equiv-eq (inv (pr1 (pair-eq-Σ p')))) ∘e
+                        ( equiv-raise l (Fin (succ-ℕ (succ-ℕ n)))))
+                    ( unit-trunc-Prop refl)))
+                ( star)
+                ( equiv-raise l (Fin (succ-ℕ (succ-ℕ n)))))))
+        ( eq-is-prop (is-prop-is-set _)))
+      ( eq-is-prop is-prop-type-trunc-Prop)
+```

--- a/src/finite-group-theory/tetrahedra-in-3-space.lagda.md
+++ b/src/finite-group-theory/tetrahedra-in-3-space.lagda.md
@@ -32,9 +32,9 @@ tetrahedron-in-3-space =
       cyclic-structure 3
         ( Σ ( 2-Element-Decidable-Subtype lzero
               ( 2-Element-Decidable-Subtype lzero
-                ( type-UU-Fin X)))
+                ( type-UU-Fin 4 X)))
             ( λ Q →
-              (x : type-UU-Fin X) →
+              (x : type-UU-Fin 4 X) →
               is-empty
                 ( (P : type-2-Element-Decidable-Subtype Q) →
                   is-in-2-Element-Decidable-Subtype
@@ -46,7 +46,7 @@ module _
   where
 
   vertex-tetrahedron-in-3-space : UU lzero
-  vertex-tetrahedron-in-3-space = type-UU-Fin (pr1 T)
+  vertex-tetrahedron-in-3-space = type-UU-Fin 4 (pr1 T)
 
   cyclic-structure-tetrahedron-in-3-space :
     cyclic-structure 3

--- a/src/finite-group-theory/transpositions.lagda.md
+++ b/src/finite-group-theory/transpositions.lagda.md
@@ -93,12 +93,12 @@ open import univalent-combinatorics.counting using
   ( count; equiv-count; inv-equiv-count; map-equiv-count; map-inv-equiv-count;
     number-of-elements-count; has-decidable-equality-count; is-set-count)
 open import univalent-combinatorics.equality-standard-finite-types using
-  ( has-decidable-equality-Fin; Fin-Set)
+  ( has-decidable-equality-Fin)
 open import univalent-combinatorics.finite-types using
   ( has-cardinality; has-cardinality-Prop)
 open import univalent-combinatorics.lists using
   (cons; list; fold-list; map-list; nil; concat-list)
-open import univalent-combinatorics.standard-finite-types using (Fin)
+open import univalent-combinatorics.standard-finite-types using (Fin; Fin-Set)
 ```
 
 ## Idea

--- a/src/foundation/commutative-operations.lagda.md
+++ b/src/foundation/commutative-operations.lagda.md
@@ -89,21 +89,21 @@ module _
     (X : UU lzero) (p : X → A) (e e' : Fin 2 ≃ X) →
     coprod
       ( htpy-equiv e e')
-      ( htpy-equiv e (e' ∘e equiv-succ-Fin)) →
-    ( f (p (map-equiv e zero-Fin)) (p (map-equiv e one-Fin))) ＝ 
-    ( f (p (map-equiv e' zero-Fin)) (p (map-equiv e' one-Fin)))
+      ( htpy-equiv e (e' ∘e equiv-succ-Fin 2)) →
+    ( f (p (map-equiv e (zero-Fin 1))) (p (map-equiv e (one-Fin 1)))) ＝ 
+    ( f (p (map-equiv e' (zero-Fin 1))) (p (map-equiv e' (one-Fin 1))))
   is-weakly-constant-on-equivalences-is-commutative f H X p e e' (inl K) =
-    ap-binary f (ap p (K zero-Fin)) (ap p (K one-Fin))
+    ap-binary f (ap p (K (zero-Fin 1))) (ap p (K (one-Fin 1)))
   is-weakly-constant-on-equivalences-is-commutative f H X p e e' (inr K) =
-    ( ap-binary f (ap p (K zero-Fin)) (ap p (K one-Fin))) ∙
-    ( H (p (map-equiv e' one-Fin)) (p (map-equiv e' zero-Fin)))
+    ( ap-binary f (ap p (K (zero-Fin 1))) (ap p (K (one-Fin 1)))) ∙
+    ( H (p (map-equiv e' (one-Fin 1))) (p (map-equiv e' (zero-Fin 1))))
   
   commutative-operation-is-commutative :
     (f : A → A → type-Set B) → is-commutative f →
     commutative-operation A (type-Set B)
   commutative-operation-is-commutative f H (pair (pair X K) p) =
     map-universal-property-set-quotient-trunc-Prop B
-      ( λ e → f (p (map-equiv e zero-Fin)) (p (map-equiv e one-Fin)))
+      ( λ e → f (p (map-equiv e (zero-Fin 1))) (p (map-equiv e (one-Fin 1))))
       ( λ e e' →
         is-weakly-constant-on-equivalences-is-commutative f H X p e e'
           ( map-equiv-coprod
@@ -111,11 +111,11 @@ module _
             ( inv-equiv (equiv-ev-zero-htpy-equiv-Fin-two-ℕ
               ( pair X K)
               ( e)
-              ( e' ∘e equiv-succ-Fin)))
+              ( e' ∘e equiv-succ-Fin 2)))
             ( decide-value-equiv-Fin-two-ℕ
               ( pair X K)
               ( e')
-              ( map-equiv e zero-Fin))))
+              ( map-equiv e (zero-Fin 1)))))
       ( K)
 
   compute-commutative-operation-is-commutative :
@@ -125,7 +125,7 @@ module _
   compute-commutative-operation-is-commutative f H x y =
     
     htpy-universal-property-set-quotient-trunc-Prop B
-      ( λ e → f (p (map-equiv e zero-Fin)) (p (map-equiv e one-Fin)))
+      ( λ e → f (p (map-equiv e (zero-Fin 1))) (p (map-equiv e (one-Fin 1))))
       ( λ e e' →
         is-weakly-constant-on-equivalences-is-commutative f H (Fin 2) p e e'
           ( map-equiv-coprod
@@ -133,11 +133,11 @@ module _
             ( inv-equiv (equiv-ev-zero-htpy-equiv-Fin-two-ℕ
               ( Fin-UU-Fin 2)
               ( e)
-              ( e' ∘e equiv-succ-Fin)))
+              ( e' ∘e equiv-succ-Fin 2)))
             ( decide-value-equiv-Fin-two-ℕ
               ( Fin-UU-Fin 2)
               ( e')
-              ( map-equiv e zero-Fin))))
+              ( map-equiv e (zero-Fin 1)))))
       ( id-equiv)
     where
     p : Fin 2 → A

--- a/src/foundation/decidable-propositions.lagda.md
+++ b/src/foundation/decidable-propositions.lagda.md
@@ -35,7 +35,9 @@ open import foundation.propositional-extensionality using
 open import foundation.propositions using
   ( is-prop; UU-Prop; type-Prop; is-prop-type-Prop; is-prop-is-inhabited;
     is-prop-prod; is-prop-is-prop; is-proof-irrelevant-is-prop)
+open import foundation.raising-universe-levels using (raise; equiv-raise)
 open import foundation.sets using (is-set; is-set-equiv)
+open import foundation.small-types using (is-small)
 open import foundation.subtypes using (is-emb-inclusion-subtype)
 open import foundation.type-arithmetic-coproduct-types using
   ( left-distributive-Σ-coprod)
@@ -248,4 +250,15 @@ module _
     (type-decidable-Prop Q → type-decidable-Prop P) → P ＝ Q
   eq-iff-decidable-Prop f g =
     map-inv-equiv extensionality-decidable-Prop (pair f g)
+```
+
+### The type of decidable propositions in any universe is small
+
+```agda
+abstract
+  is-small-decidable-Prop :
+    (l1 l2 : Level) → is-small l2 (decidable-Prop l1)
+  pr1 (is-small-decidable-Prop l1 l2) = raise l2 bool
+  pr2 (is-small-decidable-Prop l1 l2) =
+    equiv-raise l2 bool ∘e equiv-bool-decidable-Prop
 ```

--- a/src/foundation/dependent-binomial-theorem.lagda.md
+++ b/src/foundation/dependent-binomial-theorem.lagda.md
@@ -56,9 +56,9 @@ module _
 
   map-inv-compute-total-fam-coprod :
     coprod A B → Σ (Fin 2) fam-coprod
-  pr1 (map-inv-compute-total-fam-coprod (inl x)) = zero-Fin
+  pr1 (map-inv-compute-total-fam-coprod (inl x)) = zero-Fin 1
   pr2 (map-inv-compute-total-fam-coprod (inl x)) = map-raise x
-  pr1 (map-inv-compute-total-fam-coprod (inr x)) = one-Fin
+  pr1 (map-inv-compute-total-fam-coprod (inr x)) = one-Fin 1
   pr2 (map-inv-compute-total-fam-coprod (inr x)) = map-raise x
 
   issec-map-inv-compute-total-fam-coprod :
@@ -71,9 +71,9 @@ module _
   isretr-map-inv-compute-total-fam-coprod :
     (map-inv-compute-total-fam-coprod ∘ map-compute-total-fam-coprod) ~ id
   isretr-map-inv-compute-total-fam-coprod (pair (inl (inr star)) y) =
-    ap (pair zero-Fin) (issec-map-inv-raise y)
+    ap (pair (zero-Fin 1)) (issec-map-inv-raise y)
   isretr-map-inv-compute-total-fam-coprod (pair (inr star) y) =
-    ap (pair one-Fin) (issec-map-inv-raise y)
+    ap (pair (one-Fin 1)) (issec-map-inv-raise y)
 
   is-equiv-map-compute-total-fam-coprod :
     is-equiv map-compute-total-fam-coprod
@@ -100,8 +100,8 @@ module _
   type-distributive-Π-coprod : UU (l1 ⊔ l2 ⊔ l3)
   type-distributive-Π-coprod =
     Σ ( X → Fin 2)
-      ( λ f → ((x : X) (p : is-zero-Fin (f x)) → A x) ×
-              ((x : X) (p : is-one-Fin (f x)) → B x))
+      ( λ f → ((x : X) (p : is-zero-Fin 2 (f x)) → A x) ×
+              ((x : X) (p : is-one-Fin 2 (f x)) → B x))
 
   distributive-Π-coprod :
     ((x : X) → coprod (A x) (B x)) ≃ type-distributive-Π-coprod

--- a/src/foundation/global-choice.lagda.md
+++ b/src/foundation/global-choice.lagda.md
@@ -48,5 +48,5 @@ abstract
   no-global-choice f =
     no-section-type-UU-Fin-Level-two-ℕ
       ( λ X →
-        f (pr1 X) (map-trunc-Prop (λ e → map-equiv e zero-Fin) (pr2 X)))
+        f (pr1 X) (map-trunc-Prop (λ e → map-equiv e (zero-Fin 1)) (pr2 X)))
 ```

--- a/src/foundation/iterating-involutions.lagda.md
+++ b/src/foundation/iterating-involutions.lagda.md
@@ -30,13 +30,13 @@ module _
   where
   
   iterate-involution :
-    (n : ℕ) (x : X) → iterate n f x ＝ iterate (nat-Fin (mod-two-ℕ n)) f x
+    (n : ℕ) (x : X) → iterate n f x ＝ iterate (nat-Fin 2 (mod-two-ℕ n)) f x
   iterate-involution zero-ℕ x = refl
   iterate-involution (succ-ℕ n) x =
     ap f (iterate-involution n x) ∙ (cases-iterate-involution (mod-two-ℕ n))
     where
     cases-iterate-involution : (k : Fin 2) →
-      Id (f (iterate (nat-Fin k) f x)) (iterate (nat-Fin (succ-Fin k)) f x) 
+      Id (f (iterate (nat-Fin 2 k) f x)) (iterate (nat-Fin 2 (succ-Fin 2 k)) f x) 
     cases-iterate-involution (inl (inr star)) = refl
     cases-iterate-involution (inr star) = P x
 ```

--- a/src/foundation/products-unordered-tuples-of-types.lagda.md
+++ b/src/foundation/products-unordered-tuples-of-types.lagda.md
@@ -38,44 +38,46 @@ Given an unordered pair of types, we can take their product. This is a commutati
 
 ```agda
 product-unordered-tuple-types :
-  {l : Level} {n : ℕ} → unordered-tuple n (UU l) → (UU l)
-product-unordered-tuple-types p =
-  (x : type-unordered-tuple p) → element-unordered-tuple p x
+  {l : Level} (n : ℕ) → unordered-tuple n (UU l) → (UU l)
+product-unordered-tuple-types n p =
+  (x : type-unordered-tuple n p) → element-unordered-tuple n p x
 
 pr-product-unordered-tuple-types :
-  {l : Level} {n : ℕ} (A : unordered-tuple-types l n)
-  (i : type-unordered-tuple A) →
-  product-unordered-tuple-types A → element-unordered-tuple A i
-pr-product-unordered-tuple-types A i f = f i
+  {l : Level} (n : ℕ) (A : unordered-tuple-types l n)
+  (i : type-unordered-tuple n A) →
+  product-unordered-tuple-types n A → element-unordered-tuple n A i
+pr-product-unordered-tuple-types n A i f = f i
 
 equiv-pr-product-unordered-tuple-types :
-  {l : Level} {n : ℕ} (A : unordered-tuple-types l (succ-ℕ n))
-  (i : type-unordered-tuple A) →
-  ( ( product-unordered-tuple-types
-      ( unordered-tuple-complement-point-type-unordered-tuple A i)) ×
-    ( element-unordered-tuple A i)) ≃
-  product-unordered-tuple-types A
-equiv-pr-product-unordered-tuple-types A i =
+  {l : Level} (n : ℕ) (A : unordered-tuple-types l (succ-ℕ n))
+  (i : type-unordered-tuple (succ-ℕ n) A) →
+  ( ( product-unordered-tuple-types n
+      ( unordered-tuple-complement-point-type-unordered-tuple n A i)) ×
+    ( element-unordered-tuple (succ-ℕ n) A i)) ≃
+  product-unordered-tuple-types (succ-ℕ n) A
+equiv-pr-product-unordered-tuple-types n A i =
   ( equiv-Π
-    ( element-unordered-tuple A)
-    ( equiv-maybe-structure-point-UU-Fin (type-unordered-tuple-UU-Fin A) i)
+    ( element-unordered-tuple (succ-ℕ n) A)
+    ( equiv-maybe-structure-point-UU-Fin n
+      ( type-unordered-tuple-UU-Fin (succ-ℕ n) A) i)
     ( λ x → id-equiv)) ∘e
   ( inv-equiv
     ( equiv-dependent-universal-property-Maybe
       ( λ j →
-        element-unordered-tuple A
-          ( map-equiv (equiv-maybe-structure-point-UU-Fin
-            ( type-unordered-tuple-UU-Fin A) i)
+        element-unordered-tuple (succ-ℕ n) A
+          ( map-equiv (equiv-maybe-structure-point-UU-Fin n
+            ( type-unordered-tuple-UU-Fin (succ-ℕ n) A) i)
             ( j)))))
 
 map-equiv-pr-product-unordered-tuple-types :
-  {l : Level} {n : ℕ} (A : unordered-tuple-types l (succ-ℕ n))
-  (i : type-unordered-tuple A) →
-  product-unordered-tuple-types
-    ( unordered-tuple-complement-point-type-unordered-tuple A i) →
-  element-unordered-tuple A i → product-unordered-tuple-types A
-map-equiv-pr-product-unordered-tuple-types A i f a =
-  map-equiv (equiv-pr-product-unordered-tuple-types A i) (pair f a)
+  {l : Level} (n : ℕ) (A : unordered-tuple-types l (succ-ℕ n))
+  (i : type-unordered-tuple (succ-ℕ n) A) →
+  product-unordered-tuple-types n
+    ( unordered-tuple-complement-point-type-unordered-tuple n A i) →
+  element-unordered-tuple (succ-ℕ n) A i →
+  product-unordered-tuple-types (succ-ℕ n) A
+map-equiv-pr-product-unordered-tuple-types n A i f a =
+  map-equiv (equiv-pr-product-unordered-tuple-types n A i) (pair f a)
 ```
 
 ### Equivalences of products of unordered pairs of types
@@ -87,11 +89,11 @@ module _
   where
 
   equiv-product-unordered-tuple-types :
-    equiv-unordered-tuple-types A B →
-    product-unordered-tuple-types A ≃ product-unordered-tuple-types B
+    equiv-unordered-tuple-types n A B →
+    product-unordered-tuple-types n A ≃ product-unordered-tuple-types n B
   equiv-product-unordered-tuple-types e =
     equiv-Π
-      ( element-unordered-tuple B)
-      ( equiv-type-equiv-unordered-tuple-types A B e)
-      ( equiv-element-equiv-unordered-tuple-types A B e)
+      ( element-unordered-tuple n B)
+      ( equiv-type-equiv-unordered-tuple-types n A B e)
+      ( equiv-element-equiv-unordered-tuple-types n A B e)
 ```

--- a/src/foundation/small-types.lagda.md
+++ b/src/foundation/small-types.lagda.md
@@ -10,8 +10,6 @@ module foundation.small-types where
 open import foundation.booleans using (bool)
 open import foundation.contractible-types using
   ( is-contr; equiv-is-contr; is-contr-equiv')
-open import foundation.decidable-propositions using
-  ( decidable-Prop; equiv-bool-decidable-Prop)
 open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2)
 open import foundation.equivalences using
   ( _≃_; map-equiv; is-equiv-map-equiv; map-inv-equiv; _∘e_; inv-equiv;
@@ -151,17 +149,6 @@ equiv-UU-is-small :
 equiv-UU-is-small l1 l2 =
   ( equiv-tot (λ X → equiv-tot (λ Y → equiv-inv-equiv))) ∘e
   ( equiv-left-swap-Σ)
-```
-
-### The type of decidable propositions in any universe is small
-
-```agda
-abstract
-  is-small-decidable-Prop :
-    (l1 l2 : Level) → is-small l2 (decidable-Prop l1)
-  pr1 (is-small-decidable-Prop l1 l2) = raise l2 bool
-  pr2 (is-small-decidable-Prop l1 l2) =
-    equiv-raise l2 bool ∘e equiv-bool-decidable-Prop
 ```
 
 ### Being small is a property

--- a/src/foundation/unordered-pairs.lagda.md
+++ b/src/foundation/unordered-pairs.lagda.md
@@ -40,12 +40,12 @@ open import univalent-combinatorics.2-element-types using
   ( 2-Element-Type; type-2-Element-Type; map-swap-2-Element-Type;
     has-two-elements; has-two-elements-type-2-Element-Type)
 open import univalent-combinatorics.equality-standard-finite-types using
-  ( is-set-Fin; has-decidable-equality-Fin)
+  ( has-decidable-equality-Fin)
 open import univalent-combinatorics.finite-types using
   ( UU-Fin; Fin-UU-Fin; equiv-UU-Fin; id-equiv-UU-Fin;
     is-contr-total-equiv-UU-Fin; type-UU-Fin)
 open import univalent-combinatorics.standard-finite-types using
-  ( Fin; equiv-succ-Fin)
+  ( Fin; equiv-succ-Fin; is-set-Fin)
 ```
 
 ## Idea
@@ -87,7 +87,7 @@ module _
   has-decidable-equality-type-unordered-pair =
     has-decidable-equality-mere-equiv'
       has-two-elements-type-unordered-pair
-      has-decidable-equality-Fin
+      ( has-decidable-equality-Fin 2)
 
   element-unordered-pair : type-unordered-pair → A
   element-unordered-pair = pr2 p
@@ -143,10 +143,10 @@ module _
 
   Eq-unordered-pair : (p q : unordered-pair A) → UU l1
   Eq-unordered-pair (pair X p) (pair Y q) =
-    Σ (equiv-UU-Fin X Y) (λ e → p ~ (q ∘ map-equiv e))
+    Σ (equiv-UU-Fin 2 X Y) (λ e → p ~ (q ∘ map-equiv e))
 
   refl-Eq-unordered-pair : (p : unordered-pair A) → Eq-unordered-pair p p
-  pr1 (refl-Eq-unordered-pair (pair X p)) = id-equiv-UU-Fin X
+  pr1 (refl-Eq-unordered-pair (pair X p)) = id-equiv-UU-Fin 2 X
   pr2 (refl-Eq-unordered-pair (pair X p)) = refl-htpy
 
   Eq-eq-unordered-pair :
@@ -159,8 +159,8 @@ module _
   is-contr-total-Eq-unordered-pair (pair X p) =
     is-contr-total-Eq-structure
       ( λ Y q e → p ~ (q ∘ map-equiv e))
-      ( is-contr-total-equiv-UU-Fin X)
-      ( pair X (id-equiv-UU-Fin X))
+      ( is-contr-total-equiv-UU-Fin 2 X)
+      ( pair X (id-equiv-UU-Fin 2 X))
       ( is-contr-total-htpy p)
 
   is-equiv-Eq-eq-unordered-pair :
@@ -222,7 +222,9 @@ is-commutative-standard-unordered-pair x y =
   eq-Eq-unordered-pair
     ( standard-unordered-pair x y)
     ( standard-unordered-pair y x)
-    ( pair equiv-succ-Fin (λ { (inl (inr star)) → refl ; (inr star) → refl}))
+    ( pair
+      ( equiv-succ-Fin 2)
+      ( λ { (inl (inr star)) → refl ; (inr star) → refl}))
 ```
 
 ### Functoriality of unordered pairs
@@ -266,7 +268,7 @@ preserves-refl-htpy-unordered-pair f p =
 equiv-unordered-pair :
   {l1 l2 : Level} {A : UU l1} {B : UU l2} →
   (A ≃ B) → (unordered-pair A ≃ unordered-pair B)
-equiv-unordered-pair e = equiv-tot (λ X → equiv-postcomp (type-UU-Fin X) e)
+equiv-unordered-pair e = equiv-tot (λ X → equiv-postcomp (type-UU-Fin 2 X) e)
 
 map-equiv-unordered-pair :
   {l1 l2 : Level} {A : UU l1} {B : UU l2} →

--- a/src/foundation/unordered-tuples-of-types.lagda.md
+++ b/src/foundation/unordered-tuples-of-types.lagda.md
@@ -39,33 +39,35 @@ unordered-tuple-types l n = unordered-tuple n (UU l)
 
 ```agda
 equiv-unordered-tuple-types :
-  {l1 l2 : Level} {n : ℕ} →
+  {l1 l2 : Level} (n : ℕ) →
   unordered-tuple-types l1 n → unordered-tuple-types l2 n → UU (l1 ⊔ l2)
-equiv-unordered-tuple-types A B =
-  Σ ( type-unordered-tuple A ≃ type-unordered-tuple B)
+equiv-unordered-tuple-types n A B =
+  Σ ( type-unordered-tuple n A ≃ type-unordered-tuple n B)
     ( λ e →
-      (i : type-unordered-tuple A) →
-      element-unordered-tuple A i ≃ element-unordered-tuple B (map-equiv e i))
+      (i : type-unordered-tuple n A) →
+      element-unordered-tuple n A i ≃
+      element-unordered-tuple n B (map-equiv e i))
 
 module _
-  {l1 l2 : Level} {n : ℕ}
+  {l1 l2 : Level} (n : ℕ)
   (A : unordered-tuple-types l1 n) (B : unordered-tuple-types l2 n)
-  (e : equiv-unordered-tuple-types A B)
+  (e : equiv-unordered-tuple-types n A B)
   where
 
   equiv-type-equiv-unordered-tuple-types :
-    type-unordered-tuple A ≃ type-unordered-tuple B
+    type-unordered-tuple n A ≃ type-unordered-tuple n B
   equiv-type-equiv-unordered-tuple-types = pr1 e
 
   map-equiv-type-equiv-unordered-tuple-types :
-    type-unordered-tuple A → type-unordered-tuple B
+    type-unordered-tuple n A → type-unordered-tuple n B
   map-equiv-type-equiv-unordered-tuple-types =
     map-equiv equiv-type-equiv-unordered-tuple-types
 
   equiv-element-equiv-unordered-tuple-types :
-    (i : type-unordered-tuple A) →
-    ( element-unordered-tuple A i) ≃
-    ( element-unordered-tuple B (map-equiv-type-equiv-unordered-tuple-types i))
+    (i : type-unordered-tuple n A) →
+    ( element-unordered-tuple n A i) ≃
+    ( element-unordered-tuple n B
+      ( map-equiv-type-equiv-unordered-tuple-types i))
   equiv-element-equiv-unordered-tuple-types = pr2 e
 ```
 
@@ -78,24 +80,24 @@ module _
   {l : Level} {n : ℕ} (A : unordered-tuple-types l n)
   where
   
-  id-equiv-unordered-tuple-types : equiv-unordered-tuple-types A A
+  id-equiv-unordered-tuple-types : equiv-unordered-tuple-types n A A
   pr1 id-equiv-unordered-tuple-types = id-equiv
   pr2 id-equiv-unordered-tuple-types i = id-equiv
 
   equiv-eq-unordered-tuple-types :
-    (B : unordered-tuple-types l n) → A ＝ B → equiv-unordered-tuple-types A B
+    (B : unordered-tuple-types l n) → A ＝ B → equiv-unordered-tuple-types n A B
   equiv-eq-unordered-tuple-types .A refl = id-equiv-unordered-tuple-types
 
   is-contr-total-equiv-unordered-tuple-types :
-    is-contr (Σ (unordered-tuple-types l n) (equiv-unordered-tuple-types A))
+    is-contr (Σ (unordered-tuple-types l n) (equiv-unordered-tuple-types n A))
   is-contr-total-equiv-unordered-tuple-types =
     is-contr-total-Eq-structure
       ( λ I B e →
-        (i : type-unordered-tuple A) →
-        element-unordered-tuple A i ≃ B (map-equiv e i))
-      ( is-contr-total-equiv-UU-Fin (type-unordered-tuple-UU-Fin A))
-      ( pair (type-unordered-tuple-UU-Fin A) id-equiv)
-      ( is-contr-total-equiv-fam (element-unordered-tuple A))
+        (i : type-unordered-tuple n A) →
+        element-unordered-tuple n A i ≃ B (map-equiv e i))
+      ( is-contr-total-equiv-UU-Fin n (type-unordered-tuple-UU-Fin n A))
+      ( pair (type-unordered-tuple-UU-Fin n A) id-equiv)
+      ( is-contr-total-equiv-fam (element-unordered-tuple n A))
 
   is-equiv-equiv-eq-unordered-tuple-types :
     (B : unordered-tuple-types l n) →
@@ -107,7 +109,8 @@ module _
       equiv-eq-unordered-tuple-types
 
   extensionality-unordered-tuple-types :
-    (B : unordered-tuple-types l n) → (A ＝ B) ≃ equiv-unordered-tuple-types A B
+    (B : unordered-tuple-types l n) →
+    (A ＝ B) ≃ equiv-unordered-tuple-types n A B
   pr1 (extensionality-unordered-tuple-types B) =
     equiv-eq-unordered-tuple-types B
   pr2 (extensionality-unordered-tuple-types B) =

--- a/src/foundation/unordered-tuples.lagda.md
+++ b/src/foundation/unordered-tuples.lagda.md
@@ -39,30 +39,30 @@ An unordered n-tuple of elements of a type `A` consists of an n-element set `X` 
 ```agda
 unordered-tuple :
   {l : Level} (n : ℕ) (A : UU l) → UU (lsuc lzero ⊔ l)
-unordered-tuple n A = Σ (UU-Fin n) (λ X → type-UU-Fin X → A)
+unordered-tuple n A = Σ (UU-Fin n) (λ X → type-UU-Fin n X → A)
 
 module _
-  {l : Level} {n : ℕ} {A : UU l} (t : unordered-tuple n A)
+  {l : Level} (n : ℕ) {A : UU l} (t : unordered-tuple n A)
   where
 
   type-unordered-tuple-UU-Fin : UU-Fin n
   type-unordered-tuple-UU-Fin = pr1 t
 
   type-unordered-tuple : UU lzero
-  type-unordered-tuple = type-UU-Fin type-unordered-tuple-UU-Fin
+  type-unordered-tuple = type-UU-Fin n type-unordered-tuple-UU-Fin
 
   has-cardinality-type-unordered-tuple : has-cardinality n type-unordered-tuple
   has-cardinality-type-unordered-tuple =
-    has-cardinality-type-UU-Fin type-unordered-tuple-UU-Fin
+    has-cardinality-type-UU-Fin n type-unordered-tuple-UU-Fin
 
   is-set-type-unordered-tuple : is-set type-unordered-tuple
   is-set-type-unordered-tuple =
-    is-set-has-cardinality has-cardinality-type-unordered-tuple
+    is-set-has-cardinality n has-cardinality-type-unordered-tuple
 
   has-decidable-equality-type-unordered-tuple :
     has-decidable-equality type-unordered-tuple
   has-decidable-equality-type-unordered-tuple =
-    has-decidable-equality-has-cardinality
+    has-decidable-equality-has-cardinality n
       has-cardinality-type-unordered-tuple
       
   element-unordered-tuple : type-unordered-tuple → A
@@ -73,38 +73,42 @@ module _
 
 ```agda
 module _
-  {l : Level} {n : ℕ} {A : UU l} (t : unordered-tuple (succ-ℕ n) A)
-  (i : type-unordered-tuple t)
+  {l : Level} (n : ℕ) {A : UU l} (t : unordered-tuple (succ-ℕ n) A)
+  (i : type-unordered-tuple (succ-ℕ n) t)
   where
 
   type-complement-point-unordered-tuple-UU-Fin : UU-Fin n
   type-complement-point-unordered-tuple-UU-Fin =
-    complement-point-UU-Fin (pair (type-unordered-tuple-UU-Fin t) i)
+    complement-point-UU-Fin n
+      ( pair (type-unordered-tuple-UU-Fin (succ-ℕ n) t) i)
 
   type-complement-point-unordered-tuple : UU lzero
   type-complement-point-unordered-tuple =
-    type-UU-Fin type-complement-point-unordered-tuple-UU-Fin
+    type-UU-Fin n type-complement-point-unordered-tuple-UU-Fin
 
   inclusion-complement-point-unordered-tuple :
-    type-complement-point-unordered-tuple → type-unordered-tuple t
+    type-complement-point-unordered-tuple → type-unordered-tuple (succ-ℕ n) t
   inclusion-complement-point-unordered-tuple =
-    inclusion-complement-point-UU-Fin (pair (type-unordered-tuple-UU-Fin t) i)
+    inclusion-complement-point-UU-Fin n
+      ( pair (type-unordered-tuple-UU-Fin (succ-ℕ n) t) i)
 
   unordered-tuple-complement-point-type-unordered-tuple :
     unordered-tuple n A
   pr1 unordered-tuple-complement-point-type-unordered-tuple =
-    complement-point-UU-Fin (pair (type-unordered-tuple-UU-Fin t) i)
+    complement-point-UU-Fin n
+      ( pair (type-unordered-tuple-UU-Fin (succ-ℕ n) t) i)
   pr2 unordered-tuple-complement-point-type-unordered-tuple =
-    element-unordered-tuple t ∘ inclusion-complement-point-unordered-tuple
+    ( element-unordered-tuple (succ-ℕ n) t) ∘
+    ( inclusion-complement-point-unordered-tuple)
 ```
 
 ### Standard unordered tuples
 
 ```agda
 standard-unordered-tuple :
-  {l : Level} {n : ℕ} {A : UU l} (f : Fin n → A) → unordered-tuple n A
-pr1 (standard-unordered-tuple f) = Fin-UU-Fin _
-pr2 (standard-unordered-tuple f) = f
+  {l : Level} (n : ℕ) {A : UU l} (f : Fin n → A) → unordered-tuple n A
+pr1 (standard-unordered-tuple n f) = Fin-UU-Fin n
+pr2 (standard-unordered-tuple n f) = f
 ```
 
 ## Properties
@@ -113,14 +117,15 @@ pr2 (standard-unordered-tuple f) = f
 
 ```agda
 module _
-  {l : Level} {n : ℕ} {A : UU l}
+  {l : Level} (n : ℕ) {A : UU l}
   where
   
   Eq-unordered-tuple : unordered-tuple n A → unordered-tuple n A → UU l
   Eq-unordered-tuple x y =
-    Σ ( type-unordered-tuple x ≃ type-unordered-tuple y)
+    Σ ( type-unordered-tuple n x ≃ type-unordered-tuple n y)
       ( λ e →
-        element-unordered-tuple x ~ (element-unordered-tuple y ∘ map-equiv e))
+        ( element-unordered-tuple n x) ~
+        ( element-unordered-tuple n y ∘ map-equiv e))
 
   refl-Eq-unordered-tuple :
     (x : unordered-tuple n A) → Eq-unordered-tuple x x
@@ -136,10 +141,10 @@ module _
     is-contr (Σ (unordered-tuple n A) (Eq-unordered-tuple x))
   is-contr-total-Eq-unordered-tuple x =
     is-contr-total-Eq-structure
-      ( λ i f e → element-unordered-tuple x ~ (f ∘ map-equiv e))
-      ( is-contr-total-equiv-UU-Fin (type-unordered-tuple-UU-Fin x))
-      ( pair (type-unordered-tuple-UU-Fin x) id-equiv)
-      ( is-contr-total-htpy (element-unordered-tuple x))
+      ( λ i f e → element-unordered-tuple n x ~ (f ∘ map-equiv e))
+      ( is-contr-total-equiv-UU-Fin n (type-unordered-tuple-UU-Fin n x))
+      ( pair (type-unordered-tuple-UU-Fin n x) id-equiv)
+      ( is-contr-total-htpy (element-unordered-tuple n x))
 
   is-equiv-Eq-eq-unordered-tuple :
     (x y : unordered-tuple n A) → is-equiv (Eq-eq-unordered-tuple x y)
@@ -172,8 +177,8 @@ module _
 map-unordered-tuple :
   {l1 l2 : Level} (n : ℕ) {A : UU l1} {B : UU l2} (f : A → B) →
   unordered-tuple n A → unordered-tuple n B
-pr1 (map-unordered-tuple n f t) = type-unordered-tuple-UU-Fin t
-pr2 (map-unordered-tuple n f t) = f ∘ element-unordered-tuple t
+pr1 (map-unordered-tuple n f t) = type-unordered-tuple-UU-Fin n t
+pr2 (map-unordered-tuple n f t) = f ∘ element-unordered-tuple n t
 
 preserves-comp-map-unordered-tuple :
   {l1 l2 l3 : Level} (n : ℕ) {A : UU l1} {B : UU l2} {C : UU l3}
@@ -191,16 +196,16 @@ htpy-unordered-tuple :
   {l1 l2 : Level} (n : ℕ) {A : UU l1} {B : UU l2} {f g : A → B} →
   (f ~ g) → (map-unordered-tuple n f ~ map-unordered-tuple n g)
 htpy-unordered-tuple n {f = f} {g = g} H t =
-  eq-Eq-unordered-tuple
+  eq-Eq-unordered-tuple n
     ( map-unordered-tuple n f t)
     ( map-unordered-tuple n g t)
-    ( pair id-equiv (H ·r element-unordered-tuple t))
+    ( pair id-equiv (H ·r element-unordered-tuple n t))
 
 preserves-refl-htpy-unordered-tuple :
   {l1 l2 : Level} (n : ℕ) {A : UU l1} {B : UU l2} (f : A → B) →
   htpy-unordered-tuple n (refl-htpy {f = f}) ~ refl-htpy
 preserves-refl-htpy-unordered-tuple n f p =
-  isretr-eq-Eq-unordered-tuple
+  isretr-eq-Eq-unordered-tuple n
     ( map-unordered-tuple n f p)
     ( map-unordered-tuple n f p)
     ( refl)
@@ -208,7 +213,7 @@ preserves-refl-htpy-unordered-tuple n f p =
 equiv-unordered-tuple :
   {l1 l2 : Level} (n : ℕ) {A : UU l1} {B : UU l2} →
   (A ≃ B) → (unordered-tuple n A ≃ unordered-tuple n B)
-equiv-unordered-tuple n e = equiv-tot (λ X → equiv-postcomp (type-UU-Fin X) e)
+equiv-unordered-tuple n e = equiv-tot (λ X → equiv-postcomp (type-UU-Fin n X) e)
 
 map-equiv-unordered-tuple :
   {l1 l2 : Level} (n : ℕ) {A : UU l1} {B : UU l2} →

--- a/src/foundation/xor.lagda.md
+++ b/src/foundation/xor.lagda.md
@@ -131,7 +131,7 @@ all-elements-equal-type-commutative-xor-Prop :
 all-elements-equal-type-commutative-xor-Prop (pair X P) x y =
   cases-is-prop-type-commutative-xor-Prop
     ( has-decidable-equality-is-finite
-      ( is-finite-type-UU-Fin-Level X)
+      ( is-finite-type-UU-Fin-Level 2 X)
       ( pr1 x)
       ( pr1 y))
   where
@@ -178,7 +178,7 @@ module _
       ( pair p
         ( tr
           ( λ t → ¬ (element-unordered-pair (standard-unordered-pair A B) t))
-          ( compute-swap-Fin-two-ℕ zero-Fin)
+          ( compute-swap-Fin-two-ℕ (zero-Fin 1))
           ( nq)))
   xor-commutative-xor (pair (inr star) (pair q np)) =
     inr
@@ -186,24 +186,24 @@ module _
         ( q)
         ( tr
           ( λ t → ¬ (element-unordered-pair (standard-unordered-pair A B) t))
-          ( compute-swap-Fin-two-ℕ one-Fin)
+          ( compute-swap-Fin-two-ℕ (one-Fin 1))
           ( np)))
 
   commutative-xor-xor :
     xor A B → commutative-xor (standard-unordered-pair A B)
-  pr1 (commutative-xor-xor (inl (pair a nb))) = zero-Fin
+  pr1 (commutative-xor-xor (inl (pair a nb))) = (zero-Fin 1)
   pr1 (pr2 (commutative-xor-xor (inl (pair a nb)))) = a
   pr2 (pr2 (commutative-xor-xor (inl (pair a nb)))) =
     tr
       ( λ t → ¬ (element-unordered-pair (standard-unordered-pair A B) t))
-      ( inv (compute-swap-Fin-two-ℕ zero-Fin))
+      ( inv (compute-swap-Fin-two-ℕ (zero-Fin 1)))
       ( nb)
-  pr1 (commutative-xor-xor (inr (pair na b))) = one-Fin
+  pr1 (commutative-xor-xor (inr (pair na b))) = (one-Fin 1)
   pr1 (pr2 (commutative-xor-xor (inr (pair b na)))) = b
   pr2 (pr2 (commutative-xor-xor (inr (pair b na)))) =
     tr
       ( λ t → ¬ (element-unordered-pair (standard-unordered-pair A B) t))
-      ( inv (compute-swap-Fin-two-ℕ one-Fin))
+      ( inv (compute-swap-Fin-two-ℕ (one-Fin 1)))
       ( na)
 
 
@@ -228,7 +228,7 @@ module _
                       ( λ b →
                         ( ¬ (type-Prop (pr2 (standard-unordered-pair P Q) b))) ≃
                         ( ¬ (type-Prop Q)))
-                      ( inv (compute-swap-Fin-two-ℕ zero-Fin))
+                      ( inv (compute-swap-Fin-two-ℕ (zero-Fin ?)))
                       ( id-equiv))) ∘e
                     ( left-unit-law-Σ
                       ( λ y →
@@ -255,7 +255,7 @@ module _
               ( λ b →
                 ¬ (type-Prop (pr2 (standard-unordered-pair P Q) b)) ≃
                 ¬ (type-Prop P))
-              ( inv (compute-swap-Fin-two-ℕ one-Fin))
+              ( inv (compute-swap-Fin-two-ℕ (one-Fin ?)))
               ( id-equiv))
             ( id-equiv)) ∘e
           ( ( commutative-prod) ∘e
@@ -298,7 +298,7 @@ module _
           ( λ t →
             ¬ ( type-Prop
                 ( element-unordered-pair (standard-unordered-pair P Q) t)))
-          ( compute-swap-Fin-two-ℕ zero-Fin)
+          ( compute-swap-Fin-two-ℕ (zero-Fin 1))
           ( nq)))
   xor-commutative-xor-Prop (pair (inr star) (pair q np)) =
     inr
@@ -307,28 +307,28 @@ module _
           ( λ t →
             ¬ ( type-Prop
                 ( element-unordered-pair (standard-unordered-pair P Q) t)))
-          ( compute-swap-Fin-two-ℕ one-Fin)
+          ( compute-swap-Fin-two-ℕ (one-Fin 1))
           ( np)))
 
   commutative-xor-xor-Prop :
     type-hom-Prop
       ( xor-Prop P Q)
       ( commutative-xor-Prop (standard-unordered-pair P Q))
-  pr1 (commutative-xor-xor-Prop (inl (pair p nq))) = zero-Fin
+  pr1 (commutative-xor-xor-Prop (inl (pair p nq))) = (zero-Fin 1)
   pr1 (pr2 (commutative-xor-xor-Prop (inl (pair p nq)))) = p
   pr2 (pr2 (commutative-xor-xor-Prop (inl (pair p nq)))) =
     tr
       ( λ t →
         ¬ (type-Prop (element-unordered-pair (standard-unordered-pair P Q) t)))
-      ( inv (compute-swap-Fin-two-ℕ zero-Fin))
+      ( inv (compute-swap-Fin-two-ℕ (zero-Fin 1)))
       ( nq)
-  pr1 (commutative-xor-xor-Prop (inr (pair q np))) = one-Fin
+  pr1 (commutative-xor-xor-Prop (inr (pair q np))) = (one-Fin 1)
   pr1 (pr2 (commutative-xor-xor-Prop (inr (pair q np)))) = q
   pr2 (pr2 (commutative-xor-xor-Prop (inr (pair q np)))) =
     tr
       ( λ t →
         ¬ (type-Prop (element-unordered-pair (standard-unordered-pair P Q) t)))
-      ( inv (compute-swap-Fin-two-ℕ one-Fin))
+      ( inv (compute-swap-Fin-two-ℕ (one-Fin 1)))
       ( np)
 
 eq-commmutative-xor-xor :

--- a/src/graph-theory/orientations-undirected-graphs.lagda.md
+++ b/src/graph-theory/orientations-undirected-graphs.lagda.md
@@ -29,7 +29,7 @@ module _
   orientation-Undirected-Graph : UU (lsuc lzero ⊔ l1 ⊔ l2)
   orientation-Undirected-Graph =
     ( p : unordered-pair-vertices-Undirected-Graph G) →
-    edge-Undirected-Graph G p → type-UU-Fin (pr1 p)
+    edge-Undirected-Graph G p → type-UU-Fin 2 (pr1 p)
 
   source-edge-orientation-Undirected-Graph :
     orientation-Undirected-Graph →

--- a/src/graph-theory/polygons.lagda.md
+++ b/src/graph-theory/polygons.lagda.md
@@ -6,7 +6,8 @@
 module graph-theory.polygons where
 
 open import elementary-number-theory.modular-arithmetic using
-  ( ℤ-Mod; succ-ℤ-Mod; is-set-ℤ-Mod; has-decidable-equality-ℤ-Mod)
+  ( ℤ-Mod; succ-ℤ-Mod; is-set-ℤ-Mod; has-decidable-equality-ℤ-Mod;
+    is-finite-ℤ-Mod)
 open import elementary-number-theory.natural-numbers using
   ( ℕ; is-nonzero-ℕ; is-not-one-ℕ)
 
@@ -35,7 +36,7 @@ open import graph-theory.undirected-graphs using
   ( Undirected-Graph; vertex-Undirected-Graph; edge-Undirected-Graph)
 
 open import univalent-combinatorics.finite-types using
-  ( is-finite; is-finite-mere-equiv; is-finite-ℤ-Mod)
+  ( is-finite; is-finite-mere-equiv)
 ```
 
 ## Idea

--- a/src/group-theory/subgroups-generated-by-subsets-groups.lagda.md
+++ b/src/group-theory/subgroups-generated-by-subsets-groups.lagda.md
@@ -109,7 +109,7 @@ module _
   inv-formal-combination-subset-Group (cons (pair s x) u) =
     concat-list
       ( inv-formal-combination-subset-Group u)
-      ( in-list (pair (succ-Fin s) x))
+      ( in-list (pair (succ-Fin 2 s) x))
     
   preserves-inv-ev-formal-combination-subset-Group :
     (u : formal-combination-subset-Group) →

--- a/src/group-theory/unordered-tuples-of-elements-commutative-monoids.lagda.md
+++ b/src/group-theory/unordered-tuples-of-elements-commutative-monoids.lagda.md
@@ -30,10 +30,10 @@ module _
   where
 
   type-unordered-tuple-Commutative-Monoid : UU lzero
-  type-unordered-tuple-Commutative-Monoid = type-unordered-tuple x
+  type-unordered-tuple-Commutative-Monoid = type-unordered-tuple n x
 
   element-unordered-tuple-Commutative-Monoid :
     type-unordered-tuple-Commutative-Monoid → type-Commutative-Monoid M
   element-unordered-tuple-Commutative-Monoid =
-    element-unordered-tuple x
+    element-unordered-tuple n x
 ```

--- a/src/order-theory/finite-preorders.lagda.md
+++ b/src/order-theory/finite-preorders.lagda.md
@@ -32,7 +32,7 @@ open import order-theory.preorders using
     is-prop-leq-Preorder; refl-leq-Preorder; transitive-leq-Preorder)
 
 open import univalent-combinatorics.decidable-subtypes using
-  ( is-finite-decidable-subtype)
+  ( is-finite-type-decidable-subtype)
 open import univalent-combinatorics.equality-finite-types using
   ( is-set-is-finite; has-decidable-equality-is-finite)
 open import univalent-combinatorics.finite-types using
@@ -201,7 +201,7 @@ module _
 
   is-finite-element-finite-sub-Preorder : is-finite element-finite-sub-Preorder
   is-finite-element-finite-sub-Preorder =
-    is-finite-decidable-subtype S (is-finite-element-Finite-Preorder X)
+    is-finite-type-decidable-subtype S (is-finite-element-Finite-Preorder X)
 
   eq-element-finite-sub-Preorder :
     (x y : element-finite-sub-Preorder) → Id (pr1 x) (pr1 y) → Id x y

--- a/src/order-theory/finitely-graded-posets.lagda.md
+++ b/src/order-theory/finitely-graded-posets.lagda.md
@@ -43,10 +43,8 @@ open import order-theory.preorders using (Preorder)
 open import order-theory.posets using (Poset)
 open import order-theory.total-posets using (is-total-poset-Prop)
 
-open import univalent-combinatorics.equality-standard-finite-types using
-  ( Fin-Set; is-set-Fin)
 open import univalent-combinatorics.standard-finite-types using
-  ( Fin; inl-Fin; succ-Fin; skip-zero-Fin; zero-Fin; neg-one-Fin)
+  ( Fin; inl-Fin; succ-Fin; skip-zero-Fin; zero-Fin; neg-one-Fin; Fin-Set; is-set-Fin)
 ```
 
 ## Idea
@@ -60,7 +58,7 @@ Finitely-Graded-Poset l1 l2 k =
   Σ ( Fin (succ-ℕ k) → UU-Set l1)
     ( λ X →
       (i : Fin k) → type-Set (X (inl-Fin k i)) →
-      type-Set (X (succ-Fin (inl-Fin k i))) → UU-Prop l2)
+      type-Set (X (succ-Fin (succ-ℕ k) (inl-Fin k i))) → UU-Prop l2)
 
 module _
   {l1 l2 : Level} {k : ℕ} (X : Finitely-Graded-Poset l1 l2 k)
@@ -84,7 +82,7 @@ module _
 
   module _
     (i : Fin k) (y : face-Finitely-Graded-Poset (inl-Fin k i))
-    (z : face-Finitely-Graded-Poset (succ-Fin (inl-Fin k i)))
+    (z : face-Finitely-Graded-Poset (succ-Fin (succ-ℕ k) (inl-Fin k i)))
     where
 
     adjacent-finitely-graded-poset-Prop : UU-Prop l2
@@ -140,7 +138,7 @@ module _
           path-faces-Finitely-Graded-Poset x
         cons-path-faces-Finitely-Graded-Poset :
           {j : Fin k} {y : face-Finitely-Graded-Poset (inl-Fin k j)}
-          {z : face-Finitely-Graded-Poset (succ-Fin (inl-Fin k j))} →
+          {z : face-Finitely-Graded-Poset (succ-Fin (succ-ℕ k) (inl-Fin k j))} →
           adjacent-Finitely-Graded-Poset j y z →
           path-faces-Finitely-Graded-Poset y →
           path-faces-Finitely-Graded-Poset z
@@ -189,17 +187,17 @@ module _
   leq-type-path-faces-Finitely-Graded-Poset :
     {i1 i2 : Fin (succ-ℕ k)} (x : face-Finitely-Graded-Poset i1)
     (y : face-Finitely-Graded-Poset i2) →
-    path-faces-Finitely-Graded-Poset x y → leq-Fin i1 i2
+    path-faces-Finitely-Graded-Poset x y → leq-Fin (succ-ℕ k) i1 i2
   leq-type-path-faces-Finitely-Graded-Poset {i1} x .x
-    refl-path-faces-Finitely-Graded-Poset = refl-leq-Fin i1
+    refl-path-faces-Finitely-Graded-Poset = refl-leq-Fin (succ-ℕ k) i1
   leq-type-path-faces-Finitely-Graded-Poset {i1} x y
     ( cons-path-faces-Finitely-Graded-Poset {i3} {z} H K) =
      transitive-leq-Fin
-       { succ-ℕ k}
+       ( succ-ℕ k)
        ( i1)
        ( inl-Fin k i3)
-       ( succ-Fin (inl-Fin k i3))
-       ( leq-succ-Fin {k} i3)
+       ( succ-Fin (succ-ℕ k) (inl-Fin k i3))
+       ( leq-succ-Fin k i3)
        ( leq-type-path-faces-Finitely-Graded-Poset x z K)
 ```
 
@@ -215,7 +213,7 @@ eq-path-elements-Finitely-Graded-Poset :
 eq-path-elements-Finitely-Graded-Poset {k} X (pair i1 x) (pair .i1 .x) p
   refl-path-faces-Finitely-Graded-Poset = refl
 eq-path-elements-Finitely-Graded-Poset {k = succ-ℕ k} X (pair i1 x)
-  (pair .(succ-Fin (inl-Fin (succ-ℕ k) i2)) y) p
+  (pair .(succ-Fin (succ-ℕ (succ-ℕ k)) (inl-Fin (succ-ℕ k) i2)) y) p
   (cons-path-faces-Finitely-Graded-Poset {i2} {z} H K) =
   ex-falso
     ( has-no-fixed-points-succ-Fin
@@ -223,21 +221,25 @@ eq-path-elements-Finitely-Graded-Poset {k = succ-ℕ k} X (pair i1 x)
       ( inl-Fin (succ-ℕ k) i2)
       ( λ (q : is-one-ℕ (succ-ℕ (succ-ℕ k))) →
         is-nonzero-succ-ℕ k (is-injective-succ-ℕ q))
-      ( antisymmetric-leq-Fin
-        { succ-ℕ (succ-ℕ k)}
-        ( succ-Fin (inl-Fin (succ-ℕ k) i2))
+      ( antisymmetric-leq-Fin 
+        ( succ-ℕ (succ-ℕ k))
+        ( succ-Fin (succ-ℕ (succ-ℕ k)) (inl-Fin (succ-ℕ k) i2))
         ( inl-Fin (succ-ℕ k) i2)
         ( transitive-leq-Fin
-          { succ-ℕ (succ-ℕ k)}
-          ( skip-zero-Fin i2)
+          ( succ-ℕ (succ-ℕ k))
+          ( skip-zero-Fin (succ-ℕ k) i2)
           ( i1)
           ( inl i2)
           ( leq-type-path-faces-Finitely-Graded-Poset X x z K)
           ( tr
-            ( leq-Fin (succ-Fin (inl-Fin (succ-ℕ k) i2)))
+            ( leq-Fin
+              ( succ-ℕ (succ-ℕ k))
+              ( succ-Fin (succ-ℕ (succ-ℕ k)) (inl-Fin (succ-ℕ k) i2)))
             ( inv p)
-            ( refl-leq-Fin (succ-Fin (inl-Fin (succ-ℕ k) i2)))))
-        ( leq-succ-Fin i2)))
+            ( refl-leq-Fin
+              ( succ-ℕ (succ-ℕ k))
+              ( succ-Fin (succ-ℕ (succ-ℕ k)) (inl-Fin (succ-ℕ k) i2)))))
+        ( leq-succ-Fin (succ-ℕ k) i2)))
 
 module _
   {l1 l2 : Level} {k : ℕ} (X : Finitely-Graded-Poset l1 l2 k)
@@ -267,7 +269,7 @@ module _
     Id x y
   antisymmetric-path-elements-Finitely-Graded-Poset (pair i x) (pair j y) H K =
     eq-path-elements-Finitely-Graded-Poset X (pair i x) (pair j y)
-      ( antisymmetric-leq-Fin
+      ( antisymmetric-leq-Fin (succ-ℕ k)
         ( type-element-Finitely-Graded-Poset X (pair i x))
         ( type-element-Finitely-Graded-Poset X (pair j y))
         ( leq-type-path-faces-Finitely-Graded-Poset X x y H)
@@ -350,7 +352,7 @@ module _
   where
 
   module _
-    (x : face-Finitely-Graded-Poset X zero-Fin)
+    (x : face-Finitely-Graded-Poset X (zero-Fin k))
     where
     
     is-least-element-finitely-graded-poset-Prop : UU-Prop (l1 ⊔ l2)
@@ -374,7 +376,7 @@ module _
 
   least-element-Finitely-Graded-Poset : UU (l1 ⊔ l2)
   least-element-Finitely-Graded-Poset =
-    Σ ( face-Finitely-Graded-Poset X zero-Fin)
+    Σ ( face-Finitely-Graded-Poset X (zero-Fin k))
       ( is-least-element-Finitely-Graded-Poset)
 
   all-elements-equal-least-element-Finitely-Graded-Poset :
@@ -384,7 +386,7 @@ module _
       ( is-least-element-finitely-graded-poset-Prop)
       ( apply-universal-property-trunc-Prop
         ( H (element-face-Finitely-Graded-Poset X y))
-        ( Id-Prop (face-finitely-graded-poset-Set X zero-Fin) x y)
+        ( Id-Prop (face-finitely-graded-poset-Set X (zero-Fin k)) x y)
         ( eq-path-faces-Finitely-Graded-Poset X x y))
 
   is-prop-least-element-Finitely-Graded-Poset :
@@ -400,7 +402,7 @@ module _
     is-prop-least-element-Finitely-Graded-Poset
 
   module _
-    (x : face-Finitely-Graded-Poset X neg-one-Fin)
+    (x : face-Finitely-Graded-Poset X (neg-one-Fin k))
     where
     
     is-largest-element-finitely-graded-poset-Prop : UU-Prop (l1 ⊔ l2)
@@ -424,7 +426,7 @@ module _
 
   largest-element-Finitely-Graded-Poset : UU (l1 ⊔ l2)
   largest-element-Finitely-Graded-Poset =
-    Σ ( face-Finitely-Graded-Poset X neg-one-Fin)
+    Σ ( face-Finitely-Graded-Poset X (neg-one-Fin k)) 
       ( is-largest-element-Finitely-Graded-Poset)
 
   all-elements-equal-largest-element-Finitely-Graded-Poset :
@@ -435,7 +437,7 @@ module _
       ( is-largest-element-finitely-graded-poset-Prop)
       ( apply-universal-property-trunc-Prop
         ( K (element-face-Finitely-Graded-Poset X x))
-        ( Id-Prop (face-finitely-graded-poset-Set X neg-one-Fin) x y)
+        ( Id-Prop (face-finitely-graded-poset-Set X (neg-one-Fin k)) x y)
         ( eq-path-faces-Finitely-Graded-Poset X x y))
 
   is-prop-largest-element-Finitely-Graded-Poset :
@@ -512,7 +514,7 @@ module _
 
   module _
     (i : Fin k) (y : face-Finitely-Graded-Subposet (inl-Fin k i))
-    (z : face-Finitely-Graded-Subposet (succ-Fin (inl-Fin k i)))
+    (z : face-Finitely-Graded-Subposet (succ-Fin (succ-ℕ k) (inl-Fin k i)))
     where
 
     adjacent-finitely-graded-subposet-Prop : UU-Prop l2

--- a/src/organic-chemistry/alkenes.lagda.md
+++ b/src/organic-chemistry/alkenes.lagda.md
@@ -29,6 +29,8 @@ An **n-alkene** is a hydrocarbon equipped with a choice of $n$ carbons, each of 
 n-alkene : hydrocarbon → ℕ → UU (lsuc lzero)
 n-alkene H n =
   Σ (UU-Fin n) λ carbons →
-    Σ (type-UU-Fin carbons ↪ vertex-hydrocarbon H) λ embed-carbons →
-      (c : type-UU-Fin carbons) → pr1 (has-double-bond-hydrocarbon H (pr1 embed-carbons c))
+    Σ ( type-UU-Fin n carbons ↪ vertex-hydrocarbon H)
+      ( λ embed-carbons →
+        ( c : type-UU-Fin n carbons) →
+        pr1 (has-double-bond-hydrocarbon H (pr1 embed-carbons c)))
 ```

--- a/src/organic-chemistry/alkynes.lagda.md
+++ b/src/organic-chemistry/alkynes.lagda.md
@@ -29,6 +29,6 @@ An **n-alkyne** is a hydrocarbon equipped with a choice of $n$ carbons, each of 
 n-alkyne : hydrocarbon → ℕ → UU (lsuc lzero)
 n-alkyne H n =
   Σ (UU-Fin n) λ carbons →
-    Σ (type-UU-Fin carbons ↪ vertex-hydrocarbon H) λ embed-carbons →
-      (c : type-UU-Fin carbons) → has-triple-bond-hydrocarbon H (pr1 embed-carbons c)
+    Σ (type-UU-Fin n carbons ↪ vertex-hydrocarbon H) λ embed-carbons →
+      (c : type-UU-Fin n carbons) → has-triple-bond-hydrocarbon H (pr1 embed-carbons c)
 ```

--- a/src/organic-chemistry/hydrocarbons.lagda.md
+++ b/src/organic-chemistry/hydrocarbons.lagda.md
@@ -51,7 +51,7 @@ hydrocarbon =
             Σ ( vertex-Undirected-Graph-𝔽 G)
               ( λ c' →
                 edge-Undirected-Graph-𝔽 G (standard-unordered-pair c c')) ↪
-                type-UU-Fin (pr1 (C c))) ×
+                type-UU-Fin 4 (pr1 (C c))) ×
           ( ( (c : vertex-Undirected-Graph-𝔽 G) →
               ¬ ( edge-Undirected-Graph-𝔽 G
                   ( standard-unordered-pair c c))) ×

--- a/src/polytopes/abstract-polytopes.lagda.md
+++ b/src/polytopes/abstract-polytopes.lagda.md
@@ -95,15 +95,17 @@ diamond-condition-finitely-graded-poset-Prop {k = succ-ℕ k} X =
         ( λ x →
           Π-Prop
             ( face-Finitely-Graded-Poset X
-              ( succ-Fin (succ-Fin (inl-Fin (succ-ℕ k) (inl-Fin k i)))))
+              ( succ-Fin
+                ( succ-ℕ (succ-ℕ k))
+                ( succ-Fin (succ-ℕ (succ-ℕ k)) (inl-Fin (succ-ℕ k) (inl-Fin k i)))))
             ( λ y →
               has-cardinality-Prop 2
                 ( Σ ( face-Finitely-Graded-Poset X
-                      ( succ-Fin (inl-Fin (succ-ℕ k) (inl-Fin k i))))
+                      ( succ-Fin (succ-ℕ (succ-ℕ k)) (inl-Fin (succ-ℕ k) (inl-Fin k i))))
                     ( λ z →
                       adjacent-Finitely-Graded-Poset X (inl-Fin k i) x z ×
                       adjacent-Finitely-Graded-Poset X
-                        ( succ-Fin (inl-Fin k i))
+                        ( succ-Fin (succ-ℕ k) (inl-Fin k i))
                         ( z)
                         ( y))))))
 
@@ -182,7 +184,7 @@ module _
 
   module _
     (i : Fin k) (y : face-Prepolytope (inl-Fin k i))
-    (z : face-Prepolytope (succ-Fin (inl-Fin k i)))
+    (z : face-Prepolytope (succ-Fin (succ-ℕ k) (inl-Fin k i)))
     where
 
     adjancent-prepolytope-Prop : UU-Prop l2
@@ -245,7 +247,7 @@ module _
   cons-path-faces-Prepolytope :
     {i : Fin (succ-ℕ k)} {x : face-Prepolytope i}
     {j : Fin k} {y : face-Prepolytope (inl-Fin k j)}
-    {z : face-Prepolytope (succ-Fin (inl-Fin k j))} →
+    {z : face-Prepolytope (succ-Fin (succ-ℕ k) (inl-Fin k j))} →
     adjacent-Prepolytope j y z → path-faces-Prepolytope x y →
     path-faces-Prepolytope x z
   cons-path-faces-Prepolytope a p = cons-path-faces-Finitely-Graded-Poset a p
@@ -282,7 +284,7 @@ module _
 
   leq-type-path-faces-Prepolytope :
     {i1 i2 : Fin (succ-ℕ k)} (x : face-Prepolytope i1)
-    (y : face-Prepolytope i2) → path-faces-Prepolytope x y → leq-Fin i1 i2
+    (y : face-Prepolytope i2) → path-faces-Prepolytope x y → leq-Fin (succ-ℕ k) i1 i2
   leq-type-path-faces-Prepolytope =
     leq-type-path-faces-Finitely-Graded-Poset finitely-graded-poset-Prepolytope
 
@@ -368,7 +370,7 @@ module _
   face-flag-Prepolytope F i =
     Σ (face-Prepolytope i) (type-subtype-flag-Prepolytope F)
 
-  face-least-element-Prepolytope : face-Prepolytope zero-Fin
+  face-least-element-Prepolytope : face-Prepolytope (zero-Fin k)
   face-least-element-Prepolytope = pr1 least-element-Prepolytope
 
   element-least-element-Prepolytope : element-Prepolytope
@@ -381,7 +383,7 @@ module _
   is-least-element-least-element-Prepolytope =
     pr2 least-element-Prepolytope
 
-  face-largest-element-Prepolytope : face-Prepolytope neg-one-Fin
+  face-largest-element-Prepolytope : face-Prepolytope (neg-one-Fin k)
   face-largest-element-Prepolytope = pr1 largest-element-Prepolytope
 
   element-largest-element-Prepolytope : element-Prepolytope
@@ -395,20 +397,20 @@ module _
     pr2 largest-element-Prepolytope
 
   is-contr-face-bottom-dimension-Prepolytope :
-    is-contr (face-Prepolytope zero-Fin)
+    is-contr (face-Prepolytope (zero-Fin k))
   pr1 is-contr-face-bottom-dimension-Prepolytope =
     face-least-element-Prepolytope
   pr2 is-contr-face-bottom-dimension-Prepolytope x =
     apply-universal-property-trunc-Prop
       ( is-least-element-least-element-Prepolytope (element-face-Prepolytope x))
       ( Id-Prop
-        ( face-prepolytope-Set zero-Fin)
+        ( face-prepolytope-Set (zero-Fin k))
         ( face-least-element-Prepolytope)
         ( x))
       ( λ p → eq-path-faces-Prepolytope face-least-element-Prepolytope x p)
 
   is-contr-face-top-dimension-Prepolytope :
-    is-contr (face-Prepolytope neg-one-Fin)
+    is-contr (face-Prepolytope (neg-one-Fin k))
   pr1 is-contr-face-top-dimension-Prepolytope =
     face-largest-element-Prepolytope
   pr2 is-contr-face-top-dimension-Prepolytope x =
@@ -416,7 +418,7 @@ module _
       ( is-largest-element-largest-element-Prepolytope
         ( element-face-Prepolytope x))
       ( Id-Prop
-        ( face-prepolytope-Set neg-one-Fin)
+        ( face-prepolytope-Set (neg-one-Fin k))
         ( face-largest-element-Prepolytope)
         ( x))
       ( λ p →

--- a/src/structured-types/finite-multiplication-magmas.lagda.md
+++ b/src/structured-types/finite-multiplication-magmas.lagda.md
@@ -17,7 +17,8 @@ open import foundation.universe-levels using (Level; UU)
 
 open import structured-types.magmas using (Magma; type-Magma; mul-Magma)
 
-open import univalent-combinatorics.counting using (count; map-equiv-count)
+open import univalent-combinatorics.counting using
+  ( count; map-equiv-count; number-of-elements-count)
 open import univalent-combinatorics.standard-finite-types using (Fin)
 ```
 
@@ -26,18 +27,19 @@ open import univalent-combinatorics.standard-finite-types using (Fin)
 ```agda
 fold-Fin-mul-Magma :
   {l : Level} (M : Magma l) → type-Magma M →
-  {k : ℕ} → (Fin k → type-Magma M) → type-Magma M
-fold-Fin-mul-Magma M m {zero-ℕ} f = m
-fold-Fin-mul-Magma M m {succ-ℕ k} f =
-  mul-Magma M (fold-Fin-mul-Magma M m (f ∘ inl)) (f (inr star))
+  (k : ℕ) → (Fin k → type-Magma M) → type-Magma M
+fold-Fin-mul-Magma M m zero-ℕ f = m
+fold-Fin-mul-Magma M m (succ-ℕ k) f =
+  mul-Magma M (fold-Fin-mul-Magma M m k (f ∘ inl)) (f (inr star))
 
 fold-count-mul-Magma' :
   {l1 l2 : Level} (M : Magma l1) → type-Magma M →
-  {A : UU l2} {k : ℕ} → (Fin k ≃ A) → (A → type-Magma M) → type-Magma M
-fold-count-mul-Magma' M m e f = fold-Fin-mul-Magma M m (f ∘ map-equiv e)
+  {A : UU l2} (k : ℕ) → (Fin k ≃ A) → (A → type-Magma M) → type-Magma M
+fold-count-mul-Magma' M m k e f = fold-Fin-mul-Magma M m k (f ∘ map-equiv e)
 
 fold-count-mul-Magma :
   {l1 l2 : Level} (M : Magma l1) → type-Magma M →
   {A : UU l2} → count A → (A → type-Magma M) → type-Magma M
-fold-count-mul-Magma M m e f = fold-Fin-mul-Magma M m (f ∘ map-equiv-count e)
+fold-count-mul-Magma M m e f =
+  fold-Fin-mul-Magma M m (number-of-elements-count e) (f ∘ map-equiv-count e)
 ```

--- a/src/univalent-combinatorics/2-element-decidable-subtypes.lagda.md
+++ b/src/univalent-combinatorics/2-element-decidable-subtypes.lagda.md
@@ -76,7 +76,7 @@ open import univalent-combinatorics.2-element-types using
     is-inhabited-2-Element-Type; has-no-fixed-points-swap-2-Element-Type;
     contradiction-3-distinct-element-2-Element-Type)
 open import univalent-combinatorics.decidable-subtypes using
-  ( is-finite-decidable-subtype)
+  ( is-finite-type-decidable-subtype)
 open import univalent-combinatorics.dependent-function-types using (is-finite-Π)
 open import univalent-combinatorics.finite-types using
   ( has-cardinality; UU-Fin-Level; type-UU-Fin-Level;
@@ -342,32 +342,32 @@ module _
   where
 
   is-finite-2-Element-Decidable-Subtype :
-    is-finite (2-Element-Decidable-Subtype l2 (type-UU-Fin-Level X))
+    is-finite (2-Element-Decidable-Subtype l2 (type-UU-Fin-Level n X))
   is-finite-2-Element-Decidable-Subtype =
-    is-finite-decidable-subtype
+    is-finite-type-decidable-subtype
       (λ P →
         pair
           ( has-cardinality 2
-            ( Σ (type-UU-Fin-Level X) (λ x → type-decidable-Prop (P x))))
+            ( Σ (type-UU-Fin-Level n X) (λ x → type-decidable-Prop (P x))))
           ( pair
             ( is-prop-type-trunc-Prop)
             ( is-decidable-equiv
               ( equiv-has-cardinality-id-number-of-elements-is-finite
-                ( Σ (type-UU-Fin-Level X) (λ x → type-decidable-Prop (P x)))
-                ( is-finite-decidable-subtype P
-                  ( is-finite-type-UU-Fin-Level X))
+                ( Σ (type-UU-Fin-Level n X) (λ x → type-decidable-Prop (P x)))
+                ( is-finite-type-decidable-subtype P
+                  ( is-finite-type-UU-Fin-Level n X))
                 ( 2))
               ( has-decidable-equality-ℕ
                 ( number-of-elements-is-finite
-                  ( is-finite-decidable-subtype P
-                    ( is-finite-type-UU-Fin-Level X)))
+                  ( is-finite-type-decidable-subtype P
+                    ( is-finite-type-UU-Fin-Level n X)))
                 ( 2)))))
       ( is-finite-Π
-        ( is-finite-type-UU-Fin-Level X)
+        ( is-finite-type-UU-Fin-Level n X)
         ( λ x →
           is-finite-equiv
             ( inv-equiv equiv-bool-decidable-Prop ∘e equiv-bool-Fin-two-ℕ)
-            ( is-finite-Fin)))
+            ( is-finite-Fin 2)))
 
 ```
 
@@ -427,7 +427,7 @@ module _
   element-subtype-2-element-decidable-subtype-Fin :
     type-2-Element-Decidable-Subtype P
   element-subtype-2-element-decidable-subtype-Fin =
-    ε-operator-decidable-subtype-Fin
+    ε-operator-decidable-subtype-Fin n
       ( decidable-subtype-2-Element-Decidable-Subtype P)
       ( is-inhabited-type-2-Element-Decidable-Subtype P)
 

--- a/src/univalent-combinatorics/2-element-types.lagda.md
+++ b/src/univalent-combinatorics/2-element-types.lagda.md
@@ -47,7 +47,7 @@ open import foundation.fundamental-theorem-of-identity-types using
   ( fundamental-theorem-id)
 open import foundation.homotopies using (_~_; refl-htpy)
 open import foundation.identity-types using
-  ( Id; refl; inv; _∙_; ap; tr; equiv-inv)
+  ( _＝_; refl; inv; _∙_; ap; tr; equiv-inv)
 open import foundation.injective-maps using (is-injective-map-equiv)
 open import foundation.involutions using (is-involution-aut)
 open import foundation.mere-equivalences using
@@ -76,7 +76,7 @@ open import foundation.universe-levels using (Level; UU; lzero; lsuc; _⊔_)
 open import univalent-combinatorics.equality-finite-types using
   ( set-UU-Fin-Level; is-set-has-cardinality)
 open import univalent-combinatorics.equality-standard-finite-types using
-  ( Eq-Fin-eq; is-set-Fin)
+  ( Eq-Fin-eq)
 open import univalent-combinatorics.finite-types using
   ( UU-Fin-Level; type-UU-Fin-Level; Fin-UU-Fin-Level; UU-Fin; type-UU-Fin;
     Fin-UU-Fin; has-cardinality; has-cardinality-Prop; equiv-UU-Fin-Level;
@@ -121,7 +121,7 @@ has-two-elements-type-2-Element-Type = pr2
 is-finite-type-2-Element-Type :
   {l : Level} (X : 2-Element-Type l) → is-finite (type-2-Element-Type X)
 is-finite-type-2-Element-Type X =
-  is-finite-has-cardinality (has-two-elements-type-2-Element-Type X)
+  is-finite-has-cardinality 2 (has-two-elements-type-2-Element-Type X)
 
 finite-type-2-Element-Type : 2-Element-Type lzero → 𝔽
 pr1 (finite-type-2-Element-Type X) = type-2-Element-Type X
@@ -154,7 +154,7 @@ is-inhabited-2-Element-Type X =
   apply-universal-property-trunc-Prop
     ( has-two-elements-type-2-Element-Type X)
     ( trunc-Prop (type-2-Element-Type X))
-    ( λ e → unit-trunc-Prop (map-equiv e zero-Fin))
+    ( λ e → unit-trunc-Prop (map-equiv e (zero-Fin 1)))
 ```
 
 ### Any 2-element type is a set
@@ -162,12 +162,12 @@ is-inhabited-2-Element-Type X =
 ```agda
 is-set-has-two-elements :
   {l : Level} {X : UU l} → has-two-elements X → is-set X
-is-set-has-two-elements H = is-set-has-cardinality H
+is-set-has-two-elements H = is-set-has-cardinality 2 H
 
 is-set-type-2-Element-Type :
   {l : Level} (X : 2-Element-Type l) → is-set (type-2-Element-Type X)
 is-set-type-2-Element-Type X =
-  is-set-has-cardinality (has-two-elements-type-2-Element-Type X)
+  is-set-has-cardinality 2 (has-two-elements-type-2-Element-Type X)
 
 set-2-Element-Type :
   {l : Level} → 2-Element-Type l → UU-Set l
@@ -180,14 +180,14 @@ pr2 (set-2-Element-Type X) = is-set-type-2-Element-Type X
 ```agda
 equiv-2-Element-Type :
   {l1 l2 : Level} → 2-Element-Type l1 → 2-Element-Type l2 → UU (l1 ⊔ l2)
-equiv-2-Element-Type X Y = equiv-UU-Fin-Level X Y
+equiv-2-Element-Type X Y = equiv-UU-Fin-Level 2 X Y
 
 id-equiv-2-Element-Type :
   {l1 : Level} (X : 2-Element-Type l1) → equiv-2-Element-Type X X
 id-equiv-2-Element-Type X = id-equiv
 
 equiv-eq-2-Element-Type :
-  {l1 : Level} (X Y : 2-Element-Type l1) → Id X Y → equiv-2-Element-Type X Y
+  {l1 : Level} (X Y : 2-Element-Type l1) → X ＝ Y → equiv-2-Element-Type X Y
 equiv-eq-2-Element-Type X Y = equiv-eq-component-UU-Level
 
 abstract
@@ -204,12 +204,12 @@ abstract
   is-equiv-equiv-eq-2-Element-Type = is-equiv-equiv-eq-component-UU-Level
 
 eq-equiv-2-Element-Type :
-  {l1 : Level} (X Y : 2-Element-Type l1) → equiv-2-Element-Type X Y → Id X Y
+  {l1 : Level} (X Y : 2-Element-Type l1) → equiv-2-Element-Type X Y → X ＝ Y
 eq-equiv-2-Element-Type X Y =
   map-inv-is-equiv (is-equiv-equiv-eq-2-Element-Type X Y)
 
 extensionality-2-Element-Type :
-  {l1 : Level} (X Y : 2-Element-Type l1) → Id X Y ≃ equiv-2-Element-Type X Y
+  {l1 : Level} (X Y : 2-Element-Type l1) → (X ＝ Y) ≃ equiv-2-Element-Type X Y
 pr1 (extensionality-2-Element-Type X Y) = equiv-eq-2-Element-Type X Y
 pr2 (extensionality-2-Element-Type X Y) = is-equiv-equiv-eq-2-Element-Type X Y
 ```
@@ -221,7 +221,7 @@ pr2 (extensionality-2-Element-Type X Y) = is-equiv-equiv-eq-2-Element-Type X Y
 ```agda
 ev-zero-equiv-Fin-two-ℕ :
   {l1 : Level} {X : UU l1} → (Fin 2 ≃ X) → X
-ev-zero-equiv-Fin-two-ℕ e = map-equiv e zero-Fin
+ev-zero-equiv-Fin-two-ℕ e = map-equiv e (zero-Fin 1)
 
 ev-zero-aut-Fin-two-ℕ : (Fin 2 ≃ Fin 2) → Fin 2
 ev-zero-aut-Fin-two-ℕ = ev-zero-equiv-Fin-two-ℕ
@@ -233,7 +233,7 @@ ev-zero-aut-Fin-two-ℕ = ev-zero-equiv-Fin-two-ℕ
 aut-point-Fin-two-ℕ :
   Fin 2 → (Fin 2 ≃ Fin 2)
 aut-point-Fin-two-ℕ (inl (inr star)) = id-equiv
-aut-point-Fin-two-ℕ (inr star) = equiv-succ-Fin
+aut-point-Fin-two-ℕ (inr star) = equiv-succ-Fin 2
 
 abstract
   issec-aut-point-Fin-two-ℕ :
@@ -243,13 +243,13 @@ abstract
 
   isretr-aut-point-Fin-two-ℕ' :
     (e : Fin 2 ≃ Fin 2) (x y : Fin 2) →
-    Id (map-equiv e zero-Fin) x →
-    Id (map-equiv e one-Fin) y → htpy-equiv (aut-point-Fin-two-ℕ x) e
+    map-equiv e (zero-Fin 1) ＝ x →
+    map-equiv e (one-Fin 1) ＝ y → htpy-equiv (aut-point-Fin-two-ℕ x) e
   isretr-aut-point-Fin-two-ℕ' e
     (inl (inr star)) (inl (inr star)) p q (inl (inr star)) = inv p
   isretr-aut-point-Fin-two-ℕ' e
     (inl (inr star)) (inl (inr star)) p q (inr star) =
-    ex-falso (Eq-Fin-eq (is-injective-map-equiv e (p ∙ inv q)))
+    ex-falso (Eq-Fin-eq 2 (is-injective-map-equiv e (p ∙ inv q)))
   isretr-aut-point-Fin-two-ℕ' e
     (inl (inr star)) (inr star) p q (inl (inr star)) = inv p
   isretr-aut-point-Fin-two-ℕ' e
@@ -260,18 +260,18 @@ abstract
     (inr star) (inl (inr star)) p q (inr star) = inv q
   isretr-aut-point-Fin-two-ℕ' e
     (inr star) (inr star) p q (inl (inr star)) =
-    ex-falso (Eq-Fin-eq (is-injective-map-equiv e (p ∙ inv q)))
+    ex-falso (Eq-Fin-eq 2 (is-injective-map-equiv e (p ∙ inv q)))
   isretr-aut-point-Fin-two-ℕ' e
     (inr star) (inr star) p q (inr star) =
-    ex-falso (Eq-Fin-eq (is-injective-map-equiv e (p ∙ inv q)))
+    ex-falso (Eq-Fin-eq 2 (is-injective-map-equiv e (p ∙ inv q)))
 
   isretr-aut-point-Fin-two-ℕ :
     (aut-point-Fin-two-ℕ ∘ ev-zero-aut-Fin-two-ℕ) ~ id
   isretr-aut-point-Fin-two-ℕ e =
     eq-htpy-equiv
       ( isretr-aut-point-Fin-two-ℕ' e
-        ( map-equiv e zero-Fin)
-        ( map-equiv e one-Fin)
+        ( map-equiv e (zero-Fin 1))
+        ( map-equiv e (one-Fin 1))
         ( refl)
         ( refl))
 
@@ -351,13 +351,13 @@ module _
 
   compute-map-equiv-point-2-Element-Type :
     (x : type-2-Element-Type X) →
-    Id (map-equiv-point-2-Element-Type x zero-Fin) x
+    map-equiv-point-2-Element-Type x (zero-Fin 1) ＝ x
   compute-map-equiv-point-2-Element-Type =
     issec-map-inv-equiv equiv-ev-zero-equiv-Fin-two-ℕ
 
   is-unique-equiv-point-2-Element-Type :
     (e : Fin 2 ≃ type-2-Element-Type X) →
-    htpy-equiv (equiv-point-2-Element-Type (map-equiv e zero-Fin)) e
+    htpy-equiv (equiv-point-2-Element-Type (map-equiv e (zero-Fin 1))) e
   is-unique-equiv-point-2-Element-Type e =
     htpy-eq-equiv (isretr-map-inv-equiv equiv-ev-zero-equiv-Fin-two-ℕ e)
 ```
@@ -367,11 +367,11 @@ module _
 ```agda
 abstract
   is-contr-total-UU-Fin-Level-two-ℕ :
-    {l : Level} → is-contr (Σ (UU-Fin-Level l 2) type-UU-Fin-Level)
+    {l : Level} → is-contr (Σ (UU-Fin-Level l 2) (type-UU-Fin-Level 2))
   is-contr-total-UU-Fin-Level-two-ℕ {l} =
     is-contr-equiv'
       ( Σ ( UU-Fin-Level l 2)
-          ( λ X → raise-Fin l 2 ≃ type-UU-Fin-Level X))
+          ( λ X → raise-Fin l 2 ≃ type-UU-Fin-Level 2 X))
       ( equiv-tot
         ( λ X →
           ( equiv-ev-zero-equiv-Fin-two-ℕ X) ∘e
@@ -386,7 +386,7 @@ abstract
 ```agda
 abstract
   is-contr-total-UU-Fin-two-ℕ :
-    is-contr (Σ (UU-Fin 2) (λ X → type-UU-Fin X))
+    is-contr (Σ (UU-Fin 2) (λ X → type-UU-Fin 2 X))
   is-contr-total-UU-Fin-two-ℕ = is-contr-total-UU-Fin-Level-two-ℕ
 ```
 
@@ -395,8 +395,8 @@ abstract
 ```agda
 point-eq-UU-Fin-Level-two-ℕ :
   {l : Level} {X : UU-Fin-Level l 2} →
-  Id (Fin-UU-Fin-Level l 2) X → type-UU-Fin-Level X
-point-eq-UU-Fin-Level-two-ℕ refl = map-raise zero-Fin
+  Fin-UU-Fin-Level l 2 ＝ X → type-UU-Fin-Level 2 X
+point-eq-UU-Fin-Level-two-ℕ refl = map-raise (zero-Fin 1)
 
 abstract
   is-equiv-point-eq-UU-Fin-Level-two-ℕ :
@@ -405,13 +405,13 @@ abstract
   is-equiv-point-eq-UU-Fin-Level-two-ℕ {l} =
     fundamental-theorem-id
       ( Fin-UU-Fin-Level l 2)
-      ( map-raise zero-Fin)
+      ( map-raise (zero-Fin 1))
       ( is-contr-total-UU-Fin-Level-two-ℕ)
       ( λ X → point-eq-UU-Fin-Level-two-ℕ {l} {X})
 
 equiv-point-eq-UU-Fin-Level-two-ℕ :
   {l : Level} {X : UU-Fin-Level l 2} →
-  Id (Fin-UU-Fin-Level l 2) X ≃ type-UU-Fin-Level X
+  (Fin-UU-Fin-Level l 2 ＝ X) ≃ type-UU-Fin-Level 2 X
 pr1 (equiv-point-eq-UU-Fin-Level-two-ℕ {l} {X}) =
   point-eq-UU-Fin-Level-two-ℕ
 pr2 (equiv-point-eq-UU-Fin-Level-two-ℕ {l} {X}) =
@@ -419,7 +419,7 @@ pr2 (equiv-point-eq-UU-Fin-Level-two-ℕ {l} {X}) =
 
 eq-point-UU-Fin-Level-two-ℕ :
   {l : Level} {X : UU-Fin-Level l 2} →
-  type-UU-Fin-Level X → Id (Fin-UU-Fin-Level l 2) X
+  type-UU-Fin-Level 2 X → Fin-UU-Fin-Level l 2 ＝ X
 eq-point-UU-Fin-Level-two-ℕ =
   map-inv-equiv equiv-point-eq-UU-Fin-Level-two-ℕ
 ```
@@ -428,8 +428,8 @@ eq-point-UU-Fin-Level-two-ℕ =
 
 ```agda
 point-eq-UU-Fin-two-ℕ :
-  {X : UU-Fin 2} → Id (Fin-UU-Fin 2) X → type-UU-Fin X
-point-eq-UU-Fin-two-ℕ refl = zero-Fin
+  {X : UU-Fin 2} → Fin-UU-Fin 2 ＝ X → type-UU-Fin 2 X
+point-eq-UU-Fin-two-ℕ refl = zero-Fin 1
 
 abstract
   is-equiv-point-eq-UU-Fin-two-ℕ :
@@ -437,17 +437,17 @@ abstract
   is-equiv-point-eq-UU-Fin-two-ℕ =
     fundamental-theorem-id
       ( Fin-UU-Fin 2)
-      ( zero-Fin)
+      ( zero-Fin 1)
       ( is-contr-total-UU-Fin-two-ℕ)
       ( λ X → point-eq-UU-Fin-two-ℕ {X})
 
 equiv-point-eq-UU-Fin-two-ℕ :
-  {X : UU-Fin 2} → Id (Fin-UU-Fin 2) X ≃ type-UU-Fin X
+  {X : UU-Fin 2} → (Fin-UU-Fin 2 ＝ X) ≃ type-UU-Fin 2 X
 pr1 (equiv-point-eq-UU-Fin-two-ℕ {X}) = point-eq-UU-Fin-two-ℕ
 pr2 (equiv-point-eq-UU-Fin-two-ℕ {X}) = is-equiv-point-eq-UU-Fin-two-ℕ X
 
 eq-point-UU-Fin-two-ℕ :
-  {X : UU-Fin 2} → type-UU-Fin X → Id (Fin-UU-Fin 2) X
+  {X : UU-Fin 2} → type-UU-Fin 2 X → Fin-UU-Fin 2 ＝ X
 eq-point-UU-Fin-two-ℕ {X} =
   map-inv-equiv equiv-point-eq-UU-Fin-two-ℕ
 ```
@@ -485,12 +485,12 @@ module _
 
   ev-zero-htpy-equiv-Fin-two-ℕ :
     (e e' : Fin 2 ≃ type-2-Element-Type X) → htpy-equiv e e' →
-    Id (map-equiv e zero-Fin) (map-equiv e' zero-Fin)
-  ev-zero-htpy-equiv-Fin-two-ℕ e e' H = H zero-Fin
+    map-equiv e (zero-Fin 1) ＝ map-equiv e' (zero-Fin 1)
+  ev-zero-htpy-equiv-Fin-two-ℕ e e' H = H (zero-Fin 1)
 
   equiv-ev-zero-htpy-equiv-Fin-two-ℕ' :
     (e e' : Fin 2 ≃ type-2-Element-Type X) →
-    htpy-equiv e e' ≃ Id (map-equiv e zero-Fin) (map-equiv e' zero-Fin)
+    htpy-equiv e e' ≃ (map-equiv e (zero-Fin 1) ＝ map-equiv e' (zero-Fin 1))
   equiv-ev-zero-htpy-equiv-Fin-two-ℕ' e e' =
     ( equiv-ap (equiv-ev-zero-equiv-Fin-two-ℕ X) e e') ∘e
     ( inv-equiv (extensionality-equiv e e'))
@@ -505,17 +505,19 @@ module _
           ( tot (ev-zero-htpy-equiv-Fin-two-ℕ e))
           ( is-contr-total-htpy-equiv e)
           ( is-contr-equiv
-            ( fib (ev-zero-equiv-Fin-two-ℕ) (map-equiv e zero-Fin))
+            ( fib (ev-zero-equiv-Fin-two-ℕ) (map-equiv e (zero-Fin 1)))
             ( equiv-tot
               ( λ e' →
-                equiv-inv (map-equiv e zero-Fin) (map-equiv e' zero-Fin)))
+                equiv-inv
+                  ( map-equiv e (zero-Fin 1))
+                  ( map-equiv e' (zero-Fin 1))))
             ( is-contr-map-is-equiv
               ( is-equiv-ev-zero-equiv-Fin-two-ℕ X)
-              ( map-equiv e zero-Fin))))
+              ( map-equiv e (zero-Fin 1)))))
 
   equiv-ev-zero-htpy-equiv-Fin-two-ℕ :
     (e e' : Fin 2 ≃ type-2-Element-Type X) →
-    htpy-equiv e e' ≃ Id (map-equiv e zero-Fin) (map-equiv e' zero-Fin)
+    htpy-equiv e e' ≃ (map-equiv e (zero-Fin 1) ＝ map-equiv e' (zero-Fin 1))
   pr1 (equiv-ev-zero-htpy-equiv-Fin-two-ℕ e e') =
     ev-zero-htpy-equiv-Fin-two-ℕ e e'
   pr2 (equiv-ev-zero-htpy-equiv-Fin-two-ℕ e e') =
@@ -527,12 +529,12 @@ module _
 ```agda
 abstract
   no-section-type-UU-Fin-Level-two-ℕ :
-    {l : Level} → ¬ ((X : UU-Fin-Level l 2) → type-UU-Fin-Level X)
+    {l : Level} → ¬ ((X : UU-Fin-Level l 2) → type-UU-Fin-Level 2 X)
   no-section-type-UU-Fin-Level-two-ℕ {l} f =
     is-not-contractible-Fin 2
       ( Eq-eq-ℕ)
       ( is-contr-equiv
-        ( Id (Fin-UU-Fin-Level l 2) (Fin-UU-Fin-Level l 2))
+        ( Fin-UU-Fin-Level l 2 ＝ Fin-UU-Fin-Level l 2)
         ( ( inv-equiv equiv-point-eq-UU-Fin-Level-two-ℕ) ∘e
           ( equiv-raise-Fin l 2))
         ( is-prop-is-contr
@@ -544,7 +546,7 @@ abstract
 
 abstract
   no-section-type-UU-Fin-two-ℕ :
-    ¬ ((X : UU-Fin 2) → type-UU-Fin X)
+    ¬ ((X : UU-Fin 2) → type-UU-Fin 2 X)
   no-section-type-UU-Fin-two-ℕ f =
     no-section-type-UU-Fin-Level-two-ℕ f
 ```
@@ -555,7 +557,7 @@ abstract
 abstract
   is-not-decidable-type-UU-Fin-Level-two-ℕ :
     {l : Level} →
-    ¬ ((X : UU-Fin-Level l 2) → is-decidable (type-UU-Fin-Level X))
+    ¬ ((X : UU-Fin-Level l 2) → is-decidable (type-UU-Fin-Level 2 X))
   is-not-decidable-type-UU-Fin-Level-two-ℕ {l} d =
     no-section-type-UU-Fin-Level-two-ℕ
       ( λ X →
@@ -565,7 +567,7 @@ abstract
           ( apply-universal-property-trunc-Prop
             ( pr2 X)
             ( dn-Prop' (pr1 X))
-            ( λ e → intro-dn {l} (map-equiv e zero-Fin)))
+            ( λ e → intro-dn {l} (map-equiv e (zero-Fin 1))))
           ( d X))
 ```
 
@@ -574,8 +576,8 @@ abstract
 ```agda
 cases-is-involution-aut-Fin-two-ℕ :
   (e : Fin 2 ≃ Fin 2) (x y z : Fin 2) →
-  Id (map-equiv e x) y → Id (map-equiv e y) z →
-  Id (map-equiv (e ∘e e) x) x
+  map-equiv e x ＝ y → map-equiv e y ＝ z →
+  map-equiv (e ∘e e) x ＝ x
 cases-is-involution-aut-Fin-two-ℕ e (inl (inr star)) (inl (inr star)) z p q =
   ap (map-equiv e) p ∙ p
 cases-is-involution-aut-Fin-two-ℕ e
@@ -608,7 +610,7 @@ module _
   is-involution-aut-2-element-type e x =
     apply-universal-property-trunc-Prop
       ( has-two-elements-type-2-Element-Type X)
-      ( Id-Prop (set-UU-Fin-Level X) (map-equiv (e ∘e e) x) x)
+      ( Id-Prop (set-UU-Fin-Level 2 X) (map-equiv (e ∘e e) x) x)
       ( λ h →
         ( ap (map-equiv (e ∘e e)) (inv (issec-map-inv-equiv h x))) ∙
         ( ( ap (map-equiv e) (inv (issec-map-inv-equiv h _))) ∙
@@ -629,16 +631,16 @@ module _
   swap-2-Element-Type : equiv-2-Element-Type X X
   swap-2-Element-Type =
     ( equiv-ev-zero-equiv-Fin-two-ℕ X) ∘e
-    ( ( equiv-precomp-equiv equiv-succ-Fin (type-2-Element-Type X)) ∘e
+    ( ( equiv-precomp-equiv (equiv-succ-Fin 2) (type-2-Element-Type X)) ∘e
       ( inv-equiv (equiv-ev-zero-equiv-Fin-two-ℕ X)))
 
   map-swap-2-Element-Type : type-2-Element-Type X → type-2-Element-Type X
   map-swap-2-Element-Type = map-equiv swap-2-Element-Type
 
   compute-swap-2-Element-Type' :
-    (x y : type-2-Element-Type X) → ¬ (Id x y) → (z : Fin 2) →
-    Id ( map-inv-equiv-point-2-Element-Type X x y) z →
-    Id ( map-swap-2-Element-Type x) y
+    (x y : type-2-Element-Type X) → ¬ (x ＝ y) → (z : Fin 2) →
+    map-inv-equiv-point-2-Element-Type X x y ＝ z →
+    map-swap-2-Element-Type x ＝ y
   compute-swap-2-Element-Type' x y f (inl (inr star)) q =
     ex-falso
       ( f
@@ -650,8 +652,8 @@ module _
     ( issec-map-inv-equiv-point-2-Element-Type X x y)
 
   compute-swap-2-Element-Type :
-    (x y : type-2-Element-Type X) → ¬ (Id x y) →
-    Id (map-swap-2-Element-Type x) y
+    (x y : type-2-Element-Type X) → ¬ (x ＝ y) →
+    map-swap-2-Element-Type x ＝ y
   compute-swap-2-Element-Type x y p =
     compute-swap-2-Element-Type' x y p
       ( map-inv-equiv-point-2-Element-Type X x y)
@@ -659,16 +661,24 @@ module _
 
   compute-map-equiv-point-2-Element-Type' :
     (x : type-2-Element-Type X) →
-    Id ( map-equiv-point-2-Element-Type X x one-Fin)
-       ( map-swap-2-Element-Type x)
+    map-equiv-point-2-Element-Type X x (one-Fin 1) ＝
+    map-swap-2-Element-Type x
   compute-map-equiv-point-2-Element-Type' x = refl
 
 compute-swap-Fin-two-ℕ :
-  map-swap-2-Element-Type (Fin-UU-Fin 2) ~ succ-Fin
+  map-swap-2-Element-Type (Fin-UU-Fin 2) ~ succ-Fin 2
 compute-swap-Fin-two-ℕ (inl (inr star)) =
-  compute-swap-2-Element-Type (Fin-UU-Fin 2) zero-Fin one-Fin neq-inl-inr
+  compute-swap-2-Element-Type
+    ( Fin-UU-Fin 2)
+    ( zero-Fin 1)
+    ( one-Fin 1)
+    ( neq-inl-inr)
 compute-swap-Fin-two-ℕ (inr star) =
-  compute-swap-2-Element-Type (Fin-UU-Fin 2) one-Fin zero-Fin neq-inr-inl
+  compute-swap-2-Element-Type
+    ( Fin-UU-Fin 2)
+    ( one-Fin 1)
+    ( zero-Fin 1)
+    ( neq-inr-inl)
 ```
 
 ### The swapping equivalence is not the identity equivalence
@@ -679,8 +689,8 @@ module _
   where
 
   is-not-identity-equiv-precomp-equiv-equiv-succ-Fin :
-    ¬ ( Id ( equiv-precomp-equiv (equiv-succ-Fin {2}) (type-2-Element-Type X))
-           ( id-equiv))
+    ¬ ( equiv-precomp-equiv (equiv-succ-Fin 2) (type-2-Element-Type X) ＝
+        id-equiv)
   is-not-identity-equiv-precomp-equiv-equiv-succ-Fin p' =
     apply-universal-property-trunc-Prop
       ( has-two-elements-type-2-Element-Type X)
@@ -688,9 +698,9 @@ module _
       ( λ f →
         neq-inr-inl
           ( is-injective-map-equiv f
-            ( htpy-eq-equiv (htpy-eq-equiv p' f) zero-Fin)))
+            ( htpy-eq-equiv (htpy-eq-equiv p' f) (zero-Fin 1))))
 
-  is-not-identity-swap-2-Element-Type : ¬ (Id (swap-2-Element-Type X) id-equiv)
+  is-not-identity-swap-2-Element-Type : ¬ (swap-2-Element-Type X ＝ id-equiv)
   is-not-identity-swap-2-Element-Type p =
     is-not-identity-equiv-precomp-equiv-equiv-succ-Fin
       ( ( ( inv (left-unit-law-equiv equiv1)) ∙
@@ -708,7 +718,7 @@ module _
               ( left-inverse-law-equiv equiv2))))))
     where
     equiv1 : (Fin 2 ≃ type-2-Element-Type X) ≃ (Fin 2 ≃ type-2-Element-Type X)
-    equiv1 = equiv-precomp-equiv (equiv-succ-Fin {2}) (type-2-Element-Type X)
+    equiv1 = equiv-precomp-equiv (equiv-succ-Fin 2) (type-2-Element-Type X)
     equiv2 : (Fin 2 ≃ type-2-Element-Type X) ≃ type-2-Element-Type X
     equiv2 = equiv-ev-zero-equiv-Fin-two-ℕ X
 ```
@@ -721,7 +731,7 @@ module _
   where
 
   has-no-fixed-points-swap-2-Element-Type :
-    {x : type-2-Element-Type X} → ¬ (Id (map-equiv (swap-2-Element-Type X) x) x)
+    {x : type-2-Element-Type X} → ¬ (map-equiv (swap-2-Element-Type X) x ＝ x)
   has-no-fixed-points-swap-2-Element-Type {x} P =
     apply-universal-property-trunc-Prop
       ( has-two-elements-type-2-Element-Type X)
@@ -742,12 +752,12 @@ module _
     where
     f : (h : type-2-Element-Type X ≃ Fin 2) → (y : type-2-Element-Type X) →
         ( k1 k2 k3 : Fin 2) →
-        Id (map-equiv h x) k1 → Id (map-equiv h y) k2 →
-        Id (map-equiv h (map-equiv (swap-2-Element-Type X) y)) k3 →
-        Id (map-equiv (swap-2-Element-Type X) y) y
+        map-equiv h x ＝ k1 → map-equiv h y ＝ k2 →
+        map-equiv h (map-equiv (swap-2-Element-Type X) y) ＝ k3 →
+        map-equiv (swap-2-Element-Type X) y ＝ y
     f h y (inl (inr star)) (inl (inr star)) k3 p q r =
       tr
-        ( λ z → Id (map-equiv (swap-2-Element-Type X) z) z)
+        ( λ z → map-equiv (swap-2-Element-Type X) z ＝ z)
         ( is-injective-map-equiv h (p ∙ inv q))
         ( P)
     f h y (inl (inr star)) (inr star) (inl (inr star)) p q r =
@@ -781,7 +791,7 @@ module _
                 ( q))))))
     f h y (inr star) (inr star) k3 p q r =
       tr
-        ( λ z → Id (map-equiv (swap-2-Element-Type X) z) z)
+        ( λ z → map-equiv (swap-2-Element-Type X) z ＝ z)
         ( is-injective-map-equiv h (p ∙ inv q))
         ( P)
 ```
@@ -791,8 +801,8 @@ module _
 ```agda
 preserves-add-aut-point-Fin-two-ℕ :
   (a b : Fin 2) →
-  Id ( aut-point-Fin-two-ℕ (add-Fin a b))
-     ( aut-point-Fin-two-ℕ a ∘e aut-point-Fin-two-ℕ b)
+  aut-point-Fin-two-ℕ (add-Fin 2 a b) ＝
+  ( aut-point-Fin-two-ℕ a ∘e aut-point-Fin-two-ℕ b)
 preserves-add-aut-point-Fin-two-ℕ (inl (inr star)) (inl (inr star)) =
   eq-htpy-equiv refl-htpy
 preserves-add-aut-point-Fin-two-ℕ (inl (inr star)) (inr star) =
@@ -800,17 +810,18 @@ preserves-add-aut-point-Fin-two-ℕ (inl (inr star)) (inr star) =
 preserves-add-aut-point-Fin-two-ℕ (inr star) (inl (inr star)) =
   eq-htpy-equiv refl-htpy
 preserves-add-aut-point-Fin-two-ℕ (inr star) (inr star) =
-  eq-htpy-equiv (λ x → inv (is-involution-aut-Fin-two-ℕ equiv-succ-Fin x))
+  eq-htpy-equiv (λ x → inv (is-involution-aut-Fin-two-ℕ (equiv-succ-Fin 2) x))
 ```
 
 ### Any Σ-type over `Fin 2` is a coproduct
 
 ```agda
 is-coprod-Σ-Fin-two-ℕ :
-  {l : Level} (P : Fin 2 → UU l) → Σ (Fin 2) P ≃ coprod (P zero-Fin) (P one-Fin)
+  {l : Level} (P : Fin 2 → UU l) →
+  Σ (Fin 2) P ≃ coprod (P (zero-Fin 1)) (P (one-Fin 1))
 is-coprod-Σ-Fin-two-ℕ P =
   ( equiv-coprod
-    ( left-unit-law-Σ-is-contr is-contr-Fin-one-ℕ zero-Fin)
+    ( left-unit-law-Σ-is-contr is-contr-Fin-one-ℕ (zero-Fin 0))
     ( left-unit-law-Σ (P ∘ inr))) ∘e
   ( right-distributive-Σ-coprod (Fin 1) unit P)
 ```
@@ -826,17 +837,19 @@ module _
     is-contr-decide-value-equiv-Fin-two-ℕ :
       (e : Fin 2 ≃ type-2-Element-Type X) (x : type-2-Element-Type X) →
       is-contr
-        ( coprod (Id x (map-equiv e zero-Fin)) (Id x (map-equiv e one-Fin)))
+        ( coprod
+          ( x ＝ map-equiv e (zero-Fin 1))
+          ( x ＝ map-equiv e (one-Fin 1)))
     is-contr-decide-value-equiv-Fin-two-ℕ e x =
       is-contr-equiv'
         ( fib (map-equiv e) x)
-        ( ( is-coprod-Σ-Fin-two-ℕ (λ y → Id x (map-equiv e y))) ∘e
+        ( ( is-coprod-Σ-Fin-two-ℕ (λ y → x ＝ map-equiv e y)) ∘e
           ( equiv-tot (λ y → equiv-inv (map-equiv e y) x)))
         ( is-contr-map-is-equiv (is-equiv-map-equiv e) x)
 
   decide-value-equiv-Fin-two-ℕ :
     (e : Fin 2 ≃ type-2-Element-Type X) (x : type-2-Element-Type X) →
-    coprod (Id x (map-equiv e zero-Fin)) (Id x (map-equiv e one-Fin))
+    coprod (x ＝ map-equiv e (zero-Fin 1)) (x ＝ map-equiv e (one-Fin 1))
   decide-value-equiv-Fin-two-ℕ e x =
     center (is-contr-decide-value-equiv-Fin-two-ℕ e x)
 ```
@@ -849,7 +862,7 @@ module _
   where
 
   contradiction-3-distinct-element-2-Element-Type : (x y z : type-2-Element-Type X) →
-    ¬ (Id x y) → ¬ (Id y z) → ¬ (Id x z) → empty
+    ¬ (x ＝ y) → ¬ (y ＝ z) → ¬ (x ＝ z) → empty
   contradiction-3-distinct-element-2-Element-Type x y z np nq nr =
     apply-universal-property-trunc-Prop
       ( has-two-elements-type-2-Element-Type X)
@@ -863,13 +876,25 @@ module _
     where
     cases-contradiction-3-distinct-element-2-Element-Type :
       (e : Fin 2 ≃ type-2-Element-Type X) →
-      coprod (Id x (map-equiv e zero-Fin)) (Id x (map-equiv e one-Fin)) →
-      coprod (Id y (map-equiv e zero-Fin)) (Id y (map-equiv e one-Fin)) →
-      coprod (Id z (map-equiv e zero-Fin)) (Id z (map-equiv e one-Fin)) →
+      coprod
+        ( x ＝ map-equiv e (zero-Fin 1))
+        ( x ＝ map-equiv e (one-Fin 1)) →
+      coprod
+        ( y ＝ map-equiv e (zero-Fin 1))
+        ( y ＝ map-equiv e (one-Fin 1)) →
+      coprod
+        ( z ＝ map-equiv e (zero-Fin 1))
+        ( z ＝ map-equiv e (one-Fin 1)) →
       empty
-    cases-contradiction-3-distinct-element-2-Element-Type e (inl refl) (inl refl) c3 = np refl
-    cases-contradiction-3-distinct-element-2-Element-Type e (inl refl) (inr refl) (inl refl) = nr refl
-    cases-contradiction-3-distinct-element-2-Element-Type e (inl refl) (inr refl) (inr refl) = nq refl
-    cases-contradiction-3-distinct-element-2-Element-Type e (inr refl) (inl refl) (inl refl) = nq refl
-    cases-contradiction-3-distinct-element-2-Element-Type e (inr refl) (inl refl) (inr refl) = nr refl
-    cases-contradiction-3-distinct-element-2-Element-Type e (inr refl) (inr refl) c3 = np refl
+    cases-contradiction-3-distinct-element-2-Element-Type e
+      (inl refl) (inl refl) c3 = np refl
+    cases-contradiction-3-distinct-element-2-Element-Type e
+      (inl refl) (inr refl) (inl refl) = nr refl
+    cases-contradiction-3-distinct-element-2-Element-Type e
+      (inl refl) (inr refl) (inr refl) = nq refl
+    cases-contradiction-3-distinct-element-2-Element-Type e
+      (inr refl) (inl refl) (inl refl) = nq refl
+    cases-contradiction-3-distinct-element-2-Element-Type e
+      (inr refl) (inl refl) (inr refl) = nr refl
+    cases-contradiction-3-distinct-element-2-Element-Type e
+      (inr refl) (inr refl) c3 = np refl

--- a/src/univalent-combinatorics/binomial-types.lagda.md
+++ b/src/univalent-combinatorics/binomial-types.lagda.md
@@ -400,10 +400,10 @@ binomial-type-Fin (succ-ℕ n) (succ-ℕ m) =
   ( binomial-type-Maybe (Fin n) (Fin m))
 
 has-cardinality-binomial-type :
-  {l1 l2 : Level} {A : UU l1} {B : UU l2} {n m : ℕ} →
+  {l1 l2 : Level} {A : UU l1} {B : UU l2} (n m : ℕ) →
   has-cardinality n A → has-cardinality m B →
   has-cardinality (n choose-ℕ m) (binomial-type A B)
-has-cardinality-binomial-type {A = A} {B} {n} {m} H K =
+has-cardinality-binomial-type {A = A} {B} n m H K =
   apply-universal-property-trunc-Prop H
     ( has-cardinality-Prop (n choose-ℕ m) (binomial-type A B))
     ( λ e →
@@ -415,30 +415,30 @@ has-cardinality-binomial-type {A = A} {B} {n} {m} H K =
               ( binomial-type-Fin n m ∘e equiv-binomial-type e f))))
 
 binomial-type-UU-Fin-Level :
-  {l1 l2 : Level} {n m : ℕ} → UU-Fin-Level l1 n → UU-Fin-Level l2 m →
+  {l1 l2 : Level} (n m : ℕ) → UU-Fin-Level l1 n → UU-Fin-Level l2 m →
   UU-Fin-Level (lsuc l1 ⊔ lsuc l2) (n choose-ℕ m)
-pr1 (binomial-type-UU-Fin-Level A B) =
-  binomial-type (type-UU-Fin-Level A) (type-UU-Fin-Level B)
-pr2 (binomial-type-UU-Fin-Level A B) =
-  has-cardinality-binomial-type
-    ( has-cardinality-type-UU-Fin-Level A)
-    ( has-cardinality-type-UU-Fin-Level B)
+pr1 (binomial-type-UU-Fin-Level n m A B) =
+  binomial-type (type-UU-Fin-Level n A) (type-UU-Fin-Level m B)
+pr2 (binomial-type-UU-Fin-Level n m A B) =
+  has-cardinality-binomial-type n m
+    ( has-cardinality-type-UU-Fin-Level n A)
+    ( has-cardinality-type-UU-Fin-Level m B)
 
 binomial-type-UU-Fin :
   {n m : ℕ} → UU-Fin n → UU-Fin m → UU-Fin (n choose-ℕ m)
 pr1 (binomial-type-UU-Fin {n} {m} A B) =
-  small-binomial-type (type-UU-Fin A) (type-UU-Fin B)
+  small-binomial-type (type-UU-Fin n A) (type-UU-Fin m B)
 pr2 (binomial-type-UU-Fin {n} {m} A B) =
   apply-universal-property-trunc-Prop
-    ( has-cardinality-binomial-type
-      ( has-cardinality-type-UU-Fin A)
-      ( has-cardinality-type-UU-Fin B))
+    ( has-cardinality-binomial-type n m
+      ( has-cardinality-type-UU-Fin n A)
+      ( has-cardinality-type-UU-Fin m B))
     ( mere-equiv-Prop
       ( Fin (n choose-ℕ m))
       ( small-binomial-type (pr1 A) (pr1 B)))
     ( λ e →
       unit-trunc-Prop
-        ( ( compute-small-binomial-type (type-UU-Fin A) (type-UU-Fin B)) ∘e
+        ( ( compute-small-binomial-type (type-UU-Fin n A) (type-UU-Fin m B)) ∘e
           ( e)))
 
 has-finite-cardinality-binomial-type :
@@ -447,7 +447,7 @@ has-finite-cardinality-binomial-type :
   has-finite-cardinality (binomial-type A B)
 pr1 (has-finite-cardinality-binomial-type (pair n H) (pair m K)) = n choose-ℕ m
 pr2 (has-finite-cardinality-binomial-type (pair n H) (pair m K)) =
-  has-cardinality-binomial-type H K
+  has-cardinality-binomial-type n m H K
 
 abstract
   is-finite-binomial-type :

--- a/src/univalent-combinatorics/cartesian-product-types.lagda.md
+++ b/src/univalent-combinatorics/cartesian-product-types.lagda.md
@@ -173,10 +173,10 @@ abstract
     map-trunc-Prop (λ e → count-right-factor e x) f
 
 prod-UU-Fin-Level :
-  {l1 l2 : Level} {k l : ℕ} → UU-Fin-Level l1 k → UU-Fin-Level l2 l →
+  {l1 l2 : Level} (k l : ℕ) → UU-Fin-Level l1 k → UU-Fin-Level l2 l →
   UU-Fin-Level (l1 ⊔ l2) (mul-ℕ k l)
-pr1 (prod-UU-Fin-Level {l1} {l2} {k} {l} (pair X H) (pair Y K)) = X × Y
-pr2 (prod-UU-Fin-Level {l1} {l2} {k} {l} (pair X H) (pair Y K)) =
+pr1 (prod-UU-Fin-Level k l (pair X H) (pair Y K)) = X × Y
+pr2 (prod-UU-Fin-Level k l (pair X H) (pair Y K)) =
   apply-universal-property-trunc-Prop H
     ( mere-equiv-Prop (Fin (mul-ℕ k l)) (X × Y))
     ( λ e1 →
@@ -186,6 +186,6 @@ pr2 (prod-UU-Fin-Level {l1} {l2} {k} {l} (pair X H) (pair Y K)) =
           unit-trunc-Prop (equiv-prod e1 e2 ∘e inv-equiv (prod-Fin k l))))
 
 prod-UU-Fin :
-  {k l : ℕ} → UU-Fin k → UU-Fin l → UU-Fin (mul-ℕ k l)
-prod-UU-Fin = prod-UU-Fin-Level
+  (k l : ℕ) → UU-Fin k → UU-Fin l → UU-Fin (mul-ℕ k l)
+prod-UU-Fin k l = prod-UU-Fin-Level k l
 ```

--- a/src/univalent-combinatorics/classical-finite-types.lagda.md
+++ b/src/univalent-combinatorics/classical-finite-types.lagda.md
@@ -75,13 +75,13 @@ eq-Eq-classical-Fin (succ-ℕ k) (pair (succ-ℕ x) p) (pair (succ-ℕ y) q) e =
 #### We define maps back and forth between the standard finite sets and the bounded natural numbers
 
 ```agda
-standard-classical-Fin : {k : ℕ} → classical-Fin k → Fin k
-standard-classical-Fin {succ-ℕ k} (pair x H) = mod-succ-ℕ k x
+standard-classical-Fin : (k : ℕ) → classical-Fin k → Fin k
+standard-classical-Fin (succ-ℕ k) (pair x H) = mod-succ-ℕ k x
 
 classical-standard-Fin :
   (k : ℕ) → Fin k → classical-Fin k
-pr1 (classical-standard-Fin k x) = nat-Fin x
-pr2 (classical-standard-Fin k x) = strict-upper-bound-nat-Fin x
+pr1 (classical-standard-Fin k x) = nat-Fin k x
+pr2 (classical-standard-Fin k x) = strict-upper-bound-nat-Fin k x
 ```
 
 #### We show that these maps are mutual inverses
@@ -89,21 +89,23 @@ pr2 (classical-standard-Fin k x) = strict-upper-bound-nat-Fin x
 ```agda
 issec-classical-standard-Fin :
   {k : ℕ} (x : Fin k) →
-  Id (standard-classical-Fin (classical-standard-Fin k x)) x
-issec-classical-standard-Fin {succ-ℕ k} x = issec-nat-Fin x
+  Id (standard-classical-Fin k (classical-standard-Fin k x)) x
+issec-classical-standard-Fin {succ-ℕ k} x = issec-nat-Fin k x
 
 isretr-classical-standard-Fin :
   {k : ℕ} (x : classical-Fin k) →
-  Id (classical-standard-Fin k (standard-classical-Fin x)) x
+  Id (classical-standard-Fin k (standard-classical-Fin k x)) x
 isretr-classical-standard-Fin {succ-ℕ k} (pair x p) =
   eq-Eq-classical-Fin (succ-ℕ k)
-    ( classical-standard-Fin (succ-ℕ k) (standard-classical-Fin (pair x p)))
+    ( classical-standard-Fin
+      ( succ-ℕ k)
+      ( standard-classical-Fin (succ-ℕ k) (pair x p)))
     ( pair x p)
     ( eq-cong-le-ℕ
       ( succ-ℕ k)
-      ( nat-Fin (mod-succ-ℕ k x))
+      ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k x))
       ( x)
-      ( strict-upper-bound-nat-Fin (mod-succ-ℕ k x))
+      ( strict-upper-bound-nat-Fin (succ-ℕ k) (mod-succ-ℕ k x))
       ( p)
       ( cong-nat-mod-succ-ℕ k x))
 ```

--- a/src/univalent-combinatorics/complements-isolated-points.lagda.md
+++ b/src/univalent-combinatorics/complements-isolated-points.lagda.md
@@ -43,108 +43,117 @@ For any point `x` in a finite type `X` of cardinality `n+1`, we can construct it
 
 ```agda
 isolated-point-UU-Fin-Level :
-  {l : Level} {k : ℕ} (X : UU-Fin-Level l (succ-ℕ k)) →
-  type-UU-Fin-Level X → isolated-point (type-UU-Fin-Level X)
-pr1 (isolated-point-UU-Fin-Level X x) = x
-pr2 (isolated-point-UU-Fin-Level X x) =
-  has-decidable-equality-has-cardinality (has-cardinality-type-UU-Fin-Level X) x
+  {l : Level} (k : ℕ) (X : UU-Fin-Level l (succ-ℕ k)) →
+  type-UU-Fin-Level (succ-ℕ k) X →
+  isolated-point (type-UU-Fin-Level (succ-ℕ k) X)
+pr1 (isolated-point-UU-Fin-Level k X x) = x
+pr2 (isolated-point-UU-Fin-Level k X x) =
+  has-decidable-equality-has-cardinality
+    ( succ-ℕ k)
+    ( has-cardinality-type-UU-Fin-Level (succ-ℕ k) X)
+    ( x)
 
 type-complement-point-UU-Fin-Level :
-  {l1 : Level} {k : ℕ} →
-  Σ (UU-Fin-Level l1 (succ-ℕ k)) type-UU-Fin-Level → UU l1
-type-complement-point-UU-Fin-Level X =
+  {l1 : Level} (k : ℕ) →
+  Σ (UU-Fin-Level l1 (succ-ℕ k)) (type-UU-Fin-Level (succ-ℕ k)) → UU l1
+type-complement-point-UU-Fin-Level k X =
   complement-isolated-point
     ( pr1 (pr1 X))
-    ( isolated-point-UU-Fin-Level (pr1 X) (pr2 X))
+    ( isolated-point-UU-Fin-Level k (pr1 X) (pr2 X))
 
 equiv-maybe-structure-point-UU-Fin-Level :
-  {l : Level} {k : ℕ} (X : UU-Fin-Level l (succ-ℕ k)) →
-  (x : type-UU-Fin-Level X) →
-  Maybe (type-complement-point-UU-Fin-Level (pair X x)) ≃ type-UU-Fin-Level X
-equiv-maybe-structure-point-UU-Fin-Level X x =
+  {l : Level} (k : ℕ) (X : UU-Fin-Level l (succ-ℕ k)) →
+  (x : type-UU-Fin-Level (succ-ℕ k) X) →
+  Maybe (type-complement-point-UU-Fin-Level k (pair X x)) ≃
+  type-UU-Fin-Level (succ-ℕ k) X
+equiv-maybe-structure-point-UU-Fin-Level k X x =
    equiv-maybe-structure-isolated-point
-     ( type-UU-Fin-Level X)
-     ( isolated-point-UU-Fin-Level X x)
+     ( type-UU-Fin-Level (succ-ℕ k) X)
+     ( isolated-point-UU-Fin-Level k X x)
 
 has-cardinality-type-complement-point-UU-Fin-Level :
-  {l1 : Level} {k : ℕ} (X : Σ (UU-Fin-Level l1 (succ-ℕ k)) type-UU-Fin-Level) →
-  has-cardinality k (type-complement-point-UU-Fin-Level X)
-has-cardinality-type-complement-point-UU-Fin-Level (pair (pair X H) x) =
+  {l1 : Level} (k : ℕ)
+  (X : Σ (UU-Fin-Level l1 (succ-ℕ k)) (type-UU-Fin-Level (succ-ℕ k))) →
+  has-cardinality k (type-complement-point-UU-Fin-Level k X)
+has-cardinality-type-complement-point-UU-Fin-Level k (pair (pair X H) x) =
   apply-universal-property-trunc-Prop H
-    ( has-cardinality-Prop _
-      ( type-complement-point-UU-Fin-Level (pair (pair X H) x)))
+    ( has-cardinality-Prop k
+      ( type-complement-point-UU-Fin-Level k (pair (pair X H) x)))
     ( λ e →
       unit-trunc-Prop
         ( equiv-equiv-Maybe
           ( ( inv-equiv
-              ( equiv-maybe-structure-point-UU-Fin-Level (pair X H) x)) ∘e
+              ( equiv-maybe-structure-point-UU-Fin-Level k (pair X H) x)) ∘e
             ( e))))
   
 complement-point-UU-Fin-Level :
-  {l1 : Level} {k : ℕ} →
-  Σ (UU-Fin-Level l1 (succ-ℕ k)) type-UU-Fin-Level → UU-Fin-Level l1 k
-pr1 (complement-point-UU-Fin-Level {l1} {k} T) =
-  type-complement-point-UU-Fin-Level T
-pr2 (complement-point-UU-Fin-Level {l1} {k} T) =
-  has-cardinality-type-complement-point-UU-Fin-Level T
+  {l1 : Level} (k : ℕ) →
+  Σ (UU-Fin-Level l1 (succ-ℕ k)) (type-UU-Fin-Level (succ-ℕ k)) →
+  UU-Fin-Level l1 k
+pr1 (complement-point-UU-Fin-Level k T) =
+  type-complement-point-UU-Fin-Level k T
+pr2 (complement-point-UU-Fin-Level k T) =
+  has-cardinality-type-complement-point-UU-Fin-Level k T
 
 inclusion-complement-point-UU-Fin-Level :
-  {l1 : Level} {k : ℕ} (X : Σ (UU-Fin-Level l1 (succ-ℕ k)) type-UU-Fin-Level) →
-  type-complement-point-UU-Fin-Level X → type-UU-Fin-Level (pr1 X)
-inclusion-complement-point-UU-Fin-Level X = pr1
+  {l1 : Level} (k : ℕ)
+  (X : Σ (UU-Fin-Level l1 (succ-ℕ k)) (type-UU-Fin-Level (succ-ℕ k))) →
+  type-complement-point-UU-Fin-Level k X → type-UU-Fin-Level (succ-ℕ k) (pr1 X)
+inclusion-complement-point-UU-Fin-Level k X x = pr1 x
 ```
 
 ### The complement of a point in a k-element type of universe level zero
 
 ```agda
 isolated-point-UU-Fin :
-  {k : ℕ} (X : UU-Fin (succ-ℕ k)) → type-UU-Fin X →
-  isolated-point (type-UU-Fin X)
-isolated-point-UU-Fin = isolated-point-UU-Fin-Level
+  (k : ℕ) (X : UU-Fin (succ-ℕ k)) → type-UU-Fin (succ-ℕ k) X →
+  isolated-point (type-UU-Fin (succ-ℕ k) X)
+isolated-point-UU-Fin k = isolated-point-UU-Fin-Level k
 
 type-complement-point-UU-Fin :
-  {k : ℕ} → Σ (UU-Fin (succ-ℕ k)) type-UU-Fin → UU lzero
-type-complement-point-UU-Fin = type-complement-point-UU-Fin-Level
+  (k : ℕ) → Σ (UU-Fin (succ-ℕ k)) (type-UU-Fin (succ-ℕ k)) → UU lzero
+type-complement-point-UU-Fin k = type-complement-point-UU-Fin-Level k
 
 equiv-maybe-structure-point-UU-Fin :
-  {k : ℕ} (X : UU-Fin (succ-ℕ k)) →
-  (x : type-UU-Fin X) →
-  Maybe (type-complement-point-UU-Fin (pair X x)) ≃ type-UU-Fin X
-equiv-maybe-structure-point-UU-Fin = equiv-maybe-structure-point-UU-Fin-Level
+  (k : ℕ) (X : UU-Fin (succ-ℕ k)) →
+  (x : type-UU-Fin (succ-ℕ k) X) →
+  Maybe (type-complement-point-UU-Fin k (pair X x)) ≃ type-UU-Fin (succ-ℕ k) X
+equiv-maybe-structure-point-UU-Fin k =
+  equiv-maybe-structure-point-UU-Fin-Level k
 
 has-cardinality-type-complement-point-UU-Fin :
-  {k : ℕ} (X : Σ (UU-Fin (succ-ℕ k)) type-UU-Fin) →
-  has-cardinality k (type-complement-point-UU-Fin X)
-has-cardinality-type-complement-point-UU-Fin =
-  has-cardinality-type-complement-point-UU-Fin-Level
+  (k : ℕ) (X : Σ (UU-Fin (succ-ℕ k)) (type-UU-Fin (succ-ℕ k))) →
+  has-cardinality k (type-complement-point-UU-Fin k X)
+has-cardinality-type-complement-point-UU-Fin k =
+  has-cardinality-type-complement-point-UU-Fin-Level k
             
 complement-point-UU-Fin :
-  {k : ℕ} → Σ (UU-Fin (succ-ℕ k)) type-UU-Fin → UU-Fin k
-complement-point-UU-Fin = complement-point-UU-Fin-Level
+  (k : ℕ) → Σ (UU-Fin (succ-ℕ k)) (type-UU-Fin (succ-ℕ k)) → UU-Fin k
+complement-point-UU-Fin k = complement-point-UU-Fin-Level k
 
 inclusion-complement-point-UU-Fin :
-  {k : ℕ} (X : Σ (UU-Fin (succ-ℕ k)) type-UU-Fin) →
-  type-complement-point-UU-Fin X → type-UU-Fin (pr1 X)
-inclusion-complement-point-UU-Fin X =
-  inclusion-complement-point-UU-Fin-Level X
+  (k : ℕ) (X : Σ (UU-Fin (succ-ℕ k)) (type-UU-Fin (succ-ℕ k))) →
+  type-complement-point-UU-Fin k X → type-UU-Fin (succ-ℕ k) (pr1 X)
+inclusion-complement-point-UU-Fin k X =
+  inclusion-complement-point-UU-Fin-Level k X
 ```
 
 ### The action of equivalences on complements of isolated points
 
 ```agda
 equiv-complement-point-UU-Fin-Level :
-  {l1 : Level} {k : ℕ}
-  (X Y : Σ (UU-Fin-Level l1 (succ-ℕ k)) type-UU-Fin-Level) →
-  (e : equiv-UU-Fin-Level (pr1 X) (pr1 Y))
+  {l1 : Level} (k : ℕ)
+  (X Y : Σ (UU-Fin-Level l1 (succ-ℕ k)) (type-UU-Fin-Level (succ-ℕ k))) →
+  (e : equiv-UU-Fin-Level (succ-ℕ k) (pr1 X) (pr1 Y))
   (p : Id (map-equiv e (pr2 X)) (pr2 Y)) →
-  equiv-UU-Fin-Level
-    ( complement-point-UU-Fin-Level X)
-    ( complement-point-UU-Fin-Level Y)
+  equiv-UU-Fin-Level k
+    ( complement-point-UU-Fin-Level k X)
+    ( complement-point-UU-Fin-Level k Y)
 equiv-complement-point-UU-Fin-Level
-  S T e p =
+  k S T e p =
   equiv-complement-isolated-point e
-    ( pair x (λ x' → has-decidable-equality-has-cardinality H x x'))
-    ( pair y (λ y' → has-decidable-equality-has-cardinality K y y'))
+    ( pair x (λ x' → has-decidable-equality-has-cardinality (succ-ℕ k) H x x'))
+    ( pair y (λ y' → has-decidable-equality-has-cardinality (succ-ℕ k) K y y'))
     ( p)
   where
   H = pr2 (pr1 S)
@@ -153,17 +162,14 @@ equiv-complement-point-UU-Fin-Level
   y = pr2 T
 
 equiv-complement-point-UU-Fin :
-  {k : ℕ} (X Y : Σ (UU-Fin (succ-ℕ k)) type-UU-Fin) →
-  (e : equiv-UU-Fin (pr1 X) (pr1 Y)) (p : Id (map-equiv e (pr2 X)) (pr2 Y)) →
-  equiv-UU-Fin (complement-point-UU-Fin X) (complement-point-UU-Fin Y)
-equiv-complement-point-UU-Fin X Y e p =
-  equiv-complement-point-UU-Fin-Level X Y e p
+  (k : ℕ) (X Y : Σ (UU-Fin (succ-ℕ k)) (type-UU-Fin (succ-ℕ k))) →
+  (e : equiv-UU-Fin (succ-ℕ k) (pr1 X) (pr1 Y))
+  (p : Id (map-equiv e (pr2 X)) (pr2 Y)) →
+  equiv-UU-Fin k (complement-point-UU-Fin k X) (complement-point-UU-Fin k Y)
+equiv-complement-point-UU-Fin k X Y e p =
+  equiv-complement-point-UU-Fin-Level k X Y e p
 ```
 
 ## Properties
 
 ### The map from a pointed (k+1)-element type to the complement of the point is an equivalence
-
-```agda
-
-```

--- a/src/univalent-combinatorics/coproduct-types.lagda.md
+++ b/src/univalent-combinatorics/coproduct-types.lagda.md
@@ -169,10 +169,10 @@ abstract
     map-trunc-Prop count-right-summand
 
 coprod-UU-Fin-Level :
-  {l1 l2 : Level} {k l : ℕ} → UU-Fin-Level l1 k → UU-Fin-Level l2 l →
+  {l1 l2 : Level} (k l : ℕ) → UU-Fin-Level l1 k → UU-Fin-Level l2 l →
   UU-Fin-Level (l1 ⊔ l2) (add-ℕ k l)
-pr1 (coprod-UU-Fin-Level {l1} {l2} {k} {l} (pair X H) (pair Y K)) = coprod X Y
-pr2 (coprod-UU-Fin-Level {l1} {l2} {k} {l} (pair X H) (pair Y K)) =
+pr1 (coprod-UU-Fin-Level {l1} {l2} k l (pair X H) (pair Y K)) = coprod X Y
+pr2 (coprod-UU-Fin-Level {l1} {l2} k l (pair X H) (pair Y K)) =
   apply-universal-property-trunc-Prop H
     ( mere-equiv-Prop (Fin (add-ℕ k l)) (coprod X Y))
     ( λ e1 →
@@ -183,8 +183,8 @@ pr2 (coprod-UU-Fin-Level {l1} {l2} {k} {l} (pair X H) (pair Y K)) =
             ( equiv-coprod e1 e2 ∘e inv-equiv (coprod-Fin k l))))
 
 coprod-UU-Fin :
-  {k l : ℕ} → UU-Fin k → UU-Fin l → UU-Fin (add-ℕ k l)
-coprod-UU-Fin X Y = coprod-UU-Fin-Level X Y
+  (k l : ℕ) → UU-Fin k → UU-Fin l → UU-Fin (add-ℕ k l)
+coprod-UU-Fin k l X Y = coprod-UU-Fin-Level k l X Y
 
 coprod-eq-is-finite :
   {l1 l2 : Level} {X : UU l1} {Y : UU l2} (P : is-finite X) (Q : is-finite Y) →
@@ -200,7 +200,12 @@ coprod-eq-is-finite {X = X} {Y = Y} P Q =
           ( number-of-elements-is-finite P)
           ( number-of-elements-is-finite Q))
         ( has-cardinality-type-UU-Fin-Level
+          ( add-ℕ
+            ( number-of-elements-is-finite P)
+            ( number-of-elements-is-finite Q))
           ( coprod-UU-Fin-Level
+            ( number-of-elements-is-finite P)
+            ( number-of-elements-is-finite Q)
             ( pair X
               ( mere-equiv-has-finite-cardinality
                 ( has-finite-cardinality-is-finite P)))

--- a/src/univalent-combinatorics/counting-dependent-pair-types.lagda.md
+++ b/src/univalent-combinatorics/counting-dependent-pair-types.lagda.md
@@ -108,7 +108,7 @@ abstract
     {l1 l2 : Level} {A : UU l1} {B : A → UU l2} (k : ℕ) (e : Fin k ≃ A) →
     (f : (x : A) → count (B x)) →
     Id ( number-of-elements-count (count-Σ' k e f))
-      ( sum-Fin-ℕ (λ x → number-of-elements-count (f (map-equiv e x)))) 
+      ( sum-Fin-ℕ k (λ x → number-of-elements-count (f (map-equiv e x)))) 
   number-of-elements-count-Σ' zero-ℕ e f = refl
   number-of-elements-count-Σ' (succ-ℕ k) e f =
     ( number-of-elements-count-coprod
@@ -185,7 +185,7 @@ section-count-base-count-Σ' e f g x with
   is-decidable-is-zero-ℕ (number-of-elements-count (f x))
 ... | inl p = inr p
 ... | inr H with is-successor-is-nonzero-ℕ H
-... | (pair k p) = inl (map-equiv-count (f x) (tr Fin (inv p) zero-Fin))
+... | (pair k p) = inl (map-equiv-count (f x) (tr Fin (inv p) (zero-Fin k)))
 
 count-base-count-Σ' :
   {l1 l2 : Level} {A : UU l1} {B : A → UU l2} → count (Σ A B) →

--- a/src/univalent-combinatorics/counting.lagda.md
+++ b/src/univalent-combinatorics/counting.lagda.md
@@ -34,9 +34,9 @@ open import foundation.unit-type using (unit; star; is-contr-unit)
 open import foundation.universe-levels using (UU; Level)
 
 open import univalent-combinatorics.equality-standard-finite-types using
-  ( is-set-Fin; Eq-Fin-eq; has-decidable-equality-Fin)
+  ( Eq-Fin-eq; has-decidable-equality-Fin)
 open import univalent-combinatorics.standard-finite-types using
-  ( Fin; zero-Fin; is-contr-Fin-one-ℕ; neg-one-Fin)
+  ( Fin; zero-Fin; is-contr-Fin-one-ℕ; neg-one-Fin; is-set-Fin)
 ```
 
 ## Idea
@@ -141,7 +141,7 @@ abstract
     is-empty X → is-zero-ℕ (number-of-elements-count e)
   is-zero-number-of-elements-count-is-empty (pair zero-ℕ e) H = refl
   is-zero-number-of-elements-count-is-empty (pair (succ-ℕ k) e) H =
-    ex-falso (H (map-equiv e zero-Fin))
+    ex-falso (H (map-equiv e (zero-Fin k)))
 
 count-is-empty :
   {l : Level} {X : UU l} → is-empty X → count X
@@ -177,9 +177,11 @@ abstract
     refl
   is-one-number-of-elements-count-is-contr (pair (succ-ℕ (succ-ℕ k)) e) H =
     ex-falso
-      ( Eq-Fin-eq
+      ( Eq-Fin-eq (succ-ℕ (succ-ℕ k))
         ( is-injective-map-equiv e
-          ( eq-is-contr' H (map-equiv e zero-Fin) (map-equiv e neg-one-Fin))))
+          ( eq-is-contr' H
+            ( map-equiv e (zero-Fin (succ-ℕ k)))
+            ( map-equiv e (neg-one-Fin (succ-ℕ k))))))
 
 count-unit : count unit
 count-unit = count-is-contr is-contr-unit
@@ -191,7 +193,7 @@ count-unit = count-is-contr is-contr-unit
 has-decidable-equality-count :
   {l : Level} {X : UU l} → count X → has-decidable-equality X
 has-decidable-equality-count (pair k e) =
-  has-decidable-equality-equiv' e has-decidable-equality-Fin
+  has-decidable-equality-equiv' e (has-decidable-equality-Fin k)
 ```
 
 ### This with a count are either inhabited or empty
@@ -202,7 +204,7 @@ is-inhabited-or-empty-count :
 is-inhabited-or-empty-count (pair zero-ℕ e) =
   inr (is-empty-is-zero-number-of-elements-count (pair zero-ℕ e) refl)
 is-inhabited-or-empty-count (pair (succ-ℕ k) e) =
-  inl (unit-trunc-Prop (map-equiv e zero-Fin))
+  inl (unit-trunc-Prop (map-equiv e (zero-Fin k)))
 ```
 
 ### If the elements of a type can be counted, then the elements of its propositional truncation can be counted
@@ -218,5 +220,5 @@ count-type-trunc-Prop (pair (succ-ℕ k) e) =
   count-is-contr
     ( is-proof-irrelevant-is-prop
       ( is-prop-type-trunc-Prop)
-      ( unit-trunc-Prop (map-equiv e zero-Fin)))
+      ( unit-trunc-Prop (map-equiv e (zero-Fin k))))
 ```

--- a/src/univalent-combinatorics/cubes.lagda.md
+++ b/src/univalent-combinatorics/cubes.lagda.md
@@ -25,56 +25,49 @@ open import univalent-combinatorics.finite-types using
 
 ```agda
 cube : ℕ → UU (lsuc lzero)
-cube k = Σ (UU-Fin k) (λ X → type-UU-Fin X → UU-Fin 2)
+cube k = Σ (UU-Fin k) (λ X → type-UU-Fin k X → UU-Fin 2)
 
-dim-cube-UU-Fin : {k : ℕ} (X : cube k) → UU-Fin k
-dim-cube-UU-Fin X = pr1 X
+module _
+  (k : ℕ) (X : cube k)
+  where
+  
+  dim-cube-UU-Fin : UU-Fin k
+  dim-cube-UU-Fin = pr1 X
 
-dim-cube : {k : ℕ} → cube k → UU lzero
-dim-cube X = type-UU-Fin (dim-cube-UU-Fin X)
+  dim-cube : UU lzero
+  dim-cube = type-UU-Fin k dim-cube-UU-Fin
 
-has-cardinality-dim-cube :
-  {k : ℕ} (X : cube k) → has-cardinality k (dim-cube X)
-has-cardinality-dim-cube X =
-  pr2 (dim-cube-UU-Fin X)
+  has-cardinality-dim-cube : has-cardinality k dim-cube
+  has-cardinality-dim-cube = pr2 dim-cube-UU-Fin
 
-has-finite-cardinality-dim-cube :
-  {k : ℕ} (X : cube k) → has-finite-cardinality (dim-cube X)
-has-finite-cardinality-dim-cube {k} X =
-  pair k (pr2 (dim-cube-UU-Fin X))
+  has-finite-cardinality-dim-cube : has-finite-cardinality dim-cube
+  has-finite-cardinality-dim-cube =
+    pair k (pr2 dim-cube-UU-Fin)
 
-is-finite-dim-cube :
-  {k : ℕ} (X : cube k) → is-finite (dim-cube X)
-is-finite-dim-cube X =
-  is-finite-has-finite-cardinality (has-finite-cardinality-dim-cube X)
+  is-finite-dim-cube : is-finite dim-cube
+  is-finite-dim-cube =
+    is-finite-has-finite-cardinality has-finite-cardinality-dim-cube
 
-axis-cube-UU-2 :
-  {k : ℕ} (X : cube k) → dim-cube X → UU-Fin 2
-axis-cube-UU-2 X = pr2 X
+  axis-cube-UU-2 : dim-cube → UU-Fin 2
+  axis-cube-UU-2 = pr2 X
 
-axis-cube : {k : ℕ} (X : cube k) → dim-cube X → UU lzero
-axis-cube X d = type-UU-Fin (axis-cube-UU-2 X d)
+  axis-cube : dim-cube → UU lzero
+  axis-cube d = type-UU-Fin 2 (axis-cube-UU-2 d)
 
-has-cardinality-axis-cube :
-  {k : ℕ} (X : cube k) (d : dim-cube X) → has-cardinality 2 (axis-cube X d)
-has-cardinality-axis-cube X d = pr2 (axis-cube-UU-2 X d)
+  has-cardinality-axis-cube : (d : dim-cube) → has-cardinality 2 (axis-cube d)
+  has-cardinality-axis-cube d = pr2 (axis-cube-UU-2 d)
 
-has-finite-cardinality-axis-cube :
-  {k : ℕ} (X : cube k) (d : dim-cube X) → has-finite-cardinality (axis-cube X d)
-has-finite-cardinality-axis-cube X d =
-  pair 2 (has-cardinality-axis-cube X d)
+  has-finite-cardinality-axis-cube :
+    (d : dim-cube) → has-finite-cardinality (axis-cube d)
+  has-finite-cardinality-axis-cube d =
+    pair 2 (has-cardinality-axis-cube d)
 
-is-finite-axis-cube :
-  {k : ℕ} (X : cube k) (d : dim-cube X) → is-finite (axis-cube X d)
-is-finite-axis-cube X d =
-  is-finite-has-cardinality (has-cardinality-axis-cube X d)
-```
+  is-finite-axis-cube : (d : dim-cube) → is-finite (axis-cube d)
+  is-finite-axis-cube d =
+    is-finite-has-cardinality 2 (has-cardinality-axis-cube d)
 
-### Vertices of cubes
-
-```agda
-vertex-cube : {k : ℕ} (X : cube k) → UU lzero
-vertex-cube X = (d : dim-cube X) → axis-cube X d
+  vertex-cube : UU lzero
+  vertex-cube = (d : dim-cube) → axis-cube d
 ```
 
 ### The standard cube
@@ -84,13 +77,13 @@ dim-standard-cube-UU-Fin : (k : ℕ) → UU-Fin k
 dim-standard-cube-UU-Fin k = Fin-UU-Fin k
 
 dim-standard-cube : ℕ → UU lzero
-dim-standard-cube k = type-UU-Fin (dim-standard-cube-UU-Fin k)
+dim-standard-cube k = type-UU-Fin k (dim-standard-cube-UU-Fin k)
 
 axis-standard-cube-UU-Fin : (k : ℕ) → dim-standard-cube k → UU-Fin 2
 axis-standard-cube-UU-Fin k d = Fin-UU-Fin 2
 
 axis-standard-cube : (k : ℕ) → dim-standard-cube k → UU lzero
-axis-standard-cube k d = type-UU-Fin (axis-standard-cube-UU-Fin k d)
+axis-standard-cube k d = type-UU-Fin 2 (axis-standard-cube-UU-Fin k d)
 
 standard-cube : (k : ℕ) → cube k
 standard-cube k =
@@ -111,11 +104,12 @@ mere-equiv-standard-cube {k} (pair (pair X H) Y) =
 
 ```agda
 face-cube :
-  {k : ℕ} (X : cube (succ-ℕ k)) (d : dim-cube X) (a : axis-cube X d) → cube k
-face-cube X d a =
-  pair ( complement-point-UU-Fin (pair (dim-cube-UU-Fin X) d))
+  (k : ℕ) (X : cube (succ-ℕ k)) (d : dim-cube (succ-ℕ k) X)
+  (a : axis-cube (succ-ℕ k) X d) → cube k
+face-cube k X d a =
+  pair ( complement-point-UU-Fin k (pair (dim-cube-UU-Fin (succ-ℕ k) X) d))
        ( λ d' →
-         axis-cube-UU-2 X
-           ( inclusion-complement-point-UU-Fin
-             ( pair (dim-cube-UU-Fin X) d) d'))
+         axis-cube-UU-2 (succ-ℕ k) X
+           ( inclusion-complement-point-UU-Fin k
+             ( pair (dim-cube-UU-Fin (succ-ℕ k) X) d) d'))
 ```

--- a/src/univalent-combinatorics/cyclic-types.lagda.md
+++ b/src/univalent-combinatorics/cyclic-types.lagda.md
@@ -405,7 +405,7 @@ issec-equiv-Eq-Cyclic-Type :
   (k : ℕ) →
   (Eq-equiv-Cyclic-Type k (ℤ-Mod-Cyclic-Type k) ∘ equiv-Eq-Cyclic-Type k) ~ id
 issec-equiv-Eq-Cyclic-Type zero-ℕ x = left-unit-law-add-ℤ x
-issec-equiv-Eq-Cyclic-Type (succ-ℕ k) x = left-unit-law-add-Fin x
+issec-equiv-Eq-Cyclic-Type (succ-ℕ k) x = left-unit-law-add-Fin k x
 
 preserves-pred-preserves-succ-map-ℤ-Mod :
   (k : ℕ) (f : ℤ-Mod k → ℤ-Mod k) →

--- a/src/univalent-combinatorics/decidable-dependent-function-types.lagda.md
+++ b/src/univalent-combinatorics/decidable-dependent-function-types.lagda.md
@@ -26,7 +26,7 @@ open import foundation.unit-type using (star)
 open import foundation.universe-levels using (Level; UU)
 
 open import univalent-combinatorics.counting using
-  ( count; equiv-count; map-equiv-count)
+  ( count; equiv-count; map-equiv-count; number-of-elements-count)
 open import univalent-combinatorics.finite-choice using (finite-choice)
 open import univalent-combinatorics.finite-types using (is-finite)
 open import univalent-combinatorics.standard-finite-types using (Fin)
@@ -38,12 +38,12 @@ We describe conditions under which dependent products are decidable.
 
 ```agda
 is-decidable-Π-Fin :
-  {l1 : Level} {k : ℕ} {B : Fin k → UU l1} →
+  {l1 : Level} (k : ℕ) {B : Fin k → UU l1} →
   ((x : Fin k) → is-decidable (B x)) → is-decidable ((x : Fin k) → B x)
-is-decidable-Π-Fin {l1} {zero-ℕ} {B} d = inl ind-empty
-is-decidable-Π-Fin {l1} {succ-ℕ k} {B} d =
+is-decidable-Π-Fin zero-ℕ {B} d = inl ind-empty
+is-decidable-Π-Fin (succ-ℕ k) {B} d =
   is-decidable-Π-Maybe
-    ( is-decidable-Π-Fin (λ x → d (inl x)))
+    ( is-decidable-Π-Fin k (λ x → d (inl x)))
     ( d (inr star))
 ```
 
@@ -55,7 +55,9 @@ is-decidable-Π-count e d =
   is-decidable-Π-equiv
     ( equiv-count e)
     ( λ x → id-equiv)
-    ( is-decidable-Π-Fin (λ x → d (map-equiv-count e x)))
+    ( is-decidable-Π-Fin
+      ( number-of-elements-count e)
+      ( λ x → d (map-equiv-count e x)))
 
 is-decidable-Π-is-finite :
   {l1 l2 : Level} {A : UU l1} {B : A → UU l2} → is-finite A →

--- a/src/univalent-combinatorics/decidable-dependent-pair-types.lagda.md
+++ b/src/univalent-combinatorics/decidable-dependent-pair-types.lagda.md
@@ -22,7 +22,7 @@ open import foundation.unit-type using (unit; star)
 open import foundation.universe-levels using (Level; UU)
 
 open import univalent-combinatorics.counting using
-  ( count; equiv-count; map-equiv-count)
+  ( count; equiv-count; map-equiv-count; number-of-elements-count)
 open import univalent-combinatorics.standard-finite-types using (Fin)
 ```
 
@@ -36,16 +36,16 @@ We describe conditions under which dependent sums are decidable. Note that it is
 
 ```agda
 is-decidable-Σ-Fin :
-  {l : Level} {k : ℕ} {P : Fin k → UU l} →
+  {l : Level} (k : ℕ) {P : Fin k → UU l} →
   ((x : Fin k) → is-decidable (P x)) → is-decidable (Σ (Fin k) P)
-is-decidable-Σ-Fin {l} {zero-ℕ} {P} d = inr pr1
-is-decidable-Σ-Fin {l} {succ-ℕ k} {P} d with d (inr star)
+is-decidable-Σ-Fin zero-ℕ {P} d = inr pr1
+is-decidable-Σ-Fin (succ-ℕ k) {P} d with d (inr star)
 ... | inl p = inl (pair (inr star) p)
 ... | inr f =
   is-decidable-iff
     ( λ t → pair (inl (pr1 t)) (pr2 t))
     ( g)
-    ( is-decidable-Σ-Fin {l} {k} {P ∘ inl} (λ x → d (inl x)))
+    ( is-decidable-Σ-Fin k {P ∘ inl} (λ x → d (inl x)))
   where
   g : Σ (Fin (succ-ℕ k)) P → Σ (Fin k) (P ∘ inl)
   g (pair (inl x) p) = pair x p
@@ -62,5 +62,7 @@ is-decidable-Σ-count e d =
   is-decidable-Σ-equiv
     ( equiv-count e)
     ( λ x → id-equiv)
-    ( is-decidable-Σ-Fin (λ x → d (map-equiv-count e x)))
+    ( is-decidable-Σ-Fin
+      ( number-of-elements-count e)
+      ( λ x → d (map-equiv-count e x)))
 ```

--- a/src/univalent-combinatorics/decidable-propositions.lagda.md
+++ b/src/univalent-combinatorics/decidable-propositions.lagda.md
@@ -36,7 +36,7 @@ is-decidable-count :
 is-decidable-count (pair zero-ℕ e) =
   inr (is-empty-is-zero-number-of-elements-count (pair zero-ℕ e) refl)
 is-decidable-count (pair (succ-ℕ k) e) =
-  inl (map-equiv e zero-Fin)
+  inl (map-equiv e (zero-Fin k))
 
 count-is-decidable-is-prop :
   {l : Level} {A : UU l} → is-prop A → is-decidable A → count A

--- a/src/univalent-combinatorics/decidable-subtypes.lagda.md
+++ b/src/univalent-combinatorics/decidable-subtypes.lagda.md
@@ -11,17 +11,34 @@ open import foundation.decidable-subtypes public
 
 open import elementary-number-theory.inequality-natural-numbers using (leq-ℕ)
 
+open import foundation.decidable-equality using (has-decidable-equality)
 open import foundation.decidable-propositions using
   ( prop-decidable-Prop; is-decidable-type-decidable-Prop)
 open import foundation.universe-levels using (Level; UU)
 
 open import univalent-combinatorics.dependent-sum-finite-types using
   ( is-finite-Σ)
+open import univalent-combinatorics.equality-finite-types
 open import univalent-combinatorics.finite-types using
-  ( is-finite; is-finite-is-decidable-Prop; number-of-elements-is-finite)
+  ( is-finite; is-finite-is-decidable-Prop; number-of-elements-is-finite;
+    is-finite-decidable-Prop; 𝔽)
+open import univalent-combinatorics.function-types
 ```
 
 ## Properties
+
+### The type of decidable subtypes of a finite type is finite
+
+```agda
+is-finite-decidable-subtype-is-finite :
+  {l1 l2 : Level} {X : UU l1} →
+  is-finite X → is-finite (decidable-subtype l2 X)
+is-finite-decidable-subtype-is-finite H =
+  is-finite-function-type H is-finite-decidable-Prop
+
+decidable-subtype-𝔽 : 𝔽 → 𝔽
+decidable-subtype-𝔽 X = {!!} 
+```
 
 ### Decidable subtypes of finite types are finite
 
@@ -31,14 +48,24 @@ module _
   where
 
   abstract
-    is-finite-decidable-subtype :
+    is-finite-type-decidable-subtype :
       is-finite X → is-finite (type-decidable-subtype P)
-    is-finite-decidable-subtype H =
+    is-finite-type-decidable-subtype H =
       is-finite-Σ H
         ( λ x →
           is-finite-is-decidable-Prop
             ( prop-decidable-Prop (P x))
             ( is-decidable-type-decidable-Prop (P x)))
+```
+
+### The underlying type of a decidable subtype has decidable equality
+
+```agda
+has-decidable-equality-type-decidable-subtype-is-finite :
+  {l1 l2 : Level} {X : UU l1} (P : decidable-subtype l2 X) → is-finite X →
+  has-decidable-equality (type-decidable-subtype P)
+has-decidable-equality-type-decidable-subtype-is-finite P H =
+  has-decidable-equality-is-finite (is-finite-type-decidable-subtype P H)
 ```
 
 ### The number of elements of a decidable subtype of a finite type is smaller than the number of elements of the ambient type
@@ -51,6 +78,6 @@ module _
   leq-number-of-elements-type-decidable-subtype :
     (H : is-finite X) →
     leq-ℕ
-      ( number-of-elements-is-finite (is-finite-decidable-subtype P H))
+      ( number-of-elements-is-finite (is-finite-type-decidable-subtype P H))
       ( number-of-elements-is-finite H)
   leq-number-of-elements-type-decidable-subtype H = {!!}

--- a/src/univalent-combinatorics/dependent-function-types.lagda.md
+++ b/src/univalent-combinatorics/dependent-function-types.lagda.md
@@ -28,7 +28,8 @@ open import foundation.universe-levels using (Level; UU; _⊔_)
 open import univalent-combinatorics.cartesian-product-types using
   ( count-prod)
 open import univalent-combinatorics.counting using
-  ( count; count-is-contr; count-equiv'; equiv-count; map-equiv-count)
+  ( count; count-is-contr; count-equiv'; equiv-count; map-equiv-count;
+    number-of-elements-count)
 open import univalent-combinatorics.finite-choice using (finite-choice)
 open import univalent-combinatorics.finite-types using
   ( is-finite; is-finite-Prop; 𝔽; type-𝔽; is-finite-type-𝔽)
@@ -47,15 +48,15 @@ If the elements of `A` can be counted and if for each `x : A` the elements of `B
 
 ```agda
 count-Π-Fin :
-  {l1 : Level} {k : ℕ} {B : Fin k → UU l1} →
+  {l1 : Level} (k : ℕ) {B : Fin k → UU l1} →
   ((x : Fin k) → count (B x)) → count ((x : Fin k) → B x)
-count-Π-Fin {l1} {zero-ℕ} {B} e =
+count-Π-Fin {l1} zero-ℕ {B} e =
   count-is-contr (dependent-universal-property-empty' B)
-count-Π-Fin {l1} {succ-ℕ k} {B} e =
+count-Π-Fin {l1} (succ-ℕ k) {B} e =
   count-equiv'
     ( equiv-dependent-universal-property-coprod B)
     ( count-prod
-      ( count-Π-Fin (λ x → e (inl x)))
+      ( count-Π-Fin k (λ x → e (inl x)))
       ( count-equiv'
         ( equiv-dependent-universal-property-unit (B ∘ inr))
         ( e (inr star))))
@@ -70,7 +71,7 @@ count-Π :
 count-Π {l1} {l2} {A} {B} e f =
   count-equiv'
     ( equiv-precomp-Π (equiv-count e) B)
-    ( count-Π-Fin (λ x → f (map-equiv-count e x)))
+    ( count-Π-Fin (number-of-elements-count e) (λ x → f (map-equiv-count e x)))
 ```
 
 ### Finiteness of dependent function types

--- a/src/univalent-combinatorics/distributivity-of-set-truncation-over-finite-products.lagda.md
+++ b/src/univalent-combinatorics/distributivity-of-set-truncation-over-finite-products.lagda.md
@@ -50,10 +50,8 @@ open import foundation.universal-property-maybe using
 open import foundation.universe-levels using (Level; UU)
 
 open import univalent-combinatorics.counting using (count)
-open import univalent-combinatorics.equality-standard-finite-types using
-  ( Fin-Set)
 open import univalent-combinatorics.finite-types using (is-finite)
-open import univalent-combinatorics.standard-finite-types using (Fin)
+open import univalent-combinatorics.standard-finite-types using (Fin; Fin-Set)
 ```
 
 ```agda

--- a/src/univalent-combinatorics/embeddings-standard-finite-types.lagda.md
+++ b/src/univalent-combinatorics/embeddings-standard-finite-types.lagda.md
@@ -25,10 +25,10 @@ open import foundation.split-surjective-maps using (is-split-surjective)
 open import foundation.unit-type using (unit; star)
 
 open import univalent-combinatorics.equality-standard-finite-types using
-  ( Eq-Fin-eq; is-set-Fin)
+  ( Eq-Fin-eq)
 open import univalent-combinatorics.standard-finite-types using
   ( Fin; is-inl-Fin; is-neg-one-Fin; is-neg-one-is-not-inl-Fin;
-    is-decidable-is-inl-Fin)
+    is-decidable-is-inl-Fin; is-set-Fin)
 ```
 
 ## Idea
@@ -39,91 +39,92 @@ Given an embedding `f : Fin (succ-ℕ k) ↪ Fin (succ-ℕ l)`, we obtain an emb
 
 ```agda
 cases-map-reduce-emb-Fin :
-  {k l : ℕ} (f : Fin (succ-ℕ k) ↪ Fin (succ-ℕ l)) →
-  is-decidable (is-inl-Fin (map-emb f (inr star))) → (x : Fin k) →
-  is-decidable (is-inl-Fin (map-emb f (inl x))) → Fin l
-cases-map-reduce-emb-Fin f (inl (pair t p)) x d =
-  repeat-Fin t (map-emb f (inl x))
-cases-map-reduce-emb-Fin f (inr g) x (inl (pair y p)) = y
-cases-map-reduce-emb-Fin f (inr g) x (inr h) =
-  ex-falso (Eq-Fin-eq (is-injective-emb f (p ∙ inv q)))
+  (k l : ℕ) (f : Fin (succ-ℕ k) ↪ Fin (succ-ℕ l)) →
+  is-decidable (is-inl-Fin l (map-emb f (inr star))) → (x : Fin k) →
+  is-decidable (is-inl-Fin l (map-emb f (inl x))) → Fin l
+cases-map-reduce-emb-Fin k l f (inl (pair t p)) x d =
+  repeat-Fin l t (map-emb f (inl x))
+cases-map-reduce-emb-Fin k l f (inr g) x (inl (pair y p)) = y
+cases-map-reduce-emb-Fin k l f (inr g) x (inr h) =
+  ex-falso (Eq-Fin-eq (succ-ℕ k) (is-injective-emb f (p ∙ inv q)))
   where
-  p : is-neg-one-Fin (map-emb f (inr star))
-  p = is-neg-one-is-not-inl-Fin (map-emb f (inr star)) g
-  q : is-neg-one-Fin (map-emb f (inl x))
-  q = is-neg-one-is-not-inl-Fin (map-emb f (inl x)) h
+  p : is-neg-one-Fin (succ-ℕ l) (map-emb f (inr star))
+  p = is-neg-one-is-not-inl-Fin l (map-emb f (inr star)) g
+  q : is-neg-one-Fin (succ-ℕ l) (map-emb f (inl x))
+  q = is-neg-one-is-not-inl-Fin l (map-emb f (inl x)) h
 
 map-reduce-emb-Fin :
-  {k l : ℕ} (f : Fin (succ-ℕ k) ↪ Fin (succ-ℕ l)) → Fin k → Fin l
-map-reduce-emb-Fin f x =
-  cases-map-reduce-emb-Fin f
-    ( is-decidable-is-inl-Fin (map-emb f (inr star)))
+  (k l : ℕ) (f : Fin (succ-ℕ k) ↪ Fin (succ-ℕ l)) → Fin k → Fin l
+map-reduce-emb-Fin k l f x =
+  cases-map-reduce-emb-Fin k l f
+    ( is-decidable-is-inl-Fin l (map-emb f (inr star)))
     ( x)
-    ( is-decidable-is-inl-Fin (map-emb f (inl x)))
+    ( is-decidable-is-inl-Fin l (map-emb f (inl x)))
 
 abstract
   is-injective-cases-map-reduce-emb-Fin :
-    {k l : ℕ} (f : Fin (succ-ℕ k) ↪ Fin (succ-ℕ l))
-    (d : is-decidable (is-inl-Fin (map-emb f (inr star))))
-    (x : Fin k) (e : is-decidable (is-inl-Fin (map-emb f (inl x))))
-    (x' : Fin k) (e' : is-decidable  (is-inl-Fin (map-emb f (inl x')))) →
-    Id (cases-map-reduce-emb-Fin f d x e) (cases-map-reduce-emb-Fin f d x' e') →
+    (k l : ℕ) (f : Fin (succ-ℕ k) ↪ Fin (succ-ℕ l))
+    (d : is-decidable (is-inl-Fin l (map-emb f (inr star))))
+    (x : Fin k) (e : is-decidable (is-inl-Fin l (map-emb f (inl x))))
+    (x' : Fin k) (e' : is-decidable  (is-inl-Fin l (map-emb f (inl x')))) →
+    Id ( cases-map-reduce-emb-Fin k l f d x e)
+       ( cases-map-reduce-emb-Fin k l f d x' e') →
     Id x x'
-  is-injective-cases-map-reduce-emb-Fin f (inl (pair t q)) x e x' e' p =
+  is-injective-cases-map-reduce-emb-Fin k l f (inl (pair t q)) x e x' e' p =
     is-injective-inl
       ( is-injective-is-emb
         ( is-emb-map-emb f)
-        ( is-almost-injective-repeat-Fin t
-          ( λ α → Eq-Fin-eq (is-injective-emb f ((inv q) ∙ α)))
-          ( λ α → Eq-Fin-eq (is-injective-emb f ((inv q) ∙ α)))
+        ( is-almost-injective-repeat-Fin l t
+          ( λ α → Eq-Fin-eq (succ-ℕ k) (is-injective-emb f ((inv q) ∙ α)))
+          ( λ α → Eq-Fin-eq (succ-ℕ k) (is-injective-emb f ((inv q) ∙ α)))
           ( p)))
   is-injective-cases-map-reduce-emb-Fin
-    f (inr g) x (inl (pair y q)) x' (inl (pair y' q')) p =
+    k l f (inr g) x (inl (pair y q)) x' (inl (pair y' q')) p =
     is-injective-inl (is-injective-emb f ((inv q) ∙ (ap inl p ∙ q')))
   is-injective-cases-map-reduce-emb-Fin
-    f (inr g) x (inl (pair y q)) x' (inr h) p =
+    k l f (inr g) x (inl (pair y q)) x' (inr h) p =
     ex-falso
-    ( Eq-Fin-eq
+    ( Eq-Fin-eq (succ-ℕ k)
       ( is-injective-emb f
-        ( ( is-neg-one-is-not-inl-Fin (pr1 f (inr star)) g) ∙
-          ( inv (is-neg-one-is-not-inl-Fin (pr1 f (inl x')) h)))))
+        ( ( is-neg-one-is-not-inl-Fin l (pr1 f (inr star)) g) ∙
+          ( inv (is-neg-one-is-not-inl-Fin l (pr1 f (inl x')) h)))))
   is-injective-cases-map-reduce-emb-Fin
-    f (inr g) x (inr h) x' (inl (pair y' q')) p =
+    k l f (inr g) x (inr h) x' (inl (pair y' q')) p =
     ex-falso
-      ( Eq-Fin-eq
+      ( Eq-Fin-eq (succ-ℕ k)
         ( is-injective-emb f
-          ( ( is-neg-one-is-not-inl-Fin (pr1 f (inr star)) g) ∙
-            ( inv (is-neg-one-is-not-inl-Fin (pr1 f (inl x)) h)))))
-  is-injective-cases-map-reduce-emb-Fin f (inr g) x (inr h) x' (inr k) p =
+          ( ( is-neg-one-is-not-inl-Fin l (pr1 f (inr star)) g) ∙
+            ( inv (is-neg-one-is-not-inl-Fin l (pr1 f (inl x)) h)))))
+  is-injective-cases-map-reduce-emb-Fin k l f (inr g) x (inr h) x' (inr m) p =
     ex-falso
-      ( Eq-Fin-eq
+      ( Eq-Fin-eq (succ-ℕ k)
         ( is-injective-emb f
-          ( ( is-neg-one-is-not-inl-Fin (pr1 f (inr star)) g) ∙
-            ( inv (is-neg-one-is-not-inl-Fin (pr1 f (inl x)) h)))))
+          ( ( is-neg-one-is-not-inl-Fin l (pr1 f (inr star)) g) ∙
+            ( inv (is-neg-one-is-not-inl-Fin l (pr1 f (inl x)) h)))))
 
 abstract
   is-injective-map-reduce-emb-Fin :
-    {k l : ℕ} (f : Fin (succ-ℕ k) ↪ Fin (succ-ℕ l)) →
-    is-injective (map-reduce-emb-Fin f)
-  is-injective-map-reduce-emb-Fin f {x} {y} =
-    is-injective-cases-map-reduce-emb-Fin f
-      ( is-decidable-is-inl-Fin (map-emb f (inr star)))
+    (k l : ℕ) (f : Fin (succ-ℕ k) ↪ Fin (succ-ℕ l)) →
+    is-injective (map-reduce-emb-Fin k l f)
+  is-injective-map-reduce-emb-Fin k l f {x} {y} =
+    is-injective-cases-map-reduce-emb-Fin k l f
+      ( is-decidable-is-inl-Fin l (map-emb f (inr star)))
       ( x)
-      ( is-decidable-is-inl-Fin (map-emb f (inl x)))
+      ( is-decidable-is-inl-Fin l (map-emb f (inl x)))
       ( y)
-      ( is-decidable-is-inl-Fin (map-emb f (inl y)))
+      ( is-decidable-is-inl-Fin l (map-emb f (inl y)))
 
 abstract
   is-emb-map-reduce-emb-Fin :
-    {k l : ℕ} (f : Fin (succ-ℕ k) ↪ Fin (succ-ℕ l)) →
-    is-emb (map-reduce-emb-Fin f)
-  is-emb-map-reduce-emb-Fin f =
-    is-emb-is-injective (is-set-Fin _) (is-injective-map-reduce-emb-Fin f)
+    (k l : ℕ) (f : Fin (succ-ℕ k) ↪ Fin (succ-ℕ l)) →
+    is-emb (map-reduce-emb-Fin k l f)
+  is-emb-map-reduce-emb-Fin k l f =
+    is-emb-is-injective (is-set-Fin l) (is-injective-map-reduce-emb-Fin k l f)
 
 reduce-emb-Fin :
   (k l : ℕ) → Fin (succ-ℕ k) ↪ Fin (succ-ℕ l) → Fin k ↪ Fin l
-pr1 (reduce-emb-Fin k l f) = map-reduce-emb-Fin f
-pr2 (reduce-emb-Fin k l f) = is-emb-map-reduce-emb-Fin f
+pr1 (reduce-emb-Fin k l f) = map-reduce-emb-Fin k l f
+pr2 (reduce-emb-Fin k l f) = is-emb-map-reduce-emb-Fin k l f
 ```
 
 ### Any embedding from `Fin k` into itself is surjective

--- a/src/univalent-combinatorics/equality-finite-types.lagda.md
+++ b/src/univalent-combinatorics/equality-finite-types.lagda.md
@@ -21,15 +21,16 @@ open import foundation.sets using (is-set; is-set-Prop; UU-Set)
 open import foundation.universe-levels using (Level; UU; _⊔_; lzero)
 
 open import univalent-combinatorics.counting using
-  ( is-set-count; equiv-count)
+  ( is-set-count; equiv-count; number-of-elements-count)
 open import univalent-combinatorics.decidable-propositions using
   ( count-eq)
 open import univalent-combinatorics.equality-standard-finite-types using
-  ( has-decidable-equality-Fin; is-set-Fin)
+  ( has-decidable-equality-Fin)
 open import univalent-combinatorics.finite-types using
   ( is-finite; has-cardinality; is-finite-count; 𝔽; type-𝔽; is-finite-type-𝔽;
     UU-Fin-Level; UU-Fin; type-UU-Fin-Level; type-UU-Fin;
     has-cardinality-type-UU-Fin-Level; has-cardinality-type-UU-Fin)
+open import univalent-combinatorics.standard-finite-types using (is-set-Fin)
 ```
 
 ## Idea
@@ -63,35 +64,37 @@ has-decidable-equality-is-finite {l1} {X} is-finite-X =
   apply-universal-property-trunc-Prop is-finite-X
     ( has-decidable-equality-Prop X)
     ( λ e →
-      has-decidable-equality-equiv' (equiv-count e) has-decidable-equality-Fin)
+      has-decidable-equality-equiv'
+        ( equiv-count e)
+        ( has-decidable-equality-Fin (number-of-elements-count e)))
 ```
 
 ### Any type of cardinality `k` is a set
 
 ```agda
 is-set-has-cardinality :
-  {l1 : Level} {X : UU l1} {k : ℕ} → has-cardinality k X → is-set X
-is-set-has-cardinality H = is-set-mere-equiv' H (is-set-Fin _)
+  {l1 : Level} {X : UU l1} (k : ℕ) → has-cardinality k X → is-set X
+is-set-has-cardinality k H = is-set-mere-equiv' H (is-set-Fin k)
 
-set-UU-Fin-Level : {l1 : Level} {k : ℕ} → UU-Fin-Level l1 k → UU-Set l1
-pr1 (set-UU-Fin-Level X) = type-UU-Fin-Level X
-pr2 (set-UU-Fin-Level X) =
-  is-set-has-cardinality (has-cardinality-type-UU-Fin-Level X)
+set-UU-Fin-Level : {l1 : Level} (k : ℕ) → UU-Fin-Level l1 k → UU-Set l1
+pr1 (set-UU-Fin-Level k X) = type-UU-Fin-Level k X
+pr2 (set-UU-Fin-Level k X) =
+  is-set-has-cardinality k (has-cardinality-type-UU-Fin-Level k X)
 
-set-UU-Fin : {k : ℕ} → UU-Fin k → UU-Set lzero
-set-UU-Fin X = set-UU-Fin-Level X
+set-UU-Fin : (k : ℕ) → UU-Fin k → UU-Set lzero
+set-UU-Fin k X = set-UU-Fin-Level k X
 ```
 
 ### Any type of finite cardinality has decidable equality
 
 ```agda
 has-decidable-equality-has-cardinality :
-  {l1 : Level} {X : UU l1} {k : ℕ} →
+  {l1 : Level} {X : UU l1} (k : ℕ) →
   has-cardinality k X → has-decidable-equality X
-has-decidable-equality-has-cardinality {l1} {X} {k} H =
+has-decidable-equality-has-cardinality {l1} {X} k H =
   apply-universal-property-trunc-Prop H
     ( has-decidable-equality-Prop X)
-    ( λ e → has-decidable-equality-equiv' e has-decidable-equality-Fin)
+    ( λ e → has-decidable-equality-equiv' e (has-decidable-equality-Fin k))
 ```
 
 ### The type of identifications between any two elements in a finite type is finite

--- a/src/univalent-combinatorics/equality-standard-finite-types.lagda.md
+++ b/src/univalent-combinatorics/equality-standard-finite-types.lagda.md
@@ -33,7 +33,7 @@ open import foundation.universe-levels using (Level; UU; lzero)
 
 open import univalent-combinatorics.standard-finite-types using
   ( Fin; zero-Fin; is-zero-Fin; one-Fin; is-one-Fin; neg-one-Fin;
-    is-neg-one-Fin; is-zero-or-one-Fin-two-ℕ)
+    is-neg-one-Fin; is-zero-or-one-Fin-two-ℕ; is-set-Fin; Fin-Set)
 ```
 
 ## Idea
@@ -51,17 +51,17 @@ Eq-Fin (succ-ℕ k) (inl x) (inr y) = empty
 Eq-Fin (succ-ℕ k) (inr x) (inl y) = empty
 Eq-Fin (succ-ℕ k) (inr x) (inr y) = unit
 
-refl-Eq-Fin : {k : ℕ} (x : Fin k) → Eq-Fin k x x
-refl-Eq-Fin {succ-ℕ k} (inl x) = refl-Eq-Fin x
-refl-Eq-Fin {succ-ℕ k} (inr x) = star
+refl-Eq-Fin : (k : ℕ) (x : Fin k) → Eq-Fin k x x
+refl-Eq-Fin (succ-ℕ k) (inl x) = refl-Eq-Fin k x
+refl-Eq-Fin (succ-ℕ k) (inr x) = star
 
-Eq-Fin-eq : {k : ℕ} {x y : Fin k} → Id x y → Eq-Fin k x y
-Eq-Fin-eq {k} refl = refl-Eq-Fin {k} _
+Eq-Fin-eq : (k : ℕ) {x y : Fin k} → Id x y → Eq-Fin k x y
+Eq-Fin-eq k refl = refl-Eq-Fin k _
 
 eq-Eq-Fin :
-  {k : ℕ} {x y : Fin k} → Eq-Fin k x y → Id x y
-eq-Eq-Fin {succ-ℕ k} {inl x} {inl y} e = ap inl (eq-Eq-Fin e)
-eq-Eq-Fin {succ-ℕ k} {inr star} {inr star} star = refl
+  (k : ℕ) {x y : Fin k} → Eq-Fin k x y → Id x y
+eq-Eq-Fin (succ-ℕ k) {inl x} {inl y} e = ap inl (eq-Eq-Fin k e)
+eq-Eq-Fin (succ-ℕ k) {inr star} {inr star} star = refl
 
 is-decidable-Eq-Fin : (k : ℕ) (x y : Fin k) → is-decidable (Eq-Fin k x y)
 is-decidable-Eq-Fin (succ-ℕ k) (inl x) (inl y) = is-decidable-Eq-Fin k x y
@@ -70,70 +70,51 @@ is-decidable-Eq-Fin (succ-ℕ k) (inr x) (inl y) = is-decidable-empty
 is-decidable-Eq-Fin (succ-ℕ k) (inr x) (inr y) = is-decidable-unit
 
 has-decidable-equality-Fin :
-  {k : ℕ} (x y : Fin k) → is-decidable (Id x y)
-has-decidable-equality-Fin {k} x y =
-  map-coprod eq-Eq-Fin (map-neg Eq-Fin-eq) (is-decidable-Eq-Fin k x y)
+  (k : ℕ) (x y : Fin k) → is-decidable (Id x y)
+has-decidable-equality-Fin k x y =
+  map-coprod (eq-Eq-Fin k) (map-neg (Eq-Fin-eq k)) (is-decidable-Eq-Fin k x y)
 
 is-decidable-is-zero-Fin :
-  {k : ℕ} (x : Fin k) → is-decidable (is-zero-Fin x)
+  {k : ℕ} (x : Fin k) → is-decidable (is-zero-Fin k x)
 is-decidable-is-zero-Fin {succ-ℕ k} x =
-  has-decidable-equality-Fin x zero-Fin
+  has-decidable-equality-Fin (succ-ℕ k) x (zero-Fin k)
 
 is-decidable-is-neg-one-Fin :
-  {k : ℕ} (x : Fin k) → is-decidable (is-neg-one-Fin x)
+  {k : ℕ} (x : Fin k) → is-decidable (is-neg-one-Fin k x)
 is-decidable-is-neg-one-Fin {succ-ℕ k} x =
-  has-decidable-equality-Fin x neg-one-Fin
+  has-decidable-equality-Fin (succ-ℕ k) x (neg-one-Fin k)
 
 is-decidable-is-one-Fin :
-  {k : ℕ} (x : Fin k) → is-decidable (is-one-Fin x)
+  {k : ℕ} (x : Fin k) → is-decidable (is-one-Fin k x)
 is-decidable-is-one-Fin {succ-ℕ k} x =
-  has-decidable-equality-Fin x one-Fin
-```
-
-### The standard finite types are sets
-
-```agda
-abstract
-  is-set-Fin : (n : ℕ) → is-set (Fin n)
-  is-set-Fin zero-ℕ = is-set-empty
-  is-set-Fin (succ-ℕ n) =
-    is-set-coprod (is-set-Fin n) is-set-unit
-
-Fin-Set : (n : ℕ) → UU-Set lzero
-pr1 (Fin-Set n) = Fin n
-pr2 (Fin-Set n) = is-set-Fin n
-```
-
-```agda
-raise-Fin-Set : (l : Level) (k : ℕ) → UU-Set l
-raise-Fin-Set l k = raise-Set l (Fin-Set k)
+  has-decidable-equality-Fin (succ-ℕ k) x (one-Fin k)
 ```
 
 ### Being zero or being one is a proposition
 
 ```agda
 is-prop-is-zero-Fin :
-  {k : ℕ} (x : Fin (succ-ℕ k)) → is-prop (is-zero-Fin x)
-is-prop-is-zero-Fin {k} x = is-set-Fin (succ-ℕ k) x zero-Fin
+  (k : ℕ) (x : Fin (succ-ℕ k)) → is-prop (is-zero-Fin (succ-ℕ k) x)
+is-prop-is-zero-Fin k x = is-set-Fin (succ-ℕ k) x (zero-Fin k)
 
 is-prop-is-one-Fin :
-  {k : ℕ} (x : Fin (succ-ℕ k)) → is-prop (is-one-Fin x)
-is-prop-is-one-Fin {k} x = is-set-Fin (succ-ℕ k) x one-Fin
+  (k : ℕ) (x : Fin (succ-ℕ k)) → is-prop (is-one-Fin (succ-ℕ k) x)
+is-prop-is-one-Fin k x = is-set-Fin (succ-ℕ k) x (one-Fin k)
 
 is-prop-is-zero-or-one-Fin-two-ℕ :
-  (x : Fin 2) → is-prop (coprod (is-zero-Fin x) (is-one-Fin x))
+  (x : Fin 2) → is-prop (coprod (is-zero-Fin 2 x) (is-one-Fin 2 x))
 is-prop-is-zero-or-one-Fin-two-ℕ x =
   is-prop-coprod
-    ( λ p q → Eq-Fin-eq (inv p ∙ q))
-    ( is-prop-is-zero-Fin x)
-    ( is-prop-is-one-Fin x)
+    ( λ p q → Eq-Fin-eq 2 (inv p ∙ q))
+    ( is-prop-is-zero-Fin 1 x)
+    ( is-prop-is-one-Fin 1 x)
 ```
 
 ### Every element in the standard two-element type is either 0 or 1.
 
 ```agda
 is-contr-is-zero-or-one-Fin-two-ℕ :
-  (x : Fin 2) → is-contr (coprod (is-zero-Fin x) (is-one-Fin x))
+  (x : Fin 2) → is-contr (coprod (is-zero-Fin 2 x) (is-one-Fin 2 x))
 is-contr-is-zero-or-one-Fin-two-ℕ x =
   is-proof-irrelevant-is-prop
     ( is-prop-is-zero-or-one-Fin-two-ℕ x)
@@ -145,7 +126,7 @@ decidable-Eq-Fin :
   (n : ℕ) (i j : Fin n) → decidable-Prop lzero
 pr1 (decidable-Eq-Fin n i j) = Id i j
 pr1 (pr2 (decidable-Eq-Fin n i j)) = is-set-Fin n i j
-pr2 (pr2 (decidable-Eq-Fin n i j)) = has-decidable-equality-Fin i j
+pr2 (pr2 (decidable-Eq-Fin n i j)) = has-decidable-equality-Fin n i j
 ```
 
 ### The standard finite types are their own set truncations

--- a/src/univalent-combinatorics/equivalences-cubes.lagda.md
+++ b/src/univalent-combinatorics/equivalences-cubes.lagda.md
@@ -37,120 +37,120 @@ open import univalent-combinatorics.finite-types using
 ### Equivalences of cubes
 
 ```agda
-equiv-cube : {k : ℕ} → cube k → cube k → UU lzero
-equiv-cube {k} X Y =
-  Σ ( (dim-cube X) ≃ (dim-cube Y))
-    ( λ e → (x : dim-cube X) → (axis-cube X x) ≃ (axis-cube Y (map-equiv e x)))
+equiv-cube : (k : ℕ) → cube k → cube k → UU lzero
+equiv-cube k X Y =
+  Σ ( (dim-cube k X) ≃ (dim-cube k Y))
+    ( λ e → (x : dim-cube k X) → (axis-cube k X x) ≃ (axis-cube k Y (map-equiv e x)))
 
 dim-equiv-cube :
-  {k : ℕ} (X Y : cube k) → equiv-cube X Y → dim-cube X ≃ dim-cube Y
-dim-equiv-cube X Y e = pr1 e
+  (k : ℕ) (X Y : cube k) → equiv-cube k X Y → dim-cube k X ≃ dim-cube k Y
+dim-equiv-cube k X Y e = pr1 e
 
 map-dim-equiv-cube :
-  {k : ℕ} (X Y : cube k) → equiv-cube X Y → dim-cube X → dim-cube Y
-map-dim-equiv-cube X Y e = map-equiv (dim-equiv-cube X Y e)
+  (k : ℕ) (X Y : cube k) → equiv-cube k X Y → dim-cube k X → dim-cube k Y
+map-dim-equiv-cube k X Y e = map-equiv (dim-equiv-cube k X Y e)
 
 axis-equiv-cube :
-  {k : ℕ} (X Y : cube k) (e : equiv-cube X Y) (d : dim-cube X) →
-  axis-cube X d ≃ axis-cube Y (map-dim-equiv-cube X Y e d)
-axis-equiv-cube X Y e = pr2 e
+  (k : ℕ) (X Y : cube k) (e : equiv-cube k X Y) (d : dim-cube k X) →
+  axis-cube k X d ≃ axis-cube k Y (map-dim-equiv-cube k X Y e d)
+axis-equiv-cube k X Y e = pr2 e
 
 map-axis-equiv-cube :
-  {k : ℕ} (X Y : cube k) (e : equiv-cube X Y) (d : dim-cube X) →
-  axis-cube X d → axis-cube Y (map-dim-equiv-cube X Y e d)
-map-axis-equiv-cube X Y e d =
-  map-equiv (axis-equiv-cube X Y e d)
+  (k : ℕ) (X Y : cube k) (e : equiv-cube k X Y) (d : dim-cube k X) →
+  axis-cube k X d → axis-cube k Y (map-dim-equiv-cube k X Y e d)
+map-axis-equiv-cube k X Y e d =
+  map-equiv (axis-equiv-cube k X Y e d)
 
 id-equiv-cube :
-  {k : ℕ} (X : cube k) → equiv-cube X X
-id-equiv-cube X = pair id-equiv (λ x → id-equiv)
+  (k : ℕ) (X : cube k) → equiv-cube k X X
+id-equiv-cube k X = pair id-equiv (λ x → id-equiv)
 
 equiv-eq-cube :
-  {k : ℕ} {X Y : cube k} → Id X Y → equiv-cube X Y
-equiv-eq-cube {k} {X} refl = id-equiv-cube X
+  (k : ℕ) {X Y : cube k} → Id X Y → equiv-cube k X Y
+equiv-eq-cube k {X} refl = id-equiv-cube k X
 
 is-contr-total-equiv-cube :
-  {k : ℕ} (X : cube k) → is-contr (Σ (cube k) (equiv-cube X))
-is-contr-total-equiv-cube X =
+  (k : ℕ) (X : cube k) → is-contr (Σ (cube k) (equiv-cube k X))
+is-contr-total-equiv-cube k X =
   is-contr-total-Eq-structure
-    ( λ D (A : type-UU-Fin D → UU-Fin 2)
-          (e : equiv-UU-Fin (dim-cube-UU-Fin X) D) →
-          (i : dim-cube X) → axis-cube X i ≃ pr1 (A (map-equiv e i)))
-    ( is-contr-total-equiv-UU-Fin (dim-cube-UU-Fin X))
-    ( pair (dim-cube-UU-Fin X) (id-equiv-UU-Fin (dim-cube-UU-Fin X)))
+    ( λ D (A : type-UU-Fin k D → UU-Fin 2)
+          (e : equiv-UU-Fin k (dim-cube-UU-Fin k X) D) →
+          (i : dim-cube k X) → axis-cube k X i ≃ pr1 (A (map-equiv e i)))
+    ( is-contr-total-equiv-UU-Fin k (dim-cube-UU-Fin k X))
+    ( pair (dim-cube-UU-Fin k X) (id-equiv-UU-Fin k (dim-cube-UU-Fin k X)))
     ( is-contr-total-Eq-Π
-      ( λ i (A : UU-Fin 2) → equiv-UU-Fin (axis-cube-UU-2 X i) A)
-      ( λ i → is-contr-total-equiv-UU-Fin (axis-cube-UU-2 X i)))
+      ( λ i (A : UU-Fin 2) → equiv-UU-Fin 2 (axis-cube-UU-2 k X i) A)
+      ( λ i → is-contr-total-equiv-UU-Fin 2 (axis-cube-UU-2 k X i)))
 
 is-equiv-equiv-eq-cube :
-  {k : ℕ} (X Y : cube k) → is-equiv (equiv-eq-cube {k} {X} {Y})
-is-equiv-equiv-eq-cube X =
+  (k : ℕ) (X Y : cube k) → is-equiv (equiv-eq-cube k {X} {Y})
+is-equiv-equiv-eq-cube k X =
   fundamental-theorem-id X
-    ( id-equiv-cube X)
-    ( is-contr-total-equiv-cube X)
-    ( λ Y → equiv-eq-cube {X = X} {Y})
+    ( id-equiv-cube k X)
+    ( is-contr-total-equiv-cube k X)
+    ( λ Y → equiv-eq-cube k {X = X} {Y})
 
 eq-equiv-cube :
-  {k : ℕ} (X Y : cube k) → equiv-cube X Y → Id X Y
-eq-equiv-cube X Y =
-  map-inv-is-equiv (is-equiv-equiv-eq-cube X Y)
+  (k : ℕ) (X Y : cube k) → equiv-cube k X Y → Id X Y
+eq-equiv-cube k X Y =
+  map-inv-is-equiv (is-equiv-equiv-eq-cube k X Y)
 
 comp-equiv-cube :
-  {k : ℕ} (X Y Z : cube k) → equiv-cube Y Z → equiv-cube X Y → equiv-cube X Z
-comp-equiv-cube X Y Z (pair dim-f axis-f) (pair dim-e axis-e) =
+  (k : ℕ) (X Y Z : cube k) → equiv-cube k Y Z → equiv-cube k X Y → equiv-cube k X Z
+comp-equiv-cube k X Y Z (pair dim-f axis-f) (pair dim-e axis-e) =
   pair (dim-f ∘e dim-e) (λ d → axis-f (map-equiv (dim-e) d) ∘e axis-e d)
 
 htpy-equiv-cube :
-  {k : ℕ} (X Y : cube k) (e f : equiv-cube X Y) → UU lzero
-htpy-equiv-cube X Y e f =
-  Σ ( map-dim-equiv-cube X Y e ~ map-dim-equiv-cube X Y f)
-    ( λ H → (d : dim-cube X) →
-            ( tr (axis-cube Y) (H d) ∘ map-axis-equiv-cube X Y e d) ~
-            ( map-axis-equiv-cube X Y f d))
+  (k : ℕ) (X Y : cube k) (e f : equiv-cube k X Y) → UU lzero
+htpy-equiv-cube k X Y e f =
+  Σ ( map-dim-equiv-cube k X Y e ~ map-dim-equiv-cube k X Y f)
+    ( λ H → (d : dim-cube k X) →
+            ( tr (axis-cube k Y) (H d) ∘ map-axis-equiv-cube k X Y e d) ~
+            ( map-axis-equiv-cube k X Y f d))
 
 refl-htpy-equiv-cube :
-  {k : ℕ} (X Y : cube k) (e : equiv-cube X Y) → htpy-equiv-cube X Y e e
-refl-htpy-equiv-cube X Y e = pair refl-htpy (λ d → refl-htpy)
+  (k : ℕ) (X Y : cube k) (e : equiv-cube k X Y) → htpy-equiv-cube k X Y e e
+refl-htpy-equiv-cube k X Y e = pair refl-htpy (λ d → refl-htpy)
 
 htpy-eq-equiv-cube :
-  {k : ℕ} (X Y : cube k) (e f : equiv-cube X Y) →
-  Id e f → htpy-equiv-cube X Y e f
-htpy-eq-equiv-cube X Y e .e refl = refl-htpy-equiv-cube X Y e
+  (k : ℕ) (X Y : cube k) (e f : equiv-cube k X Y) →
+  Id e f → htpy-equiv-cube k X Y e f
+htpy-eq-equiv-cube k X Y e .e refl = refl-htpy-equiv-cube k X Y e
 
 is-contr-total-htpy-equiv-cube :
-  {k : ℕ} (X Y : cube k) (e : equiv-cube X Y) →
-  is-contr (Σ (equiv-cube X Y) (htpy-equiv-cube X Y e))
-is-contr-total-htpy-equiv-cube X Y e =
+  (k : ℕ) (X Y : cube k) (e : equiv-cube k X Y) →
+  is-contr (Σ (equiv-cube k X Y) (htpy-equiv-cube k X Y e))
+is-contr-total-htpy-equiv-cube k X Y e =
   is-contr-total-Eq-structure
     ( λ α β H →
-      ( d : dim-cube X) →
-      ( tr (axis-cube Y) (H d) ∘ map-axis-equiv-cube X Y e d) ~
+      ( d : dim-cube k X) →
+      ( tr (axis-cube k Y) (H d) ∘ map-axis-equiv-cube k X Y e d) ~
       ( map-equiv (β d)))
-    ( is-contr-total-htpy-equiv (dim-equiv-cube X Y e))
-    ( pair (dim-equiv-cube X Y e) refl-htpy)
+    ( is-contr-total-htpy-equiv (dim-equiv-cube k X Y e))
+    ( pair (dim-equiv-cube k X Y e) refl-htpy)
     ( is-contr-total-Eq-Π
-      ( λ d β → htpy-equiv (axis-equiv-cube X Y e d) β)
-      ( λ d → is-contr-total-htpy-equiv (axis-equiv-cube X Y e d)))
+      ( λ d β → htpy-equiv (axis-equiv-cube k X Y e d) β)
+      ( λ d → is-contr-total-htpy-equiv (axis-equiv-cube k X Y e d)))
 
 is-equiv-htpy-eq-equiv-cube :
-  {k : ℕ} (X Y : cube k) (e f : equiv-cube X Y) →
-  is-equiv (htpy-eq-equiv-cube X Y e f)
-is-equiv-htpy-eq-equiv-cube X Y e =
+  (k : ℕ) (X Y : cube k) (e f : equiv-cube k X Y) →
+  is-equiv (htpy-eq-equiv-cube k X Y e f)
+is-equiv-htpy-eq-equiv-cube k X Y e =
   fundamental-theorem-id e
-    ( refl-htpy-equiv-cube X Y e)
-    ( is-contr-total-htpy-equiv-cube X Y e)
-    ( htpy-eq-equiv-cube X Y e)
+    ( refl-htpy-equiv-cube k X Y e)
+    ( is-contr-total-htpy-equiv-cube k X Y e)
+    ( htpy-eq-equiv-cube k X Y e)
 
 eq-htpy-equiv-cube :
-  {k : ℕ} (X Y : cube k) (e f : equiv-cube X Y) →
-  htpy-equiv-cube X Y e f → Id e f
-eq-htpy-equiv-cube X Y e f =
-  map-inv-is-equiv (is-equiv-htpy-eq-equiv-cube X Y e f)
+  (k : ℕ) (X Y : cube k) (e f : equiv-cube k X Y) →
+  htpy-equiv-cube k X Y e f → Id e f
+eq-htpy-equiv-cube k X Y e f =
+  map-inv-is-equiv (is-equiv-htpy-eq-equiv-cube k X Y e f)
 ```
 
 ### Labelings of cubes
 
 ```agda
-labelling-cube : {k : ℕ} (X : cube k) → UU lzero
-labelling-cube {k} X = equiv-cube (standard-cube k) X
+labelling-cube : (k : ℕ) (X : cube k) → UU lzero
+labelling-cube k X = equiv-cube k (standard-cube k) X
 ```

--- a/src/univalent-combinatorics/finite-choice.lagda.md
+++ b/src/univalent-combinatorics/finite-choice.lagda.md
@@ -53,7 +53,7 @@ open import foundation.universe-levels using (Level; UU)
 
 open import univalent-combinatorics.counting using
   ( count; is-empty-is-zero-number-of-elements-count; equiv-count;
-    map-equiv-count)
+    map-equiv-count; number-of-elements-count)
 open import univalent-combinatorics.counting-decidable-subtypes using
   ( count-domain-emb-is-finite-domain-emb)
 open import univalent-combinatorics.finite-types using (is-finite)
@@ -69,15 +69,15 @@ Propositional truncations distributes over finite products.
 ```agda
 abstract
   finite-choice-Fin :
-    {l1 : Level} {k : ℕ} {Y : Fin k → UU l1} →
+    {l1 : Level} (k : ℕ) {Y : Fin k → UU l1} →
     ((x : Fin k) → type-trunc-Prop (Y x)) → type-trunc-Prop ((x : Fin k) → Y x)
-  finite-choice-Fin {l1} {zero-ℕ} {Y} H = unit-trunc-Prop ind-empty
-  finite-choice-Fin {l1} {succ-ℕ k} {Y} H =
+  finite-choice-Fin {l1} zero-ℕ {Y} H = unit-trunc-Prop ind-empty
+  finite-choice-Fin {l1} (succ-ℕ k) {Y} H =
     map-inv-equiv-trunc-Prop
       ( equiv-dependent-universal-property-coprod Y)
       ( map-inv-distributive-trunc-prod-Prop
         ( pair
-          ( finite-choice-Fin (λ x → H (inl x)))
+          ( finite-choice-Fin k (λ x → H (inl x)))
           ( map-inv-equiv-trunc-Prop
             ( equiv-dependent-universal-property-unit (Y ∘ inr))
             ( H (inr star)))))
@@ -89,7 +89,7 @@ abstract
   finite-choice-count {l1} {l2} {X} {Y} (pair k e) H =
     map-inv-equiv-trunc-Prop
       ( equiv-precomp-Π e Y)
-      ( finite-choice-Fin (λ x → H (map-equiv e x)))
+      ( finite-choice-Fin k (λ x → H (map-equiv e x)))
 
 abstract
   finite-choice :
@@ -110,7 +110,7 @@ abstract
       ( is-empty-type-trunc-Prop
         ( is-empty-is-zero-number-of-elements-count (pair zero-ℕ e) refl)
         ( t))
-  ε-operator-count (pair (succ-ℕ k) e) t = map-equiv e zero-Fin
+  ε-operator-count (pair (succ-ℕ k) e) t = map-equiv e (zero-Fin k)
 
 abstract
   ε-operator-decidable-subtype-count :
@@ -120,6 +120,7 @@ abstract
     ε-operator-equiv
       ( equiv-Σ-equiv-base (is-in-decidable-subtype P) (equiv-count e))
       ( ε-operator-decidable-subtype-Fin
+        ( number-of-elements-count e)
         ( λ x → P (map-equiv-count e x)))
 ```
 

--- a/src/univalent-combinatorics/finite-types.lagda.md
+++ b/src/univalent-combinatorics/finite-types.lagda.md
@@ -9,7 +9,6 @@ module univalent-combinatorics.finite-types where
 
 open import elementary-number-theory.equality-natural-numbers using
   ( is-set-ℕ; ℕ-Set; has-decidable-equality-ℕ)
-open import elementary-number-theory.modular-arithmetic using (ℤ-Mod)
 open import elementary-number-theory.natural-numbers using
   ( ℕ; zero-ℕ; is-nonzero-ℕ; succ-ℕ; is-zero-ℕ; is-one-ℕ)
 
@@ -111,18 +110,31 @@ abstract
   is-finite-count = unit-trunc-Prop
 ```
 
-### The type of all finite types
+### The type of all finite types of a universe level
+
+```agda
+𝔽-Level : (l : Level) → UU (lsuc l)
+𝔽-Level l = Σ (UU l) is-finite
+
+type-𝔽-Level : {l : Level} → 𝔽-Level l → UU l
+type-𝔽-Level X = pr1 X
+
+is-finite-type-𝔽-Level :
+  {l : Level} (X : 𝔽-Level l) → is-finite (type-𝔽-Level X)
+is-finite-type-𝔽-Level X = pr2 X
+```
+
+### The type of all finite types of universe level `lzero`
 
 ```agda
 𝔽 : UU (lsuc lzero)
-𝔽 = Σ (UU lzero) is-finite
+𝔽 = 𝔽-Level lzero
 
 type-𝔽 : 𝔽 → UU lzero
-type-𝔽 X = pr1 X
+type-𝔽 = type-𝔽-Level
 
-abstract
-  is-finite-type-𝔽 : (X : 𝔽) → is-finite (type-𝔽 X)
-  is-finite-type-𝔽 X = pr2 X
+is-finite-type-𝔽 : (X : 𝔽) → is-finite (type-𝔽 X)
+is-finite-type-𝔽 = is-finite-type-𝔽-Level
 ```
 
 ### Types with cardinality `k`
@@ -143,14 +155,14 @@ has-cardinality k X = mere-equiv (Fin k) X
 UU-Fin-Level : (l : Level) → ℕ → UU (lsuc l)
 UU-Fin-Level l k = Σ (UU l) (mere-equiv (Fin k))
 
-type-UU-Fin-Level : {l : Level} {k : ℕ} → UU-Fin-Level l k → UU l
-type-UU-Fin-Level X = pr1 X
+type-UU-Fin-Level : {l : Level} (k : ℕ) → UU-Fin-Level l k → UU l
+type-UU-Fin-Level k X = pr1 X
 
 abstract
   has-cardinality-type-UU-Fin-Level :
-    {l : Level} {k : ℕ} (X : UU-Fin-Level l k) →
-    mere-equiv (Fin k) (type-UU-Fin-Level X)
-  has-cardinality-type-UU-Fin-Level X = pr2 X
+    {l : Level} (k : ℕ) (X : UU-Fin-Level l k) →
+    mere-equiv (Fin k) (type-UU-Fin-Level k X)
+  has-cardinality-type-UU-Fin-Level k X = pr2 X
 ```
 
 ### The type of all types of cardinality k of univerese level `lzero`
@@ -159,13 +171,13 @@ abstract
 UU-Fin : ℕ → UU (lsuc lzero)
 UU-Fin k = UU-Fin-Level lzero k
 
-type-UU-Fin : {k : ℕ} → UU-Fin k → UU lzero
-type-UU-Fin X = pr1 X
+type-UU-Fin : (k : ℕ) → UU-Fin k → UU lzero
+type-UU-Fin k X = pr1 X
 
 abstract
   has-cardinality-type-UU-Fin :
-    {k : ℕ} (X : UU-Fin k) → has-cardinality k (type-UU-Fin X)
-  has-cardinality-type-UU-Fin X = pr2 X
+    (k : ℕ) (X : UU-Fin k) → has-cardinality k (type-UU-Fin k X)
+  has-cardinality-type-UU-Fin k X = pr2 X
 ```
 
 ### Types of finite cardinality
@@ -320,31 +332,31 @@ abstract
 
 ```agda
 abstract
-  is-finite-Fin : {k : ℕ} → is-finite (Fin k)
-  is-finite-Fin {k} = is-finite-count (count-Fin k)
+  is-finite-Fin : (k : ℕ) → is-finite (Fin k)
+  is-finite-Fin k = is-finite-count (count-Fin k)
 
 Fin-𝔽 : ℕ → 𝔽
 pr1 (Fin-𝔽 k) = Fin k
-pr2 (Fin-𝔽 k) = is-finite-Fin
+pr2 (Fin-𝔽 k) = is-finite-Fin k
 
 Fin-UU-Fin : (k : ℕ) → UU-Fin k
 pr1 (Fin-UU-Fin k) = Fin k
 pr2 (Fin-UU-Fin k) = unit-trunc-Prop id-equiv
 
 has-cardinality-raise-Fin :
-  {l : Level} {k : ℕ} → has-cardinality k (raise-Fin l k)
-has-cardinality-raise-Fin {l} {k} = unit-trunc-Prop (equiv-raise-Fin l k)
+  {l : Level} (k : ℕ) → has-cardinality k (raise-Fin l k)
+has-cardinality-raise-Fin {l} k = unit-trunc-Prop (equiv-raise-Fin l k)
 
 Fin-UU-Fin-Level : (l : Level) (k : ℕ) → UU-Fin-Level l k
 pr1 (Fin-UU-Fin-Level l k) = raise-Fin l k
-pr2 (Fin-UU-Fin-Level l k) = has-cardinality-raise-Fin
+pr2 (Fin-UU-Fin-Level l k) = has-cardinality-raise-Fin k
 ```
 
 ### The type of booleans is finite
 
 ```agda
 is-finite-bool : is-finite bool
-is-finite-bool = is-finite-equiv equiv-bool-Fin-two-ℕ is-finite-Fin
+is-finite-bool = is-finite-equiv equiv-bool-Fin-two-ℕ (is-finite-Fin 2)
 ```
 
 ### The type of decidable propositions of any universe level is finite
@@ -355,34 +367,22 @@ is-finite-decidable-Prop {l} =
   is-finite-equiv' equiv-bool-decidable-Prop is-finite-bool
 ```
 
-### The types `ℤ-Mod k` are finite for nonzero natural numbers `k`
-
-```agda
-abstract
-  is-finite-ℤ-Mod : {k : ℕ} → is-nonzero-ℕ k → is-finite (ℤ-Mod k)
-  is-finite-ℤ-Mod {zero-ℕ} H = ex-falso (H refl)
-  is-finite-ℤ-Mod {succ-ℕ k} H = is-finite-Fin
-
-ℤ-Mod-𝔽 : (k : ℕ) → is-nonzero-ℕ k → 𝔽
-pr1 (ℤ-Mod-𝔽 k H) = ℤ-Mod k
-pr2 (ℤ-Mod-𝔽 k H) = is-finite-ℤ-Mod H
-```
-
 ### Every type of cardinality `k` is finite
 
 ```agda
 abstract
   is-finite-type-UU-Fin-Level :
-    {l : Level} {k : ℕ} (X : UU-Fin-Level l k) → is-finite (type-UU-Fin-Level X)
-  is-finite-type-UU-Fin-Level X =
+    {l : Level} (k : ℕ) (X : UU-Fin-Level l k) →
+    is-finite (type-UU-Fin-Level k X)
+  is-finite-type-UU-Fin-Level k X =
     is-finite-mere-equiv
-      ( has-cardinality-type-UU-Fin-Level X)
-      ( is-finite-Fin)
+      ( has-cardinality-type-UU-Fin-Level k X)
+      ( is-finite-Fin k)
 
 abstract
   is-finite-type-UU-Fin :
-    {k : ℕ} (X : UU-Fin k) → is-finite (type-UU-Fin X)
-  is-finite-type-UU-Fin X = is-finite-type-UU-Fin-Level X
+    (k : ℕ) (X : UU-Fin k) → is-finite (type-UU-Fin k X)
+  is-finite-type-UU-Fin k X = is-finite-type-UU-Fin-Level k X
 ```
 
 ### Having a finite cardinality is a proposition
@@ -428,8 +428,8 @@ module _
         ( is-finite-count ∘ (pair k))
 
   abstract
-    is-finite-has-cardinality : {k : ℕ} → has-cardinality k X → is-finite X
-    is-finite-has-cardinality {k} H =
+    is-finite-has-cardinality : (k : ℕ) → has-cardinality k X → is-finite X
+    is-finite-has-cardinality k H =
       is-finite-has-finite-cardinality (pair k H)
 
   has-finite-cardinality-count : count X → has-finite-cardinality X
@@ -476,10 +476,10 @@ module _
   has-cardinality-is-finite H =
     pr2 (has-finite-cardinality-is-finite H)
 
-finite-type-UU-Fin : {k : ℕ} → UU-Fin k → 𝔽
-pr1 (finite-type-UU-Fin X) = type-UU-Fin X
-pr2 (finite-type-UU-Fin X) =
-  is-finite-has-cardinality (has-cardinality-type-UU-Fin X)
+finite-type-UU-Fin : (k : ℕ) → UU-Fin k → 𝔽
+pr1 (finite-type-UU-Fin k X) = type-UU-Fin k X
+pr2 (finite-type-UU-Fin k X) =
+  is-finite-has-cardinality k (has-cardinality-type-UU-Fin k X)
 ```
 
 ### If a type has cardinality `k` and cardinality `l`, then `k = l`.
@@ -646,78 +646,78 @@ extensionality-fam-𝔽 = extensionality-fam-subuniverse is-finite-Prop
 
 ```agda
 equiv-UU-Fin-Level :
-  {l1 l2 : Level} {k : ℕ} → UU-Fin-Level l1 k → UU-Fin-Level l2 k → UU (l1 ⊔ l2)
-equiv-UU-Fin-Level X Y = type-UU-Fin-Level X ≃ type-UU-Fin-Level Y
+  {l1 l2 : Level} (k : ℕ) → UU-Fin-Level l1 k → UU-Fin-Level l2 k → UU (l1 ⊔ l2)
+equiv-UU-Fin-Level k X Y = type-UU-Fin-Level k X ≃ type-UU-Fin-Level k Y
 
 id-equiv-UU-Fin-Level :
-  {l : Level} {k : ℕ} (X : UU-Fin-Level l k) → equiv-UU-Fin-Level X X
+  {l : Level} {k : ℕ} (X : UU-Fin-Level l k) → equiv-UU-Fin-Level k X X
 id-equiv-UU-Fin-Level X = id-equiv-component-UU-Level X
 
 equiv-eq-UU-Fin-Level :
-  {l : Level} {k : ℕ} {X Y : UU-Fin-Level l k} → Id X Y → equiv-UU-Fin-Level X Y
-equiv-eq-UU-Fin-Level p = equiv-eq-component-UU-Level p
+  {l : Level} (k : ℕ) {X Y : UU-Fin-Level l k} → Id X Y → equiv-UU-Fin-Level k X Y
+equiv-eq-UU-Fin-Level k p = equiv-eq-component-UU-Level p
 
 abstract
   is-contr-total-equiv-UU-Fin-Level :
     {l : Level} {k : ℕ} (X : UU-Fin-Level l k) →
-    is-contr (Σ (UU-Fin-Level l k) (equiv-UU-Fin-Level X))
+    is-contr (Σ (UU-Fin-Level l k) (equiv-UU-Fin-Level k X))
   is-contr-total-equiv-UU-Fin-Level {l} {k} X =
     is-contr-total-equiv-component-UU-Level X
 
 abstract
   is-equiv-equiv-eq-UU-Fin-Level :
-    {l : Level} {k : ℕ} (X Y : UU-Fin-Level l k) →
-    is-equiv (equiv-eq-UU-Fin-Level {X = X} {Y})
-  is-equiv-equiv-eq-UU-Fin-Level X =
+    {l : Level} (k : ℕ) (X Y : UU-Fin-Level l k) →
+    is-equiv (equiv-eq-UU-Fin-Level k {X = X} {Y})
+  is-equiv-equiv-eq-UU-Fin-Level k X =
     is-equiv-equiv-eq-component-UU-Level X
 
 eq-equiv-UU-Fin-Level :
-  {l : Level} {k : ℕ} (X Y : UU-Fin-Level l k) →
-  equiv-UU-Fin-Level X Y → Id X Y
-eq-equiv-UU-Fin-Level X Y =
+  {l : Level} (k : ℕ) (X Y : UU-Fin-Level l k) →
+  equiv-UU-Fin-Level k X Y → Id X Y
+eq-equiv-UU-Fin-Level k X Y =
   eq-equiv-component-UU-Level X Y
 
 equiv-equiv-eq-UU-Fin-Level :
-  {l : Level} {k : ℕ} (X Y : UU-Fin-Level l k) →
-  Id X Y ≃ equiv-UU-Fin-Level X Y
-pr1 (equiv-equiv-eq-UU-Fin-Level X Y) = equiv-eq-UU-Fin-Level
-pr2 (equiv-equiv-eq-UU-Fin-Level X Y) = is-equiv-equiv-eq-UU-Fin-Level X Y
+  {l : Level} (k : ℕ) (X Y : UU-Fin-Level l k) →
+  Id X Y ≃ equiv-UU-Fin-Level k X Y
+pr1 (equiv-equiv-eq-UU-Fin-Level k X Y) = equiv-eq-UU-Fin-Level k
+pr2 (equiv-equiv-eq-UU-Fin-Level k X Y) = is-equiv-equiv-eq-UU-Fin-Level k X Y
 ```
 
 ### We characterize the identity type of `UU-Fin`
 
 ```agda
-equiv-UU-Fin : {k : ℕ} (X Y : UU-Fin k) → UU lzero
-equiv-UU-Fin X Y = equiv-component-UU X Y
+equiv-UU-Fin : (k : ℕ) (X Y : UU-Fin k) → UU lzero
+equiv-UU-Fin k X Y = equiv-component-UU X Y
 
 id-equiv-UU-Fin :
-  {k : ℕ} (X : UU-Fin k) → equiv-UU-Fin X X
-id-equiv-UU-Fin X = id-equiv-component-UU X
+  (k : ℕ) (X : UU-Fin k) → equiv-UU-Fin k X X
+id-equiv-UU-Fin k X = id-equiv-component-UU X
 
 equiv-eq-UU-Fin :
-  {k : ℕ} {X Y : UU-Fin k} → Id X Y → equiv-UU-Fin X Y
-equiv-eq-UU-Fin p = equiv-eq-component-UU p
+  (k : ℕ) {X Y : UU-Fin k} → Id X Y → equiv-UU-Fin k X Y
+equiv-eq-UU-Fin k p = equiv-eq-component-UU p
 
 abstract
   is-contr-total-equiv-UU-Fin :
-    {k : ℕ} (X : UU-Fin k) → is-contr (Σ (UU-Fin k) (equiv-UU-Fin X))
-  is-contr-total-equiv-UU-Fin X =
+    (k : ℕ) (X : UU-Fin k) → is-contr (Σ (UU-Fin k) (equiv-UU-Fin k X))
+  is-contr-total-equiv-UU-Fin k X =
     is-contr-total-equiv-component-UU X
 
 abstract
   is-equiv-equiv-eq-UU-Fin :
-    {k : ℕ} (X Y : UU-Fin k) → is-equiv (equiv-eq-UU-Fin {X = X} {Y})
-  is-equiv-equiv-eq-UU-Fin X =
+    (k : ℕ) (X Y : UU-Fin k) → is-equiv (equiv-eq-UU-Fin k {X = X} {Y})
+  is-equiv-equiv-eq-UU-Fin k X =
     is-equiv-equiv-eq-component-UU X
 
 eq-equiv-UU-Fin :
-  {k : ℕ} (X Y : UU-Fin k) → equiv-UU-Fin X Y → Id X Y
-eq-equiv-UU-Fin X Y = eq-equiv-component-UU X Y
+  (k : ℕ) (X Y : UU-Fin k) → equiv-UU-Fin k X Y → Id X Y
+eq-equiv-UU-Fin k X Y = eq-equiv-component-UU X Y
 
 equiv-equiv-eq-UU-Fin :
-  {k : ℕ} (X Y : UU-Fin k) → Id X Y ≃ equiv-UU-Fin X Y
-pr1 (equiv-equiv-eq-UU-Fin X Y) = equiv-eq-UU-Fin
-pr2 (equiv-equiv-eq-UU-Fin X Y) = is-equiv-equiv-eq-UU-Fin X Y
+  (k : ℕ) (X Y : UU-Fin k) → Id X Y ≃ equiv-UU-Fin k X Y
+pr1 (equiv-equiv-eq-UU-Fin k X Y) = equiv-eq-UU-Fin k
+pr2 (equiv-equiv-eq-UU-Fin k X Y) = is-equiv-equiv-eq-UU-Fin k X Y
 ```
 
 ### The types `UU-Fin-Level` and `UU-Fin` are connected
@@ -731,11 +731,11 @@ abstract
       ( Fin-UU-Fin-Level l n)
       ( λ A →
         map-trunc-Prop
-          ( ( eq-equiv-UU-Fin-Level (Fin-UU-Fin-Level l n) A) ∘
+          ( ( eq-equiv-UU-Fin-Level n (Fin-UU-Fin-Level l n) A) ∘
             ( map-equiv
               ( equiv-precomp-equiv
                 ( inv-equiv (equiv-raise l (Fin n)))
-                ( type-UU-Fin-Level A))))
+                ( type-UU-Fin-Level n A))))
           ( pr2 A))
 
 abstract
@@ -744,7 +744,7 @@ abstract
   is-path-connected-UU-Fin n =
     is-path-connected-mere-eq
       ( Fin-UU-Fin n)
-      ( λ A → map-trunc-Prop (eq-equiv-UU-Fin (Fin-UU-Fin n) A) (pr2 A))
+      ( λ A → map-trunc-Prop (eq-equiv-UU-Fin n (Fin-UU-Fin n) A) (pr2 A))
 ```
 
 ```agda

--- a/src/univalent-combinatorics/finitely-presented-types.lagda.md
+++ b/src/univalent-combinatorics/finitely-presented-types.lagda.md
@@ -26,14 +26,12 @@ open import foundation.sets using (Id-Prop)
 open import foundation.subtypes using (eq-subtype)
 open import foundation.universe-levels using (Level; UU)
 
-open import univalent-combinatorics.equality-standard-finite-types using
-  ( Fin-Set)
 open import univalent-combinatorics.finite-choice using (finite-choice-Fin)
 open import univalent-combinatorics.finite-connected-components using
   ( has-cardinality-components; has-cardinality-components-Prop)
 open import univalent-combinatorics.finite-types using (eq-cardinality)
 open import univalent-combinatorics.standard-finite-types using
-  ( Fin; is-injective-Fin)
+  ( Fin; is-injective-Fin; Fin-Set)
 ```
 
 ## Idea
@@ -68,9 +66,9 @@ is-finitely-presented A =
 
 ```agda
 has-presentation-of-cardinality-has-cardinality-components :
-  {l : Level} {k : ℕ} {A : UU l} → has-cardinality-components k A →
+  {l : Level} (k : ℕ) {A : UU l} → has-cardinality-components k A →
   has-presentation-of-cardinality k A
-has-presentation-of-cardinality-has-cardinality-components {l} {k} {A} H =
+has-presentation-of-cardinality-has-cardinality-components {l} k {A} H =
   apply-universal-property-trunc-Prop H
     ( has-presentation-of-cardinality-Prop k A)
     ( λ e →
@@ -88,12 +86,12 @@ has-presentation-of-cardinality-has-cardinality-components {l} {k} {A} H =
   P1 e x = is-surjective-unit-trunc-Set A (map-equiv e x)
   P2 : (e : Fin k ≃ type-trunc-Set A) →
        type-trunc-Prop ((x : Fin k) → fib unit-trunc-Set (map-equiv e x))
-  P2 e = finite-choice-Fin (P1 e)
+  P2 e = finite-choice-Fin k (P1 e)
 
 has-cardinality-components-has-presentation-of-cardinality :
-  {l : Level} {k : ℕ} {A : UU l} → has-presentation-of-cardinality k A →
+  {l : Level} (k : ℕ) {A : UU l} → has-presentation-of-cardinality k A →
   has-cardinality-components k A
-has-cardinality-components-has-presentation-of-cardinality {l} {k} {A} H =
+has-cardinality-components-has-presentation-of-cardinality {l} k {A} H =
   apply-universal-property-trunc-Prop H
     ( has-cardinality-components-Prop k A)
     ( λ { (pair f E) → unit-trunc-Prop (pair (unit-trunc-Set ∘ f) E)})
@@ -108,8 +106,8 @@ all-elements-equal-is-finitely-presented {l1} {A} (pair k K) (pair l L) =
   eq-subtype
     ( λ n → has-set-presentation-Prop (Fin-Set n) A)
     ( eq-cardinality
-      ( has-cardinality-components-has-presentation-of-cardinality K)
-      ( has-cardinality-components-has-presentation-of-cardinality L))
+      ( has-cardinality-components-has-presentation-of-cardinality k K)
+      ( has-cardinality-components-has-presentation-of-cardinality l L))
 
 is-prop-is-finitely-presented :
   {l1 : Level} {A : UU l1} → is-prop (is-finitely-presented A)

--- a/src/univalent-combinatorics/inequality-types-with-counting.lagda.md
+++ b/src/univalent-combinatorics/inequality-types-with-counting.lagda.md
@@ -34,7 +34,10 @@ If a type comes equipped with a counting of its elements, then it inherits the i
 leq-count :
   {l : Level} {X : UU l} → count X → X → X → UU lzero
 leq-count e x y =
-  leq-Fin (map-inv-equiv-count e x) (map-inv-equiv-count e y)
+  leq-Fin
+    ( number-of-elements-count e)
+    ( map-inv-equiv-count e x)
+    ( map-inv-equiv-count e y)
 ```
 
 ## Properties
@@ -42,19 +45,22 @@ leq-count e x y =
 ```agda
 refl-leq-count :
   {l : Level} {X : UU l} (e : count X) (x : X) → leq-count e x x
-refl-leq-count (pair k e) x = refl-leq-Fin (map-inv-equiv e x)
+refl-leq-count e x =
+  refl-leq-Fin (number-of-elements-count e) (map-inv-equiv-count e x)
 
 antisymmetric-leq-count :
   {l : Level} {X : UU l} (e : count X) {x y : X} →
   leq-count e x y → leq-count e y x → Id x y
-antisymmetric-leq-count (pair k e) H K =
-  is-injective-map-inv-equiv e (antisymmetric-leq-Fin _ _ H K)
+antisymmetric-leq-count e H K =
+  is-injective-map-inv-equiv
+    ( equiv-count e)
+    ( antisymmetric-leq-Fin (number-of-elements-count e) _ _ H K)
 
 transitive-leq-count :
   {l : Level} {X : UU l} (e : count X) {x y z : X} →
   leq-count e y z → leq-count e x y → leq-count e x z
 transitive-leq-count (pair k e) {x} {y} {z} =
-  transitive-leq-Fin
+  transitive-leq-Fin k
     ( map-inv-equiv e x)
     ( map-inv-equiv e y)
     ( map-inv-equiv-count (pair k e) z)
@@ -62,9 +68,11 @@ transitive-leq-count (pair k e) {x} {y} {z} =
 preserves-leq-equiv-count :
   {l : Level} {X : UU l} (e : count X)
   {x y : Fin (number-of-elements-count e)} →
-  leq-Fin x y → leq-count e (map-equiv-count e x) (map-equiv-count e y)
+  leq-Fin (number-of-elements-count e) x y →
+  leq-count e (map-equiv-count e x) (map-equiv-count e y)
 preserves-leq-equiv-count e {x} {y} H =
   concatenate-eq-leq-eq-Fin
+    ( number-of-elements-count e)
     ( isretr-map-inv-equiv (equiv-count e) x)
     ( H)
     ( inv (isretr-map-inv-equiv (equiv-count e) y))
@@ -72,9 +80,11 @@ preserves-leq-equiv-count e {x} {y} H =
 reflects-leq-equiv-count :
   {l : Level} {X : UU l} (e : count X)
   {x y : Fin (number-of-elements-count e)} →
-  leq-count e (map-equiv-count e x) (map-equiv-count e y) → leq-Fin x y
+  leq-count e (map-equiv-count e x) (map-equiv-count e y) →
+  leq-Fin (number-of-elements-count e) x y
 reflects-leq-equiv-count e {x} {y} H =
   concatenate-eq-leq-eq-Fin
+    ( number-of-elements-count e)
     ( inv (isretr-map-inv-equiv (equiv-count e) x))
     ( H)
     ( isretr-map-inv-equiv (equiv-count e) y)
@@ -82,9 +92,12 @@ reflects-leq-equiv-count e {x} {y} H =
 transpose-leq-equiv-count :
   {l : Level} {X : UU l} (e : count X) →
   {x : Fin (number-of-elements-count e)} {y : X} →
-  leq-Fin x (map-inv-equiv-count e y) → leq-count e (map-equiv-count e x) y
+  leq-Fin
+    ( number-of-elements-count e) x (map-inv-equiv-count e y) →
+  leq-count e (map-equiv-count e x) y
 transpose-leq-equiv-count e {x} {y} H =
   concatenate-eq-leq-eq-Fin
+    ( number-of-elements-count e)
     ( isretr-map-inv-equiv (equiv-count e) x)
     ( H)
     ( refl)
@@ -92,9 +105,11 @@ transpose-leq-equiv-count e {x} {y} H =
 transpose-leq-equiv-count' :
   {l : Level} {X : UU l} (e : count X) →
   {x : X} {y : Fin (number-of-elements-count e)} →
-  leq-Fin (map-inv-equiv-count e x) y → leq-count e x (map-equiv-count e y)
+  leq-Fin (number-of-elements-count e) (map-inv-equiv-count e x) y →
+  leq-count e x (map-equiv-count e y)
 transpose-leq-equiv-count' e {x} {y} H =
   concatenate-eq-leq-eq-Fin
+    ( number-of-elements-count e)
     ( refl)
     ( H)
     ( inv (isretr-map-inv-equiv (equiv-count e) y))

--- a/src/univalent-combinatorics/main-classes-of-latin-hypercubes.lagda.md
+++ b/src/univalent-combinatorics/main-classes-of-latin-hypercubes.lagda.md
@@ -36,18 +36,18 @@ Main-Class-Latin-Hypercube : (l1 l2 : Level) (n : ℕ) → UU (lsuc l1 ⊔ lsuc 
 Main-Class-Latin-Hypercube l1 l2 n =
   Σ ( unordered-tuple (succ-ℕ n) (Inhabited-Type l1))
     ( λ A →
-      Σ ( product-unordered-tuple-types
+      Σ ( product-unordered-tuple-types (succ-ℕ n)
           ( map-unordered-tuple (succ-ℕ n) type-Inhabited-Type A) → UU l2)
         ( λ R →
-          ( i : type-unordered-tuple A)
-          ( f : product-unordered-tuple-types
-                ( unordered-tuple-complement-point-type-unordered-tuple
+          ( i : type-unordered-tuple (succ-ℕ n) A)
+          ( f : product-unordered-tuple-types n
+                ( unordered-tuple-complement-point-type-unordered-tuple n
                   ( map-unordered-tuple (succ-ℕ n) type-Inhabited-Type A)
                   ( i))) →
           is-contr
-            ( Σ ( type-Inhabited-Type (element-unordered-tuple A i))
+            ( Σ ( type-Inhabited-Type (element-unordered-tuple (succ-ℕ n) A i))
                 ( λ a →
-                  R ( map-equiv-pr-product-unordered-tuple-types
+                  R ( map-equiv-pr-product-unordered-tuple-types n
                       ( map-unordered-tuple (succ-ℕ n) type-Inhabited-Type A)
                       ( i)
                       ( f)
@@ -61,21 +61,21 @@ Main-Class-Latin-Hypercube-of-Order : (n m : ℕ) → UU (lsuc lzero)
 Main-Class-Latin-Hypercube-of-Order n m =
   Σ ( unordered-tuple (succ-ℕ n) (UU-Fin m))
     ( λ A →
-      Σ ( product-unordered-tuple-types
-          ( map-unordered-tuple (succ-ℕ n) type-UU-Fin A) →
+      Σ ( product-unordered-tuple-types (succ-ℕ n)
+          ( map-unordered-tuple (succ-ℕ n) (type-UU-Fin m) A) →
           decidable-Prop lzero)
         ( λ R →
-          (i : type-unordered-tuple A)
-          (f : product-unordered-tuple-types
-               ( unordered-tuple-complement-point-type-unordered-tuple
-                 ( map-unordered-tuple (succ-ℕ n) type-UU-Fin A)
+          (i : type-unordered-tuple (succ-ℕ n) A)
+          (f : product-unordered-tuple-types n
+               ( unordered-tuple-complement-point-type-unordered-tuple n
+                 ( map-unordered-tuple (succ-ℕ n) (type-UU-Fin m) A)
                  ( i))) →
           is-contr
-            ( Σ ( type-UU-Fin (element-unordered-tuple A i))
+            ( Σ ( type-UU-Fin m (element-unordered-tuple (succ-ℕ n) A i))
                 ( λ a →
                   type-decidable-Prop
-                    ( R ( map-equiv-pr-product-unordered-tuple-types
-                          ( map-unordered-tuple (succ-ℕ n) type-UU-Fin A)
+                    ( R ( map-equiv-pr-product-unordered-tuple-types n
+                          ( map-unordered-tuple (succ-ℕ n) (type-UU-Fin m) A)
                           ( i)
                           ( f)
                           ( a)))))))
@@ -96,7 +96,7 @@ is-π-finite-Main-Class-Latin-Hypercube-of-Order k n m =
       ( λ X →
         is-π-finite-Π
           ( succ-ℕ k)
-          ( is-finite-type-UU-Fin X)
+          ( is-finite-type-UU-Fin (succ-ℕ n) X)
           ( λ i → is-π-finite-UU-Fin (succ-ℕ k) m)))
     ( λ A →
       is-π-finite-Σ k
@@ -104,35 +104,44 @@ is-π-finite-Main-Class-Latin-Hypercube-of-Order k n m =
           ( succ-ℕ k)
           ( is-finite-Π
             ( is-finite-Π
-              ( is-finite-type-UU-Fin (type-unordered-tuple-UU-Fin A))
-              ( λ i → is-finite-type-UU-Fin (element-unordered-tuple A i)))
+              ( is-finite-type-UU-Fin
+                ( succ-ℕ n)
+                ( type-unordered-tuple-UU-Fin (succ-ℕ n) A))
+              ( λ i →
+                is-finite-type-UU-Fin m
+                  ( element-unordered-tuple (succ-ℕ n) A i)))
             ( λ f → is-finite-decidable-Prop)))
         ( λ R →
           is-π-finite-is-finite k
             ( is-finite-Π
-              ( is-finite-type-UU-Fin (type-unordered-tuple-UU-Fin A))
+              ( is-finite-type-UU-Fin
+                ( succ-ℕ n)
+                ( type-unordered-tuple-UU-Fin (succ-ℕ n) A))
               ( λ i →
                 is-finite-Π
                   ( is-finite-Π
-                    ( is-finite-has-cardinality
-                      ( has-cardinality-type-complement-point-UU-Fin
-                        ( pair (type-unordered-tuple-UU-Fin A) i)))
+                    ( is-finite-has-cardinality n
+                      ( has-cardinality-type-complement-point-UU-Fin n
+                        ( pair (type-unordered-tuple-UU-Fin (succ-ℕ n) A) i)))
                     ( λ j →
-                      is-finite-type-UU-Fin
-                        ( element-unordered-tuple A (pr1 j))))
+                      is-finite-type-UU-Fin m
+                        ( element-unordered-tuple (succ-ℕ n) A (pr1 j))))
                   ( λ f →
                     is-finite-is-decidable-Prop
                       ( is-contr-Prop _)
                       ( is-decidable-is-contr-is-finite
-                        ( is-finite-decidable-subtype
+                        ( is-finite-type-decidable-subtype
                           ( λ x →
-                            R ( map-equiv-pr-product-unordered-tuple-types
-                                ( map-unordered-tuple (succ-ℕ n) type-UU-Fin A)
+                            R ( map-equiv-pr-product-unordered-tuple-types n
+                                ( map-unordered-tuple
+                                  ( succ-ℕ n)
+                                  ( type-UU-Fin m)
+                                  ( A))
                                 ( i)
                                 ( f)
                                 ( x)))
-                          ( is-finite-type-UU-Fin
-                            ( element-unordered-tuple A i)))))))))
+                          ( is-finite-type-UU-Fin m
+                            ( element-unordered-tuple (succ-ℕ n) A i)))))))))
 ```
 
 ### The sequence of main classes of Latin hypercubes of fixed finite order

--- a/src/univalent-combinatorics/maybe.lagda.md
+++ b/src/univalent-combinatorics/maybe.lagda.md
@@ -21,9 +21,9 @@ open import univalent-combinatorics.finite-types using
 
 ```agda
 add-free-point-UU-Fin-Level :
-  {l1 : Level} {k : ℕ} → UU-Fin-Level l1 k → UU-Fin-Level l1 (succ-ℕ k)
-add-free-point-UU-Fin-Level X = coprod-UU-Fin-Level X unit-UU-Fin
+  {l1 : Level} (k : ℕ) → UU-Fin-Level l1 k → UU-Fin-Level l1 (succ-ℕ k)
+add-free-point-UU-Fin-Level k X = coprod-UU-Fin-Level k 1 X unit-UU-Fin
 
-add-free-point-UU-Fin : {k : ℕ} → UU-Fin k → UU-Fin (succ-ℕ k)
-add-free-point-UU-Fin X = add-free-point-UU-Fin-Level X
+add-free-point-UU-Fin : (k : ℕ) → UU-Fin k → UU-Fin (succ-ℕ k)
+add-free-point-UU-Fin k X = add-free-point-UU-Fin-Level k X
 ```

--- a/src/univalent-combinatorics/necklaces.lagda.md
+++ b/src/univalent-combinatorics/necklaces.lagda.md
@@ -38,7 +38,7 @@ necklace : (l : Level) → ℕ → ℕ → UU (lsuc l)
 necklace l m n = Σ (Cyclic-Type l m) (λ X → type-Cyclic-Type m X → Fin n)
 
 module _
-  {l : Level} (m : ℕ) {n : ℕ} (N : necklace l m n)
+  {l : Level} (m : ℕ) (n : ℕ) (N : necklace l m n)
   where
 
   cyclic-necklace : Cyclic-Type l m
@@ -66,7 +66,7 @@ module _
 necklace-pattern : (l : Level) → ℕ → ℕ → UU (lsuc l)
 necklace-pattern l m n =
   Σ ( Cyclic-Type l m)
-    ( λ X → Σ (UU-Fin n) (λ C → type-Cyclic-Type m X → type-UU-Fin C))
+    ( λ X → Σ (UU-Fin n) (λ C → type-Cyclic-Type m X → type-UU-Fin n C))
 ```
 
 ## Properties
@@ -75,48 +75,48 @@ necklace-pattern l m n =
 
 ```agda
 module _
-  {l1 l2 : Level} (m : ℕ) {n : ℕ}
+  {l1 l2 : Level} (m n : ℕ)
   where
   
   equiv-necklace :
     (N1 : necklace l1 m n) (N2 : necklace l2 m n) → UU (l1 ⊔ l2)
   equiv-necklace N1 N2 =
-    Σ ( equiv-Cyclic-Type m (cyclic-necklace m N1) (cyclic-necklace m N2))
+    Σ ( equiv-Cyclic-Type m (cyclic-necklace m n N1) (cyclic-necklace m n N2))
       ( λ e →
-        ( colouring-necklace m N1) ~
-        ( ( colouring-necklace m N2) ∘
+        ( colouring-necklace m n N1) ~
+        ( ( colouring-necklace m n N2) ∘
           ( map-equiv-Cyclic-Type m
-            ( cyclic-necklace m N1)
-            ( cyclic-necklace m N2)
+            ( cyclic-necklace m n N1)
+            ( cyclic-necklace m n N2)
             ( e))))
 
 module _
-  {l : Level} (m : ℕ) {n : ℕ}
+  {l : Level} (m n : ℕ)
   where
 
   id-equiv-necklace :
-    (N : necklace l m n) → equiv-necklace m N N
-  pr1 (id-equiv-necklace N) = id-equiv-Cyclic-Type m (cyclic-necklace m N)
+    (N : necklace l m n) → equiv-necklace m n N N
+  pr1 (id-equiv-necklace N) = id-equiv-Cyclic-Type m (cyclic-necklace m n N)
   pr2 (id-equiv-necklace N) = refl-htpy
 
 module _
-  {l : Level} (m : ℕ) {n : ℕ}
+  {l : Level} (m n : ℕ)
   where
   
   extensionality-necklace :
-    (N1 N2 : necklace l m n) → Id N1 N2 ≃ equiv-necklace m N1 N2
+    (N1 N2 : necklace l m n) → Id N1 N2 ≃ equiv-necklace m n N1 N2
   extensionality-necklace N1 =
     extensionality-Σ
       ( λ {X} f e →
-        ( colouring-necklace m N1) ~
-        ( f ∘ map-equiv-Cyclic-Type m (cyclic-necklace m N1) X e))
-      ( id-equiv-Cyclic-Type m (cyclic-necklace m N1))
+        ( colouring-necklace m n N1) ~
+        ( f ∘ map-equiv-Cyclic-Type m (cyclic-necklace m n N1) X e))
+      ( id-equiv-Cyclic-Type m (cyclic-necklace m n N1))
       ( refl-htpy)
-      ( extensionality-Cyclic-Type m (cyclic-necklace m N1))
+      ( extensionality-Cyclic-Type m (cyclic-necklace m n N1))
       ( λ f → equiv-funext)
 
   refl-extensionality-necklace :
     (N : necklace l m n) →
-    Id (map-equiv (extensionality-necklace N N) refl) (id-equiv-necklace m N)
+    Id (map-equiv (extensionality-necklace N N) refl) (id-equiv-necklace m n N)
   refl-extensionality-necklace N = refl
 ```

--- a/src/univalent-combinatorics/orientations-complete-undirected-graph.lagda.md
+++ b/src/univalent-combinatorics/orientations-complete-undirected-graph.lagda.md
@@ -110,12 +110,12 @@ open import univalent-combinatorics.2-element-types using
 open import univalent-combinatorics.counting using
   ( has-decidable-equality-count; count; number-of-elements-count;
     map-equiv-count; equiv-count; is-set-count)
-open import univalent-combinatorics.decidable-subtypes using (is-finite-decidable-subtype)
+open import univalent-combinatorics.decidable-subtypes using (is-finite-type-decidable-subtype)
 open import univalent-combinatorics.dependent-function-types using (is-finite-Π)
 open import univalent-combinatorics.equality-finite-types using
   ( set-UU-Fin; has-decidable-equality-is-finite; is-set-is-finite)
 open import univalent-combinatorics.equality-standard-finite-types using
-  ( Fin-Set; two-distinct-elements-leq-2-Fin)
+  ( two-distinct-elements-leq-2-Fin)
 open import univalent-combinatorics.finite-types using
   ( has-cardinality; UU-Fin-Level; type-UU-Fin-Level; has-cardinality-type-UU-Fin; is-finite; 
     equiv-has-cardinality-id-number-of-elements-is-finite; number-of-elements-is-finite;
@@ -124,7 +124,8 @@ open import univalent-combinatorics.finite-types using
     all-elements-equal-has-finite-cardinality; has-finite-cardinality;
     is-finite-has-finite-cardinality; has-cardinality-type-UU-Fin-Level)
 open import univalent-combinatorics.standard-finite-types using
-  ( Fin; zero-Fin; one-Fin; equiv-bool-Fin-two-ℕ; nat-Fin; is-zero-nat-zero-Fin)
+  ( Fin; zero-Fin; one-Fin; equiv-bool-Fin-two-ℕ; nat-Fin; is-zero-nat-zero-Fin;
+    Fin-Set)
 open import univalent-combinatorics.symmetric-difference using
   (eq-symmetric-difference; symmetric-difference-decidable-subtype)
 
@@ -133,12 +134,14 @@ module _
   where
 
   orientation-Complete-Undirected-Graph : UU (lsuc l)
-  orientation-Complete-Undirected-Graph = ((pair P H) : 2-Element-Decidable-Subtype l (type-UU-Fin-Level X)) →
-    Σ (type-UU-Fin-Level X) (λ x → type-decidable-Prop (P x))
+  orientation-Complete-Undirected-Graph =
+    ((pair P H) : 2-Element-Decidable-Subtype l (type-UU-Fin-Level n X)) →
+    Σ (type-UU-Fin-Level n X) (λ x → type-decidable-Prop (P x))
 
   2-Element-Decidable-Subtype-subtype-pointwise-difference :
-    orientation-Complete-Undirected-Graph → orientation-Complete-Undirected-Graph →
-    2-Element-Decidable-Subtype l (type-UU-Fin-Level X) → decidable-Prop l
+    orientation-Complete-Undirected-Graph →
+    orientation-Complete-Undirected-Graph →
+    2-Element-Decidable-Subtype l (type-UU-Fin-Level n X) → decidable-Prop l
   pr1 (2-Element-Decidable-Subtype-subtype-pointwise-difference d d' Y) =
     ¬ (Id (d Y) (d' Y))
   pr1 (pr2 (2-Element-Decidable-Subtype-subtype-pointwise-difference d d' Y)) =
@@ -146,7 +149,9 @@ module _
   pr2 (pr2 (2-Element-Decidable-Subtype-subtype-pointwise-difference d d' Y)) =
     is-decidable-neg
       ( has-decidable-equality-is-finite
-        ( is-finite-decidable-subtype (pr1 Y) (is-finite-type-UU-Fin-Level X))
+        ( is-finite-type-decidable-subtype
+          ( pr1 Y)
+          ( is-finite-type-UU-Fin-Level n X))
         ( d Y)
         ( d' Y))
 
@@ -154,17 +159,21 @@ module _
     (d d' : orientation-Complete-Undirected-Graph) →
     is-finite
       ( Σ
-        ( 2-Element-Decidable-Subtype l (type-UU-Fin-Level X))
-        ( λ Y → type-decidable-Prop (2-Element-Decidable-Subtype-subtype-pointwise-difference d d' Y)))
+        ( 2-Element-Decidable-Subtype l (type-UU-Fin-Level n X))
+        ( λ Y →
+          type-decidable-Prop
+            ( 2-Element-Decidable-Subtype-subtype-pointwise-difference d d' Y)))
   is-finite-subtype-pointwise-difference d d' =
-    is-finite-decidable-subtype
+    is-finite-type-decidable-subtype
       ( 2-Element-Decidable-Subtype-subtype-pointwise-difference d d')
       ( is-finite-2-Element-Decidable-Subtype n X)
 
   mod-two-number-of-differences-orientation-Complete-Undirected-Graph :
-    orientation-Complete-Undirected-Graph → orientation-Complete-Undirected-Graph → Fin 2
+    orientation-Complete-Undirected-Graph →
+    orientation-Complete-Undirected-Graph → Fin 2
   mod-two-number-of-differences-orientation-Complete-Undirected-Graph d d' =
-    mod-two-ℕ (number-of-elements-is-finite (is-finite-subtype-pointwise-difference d d'))
+    mod-two-ℕ (number-of-elements-is-finite
+      ( is-finite-subtype-pointwise-difference d d'))
 
   abstract
     equiv-symmetric-difference-subtype-pointwise-difference :
@@ -187,29 +196,37 @@ module _
           equiv-iff
             ( prop-decidable-Prop
               ( symmetric-difference-decidable-subtype
-                ( 2-Element-Decidable-Subtype-subtype-pointwise-difference d1 d2)
-                ( 2-Element-Decidable-Subtype-subtype-pointwise-difference d2 d3)
+                ( 2-Element-Decidable-Subtype-subtype-pointwise-difference
+                  d1 d2)
+                ( 2-Element-Decidable-Subtype-subtype-pointwise-difference
+                  d2 d3)
                 ( Y)))
-            ( prop-decidable-Prop (2-Element-Decidable-Subtype-subtype-pointwise-difference d1 d3 Y))
+            ( prop-decidable-Prop
+              ( 2-Element-Decidable-Subtype-subtype-pointwise-difference
+                d1 d3 Y))
             ( f Y)
             ( g Y))
       where
-      f : (Y : 2-Element-Decidable-Subtype l (type-UU-Fin-Level X)) →
+      f : (Y : 2-Element-Decidable-Subtype l (type-UU-Fin-Level n X)) →
         type-Prop
           ( prop-decidable-Prop
             ( symmetric-difference-decidable-subtype
               ( 2-Element-Decidable-Subtype-subtype-pointwise-difference d1 d2)
-              ( 2-Element-Decidable-Subtype-subtype-pointwise-difference d2 d3) Y)) →
-          type-Prop (prop-decidable-Prop (2-Element-Decidable-Subtype-subtype-pointwise-difference d1 d3 Y))
+              ( 2-Element-Decidable-Subtype-subtype-pointwise-difference d2 d3)
+              ( Y))) →
+          type-Prop
+            ( prop-decidable-Prop
+              ( 2-Element-Decidable-Subtype-subtype-pointwise-difference
+                d1 d3 Y))
       f Y (inl (pair np nnq)) r =
         np (r ∙
           inv
             ( dn-elim-is-decidable
               ( Id (d2 Y) (d3 Y))
               ( has-decidable-equality-is-finite
-                ( is-finite-decidable-subtype
+                ( is-finite-type-decidable-subtype
                   ( pr1 Y)
-                  ( is-finite-type-UU-Fin-Level X))
+                  ( is-finite-type-UU-Fin-Level n X))
                 ( d2 Y)
                 ( d3 Y))
               ( nnq)))
@@ -219,14 +236,14 @@ module _
               ( dn-elim-is-decidable
                 ( Id (d1 Y) (d2 Y))
                 ( has-decidable-equality-is-finite
-                  ( is-finite-decidable-subtype
+                  ( is-finite-type-decidable-subtype
                     ( pr1 Y)
-                    ( is-finite-type-UU-Fin-Level X))
+                    ( is-finite-type-UU-Fin-Level n X))
                   ( d1 Y)
                   ( d2 Y))
                 ( nnp))) ∙
             ( r))
-      cases-g : (Y : 2-Element-Decidable-Subtype l (type-UU-Fin-Level X)) →
+      cases-g : (Y : 2-Element-Decidable-Subtype l (type-UU-Fin-Level n X)) →
         ¬ (Id (d1 Y) (d3 Y)) → (is-decidable (Id (d1 Y) (d2 Y))) →
         is-decidable (Id (d2 Y) (d3 Y)) →
         coprod
@@ -249,7 +266,7 @@ module _
                 ( np)
                 ( nq)
                 ( nr)))
-      g : (Y : 2-Element-Decidable-Subtype l (type-UU-Fin-Level X)) →
+      g : (Y : 2-Element-Decidable-Subtype l (type-UU-Fin-Level n X)) →
         type-decidable-Prop
           ( 2-Element-Decidable-Subtype-subtype-pointwise-difference d1 d3 Y) →
         type-decidable-Prop
@@ -259,43 +276,62 @@ module _
       g Y r =
         cases-g Y r
           ( has-decidable-equality-is-finite
-            ( is-finite-decidable-subtype (pr1 Y) (is-finite-type-UU-Fin-Level X))
+            ( is-finite-type-decidable-subtype
+              ( pr1 Y)
+              ( is-finite-type-UU-Fin-Level n X))
             ( d1 Y)
             ( d2 Y))
           ( has-decidable-equality-is-finite
-            ( is-finite-decidable-subtype (pr1 Y) (is-finite-type-UU-Fin-Level X))
+            ( is-finite-type-decidable-subtype
+              ( pr1 Y)
+              ( is-finite-type-UU-Fin-Level n X))
             ( d2 Y)
             ( d3 Y)) 
   is-symmetric-mod-two-number-of-differences-orientation-Complete-Undirected-Graph :
     ( d d' : orientation-Complete-Undirected-Graph) (m : Fin 2) →
-      Id m (mod-two-number-of-differences-orientation-Complete-Undirected-Graph d d') →
-      Id m (mod-two-number-of-differences-orientation-Complete-Undirected-Graph d' d)
+    Id
+      ( m)
+      ( mod-two-number-of-differences-orientation-Complete-Undirected-Graph
+        d d') →
+    Id
+      ( m)
+      ( mod-two-number-of-differences-orientation-Complete-Undirected-Graph
+        d' d)
   is-symmetric-mod-two-number-of-differences-orientation-Complete-Undirected-Graph d d' m p =
-    p ∙
-      ap
-        ( mod-two-ℕ ∘ number-of-elements-has-finite-cardinality)
-        ( all-elements-equal-has-finite-cardinality
-          ( has-finite-cardinality-d'-d)
-          ( has-finite-cardinality-is-finite (is-finite-subtype-pointwise-difference d' d)))
+    ( p) ∙
+    ( ap
+      ( mod-two-ℕ ∘ number-of-elements-has-finite-cardinality)
+      ( all-elements-equal-has-finite-cardinality
+        ( has-finite-cardinality-d'-d)
+        ( has-finite-cardinality-is-finite (is-finite-subtype-pointwise-difference d' d))))
     where
     has-finite-cardinality-d'-d :
       has-finite-cardinality
-        ( Σ
-          ( 2-Element-Decidable-Subtype l (type-UU-Fin-Level X))
-          ( λ Y → type-decidable-Prop (2-Element-Decidable-Subtype-subtype-pointwise-difference d' d Y)))
+        ( Σ ( 2-Element-Decidable-Subtype l (type-UU-Fin-Level n X))
+            ( λ Y →
+              type-decidable-Prop
+                ( 2-Element-Decidable-Subtype-subtype-pointwise-difference
+                  d' d Y)))
     pr1 has-finite-cardinality-d'-d =
-      pr1 (has-finite-cardinality-is-finite (is-finite-subtype-pointwise-difference d d'))
+      pr1
+        ( has-finite-cardinality-is-finite
+          ( is-finite-subtype-pointwise-difference d d'))
     pr2 has-finite-cardinality-d'-d =
       apply-universal-property-trunc-Prop
-        ( pr2 (has-finite-cardinality-is-finite (is-finite-subtype-pointwise-difference d d')))
+        ( pr2
+          ( has-finite-cardinality-is-finite
+            ( is-finite-subtype-pointwise-difference d d')))
         ( trunc-Prop
-          ( Fin (pr1 has-finite-cardinality-d'-d) ≃
-            ( Σ (2-Element-Decidable-Subtype l (type-UU-Fin-Level X)) (λ Y → ¬ (Id (d' Y) (d Y))))))
+          ( ( Fin (pr1 has-finite-cardinality-d'-d)) ≃
+            ( Σ ( 2-Element-Decidable-Subtype l (type-UU-Fin-Level n X))
+                ( λ Y → ¬ (Id (d' Y) (d Y))))))
         ( λ h → unit-trunc-Prop (h' ∘e h))
       where
       h' :
-        (Σ (2-Element-Decidable-Subtype l (type-UU-Fin-Level X)) (λ Y → ¬ (Id (d Y) (d' Y))) ≃
-          Σ (2-Element-Decidable-Subtype l (type-UU-Fin-Level X)) (λ Y → ¬ (Id (d' Y) (d Y))))
+        Σ ( 2-Element-Decidable-Subtype l (type-UU-Fin-Level n X))
+          ( λ Y → ¬ (Id (d Y) (d' Y))) ≃
+        Σ ( 2-Element-Decidable-Subtype l (type-UU-Fin-Level n X))
+          ( λ Y → ¬ (Id (d' Y) (d Y)))
       pr1 h' (pair Y np) = pair Y (λ p' → np (inv p'))
       pr2 h' =
         is-equiv-has-inverse
@@ -304,11 +340,21 @@ module _
           ( λ (pair Y np) → eq-pair-Σ refl (eq-is-prop is-prop-neg))
 
   eq-mod-two-number-of-differences-orientation-Complete-Undirected-Graph :
-    (d1 d2 d3 : orientation-Complete-Undirected-Graph) ( m : Fin 2) →
-    Id m (mod-two-number-of-differences-orientation-Complete-Undirected-Graph d1 d2) →
-    Id m (mod-two-number-of-differences-orientation-Complete-Undirected-Graph d2 d3) →
-    Id zero-Fin (mod-two-number-of-differences-orientation-Complete-Undirected-Graph d1 d3)
-  eq-mod-two-number-of-differences-orientation-Complete-Undirected-Graph d1 d2 d3 m p1 p2 =
+    (d1 d2 d3 : orientation-Complete-Undirected-Graph) (m : Fin 2) →
+    Id
+      ( m)
+      ( mod-two-number-of-differences-orientation-Complete-Undirected-Graph
+        d1 d2) →
+    Id
+      ( m)
+      ( mod-two-number-of-differences-orientation-Complete-Undirected-Graph
+        d2 d3) →
+    Id
+      ( zero-Fin 1)
+      ( mod-two-number-of-differences-orientation-Complete-Undirected-Graph
+        d1 d3)
+  eq-mod-two-number-of-differences-orientation-Complete-Undirected-Graph
+    d1 d2 d3 m p1 p2 =
     inv
       ( is-zero-mod-succ-ℕ
         ( 1)
@@ -321,26 +367,26 @@ module _
           ( trans-cong-ℕ 2
             ( add-ℕ k1 k2)
             ( add-ℕ
-              ( nat-Fin
+              ( nat-Fin 2
                 ( mod-two-number-of-differences-orientation-Complete-Undirected-Graph d1 d2))
-              ( nat-Fin
+              ( nat-Fin 2
                 ( mod-two-number-of-differences-orientation-Complete-Undirected-Graph d2 d3)))
             ( zero-ℕ)
             ( symm-cong-ℕ 2
               ( add-ℕ
-                ( nat-Fin
+                ( nat-Fin 2
                   ( mod-two-number-of-differences-orientation-Complete-Undirected-Graph d1 d2))
-                ( nat-Fin
+                ( nat-Fin 2
                   ( mod-two-number-of-differences-orientation-Complete-Undirected-Graph d2 d3)))
               ( add-ℕ k1 k2)
               ( cong-add-ℕ k1 k2))
             ( concatenate-eq-cong-ℕ 2
               ( ( ap-binary
                 ( add-ℕ)
-                ( ap nat-Fin (inv p1))
-                ( ap nat-Fin (inv p2))) ∙
-                ( ap (λ n → add-ℕ n (nat-Fin m)) (inv (left-unit-law-mul-ℕ (nat-Fin m)))))
-              ( scalar-invariant-cong-ℕ' 2 2 0 (nat-Fin m) (cong-zero-ℕ' 2))))
+                ( ap (nat-Fin 2) (inv p1))
+                ( ap (nat-Fin 2) (inv p2))) ∙
+                ( ap (λ n → add-ℕ n (nat-Fin 2 m)) (inv (left-unit-law-mul-ℕ (nat-Fin 2 m)))))
+              ( scalar-invariant-cong-ℕ' 2 2 0 (nat-Fin 2 m) (cong-zero-ℕ' 2))))
           ( scalar-invariant-cong-ℕ' 2 0 2 k' (cong-zero-ℕ' 2)))) ∙
       ( ap
         ( mod-two-ℕ)
@@ -352,7 +398,7 @@ module _
               ( add-ℕ k1 k2)
               ( inv
                 ( eq-symmetric-difference
-                  ( 2-Element-Decidable-Subtype l (type-UU-Fin-Level X))
+                  ( 2-Element-Decidable-Subtype l (type-UU-Fin-Level n X))
                   ( is-finite-2-Element-Decidable-Subtype n X)
                   ( 2-Element-Decidable-Subtype-subtype-pointwise-difference d1 d2)
                   ( 2-Element-Decidable-Subtype-subtype-pointwise-difference d2 d3)))) ∙
@@ -360,20 +406,20 @@ module _
               ( number-of-elements-has-finite-cardinality)
               ( all-elements-equal-has-finite-cardinality
                 ( has-finite-cardinality-is-finite
-                  ( is-finite-decidable-subtype
+                  ( is-finite-type-decidable-subtype
                     ( symmetric-difference-decidable-subtype
                       ( 2-Element-Decidable-Subtype-subtype-pointwise-difference d1 d2)
                       ( 2-Element-Decidable-Subtype-subtype-pointwise-difference d2 d3))
                     ( is-finite-2-Element-Decidable-Subtype n X)))
                ( pair
                  ( number-of-elements-is-finite
-                   ( is-finite-decidable-subtype
+                   ( is-finite-type-decidable-subtype
                      ( 2-Element-Decidable-Subtype-subtype-pointwise-difference d1 d3)
                      ( is-finite-2-Element-Decidable-Subtype n X)))
                  ( transitive-mere-equiv
                    ( pr2
                     ( has-finite-cardinality-is-finite
-                      ( is-finite-decidable-subtype
+                      ( is-finite-type-decidable-subtype
                         (2-Element-Decidable-Subtype-subtype-pointwise-difference d1 d3)
                         ( is-finite-2-Element-Decidable-Subtype n X))))
                    ( unit-trunc-Prop
@@ -383,7 +429,7 @@ module _
     k : ℕ
     k =
       number-of-elements-is-finite
-        ( is-finite-decidable-subtype
+        ( is-finite-type-decidable-subtype
           ( symmetric-difference-decidable-subtype
             ( 2-Element-Decidable-Subtype-subtype-pointwise-difference d1 d2)
             ( 2-Element-Decidable-Subtype-subtype-pointwise-difference d2 d3))
@@ -395,7 +441,7 @@ module _
     k' : ℕ
     k' =
       number-of-elements-is-finite
-        ( is-finite-decidable-subtype
+        ( is-finite-type-decidable-subtype
           ( intersection-decidable-subtype
             ( 2-Element-Decidable-Subtype-subtype-pointwise-difference d1 d2)
             ( 2-Element-Decidable-Subtype-subtype-pointwise-difference d2 d3))
@@ -406,7 +452,7 @@ module _
   pr1 even-difference-orientation-Complete-Undirected-Graph d d' =
     Id-Prop
       ( Fin-Set 2)
-      ( zero-Fin)
+      ( zero-Fin 1)
       ( mod-two-number-of-differences-orientation-Complete-Undirected-Graph d d')
   pr1 (pr2 even-difference-orientation-Complete-Undirected-Graph) {d} =
     ap
@@ -415,9 +461,9 @@ module _
         ( pair 0 (unit-trunc-Prop (equiv-is-empty id (λ (pair _ np) → np refl))))
         ( has-finite-cardinality-is-finite (is-finite-subtype-pointwise-difference d d)))
   pr1 (pr2 (pr2 even-difference-orientation-Complete-Undirected-Graph)) {d} {d'} p =
-    is-symmetric-mod-two-number-of-differences-orientation-Complete-Undirected-Graph d d' zero-Fin p  
+    is-symmetric-mod-two-number-of-differences-orientation-Complete-Undirected-Graph d d' (zero-Fin 1) p  
   pr2 (pr2 (pr2 even-difference-orientation-Complete-Undirected-Graph)) {d1} {d2} {d3} p1 p2 =
-    eq-mod-two-number-of-differences-orientation-Complete-Undirected-Graph d1 d2 d3 zero-Fin p1 p2
+    eq-mod-two-number-of-differences-orientation-Complete-Undirected-Graph d1 d2 d3 (zero-Fin 1) p1 p2
 
   abstract
     is-decidable-even-difference-orientation-Complete-Undirected-Graph :
@@ -426,8 +472,8 @@ module _
         (sim-Eq-Rel even-difference-orientation-Complete-Undirected-Graph Y Y')
     is-decidable-even-difference-orientation-Complete-Undirected-Graph Y Y' =
       has-decidable-equality-is-finite
-        ( is-finite-Fin)
-        ( zero-Fin)
+        ( is-finite-Fin 2)
+        ( zero-Fin 1)
         ( mod-two-number-of-differences-orientation-Complete-Undirected-Graph Y Y')
 
   quotient-sign : UU (lsuc l)
@@ -441,7 +487,7 @@ module _
   where
 
   map-orientation-complete-undirected-graph-equiv : (X X' : UU-Fin-Level l n) →
-    (type-UU-Fin-Level X ≃ type-UU-Fin-Level X') → orientation-Complete-Undirected-Graph n X' →
+    (type-UU-Fin-Level n X ≃ type-UU-Fin-Level n X') → orientation-Complete-Undirected-Graph n X' →
     orientation-Complete-Undirected-Graph n X
   pr1 (map-orientation-complete-undirected-graph-equiv X X' e d Y) =
     map-inv-equiv e (pr1 (d (precomp-equiv-2-Element-Decidable-Subtype e Y)))
@@ -449,7 +495,7 @@ module _
     pr2 (d (precomp-equiv-2-Element-Decidable-Subtype e Y))
 
   orientation-complete-undirected-graph-equiv : (X X' : UU-Fin-Level l n) →
-    (type-UU-Fin-Level X ≃ type-UU-Fin-Level X') →
+    (type-UU-Fin-Level n X ≃ type-UU-Fin-Level n X') →
     orientation-Complete-Undirected-Graph n X' ≃ orientation-Complete-Undirected-Graph n X
   pr1 (orientation-complete-undirected-graph-equiv X X' e) =
     map-orientation-complete-undirected-graph-equiv X X' e
@@ -497,8 +543,8 @@ module _
                 ( eq-is-prop (is-prop-type-decidable-Prop (pr1 Y (pr1 (map-equiv id-equiv d Y)))))))
 
     preserves-comp-orientation-complete-undirected-graph-equiv :
-      ( X Y Z : UU-Fin-Level l n) (e : type-UU-Fin-Level X ≃ type-UU-Fin-Level Y) →
-      ( f : type-UU-Fin-Level Y ≃ type-UU-Fin-Level Z) →
+      ( X Y Z : UU-Fin-Level l n) (e : type-UU-Fin-Level n X ≃ type-UU-Fin-Level n Y) →
+      ( f : type-UU-Fin-Level n Y ≃ type-UU-Fin-Level n Z) →
       Id
         ( orientation-complete-undirected-graph-equiv X Z (f ∘e e))
         ( ( orientation-complete-undirected-graph-equiv X Y e) ∘e
@@ -535,7 +581,7 @@ module _
                           ( S))))))))
 
     preserves-even-difference-orientation-complete-undirected-graph-equiv :
-      (X X' : UU-Fin-Level l n) ( e : type-UU-Fin-Level X ≃ type-UU-Fin-Level X') →
+      (X X' : UU-Fin-Level l n) ( e : type-UU-Fin-Level n X ≃ type-UU-Fin-Level n X') →
       ( d d' : orientation-Complete-Undirected-Graph n X') →
       ( sim-Eq-Rel (even-difference-orientation-Complete-Undirected-Graph n X') d d' ↔
         sim-Eq-Rel
@@ -562,14 +608,14 @@ module _
                       ( map-orientation-complete-undirected-graph-equiv X X' e d'))))))))
       where
       equiv-subtype-pointwise-difference-equiv :
-        Σ (2-Element-Decidable-Subtype l (type-UU-Fin-Level X))
+        Σ (2-Element-Decidable-Subtype l (type-UU-Fin-Level n X))
           ( λ Y →
             type-decidable-Prop
               ( 2-Element-Decidable-Subtype-subtype-pointwise-difference n X
                 ( map-orientation-complete-undirected-graph-equiv X X' e d)
                 ( map-orientation-complete-undirected-graph-equiv X X' e d')
                 ( Y))) ≃
-        Σ (2-Element-Decidable-Subtype l (type-UU-Fin-Level X'))
+        Σ (2-Element-Decidable-Subtype l (type-UU-Fin-Level n X'))
           ( λ Y →
             type-decidable-Prop
               ( 2-Element-Decidable-Subtype-subtype-pointwise-difference n X' d d' Y))
@@ -3241,11 +3287,11 @@ module _
   {l : Level} (n : ℕ) (X : UU-Fin-Level l n) (ineq : leq-ℕ 2 n)
   where
   
-  equiv-fin-2-quotient-sign-equiv-Fin : (h : Fin n ≃ type-UU-Fin-Level X) →
+  equiv-fin-2-quotient-sign-equiv-Fin : (h : Fin n ≃ type-UU-Fin-Level n X) →
     ( Fin 2 ≃ quotient-sign n X)
   equiv-fin-2-quotient-sign-equiv-Fin h =
     tr
-      ( λ e → Fin 2 ≃ quotient-sign n (pair (type-UU-Fin-Level X) e))
+      ( λ e → Fin 2 ≃ quotient-sign n (pair (type-UU-Fin-Level n X) e))
       ( all-elements-equal-type-trunc-Prop (unit-trunc-Prop (equiv-count (pair n h))) (pr2 X))
       ( equiv-fin-2-quotient-sign-count (pair n h) ineq)
     
@@ -3255,5 +3301,5 @@ module _
     mere-equiv-fin-2-quotient-sign =
       map-trunc-Prop
         ( equiv-fin-2-quotient-sign-equiv-Fin)
-        ( has-cardinality-type-UU-Fin-Level X)
+        ( has-cardinality-type-UU-Fin-Level n X)
 ```

--- a/src/univalent-combinatorics/orientations-cubes.lagda.md
+++ b/src/univalent-combinatorics/orientations-cubes.lagda.md
@@ -33,22 +33,22 @@ open import univalent-combinatorics.standard-finite-types using
 ```agda
 orientation-cube : {k : ℕ} → cube k → UU (lzero)
 orientation-cube {k} X =
-  Σ ( vertex-cube X → Fin 2)
+  Σ ( vertex-cube k X → Fin 2)
     ( λ h →
-      ( x y : vertex-cube X) →
+      ( x y : vertex-cube k X) →
         Id ( iterate
              ( number-of-elements-is-finite
                ( is-finite-Σ
-                 ( is-finite-dim-cube X)
+                 ( is-finite-dim-cube k X)
                  ( λ d →
                    is-finite-function-type
                      ( is-finite-eq
                        ( has-decidable-equality-is-finite
-                         ( is-finite-axis-cube X d))
+                         ( is-finite-axis-cube k X d))
                      { x d}
                      { y d})
                      ( is-finite-empty))))
-             ( succ-Fin)
+             ( succ-Fin 2)
              ( h x))
            ( h y))
 ```

--- a/src/univalent-combinatorics/pi-finite-types.lagda.md
+++ b/src/univalent-combinatorics/pi-finite-types.lagda.md
@@ -402,7 +402,7 @@ is-π-finite-UU-Fin zero-ℕ n =
 pr1 (is-π-finite-UU-Fin (succ-ℕ k) n) = is-π-finite-UU-Fin zero-ℕ n
 pr2 (is-π-finite-UU-Fin (succ-ℕ k) n) x y =
   is-π-finite-equiv k
-    ( equiv-equiv-eq-UU-Fin x y)
+    ( equiv-equiv-eq-UU-Fin n x y)
     ( is-π-finite-is-finite k
       ( is-finite-≃
         ( is-finite-has-finite-cardinality (pair n (pr2 x)))
@@ -417,7 +417,7 @@ pr1 (is-π-finite-UU-Fin-Level {l} (succ-ℕ k) n) =
   is-π-finite-UU-Fin-Level zero-ℕ n
 pr2 (is-π-finite-UU-Fin-Level {l} (succ-ℕ k) n) x y =
   is-π-finite-equiv k
-    ( equiv-equiv-eq-UU-Fin-Level x y)
+    ( equiv-equiv-eq-UU-Fin-Level n x y)
     ( is-π-finite-is-finite k
       ( is-finite-≃
         ( is-finite-has-finite-cardinality (pair n (pr2 x)))
@@ -494,16 +494,16 @@ is-locally-finite-prod f g x y =
     ( is-finite-prod (f (pr1 x) (pr1 y)) (g (pr2 x) (pr2 y)))
 
 is-locally-finite-Π-Fin :
-  {l1 : Level} {k : ℕ} {B : Fin k → UU l1} →
+  {l1 : Level} (k : ℕ) {B : Fin k → UU l1} →
   ((x : Fin k) → is-locally-finite (B x)) →
   is-locally-finite ((x : Fin k) → B x)
-is-locally-finite-Π-Fin {l1} {zero-ℕ} {B} f =
+is-locally-finite-Π-Fin {l1} zero-ℕ {B} f =
   is-locally-finite-is-contr (dependent-universal-property-empty' B)
-is-locally-finite-Π-Fin {l1} {succ-ℕ k} {B} f =
+is-locally-finite-Π-Fin {l1} (succ-ℕ k) {B} f =
   is-locally-finite-equiv
     ( equiv-dependent-universal-property-coprod B)
     ( is-locally-finite-prod
-      ( is-locally-finite-Π-Fin (λ x → f (inl x)))
+      ( is-locally-finite-Π-Fin k (λ x → f (inl x)))
       ( is-locally-finite-equiv
         ( equiv-dependent-universal-property-unit (B ∘ inr))
         ( f (inr star))))
@@ -514,7 +514,7 @@ is-locally-finite-Π-count :
 is-locally-finite-Π-count {l1} {l2} {A} {B} (pair k e) g =
   is-locally-finite-equiv
     ( equiv-precomp-Π e B )
-    ( is-locally-finite-Π-Fin (λ x → g (map-equiv e x)))
+    ( is-locally-finite-Π-Fin k (λ x → g (map-equiv e x)))
 
 is-locally-finite-Π :
   {l1 l2 : Level} {A : UU l1} {B : A → UU l2} → is-finite A →
@@ -820,7 +820,7 @@ has-finite-connected-components-Σ' zero-ℕ e H K =
     ( is-empty-is-empty-trunc-Set (map-inv-equiv e) ∘ pr1)
 has-finite-connected-components-Σ' {l1} {l2} {A} {B} (succ-ℕ k) e H K =
   apply-universal-property-trunc-Prop
-    ( has-presentation-of-cardinality-has-cardinality-components
+    ( has-presentation-of-cardinality-has-cardinality-components (succ-ℕ k)
       ( unit-trunc-Prop e))
     ( has-finite-connected-components-Prop (Σ A B))
     ( α)

--- a/src/univalent-combinatorics/quotients-finite-types.lagda.md
+++ b/src/univalent-combinatorics/quotients-finite-types.lagda.md
@@ -7,10 +7,13 @@ title: Quotients of finite types
 
 module univalent-combinatorics.quotients-finite-types where
 
+open import foundation.decidable-propositions
 open import foundation.equivalence-classes
 open import foundation.universe-levels
 
 open import univalent-combinatorics.decidable-equivalence-relations
+open import univalent-combinatorics.function-types
+open import univalent-combinatorics.equality-finite-types
 open import univalent-combinatorics.image-of-maps
 open import univalent-combinatorics.finite-types
 ```
@@ -36,7 +39,8 @@ module _
   is-finite-equivalence-class-Decidable-Equivalence-Relation-𝔽' =
     is-finite-im
       ( is-finite-type-𝔽 X)
-      {!!}
+      ( has-decidable-equality-is-finite
+        ( ?))
 
   quotient-𝔽 : 𝔽
   quotient-𝔽 = {!!}

--- a/src/univalent-combinatorics/retracts-of-finite-types.lagda.md
+++ b/src/univalent-combinatorics/retracts-of-finite-types.lagda.md
@@ -43,9 +43,9 @@ open import univalent-combinatorics.standard-finite-types using (Fin)
 
 ```agda
 is-decidable-map-retr-Fin :
-  {l1 : Level} {k : ℕ} {A : UU l1} (i : A → Fin k) → retr i → is-decidable-map i
-is-decidable-map-retr-Fin =
-  is-decidable-map-retr has-decidable-equality-Fin
+  {l1 : Level} (k : ℕ) {A : UU l1} (i : A → Fin k) → retr i → is-decidable-map i
+is-decidable-map-retr-Fin k =
+  is-decidable-map-retr (has-decidable-equality-Fin k)
 ```
 
 ### If a map `i : A → B` into a finite type `B` has a retraction, then `i` is decidable and `A` is finite.

--- a/src/univalent-combinatorics/sequences-finite-types.lagda.md
+++ b/src/univalent-combinatorics/sequences-finite-types.lagda.md
@@ -36,12 +36,12 @@ repetition-sequence-Fin :
   (k : ℕ) (f : sequence (Fin k)) → repetition-sequence f
 repetition-sequence-Fin k f =
   map-emb-repetition
-    ( f ∘ nat-Fin {succ-ℕ k})
+    ( f ∘ nat-Fin (succ-ℕ k))
     ( f)
     ( emb-nat-Fin (succ-ℕ k))
     ( id-emb)
     ( refl-htpy)
-    ( repetition-le-Fin (f ∘ nat-Fin) (le-succ-ℕ {k}))
+    ( repetition-le-Fin (succ-ℕ k) k (f ∘ nat-Fin (succ-ℕ k)) (le-succ-ℕ {k}))
 
 pair-of-distinct-elements-repetition-sequence-Fin :
   {k : ℕ} (f : sequence (Fin k)) → pair-of-distinct-elements ℕ
@@ -77,7 +77,8 @@ le-fst-repetition-sequence-Fin :
   le-ℕ (fst-repetition-sequence-Fin f) (succ-ℕ k)
 le-fst-repetition-sequence-Fin {k} f =
   strict-upper-bound-nat-Fin
+    ( succ-ℕ k)
     ( pr1
       ( pr1
-        ( repetition-le-Fin {succ-ℕ k} {k} (f ∘ nat-Fin) (le-succ-ℕ {k}))))
+        ( repetition-le-Fin (succ-ℕ k) k (f ∘ nat-Fin (succ-ℕ k)) (le-succ-ℕ {k}))))
 ```

--- a/src/univalent-combinatorics/skipping-element-standard-finite-types.lagda.md
+++ b/src/univalent-combinatorics/skipping-element-standard-finite-types.lagda.md
@@ -18,39 +18,37 @@ open import foundation.injective-maps using
   ( is-injective; is-injective-is-emb; is-emb-is-injective)
 open import foundation.unit-type using (star; unit)
 
-open import univalent-combinatorics.equality-standard-finite-types using
-  ( is-set-Fin)
 open import univalent-combinatorics.standard-finite-types using
-  ( Fin)
+  ( Fin; is-set-Fin)
 ```
 
 ```agda
 skip-Fin :
-  {k : ℕ} → Fin (succ-ℕ k) → Fin k → Fin (succ-ℕ k)
-skip-Fin {succ-ℕ k} (inl x) (inl y) = inl (skip-Fin x y)
-skip-Fin {succ-ℕ k} (inl x) (inr y) = inr star
-skip-Fin {succ-ℕ k} (inr x) y = inl y
+  (k : ℕ) → Fin (succ-ℕ k) → Fin k → Fin (succ-ℕ k)
+skip-Fin (succ-ℕ k) (inl x) (inl y) = inl (skip-Fin k x y)
+skip-Fin (succ-ℕ k) (inl x) (inr y) = inr star
+skip-Fin (succ-ℕ k) (inr x) y = inl y
 
 abstract
   is-injective-skip-Fin :
-    {k : ℕ} (x : Fin (succ-ℕ k)) → is-injective (skip-Fin x)
-  is-injective-skip-Fin {succ-ℕ k} (inl x) {inl y} {inl z} p =
+    (k : ℕ) (x : Fin (succ-ℕ k)) → is-injective (skip-Fin k x)
+  is-injective-skip-Fin (succ-ℕ k) (inl x) {inl y} {inl z} p =
     ap ( inl)
-       ( is-injective-skip-Fin x
+       ( is-injective-skip-Fin k x
          ( is-injective-is-emb (is-emb-inl (Fin (succ-ℕ k)) unit) p))
-  is-injective-skip-Fin {succ-ℕ k} (inl x) {inr star} {inr star} p = refl
-  is-injective-skip-Fin {succ-ℕ k} (inr star) {y} {z} p =
+  is-injective-skip-Fin (succ-ℕ k) (inl x) {inr star} {inr star} p = refl
+  is-injective-skip-Fin (succ-ℕ k) (inr star) {y} {z} p =
     is-injective-is-emb (is-emb-inl (Fin (succ-ℕ k)) unit) p
 
 abstract
   is-emb-skip-Fin :
-    {k : ℕ} (x : Fin (succ-ℕ k)) → is-emb (skip-Fin x)
-  is-emb-skip-Fin {k} x =
+    (k : ℕ) (x : Fin (succ-ℕ k)) → is-emb (skip-Fin k x)
+  is-emb-skip-Fin k x =
     is-emb-is-injective
       ( is-set-Fin (succ-ℕ k))
-      ( is-injective-skip-Fin x)
+      ( is-injective-skip-Fin k x)
 
-emb-skip-Fin : {k : ℕ} (x : Fin (succ-ℕ k)) → Fin k ↪ Fin (succ-ℕ k)
-pr1 (emb-skip-Fin x) = skip-Fin x
-pr2 (emb-skip-Fin x) = is-emb-skip-Fin x
+emb-skip-Fin : (k : ℕ) (x : Fin (succ-ℕ k)) → Fin k ↪ Fin (succ-ℕ k)
+pr1 (emb-skip-Fin k x) = skip-Fin k x
+pr2 (emb-skip-Fin k x) = is-emb-skip-Fin k x
 ```

--- a/src/univalent-combinatorics/standard-finite-trees.lagda.md
+++ b/src/univalent-combinatorics/standard-finite-trees.lagda.md
@@ -36,7 +36,8 @@ root-Tree-Fin = tree-Fin zero-ℕ ex-falso
 
 number-nodes-Tree-Fin : Tree-Fin → ℕ
 number-nodes-Tree-Fin (tree-Fin zero-ℕ _) = zero-ℕ
-number-nodes-Tree-Fin (tree-Fin (succ-ℕ n) f) = succ-ℕ (sum-Fin-ℕ (λ k → number-nodes-Tree-Fin (f k)))
+number-nodes-Tree-Fin (tree-Fin (succ-ℕ n) f) =
+  succ-ℕ (sum-Fin-ℕ (succ-ℕ n) (λ k → number-nodes-Tree-Fin (f k)))
 
 height-Tree-Fin : Tree-Fin → ℕ
 height-Tree-Fin (tree-Fin zero-ℕ f) = zero-ℕ

--- a/src/univalent-combinatorics/standard-finite-types.lagda.md
+++ b/src/univalent-combinatorics/standard-finite-types.lagda.md
@@ -21,8 +21,8 @@ open import foundation.coproduct-types using (coprod; inl; inr; neq-inl-inr)
 open import foundation.decidable-types using (is-decidable)
 open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2)
 open import foundation.embeddings using (is-emb; _↪_)
-open import foundation.empty-types using (empty; ex-falso)
-open import foundation.equality-coproduct-types using (is-emb-inl)
+open import foundation.empty-types using (empty; ex-falso; empty-Set)
+open import foundation.equality-coproduct-types using (is-emb-inl; coprod-Set)
 open import foundation.equivalences using
   ( is-equiv; _≃_; is-equiv-has-inverse; map-inv-equiv; map-equiv)
 open import foundation.functions using (_∘_; id)
@@ -34,8 +34,9 @@ open import foundation.negation using (¬; map-neg)
 open import foundation.non-contractible-types using
   ( is-not-contractible; is-not-contractible-empty)
 open import foundation.raising-universe-levels using
-  ( raise; equiv-raise; map-raise)
-open import foundation.unit-type using (unit; star; is-contr-unit)
+  ( raise; equiv-raise; map-raise; raise-Set)
+open import foundation.sets using (UU-Set; type-Set; is-set-type-Set; is-set)
+open import foundation.unit-type using (unit; star; is-contr-unit; unit-Set)
 open import foundation.universe-levels using (Level; UU; lzero)
 
 open import structured-types.types-equipped-with-endomorphisms
@@ -50,9 +51,15 @@ The standard finite types are defined inductively by `Fin 0 := empty` and `Fin (
 ### The standard finite types in universe level zero.
 
 ```agda
+Fin-Set : ℕ → UU-Set lzero
+Fin-Set zero-ℕ = empty-Set
+Fin-Set (succ-ℕ n) = coprod-Set (Fin-Set n) unit-Set
+
 Fin : ℕ → UU lzero
-Fin zero-ℕ = empty
-Fin (succ-ℕ k) = coprod (Fin k) unit
+Fin n = type-Set (Fin-Set n)
+
+is-set-Fin : (n : ℕ) → is-set (Fin n)
+is-set-Fin n = is-set-type-Set (Fin-Set n)
 
 inl-Fin :
   (k : ℕ) → Fin k → Fin (succ-ℕ k)
@@ -62,24 +69,24 @@ emb-inl-Fin : (k : ℕ) → Fin k ↪ Fin (succ-ℕ k)
 pr1 (emb-inl-Fin k) = inl-Fin k
 pr2 (emb-inl-Fin k) = is-emb-inl (Fin k) unit
 
-neg-one-Fin : {k : ℕ} → Fin (succ-ℕ k)
-neg-one-Fin {k} = inr star
+neg-one-Fin : (k : ℕ) → Fin (succ-ℕ k)
+neg-one-Fin k = inr star
 
-is-neg-one-Fin : {k : ℕ} → Fin k → UU lzero
-is-neg-one-Fin {succ-ℕ k} x = Id x neg-one-Fin
+is-neg-one-Fin : (k : ℕ) → Fin k → UU lzero
+is-neg-one-Fin (succ-ℕ k) x = Id x (neg-one-Fin k)
 
-neg-two-Fin :
-  {k : ℕ} → Fin (succ-ℕ k)
-neg-two-Fin {zero-ℕ} = inr star
-neg-two-Fin {succ-ℕ k} = inl (inr star)
+neg-two-Fin : (k : ℕ) → Fin (succ-ℕ k)
+neg-two-Fin zero-ℕ = inr star
+neg-two-Fin (succ-ℕ k) = inl (inr star)
 
-is-inl-Fin : {k : ℕ} → Fin (succ-ℕ k) → UU lzero
-is-inl-Fin {k} x = Σ (Fin k) (λ y → Id (inl y) x)
+is-inl-Fin : (k : ℕ) → Fin (succ-ℕ k) → UU lzero
+is-inl-Fin k x = Σ (Fin k) (λ y → Id (inl y) x)
 
 is-neg-one-is-not-inl-Fin :
-  {k : ℕ} (x : Fin (succ-ℕ k)) → ¬ (is-inl-Fin x) → is-neg-one-Fin x
-is-neg-one-is-not-inl-Fin (inl x) H = ex-falso (H (pair x refl))
-is-neg-one-is-not-inl-Fin (inr star) H = refl
+  (k : ℕ) (x : Fin (succ-ℕ k)) →
+  ¬ (is-inl-Fin k x) → is-neg-one-Fin (succ-ℕ k) x
+is-neg-one-is-not-inl-Fin k (inl x) H = ex-falso (H (pair x refl))
+is-neg-one-is-not-inl-Fin k (inr star) H = refl
 ```
 
 ### The standard finite types in an arbitrary universe
@@ -93,6 +100,9 @@ equiv-raise-Fin l k = equiv-raise l (Fin k)
 
 map-raise-Fin : (l : Level) (k : ℕ) → Fin k → raise-Fin l k
 map-raise-Fin l k = map-raise
+
+raise-Fin-Set : (l : Level) (k : ℕ) → UU-Set l
+raise-Fin-Set l k = raise-Set l (Fin-Set k)
 ```
 
 ## Properties
@@ -101,11 +111,11 @@ map-raise-Fin l k = map-raise
 
 ```agda
 is-decidable-is-inl-Fin :
-  {k : ℕ} (x : Fin (succ-ℕ k)) → is-decidable (is-inl-Fin x)
-is-decidable-is-inl-Fin (inl x) = inl (pair x refl)
-is-decidable-is-inl-Fin (inr star) = inr α
+  (k : ℕ) (x : Fin (succ-ℕ k)) → is-decidable (is-inl-Fin k x)
+is-decidable-is-inl-Fin k (inl x) = inl (pair x refl)
+is-decidable-is-inl-Fin k (inr star) = inr α
   where
-  α : is-inl-Fin (inr star) → empty
+  α : is-inl-Fin k (inr star) → empty
   α (pair y ())
 ```
 
@@ -145,7 +155,7 @@ is-not-contractible-Fin :
 is-not-contractible-Fin zero-ℕ f = is-not-contractible-empty
 is-not-contractible-Fin (succ-ℕ zero-ℕ) f C = f refl
 is-not-contractible-Fin (succ-ℕ (succ-ℕ k)) f C =
-  neq-inl-inr (eq-is-contr' C neg-two-Fin neg-one-Fin)
+  neq-inl-inr (eq-is-contr' C (neg-two-Fin (succ-ℕ k)) (neg-one-Fin (succ-ℕ k)))
 ```
 
 ### `Fin 2` is equivalent to `bool`
@@ -181,219 +191,222 @@ pr2 equiv-bool-Fin-two-ℕ =
 ### The inclusion of Fin k into ℕ
 
 ```agda
-nat-Fin : {k : ℕ} → Fin k → ℕ
-nat-Fin {succ-ℕ k} (inl x) = nat-Fin x
-nat-Fin {succ-ℕ k} (inr x) = k
+nat-Fin : (k : ℕ) → Fin k → ℕ
+nat-Fin (succ-ℕ k) (inl x) = nat-Fin k x
+nat-Fin (succ-ℕ k) (inr x) = k
 
-strict-upper-bound-nat-Fin : {k : ℕ} (x : Fin k) → le-ℕ (nat-Fin x) k
-strict-upper-bound-nat-Fin {succ-ℕ k} (inl x) =
+strict-upper-bound-nat-Fin : (k : ℕ) (x : Fin k) → le-ℕ (nat-Fin k x) k
+strict-upper-bound-nat-Fin (succ-ℕ k) (inl x) =
   transitive-le-ℕ
-    ( nat-Fin x)
+    ( nat-Fin k x)
     ( k)
     ( succ-ℕ k)
-    ( strict-upper-bound-nat-Fin x)
+    ( strict-upper-bound-nat-Fin k x)
     ( succ-le-ℕ k)
-strict-upper-bound-nat-Fin {succ-ℕ k} (inr star) =
+strict-upper-bound-nat-Fin (succ-ℕ k) (inr star) =
   succ-le-ℕ k
 
-upper-bound-nat-Fin : {k : ℕ} (x : Fin (succ-ℕ k)) → leq-ℕ (nat-Fin x) k
-upper-bound-nat-Fin {zero-ℕ} (inr star) = star
-upper-bound-nat-Fin {succ-ℕ k} (inl x) =
-  preserves-leq-succ-ℕ (nat-Fin x) k (upper-bound-nat-Fin x)
-upper-bound-nat-Fin {succ-ℕ k} (inr star) = refl-leq-ℕ (succ-ℕ k)
+upper-bound-nat-Fin :
+  (k : ℕ) (x : Fin (succ-ℕ k)) → leq-ℕ (nat-Fin (succ-ℕ k) x) k
+upper-bound-nat-Fin zero-ℕ (inr star) = star
+upper-bound-nat-Fin (succ-ℕ k) (inl x) =
+  preserves-leq-succ-ℕ (nat-Fin (succ-ℕ k) x) k (upper-bound-nat-Fin k x)
+upper-bound-nat-Fin (succ-ℕ k) (inr star) = refl-leq-ℕ (succ-ℕ k)
 
-is-injective-nat-Fin : {k : ℕ} → is-injective (nat-Fin {k})
-is-injective-nat-Fin {succ-ℕ k} {inl x} {inl y} p =
-  ap inl (is-injective-nat-Fin p)
-is-injective-nat-Fin {succ-ℕ k} {inl x} {inr star} p =
-  ex-falso (neq-le-ℕ (strict-upper-bound-nat-Fin x) p)
-is-injective-nat-Fin {succ-ℕ k} {inr star} {inl y} p =
-  ex-falso (neq-le-ℕ (strict-upper-bound-nat-Fin y) (inv p))
-is-injective-nat-Fin {succ-ℕ k} {inr star} {inr star} p =
+is-injective-nat-Fin : (k : ℕ) → is-injective (nat-Fin k)
+is-injective-nat-Fin (succ-ℕ k) {inl x} {inl y} p =
+  ap inl (is-injective-nat-Fin k p)
+is-injective-nat-Fin (succ-ℕ k) {inl x} {inr star} p =
+  ex-falso (neq-le-ℕ (strict-upper-bound-nat-Fin k x) p)
+is-injective-nat-Fin (succ-ℕ k) {inr star} {inl y} p =
+  ex-falso (neq-le-ℕ (strict-upper-bound-nat-Fin k y) (inv p))
+is-injective-nat-Fin (succ-ℕ k) {inr star} {inr star} p =
   refl
 
-is-emb-nat-Fin : {k : ℕ} → is-emb (nat-Fin {k})
-is-emb-nat-Fin {k} = is-emb-is-injective is-set-ℕ is-injective-nat-Fin
+is-emb-nat-Fin : (k : ℕ) → is-emb (nat-Fin k)
+is-emb-nat-Fin k = is-emb-is-injective is-set-ℕ (is-injective-nat-Fin k)
 
 emb-nat-Fin : (k : ℕ) → Fin k ↪ ℕ
-pr1 (emb-nat-Fin k) = nat-Fin
-pr2 (emb-nat-Fin k) = is-emb-nat-Fin
+pr1 (emb-nat-Fin k) = nat-Fin k
+pr2 (emb-nat-Fin k) = is-emb-nat-Fin k
 ```
 
 ### The zero elements in the standard finite types
 
 ```agda
-zero-Fin : {k : ℕ} → Fin (succ-ℕ k)
-zero-Fin {zero-ℕ} = inr star
-zero-Fin {succ-ℕ k} = inl zero-Fin
+zero-Fin : (k : ℕ) → Fin (succ-ℕ k)
+zero-Fin zero-ℕ = inr star
+zero-Fin (succ-ℕ k) = inl (zero-Fin k)
 
-is-zero-Fin : {k : ℕ} → Fin k → UU lzero
-is-zero-Fin {succ-ℕ k} x = Id x zero-Fin
+is-zero-Fin : (k : ℕ) → Fin k → UU lzero
+is-zero-Fin (succ-ℕ k) x = Id x (zero-Fin k)
 
-is-zero-Fin' : {k : ℕ} → Fin k → UU lzero
-is-zero-Fin' {succ-ℕ k} x = Id zero-Fin x
+is-zero-Fin' : (k : ℕ) → Fin k → UU lzero
+is-zero-Fin' (succ-ℕ k) x = Id (zero-Fin k) x
 
-is-nonzero-Fin : {k : ℕ} → Fin k → UU lzero
-is-nonzero-Fin {succ-ℕ k} x = ¬ (is-zero-Fin x)
+is-nonzero-Fin : (k : ℕ) → Fin k → UU lzero
+is-nonzero-Fin (succ-ℕ k) x = ¬ (is-zero-Fin (succ-ℕ k) x)
 ```
 
 ### The successor function on the standard finite types
 
 ```agda
-skip-zero-Fin : {k : ℕ} → Fin k → Fin (succ-ℕ k)
-skip-zero-Fin {succ-ℕ k} (inl x) = inl (skip-zero-Fin x)
-skip-zero-Fin {succ-ℕ k} (inr star) = inr star
+skip-zero-Fin : (k : ℕ) → Fin k → Fin (succ-ℕ k)
+skip-zero-Fin (succ-ℕ k) (inl x) = inl (skip-zero-Fin k x)
+skip-zero-Fin (succ-ℕ k) (inr star) = inr star
 
-succ-Fin : {k : ℕ} → Fin k → Fin k
-succ-Fin {succ-ℕ k} (inl x) = skip-zero-Fin x
-succ-Fin {succ-ℕ k} (inr star) = zero-Fin
+succ-Fin : (k : ℕ) → Fin k → Fin k
+succ-Fin (succ-ℕ k) (inl x) = skip-zero-Fin k x
+succ-Fin (succ-ℕ k) (inr star) = (zero-Fin k)
 
 Fin-Endo : ℕ → Endo lzero
 pr1 (Fin-Endo k) = Fin k
-pr2 (Fin-Endo k) = succ-Fin
+pr2 (Fin-Endo k) = succ-Fin k
 ```
 
 ```agda
-is-zero-nat-zero-Fin : {k : ℕ} → is-zero-ℕ (nat-Fin (zero-Fin {k}))
+is-zero-nat-zero-Fin : {k : ℕ} → is-zero-ℕ (nat-Fin (succ-ℕ k) (zero-Fin k))
 is-zero-nat-zero-Fin {zero-ℕ} = refl
 is-zero-nat-zero-Fin {succ-ℕ k} = is-zero-nat-zero-Fin {k}
 
 nat-skip-zero-Fin :
-  {k : ℕ} (x : Fin k) → Id (nat-Fin (skip-zero-Fin x)) (succ-ℕ (nat-Fin x))
-nat-skip-zero-Fin {succ-ℕ k} (inl x) = nat-skip-zero-Fin x
-nat-skip-zero-Fin {succ-ℕ k} (inr star) = refl
+  (k : ℕ) (x : Fin k) →
+  Id (nat-Fin (succ-ℕ k) (skip-zero-Fin k x)) (succ-ℕ (nat-Fin k x))
+nat-skip-zero-Fin (succ-ℕ k) (inl x) = nat-skip-zero-Fin k x
+nat-skip-zero-Fin (succ-ℕ k) (inr star) = refl
 
 nat-succ-Fin :
-  {k : ℕ} (x : Fin k) → Id (nat-Fin (succ-Fin (inl x))) (succ-ℕ (nat-Fin x))
-nat-succ-Fin {k} x = nat-skip-zero-Fin x
+  (k : ℕ) (x : Fin k) → Id (nat-Fin (succ-ℕ k) (succ-Fin (succ-ℕ k) (inl x))) (succ-ℕ (nat-Fin k x))
+nat-succ-Fin k x = nat-skip-zero-Fin k x
 ```
 
 ```agda
-one-Fin : {k : ℕ} → Fin (succ-ℕ k)
-one-Fin {k} = succ-Fin zero-Fin
+one-Fin : (k : ℕ) → Fin (succ-ℕ k)
+one-Fin k = succ-Fin (succ-ℕ k) (zero-Fin k)
 
-is-one-Fin : {k : ℕ} → Fin k → UU lzero
-is-one-Fin {succ-ℕ k} x = Id x one-Fin
+is-one-Fin : (k : ℕ) → Fin k → UU lzero
+is-one-Fin (succ-ℕ k) x = Id x (one-Fin k)
 
 is-zero-or-one-Fin-two-ℕ :
-  (x : Fin 2) → coprod (is-zero-Fin x) (is-one-Fin x)
+  (x : Fin 2) → coprod (is-zero-Fin 2 x) (is-one-Fin 2 x)
 is-zero-or-one-Fin-two-ℕ (inl (inr star)) = inl refl
 is-zero-or-one-Fin-two-ℕ (inr star) = inr refl
 
 is-one-nat-one-Fin :
-  (k : ℕ) → is-one-ℕ (nat-Fin (one-Fin {succ-ℕ k}))
+  (k : ℕ) → is-one-ℕ (nat-Fin (succ-ℕ (succ-ℕ k)) (one-Fin (succ-ℕ k)))
 is-one-nat-one-Fin zero-ℕ = refl
 is-one-nat-one-Fin (succ-ℕ k) = is-one-nat-one-Fin k
 ```
 
 ```agda
-is-injective-inl-Fin : {k : ℕ} → is-injective (inl-Fin k)
-is-injective-inl-Fin refl = refl
+is-injective-inl-Fin : (k : ℕ) → is-injective (inl-Fin k)
+is-injective-inl-Fin k refl = refl
 
 -- Exercise 7.5 (c)
 
 neq-zero-succ-Fin :
-  {k : ℕ} {x : Fin k} → is-nonzero-Fin (succ-Fin (inl-Fin k x))
+  {k : ℕ} {x : Fin k} → is-nonzero-Fin (succ-ℕ k) (succ-Fin (succ-ℕ k) (inl-Fin k x))
 neq-zero-succ-Fin {succ-ℕ k} {inl x} p =
-  neq-zero-succ-Fin (is-injective-inl-Fin p)
+  neq-zero-succ-Fin (is-injective-inl-Fin (succ-ℕ k) p)
 neq-zero-succ-Fin {succ-ℕ k} {inr star} ()
 
 -- Exercise 7.5 (d)
 
-is-injective-skip-zero-Fin : {k : ℕ} → is-injective (skip-zero-Fin {k})
-is-injective-skip-zero-Fin {succ-ℕ k} {inl x} {inl y} p =
-  ap inl (is-injective-skip-zero-Fin (is-injective-inl-Fin p))
-is-injective-skip-zero-Fin {succ-ℕ k} {inl x} {inr star} ()
-is-injective-skip-zero-Fin {succ-ℕ k} {inr star} {inl y} ()
-is-injective-skip-zero-Fin {succ-ℕ k} {inr star} {inr star} p = refl
+is-injective-skip-zero-Fin : (k : ℕ) → is-injective (skip-zero-Fin k)
+is-injective-skip-zero-Fin (succ-ℕ k) {inl x} {inl y} p =
+  ap inl (is-injective-skip-zero-Fin k (is-injective-inl-Fin (succ-ℕ k) p))
+is-injective-skip-zero-Fin (succ-ℕ k) {inl x} {inr star} ()
+is-injective-skip-zero-Fin (succ-ℕ k) {inr star} {inl y} ()
+is-injective-skip-zero-Fin (succ-ℕ k) {inr star} {inr star} p = refl
 
-is-injective-succ-Fin : {k : ℕ} → is-injective (succ-Fin {k})
-is-injective-succ-Fin {succ-ℕ k} {inl x} {inl y} p =
-  ap inl (is-injective-skip-zero-Fin {k} {x} {y} p)
-is-injective-succ-Fin {succ-ℕ k} {inl x} {inr star} p =
+is-injective-succ-Fin : (k : ℕ) → is-injective (succ-Fin k)
+is-injective-succ-Fin (succ-ℕ k) {inl x} {inl y} p =
+  ap inl (is-injective-skip-zero-Fin k {x} {y} p)
+is-injective-succ-Fin (succ-ℕ k) {inl x} {inr star} p =
   ex-falso (neq-zero-succ-Fin {succ-ℕ k} {inl x} (ap inl p))
-is-injective-succ-Fin {succ-ℕ k} {inr star} {inl y} p =
+is-injective-succ-Fin (succ-ℕ k) {inr star} {inl y} p =
   ex-falso (neq-zero-succ-Fin {succ-ℕ k} {inl y} (ap inl (inv p)))
-is-injective-succ-Fin {succ-ℕ k} {inr star} {inr star} p = refl
+is-injective-succ-Fin (succ-ℕ k) {inr star} {inr star} p = refl
 ```
 
 ```agda
 -- We define a function skip-neg-two-Fin in order to define pred-Fin.
 
 skip-neg-two-Fin :
-  {k : ℕ} → Fin k → Fin (succ-ℕ k)
-skip-neg-two-Fin {succ-ℕ k} (inl x) = inl (inl x)
-skip-neg-two-Fin {succ-ℕ k} (inr x) = neg-one-Fin {succ-ℕ k}
+  (k : ℕ) → Fin k → Fin (succ-ℕ k)
+skip-neg-two-Fin (succ-ℕ k) (inl x) = inl (inl x)
+skip-neg-two-Fin (succ-ℕ k) (inr x) = neg-one-Fin (succ-ℕ k)
 
 -- We define the predecessor function on Fin k.
 
-pred-Fin : {k : ℕ} → Fin k → Fin k
-pred-Fin {succ-ℕ k} (inl x) = skip-neg-two-Fin (pred-Fin x)
-pred-Fin {succ-ℕ k} (inr x) = neg-two-Fin
+pred-Fin : (k : ℕ) → Fin k → Fin k
+pred-Fin (succ-ℕ k) (inl x) = skip-neg-two-Fin k (pred-Fin k x)
+pred-Fin (succ-ℕ k) (inr x) = neg-two-Fin k
 
 -- We now turn to the exercise.
 
 pred-zero-Fin :
-  {k : ℕ} → is-neg-one-Fin (pred-Fin {succ-ℕ k} zero-Fin)
-pred-zero-Fin {zero-ℕ} = refl
-pred-zero-Fin {succ-ℕ k} = ap skip-neg-two-Fin (pred-zero-Fin {k})
+  (k : ℕ) → is-neg-one-Fin (succ-ℕ k) (pred-Fin (succ-ℕ k) (zero-Fin k))
+pred-zero-Fin (zero-ℕ) = refl
+pred-zero-Fin (succ-ℕ k) = ap (skip-neg-two-Fin (succ-ℕ k)) (pred-zero-Fin k)
 
 succ-skip-neg-two-Fin :
-  {k : ℕ} (x : Fin (succ-ℕ k)) →
-  Id (succ-Fin (skip-neg-two-Fin x)) (inl (succ-Fin x))
-succ-skip-neg-two-Fin {zero-ℕ} (inr star) = refl
-succ-skip-neg-two-Fin {succ-ℕ k} (inl x) = refl
-succ-skip-neg-two-Fin {succ-ℕ k} (inr star) = refl
+  (k : ℕ) (x : Fin (succ-ℕ k)) →
+  Id (succ-Fin (succ-ℕ (succ-ℕ k)) (skip-neg-two-Fin (succ-ℕ k) x)) (inl (succ-Fin (succ-ℕ k) x))
+succ-skip-neg-two-Fin zero-ℕ (inr star) = refl
+succ-skip-neg-two-Fin (succ-ℕ k) (inl x) = refl
+succ-skip-neg-two-Fin (succ-ℕ k) (inr star) = refl
 
 issec-pred-Fin :
-  {k : ℕ} (x : Fin k) → Id (succ-Fin (pred-Fin x)) x
-issec-pred-Fin {succ-ℕ zero-ℕ} (inr star) = refl
-issec-pred-Fin {succ-ℕ (succ-ℕ k)} (inl x) =
-  succ-skip-neg-two-Fin (pred-Fin x) ∙ ap inl (issec-pred-Fin x)
-issec-pred-Fin {succ-ℕ (succ-ℕ k)} (inr star) = refl
+  (k : ℕ) (x : Fin k) → Id (succ-Fin k (pred-Fin k x)) x
+issec-pred-Fin (succ-ℕ zero-ℕ) (inr star) = refl
+issec-pred-Fin (succ-ℕ (succ-ℕ k)) (inl x) =
+  ( succ-skip-neg-two-Fin k (pred-Fin (succ-ℕ k) x)) ∙
+  ( ap inl (issec-pred-Fin (succ-ℕ k) x))
+issec-pred-Fin (succ-ℕ (succ-ℕ k)) (inr star) = refl
 
 isretr-pred-Fin :
-  {k : ℕ} (x : Fin k) → Id (pred-Fin (succ-Fin x)) x
-isretr-pred-Fin {succ-ℕ zero-ℕ} (inr star) = refl
-isretr-pred-Fin {succ-ℕ (succ-ℕ k)} (inl (inl x)) =
-  ap skip-neg-two-Fin (isretr-pred-Fin (inl x))
-isretr-pred-Fin {succ-ℕ (succ-ℕ k)} (inl (inr star)) = refl
-isretr-pred-Fin {succ-ℕ (succ-ℕ k)} (inr star) = pred-zero-Fin
+  (k : ℕ) (x : Fin k) → Id (pred-Fin k (succ-Fin k x)) x
+isretr-pred-Fin (succ-ℕ zero-ℕ) (inr star) = refl
+isretr-pred-Fin (succ-ℕ (succ-ℕ k)) (inl (inl x)) =
+  ap (skip-neg-two-Fin (succ-ℕ k)) (isretr-pred-Fin (succ-ℕ k) (inl x))
+isretr-pred-Fin (succ-ℕ (succ-ℕ k)) (inl (inr star)) = refl
+isretr-pred-Fin (succ-ℕ (succ-ℕ k)) (inr star) = pred-zero-Fin (succ-ℕ k)
 
-is-equiv-succ-Fin : {k : ℕ} → is-equiv (succ-Fin {k})
-pr1 (pr1 is-equiv-succ-Fin) = pred-Fin
-pr2 (pr1 is-equiv-succ-Fin) = issec-pred-Fin
-pr1 (pr2 is-equiv-succ-Fin) = pred-Fin
-pr2 (pr2 is-equiv-succ-Fin) = isretr-pred-Fin
+is-equiv-succ-Fin : (k : ℕ) → is-equiv (succ-Fin k)
+pr1 (pr1 (is-equiv-succ-Fin k)) = pred-Fin k
+pr2 (pr1 (is-equiv-succ-Fin k)) = issec-pred-Fin k
+pr1 (pr2 (is-equiv-succ-Fin k)) = pred-Fin k
+pr2 (pr2 (is-equiv-succ-Fin k)) = isretr-pred-Fin k
 
-equiv-succ-Fin : {k : ℕ} → Fin k ≃ Fin k
-pr1 equiv-succ-Fin = succ-Fin
-pr2 equiv-succ-Fin = is-equiv-succ-Fin
+equiv-succ-Fin : (k : ℕ) → Fin k ≃ Fin k
+pr1 (equiv-succ-Fin k) = succ-Fin k
+pr2 (equiv-succ-Fin k) = is-equiv-succ-Fin k
 
-is-equiv-pred-Fin : {k : ℕ} → is-equiv (pred-Fin {k})
-pr1 (pr1 is-equiv-pred-Fin) = succ-Fin
-pr2 (pr1 is-equiv-pred-Fin) = isretr-pred-Fin
-pr1 (pr2 is-equiv-pred-Fin) = succ-Fin
-pr2 (pr2 is-equiv-pred-Fin) = issec-pred-Fin
+is-equiv-pred-Fin : (k : ℕ) → is-equiv (pred-Fin k)
+pr1 (pr1 (is-equiv-pred-Fin k)) = succ-Fin k
+pr2 (pr1 (is-equiv-pred-Fin k)) = isretr-pred-Fin k
+pr1 (pr2 (is-equiv-pred-Fin k)) = succ-Fin k
+pr2 (pr2 (is-equiv-pred-Fin k)) = issec-pred-Fin k
 
-equiv-pred-Fin : {k : ℕ} → Fin k ≃ Fin k
-pr1 equiv-pred-Fin = pred-Fin
-pr2 equiv-pred-Fin = is-equiv-pred-Fin
+equiv-pred-Fin : (k : ℕ) → Fin k ≃ Fin k
+pr1 (equiv-pred-Fin k) = pred-Fin k
+pr2 (equiv-pred-Fin k) = is-equiv-pred-Fin k
 ```
 
 ```agda
 leq-nat-succ-Fin :
-  (k : ℕ) (x : Fin k) → leq-ℕ (nat-Fin (succ-Fin x)) (succ-ℕ (nat-Fin x))
+  (k : ℕ) (x : Fin k) → leq-ℕ (nat-Fin k (succ-Fin k x)) (succ-ℕ (nat-Fin k x))
 leq-nat-succ-Fin (succ-ℕ k) (inl x) =
   leq-eq-ℕ
-    ( nat-Fin (skip-zero-Fin x))
-    ( succ-ℕ (nat-Fin (inl x)))
-    ( nat-skip-zero-Fin x)
+    ( nat-Fin (succ-ℕ k) (skip-zero-Fin k x))
+    ( succ-ℕ (nat-Fin (succ-ℕ k) (inl x)))
+    ( nat-skip-zero-Fin k x)
 leq-nat-succ-Fin (succ-ℕ k) (inr star) =
   concatenate-eq-leq-ℕ
-    ( succ-ℕ (nat-Fin (inr star)))
+    ( succ-ℕ (nat-Fin (succ-ℕ k) (inr star)))
     ( is-zero-nat-zero-Fin {succ-ℕ k})
-    ( leq-zero-ℕ (succ-ℕ (nat-Fin {succ-ℕ k} (inr star))))
+    ( leq-zero-ℕ (succ-ℕ (nat-Fin (succ-ℕ k) (inr star))))
 ```
 
 ### Fin is injective
@@ -402,8 +415,10 @@ leq-nat-succ-Fin (succ-ℕ k) (inr star) =
 abstract
   is-injective-Fin : {k l : ℕ} → (Fin k ≃ Fin l) → Id k l
   is-injective-Fin {zero-ℕ} {zero-ℕ} e = refl
-  is-injective-Fin {zero-ℕ} {succ-ℕ l} e = ex-falso (map-inv-equiv e zero-Fin)
-  is-injective-Fin {succ-ℕ k} {zero-ℕ} e = ex-falso (map-equiv e zero-Fin)
+  is-injective-Fin {zero-ℕ} {succ-ℕ l} e =
+    ex-falso (map-inv-equiv e (zero-Fin l))
+  is-injective-Fin {succ-ℕ k} {zero-ℕ} e =
+    ex-falso (map-equiv e (zero-Fin k))
   is-injective-Fin {succ-ℕ k} {succ-ℕ l} e =
     ap succ-ℕ (is-injective-Fin (equiv-equiv-Maybe e))
 ```

--- a/src/univalent-combinatorics/symmetric-difference.lagda.md
+++ b/src/univalent-combinatorics/symmetric-difference.lagda.md
@@ -27,7 +27,8 @@ open import foundation.xor using (xor-Prop; xor-decidable-Prop)
 
 open import univalent-combinatorics.coproduct-types using
   ( coprod-eq-is-finite; is-finite-coprod)
-open import univalent-combinatorics.decidable-subtypes using ( is-finite-decidable-subtype)
+open import univalent-combinatorics.decidable-subtypes using
+  ( is-finite-type-decidable-subtype)
 open import univalent-combinatorics.finite-types using
   ( UU-Fin-Level; type-UU-Fin-Level; has-cardinality-type-UU-Fin-Level; number-of-elements-is-finite;
     is-finite; is-finite-has-cardinality; number-of-elements-has-finite-cardinality;
@@ -46,37 +47,43 @@ module _
   eq-symmetric-difference :
     Id
       ( add-ℕ
-        ( number-of-elements-is-finite (is-finite-decidable-subtype P F))        
-        ( number-of-elements-is-finite (is-finite-decidable-subtype Q F)))
+        ( number-of-elements-is-finite
+          ( is-finite-type-decidable-subtype P F))        
+        ( number-of-elements-is-finite (is-finite-type-decidable-subtype Q F)))
       ( add-ℕ
         ( number-of-elements-is-finite
-          ( is-finite-decidable-subtype (symmetric-difference-decidable-subtype P Q) F))
+          ( is-finite-type-decidable-subtype
+            ( symmetric-difference-decidable-subtype P Q) F))
         ( mul-ℕ
           2
           ( number-of-elements-is-finite
-            ( is-finite-decidable-subtype
+            ( is-finite-type-decidable-subtype
               ( intersection-decidable-subtype P Q)
               ( F)))))
   eq-symmetric-difference =
     ( ( coprod-eq-is-finite
-      ( is-finite-decidable-subtype P F)
-      ( is-finite-decidable-subtype Q F))) ∙
+      ( is-finite-type-decidable-subtype P F)
+      ( is-finite-type-decidable-subtype Q F))) ∙
       ( ( ap
         ( number-of-elements-has-finite-cardinality)
         ( all-elements-equal-has-finite-cardinality
           ( has-finite-cardinality-is-finite
             ( is-finite-coprod
-              ( is-finite-decidable-subtype P F)
-              ( is-finite-decidable-subtype Q F)))
+              ( is-finite-type-decidable-subtype P F)
+              ( is-finite-type-decidable-subtype Q F)))
           ( pair
-            ( number-of-elements-is-finite is-finite-coprod-symmetric-difference)
+            ( number-of-elements-is-finite
+              ( is-finite-coprod-symmetric-difference))
             ( transitive-mere-equiv
               ( mere-equiv-has-finite-cardinality
-                ( has-finite-cardinality-is-finite is-finite-coprod-symmetric-difference))
-              ( unit-trunc-Prop (inv-equiv (equiv-symmetric-difference P Q))))))) ∙
+                ( has-finite-cardinality-is-finite
+                  ( is-finite-coprod-symmetric-difference)))
+              ( unit-trunc-Prop
+                ( inv-equiv (equiv-symmetric-difference P Q))))))) ∙
         ( inv
           ( coprod-eq-is-finite
-            ( is-finite-decidable-subtype (symmetric-difference-decidable-subtype P Q) F)
+            ( is-finite-type-decidable-subtype
+              ( symmetric-difference-decidable-subtype P Q) F)
             ( is-finite-coprod is-finite-intersection is-finite-intersection)) ∙
           ( ap
             ( λ n →
@@ -85,7 +92,9 @@ module _
                   ( symmetric-difference-decidable-subtype P Q))
                 ( n))
             ( ( inv
-              ( coprod-eq-is-finite is-finite-intersection is-finite-intersection)) ∙
+              ( coprod-eq-is-finite
+                ( is-finite-intersection)
+                ( is-finite-intersection))) ∙
               ( ap
                 ( λ n →
                   add-ℕ
@@ -100,11 +109,11 @@ module _
     is-finite-intersection :
       is-finite (type-decidable-subtype (intersection-decidable-subtype P Q))
     is-finite-intersection =
-      is-finite-decidable-subtype (intersection-decidable-subtype P Q) F
+      is-finite-type-decidable-subtype (intersection-decidable-subtype P Q) F
     number-of-elements-decidable-subtype-X : {l' : Level} →
       (decidable-subtype l' X) → ℕ
     number-of-elements-decidable-subtype-X R =
-      number-of-elements-is-finite (is-finite-decidable-subtype R F)
+      number-of-elements-is-finite (is-finite-type-decidable-subtype R F)
     is-finite-coprod-symmetric-difference :
       is-finite
         ( coprod
@@ -117,5 +126,7 @@ module _
               ( intersection-decidable-subtype P Q))))
     is-finite-coprod-symmetric-difference =
       is-finite-coprod
-        ( is-finite-decidable-subtype (symmetric-difference-decidable-subtype P Q) F)
+        ( is-finite-type-decidable-subtype
+          ( symmetric-difference-decidable-subtype P Q)
+          ( F))
         ( is-finite-coprod is-finite-intersection is-finite-intersection)

--- a/src/univalent-combinatorics/universal-property-standard-finite-types.lagda.md
+++ b/src/univalent-combinatorics/universal-property-standard-finite-types.lagda.md
@@ -34,9 +34,10 @@ The universal property of the standard finite types asserts that for any family 
 ```agda
 iterated-prod : {l : Level} (n : ℕ) (A : Fin n → UU l) → UU l
 iterated-prod zero-ℕ A = raise-unit _
-iterated-prod (succ-ℕ zero-ℕ) A = A zero-Fin
+iterated-prod (succ-ℕ zero-ℕ) A = A (zero-Fin 0)
 iterated-prod (succ-ℕ (succ-ℕ n)) A =
-  iterated-prod (succ-ℕ n) (A ∘ inl-Fin (succ-ℕ n)) × A neg-one-Fin
+  ( iterated-prod (succ-ℕ n) (A ∘ inl-Fin (succ-ℕ n))) ×
+  ( A (neg-one-Fin (succ-ℕ n)))
 ```
 
 ## Properties
@@ -52,7 +53,7 @@ equiv-dependent-universal-property-Fin zero-ℕ A =
     ( dependent-universal-property-empty' A)
     ( is-contr-raise-unit)
 equiv-dependent-universal-property-Fin (succ-ℕ zero-ℕ) A =
-  equiv-dependent-universal-property-contr zero-Fin is-contr-Fin-one-ℕ A
+  equiv-dependent-universal-property-contr (zero-Fin 0) is-contr-Fin-one-ℕ A
 equiv-dependent-universal-property-Fin (succ-ℕ (succ-ℕ n)) A =
   ( equiv-prod
     ( equiv-dependent-universal-property-Fin (succ-ℕ n) (A ∘ inl))
@@ -61,7 +62,7 @@ equiv-dependent-universal-property-Fin (succ-ℕ (succ-ℕ n)) A =
 
 equiv-dependent-universal-property-Fin-two-ℕ :
   {l : Level} (A : Fin 2 → UU l) →
-  ((i : Fin 2) → A i) ≃ (A zero-Fin × A one-Fin)
+  ((i : Fin 2) → A i) ≃ (A (zero-Fin 1) × A (one-Fin 1))
 equiv-dependent-universal-property-Fin-two-ℕ =
   equiv-dependent-universal-property-Fin 2
 ```

--- a/src/univalent-combinatorics/unlabeled-structures-species.lagda.md
+++ b/src/univalent-combinatorics/unlabeled-structures-species.lagda.md
@@ -28,7 +28,7 @@ The type of unlabeled `F`-structures of order `n` of a species `F` is the type o
 ```agda
 unlabeled-structure-species :
   {l : Level} (F : species l) → ℕ → UU (lsuc lzero ⊔ l)
-unlabeled-structure-species F n = Σ (UU-Fin n) (λ X → F (finite-type-UU-Fin X))
+unlabeled-structure-species F n = Σ (UU-Fin n) (λ X → F (finite-type-UU-Fin n X))
 
 module _
   {l : Level} (F : species l) {k : ℕ} (X : unlabeled-structure-species F k)
@@ -39,16 +39,16 @@ module _
 
   type-unlabeled-structure-species : UU lzero
   type-unlabeled-structure-species =
-    type-UU-Fin type-of-cardinality-unlabeled-structure-species
+    type-UU-Fin k type-of-cardinality-unlabeled-structure-species
 
   has-cardinality-type-unlabeled-structure-species :
     has-cardinality k type-unlabeled-structure-species
   has-cardinality-type-unlabeled-structure-species =
-    has-cardinality-type-UU-Fin type-of-cardinality-unlabeled-structure-species
+    has-cardinality-type-UU-Fin k type-of-cardinality-unlabeled-structure-species
 
   finite-type-unlabeled-structure-species : 𝔽
   finite-type-unlabeled-structure-species =
-    finite-type-UU-Fin type-of-cardinality-unlabeled-structure-species
+    finite-type-UU-Fin k type-of-cardinality-unlabeled-structure-species
 
   structure-unlabeled-structure-species :
     F finite-type-unlabeled-structure-species
@@ -56,16 +56,3 @@ module _
 ```
 
 ### Equivalences of unlabeled structures of a speces
-
-```agda
-module _
-  {l : Level} (F : species l)
-  where
-  
-  equiv-unlabeled-structure-species :
-    {k : ℕ} (X Y : unlabeled-structure-species F k) → UU {!!}
-  equiv-unlabeled-structure-species X Y =
-    Σ ( type-unlabeled-structure-species F X ≃
-        type-unlabeled-structure-species F Y)
-      {!!}
-```


### PR DESCRIPTION
The implicit arguments in the files about finite mathematics caused serious slowdowns. I made them explicit. The library now compiles in 325 seconds on my machine, where this was normally over 600 seconds.