### PR TITLE
Rename equational-reasoning_ to equality-reasoning_

### DIFF
--- a/src/category-theory/isomorphisms-categories.lagda.md
+++ b/src/category-theory/isomorphisms-categories.lagda.md
@@ -133,7 +133,7 @@ module _
     comp-hom-Cat C (hom-comp-iso-Cat g f) (hom-inv-comp-iso-Cat g f)
     ＝ id-hom-Cat C
   issec-hom-inv-comp-iso-Cat g f =
-    equational-reasoning
+    equality-reasoning
       comp-hom-Cat C (hom-comp-iso-Cat g f) (hom-inv-comp-iso-Cat g f)
       ＝ comp-hom-Cat C
           ( hom-iso-Cat C g)
@@ -185,7 +185,7 @@ module _
     ( comp-hom-Cat C (hom-inv-comp-iso-Cat g f) (hom-comp-iso-Cat g f)) ＝
     ( id-hom-Cat C)
   isretr-hom-inv-comp-iso-Cat g f =
-    equational-reasoning
+    equality-reasoning
       comp-hom-Cat C (hom-inv-comp-iso-Cat g f) (hom-comp-iso-Cat g f)
       ＝ comp-hom-Cat C
           ( hom-inv-iso-Cat C f)
@@ -424,7 +424,7 @@ module _
     {x y z : obj-Cat C} (g : iso-Cat C y z) (f : iso-Cat C x y) →
     eq-iso-Cat (comp-iso-Cat C g f) ＝ (eq-iso-Cat f ∙ eq-iso-Cat g)
   preserves-comp-eq-iso-Cat g f =
