### PR TITLE
Fix the group solver demo

### DIFF
--- a/src/group-theory/commutators-groups.lagda.md
+++ b/src/group-theory/commutators-groups.lagda.md
@@ -75,17 +75,25 @@ We first introduce some shorter names to make the proofs less verbose
     _*'_ : ∀ {n} → GroupSyntax n → GroupSyntax n → GroupSyntax n
     _*'_ = gMul
     infixl 20 _*'_
+  gCommutator : ∀ {n} → GroupSyntax n → GroupSyntax n → GroupSyntax n
+  gCommutator x y = x *' y *' gInv (y *' x)
+
   inv-Commutator-law' : ∀ x y → inv-Group G (commutator-Group x y) ＝ commutator-Group y x
   inv-Commutator-law' x y =
-    (x * y * (y * x) ⁻¹) ⁻¹  ＝ by simplifyExpr G (x ∷ y ∷ empty-vec) (λ x y → gInv (x *' y *' gInv (y *' x))) to
-    y * x * y ⁻¹ * x ⁻¹      ＝ by inv (simplifyExpr G (x ∷ y ∷ empty-vec) (λ x y → y *' x *' gInv (x *' y))) to
-    y * x * (x * y) ⁻¹       ∎
+    (commutator-Group x y) ⁻¹  ＝ by simplifyExpr G (x ∷ y ∷ empty-vec) (λ x y → gInv (gCommutator x y)) to
+    y * x * y ⁻¹ * x ⁻¹        ＝ by inv (simplifyExpr G (x ∷ y ∷ empty-vec) (λ x y → gCommutator y x)) to
+    commutator-Group y x       ∎
+
+  inv-Commutator-law'' : ∀ x y → inv-Group G (commutator-Group x y) ＝ commutator-Group y x
+  inv-Commutator-law'' x y =
+    simplifyExpr G (x ∷ y ∷ empty-vec) (λ x y → gInv (gCommutator x y)) ∙
+      inv (simplifyExpr G (x ∷ y ∷ empty-vec) (λ x y → gCommutator y x))
 
   commutes-when-commutor-is-unit' :
     ∀ x y → (commutator-Group x y ＝ unit-Group G) → mul-Group G x y ＝ mul-Group G y x
   commutes-when-commutor-is-unit' x y comm-unit =
-    x * y                         ＝ by inv (simplifyExpr G (x ∷ y ∷ empty-vec) (λ x y → (x *' y *' gInv (y *' x) *' y *' x))) to
-    x * y * (y * x) ⁻¹ * y * x    ＝ by ap (λ z → z * y * x) comm-unit to
+    x * y                         ＝ by inv (simplifyExpr G (x ∷ y ∷ empty-vec) (λ x y → (gCommutator x y *' y *' x))) to
+    commutator-Group x y * y * x  ＝ by ap (λ z → z * y * x) comm-unit to
     unit * y * x                  ＝ by simplifyExpr G (x ∷ y ∷ empty-vec) (λ x y → (gUnit *' y *' x)) to
     y * x                         ∎
 

--- a/src/group-theory/commutators-groups.lagda.md
+++ b/src/group-theory/commutators-groups.lagda.md
@@ -62,7 +62,7 @@ We first introduce some shorter names to make the proofs less verbose
 
 ### Demonstration of the group solver
 
-{-
+```agda
   private
     _*_ = mul-Group G
     infixl 30 _*_
@@ -76,22 +76,23 @@ We first introduce some shorter names to make the proofs less verbose
     _*'_ = gMul
     infixl 20 _*'_
   inv-Commutator-law' : ∀ x y → inv-Group G (commutator-Group x y) ＝ commutator-Group y x
-  inv-Commutator-law' x y = simplifyExpr G ? ?
-  -- simplifyExpr G (x ∷ y ∷ empty-vec) (λ x y → gInv (x *' y *' gInv x *' gInv y))
+  inv-Commutator-law' x y =
+    (x * y * (y * x) ⁻¹) ⁻¹  ＝ by simplifyExpr G (x ∷ y ∷ empty-vec) (λ x y → gInv (x *' y *' gInv (y *' x))) to
+    y * x * y ⁻¹ * x ⁻¹      ＝ by inv (simplifyExpr G (x ∷ y ∷ empty-vec) (λ x y → y *' x *' gInv (x *' y))) to
+    y * x * (x * y) ⁻¹       ∎
 
   commutes-when-commutor-is-unit' :
     ∀ x y → (commutator-Group x y ＝ unit-Group G) → mul-Group G x y ＝ mul-Group G y x
   commutes-when-commutor-is-unit' x y comm-unit =
-    x * y                         ＝ by inv (simplifyExpr G (x ∷ (y ∷ empty-vec)) (λ x y → (x *' y *' gInv x *' gInv y *' y *' x))) to
-    x * y * x ⁻¹ * y ⁻¹ * y * x   ＝ by ap (λ z → z * y * x) comm-unit to
-    unit * y * x                  ＝ by simplifyExpr G (x ∷ (y ∷ empty-vec)) (λ x y → (gUnit *' y *' x)) to
+    x * y                         ＝ by inv (simplifyExpr G (x ∷ y ∷ empty-vec) (λ x y → (x *' y *' gInv (y *' x) *' y *' x))) to
+    x * y * (y * x) ⁻¹ * y * x    ＝ by ap (λ z → z * y * x) comm-unit to
+    unit * y * x                  ＝ by simplifyExpr G (x ∷ y ∷ empty-vec) (λ x y → (gUnit *' y *' x)) to
     y * x                         ∎
 
   commutor-is-unit-when-commutes' :
     ∀ x y → (mul-Group G x y ＝ mul-Group G y x) → commutator-Group x y ＝ unit-Group G
   commutor-is-unit-when-commutes' x y commutes =
-    x * y * x ⁻¹ * y ⁻¹ ＝ by ap (λ z → z * x ⁻¹ * y ⁻¹) commutes to
-    y * x * x ⁻¹ * y ⁻¹ ＝ by simplifyExpr G (x ∷ y ∷ empty-vec) (λ x y → (y *' x *' gInv x *' gInv y)) to
-    unit                  ∎
--}
+    x * y * (y * x) ⁻¹ ＝ by ap (λ z → z * (y * x) ⁻¹) commutes to
+    y * x * (y * x) ⁻¹ ＝ by simplifyExpr G (x ∷ y ∷ empty-vec) (λ x y → (y *' x *' gInv (y *' x))) to
+    unit               ∎
 ```


### PR DESCRIPTION
The basic usage of the solver, assuming both sides reduce to the same value, is:

```agda
  some-theorem : ∀ x y → inv-Group G (commutator-Group x y) ＝ commutator-Group y x
  some-theorem x y =
    simplifyExpr G (x ∷ y ∷ empty-vec) (λ x y → gInv (gCommutator x y)) ∙
      inv (simplifyExpr G (x ∷ y ∷ empty-vec) (λ x y → gCommutator y x))
```
where the environment `(x ∷ y ∷ empty-vec)` specifies the variables that are used in the expression and
`(λ x y → gInv (gCommutator x y))` is the quoted version of the LHS of the equation. The function is variadic depending on how many variables were used in the environment.