### PR TITLE
Change that uses explicit composition to simplify the proof

### DIFF
--- a/src/foundation-core/propositions.lagda.md
+++ b/src/foundation-core/propositions.lagda.md
@@ -116,11 +116,11 @@ module _
 
   abstract
     is-prop-is-proof-irrelevant : is-proof-irrelevant A → is-prop A
-    is-prop-is-proof-irrelevant H x y = is-prop-is-contr (H x) x y
+    is-prop-is-proof-irrelevant H x y = is-prop-is-contr (H x) x y 
 
   abstract
     eq-is-proof-irrelevant : is-proof-irrelevant A → all-elements-equal A
-    eq-is-proof-irrelevant H = eq-is-prop' (is-prop-is-proof-irrelevant H)
+    eq-is-proof-irrelevant = eq-is-prop' ∘ is-prop-is-proof-irrelevant 
 ```
 
 ### A map between propositions is an equivalence if there is a map in the reverse direction


### PR DESCRIPTION
Egbert, I noticed when going through propositions that eq-is-proof-irrelevant is just a compositon of two existing terms. The current code base is introducing a term H of is-proof-irrelevant A and then applying the two terms to H rather than just utilizing composition. Small change but thought it was worth getting used to commits, etc. 

Btw I thought I could simplify line 119 by removing the x y at first, but shorty realized we needed the x to be introduced so I reverted the changes. I would have went back and removed these changes so they weren't showing up here and to avoid confusion but I am still alittle new to this... Sorry.