-    equational-reasoning
+    equality-reasoning
       eq-iso-Cat (comp-iso-Cat C g f)
       ＝ eq-iso-Cat
           ( comp-iso-Cat C

--- a/src/category-theory/isomorphisms-precategories.lagda.md
+++ b/src/category-theory/isomorphisms-precategories.lagda.md
@@ -226,7 +226,7 @@ module _
     (H : is-iso-Precat C f) (z : obj-Precat C) →
     ( precomp-hom-Precat C f z ∘ precomp-hom-inv-is-iso-Precat H z) ~ id
   issec-precomp-hom-inv-is-iso-Precat H z g =
-    equational-reasoning
+    equality-reasoning
       comp-hom-Precat C (comp-hom-Precat C g (hom-inv-is-iso-Precat C H)) f
       ＝ comp-hom-Precat C g (comp-hom-Precat C (hom-inv-is-iso-Precat C H) f)
         by assoc-comp-hom-Precat C g (hom-inv-is-iso-Precat C H) f
@@ -239,7 +239,7 @@ module _
     (H : is-iso-Precat C f) (z : obj-Precat C) →
     (precomp-hom-inv-is-iso-Precat H z ∘ precomp-hom-Precat C f z) ~ id
   isretr-precomp-hom-inv-is-iso-Precat H z g =
-    equational-reasoning
+    equality-reasoning
       comp-hom-Precat C (comp-hom-Precat C g f) (hom-inv-is-iso-Precat C H)
       ＝ comp-hom-Precat C g (comp-hom-Precat C f (hom-inv-is-iso-Precat C H))
         by assoc-comp-hom-Precat C g f (hom-inv-is-iso-Precat C H)

--- a/src/category-theory/natural-transformations-precategories.lagda.md
+++ b/src/category-theory/natural-transformations-precategories.lagda.md
@@ -85,7 +85,7 @@ module _
   pr1 (comp-nat-trans-Precat F G H β α) =
     λ x → comp-hom-Precat D (components-nat-trans-Precat C D G H β x) (components-nat-trans-Precat C D F G α x)
   pr2 (comp-nat-trans-Precat F G H β α) f =
-    equational-reasoning
+    equality-reasoning
        comp-hom-Precat D (hom-functor-Precat C D H f)
          (comp-hom-Precat D (components-nat-trans-Precat C D G H β _)
           (pr1 α _))

--- a/src/elementary-number-theory/absolute-value-integers.lagda.md
+++ b/src/elementary-number-theory/absolute-value-integers.lagda.md
@@ -139,13 +139,13 @@ is-nonzero-abs-ℤ (inr (inr x)) H = is-nonzero-succ-ℕ x
 ### Absolute value is multiplicative
 ```agda
 neg-left-abs-ℤ-mul-ℤ : (x y : ℤ) → abs-ℤ (mul-ℤ x y) ＝ abs-ℤ (mul-ℤ (neg-ℤ x) y)
-neg-left-abs-ℤ-mul-ℤ x y = equational-reasoning
+neg-left-abs-ℤ-mul-ℤ x y = equality-reasoning
   abs-ℤ (mul-ℤ x y)
   ＝ abs-ℤ (neg-ℤ (mul-ℤ x y)) by (inv (negative-law-abs-ℤ (mul-ℤ x y)))
   ＝ abs-ℤ (mul-ℤ (neg-ℤ x) y) by (ap abs-ℤ (inv (left-negative-law-mul-ℤ x y)))
 
 neg-right-abs-ℤ-mul-ℤ : (x y : ℤ) → abs-ℤ (mul-ℤ x y) ＝ abs-ℤ (mul-ℤ x (neg-ℤ y))
-neg-right-abs-ℤ-mul-ℤ x y = equational-reasoning
+neg-right-abs-ℤ-mul-ℤ x y = equality-reasoning
   abs-ℤ (mul-ℤ x y)
   ＝ abs-ℤ (neg-ℤ (mul-ℤ x y)) by (inv (negative-law-abs-ℤ (mul-ℤ x y)))
   ＝ abs-ℤ (mul-ℤ x (neg-ℤ y)) by (ap abs-ℤ (inv (right-negative-law-mul-ℤ x y)))
@@ -156,7 +156,7 @@ neg-both-abs-ℤ-mul-ℤ x y = (neg-right-abs-ℤ-mul-ℤ x y) ∙ (neg-left-abs
 int-ℕ-abs-ℤ-mult-positive-ints : (x y : ℕ) →
   int-ℕ (abs-ℤ (mul-ℤ (inr (inr x)) (inr (inr y)))) 
   ＝ int-ℕ (mul-ℕ (abs-ℤ (inr (inr x))) (abs-ℤ (inr (inr y))))
-int-ℕ-abs-ℤ-mult-positive-ints x y = equational-reasoning  
+int-ℕ-abs-ℤ-mult-positive-ints x y = equality-reasoning  
   int-ℕ (abs-ℤ (mul-ℤ (inr (inr x)) (inr (inr y)))) 
     ＝ mul-ℤ (inr (inr x)) (inr (inr y)) 
       by (int-abs-is-nonnegative-ℤ (mul-ℤ (inr (inr x)) (inr (inr y))) 
@@ -175,18 +175,18 @@ int-ℕ-abs-ℤ-mult-positive-ints x y = equational-reasoning
 
 multiplicative-abs-ℤ : (x y : ℤ) → abs-ℤ (mul-ℤ x y) ＝ mul-ℕ (abs-ℤ x) (abs-ℤ y)
 multiplicative-abs-ℤ (inl x) (inl y) = is-injective-int-ℕ 
-  (equational-reasoning
+  ( equality-reasoning
     int-ℕ (abs-ℤ (mul-ℤ (inl x) (inl y)))
     ＝ int-ℕ (abs-ℤ (mul-ℤ (inr (inr x)) (inr (inr y)))) 
       by (ap int-ℕ (neg-both-abs-ℤ-mul-ℤ (inl x) (inl y))) 
     ＝ int-ℕ (mul-ℕ (abs-ℤ (inr (inr x))) (abs-ℤ (inr (inr y)))) 
       by (int-ℕ-abs-ℤ-mult-positive-ints x y))
-multiplicative-abs-ℤ (inl x) (inr (inl star)) = equational-reasoning
+multiplicative-abs-ℤ (inl x) (inr (inl star)) = equality-reasoning
   abs-ℤ (mul-ℤ (inl x) zero-ℤ)
   ＝ zero-ℕ by (ap (abs-ℤ) (right-zero-law-mul-ℤ (inl x)))
   ＝ mul-ℕ (abs-ℤ (inl x)) zero-ℕ by (inv (right-zero-law-mul-ℕ (abs-ℤ (inl x))))
 multiplicative-abs-ℤ (inl x) (inr (inr y)) = is-injective-int-ℕ
-  (equational-reasoning
+  ( equality-reasoning
     int-ℕ (abs-ℤ (mul-ℤ (inl x) (inr (inr y))))
     ＝ int-ℕ (abs-ℤ (mul-ℤ (inr (inr x)) (inr (inr y)))) 
       by (ap int-ℕ (neg-left-abs-ℤ-mul-ℤ (inl x) (inr (inr y)))) 
@@ -194,13 +194,13 @@ multiplicative-abs-ℤ (inl x) (inr (inr y)) = is-injective-int-ℕ
       by (int-ℕ-abs-ℤ-mult-positive-ints x y))
 multiplicative-abs-ℤ (inr (inl star)) y = refl 
 multiplicative-abs-ℤ (inr (inr x)) (inl y) = is-injective-int-ℕ
-  (equational-reasoning 
+  ( equality-reasoning 
     int-ℕ (abs-ℤ (mul-ℤ (inr (inr x)) (inl y)))
     ＝ int-ℕ (abs-ℤ (mul-ℤ (inr (inr x)) (inr (inr y)))) 
       by (ap int-ℕ (neg-right-abs-ℤ-mul-ℤ (inr (inr x)) (inl y))) 
     ＝ int-ℕ (mul-ℕ (abs-ℤ (inr (inr x))) (abs-ℤ (inr (inr y)))) 
       by (int-ℕ-abs-ℤ-mult-positive-ints x y))
-multiplicative-abs-ℤ (inr (inr x)) (inr (inl star)) = equational-reasoning
+multiplicative-abs-ℤ (inr (inr x)) (inr (inl star)) = equality-reasoning
   abs-ℤ (mul-ℤ (inr (inr x)) zero-ℤ)
   ＝ zero-ℕ by (ap (abs-ℤ) (right-zero-law-mul-ℤ (inr (inr x))))
   ＝ mul-ℕ (abs-ℤ (inr (inr x))) zero-ℕ by (inv (right-zero-law-mul-ℕ (abs-ℤ (inr (inr x)))))

--- a/src/elementary-number-theory/addition-integers.lagda.md
+++ b/src/elementary-number-theory/addition-integers.lagda.md
@@ -101,12 +101,12 @@ abstract
     ap pred-ℤ (right-predecessor-law-add-ℤ (inl m) n)
   right-predecessor-law-add-ℤ (inr (inl star)) n = refl
   right-predecessor-law-add-ℤ (inr (inr zero-ℕ)) n =
-    equational-reasoning
+    equality-reasoning
       succ-ℤ (pred-ℤ n)
       ＝ n                                       by issec-pred-ℤ n
       ＝ pred-ℤ (succ-ℤ n)                       by inv (isretr-pred-ℤ n)
   right-predecessor-law-add-ℤ (inr (inr (succ-ℕ x))) n =
-    equational-reasoning
+    equality-reasoning
       succ-ℤ (inr (inr x) +ℤ pred-ℤ n)
       ＝ succ-ℤ (pred-ℤ (inr (inr x) +ℤ n))      by ap succ-ℤ (right-predecessor-law-add-ℤ (inr (inr x)) n)
       ＝ inr (inr x) +ℤ n                        by issec-pred-ℤ (add-ℤ (inr (inr x)) n)
@@ -122,7 +122,7 @@ abstract
   left-successor-law-add-ℤ (inl zero-ℕ) y =
     inv (issec-pred-ℤ y)
   left-successor-law-add-ℤ (inl (succ-ℕ x)) y =
-    equational-reasoning
+    equality-reasoning
       inl x +ℤ y
       ＝ succ-ℤ (pred-ℤ (inl x +ℤ y))            by inv (issec-pred-ℤ (add-ℤ (inl x) y))
       ＝ succ-ℤ (pred-ℤ (inl x) +ℤ y)            by ap succ-ℤ (inv (left-predecessor-law-add-ℤ (inl x) y))
@@ -132,11 +132,11 @@ abstract
   right-successor-law-add-ℤ :
     (x y : ℤ) → x +ℤ succ-ℤ y ＝ succ-ℤ (x +ℤ y)
   right-successor-law-add-ℤ (inl zero-ℕ) y =
-    equational-reasoning
+    equality-reasoning
       pred-ℤ (succ-ℤ y) ＝ y                     by isretr-pred-ℤ y
                         ＝ succ-ℤ (pred-ℤ y)     by inv (issec-pred-ℤ y)
   right-successor-law-add-ℤ (inl (succ-ℕ x)) y =
-    equational-reasoning
+    equality-reasoning
       pred-ℤ (inl x +ℤ succ-ℤ y)
       ＝ pred-ℤ (succ-ℤ (inl x +ℤ y))            by ap pred-ℤ (right-successor-law-add-ℤ (inl x) y)
       ＝ inl x +ℤ y                              by isretr-pred-ℤ (add-ℤ (inl x) y)
@@ -153,7 +153,7 @@ abstract
 abstract
   is-add-one-succ-ℤ' : (x : ℤ) → succ-ℤ x ＝ x +ℤ one-ℤ
   is-add-one-succ-ℤ' x =
-    equational-reasoning
+    equality-reasoning
       succ-ℤ x ＝ succ-ℤ (x +ℤ zero-ℤ)           by inv (ap succ-ℤ (right-unit-law-add-ℤ x))
                ＝ x +ℤ one-ℤ                     by inv (right-successor-law-add-ℤ x zero-ℤ)
 
@@ -176,7 +176,7 @@ abstract
 
   is-add-neg-one-pred-ℤ' : (x : ℤ) → pred-ℤ x ＝ x +ℤ neg-one-ℤ
   is-add-neg-one-pred-ℤ' x =
-    equational-reasoning
+    equality-reasoning
       pred-ℤ x ＝ pred-ℤ (x +ℤ zero-ℤ)           by inv (ap pred-ℤ (right-unit-law-add-ℤ x))
                ＝ x +ℤ neg-one-ℤ                 by inv (right-predecessor-law-add-ℤ x zero-ℤ)
 
@@ -194,13 +194,13 @@ abstract
   associative-add-ℤ :
     (x y z : ℤ) → ((x +ℤ y) +ℤ z) ＝ (x +ℤ (y +ℤ z))
   associative-add-ℤ (inl zero-ℕ) y z =
-    equational-reasoning
+    equality-reasoning
       (neg-one-ℤ +ℤ y) +ℤ z
       ＝ (pred-ℤ (zero-ℤ +ℤ y)) +ℤ z             by ap (add-ℤ' z) (left-predecessor-law-add-ℤ zero-ℤ y)
       ＝ pred-ℤ (y +ℤ z)                         by left-predecessor-law-add-ℤ y z
       ＝ neg-one-ℤ +ℤ (y +ℤ z)                   by inv (left-predecessor-law-add-ℤ zero-ℤ (add-ℤ y z))
   associative-add-ℤ (inl (succ-ℕ x)) y z =
-    equational-reasoning
+    equality-reasoning
       (pred-ℤ (inl x) +ℤ y) +ℤ z
       ＝ pred-ℤ (inl x +ℤ y) +ℤ z                by ap (add-ℤ' z) (left-predecessor-law-add-ℤ (inl x) y)
       ＝ pred-ℤ ((inl x +ℤ y) +ℤ z)              by left-predecessor-law-add-ℤ (add-ℤ (inl x) y) z
@@ -209,13 +209,13 @@ abstract
   associative-add-ℤ (inr (inl star)) y z =
     refl
   associative-add-ℤ (inr (inr zero-ℕ)) y z =
-    equational-reasoning
+    equality-reasoning
       (one-ℤ +ℤ y) +ℤ z
       ＝ succ-ℤ (zero-ℤ +ℤ y) +ℤ z               by ap (add-ℤ' z) (left-successor-law-add-ℤ zero-ℤ y)
       ＝ succ-ℤ (y +ℤ z)                         by left-successor-law-add-ℤ y z
       ＝ one-ℤ +ℤ (y +ℤ z)                       by inv (left-successor-law-add-ℤ zero-ℤ (add-ℤ y z))
   associative-add-ℤ (inr (inr (succ-ℕ x))) y z =
-    equational-reasoning
+    equality-reasoning
       (succ-ℤ (inr (inr x)) +ℤ y) +ℤ z
       ＝ succ-ℤ (inr (inr x) +ℤ y) +ℤ z          by ap (add-ℤ' z) (left-successor-law-add-ℤ (inr (inr x)) y)
       ＝ succ-ℤ ((inr (inr x) +ℤ y) +ℤ z)        by left-successor-law-add-ℤ (add-ℤ (inr (inr x)) y) z
@@ -229,25 +229,25 @@ abstract
 abstract
   commutative-add-ℤ : (x y : ℤ) → x +ℤ y ＝ y +ℤ x
   commutative-add-ℤ (inl zero-ℕ) y =
-    equational-reasoning
+    equality-reasoning
       add-ℤ neg-one-ℤ y
       ＝ pred-ℤ (add-ℤ zero-ℤ y)                 by left-predecessor-law-add-ℤ zero-ℤ y
       ＝ pred-ℤ (add-ℤ y zero-ℤ)                 by inv (ap pred-ℤ (right-unit-law-add-ℤ y))
       ＝ add-ℤ y neg-one-ℤ                       by inv (right-predecessor-law-add-ℤ y zero-ℤ)
   commutative-add-ℤ (inl (succ-ℕ x)) y =
-    equational-reasoning
+    equality-reasoning
       add-ℤ (inl (succ-ℕ x)) y
       ＝ pred-ℤ (add-ℤ y (inl x))                by ap pred-ℤ (commutative-add-ℤ (inl x) y)
       ＝ add-ℤ y (inl (succ-ℕ x))                by inv (right-predecessor-law-add-ℤ y (inl x))
   commutative-add-ℤ (inr (inl star)) y =
     inv (right-unit-law-add-ℤ y)
   commutative-add-ℤ (inr (inr zero-ℕ)) y =
-    equational-reasoning
+    equality-reasoning
       succ-ℤ y
       ＝ succ-ℤ (add-ℤ y zero-ℤ)                 by inv (ap succ-ℤ (right-unit-law-add-ℤ y))
       ＝ add-ℤ y one-ℤ                           by inv (right-successor-law-add-ℤ y zero-ℤ)
   commutative-add-ℤ (inr (inr (succ-ℕ x))) y =
-    equational-reasoning
+    equality-reasoning
       succ-ℤ (add-ℤ (inr (inr x)) y)
       ＝ succ-ℤ (add-ℤ y (inr (inr x)))          by ap succ-ℤ (commutative-add-ℤ (inr (inr x)) y)
       ＝ add-ℤ y (succ-ℤ (inr (inr x)))          by inv (right-successor-law-add-ℤ y (inr (inr x)))
@@ -261,14 +261,14 @@ abstract
     (x : ℤ) → neg-ℤ x +ℤ x ＝ zero-ℤ
   left-inverse-law-add-ℤ (inl zero-ℕ) = refl
   left-inverse-law-add-ℤ (inl (succ-ℕ x)) =
-    equational-reasoning
+    equality-reasoning
       succ-ℤ (inr (inr x) +ℤ pred-ℤ (inl x))
       ＝ succ-ℤ (pred-ℤ (inr (inr x) +ℤ inl x))  by ap succ-ℤ (right-predecessor-law-add-ℤ (inr (inr x)) (inl x))
       ＝ inr (inr x) +ℤ inl x                    by issec-pred-ℤ (add-ℤ (inr (inr x)) (inl x))
       ＝ zero-ℤ                                  by left-inverse-law-add-ℤ (inl x)
   left-inverse-law-add-ℤ (inr (inl star)) = refl
   left-inverse-law-add-ℤ (inr (inr x)) =
-    equational-reasoning
+    equality-reasoning
       neg-ℤ (inr (inr x)) +ℤ inr (inr x)
       ＝ inr (inr x) +ℤ inl x                    by commutative-add-ℤ (inl x) (inr (inr x))
       ＝ zero-ℤ                                  by left-inverse-law-add-ℤ (inl x)
@@ -276,7 +276,7 @@ abstract
   right-inverse-law-add-ℤ :
     (x : ℤ) → x +ℤ neg-ℤ x ＝ zero-ℤ
   right-inverse-law-add-ℤ x =
-    equational-reasoning
+    equality-reasoning
       x +ℤ neg-ℤ x ＝ neg-ℤ x +ℤ x               by commutative-add-ℤ x (neg-ℤ x)
                    ＝ zero-ℤ                     by left-inverse-law-add-ℤ x
 ```
@@ -298,14 +298,14 @@ interchange-law-add-add-ℤ =
 issec-add-neg-ℤ :
   (x y : ℤ) → x +ℤ (neg-ℤ x +ℤ y) ＝ y
 issec-add-neg-ℤ x y =
-  equational-reasoning
+  equality-reasoning
     x +ℤ (neg-ℤ x +ℤ y) ＝ (x +ℤ neg-ℤ x) +ℤ y   by inv (associative-add-ℤ x (neg-ℤ x) y)
                         ＝ y                     by ap (add-ℤ' y) (right-inverse-law-add-ℤ x)
 
 isretr-add-neg-ℤ :
   (x y : ℤ) → add-ℤ (neg-ℤ x) (add-ℤ x y) ＝ y
 isretr-add-neg-ℤ x y =
-  equational-reasoning
+  equality-reasoning
     neg-ℤ x +ℤ (x +ℤ y) ＝ (neg-ℤ x +ℤ x) +ℤ y   by inv (associative-add-ℤ (neg-ℤ x) x y)
                         ＝ y                     by ap (add-ℤ' y) (left-inverse-law-add-ℤ x)
 
@@ -323,7 +323,7 @@ pr2 (equiv-add-ℤ x) = is-equiv-add-ℤ x
 issec-add-neg-ℤ' :
   (x y : ℤ) → (y +ℤ neg-ℤ x) +ℤ x ＝ y
 issec-add-neg-ℤ' x y =
-  equational-reasoning
+  equality-reasoning
     (y +ℤ neg-ℤ x) +ℤ x ＝ y +ℤ (neg-ℤ x +ℤ x)   by associative-add-ℤ y (neg-ℤ x) x
                         ＝ y +ℤ zero-ℤ           by ap (add-ℤ y) (left-inverse-law-add-ℤ x)
                         ＝ y                     by right-unit-law-add-ℤ y
@@ -331,7 +331,7 @@ issec-add-neg-ℤ' x y =
 isretr-add-neg-ℤ' :
   (x y : ℤ) → (y +ℤ x) +ℤ neg-ℤ x ＝ y
 isretr-add-neg-ℤ' x y =
-  equational-reasoning
+  equality-reasoning
     (y +ℤ x) +ℤ neg-ℤ x ＝ y +ℤ (x +ℤ neg-ℤ x)   by associative-add-ℤ y x (neg-ℤ x)
                         ＝ y +ℤ zero-ℤ           by ap (add-ℤ y) (right-inverse-law-add-ℤ x)
                         ＝ y                     by right-unit-law-add-ℤ y
@@ -385,12 +385,12 @@ is-injective-add-ℤ x = is-injective-is-emb (is-emb-add-ℤ x)
 right-negative-law-add-ℤ :
   (k l : ℤ) → k +ℤ neg-ℤ l ＝ neg-ℤ (neg-ℤ k +ℤ l)
 right-negative-law-add-ℤ (inl zero-ℕ) l =
-  equational-reasoning
+  equality-reasoning
     neg-one-ℤ +ℤ neg-ℤ l
     ＝ pred-ℤ (zero-ℤ +ℤ neg-ℤ l)                by left-predecessor-law-add-ℤ zero-ℤ (neg-ℤ l)
     ＝ neg-ℤ (succ-ℤ l)                          by pred-neg-ℤ l
 right-negative-law-add-ℤ (inl (succ-ℕ x)) l =
-  equational-reasoning
+  equality-reasoning
     pred-ℤ (inl x) +ℤ neg-ℤ l
     ＝ pred-ℤ (inl x +ℤ neg-ℤ l)                 by left-predecessor-law-add-ℤ (inl x) (neg-ℤ l)
     ＝ pred-ℤ (neg-ℤ (neg-ℤ (inl x) +ℤ l))       by ap pred-ℤ (right-negative-law-add-ℤ (inl x) l)
@@ -400,7 +400,7 @@ right-negative-law-add-ℤ (inr (inl star)) l =
 right-negative-law-add-ℤ (inr (inr zero-ℕ)) l =
   inv (neg-pred-ℤ l)
 right-negative-law-add-ℤ (inr (inr (succ-ℕ n))) l =
-  equational-reasoning
+  equality-reasoning
     succ-ℤ (in-pos n) +ℤ neg-ℤ l
     ＝ succ-ℤ (in-pos n +ℤ neg-ℤ l)              by left-successor-law-add-ℤ (in-pos n) (neg-ℤ l)
     ＝ succ-ℤ (neg-ℤ (neg-ℤ (inr (inr n)) +ℤ l)) by ap succ-ℤ (right-negative-law-add-ℤ (inr (inr n)) l)
@@ -413,12 +413,12 @@ right-negative-law-add-ℤ (inr (inr (succ-ℕ n))) l =
 distributive-neg-add-ℤ :
   (k l : ℤ) → neg-ℤ (k +ℤ l) ＝ neg-ℤ k +ℤ neg-ℤ l
 distributive-neg-add-ℤ (inl zero-ℕ) l =
-  equational-reasoning
+  equality-reasoning
     neg-ℤ (inl zero-ℕ +ℤ l)
     ＝ neg-ℤ (pred-ℤ (zero-ℤ +ℤ l))              by ap neg-ℤ (left-predecessor-law-add-ℤ zero-ℤ l)
     ＝ neg-ℤ (inl zero-ℕ) +ℤ neg-ℤ l             by neg-pred-ℤ l
 distributive-neg-add-ℤ (inl (succ-ℕ n)) l =
-  equational-reasoning
+  equality-reasoning
     neg-ℤ (pred-ℤ (inl n +ℤ l))
     ＝ succ-ℤ (neg-ℤ (inl n +ℤ l))               by neg-pred-ℤ (inl n +ℤ l)
     ＝ succ-ℤ (neg-ℤ (inl n) +ℤ neg-ℤ l)         by ap succ-ℤ (distributive-neg-add-ℤ (inl n) l)
@@ -428,7 +428,7 @@ distributive-neg-add-ℤ (inr (inl star)) l =
 distributive-neg-add-ℤ (inr (inr zero-ℕ)) l =
   inv (pred-neg-ℤ l)
 distributive-neg-add-ℤ (inr (inr (succ-ℕ n))) l =
-  equational-reasoning
+  equality-reasoning
     neg-ℤ (succ-ℤ (in-pos n +ℤ l))
     ＝ pred-ℤ (neg-ℤ (in-pos n +ℤ l))            by inv (pred-neg-ℤ (in-pos n +ℤ l))
     ＝ pred-ℤ (neg-ℤ (inr (inr n)) +ℤ neg-ℤ l)   by ap pred-ℤ (distributive-neg-add-ℤ (inr (inr n)) l)
@@ -472,7 +472,7 @@ is-positive-add-ℤ {inr (inr (succ-ℕ x))} {inr (inr y)} H K =
 add-int-ℕ : (x y : ℕ) → add-ℤ (int-ℕ x) (int-ℕ y) ＝ int-ℕ (add-ℕ x y)
 add-int-ℕ x zero-ℕ = right-unit-law-add-ℤ (int-ℕ x)
 add-int-ℕ x (succ-ℕ y) =
-  equational-reasoning
+  equality-reasoning
     int-ℕ x +ℤ int-ℕ (succ-ℕ y)
     ＝ int-ℕ x +ℤ succ-ℤ (int-ℕ y)               by ap (add-ℤ (int-ℕ x)) (inv (succ-int-ℕ y))
     ＝ succ-ℤ (int-ℕ x +ℤ int-ℕ y)               by right-successor-law-add-ℤ (int-ℕ x) (int-ℕ y)
@@ -486,7 +486,7 @@ add-int-ℕ x (succ-ℕ y) =
 is-zero-add-ℤ :
   (x y : ℤ) → add-ℤ x y ＝ y → is-zero-ℤ x
 is-zero-add-ℤ x y H =
-  equational-reasoning
+  equality-reasoning
     x ＝ x +ℤ zero-ℤ                             by inv (right-unit-law-add-ℤ x)
       ＝ x +ℤ (y +ℤ neg-ℤ y)                     by inv (ap (add-ℤ x) (right-inverse-law-add-ℤ y))
       ＝ (x +ℤ y) +ℤ neg-ℤ y                     by inv (associative-add-ℤ x y (neg-ℤ y))
@@ -506,7 +506,7 @@ negatives-add-ℤ :
   (x y : ℕ) → in-neg x +ℤ in-neg y ＝ in-neg (succ-ℕ (add-ℕ x y))
 negatives-add-ℤ zero-ℕ y = ap (inl ∘ succ-ℕ) (inv (left-unit-law-add-ℕ y))
 negatives-add-ℤ (succ-ℕ x) y =
-  equational-reasoning
+  equality-reasoning
     pred-ℤ (in-neg x +ℤ in-neg y)
     ＝ pred-ℤ (in-neg (succ-ℕ (add-ℕ x y)))      by ap pred-ℤ (negatives-add-ℤ x y)
     ＝ (inl ∘ succ-ℕ) (add-ℕ (succ-ℕ x) y)       by ap (inl ∘ succ-ℕ) (inv (left-successor-law-add-ℕ x y))

--- a/src/elementary-number-theory/bezouts-lemma.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma.lagda.md
@@ -100,7 +100,7 @@ int-is-distance-between-multiples-ℕ :
       (int-ℕ (is-distance-between-multiples-snd-coeff-ℕ d)) 
       (int-ℕ y)
 int-is-distance-between-multiples-ℕ x y z (k , l , p) H =
-  equational-reasoning
+  equality-reasoning
     add-ℤ (int-ℕ z) (mul-ℤ (int-ℕ k) (int-ℕ x))
     ＝ add-ℤ (int-ℕ z) (int-ℕ (mul-ℕ k x))
       by ap (λ p → add-ℤ (int-ℕ z) p) (mul-int-ℕ k x) 
@@ -122,7 +122,7 @@ div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
       (leq-ℕ (mul-ℕ k x) (mul-ℕ l y) + leq-ℕ (mul-ℕ l y) (mul-ℕ k x))
       → div-ℤ-Mod x (mod-ℕ x y) (mod-ℕ x z)
     kxly-case-split (inl kxly) = (mod-ℕ x l , 
-      (equational-reasoning
+      (equality-reasoning
       mul-ℤ-Mod x (mod-ℕ x l) (mod-ℕ x y)
       ＝ mul-ℤ-Mod x (mod-ℤ x (int-ℕ l)) (mod-ℕ x y) 
         by inv (ap (λ p → mul-ℤ-Mod x p (mod-ℕ x y)) (mod-int-ℕ x l))
@@ -159,7 +159,7 @@ div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
       ＝ mod-ℕ x z by mod-int-ℕ x z
      ))
     kxly-case-split (inr lykx) = (mod-ℤ x (neg-ℤ (int-ℕ l)) , 
-      (equational-reasoning
+      (equality-reasoning
       mul-ℤ-Mod x (mod-ℤ x (neg-ℤ (int-ℕ l))) (mod-ℕ x y)
       ＝ mul-ℤ-Mod x (mod-ℤ x (neg-ℤ (int-ℕ l))) (mod-ℤ x (int-ℕ y)) 
         by inv (ap (λ p → mul-ℤ-Mod x (mod-ℤ x (neg-ℤ (int-ℕ l))) p) 
@@ -198,7 +198,7 @@ div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
         by inv (preserves-add-mod-ℤ x (mul-ℤ (neg-ℤ (int-ℕ l)) (int-ℕ y))
           (mul-ℤ (int-ℕ k) (int-ℕ x)))
       ＝ mod-ℤ x (int-ℕ z)
-        by ap (mod-ℤ x) (equational-reasoning
+        by ap (mod-ℤ x) (equality-reasoning
           add-ℤ (mul-ℤ (neg-ℤ (int-ℕ l)) (int-ℕ y)) 
             (mul-ℤ (int-ℕ k) (int-ℕ x))
           ＝ add-ℤ (neg-ℤ (mul-ℤ (int-ℕ l) (int-ℕ y))) 
@@ -230,7 +230,7 @@ cong-div-mod-ℤ : (x y z : ℕ) → (q : div-ℤ-Mod x (mod-ℕ x y) (mod-ℕ x
     (mul-ℤ (int-ℤ-Mod x (pr1 q)) (int-ℕ y)) (int-ℕ z)
 cong-div-mod-ℤ x y z (u , p) = cong-eq-mod-ℤ x 
   (mul-ℤ (int-ℤ-Mod x u) (int-ℕ y)) (int-ℕ z)
-  (equational-reasoning 
+  (equality-reasoning 
     mod-ℤ x (mul-ℤ (int-ℤ-Mod x u) (int-ℕ y))
     ＝ mul-ℤ-Mod x (mod-ℤ x (int-ℤ-Mod x u)) (mod-ℤ x (int-ℕ y))
       by preserves-mul-mod-ℤ x (int-ℤ-Mod x u) (int-ℕ y) 
@@ -273,7 +273,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
 
   a-eqn-pos : add-ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)) 
     (neg-ℤ (mul-ℤ a (int-ℕ (succ-ℕ x)))) ＝ int-ℕ z 
-  a-eqn-pos = (equational-reasoning 
+  a-eqn-pos = (equality-reasoning 
     add-ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)) 
       (neg-ℤ (mul-ℤ a (int-ℕ (succ-ℕ x))))
     ＝ add-ℤ (neg-ℤ (mul-ℤ a (int-ℕ (succ-ℕ x))))
@@ -319,7 +319,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
         (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) (int-ℕ y)))
     ＝ add-ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)) 
     (neg-ℤ (mul-ℤ a (int-ℕ (succ-ℕ x))))
-  a-extra-eqn-neg = equational-reasoning
+  a-extra-eqn-neg = equality-reasoning
     add-ℤ (mul-ℤ (add-ℤ (neg-ℤ a) (int-ℕ y)) (int-ℕ (succ-ℕ x))) 
       (neg-ℤ (mul-ℤ (add-ℤ (int-ℕ (succ-ℕ x)) 
         (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) (int-ℕ y))) 
@@ -335,7 +335,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
         (int-ℕ y)) 
     by ap (λ p → add-ℤ (mul-ℤ (add-ℤ (neg-ℤ a) (int-ℕ y)) 
         (int-ℕ (succ-ℕ x))) (mul-ℤ p (int-ℕ y))) 
-      (equational-reasoning
+      (equality-reasoning
         neg-ℤ (add-ℤ (int-ℕ (succ-ℕ x)) (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
         ＝ neg-ℤ (add-ℤ (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)) (int-ℕ (succ-ℕ x)))
         by ap (neg-ℤ) (commutative-add-ℤ (int-ℕ (succ-ℕ x)) 
@@ -410,7 +410,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
         (neg-ℤ (int-ℕ z)))))
     → is-distance-between-multiples-ℕ (succ-ℕ x) y z 
   uy-z-case-split (inl uy-z) = (abs-ℤ a , nat-Fin (succ-ℕ x) u , 
-    (equational-reasoning
+    (equality-reasoning
       dist-ℕ (mul-ℕ (abs-ℤ a) (succ-ℕ x)) (mul-ℕ (nat-Fin (succ-ℕ x) u) y)
       ＝ dist-ℕ (mul-ℕ (nat-Fin (succ-ℕ x) u) y) (mul-ℕ (abs-ℤ a) (succ-ℕ x)) 
         by symmetric-dist-ℕ (mul-ℕ (abs-ℤ a) (succ-ℕ x)) 
@@ -444,7 +444,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
 
   uy-z-case-split (inr z-uy) = (add-ℕ (abs-ℤ a) y , 
     abs-ℤ (add-ℤ (int-ℕ (succ-ℕ x)) (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) , 
-      (equational-reasoning
+      (equality-reasoning
         dist-ℕ (mul-ℕ (add-ℕ (abs-ℤ a) y) (succ-ℕ x)) 
           (mul-ℕ (abs-ℤ (add-ℤ (int-ℕ (succ-ℕ x)) 
           (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))) y)
@@ -502,7 +502,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
     neg-a-is-nonnegative-ℤ : is-nonnegative-ℤ (neg-ℤ a)
     neg-a-is-nonnegative-ℤ = (is-nonnegative-left-factor-mul-ℤ 
       (tr is-nonnegative-ℤ 
-      (equational-reasoning
+      (equality-reasoning
         neg-ℤ (add-ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)) 
           (neg-ℤ (int-ℕ z)))
         ＝ add-ℤ (neg-ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))) 
@@ -631,7 +631,7 @@ minimal-positive-distance-div-succ-x-eqn : (x y : ℕ) → add-ℤ
     (mul-ℤ (int-ℕ (quotient-euclidean-division-ℕ (minimal-positive-distance (succ-ℕ x) y) (succ-ℕ x))) (int-ℕ (minimal-positive-distance (succ-ℕ x) y))) 
     (int-ℕ (remainder-euclidean-division-ℕ (minimal-positive-distance (succ-ℕ x) y) (succ-ℕ x))) ＝ int-ℕ (succ-ℕ x)
 minimal-positive-distance-div-succ-x-eqn x y = 
-    equational-reasoning
+    equality-reasoning
       add-ℤ 
         (mul-ℤ (int-ℕ (quotient-euclidean-division-ℕ (minimal-positive-distance (succ-ℕ x) y) (succ-ℕ x))) (int-ℕ (minimal-positive-distance (succ-ℕ x) y))) 
         (int-ℕ (remainder-euclidean-division-ℕ (minimal-positive-distance (succ-ℕ x) y) (succ-ℕ x)))
@@ -681,7 +681,7 @@ remainder-min-dist-succ-x-is-distance x y =
     where
     add-dist-eqn : int-ℕ d ＝ add-ℤ (mul-ℤ (int-ℕ t) (int-ℕ y)) 
       (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))
-    add-dist-eqn = equational-reasoning
+    add-dist-eqn = equality-reasoning
       int-ℕ d
       ＝ add-ℤ (add-ℤ (int-ℕ d) (int-ℕ (mul-ℕ s (succ-ℕ x))))
         (neg-ℤ (int-ℕ (mul-ℕ s (succ-ℕ x))))
@@ -711,7 +711,7 @@ remainder-min-dist-succ-x-is-distance x y =
       add-ℤ (neg-ℤ (mul-ℤ (int-ℕ q) (add-ℤ (mul-ℤ (int-ℕ t) (int-ℕ y)) 
         (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
         (int-ℕ (succ-ℕ x))
-    isolate-rem-eqn = equational-reasoning
+    isolate-rem-eqn = equality-reasoning
         int-ℕ r
         ＝ add-ℤ (neg-ℤ (mul-ℤ (int-ℕ q) (add-ℤ (mul-ℤ (int-ℕ t) (int-ℕ y)) 
              (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))) 
@@ -742,7 +742,7 @@ remainder-min-dist-succ-x-is-distance x y =
       ＝ add-ℤ (mul-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) one-ℤ) 
           (int-ℕ (succ-ℕ x)))
         (neg-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y)))
-    rearrange-arith-eqn = equational-reasoning
+    rearrange-arith-eqn = equality-reasoning
         add-ℤ (neg-ℤ (mul-ℤ (int-ℕ q) (add-ℤ (mul-ℤ (int-ℕ t) (int-ℕ y)) 
           (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x))
         ＝ add-ℤ (neg-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (mul-ℤ (int-ℕ t) (int-ℕ y)))
@@ -762,7 +762,7 @@ remainder-min-dist-succ-x-is-distance x y =
             (int-ℕ (succ-ℕ x))
         by ap (λ H → add-ℤ (neg-ℤ (add-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y)) H))
           (int-ℕ (succ-ℕ x)))
-          (equational-reasoning
+          (equality-reasoning
             (mul-ℤ (int-ℕ q) (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))
             ＝ mul-ℤ (mul-ℤ (int-ℕ q) (neg-ℤ (int-ℕ s))) (int-ℕ (succ-ℕ x))
             by inv (associative-mul-ℤ (int-ℕ q) (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))
@@ -809,7 +809,7 @@ remainder-min-dist-succ-x-is-distance x y =
 
     dist-eqn : r ＝ dist-ℕ (mul-ℕ (add-ℕ (mul-ℕ q s) 1) (succ-ℕ x))
       (mul-ℕ (mul-ℕ q t) y)
-    dist-eqn = equational-reasoning r
+    dist-eqn = equality-reasoning r
       ＝ abs-ℤ (int-ℕ r) by (inv (abs-int-ℕ r))
       ＝ dist-ℤ (mul-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) one-ℤ) 
           (int-ℕ (succ-ℕ x)))
@@ -856,7 +856,7 @@ remainder-min-dist-succ-x-is-distance x y =
     quotient-min-dist-succ-x-nonzero iszero = contradiction-le-ℕ (succ-ℕ x) d le-x-d leq-d-x
       where
       x-r-equality : succ-ℕ x ＝ r
-      x-r-equality = equational-reasoning succ-ℕ x
+      x-r-equality = equality-reasoning succ-ℕ x
         ＝ add-ℕ (mul-ℕ q d) r by (inv (eq-euclidean-division-ℕ d (succ-ℕ x)))
         ＝ add-ℕ (mul-ℕ 0 d) r by (ap (λ H → add-ℕ (mul-ℕ H d) r) iszero)
         ＝ add-ℕ 0 r by (ap (λ H → add-ℕ H r) (left-zero-law-mul-ℕ d))
@@ -875,7 +875,7 @@ remainder-min-dist-succ-x-is-distance x y =
     min-dist-succ-x-coeff-nonzero iszero = minimal-positive-distance-nonzero (succ-ℕ x) y (tr (is-nonzero-ℕ) (inv (left-successor-law-add-ℕ x y)) (is-nonzero-succ-ℕ (add-ℕ x y))) d-is-zero
       where
       zero-addition : add-ℕ (mul-ℕ t y) d ＝ 0
-      zero-addition = equational-reasoning
+      zero-addition = equality-reasoning
         add-ℕ (mul-ℕ t y) d 
         ＝ (mul-ℕ s (succ-ℕ x))
           by rewrite-dist
@@ -897,7 +897,7 @@ remainder-min-dist-succ-x-is-distance x y =
 
     add-dist-eqn : int-ℕ d 
       ＝ add-ℤ (mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y)) (mul-ℤ (int-ℕ s) (int-ℕ (succ-ℕ x)))
-    add-dist-eqn = equational-reasoning int-ℕ d
+    add-dist-eqn = equality-reasoning int-ℕ d
       ＝ add-ℤ (neg-ℤ (int-ℕ (mul-ℕ t y))) (add-ℤ (int-ℕ (mul-ℕ t y)) (int-ℕ d)) 
       by inv (isretr-add-neg-ℤ (int-ℕ (mul-ℕ t y)) (int-ℕ d))
       ＝ add-ℤ (neg-ℤ (int-ℕ (mul-ℕ t y))) (int-ℕ (add-ℕ (mul-ℕ t y) d))
@@ -915,7 +915,7 @@ remainder-min-dist-succ-x-is-distance x y =
       (add-ℤ (mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y)) 
         (mul-ℤ (int-ℕ s) (int-ℕ (succ-ℕ x))))))
       (int-ℕ (succ-ℕ x))
-    isolate-rem-eqn = equational-reasoning int-ℕ r
+    isolate-rem-eqn = equality-reasoning int-ℕ r
       ＝ add-ℤ (neg-ℤ (mul-ℤ (int-ℕ q) (add-ℤ (mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y)) 
         (mul-ℤ ((int-ℕ s)) (int-ℕ (succ-ℕ x)))))) 
         (add-ℤ (mul-ℤ (int-ℕ q) (add-ℤ (mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y)) 
@@ -941,7 +941,7 @@ remainder-min-dist-succ-x-is-distance x y =
       ＝ add-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
         (neg-ℤ (mul-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (neg-ℤ one-ℤ))
           (int-ℕ (succ-ℕ x))))
-    rearrange-arith = equational-reasoning
+    rearrange-arith = equality-reasoning
       add-ℤ (neg-ℤ (mul-ℤ (int-ℕ q) (add-ℤ (mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y)) 
         (mul-ℤ (int-ℕ s) (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x))
       ＝ add-ℤ (neg-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))) 
@@ -1033,7 +1033,7 @@ remainder-min-dist-succ-x-is-distance x y =
     dist-eqn : r ＝ dist-ℕ 
       (mul-ℕ (abs-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (neg-ℤ one-ℤ))) (succ-ℕ x))
       (mul-ℕ (mul-ℕ q t) y)
-    dist-eqn = equational-reasoning r 
+    dist-eqn = equality-reasoning r 
       ＝ abs-ℤ (int-ℕ r) by (inv (abs-int-ℕ r))
       ＝ abs-ℤ (add-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
           (neg-ℤ (mul-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (neg-ℤ one-ℤ))
@@ -1123,7 +1123,7 @@ minimal-positive-distance-div-fst (succ-ℕ x) y = pair (quotient-euclidean-divi
   where 
   eqn : mul-ℕ (quotient-euclidean-division-ℕ (minimal-positive-distance (succ-ℕ x) y) (succ-ℕ x)) (minimal-positive-distance (succ-ℕ x) y) ＝ (succ-ℕ x)
   eqn = 
-    equational-reasoning
+    equality-reasoning
       mul-ℕ (quotient-euclidean-division-ℕ (minimal-positive-distance (succ-ℕ x) y) (succ-ℕ x)) (minimal-positive-distance (succ-ℕ x) y)
       ＝ add-ℕ (mul-ℕ (quotient-euclidean-division-ℕ (minimal-positive-distance (succ-ℕ x) y) (succ-ℕ x)) (minimal-positive-distance (succ-ℕ x) y)) zero-ℕ 
         by (inv (right-unit-law-add-ℕ (mul-ℕ (quotient-euclidean-division-ℕ (minimal-positive-distance (succ-ℕ x) y) (succ-ℕ x)) (minimal-positive-distance (succ-ℕ x) y)) ))
@@ -1203,7 +1203,7 @@ bezouts-lemma-eqn-to-int :
         (abs-ℤ (mul-ℤ (int-ℕ (minimal-positive-distance-x-coeff (abs-ℤ x) (abs-ℤ y) H)) x)) 
         (abs-ℤ (mul-ℤ (int-ℕ (minimal-positive-distance-y-coeff (abs-ℤ x) (abs-ℤ y) H)) y))
 bezouts-lemma-eqn-to-int x y H = 
-  equational-reasoning
+  equality-reasoning
     nat-gcd-ℤ x y 
     ＝ dist-ℕ (mul-ℕ (minimal-positive-distance-x-coeff (abs-ℤ x) (abs-ℤ y) H) (abs-ℤ x)) (mul-ℕ (minimal-positive-distance-y-coeff (abs-ℤ x) (abs-ℤ y) H) (abs-ℤ y)) 
       by (inv (bezouts-lemma-eqn-ℕ (abs-ℤ x) (abs-ℤ y) H))
@@ -1240,7 +1240,7 @@ bezouts-lemma-refactor-hypotheses : (x y : ℤ) → (H : is-positive-ℤ x) → 
       abs-ℤ (diff-ℤ 
         (mul-ℤ (int-ℕ (minimal-positive-distance-x-coeff (abs-ℤ x) (abs-ℤ y) (refactor-pos-cond x y H K))) x) 
         (mul-ℤ (int-ℕ (minimal-positive-distance-y-coeff (abs-ℤ x) (abs-ℤ y) (refactor-pos-cond x y H K))) y))
-bezouts-lemma-refactor-hypotheses x y H K = (equational-reasoning
+bezouts-lemma-refactor-hypotheses x y H K = (equality-reasoning
     nat-gcd-ℤ x y
     ＝ dist-ℕ 
         (abs-ℤ (mul-ℤ (int-ℕ (minimal-positive-distance-x-coeff (abs-ℤ x) (abs-ℤ y) P)) x)) 
@@ -1282,7 +1282,7 @@ bezouts-lemma-pos-ints x y H K =
     + is-nonnegative-ℤ (neg-ℤ (diff-ℤ (mul-ℤ s x) (mul-ℤ t y))))
     → Σ ℤ (λ s → Σ ℤ (λ t → add-ℤ (mul-ℤ s x) (mul-ℤ t y) ＝ gcd-ℤ x y))
   sx-ty-nonneg-case-split (inl pos) = (s , (neg-ℤ t) , 
-    inv (equational-reasoning
+    inv (equality-reasoning
       gcd-ℤ x y
       ＝ int-ℕ (abs-ℤ (diff-ℤ (mul-ℤ s x) (mul-ℤ t y)))
       by ap int-ℕ (bezouts-lemma-refactor-hypotheses x y H K)
@@ -1291,7 +1291,7 @@ bezouts-lemma-pos-ints x y H K =
       ＝ add-ℤ (mul-ℤ s x) (mul-ℤ (neg-ℤ t) y) 
       by ap (λ M → add-ℤ (mul-ℤ s x) M) (inv (left-negative-law-mul-ℤ t y))))
   sx-ty-nonneg-case-split (inr neg) = ((neg-ℤ s) , t ,
-    inv (equational-reasoning
+    inv (equality-reasoning
       gcd-ℤ x y
       ＝ int-ℕ (abs-ℤ (diff-ℤ (mul-ℤ s x) (mul-ℤ t y)))
       by ap int-ℕ (bezouts-lemma-refactor-hypotheses x y H K)
@@ -1317,7 +1317,7 @@ bezouts-lemma-ℤ (inl x) (inl y) = pair (neg-ℤ s) (pair (neg-ℤ t) eqn)
   t : ℤ 
   t = pr1 (pr2 (pos-bezout))
   eqn : add-ℤ (mul-ℤ (neg-ℤ s) (inl x)) (mul-ℤ (neg-ℤ t) (inl y)) ＝ gcd-ℤ (inl x) (inl y)
-  eqn = equational-reasoning
+  eqn = equality-reasoning
     add-ℤ (mul-ℤ (neg-ℤ s) (neg-ℤ (inr (inr x)))) (mul-ℤ (neg-ℤ t) (neg-ℤ (inr (inr y))))
     ＝ add-ℤ (mul-ℤ s (inr (inr x))) (mul-ℤ (neg-ℤ t) (neg-ℤ (inr (inr y))))
     by (ap (λ M → add-ℤ M (mul-ℤ (neg-ℤ t) (neg-ℤ (inr (inr y)))))
@@ -1330,7 +1330,7 @@ bezouts-lemma-ℤ (inl x) (inl y) = pair (neg-ℤ s) (pair (neg-ℤ t) eqn)
 bezouts-lemma-ℤ (inl x) (inr (inl star)) = pair neg-one-ℤ (pair one-ℤ eqn)
   where
   eqn : add-ℤ (mul-ℤ neg-one-ℤ (inl x)) (mul-ℤ one-ℤ (inr (inl star))) ＝ gcd-ℤ (inl x) (inr (inl star))
-  eqn = equational-reasoning
+  eqn = equality-reasoning
     add-ℤ (mul-ℤ neg-one-ℤ (inl x)) (mul-ℤ one-ℤ (inr (inl star)))
     ＝ add-ℤ (inr (inr x)) (mul-ℤ one-ℤ (inr (inl star)))
     by ap (λ M → add-ℤ M (mul-ℤ one-ℤ (inr (inl star)))) (inv (is-mul-neg-one-neg-ℤ (inl x)))
@@ -1346,7 +1346,7 @@ bezouts-lemma-ℤ (inl x) (inr (inr y)) = pair (neg-ℤ s) (pair t eqn)
   t : ℤ 
   t = pr1 (pr2 (pos-bezout))
   eqn : add-ℤ (mul-ℤ (neg-ℤ s) (inl x)) (mul-ℤ t (inr (inr y))) ＝ gcd-ℤ (inl x) (inr (inr y))
-  eqn = equational-reasoning
+  eqn = equality-reasoning
     add-ℤ (mul-ℤ (neg-ℤ s) (neg-ℤ (inr (inr x)))) (mul-ℤ t (inr (inr y)))
     ＝ add-ℤ (mul-ℤ s (inr (inr x))) (mul-ℤ t (inr (inr y)))
     by ap (λ M → add-ℤ M (mul-ℤ t (inr (inr y))))
@@ -1356,7 +1356,7 @@ bezouts-lemma-ℤ (inl x) (inr (inr y)) = pair (neg-ℤ s) (pair t eqn)
 bezouts-lemma-ℤ (inr (inl star)) (inl y) = pair one-ℤ (pair neg-one-ℤ eqn)
   where
   eqn : add-ℤ (mul-ℤ one-ℤ (inr (inl star))) (mul-ℤ neg-one-ℤ (inl y)) ＝ gcd-ℤ (inr (inl star)) (inl y)
-  eqn = equational-reasoning
+  eqn = equality-reasoning
     add-ℤ (mul-ℤ one-ℤ (inr (inl star))) (mul-ℤ neg-one-ℤ (inl y))
     ＝ add-ℤ (mul-ℤ one-ℤ (inr (inl star))) (inr (inr y))
     by ap (λ M → add-ℤ (mul-ℤ one-ℤ (inr (inl star))) M) (inv (is-mul-neg-one-neg-ℤ (inl y)))
@@ -1366,7 +1366,7 @@ bezouts-lemma-ℤ (inr (inl star)) (inl y) = pair one-ℤ (pair neg-one-ℤ eqn)
 bezouts-lemma-ℤ (inr (inl star)) (inr (inl star)) = pair one-ℤ (pair one-ℤ eqn)
   where
   eqn : add-ℤ (mul-ℤ one-ℤ (inr (inl star))) (mul-ℤ one-ℤ (inr (inl star))) ＝ gcd-ℤ zero-ℤ zero-ℤ
-  eqn = equational-reasoning
+  eqn = equality-reasoning
     add-ℤ (mul-ℤ one-ℤ (inr (inl star))) (mul-ℤ one-ℤ (inr (inl star)))
     ＝ add-ℤ zero-ℤ (mul-ℤ one-ℤ (inr (inl star))) by ap (λ M → add-ℤ M (mul-ℤ one-ℤ (inr (inl star)))) (right-zero-law-mul-ℤ one-ℤ)
     ＝ add-ℤ zero-ℤ zero-ℤ by ap (λ M → add-ℤ zero-ℤ M) (right-zero-law-mul-ℤ one-ℤ)
@@ -1374,7 +1374,7 @@ bezouts-lemma-ℤ (inr (inl star)) (inr (inl star)) = pair one-ℤ (pair one-ℤ
 bezouts-lemma-ℤ (inr (inl star)) (inr (inr y)) = pair one-ℤ (pair one-ℤ eqn)
   where
   eqn : add-ℤ (mul-ℤ one-ℤ (inr (inl star))) (mul-ℤ one-ℤ (inr (inr y))) ＝ gcd-ℤ (inr (inl star)) (inr (inr y))
-  eqn = equational-reasoning
+  eqn = equality-reasoning
     add-ℤ (mul-ℤ one-ℤ (inr (inl star))) (mul-ℤ one-ℤ (inr (inr y)))
     ＝ add-ℤ (mul-ℤ one-ℤ (inr (inl star))) (inr (inr y))
     by ap (λ M → add-ℤ (mul-ℤ one-ℤ (inr (inl star))) M) (inv (left-unit-law-mul-ℤ (inr (inr y))))
@@ -1390,7 +1390,7 @@ bezouts-lemma-ℤ (inr (inr x)) (inl y) = pair s (pair (neg-ℤ t) eqn)
   t : ℤ 
   t = pr1 (pr2 (pos-bezout))
   eqn : add-ℤ (mul-ℤ s (inr (inr x))) (mul-ℤ (neg-ℤ t) (inl y)) ＝ gcd-ℤ (inr (inr x)) (inl y)
-  eqn = equational-reasoning
+  eqn = equality-reasoning
     add-ℤ (mul-ℤ s (inr (inr x))) (mul-ℤ (neg-ℤ t) (neg-ℤ (inr (inr y))))
     ＝ add-ℤ (mul-ℤ s (inr (inr x))) (mul-ℤ t (inr (inr y)))
     by ap (λ M → add-ℤ (mul-ℤ s (inr (inr x))) M)
@@ -1400,7 +1400,7 @@ bezouts-lemma-ℤ (inr (inr x)) (inl y) = pair s (pair (neg-ℤ t) eqn)
 bezouts-lemma-ℤ (inr (inr x)) (inr (inl star)) = pair one-ℤ (pair one-ℤ eqn)
   where
   eqn : add-ℤ (mul-ℤ one-ℤ (inr (inr x))) (mul-ℤ one-ℤ (inr (inl star))) ＝ gcd-ℤ (inr (inr x)) (inr (inl star))
-  eqn = equational-reasoning
+  eqn = equality-reasoning
     add-ℤ (mul-ℤ one-ℤ (inr (inr x))) (mul-ℤ one-ℤ (inr (inl star)))
     ＝ add-ℤ (inr (inr x)) (mul-ℤ one-ℤ (inr (inl star)))
     by ap (λ M → add-ℤ M (mul-ℤ one-ℤ (inr (inl star)))) (left-unit-law-mul-ℤ (inr (inr x)))
@@ -1430,17 +1430,17 @@ div-right-factor-coprime-ℤ x y z H K = pair (add-ℤ (mul-ℤ s z) (mul-ℤ t 
   div-yz : mul-ℤ k x ＝ mul-ℤ y z
   div-yz = pr2 H 
   eqn : mul-ℤ (add-ℤ (mul-ℤ s z) (mul-ℤ t k)) x ＝ z
-  eqn = equational-reasoning 
+  eqn = equality-reasoning 
     mul-ℤ (add-ℤ (mul-ℤ s z) (mul-ℤ t k)) x
     ＝ add-ℤ (mul-ℤ (mul-ℤ s z) x) (mul-ℤ (mul-ℤ t k) x) by right-distributive-mul-add-ℤ (mul-ℤ s z) (mul-ℤ t k) x
     ＝ add-ℤ (mul-ℤ (mul-ℤ s x) z) (mul-ℤ (mul-ℤ t k) x) by ap (λ M → add-ℤ M (mul-ℤ (mul-ℤ t k) x))
-      (equational-reasoning
+      (equality-reasoning
         mul-ℤ (mul-ℤ s z) x
         ＝ mul-ℤ s (mul-ℤ z x) by associative-mul-ℤ s z x
         ＝ mul-ℤ s (mul-ℤ x z) by ap (λ P → mul-ℤ s P) (commutative-mul-ℤ z x)
         ＝ mul-ℤ (mul-ℤ s x) z by inv (associative-mul-ℤ s x z))
     ＝ add-ℤ (mul-ℤ (mul-ℤ s x) z) (mul-ℤ (mul-ℤ t y) z) by ap (λ M → add-ℤ (mul-ℤ (mul-ℤ s x) z) M) 
-    (equational-reasoning
+    (equality-reasoning
       mul-ℤ (mul-ℤ t k) x
       ＝ mul-ℤ t (mul-ℤ k x) by associative-mul-ℤ t k x
       ＝ mul-ℤ t (mul-ℤ y z) by ap (λ P → mul-ℤ t P) div-yz

--- a/src/elementary-number-theory/distance-integers.lagda.md
+++ b/src/elementary-number-theory/distance-integers.lagda.md
@@ -51,15 +51,15 @@ dist-int-ℕ (succ-ℕ x) (succ-ℕ y) =
 dist-abs-ℤ : 
   (x y : ℤ) → (H : is-nonnegative-ℤ x) → (K : is-nonnegative-ℤ y)
     → dist-ℕ (abs-ℤ x) (abs-ℤ y) ＝ dist-ℤ x y
-dist-abs-ℤ (inr (inl star)) y H K = equational-reasoning
+dist-abs-ℤ (inr (inl star)) y H K = equality-reasoning
   dist-ℕ 0 (abs-ℤ y)
   ＝ abs-ℤ y by left-unit-law-dist-ℕ (abs-ℤ y)
   ＝ dist-ℤ (zero-ℤ) y by inv (left-zero-law-dist-ℤ y)
-dist-abs-ℤ (inr (inr x)) (inr (inl star)) H K = equational-reasoning
+dist-abs-ℤ (inr (inr x)) (inr (inl star)) H K = equality-reasoning
   dist-ℕ (abs-ℤ (inr (inr x))) 0
   ＝ succ-ℕ x by right-unit-law-dist-ℕ (abs-ℤ (inr (inr x)))
   ＝ dist-ℤ (inr (inr x)) zero-ℤ by inv (right-zero-law-dist-ℤ (inr (inr x)))
-dist-abs-ℤ (inr (inr x)) (inr (inr y)) H K = equational-reasoning
+dist-abs-ℤ (inr (inr x)) (inr (inr y)) H K = equality-reasoning
   dist-ℕ (succ-ℕ x) (succ-ℕ y) 
   ＝ dist-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ (succ-ℕ y)) by inv (dist-int-ℕ (succ-ℕ x) (succ-ℕ y)) 
 ```

--- a/src/elementary-number-theory/divisibility-integers.lagda.md
+++ b/src/elementary-number-theory/divisibility-integers.lagda.md
@@ -156,7 +156,7 @@ pr2 (div-neg-ℤ x y (pair d p)) = left-negative-law-mul-ℤ d x ∙ ap neg-ℤ 
 neg-div-ℤ : (x y : ℤ) → div-ℤ x y → div-ℤ (neg-ℤ x) y
 pr1 (neg-div-ℤ x y (pair d p)) = neg-ℤ d
 pr2 (neg-div-ℤ x y (pair d p)) =
-  equational-reasoning
+  equality-reasoning
     mul-ℤ (neg-ℤ d) (neg-ℤ x)
     ＝ neg-ℤ (mul-ℤ d (neg-ℤ x))   by left-negative-law-mul-ℤ d (neg-ℤ x)
     ＝ neg-ℤ (neg-ℤ (mul-ℤ d x))   by ap neg-ℤ (right-negative-law-mul-ℤ d x)
@@ -587,11 +587,11 @@ is-plus-or-minus-sim-unit-ℤ {x} {y} H | inl z = inl (z ∙ inv (is-zero-sim-un
 is-plus-or-minus-sim-unit-ℤ {x} {y} H | inr nz with ( is-one-or-neg-one-is-unit-ℤ
         (int-unit-ℤ (pr1 (H (λ - → nz (pr1 -)))))
         (is-unit-int-unit-ℤ (pr1 (H (λ - → nz (pr1 -))))) ) 
-is-plus-or-minus-sim-unit-ℤ {x} {y} H | inr nz | inl pos = inl (equational-reasoning
+is-plus-or-minus-sim-unit-ℤ {x} {y} H | inr nz | inl pos = inl (equality-reasoning
          x  ＝ mul-ℤ one-ℤ x                             by (inv (left-unit-law-mul-ℤ x))
             ＝ mul-ℤ (int-unit-ℤ (pr1 (H (λ - → nz (pr1 -))))) x by inv (ap (λ - → mul-ℤ - x) pos)
             ＝ y                                         by pr2 (H (λ - → nz (pr1 -))))
-is-plus-or-minus-sim-unit-ℤ {x} {y} H | inr nz | inr neg = inr (equational-reasoning
+is-plus-or-minus-sim-unit-ℤ {x} {y} H | inr nz | inr neg = inr (equality-reasoning
          neg-ℤ x
          ＝ mul-ℤ (int-unit-ℤ (pr1 (H (λ - → nz (pr1 -))))) x by tr (λ - → neg-ℤ x ＝ mul-ℤ - x)
                                                            (inv neg)
@@ -610,7 +610,7 @@ eq-sim-unit-is-nonnegative-ℤ {a} {b} H H' K with
 eq-sim-unit-is-nonnegative-ℤ {a} {b} H H' K | inl pos = pos
 eq-sim-unit-is-nonnegative-ℤ {a} {b} H H' K | inr neg with ( is-decidable-is-zero-ℤ a )
 eq-sim-unit-is-nonnegative-ℤ {a} {b} H H' K | inr neg | inl z = 
-  equational-reasoning
+  equality-reasoning
     a ＝ zero-ℤ   by z
       ＝ neg-ℤ a  by inv (ap neg-ℤ z)
       ＝ b        by neg 

--- a/src/elementary-number-theory/multiplication-integers.lagda.md
+++ b/src/elementary-number-theory/multiplication-integers.lagda.md
@@ -332,7 +332,7 @@ is-mul-neg-one-neg-ℤ' x =
   is-mul-neg-one-neg-ℤ x ∙ commutative-mul-ℤ neg-one-ℤ x
 
 double-negative-law-mul-ℤ : (k l : ℤ) → mul-ℤ (neg-ℤ k) (neg-ℤ l) ＝ mul-ℤ k l
-double-negative-law-mul-ℤ k l = equational-reasoning
+double-negative-law-mul-ℤ k l = equality-reasoning
   mul-ℤ (neg-ℤ k) (neg-ℤ l)
   ＝ neg-ℤ (mul-ℤ k (neg-ℤ l))
     by left-negative-law-mul-ℤ k (neg-ℤ l)

--- a/src/elementary-number-theory/rational-numbers.lagda.md
+++ b/src/elementary-number-theory/rational-numbers.lagda.md
@@ -266,7 +266,7 @@ is-reduced-reduce-fraction-ℤ x =
 
 
 sim-reduced-fraction-ℤ : (x : fraction-ℤ) → (sim-fraction-ℤ x (reduce-fraction-ℤ x))
-sim-reduced-fraction-ℤ x = equational-reasoning
+sim-reduced-fraction-ℤ x = equality-reasoning
   mul-ℤ (numerator-fraction-ℤ x) (denominator-fraction-ℤ (reduce-fraction-ℤ x))
   ＝ mul-ℤ (mul-ℤ (numerator-fraction-ℤ (reduce-fraction-ℤ x))
       (gcd-ℤ (numerator-fraction-ℤ x) (denominator-fraction-ℤ x)))
@@ -380,7 +380,7 @@ unique-numerator-reduce-fraction-ℤ x y H =
       reduced-eqn : 
         mul-ℤ (int-reduce-numerator-fraction-ℤ x) (int-reduce-denominator-fraction-ℤ y) 
         ＝ mul-ℤ (int-reduce-numerator-fraction-ℤ x) (mul-ℤ neg-one-ℤ (int-reduce-denominator-fraction-ℤ x))  
-      reduced-eqn = equational-reasoning
+      reduced-eqn = equality-reasoning
         mul-ℤ (int-reduce-numerator-fraction-ℤ x) (int-reduce-denominator-fraction-ℤ y)
         ＝ mul-ℤ (int-reduce-numerator-fraction-ℤ y) (int-reduce-denominator-fraction-ℤ x) 
         by reduce-preserves-sim-ℤ x y H
@@ -397,7 +397,7 @@ unique-numerator-reduce-fraction-ℤ x y H =
       y-nat = pr1 (lem (int-reduce-denominator-fraction-ℤ y) (is-positive-int-reduce-denominator-fraction-ℤ y)) 
   
       contra : inr (inr y-nat) ＝ neg-ℤ (inr (inr x-nat))
-      contra = equational-reasoning
+      contra = equality-reasoning
         inr (inr y-nat)
         ＝ (int-reduce-denominator-fraction-ℤ y)
         by inv (pr2 (lem (int-reduce-denominator-fraction-ℤ y) (is-positive-int-reduce-denominator-fraction-ℤ y)))

--- a/src/foundation/equational-reasoning.lagda.md
+++ b/src/foundation/equational-reasoning.lagda.md
@@ -171,35 +171,32 @@ logical-equivalence-reasoning
 
 ### Equational reasoning for preorders
 
-Note: In an equational reasoning argument, the preorder is always specified at the last step. So do we really need to specify it at each of the earlier steps?
-
 ```agda
-private
-  transitivity :
-    {l1 l2 : Level} (X : Preorder l1 l2)
-    (x : element-Preorder X) {y z : element-Preorder X} →
-    leq-Preorder X x y → leq-Preorder X y z → leq-Preorder X x z
-  transitivity X x {y} {z} u v = transitive-leq-Preorder X x y z v u
+preorder_reasoning_ :
+  {l1 l2 : Level} (X : Preorder l1 l2) (x : element-Preorder X) →
+  leq-Preorder X x x
+preorder_reasoning_ = refl-leq-Preorder
 
-syntax transitivity X x u v = x ≤ X by u to v
-infixr 0 transitivity
+step-preorder-reasoning :
+  {l1 l2 : Level} (X : Preorder l1 l2)
+  {x y : element-Preorder X} → leq-Preorder X x y →
+  (z : element-Preorder X) → leq-Preorder X y z → leq-Preorder X x z
+step-preorder-reasoning X {x} {y} u z v =
+  transitive-leq-Preorder X x y z v u
 
-private
-  reflexivity :
-    {l1 l2 : Level} (X : Preorder l1 l2) (x : element-Preorder X) →
-    leq-Preorder X x x
-  reflexivity = refl-leq-Preorder
+syntax step-preorder-reasoning X u z v = u ≤ z by v inside X
 
-syntax reflexivity X x = x ∎ X
-infix 1 reflexivity
+infixl 1 preorder_reasoning_
+infixl 0 step-preorder-reasoning
 ```
 
 For a preorder `X` we thus write the chains as follows
 
 ```md
-x ≤ X by ineq-1 to
-y ≤ X by ineq-2 to
-z ∎ X
+preorder X reasoning
+  x ≤ y by ineq-1 inside X
+    ≤ z by ineq-2 inside X
+    ≤ v by ineq-3 inside X
 ```
 
 ## References

--- a/src/foundation/equational-reasoning.lagda.md
+++ b/src/foundation/equational-reasoning.lagda.md
@@ -74,7 +74,7 @@ syntax step-equality-reasoning p z q = p ＝ z by q
 For equalities we thus write the chains as follows
 
 ```md
-equational-reasoning
+equality-reasoning
   x ＝ y by eq-1
     ＝ z by eq-2
     ＝ v by eq-3

--- a/src/foundation/equational-reasoning.lagda.md
+++ b/src/foundation/equational-reasoning.lagda.md
@@ -26,7 +26,7 @@ open import order-theory.preorders using
 
 ## Idea
 
-Often it's convenient to reason by chains of (in)equalities or equivalences,
+Often it is convenient to reason by chains of (in)equalities or equivalences,
 i.e., to write a proof in the following form:
 
 ```md
@@ -56,21 +56,19 @@ reasoning for equalities and equivalences is based on Martín Escardó's Agda co
 ### Equational reasoning for identifications
 
 ```agda
-module _
-  {l : Level} {X : UU l}
-  where
+infixl 1 equational-reasoning_
+infixl 0 step-equational-reasoning
 
-  infixl 1 equational-reasoning_
-  infixl 0 step-equational-reasoning
+equational-reasoning_ :
+  {l : Level} {X : UU l} (x : X) → x ＝ x
+equational-reasoning x = refl
 
-  equational-reasoning_ : (x : X) → x ＝ x
-  equational-reasoning x = refl
+step-equational-reasoning :
+  {l : Level} {X : UU l} {x y : X} →
+  (x ＝ y) → (u : X) → (y ＝ u) → (x ＝ u)
+step-equational-reasoning p z q = p ∙ q
 
-  step-equational-reasoning :
-    {x y : X} → (x ＝ y) → (u : X) → (y ＝ u) → (x ＝ u)
-  step-equational-reasoning p z q = p ∙ q
-
-  syntax step-equational-reasoning p z q = p ＝ z by q
+syntax step-equational-reasoning p z q = p ＝ z by q
 ```
 
 For equalities we thus write the chains as follows
@@ -85,21 +83,21 @@ equational-reasoning
 ### Equational reasoning for function homotopies
 
 ```agda
-module _
+infixl 1 homotopy-reasoning_
+infixl 0 step-homotopy-reasoning
+
+homotopy-reasoning_ :
   {l1 l2 : Level} {X : UU l1} {Y : X → UU l2}
-  where
+  (f : (x : X) → Y x) → f ~ f
+homotopy-reasoning f = refl-htpy
 
-  infixl 1 homotopy-reasoning_
-  infixl 0 step-homotopy-reasoning
+step-homotopy-reasoning :
+  {l1 l2 : Level} {X : UU l1} {Y : X → UU l2}
+  {f g : (x : X) → Y x} → (f ~ g) →
+  (h : (x : X) → Y x) → (g ~ h) → (f ~ h)
+step-homotopy-reasoning p h q = p ∙h q
 
-  homotopy-reasoning_ : (f : (x : X) → Y x) → f ~ f
-  homotopy-reasoning f = refl-htpy
-
-  step-homotopy-reasoning :
-    {f g : (x : X) → Y x} → (f ~ g) → (h : (x : X) → Y x) → (g ~ h) → (f ~ h)
-  step-homotopy-reasoning p h q = p ∙h q
-
-  syntax step-homotopy-reasoning p h q = p ~ h by q
+syntax step-homotopy-reasoning p h q = p ~ h by q
 ```
 
 For function homotopies we thus write the chains as follows
@@ -117,7 +115,8 @@ homotopy-reasoning
 infixl 1 equivalence-reasoning_
 infixl 0 step-equivalence-reasoning
 
-equivalence-reasoning_ : {l1 : Level} (X : UU l1) → X ≃ X
+equivalence-reasoning_ :
+  {l1 : Level} (X : UU l1) → X ≃ X
 equivalence-reasoning X = id-equiv
 
 step-equivalence-reasoning :
@@ -143,7 +142,8 @@ equivalence-reasoning
 infixl 1 logical-equivalence-reasoning_
 infixl 0 step-logical-equivalence-reasoning
 
-logical-equivalence-reasoning_ : {l1 : Level} (X : UU l1) → X ↔ X
+logical-equivalence-reasoning_ :
+  {l1 : Level} (X : UU l1) → X ↔ X
 logical-equivalence-reasoning X = pair id id
 
 step-logical-equivalence-reasoning :
@@ -166,9 +166,12 @@ logical-equivalence-reasoning
 ### Equational reasoning for preorders
 
 ```agda
+infixl 1 preorder_reasoning_
+infixl 0 step-preorder-reasoning
+
 preorder_reasoning_ :
-  {l1 l2 : Level} (X : Preorder l1 l2) (x : element-Preorder X) →
-  leq-Preorder X x x
+  {l1 l2 : Level} (X : Preorder l1 l2)
+  (x : element-Preorder X) → leq-Preorder X x x
 preorder_reasoning_ = refl-leq-Preorder
 
 step-preorder-reasoning :
@@ -179,9 +182,6 @@ step-preorder-reasoning X {x} {y} u z v =
   transitive-leq-Preorder X x y z v u
 
 syntax step-preorder-reasoning X u z v = u ≤ z by v inside X
-
-infixl 1 preorder_reasoning_
-infixl 0 step-preorder-reasoning
 ```
 
 For a preorder `X` we thus write the chains as follows

--- a/src/foundation/equational-reasoning.lagda.md
+++ b/src/foundation/equational-reasoning.lagda.md
@@ -40,7 +40,7 @@ or
 ```md
 x ≤ a by ineq-1 inside X
   ≤ b by ineq-2 inside X
-  ≤ c by ineq-3 inside X
+  ≤ c by ineq-3 inside X∎
 ```
 
 where `equiv-x` and `ineq-x` are proofs of respectively the equivalences or
@@ -56,19 +56,19 @@ reasoning for equalities and equivalences is based on Martín Escardó's Agda co
 ### Equational reasoning for identifications
 
 ```agda
-infixl 1 equational-reasoning_
-infixl 0 step-equational-reasoning
+infixl 1 equality-reasoning_
+infixl 0 step-equality-reasoning
 
-equational-reasoning_ :
+equality-reasoning_ :
   {l : Level} {X : UU l} (x : X) → x ＝ x
-equational-reasoning x = refl
+equality-reasoning x = refl
 
-step-equational-reasoning :
+step-equality-reasoning :
   {l : Level} {X : UU l} {x y : X} →
   (x ＝ y) → (u : X) → (y ＝ u) → (x ＝ u)
-step-equational-reasoning p z q = p ∙ q
+step-equality-reasoning p z q = p ∙ q
 
-syntax step-equational-reasoning p z q = p ＝ z by q
+syntax step-equality-reasoning p z q = p ＝ z by q
 ```
 
 For equalities we thus write the chains as follows

--- a/src/foundation/equational-reasoning.lagda.md
+++ b/src/foundation/equational-reasoning.lagda.md
@@ -36,21 +36,15 @@ X ≃ A by equiv-1
 ```
 
 or
+
 ```md
-x ≤ X by ineq-1 to
-a ≤ X by ineq-2 to
-b ≤ X by ineq-3 to
-c ∎ X
+x ≤ a by ineq-1 inside X
+  ≤ b by ineq-2 inside X
+  ≤ c by ineq-3 inside X
 ```
 
 where `equiv-x` and `ineq-x` are proofs of respectively the equivalences or
-inequalities. The symbol ∎ marks the end of a chain.
-
-Because we will want to have equational reasoning for both identifications and
-equivalences and we can't use the same symbol twice, we use ∎ for
-identifications and ■ for equivalences in the code below.
-
-For inequalities we also need to pass the preorder as an argument.
+inequalities. Note that for inequalities we also need to pass the preorder as an argument.
 
 We write Agda code that allows for such reasoning. The code for equational
 reasoning for equalities and equivalences is based on Martín Escardó's Agda code

--- a/src/group-theory/commutators-groups.lagda.md
+++ b/src/group-theory/commutators-groups.lagda.md
@@ -92,7 +92,7 @@ module _
 
   inv-Commutator-law' : ∀ x y → inv-Group G (commutator-Group G x y) ＝ commutator-Group G y x
   inv-Commutator-law' x y =
-    equational-reasoning
+    equality-reasoning
       ( commutator-Group G x y) ⁻¹
         ＝ y * x * y ⁻¹ * x ⁻¹       by simplifyExpr G (x ∷ y ∷ empty-vec) (λ x y → gInv (gCommutator x y))
         ＝ commutator-Group G y x    by inv (simplifyExpr G (x ∷ y ∷ empty-vec) (λ x y → gCommutator y x))
@@ -105,7 +105,7 @@ module _
   commutes-when-commutor-is-unit' :
     ∀ x y → (commutator-Group G x y ＝ unit-Group G) → mul-Group G x y ＝ mul-Group G y x
   commutes-when-commutor-is-unit' x y comm-unit =
-    equational-reasoning
+    equality-reasoning
       x * y ＝ commutator-Group G x y * y * x    by inv (simplifyExpr G (x ∷ y ∷ empty-vec) (λ x y → (gCommutator x y *' y *' x)))
             ＝ unit * y * x                      by ap (λ z → z * y * x) comm-unit
             ＝ y * x                             by simplifyExpr G (x ∷ y ∷ empty-vec) (λ x y → (gUnit *' y *' x))
@@ -113,7 +113,7 @@ module _
   commutor-is-unit-when-commutes' :
     ∀ x y → (mul-Group G x y ＝ mul-Group G y x) → commutator-Group G x y ＝ unit-Group G
   commutor-is-unit-when-commutes' x y commutes =
-    equational-reasoning
+    equality-reasoning
       x * y * (y * x) ⁻¹ ＝ y * x * (y * x) ⁻¹    by ap (λ z → z * (y * x) ⁻¹) commutes
                          ＝ unit                  by simplifyExpr G (x ∷ y ∷ empty-vec) (λ x y → (y *' x *' gInv (y *' x)))
 ```

--- a/src/group-theory/groups.lagda.md
+++ b/src/group-theory/groups.lagda.md
@@ -374,7 +374,7 @@ module _
   inv-left-div-Group :
     (x y : type-Group) → inv-Group (left-div-Group x y) ＝ left-div-Group y x
   inv-left-div-Group x y =
-    equational-reasoning
+    equality-reasoning
       inv-Group (left-div-Group x y)
         ＝ left-div-Group y (inv-Group (inv-Group x))    by distributive-inv-mul-Group (inv-Group x) y
         ＝ left-div-Group y x                            by ap (left-div-Group y) (inv-inv-Group x)
@@ -386,7 +386,7 @@ module _
   inv-right-div-Group :
     (x y : type-Group) → inv-Group (right-div-Group x y) ＝ right-div-Group y x
   inv-right-div-Group x y =
-    equational-reasoning
+    equality-reasoning
       inv-Group (right-div-Group x y)
         ＝ right-div-Group (inv-Group (inv-Group y)) x   by distributive-inv-mul-Group x (inv-Group y)
         ＝ right-div-Group y x                           by ap (mul-Group' (inv-Group x)) (inv-inv-Group y)
@@ -399,7 +399,7 @@ module _
     (x y z : type-Group) →
     mul-Group (left-div-Group x y) (left-div-Group y z) ＝ left-div-Group x z
   mul-left-div-Group x y z =
-    equational-reasoning
+    equality-reasoning
       mul-Group (left-div-Group x y) (left-div-Group y z)
       ＝ mul-Group (inv-Group x) (mul-Group y (left-div-Group y z))
         by associative-mul-Group (inv-Group x) y (left-div-Group y z)
@@ -414,7 +414,7 @@ module _
     (x y z : type-Group) →
     mul-Group (right-div-Group x y) (right-div-Group y z) ＝ right-div-Group x z
   mul-right-div-Group x y z =
-    equational-reasoning
+    equality-reasoning
       mul-Group (right-div-Group x y) (right-div-Group y z)
       ＝ mul-Group x (mul-Group (inv-Group y) (right-div-Group y z))
         by associative-mul-Group x (inv-Group y) (right-div-Group y z)
@@ -443,7 +443,7 @@ abstract
           ( Π-Prop (type-Set G) (λ x → Id-Prop G (μ x (i x)) e)))
       ( eq-htpy
         ( λ x →
-          equational-reasoning
+          equality-reasoning
           i x ＝ μ e (i x)            by inv (left-unit-G (i x)) 
               ＝ μ (μ (i' x) x) (i x) by ap (λ y → μ y (i x)) (inv (left-inv-i' x))
               ＝ μ (i' x) (μ x (i x)) by assoc-G (i' x) x (i x)

--- a/src/ring-theory/ideals-rings.lagda.md
+++ b/src/ring-theory/ideals-rings.lagda.md
@@ -258,7 +258,7 @@ module _
   pr2 normal-subgroup-two-sided-ideal-Ring x (y , H) =
     tr
       ( is-in-two-sided-ideal-Ring)
-      ( equational-reasoning
+      ( equality-reasoning
         y
         ＝ add-Ring R y (zero-Ring R)                 by inv (right-unit-law-add-Ring R y)
         ＝ add-Ring R y (add-Ring R x (neg-Ring R x)) by inv (ap (add-Ring R y) (right-inverse-law-add-Ring R x))


### PR DESCRIPTION
I suspect this change is somewhat controversial as this syntax is already in wide usage, but the phrasing `equality-reasoning_` is more consistent with its variants, hence the suggestion.

Compare "equational reasoning" to "equivalence reasoning", "logical equivalence reasoning", "homotopy reasoning" and "preorder reasoning", as opposed to "equality reasoning" or "identity reasoning".

Changes the syntax

```agda
equational-reasoning
  x ＝ y by eq-1
    ＝ z by eq-2
    ＝ v by eq-3
```

to

```agda
equality-reasoning
  x ＝ y by eq-1
    ＝ z by eq-2
    ＝ v by eq-3
```
