### PR TITLE
Fixing definition of trees

### DIFF
--- a/src/README.lagda.md
+++ b/src/README.lagda.md
@@ -507,6 +507,7 @@ open import graph-theory.regular-undirected-graphs
 open import graph-theory.rooted-trees
 open import graph-theory.simple-undirected-graphs
 open import graph-theory.totally-faithful-morphisms-undirected-graphs
+open import graph-theory.trails-undirected-graphs
 open import graph-theory.trees
 open import graph-theory.undirected-graph-structures-on-standard-finite-sets
 open import graph-theory.undirected-graphs

--- a/src/graph-theory.lagda.md
+++ b/src/graph-theory.lagda.md
@@ -36,6 +36,7 @@ open import graph-theory.regular-undirected-graphs public
 open import graph-theory.rooted-trees public
 open import graph-theory.simple-undirected-graphs public
 open import graph-theory.totally-faithful-morphisms-undirected-graphs public
+open import graph-theory.trails-undirected-graphs public
 open import graph-theory.trees public
 open import graph-theory.undirected-graph-structures-on-standard-finite-sets public
 open import graph-theory.undirected-graphs public

--- a/src/graph-theory/rooted-trees.lagda.md
+++ b/src/graph-theory/rooted-trees.lagda.md
@@ -7,10 +7,13 @@ module graph-theory.rooted-trees where
 
 open import elementary-number-theory.natural-numbers
 
+open import foundation.coproduct-types
 open import foundation.dependent-pair-types
+open import foundation.unit-type
 open import foundation.universe-levels
+open import foundation.unordered-pairs
 
-open import graph-theory.paths-undirected-graphs
+open import graph-theory.trails-undirected-graphs
 open import graph-theory.trees
 open import graph-theory.undirected-graphs
 ```
@@ -41,17 +44,17 @@ module _
   root-Rooted-Tree : node-Rooted-Tree
   root-Rooted-Tree = pr2 T
 
-  path-to-root-Rooted-Tree :
+  trail-to-root-Rooted-Tree :
     (x : node-Rooted-Tree) →
-    path-Undirected-Graph undirected-graph-Rooted-Tree x root-Rooted-Tree
-  path-to-root-Rooted-Tree x =
-    path-Tree tree-Rooted-Tree x root-Rooted-Tree
+    trail-Undirected-Graph undirected-graph-Rooted-Tree x root-Rooted-Tree
+  trail-to-root-Rooted-Tree x =
+    trail-Tree tree-Rooted-Tree x root-Rooted-Tree
 
   height-node-Rooted-Tree : node-Rooted-Tree → ℕ
   height-node-Rooted-Tree x =
-    length-path-Undirected-Graph
+    length-trail-Undirected-Graph
       ( undirected-graph-Rooted-Tree)
-      ( path-to-root-Rooted-Tree x)
+      ( trail-to-root-Rooted-Tree x)
 
   node-of-height-one-Rooted-Tree : UU l1
   node-of-height-one-Rooted-Tree =
@@ -65,4 +68,27 @@ module _
 ```agda
 Forest-Rooted-Trees : (l1 l2 l3 : Level) → UU (lsuc l1 ⊔ lsuc l2 ⊔ lsuc l3)
 Forest-Rooted-Trees l1 l2 l3 = Σ (UU l1) (λ X → X → Rooted-Tree l2 l3)
+
+module _
+  {l1 l2 l3 : Level} (F : Forest-Rooted-Trees l1 l2 l3)
+  where
+
+  indexing-type-Forest-Rooted-Trees : UU l1
+  indexing-type-Forest-Rooted-Trees = pr1 F
+
+  family-of-rooted-trees-Forest-Rooted-Trees :
+    indexing-type-Forest-Rooted-Trees → Rooted-Tree l2 l3
+  family-of-rooted-trees-Forest-Rooted-Trees = pr2 F
+
+  node-rooted-tree-Forest-Rooted-Trees : UU (l1 ⊔ l2)
+  node-rooted-tree-Forest-Rooted-Trees =
+    ( Σ indexing-type-Forest-Rooted-Trees
+      ( λ x →
+        node-Rooted-Tree (family-of-rooted-trees-Forest-Rooted-Trees x))) +
+    ( unit)
+
+  unordered-pair-of-nodes-rooted-tree-Forest-Rooted-Trees :
+    UU (lsuc lzero ⊔ l1 ⊔ l2)
+  unordered-pair-of-nodes-rooted-tree-Forest-Rooted-Trees =
+    unordered-pair node-rooted-tree-Forest-Rooted-Trees
 ```

--- a/src/graph-theory/trails-undirected-graphs.lagda.md
+++ b/src/graph-theory/trails-undirected-graphs.lagda.md
@@ -1,0 +1,49 @@
+---
+title: Trails in undirected graphs
+---
+
+```agda
+module graph-theory.trails-undirected-graphs where
+
+open import elementary-number-theory.natural-numbers
+
+open import foundation.dependent-pair-types
+open import foundation.injective-maps
+open import foundation.universe-levels
+
+open import graph-theory.undirected-graphs
+open import graph-theory.walks-undirected-graphs
+```
+
+## Idea
+
+A trail in an undirected graph is a walk that passes through each edge at most once
+
+## Definition
+
+```agda
+module _
+  {l1 l2 : Level} (G : Undirected-Graph l1 l2)
+  where
+  
+  is-trail-walk-Undirected-Graph :
+    {x y : vertex-Undirected-Graph G} → walk-Undirected-Graph G x y →
+    UU (lsuc lzero ⊔ l1 ⊔ l2)
+  is-trail-walk-Undirected-Graph w =
+    is-injective (edge-edge-on-walk-Undirected-Graph G w)
+
+  trail-Undirected-Graph :
+    (x y : vertex-Undirected-Graph G) → UU (lsuc lzero ⊔ l1 ⊔ l2)
+  trail-Undirected-Graph x y =
+    Σ (walk-Undirected-Graph G x y) is-trail-walk-Undirected-Graph
+
+  walk-trail-Undirected-Graph :
+    {x y : vertex-Undirected-Graph G} →
+    trail-Undirected-Graph x y → walk-Undirected-Graph G x y
+  walk-trail-Undirected-Graph = pr1
+
+  length-trail-Undirected-Graph :
+    {x y : vertex-Undirected-Graph G} → trail-Undirected-Graph x y → ℕ
+  length-trail-Undirected-Graph t =
+    length-walk-Undirected-Graph G (walk-trail-Undirected-Graph t)
+```

--- a/src/graph-theory/trees.lagda.md
+++ b/src/graph-theory/trees.lagda.md
@@ -9,13 +9,13 @@ open import foundation.contractible-types
 open import foundation.dependent-pair-types
 open import foundation.universe-levels
 
-open import graph-theory.paths-undirected-graphs
+open import graph-theory.trails-undirected-graphs
 open import graph-theory.undirected-graphs
 ```
 
 ## Idea
 
-A tree is a graph such that the type of paths from x to y is contractible for any two vertices x and y.
+A tree is a graph such that the type of trails from x to y is contractible for any two vertices x and y.
 
 ## Definition
 
@@ -23,7 +23,7 @@ A tree is a graph such that the type of paths from x to y is contractible for an
 is-tree-Undirected-Graph :
   {l1 l2 : Level} (G : Undirected-Graph l1 l2) → UU (lsuc lzero ⊔ l1 ⊔ l2)
 is-tree-Undirected-Graph G =
-  (x y : vertex-Undirected-Graph G) → is-contr (path-Undirected-Graph G x y)
+  (x y : vertex-Undirected-Graph G) → is-contr (trail-Undirected-Graph G x y)
 
 Tree : (l1 l2 : Level) → UU (lsuc l1 ⊔ lsuc l2)
 Tree l1 l2 = Σ (Undirected-Graph l1 l2) is-tree-Undirected-Graph
@@ -38,7 +38,7 @@ module _
   node-Tree : UU l1
   node-Tree = vertex-Undirected-Graph undirected-graph-Tree
 
-  path-Tree :
-    (x y : node-Tree) → path-Undirected-Graph undirected-graph-Tree x y
-  path-Tree x y = center (pr2 T x y)
+  trail-Tree :
+    (x y : node-Tree) → trail-Undirected-Graph undirected-graph-Tree x y
+  trail-Tree x y = center (pr2 T x y)
 ```

--- a/src/graph-theory/undirected-graphs.lagda.md
+++ b/src/graph-theory/undirected-graphs.lagda.md
@@ -48,6 +48,10 @@ module _
 
   edge-Undirected-Graph : unordered-pair-vertices-Undirected-Graph → UU l2
   edge-Undirected-Graph = pr2 G
+
+  total-edge-Undirected-Graph : UU (lsuc lzero ⊔ l1 ⊔ l2)
+  total-edge-Undirected-Graph =
+    Σ unordered-pair-vertices-Undirected-Graph edge-Undirected-Graph
 ```
 
 ### The forgetful functor from directed graphs to undirected graphs

--- a/src/graph-theory/walks-undirected-graphs.lagda.md
+++ b/src/graph-theory/walks-undirected-graphs.lagda.md
@@ -10,7 +10,9 @@ open import elementary-number-theory.natural-numbers
 open import foundation.contractible-types
 open import foundation.coproduct-types
 open import foundation.dependent-pair-types
+open import foundation.empty-types
 open import foundation.equivalences
+open import foundation.functions
 open import foundation.functoriality-coproduct-types
 open import foundation.identity-types
 open import foundation.type-arithmetic-coproduct-types
@@ -75,6 +77,42 @@ module _
   vertex-vertex-on-walk-Undirected-Graph w = pr1
 ```
 
+### Edges on a walk
+
+```agda
+module _
+  {l1 l2 : Level} (G : Undirected-Graph l1 l2) {x : vertex-Undirected-Graph G}
+  where
+
+  is-edge-on-walk-Undirected-Graph' :
+    {y : vertex-Undirected-Graph G} (w : walk-Undirected-Graph G x y) →
+    total-edge-Undirected-Graph G → UU (lsuc lzero ⊔ l1 ⊔ l2)
+  is-edge-on-walk-Undirected-Graph' refl-walk-Undirected-Graph e =
+    raise-empty (lsuc lzero ⊔ l1 ⊔ l2)
+  is-edge-on-walk-Undirected-Graph' (cons-walk-Undirected-Graph q f w) e =
+    ( is-edge-on-walk-Undirected-Graph' w e) +
+    ( pair q f ＝ e)
+
+  is-edge-on-walk-Undirected-Graph :
+    {y : vertex-Undirected-Graph G} (w : walk-Undirected-Graph G x y) →
+    (p : unordered-pair-vertices-Undirected-Graph G) →
+    edge-Undirected-Graph G p → UU (lsuc lzero ⊔ (l1 ⊔ l2))
+  is-edge-on-walk-Undirected-Graph w p e =
+    is-edge-on-walk-Undirected-Graph' w (pair p e)
+
+  edge-on-walk-Undirected-Graph :
+    {y : vertex-Undirected-Graph G} (w : walk-Undirected-Graph G x y) →
+    UU (lsuc lzero ⊔ l1 ⊔ l2)
+  edge-on-walk-Undirected-Graph w =
+    Σ ( total-edge-Undirected-Graph G)
+      ( λ e → is-edge-on-walk-Undirected-Graph' w e)
+
+  edge-edge-on-walk-Undirected-Graph :
+    {y : vertex-Undirected-Graph G} (w : walk-Undirected-Graph G x y) →
+    edge-on-walk-Undirected-Graph w → total-edge-Undirected-Graph G
+  edge-edge-on-walk-Undirected-Graph w = pr1
+```
+
 ### Concatenating walks
 
 ```agda
@@ -123,4 +161,23 @@ module _
       ( vertex-Undirected-Graph G)
       ( is-vertex-on-walk-Undirected-Graph G w)
       ( λ z → other-element-unordered-pair p y ＝ z))
+
+  compute-edge-on-walk-Undirected-Graph :
+    {y : vertex-Undirected-Graph G} (w : walk-Undirected-Graph G x y) →
+    edge-on-walk-Undirected-Graph G w ≃ Fin (length-walk-Undirected-Graph w)
+  compute-edge-on-walk-Undirected-Graph refl-walk-Undirected-Graph =
+    equiv-is-empty
+      ( is-empty-raise-empty ∘ pr2)
+      ( id)
+  compute-edge-on-walk-Undirected-Graph (cons-walk-Undirected-Graph p e w) =
+    ( equiv-coprod
+      ( compute-edge-on-walk-Undirected-Graph w)
+      ( equiv-is-contr
+        ( is-contr-total-path (pair p e))
+        ( is-contr-unit))) ∘e
+    ( left-distributive-Σ-coprod
+      ( total-edge-Undirected-Graph G)
+      ( is-edge-on-walk-Undirected-Graph' G w)
+      ( λ z → pair p e ＝ z))
+
 ```


### PR DESCRIPTION
Using trails instead of paths, to avoid loops of length one.