### PR TITLE
reorganize `section-comp` and variants

### DIFF
--- a/src/foundation-core/equality-fibers-of-maps.lagda.md
+++ b/src/foundation-core/equality-fibers-of-maps.lagda.md
@@ -11,7 +11,7 @@ open import foundation-core.dependent-pair-types using (Σ; pair; pr1; pr2)
 open import foundation-core.equality-dependent-pair-types using
   ( pair-eq-Σ; is-equiv-pair-eq-Σ)
 open import foundation-core.equivalences using
-  ( is-fiberwise-equiv; is-equiv-comp; is-equiv; _≃_)
+  ( is-fiberwise-equiv; is-equiv-comp-htpy; is-equiv-comp; is-equiv; _≃_)
 open import foundation-core.fibers-of-maps using (fib)
 open import foundation-core.functions using (_∘_)
 open import foundation-core.functoriality-dependent-pair-types using
@@ -54,10 +54,8 @@ module _
       (s t : fib f b) → is-fiberwise-equiv (fib-ap-eq-fib-fiberwise s t)
     is-fiberwise-equiv-fib-ap-eq-fib-fiberwise (pair x y) (pair .x refl) refl =
       is-equiv-comp
-        ( fib-ap-eq-fib-fiberwise (pair x y) (pair x refl) refl)
         ( inv)
         ( concat right-unit refl)
-        ( refl-htpy)
         ( is-equiv-concat right-unit refl)
         ( is-equiv-inv (y ∙ refl) refl)
 
@@ -76,7 +74,7 @@ module _
   abstract
     is-equiv-fib-ap-eq-fib : (s t : fib f b) → is-equiv (fib-ap-eq-fib s t)
     is-equiv-fib-ap-eq-fib s t =
-      is-equiv-comp
+      is-equiv-comp-htpy
         ( fib-ap-eq-fib s t)
         ( tot (fib-ap-eq-fib-fiberwise s t))
         ( pair-eq-Σ {s = s} {t})
@@ -105,10 +103,8 @@ module _
       (q : (f x) ＝ (f y)) → is-equiv (eq-fib-fib-ap q)
     is-equiv-eq-fib-fib-ap q =
       is-equiv-comp
-        ( eq-fib-fib-ap q)
         ( tr (fib (ap f)) right-unit)
         ( fib-ap-eq-fib f (pair x q) (pair y refl))
-        ( refl-htpy)
         ( is-equiv-fib-ap-eq-fib f (pair x q) (pair y refl))
         ( is-equiv-tr (fib (ap f)) right-unit)
 ```

--- a/src/foundation-core/equivalence-induction.lagda.md
+++ b/src/foundation-core/equivalence-induction.lagda.md
@@ -57,8 +57,8 @@ module _
       (P : (Σ (UU l1) (λ X → A ≃ X)) → UU l) → IND-EQUIV (λ B e → P (pair B e))
     IND-EQUIV-is-contr-total-equiv c P =
       section-left-factor
-        ( ev-pair)
         ( ev-id (λ X e → P (pair X e)))
+        ( ev-pair)
         ( is-singleton-is-contr
           ( pair A id-equiv)
           ( pair
@@ -79,8 +79,8 @@ module _
         ( Σ (UU l1) (λ X → A ≃ X))
         ( pair A id-equiv)
         ( λ P → section-comp
-          ( ev-pair {A = UU l1} {B = λ X → A ≃ X} {C = P})
           ( ev-id (λ X e → P (pair X e)))
+          ( ev-pair {A = UU l1} {B = λ X → A ≃ X} {C = P})
           ( pair ind-Σ refl-htpy)
           ( ind P))
 ```

--- a/src/foundation-core/equivalence-induction.lagda.md
+++ b/src/foundation-core/equivalence-induction.lagda.md
@@ -15,7 +15,7 @@ open import foundation-core.functions using (ev-pt; _∘_; id)
 open import foundation-core.homotopies using (_~_; refl-htpy)
 open import foundation-core.identity-types using (refl; inv; _∙_)
 open import foundation-core.sections using
-  ( sec; section-comp; section-comp')
+  ( sec; section-comp; section-left-factor)
 open import foundation-core.singleton-induction using
   ( is-singleton-is-contr; is-contr-is-singleton)
 open import foundation-core.universe-levels using (Level; UU)
@@ -56,12 +56,9 @@ module _
       {l : Level} →
       (P : (Σ (UU l1) (λ X → A ≃ X)) → UU l) → IND-EQUIV (λ B e → P (pair B e))
     IND-EQUIV-is-contr-total-equiv c P =
-      section-comp
-        ( ev-pt (pair A id-equiv) P)
-        ( ev-id (λ X e → P (pair X e)))
+      section-left-factor
         ( ev-pair)
-        ( triangle-ev-id P)
-        ( pair ind-Σ refl-htpy)
+        ( ev-id (λ X e → P (pair X e)))
         ( is-singleton-is-contr
           ( pair A id-equiv)
           ( pair
@@ -81,11 +78,9 @@ module _
       is-contr-is-singleton
         ( Σ (UU l1) (λ X → A ≃ X))
         ( pair A id-equiv)
-        ( λ P → section-comp'
-          ( ev-pt (pair A id-equiv) P)
-          ( ev-id (λ X e → P (pair X e)))
+        ( λ P → section-comp
           ( ev-pair {A = UU l1} {B = λ X → A ≃ X} {C = P})
-          ( triangle-ev-id P)
+          ( ev-id (λ X e → P (pair X e)))
           ( pair ind-Σ refl-htpy)
           ( ind P))
 ```

--- a/src/foundation-core/equivalence-induction.lagda.md
+++ b/src/foundation-core/equivalence-induction.lagda.md
@@ -10,12 +10,12 @@ module foundation-core.equivalence-induction where
 open import foundation-core.contractible-types using (is-contr; contraction)
 open import foundation-core.dependent-pair-types using
   ( Σ; pair; pr1; pr2; ev-pair; ind-Σ)
-open import foundation-core.equivalences using
-  ( _≃_; id-equiv; section-comp; section-comp')
+open import foundation-core.equivalences using (_≃_; id-equiv)
 open import foundation-core.functions using (ev-pt; _∘_; id)
 open import foundation-core.homotopies using (_~_; refl-htpy)
 open import foundation-core.identity-types using (refl; inv; _∙_)
-open import foundation-core.sections using (sec)
+open import foundation-core.sections using
+  ( sec; section-comp; section-comp')
 open import foundation-core.singleton-induction using
   ( is-singleton-is-contr; is-contr-is-singleton)
 open import foundation-core.universe-levels using (Level; UU)

--- a/src/foundation-core/equivalences.lagda.md
+++ b/src/foundation-core/equivalences.lagda.md
@@ -328,11 +328,10 @@ module _
   is-equiv-htpy-equiv' e H =
     is-equiv-htpy' (map-equiv e) H (is-equiv-map-equiv e)
 
-  -- Note: This should probably be called `htpy-map-inv-is-equiv`
-  inv-htpy-is-equiv :
+  htpy-map-inv-is-equiv :
     {f g : A → B} (G : f ~ g) (H : is-equiv f) (K : is-equiv g) →
     (map-inv-is-equiv H) ~ (map-inv-is-equiv K)
-  inv-htpy-is-equiv G H K b =
+  htpy-map-inv-is-equiv G H K b =
     ( inv
       ( isretr-map-inv-is-equiv K (map-inv-is-equiv H b))) ∙
     ( ap (map-inv-is-equiv K)

--- a/src/foundation-core/equivalences.lagda.md
+++ b/src/foundation-core/equivalences.lagda.md
@@ -18,8 +18,8 @@ open import foundation-core.homotopies using
 open import foundation-core.identity-types using
   ( _＝_; refl; inv; _∙_; ap; ap-concat; ap-binary; ap-inv; ap-id; ap-comp;
     inv-con; left-inv)
-open import foundation-core.retractions using (retr)
-open import foundation-core.sections using (sec)
+open import foundation-core.retractions
+open import foundation-core.sections
 open import foundation-core.universe-levels using (Level; UU; _⊔_)
 ```
 
@@ -205,19 +205,6 @@ module _
   (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
   where
 
-  triangle-section : (S : sec h) → g ~ (f ∘ (pr1 S))
-  triangle-section (pair s issec) = inv-htpy ((H ·r s) ∙h (g ·l issec))
-
-  section-comp : sec h → sec f → sec g
-  pr1 (section-comp sec-h sec-f) = h ∘ (pr1 sec-f)
-  pr2 (section-comp sec-h sec-f) = (inv-htpy (H ·r (pr1 sec-f))) ∙h (pr2 sec-f)
-  
-  section-comp' : sec h → sec g → sec f
-  pr1 (section-comp' sec-h sec-g) = (pr1 sec-h) ∘ (pr1 sec-g)
-  pr2 (section-comp' sec-h sec-g) =
-    ( H ·r ((pr1 sec-h) ∘ (pr1 sec-g))) ∙h
-    ( ( g ·l ((pr2 sec-h) ·r (pr1 sec-g))) ∙h ((pr2 sec-g)))
-
   triangle-retraction : (R : retr g) → h ~ ((pr1 R) ∘ f)
   triangle-retraction (pair r isretr) = inv-htpy ((r ·l H) ∙h (isretr ·r h))
 
@@ -235,7 +222,7 @@ module _
   abstract
     is-equiv-comp : is-equiv h → is-equiv g → is-equiv f
     pr1 (is-equiv-comp (pair sec-h retr-h) (pair sec-g retr-g)) =
-      section-comp' sec-h sec-g
+      section-comp' f g h H sec-h sec-g
     pr2 (is-equiv-comp (pair sec-h retr-h) (pair sec-g retr-g)) =
       retraction-comp' retr-g retr-h
 

--- a/src/foundation-core/equivalences.lagda.md
+++ b/src/foundation-core/equivalences.lagda.md
@@ -222,7 +222,7 @@ module _
   abstract
     is-equiv-comp : is-equiv h → is-equiv g → is-equiv f
     pr1 (is-equiv-comp (pair sec-h retr-h) (pair sec-g retr-g)) =
-      section-comp' f g h H sec-h sec-g
+      section-comp-htpy h g f H sec-h sec-g
     pr2 (is-equiv-comp (pair sec-h retr-h) (pair sec-g retr-g)) =
       retraction-comp' retr-g retr-h
 
@@ -257,7 +257,7 @@ module _
       ( is-equiv-left-factor
         ( pair sec-f retr-f)
         ( pair (pair sh sh-issec) retr-h)) =
-      section-comp f g h H (pair sh sh-issec) sec-f
+      section-left-factor-htpy h g f H sec-f
     pr2
       ( is-equiv-left-factor
         ( pair sec-f retr-f)
@@ -282,7 +282,7 @@ module _
       ( is-equiv-right-factor
         ( pair sec-g (pair rg rg-isretr))
         ( pair sec-f retr-f)) =
-      section-comp' h rg f
+      section-comp-htpy f rg h
         ( triangle-retraction f g h H (pair rg rg-isretr))
         ( sec-f)
         ( pair g rg-isretr)

--- a/src/foundation-core/equivalences.lagda.md
+++ b/src/foundation-core/equivalences.lagda.md
@@ -208,7 +208,7 @@ module _
   abstract
     is-equiv-comp : is-equiv h → is-equiv g → is-equiv f
     pr1 (is-equiv-comp (pair sec-h retr-h) (pair sec-g retr-g)) =
-      section-comp-htpy h g f H sec-h sec-g
+      section-comp-htpy f g h H sec-h sec-g
     pr2 (is-equiv-comp (pair sec-h retr-h) (pair sec-g retr-g)) =
       retraction-comp-htpy f g h H retr-g retr-h
 
@@ -220,7 +220,7 @@ module _
     is-equiv-comp' :
       (g : B → X) (h : A → B) → is-equiv h → is-equiv g → is-equiv (g ∘ h)
     pr1 (is-equiv-comp' g h (pair sec-h retr-h) (pair sec-g retr-g)) =
-      section-comp h g sec-h sec-g
+      section-comp g h sec-h sec-g
     pr2 (is-equiv-comp' g h (pair sec-h retr-h) (pair sec-g retr-g)) =
       retraction-comp g h retr-g retr-h
 
@@ -246,7 +246,7 @@ module _
       ( is-equiv-left-factor
         ( pair sec-f retr-f)
         ( pair (pair sh issec-sh) retr-h)) =
-      section-left-factor-htpy h g f H sec-f
+      section-left-factor-htpy f g h H sec-f
     pr2
       ( is-equiv-left-factor
         ( pair sec-f retr-f)
@@ -271,7 +271,7 @@ module _
       ( is-equiv-right-factor
         ( pair sec-g (pair rg isretr-rg))
         ( pair sec-f retr-f)) =
-      section-comp-htpy f rg h
+      section-comp-htpy h rg f
         ( triangle-retraction f g h H (pair rg isretr-rg))
         ( sec-f)
         ( pair g isretr-rg)

--- a/src/foundation-core/equivalences.lagda.md
+++ b/src/foundation-core/equivalences.lagda.md
@@ -205,26 +205,12 @@ module _
   (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
   where
 
-  triangle-retraction : (R : retr g) → h ~ ((pr1 R) ∘ f)
-  triangle-retraction (pair r isretr) = inv-htpy ((r ·l H) ∙h (isretr ·r h))
-
-  retraction-comp : retr g → retr f → retr h
-  pr1 (retraction-comp retr-g retr-f) = (pr1 retr-f) ∘ g
-  pr2 (retraction-comp retr-g retr-f) =
-    (inv-htpy ((pr1 retr-f) ·l H)) ∙h (pr2 retr-f)
-
-  retraction-comp' : retr g → retr h → retr f
-  pr1 (retraction-comp' retr-g retr-h) = (pr1 retr-h) ∘ (pr1 retr-g)
-  pr2 (retraction-comp' retr-g retr-h) =
-    ( ((pr1 retr-h) ∘ (pr1 retr-g)) ·l H) ∙h
-    ( ((pr1 retr-h) ·l ((pr2 retr-g) ·r h)) ∙h (pr2 retr-h))
-
   abstract
     is-equiv-comp : is-equiv h → is-equiv g → is-equiv f
     pr1 (is-equiv-comp (pair sec-h retr-h) (pair sec-g retr-g)) =
       section-comp-htpy h g f H sec-h sec-g
     pr2 (is-equiv-comp (pair sec-h retr-h) (pair sec-g retr-g)) =
-      retraction-comp' retr-g retr-h
+      retraction-comp-htpy h g f H retr-h retr-g
 
 module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
@@ -256,16 +242,16 @@ module _
     pr1
       ( is-equiv-left-factor
         ( pair sec-f retr-f)
-        ( pair (pair sh sh-issec) retr-h)) =
+        ( pair (pair sh issec-sh) retr-h)) =
       section-left-factor-htpy h g f H sec-f
     pr2
       ( is-equiv-left-factor
         ( pair sec-f retr-f)
-        ( pair (pair sh sh-issec) retr-h)) =
-      retraction-comp' g f sh
-        ( triangle-section f g h H (pair sh sh-issec))
+        ( pair (pair sh issec-sh) retr-h)) =
+      retraction-comp-htpy sh f g
+        ( triangle-section f g h H (pair sh issec-sh))
+        ( pair h issec-sh)
         ( retr-f)
-        ( pair h sh-issec)
 ```
 
 #### If a composite and its left factor are equivalences, then so is its right factor
@@ -280,17 +266,17 @@ module _
     is-equiv-right-factor : is-equiv g → is-equiv f → is-equiv h
     pr1
       ( is-equiv-right-factor
-        ( pair sec-g (pair rg rg-isretr))
+        ( pair sec-g (pair rg isretr-rg))
         ( pair sec-f retr-f)) =
       section-comp-htpy f rg h
-        ( triangle-retraction f g h H (pair rg rg-isretr))
+        ( triangle-retraction h g f H (pair rg isretr-rg))
         ( sec-f)
-        ( pair g rg-isretr)
+        ( pair g isretr-rg)
     pr2
       ( is-equiv-right-factor
-        ( pair sec-g (pair rg rg-isretr))
+        ( pair sec-g (pair rg isretr-rg))
         ( pair sec-f retr-f)) =
-      retraction-comp f g h H (pair rg rg-isretr) retr-f
+      retraction-right-factor-htpy h g f H retr-f
 ```
 
 ```agda

--- a/src/foundation-core/equivalences.lagda.md
+++ b/src/foundation-core/equivalences.lagda.md
@@ -206,10 +206,10 @@ module _
   where
 
   abstract
-    is-equiv-comp : is-equiv h → is-equiv g → is-equiv f
-    pr1 (is-equiv-comp (pair sec-h retr-h) (pair sec-g retr-g)) =
+    is-equiv-comp-htpy : is-equiv h → is-equiv g → is-equiv f
+    pr1 (is-equiv-comp-htpy (pair sec-h retr-h) (pair sec-g retr-g)) =
       section-comp-htpy f g h H sec-h sec-g
-    pr2 (is-equiv-comp (pair sec-h retr-h) (pair sec-g retr-g)) =
+    pr2 (is-equiv-comp-htpy (pair sec-h retr-h) (pair sec-g retr-g)) =
       retraction-comp-htpy f g h H retr-g retr-h
 
 module _
@@ -217,16 +217,16 @@ module _
   where
 
   abstract
-    is-equiv-comp' :
+    is-equiv-comp :
       (g : B → X) (h : A → B) → is-equiv h → is-equiv g → is-equiv (g ∘ h)
-    pr1 (is-equiv-comp' g h (pair sec-h retr-h) (pair sec-g retr-g)) =
+    pr1 (is-equiv-comp g h (pair sec-h retr-h) (pair sec-g retr-g)) =
       section-comp g h sec-h sec-g
-    pr2 (is-equiv-comp' g h (pair sec-h retr-h) (pair sec-g retr-g)) =
+    pr2 (is-equiv-comp g h (pair sec-h retr-h) (pair sec-g retr-g)) =
       retraction-comp g h retr-g retr-h
 
   equiv-comp : (B ≃ X) → (A ≃ B) → (A ≃ X)
   pr1 (equiv-comp g h) = (map-equiv g) ∘ (map-equiv h)
-  pr2 (equiv-comp g h) = is-equiv-comp' (pr1 g) (pr1 h) (pr2 h) (pr2 g)
+  pr2 (equiv-comp g h) = is-equiv-comp (pr1 g) (pr1 h) (pr2 h) (pr2 g)
 
   _∘e_ : (B ≃ X) → (A ≃ B) → (A ≃ X)
   _∘e_ = equiv-comp
@@ -394,7 +394,7 @@ is-equiv-equiv {f = f} {g} i j H K =
     ( map-equiv j)
     ( f)
     ( is-equiv-map-equiv j)
-    ( is-equiv-comp
+    ( is-equiv-comp-htpy
       ( map-equiv j ∘ f)
       ( g)
       ( map-equiv i)
@@ -410,7 +410,7 @@ is-equiv-equiv' {f = f} {g} i j H K =
   is-equiv-left-factor'
     ( g)
     ( map-equiv i)
-    ( is-equiv-comp
+    ( is-equiv-comp-htpy
       ( g ∘ map-equiv i)
       ( map-equiv j)
       ( f)
@@ -442,31 +442,31 @@ module _
     is-equiv-top-is-equiv-left-square :
       is-equiv i → is-equiv f → is-equiv g → is-equiv h
     is-equiv-top-is-equiv-left-square Ei Ef Eg =
-      is-equiv-right-factor (i ∘ f) g h H Eg (is-equiv-comp' i f Ef Ei)
+      is-equiv-right-factor (i ∘ f) g h H Eg (is-equiv-comp i f Ef Ei)
 
   abstract
     is-equiv-top-is-equiv-bottom-square :
       is-equiv f → is-equiv g → is-equiv i → is-equiv h
     is-equiv-top-is-equiv-bottom-square Ef Eg Ei =
-      is-equiv-right-factor (i ∘ f) g h H Eg (is-equiv-comp' i f Ef Ei)
+      is-equiv-right-factor (i ∘ f) g h H Eg (is-equiv-comp i f Ef Ei)
 
   abstract
     is-equiv-bottom-is-equiv-top-square :
       is-equiv f → is-equiv g → is-equiv h → is-equiv i
     is-equiv-bottom-is-equiv-top-square Ef Eg Eh = 
-      is-equiv-left-factor' i f (is-equiv-comp (i ∘ f) g h H Eh Eg) Ef
+      is-equiv-left-factor' i f (is-equiv-comp-htpy (i ∘ f) g h H Eh Eg) Ef
 
   abstract
     is-equiv-left-is-equiv-right-square :
       is-equiv h → is-equiv i → is-equiv g → is-equiv f
     is-equiv-left-is-equiv-right-square Eh Ei Eg =
-      is-equiv-right-factor' i f Ei (is-equiv-comp (i ∘ f) g h H Eh Eg)
+      is-equiv-right-factor' i f Ei (is-equiv-comp-htpy (i ∘ f) g h H Eh Eg)
 
   abstract
     is-equiv-right-is-equiv-left-square :
       is-equiv h → is-equiv i → is-equiv f → is-equiv g
     is-equiv-right-is-equiv-left-square Eh Ei Ef =
-      is-equiv-left-factor (i ∘ f) g h H (is-equiv-comp' i f Ef Ei) Eh
+      is-equiv-left-factor (i ∘ f) g h H (is-equiv-comp i f Ef Ei) Eh
 ```
 
 ### Equivalences are embeddings

--- a/src/foundation-core/equivalences.lagda.md
+++ b/src/foundation-core/equivalences.lagda.md
@@ -210,7 +210,7 @@ module _
     pr1 (is-equiv-comp (pair sec-h retr-h) (pair sec-g retr-g)) =
       section-comp-htpy h g f H sec-h sec-g
     pr2 (is-equiv-comp (pair sec-h retr-h) (pair sec-g retr-g)) =
-      retraction-comp-htpy h g f H retr-h retr-g
+      retraction-comp-htpy f g h H retr-g retr-h
 
 module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
@@ -219,7 +219,10 @@ module _
   abstract
     is-equiv-comp' :
       (g : B → X) (h : A → B) → is-equiv h → is-equiv g → is-equiv (g ∘ h)
-    is-equiv-comp' g h = is-equiv-comp (g ∘ h) g h refl-htpy
+    pr1 (is-equiv-comp' g h (pair sec-h retr-h) (pair sec-g retr-g)) =
+      section-comp h g sec-h sec-g
+    pr2 (is-equiv-comp' g h (pair sec-h retr-h) (pair sec-g retr-g)) =
+      retraction-comp g h retr-g retr-h
 
   equiv-comp : (B ≃ X) → (A ≃ B) → (A ≃ X)
   pr1 (equiv-comp g h) = (map-equiv g) ∘ (map-equiv h)
@@ -248,10 +251,10 @@ module _
       ( is-equiv-left-factor
         ( pair sec-f retr-f)
         ( pair (pair sh issec-sh) retr-h)) =
-      retraction-comp-htpy sh f g
+      retraction-comp-htpy g f sh
         ( triangle-section f g h H (pair sh issec-sh))
-        ( pair h issec-sh)
         ( retr-f)
+        ( pair h issec-sh)
 ```
 
 #### If a composite and its left factor are equivalences, then so is its right factor
@@ -269,14 +272,14 @@ module _
         ( pair sec-g (pair rg isretr-rg))
         ( pair sec-f retr-f)) =
       section-comp-htpy f rg h
-        ( triangle-retraction h g f H (pair rg isretr-rg))
+        ( triangle-retraction f g h H (pair rg isretr-rg))
         ( sec-f)
         ( pair g isretr-rg)
     pr2
       ( is-equiv-right-factor
         ( pair sec-g (pair rg isretr-rg))
         ( pair sec-f retr-f)) =
-      retraction-right-factor-htpy h g f H retr-f
+      retraction-right-factor-htpy f g h H retr-f
 ```
 
 ```agda
@@ -513,3 +516,4 @@ module _
   pr1 (equiv-ap e x y) = ap (map-equiv e)
   pr2 (equiv-ap e x y) = is-emb-is-equiv (is-equiv-map-equiv e) x y
 ```
+ 

--- a/src/foundation-core/fibers-of-maps.lagda.md
+++ b/src/foundation-core/fibers-of-maps.lagda.md
@@ -9,7 +9,7 @@ module foundation-core.fibers-of-maps where
 
 open import foundation-core.dependent-pair-types using (Σ; pair; pr1; pr2)
 open import foundation-core.equivalences using
-  ( is-equiv; is-equiv-has-inverse; _≃_; is-fiberwise-equiv; is-equiv-comp)
+  ( is-equiv; is-equiv-has-inverse; _≃_; is-fiberwise-equiv)
 open import foundation-core.function-extensionality
 open import foundation-core.functions using (_∘_; id)
 open import foundation-core.homotopies using (_~_; refl-htpy)

--- a/src/foundation-core/functoriality-dependent-function-types.lagda.md
+++ b/src/foundation-core/functoriality-dependent-function-types.lagda.md
@@ -87,7 +87,7 @@ is-equiv-precomp-Π-fiber-condition :
   ((b : B) → is-equiv (λ (c : C b) → const (fib f b) (C b) c)) →
   is-equiv (precomp-Π f C)
 is-equiv-precomp-Π-fiber-condition {f = f} {C} H =
-  is-equiv-comp'
+  is-equiv-comp
     ( map-reduce-Π-fib f (λ b u → C b))
     ( map-Π (λ b u t → u))
     ( is-equiv-map-Π (λ b u t → u) H)

--- a/src/foundation-core/functoriality-dependent-pair-types.lagda.md
+++ b/src/foundation-core/functoriality-dependent-pair-types.lagda.md
@@ -16,7 +16,7 @@ open import foundation-core.equality-dependent-pair-types using
   ( eq-pair-Σ; eq-pair-Σ')
 open import foundation-core.equivalences using
   ( is-equiv; is-equiv-has-inverse; _≃_; map-equiv; is-equiv-map-equiv;
-    is-equiv-comp; is-equiv-right-factor; is-fiberwise-equiv;
+    is-equiv-comp-htpy; is-equiv-right-factor; is-fiberwise-equiv;
     is-equiv-top-is-equiv-bottom-square; is-equiv-bottom-is-equiv-top-square)
 open import foundation-core.fibers-of-maps using
   ( fib; map-equiv-total-fib; is-equiv-map-equiv-total-fib)
@@ -320,7 +320,7 @@ module _
       (f : A → B) (g : (x : A) → C x → D (f x)) →
       is-equiv f → is-fiberwise-equiv g → is-equiv (map-Σ D f g)
     is-equiv-map-Σ f g is-equiv-f is-fiberwise-equiv-g =
-      is-equiv-comp
+      is-equiv-comp-htpy
         ( map-Σ D f g)
         ( map-Σ-map-base f D)
         ( tot g)

--- a/src/foundation-core/propositional-maps.lagda.md
+++ b/src/foundation-core/propositional-maps.lagda.md
@@ -12,7 +12,7 @@ open import foundation-core.contractible-types using
 open import foundation-core.dependent-pair-types using (Σ; pair; pr1; pr2)
 open import foundation-core.embeddings using
   ( is-emb; _↪_; map-emb; is-emb-map-emb)
-open import foundation-core.equivalences using (is-equiv-comp'; _≃_)
+open import foundation-core.equivalences using (is-equiv-comp; _≃_)
 open import foundation-core.fibers-of-maps using (fib; equiv-fib; fib')
 open import foundation-core.functions using (_∘_)
 open import foundation-core.functoriality-dependent-pair-types using

--- a/src/foundation-core/pullbacks.lagda.md
+++ b/src/foundation-core/pullbacks.lagda.md
@@ -185,10 +185,8 @@ module _
       universal-property-pullback l f g (cone-canonical-pullback f g)
     universal-property-pullback-canonical-pullback C =
       is-equiv-comp
-        ( cone-map f g (cone-canonical-pullback f g))
         ( tot (λ p → map-distributive-Π-Σ))
         ( mapping-into-Σ)
-        ( refl-htpy)
         ( is-equiv-mapping-into-Σ)
         ( is-equiv-tot-is-fiberwise-equiv
           ( λ p → is-equiv-map-distributive-Π-Σ))
@@ -346,7 +344,7 @@ abstract
     (f : A → X) (g : B → X) (c : cone f g C) →
     is-pullback f g c → is-pullback g f (swap-cone f g c)
   is-pullback-swap-cone f g c is-pb-c =
-    is-equiv-comp
+    is-equiv-comp-htpy
       ( gap g f (swap-cone f g c))
       ( map-commutative-canonical-pullback f g)
       ( gap f g c)
@@ -473,7 +471,7 @@ abstract
     is-pullback f g c →
     is-pullback (map-prod f g) (diagonal X) (fold-cone f g c)
   is-pullback-fold-cone-is-pullback f g c is-pb-c =
-    is-equiv-comp
+    is-equiv-comp-htpy
       ( gap (map-prod f g) (diagonal _) (fold-cone f g c))
       ( map-fold-cone f g)
       ( gap f g c)
@@ -549,29 +547,21 @@ abstract
     is-equiv (map-prod-cone f g f' g')
   is-equiv-map-prod-cone f g f' g' =
     is-equiv-comp
-      ( map-prod-cone f g f' g')
       ( tot ( λ t →
         ( tot (λ s → eq-pair')) ∘
         ( map-interchange-Σ-Σ _)))
       ( map-interchange-Σ-Σ _)
-      ( refl-htpy)
       ( is-equiv-map-interchange-Σ-Σ _)
       ( is-equiv-tot-is-fiberwise-equiv
         ( λ t → is-equiv-comp
-          ( ( tot (λ s → eq-pair')) ∘
-            ( map-interchange-Σ-Σ
-              ( λ y p y' → Id (f' (pr2 t)) (g' y'))))
           ( tot (λ s → eq-pair'))
           ( map-interchange-Σ-Σ
             ( λ y p y' → Id (f' (pr2 t)) (g' y')))
-          ( refl-htpy)
           ( is-equiv-map-interchange-Σ-Σ _)
           ( is-equiv-tot-is-fiberwise-equiv
             ( λ s → is-equiv-comp
               ( eq-pair')
-              ( eq-pair')
               ( id)
-              ( refl-htpy)
               ( is-equiv-id)
               ( is-equiv-eq-pair
                 ( map-prod f f' t)
@@ -588,7 +578,7 @@ abstract
     is-pullback
       ( map-prod f f') (map-prod g g') (prod-cone f g f' g' c c')
   is-pullback-prod-is-pullback-pair f g c f' g' c' is-pb-c is-pb-c' =
-    is-equiv-comp
+    is-equiv-comp-htpy
       ( gap (map-prod f f') (map-prod g g') (prod-cone f g f' g' c c'))
       ( map-prod-cone f g f' g')
       ( map-prod (gap f g c) (gap f' g' c'))
@@ -697,10 +687,8 @@ module _
       is-fiberwise-equiv g → is-pullback f (pr1 {B = Q}) cone-map-Σ
     is-pullback-is-fiberwise-equiv is-equiv-g =
       is-equiv-comp
-        ( gap f pr1 cone-map-Σ)
         ( gap f pr1 (cone-canonical-pullback-Σ f Q))
         ( tot g)
-        ( refl-htpy)
         ( is-equiv-tot-is-fiberwise-equiv is-equiv-g)
         ( is-pullback-cone-canonical-pullback-Σ f Q)
 
@@ -804,7 +792,7 @@ module _
     is-pullback-rectangle-is-pullback-left-square c d is-pb-c is-pb-d =
       is-pullback-is-fiberwise-equiv-map-fib-cone (j ∘ i) h
         ( cone-comp-horizontal i j h c d)
-        ( λ x → is-equiv-comp
+        ( λ x → is-equiv-comp-htpy
           ( map-fib-cone (j ∘ i) h (cone-comp-horizontal i j h c d) x)
           ( map-fib-cone j h c (i x))
           ( map-fib-cone i (vertical-map-cone j h c) d x)

--- a/src/foundation-core/retractions.lagda.md
+++ b/src/foundation-core/retractions.lagda.md
@@ -87,48 +87,48 @@ pr2 (retract-eq (pair i (pair r H)) x y) = retr-ap i (pair r H) x y
 
 ```agda
 module _
-  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
   where
 
   retraction-right-factor :
-    (f : A → B) (g : B → C) → retr (g ∘ f) → retr f
-  pr1 (retraction-right-factor f g retr-gf) = pr1 retr-gf ∘ g
-  pr2 (retraction-right-factor f g retr-gf) = pr2 retr-gf
+    (g : B → X) (h : A → B) → retr (g ∘ h) → retr h
+  pr1 (retraction-right-factor g h retr-gh) = pr1 retr-gh ∘ g
+  pr2 (retraction-right-factor g h retr-gh) = pr2 retr-gh
   
   retraction-right-factor-htpy :
-    (f : A → B) (g : B → C) (h : A → C) (H : h ~ (g ∘ f)) → retr h → retr f
-  pr1 (retraction-right-factor-htpy f g h H retr-h) =
-    pr1 retr-h ∘ g
-  pr2 (retraction-right-factor-htpy f g h H retr-h) = 
-    (inv-htpy ((pr1 retr-h) ·l H)) ∙h (pr2 retr-h)
+    (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) → retr f → retr h
+  pr1 (retraction-right-factor-htpy f g h H retr-f) =
+    pr1 retr-f ∘ g
+  pr2 (retraction-right-factor-htpy f g h H retr-f) = 
+    (inv-htpy ((pr1 retr-f) ·l H)) ∙h (pr2 retr-f)
 ```
 
 ### Composites of retractions are retractions
 
 ```agda
   retraction-comp : 
-    (f : A → B) (g : B → C) → retr f → retr g → retr (g ∘ f)
-  pr1 (retraction-comp f g retr-f retr-g) = pr1 retr-f ∘ pr1 retr-g
-  pr2 (retraction-comp f g retr-f retr-g) =
-    ((pr1 retr-f) ·l (pr2 retr-g ·r f)) ∙h (pr2 retr-f)
+    (g : B → X) (h : A → B) → retr g → retr h → retr (g ∘ h)
+  pr1 (retraction-comp g h retr-g retr-h) = pr1 retr-h ∘ pr1 retr-g
+  pr2 (retraction-comp g h retr-g retr-h) =
+    ((pr1 retr-h) ·l (pr2 retr-g ·r h)) ∙h (pr2 retr-h)
 
   retraction-comp-htpy : 
-    (f : A → B) (g : B → C) (h : A → C) (H : h ~ (g ∘ f)) →
-    retr f → retr g → retr h
-  pr1 (retraction-comp-htpy f g h H retr-f retr-g) =
-    pr1 (retraction-comp f g retr-f retr-g)
-  pr2 (retraction-comp-htpy f g h H retr-f retr-g) =
-    ( pr1 (retraction-comp f g retr-f retr-g) ·l H) ∙h
-    pr2 (retraction-comp f g retr-f retr-g)
+    (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
+    retr g → retr h → retr f
+  pr1 (retraction-comp-htpy f g h H retr-g retr-h) =
+    pr1 (retraction-comp g h retr-g retr-h)
+  pr2 (retraction-comp-htpy f g h H retr-g retr-h) =
+    ( pr1 (retraction-comp g h retr-g retr-h) ·l H) ∙h
+    pr2 (retraction-comp g h retr-g retr-h)
   
 
   inv-triangle-retraction :
-    (h : A → B) (g : B → C) (f : A → C) (H : f ~ (g ∘ h))
+    (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
     (retr-g : retr g) → ((pr1 retr-g) ∘ f) ~ h 
-  inv-triangle-retraction h g f H retr-g = (pr1 retr-g ·l H) ∙h (pr2 retr-g ·r h)
+  inv-triangle-retraction f g h H retr-g = (pr1 retr-g ·l H) ∙h (pr2 retr-g ·r h)
 
   triangle-retraction :
-    (h : A → B) (g : B → C) (f : A → C) (H : f ~ (g ∘ h))
+    (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
     (retr-g : retr g) → h ~ ((pr1 retr-g) ∘ f)
-  triangle-retraction h g f H retr-g = inv-htpy (inv-triangle-retraction h g f H retr-g)
+  triangle-retraction f g h H retr-g = inv-htpy (inv-triangle-retraction f g h H retr-g)
 ``` 

--- a/src/foundation-core/retractions.lagda.md
+++ b/src/foundation-core/retractions.lagda.md
@@ -7,12 +7,12 @@ title: Retractions
 
 module foundation-core.retractions where
 
-open import foundation-core.dependent-pair-types using (Σ; pair; pr1; pr2)
+open import foundation-core.dependent-pair-types
 open import foundation-core.functions using (_∘_; id)
-open import foundation-core.homotopies using (_~_)
+open import foundation-core.homotopies
 open import foundation-core.identity-types using
   ( _＝_; inv; _∙_; ap; refl; left-inv)
-open import foundation-core.universe-levels using (Level; UU; _⊔_)
+open import foundation-core.universe-levels
 ```
 
 ## Idea
@@ -82,3 +82,53 @@ retract-eq :
 pr1 (retract-eq (pair i (pair r H)) x y) = ap i
 pr2 (retract-eq (pair i (pair r H)) x y) = retr-ap i (pair r H) x y
 ```
+
+### If `g ∘ f` has a retraction then `f` has a retraction
+
+```agda
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
+  where
+
+  retraction-right-factor :
+    (f : A → B) (g : B → C) → retr (g ∘ f) → retr f
+  pr1 (retraction-right-factor f g retr-gf) = pr1 retr-gf ∘ g
+  pr2 (retraction-right-factor f g retr-gf) = pr2 retr-gf
+  
+  retraction-right-factor-htpy :
+    (f : A → B) (g : B → C) (h : A → C) (H : h ~ (g ∘ f)) → retr h → retr f
+  pr1 (retraction-right-factor-htpy f g h H retr-h) =
+    pr1 retr-h ∘ g
+  pr2 (retraction-right-factor-htpy f g h H retr-h) = 
+    (inv-htpy ((pr1 retr-h) ·l H)) ∙h (pr2 retr-h)
+```
+
+### Composites of retractions are retractions
+
+```agda
+  retraction-comp : 
+    (f : A → B) (g : B → C) → retr f → retr g → retr (g ∘ f)
+  pr1 (retraction-comp f g retr-f retr-g) = pr1 retr-f ∘ pr1 retr-g
+  pr2 (retraction-comp f g retr-f retr-g) =
+    ((pr1 retr-f) ·l (pr2 retr-g ·r f)) ∙h (pr2 retr-f)
+
+  retraction-comp-htpy : 
+    (f : A → B) (g : B → C) (h : A → C) (H : h ~ (g ∘ f)) →
+    retr f → retr g → retr h
+  pr1 (retraction-comp-htpy f g h H retr-f retr-g) =
+    pr1 (retraction-comp f g retr-f retr-g)
+  pr2 (retraction-comp-htpy f g h H retr-f retr-g) =
+    ( pr1 (retraction-comp f g retr-f retr-g) ·l H) ∙h
+    pr2 (retraction-comp f g retr-f retr-g)
+  
+
+  inv-triangle-retraction :
+    (h : A → B) (g : B → C) (f : A → C) (H : f ~ (g ∘ h))
+    (retr-g : retr g) → ((pr1 retr-g) ∘ f) ~ h 
+  inv-triangle-retraction h g f H retr-g = (pr1 retr-g ·l H) ∙h (pr2 retr-g ·r h)
+
+  triangle-retraction :
+    (h : A → B) (g : B → C) (f : A → C) (H : f ~ (g ∘ h))
+    (retr-g : retr g) → h ~ ((pr1 retr-g) ∘ f)
+  triangle-retraction h g f H retr-g = inv-htpy (inv-triangle-retraction h g f H retr-g)
+``` 

--- a/src/foundation-core/sections.lagda.md
+++ b/src/foundation-core/sections.lagda.md
@@ -34,58 +34,58 @@ module _
 
 ```agda
 module _
-  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
   where
   
   section-left-factor :
-    (f : A → B) (g : B → C) → sec (g ∘ f) → sec g
-  pr1 (section-left-factor f g sec-gf) = f ∘ (pr1 sec-gf)
-  pr2 (section-left-factor f g sec-gf) = pr2 sec-gf
+    (g : B → X) (h : A → B) → sec (g ∘ h) → sec g
+  pr1 (section-left-factor g h sec-gh) = h ∘ (pr1 sec-gh)
+  pr2 (section-left-factor g h sec-gh) = pr2 sec-gh
 
   section-left-factor-htpy' :
-    (f : A → B) (g : B → C) (h : A → C) (H' : (g ∘ f) ~ h) →
-    sec h → sec g
-  pr1 (section-left-factor-htpy' f g h H' sec-h) =
-    f ∘ (pr1 sec-h)
-  pr2 (section-left-factor-htpy' f g h H' sec-h) =
-    (H' ·r pr1 sec-h) ∙h (pr2 sec-h)
+    (f : A → X) (g : B → X) (h : A → B) (H' : (g ∘ h) ~ f) →
+    sec f → sec g
+  pr1 (section-left-factor-htpy' f g h H' sec-f) =
+    h ∘ (pr1 sec-f)
+  pr2 (section-left-factor-htpy' f g h H' sec-f) =
+    (H' ·r pr1 sec-f) ∙h (pr2 sec-f)
 
   section-left-factor-htpy :
-    (f : A → B) (g : B → C) (h : A → C) (H : h ~ (g ∘ f)) →
-    sec h → sec g
-  section-left-factor-htpy f g h H sec-h =
-    section-left-factor-htpy' f g h (inv-htpy H) sec-h
+    (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
+    sec f → sec g
+  section-left-factor-htpy f g h H sec-f =
+    section-left-factor-htpy' f g h (inv-htpy H) sec-f
 ```
 
 ### Composites of sections are sections
 
 ```agda
   section-comp :
-    (f : A → B) (g : B → C) → sec f → sec g → sec (g ∘ f)
-  pr1 (section-comp f g sec-f sec-g) = pr1 sec-f ∘ pr1 sec-g
-  pr2 (section-comp f g sec-f sec-g) =
-    (g ·l (pr2 sec-f ·r (pr1 sec-g))) ∙h (pr2 sec-g)
+    (g : B → X) (h : A → B) → sec h → sec g → sec (g ∘ h)
+  pr1 (section-comp g h sec-h sec-g) = pr1 sec-h ∘ pr1 sec-g
+  pr2 (section-comp g h sec-h sec-g) =
+    (g ·l (pr2 sec-h ·r (pr1 sec-g))) ∙h (pr2 sec-g)
 
   section-comp-htpy :
-    (f : A → B) (g : B → C) (h : A → C) (H : h ~ (g ∘ f)) →
-    sec f → sec g → sec h
-  pr1 (section-comp-htpy f g h H sec-f sec-g) =
-    pr1 (section-comp f g sec-f sec-g)
-  pr2 (section-comp-htpy f g h H sec-f sec-g) =
-    (H ·r pr1 (section-comp f g sec-f sec-g)) ∙h
-    (pr2 (section-comp f g sec-f sec-g))
+    (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
+    sec h → sec g → sec f
+  pr1 (section-comp-htpy f g h H sec-h sec-g) =
+    pr1 (section-comp g h sec-h sec-g)
+  pr2 (section-comp-htpy f g h H sec-h sec-g) =
+    (H ·r pr1 (section-comp g h sec-h sec-g)) ∙h
+    (pr2 (section-comp g h sec-h sec-g))
 
 
   inv-triangle-section :
-    (h : A → C) (g : B → C) (f : A → B) (H : h ~ (g ∘ f))
-    (sec-f : sec f) → (h ∘ (pr1 sec-f)) ~ g 
-  inv-triangle-section h g f H sec-f =
-    (H ·r (pr1 sec-f)) ∙h (g ·l (pr2 sec-f))
+    (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
+    (sec-h : sec h) → (f ∘ (pr1 sec-h)) ~ g
+  inv-triangle-section h g f H sec-h =
+    (H ·r (pr1 sec-h)) ∙h (g ·l (pr2 sec-h))
 
   triangle-section :
-    (h : A → C) (g : B → C) (f : A → B) (H : h ~ (g ∘ f))
-    (sec-f : sec f) → g ~ (h ∘ (pr1 sec-f))
-  triangle-section h g f H sec-f =
-    inv-htpy (inv-triangle-section h g f H sec-f)
+    (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
+    (sec-h : sec h) → g ~ (f ∘ (pr1 sec-h))
+  triangle-section h g f H sec-h =
+    inv-htpy (inv-triangle-section h g f H sec-h)
 ```
  

--- a/src/foundation-core/sections.lagda.md
+++ b/src/foundation-core/sections.lagda.md
@@ -7,10 +7,10 @@ title: Sections of type families
 
 module foundation-core.sections where
 
-open import foundation-core.dependent-pair-types using (Σ)
+open import foundation-core.dependent-pair-types
 open import foundation-core.functions using (_∘_; id)
-open import foundation-core.homotopies using (_~_)
-open import foundation-core.universe-levels using (Level; UU; _⊔_)
+open import foundation-core.homotopies
+open import foundation-core.universe-levels
 ```
 
 ## Idea
@@ -26,3 +26,29 @@ module _
 
   sec : (A → B) → UU (l1 ⊔ l2)
   sec f = Σ (B → A) (λ g → (f ∘ g) ~ id)
+```
+
+## Properties
+
+### Composites of sections are sections
+
+```agda
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
+  (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
+  where
+
+  triangle-section : (S : sec h) → g ~ (f ∘ (pr1 S))
+  triangle-section (pair s issec) = inv-htpy ((H ·r s) ∙h (g ·l issec))
+
+  section-comp : sec h → sec f → sec g
+  pr1 (section-comp sec-h sec-f) = h ∘ (pr1 sec-f)
+  pr2 (section-comp sec-h sec-f) = (inv-htpy (H ·r (pr1 sec-f))) ∙h (pr2 sec-f)
+  
+  section-comp' : sec h → sec g → sec f
+  pr1 (section-comp' sec-h sec-g) = (pr1 sec-h) ∘ (pr1 sec-g)
+  pr2 (section-comp' sec-h sec-g) =
+    ( H ·r ((pr1 sec-h) ∘ (pr1 sec-g))) ∙h
+    ( ( g ·l ((pr2 sec-h) ·r (pr1 sec-g))) ∙h ((pr2 sec-g)))
+```
+ 

--- a/src/foundation-core/sections.lagda.md
+++ b/src/foundation-core/sections.lagda.md
@@ -30,7 +30,7 @@ module _
 
 ## Properties
 
-### If the composite `g ∘ f` admits a section then `g` admits a section
+### If `g ∘ f` admits a section then `g` admits a section
 
 ```agda
 module _
@@ -70,9 +70,6 @@ module _
   pr1 (section-comp-htpy f g h H sec-f sec-g) = pr1 (section-comp f g sec-f sec-g)
   pr2 (section-comp-htpy f g h H sec-f sec-g) =
     (H ·r pr1 (section-comp f g sec-f sec-g)) ∙h (pr2 (section-comp f g sec-f sec-g))
-
-  _∘sec_ : {f : A → B} {g : B → C} → sec g → sec f → sec (g ∘ f)
-  _∘sec_ {f} {g} sec-g sec-f = section-comp f g sec-f sec-g
 
 
   triangle-section' :

--- a/src/foundation-core/sections.lagda.md
+++ b/src/foundation-core/sections.lagda.md
@@ -30,25 +30,61 @@ module _
 
 ## Properties
 
-### Composites of sections are sections
+### If the composite `g ∘ f` admits a section then `g` admits a section
 
 ```agda
 module _
-  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
-  (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
   where
-
-  triangle-section : (S : sec h) → g ~ (f ∘ (pr1 S))
-  triangle-section (pair s issec) = inv-htpy ((H ·r s) ∙h (g ·l issec))
-
-  section-comp : sec h → sec f → sec g
-  pr1 (section-comp sec-h sec-f) = h ∘ (pr1 sec-f)
-  pr2 (section-comp sec-h sec-f) = (inv-htpy (H ·r (pr1 sec-f))) ∙h (pr2 sec-f)
   
-  section-comp' : sec h → sec g → sec f
-  pr1 (section-comp' sec-h sec-g) = (pr1 sec-h) ∘ (pr1 sec-g)
-  pr2 (section-comp' sec-h sec-g) =
-    ( H ·r ((pr1 sec-h) ∘ (pr1 sec-g))) ∙h
-    ( ( g ·l ((pr2 sec-h) ·r (pr1 sec-g))) ∙h ((pr2 sec-g)))
+  section-left-factor :
+    (f : A → B) (g : B → C) → sec (g ∘ f) → sec g
+  section-left-factor f g sec-gf = f ∘ (pr1 sec-gf) , pr2 sec-gf
+
+  section-left-factor-htpy' :
+    (f : A → B) (g : B → C) (h : A → C) (H' : (g ∘ f) ~ h) →
+    sec h → sec g
+  pr1 (section-left-factor-htpy' f g h H' sec-h) =
+    f ∘ (pr1 sec-h)
+  pr2 (section-left-factor-htpy' f g h H' sec-h) =
+    (H' ·r pr1 sec-h) ∙h (pr2 sec-h)
+
+  section-left-factor-htpy :
+    (f : A → B) (g : B → C) (h : A → C) (H : h ~ (g ∘ f)) →
+    sec h → sec g
+  section-left-factor-htpy f g h H sec-h =
+    section-left-factor-htpy' f g h (inv-htpy H) sec-h
+```
+
+### Composites of sections are sections
+
+```agda
+  section-comp :
+    (f : A → B) (g : B → C) → sec f → sec g → sec (g ∘ f)
+  pr1 (section-comp f g sec-f sec-g) = pr1 sec-f ∘ pr1 sec-g
+  pr2 (section-comp f g sec-f sec-g) =
+    (g ·l (pr2 sec-f ·r (pr1 sec-g))) ∙h pr2 sec-g
+
+  section-comp-htpy :
+    (f : A → B) (g : B → C) (h : A → C) (H : h ~ (g ∘ f)) → sec f → sec g → sec h
+  pr1 (section-comp-htpy f g h H sec-f sec-g) = pr1 (section-comp f g sec-f sec-g)
+  pr2 (section-comp-htpy f g h H sec-f sec-g) =
+    (H ·r pr1 (section-comp f g sec-f sec-g)) ∙h (pr2 (section-comp f g sec-f sec-g))
+
+  _∘sec_ : {f : A → B} {g : B → C} → sec g → sec f → sec (g ∘ f)
+  _∘sec_ {f} {g} sec-g sec-f = section-comp f g sec-f sec-g
+
+
+  triangle-section' :
+    (h : A → C) (g : B → C) (f : A → B)  (H : h ~ (g ∘ f))
+    (sec-f : sec f) → (h ∘ (pr1 sec-f)) ~ g 
+  triangle-section' h g f H sec-f =
+    (H ·r (pr1 sec-f)) ∙h (g ·l (pr2 sec-f))
+
+  triangle-section :
+    (h : A → C) (g : B → C) (f : A → B) (H : h ~ (g ∘ f))
+    (sec-f : sec f) → g ~ (h ∘ (pr1 sec-f))
+  triangle-section h g f H sec-f =
+    inv-htpy (triangle-section' h g f H sec-f)
 ```
  

--- a/src/foundation-core/sections.lagda.md
+++ b/src/foundation-core/sections.lagda.md
@@ -1,5 +1,5 @@
 ---
-title: Sections of type families
+title: Sections
 ---
 
 ```agda

--- a/src/foundation-core/sections.lagda.md
+++ b/src/foundation-core/sections.lagda.md
@@ -30,7 +30,7 @@ module _
 
 ## Properties
 
-### If `g ∘ f` admits a section then `g` admits a section
+### If `g ∘ f` has a section then `g` has a section
 
 ```agda
 module _
@@ -39,7 +39,8 @@ module _
   
   section-left-factor :
     (f : A → B) (g : B → C) → sec (g ∘ f) → sec g
-  section-left-factor f g sec-gf = f ∘ (pr1 sec-gf) , pr2 sec-gf
+  pr1 (section-left-factor f g sec-gf) = f ∘ (pr1 sec-gf)
+  pr2 (section-left-factor f g sec-gf) = pr2 sec-gf
 
   section-left-factor-htpy' :
     (f : A → B) (g : B → C) (h : A → C) (H' : (g ∘ f) ~ h) →
@@ -63,25 +64,28 @@ module _
     (f : A → B) (g : B → C) → sec f → sec g → sec (g ∘ f)
   pr1 (section-comp f g sec-f sec-g) = pr1 sec-f ∘ pr1 sec-g
   pr2 (section-comp f g sec-f sec-g) =
-    (g ·l (pr2 sec-f ·r (pr1 sec-g))) ∙h pr2 sec-g
+    (g ·l (pr2 sec-f ·r (pr1 sec-g))) ∙h (pr2 sec-g)
 
   section-comp-htpy :
-    (f : A → B) (g : B → C) (h : A → C) (H : h ~ (g ∘ f)) → sec f → sec g → sec h
-  pr1 (section-comp-htpy f g h H sec-f sec-g) = pr1 (section-comp f g sec-f sec-g)
+    (f : A → B) (g : B → C) (h : A → C) (H : h ~ (g ∘ f)) →
+    sec f → sec g → sec h
+  pr1 (section-comp-htpy f g h H sec-f sec-g) =
+    pr1 (section-comp f g sec-f sec-g)
   pr2 (section-comp-htpy f g h H sec-f sec-g) =
-    (H ·r pr1 (section-comp f g sec-f sec-g)) ∙h (pr2 (section-comp f g sec-f sec-g))
+    (H ·r pr1 (section-comp f g sec-f sec-g)) ∙h
+    (pr2 (section-comp f g sec-f sec-g))
 
 
-  triangle-section' :
-    (h : A → C) (g : B → C) (f : A → B)  (H : h ~ (g ∘ f))
+  inv-triangle-section :
+    (h : A → C) (g : B → C) (f : A → B) (H : h ~ (g ∘ f))
     (sec-f : sec f) → (h ∘ (pr1 sec-f)) ~ g 
-  triangle-section' h g f H sec-f =
+  inv-triangle-section h g f H sec-f =
     (H ·r (pr1 sec-f)) ∙h (g ·l (pr2 sec-f))
 
   triangle-section :
     (h : A → C) (g : B → C) (f : A → B) (H : h ~ (g ∘ f))
     (sec-f : sec f) → g ~ (h ∘ (pr1 sec-f))
   triangle-section h g f H sec-f =
-    inv-htpy (triangle-section' h g f H sec-f)
+    inv-htpy (inv-triangle-section h g f H sec-f)
 ```
  

--- a/src/foundation-core/type-arithmetic-cartesian-product-types.lagda.md
+++ b/src/foundation-core/type-arithmetic-cartesian-product-types.lagda.md
@@ -11,7 +11,7 @@ open import foundation-core.cartesian-product-types using (_×_)
 open import foundation-core.contractible-types using (is-contr; center)
 open import foundation-core.dependent-pair-types using (Σ; pair; pr1; pr2)
 open import foundation-core.equivalences using
-  ( is-equiv; is-equiv-has-inverse; _≃_; inv-equiv; _∘e_; is-equiv-comp')
+  ( is-equiv; is-equiv-has-inverse; _≃_; inv-equiv; _∘e_; is-equiv-comp)
 open import foundation-core.functions using (_∘_; id)
 open import foundation-core.homotopies using (_~_)
 open import foundation-core.identity-types using (refl)
@@ -106,7 +106,7 @@ module _
 
   is-equiv-pr2-prod-is-contr : is-equiv (pr2 {B = λ a → B})
   is-equiv-pr2-prod-is-contr =
-    is-equiv-comp'
+    is-equiv-comp
       ( pr1)
       ( map-commutative-prod)
       ( is-equiv-map-commutative-prod)

--- a/src/foundation-core/universal-property-pullbacks.lagda.md
+++ b/src/foundation-core/universal-property-pullbacks.lagda.md
@@ -80,7 +80,7 @@ module _
       ({l : Level} → universal-property-pullback l f g c) →
       ({l : Level} → universal-property-pullback l f g c')
     up-pullback-up-pullback-is-equiv is-equiv-h up D =
-      is-equiv-comp
+      is-equiv-comp-htpy
         ( cone-map f g c')
         ( cone-map f g c)
         ( λ k → h ∘ k)

--- a/src/foundation/binary-embeddings.lagda.md
+++ b/src/foundation/binary-embeddings.lagda.md
@@ -11,7 +11,7 @@ open import foundation.binary-equivalences using
   ( is-binary-equiv; fix-left; fix-right; is-equiv-fix-left; is-equiv-fix-right)
 open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2)
 open import foundation.embeddings using (is-emb)
-open import foundation.equivalences using (is-equiv-comp; is-emb-is-equiv)
+open import foundation.equivalences using (is-equiv-comp-htpy; is-emb-is-equiv)
 open import foundation.identity-types using
   ( _＝_; ap-binary; concat'; ap; triangle-ap-binary; is-equiv-concat'; concat;
     is-equiv-concat)
@@ -56,7 +56,7 @@ is-binary-emb-is-binary-equiv :
 is-binary-emb-is-binary-equiv {f = f} H {x} {x'} {y} {y'} =
   pair
     ( λ q →
-      is-equiv-comp
+      is-equiv-comp-htpy
         ( λ p → ap-binary f p q)
         ( concat' (f x y) (ap (fix-left f x') q))
         ( λ p → ap (fix-right f y) p)
@@ -64,7 +64,7 @@ is-binary-emb-is-binary-equiv {f = f} H {x} {x'} {y} {y'} =
         ( is-emb-fix-right-is-binary-equiv f H x x')
         ( is-equiv-concat' (f x y) (ap (fix-left f x') q)))
     ( λ p →
-      is-equiv-comp
+      is-equiv-comp-htpy
         ( λ q → ap-binary f p q)
         ( concat (ap (fix-right f y) p) (f x' y'))
         ( λ q → ap (fix-left f x') q)

--- a/src/foundation/coherently-invertible-maps.lagda.md
+++ b/src/foundation/coherently-invertible-maps.lagda.md
@@ -29,7 +29,7 @@ open import foundation.contractible-types using
 open import foundation.equivalences using
   ( is-equiv; is-equiv-is-coherently-invertible; is-contr-sec-is-equiv;
     is-emb-is-equiv; is-coherently-invertible-is-equiv; is-property-is-equiv;
-    is-equiv-id; is-equiv-comp)
+    is-equiv-id; is-equiv-comp-htpy)
 open import foundation.identity-types using (Id; ap; equiv-inv; refl)
 open import foundation.type-theoretic-principle-of-choice using
   ( distributive-Π-Σ)
@@ -115,7 +115,7 @@ abstract
   is-equiv-invertible-id-htpy-id-id :
     {l : Level} (A : UU l) → is-equiv (is-invertible-id-htpy-id-id A)
   is-equiv-invertible-id-htpy-id-id A =
-    is-equiv-comp
+    is-equiv-comp-htpy
       ( is-invertible-id-htpy-id-id A)
       ( map-assoc-Σ (A → A) (λ g → (id ∘ g) ~ id) (λ s → ((pr1 s) ∘ id) ~ id))
       ( map-inv-left-unit-law-Σ-is-contr

--- a/src/foundation/connected-types.lagda.md
+++ b/src/foundation/connected-types.lagda.md
@@ -44,7 +44,7 @@ is-equiv-diagonal-is-connected :
   is-connected k A →
   is-equiv (λ (b : type-Truncated-Type B) → const A (type-Truncated-Type B) b)
 is-equiv-diagonal-is-connected B H =
-  is-equiv-comp'
+  is-equiv-comp
     ( precomp unit-trunc (type-Truncated-Type B))
     ( λ b → const _ _ b)
     ( is-equiv-diagonal-is-contr H (type-Truncated-Type B))

--- a/src/foundation/descent-coproduct-types.lagda.md
+++ b/src/foundation/descent-coproduct-types.lagda.md
@@ -137,7 +137,7 @@ module _
       is-pullback f i cone-A'
     descent-coprod-inl (pair h (pair f' H)) (pair k (pair g' K)) is-pb-dsq =
         is-pullback-is-fiberwise-equiv-map-fib-cone f i (triple h f' H)
-          ( λ a → is-equiv-comp
+          ( λ a → is-equiv-comp-htpy
             ( map-fib-cone f i (triple h f' H) a)
             ( map-fib-cone (ind-coprod _ f g) i
               ( cone-descent-coprod (triple h f' H) (triple k g' K))
@@ -158,7 +158,7 @@ module _
       is-pullback g i cone-B'
     descent-coprod-inr (pair h (pair f' H)) (pair k (pair g' K)) is-pb-dsq =
         is-pullback-is-fiberwise-equiv-map-fib-cone g i (triple k g' K)
-          ( λ b → is-equiv-comp
+          ( λ b → is-equiv-comp-htpy
             ( map-fib-cone g i (triple k g' K) b)
             ( map-fib-cone (ind-coprod _ f g) i
               ( cone-descent-coprod (triple h f' H) (triple k g' K))

--- a/src/foundation/descent-dependent-pair-types.lagda.md
+++ b/src/foundation/descent-dependent-pair-types.lagda.md
@@ -66,7 +66,7 @@ module _
       ((i : I) → is-pullback (f i) h (c i))
     descent-Σ' is-pb-dsq i =
       is-pullback-is-fiberwise-equiv-map-fib-cone (f i) h (c i)
-        ( λ a → is-equiv-comp
+        ( λ a → is-equiv-comp-htpy
           ( map-fib-cone (f i) h (c i) a)
           ( map-fib-cone (ind-Σ f) h cone-descent-Σ (pair i a))
           ( map-inv-compute-fib-tot (λ i → pr1 (c i)) (pair i a))

--- a/src/foundation/embeddings.lagda.md
+++ b/src/foundation/embeddings.lagda.md
@@ -27,7 +27,7 @@ open import foundation-core.truncation-levels using (neg-one-𝕋)
 open import foundation-core.universe-levels using (Level; UU; _⊔_)
 
 open import foundation.equivalences using
-  ( is-equiv-top-is-equiv-left-square; is-equiv-comp; is-equiv-right-factor;
+  ( is-equiv-top-is-equiv-left-square; is-equiv-comp-htpy; is-equiv-right-factor;
     is-equiv; is-emb-is-equiv; map-inv-is-equiv; issec-map-inv-is-equiv;
     is-equiv-map-inv-is-equiv; is-property-is-equiv; _≃_; map-equiv;
     is-equiv-htpy-equiv; inv-equiv; isretr-map-inv-equiv)
@@ -112,7 +112,7 @@ module _
       is-emb h → is-emb f
     is-emb-comp f g h H is-emb-g is-emb-h =
       is-emb-htpy f (g ∘ h) H
-        ( λ x y → is-equiv-comp (ap (g ∘ h)) (ap g) (ap h) (ap-comp g h)
+        ( λ x y → is-equiv-comp-htpy (ap (g ∘ h)) (ap g) (ap h) (ap-comp g h)
           ( is-emb-h x y)
           ( is-emb-g (h x) (h y)))
 

--- a/src/foundation/embeddings.lagda.md
+++ b/src/foundation/embeddings.lagda.md
@@ -22,15 +22,15 @@ open import foundation-core.homotopies using
 open import foundation-core.propositional-maps using
   ( is-emb-is-prop-map; is-prop-map-is-emb)
 open import foundation-core.pullbacks using (is-pullback)
-open import foundation-core.sections using (sec)
+open import foundation-core.sections using (sec; triangle-section)
 open import foundation-core.truncation-levels using (neg-one-𝕋)
 open import foundation-core.universe-levels using (Level; UU; _⊔_)
 
 open import foundation.equivalences using
   ( is-equiv-top-is-equiv-left-square; is-equiv-comp; is-equiv-right-factor;
-    is-equiv; is-emb-is-equiv; map-inv-is-equiv; triangle-section;
-    issec-map-inv-is-equiv; is-equiv-map-inv-is-equiv; is-property-is-equiv;
-    _≃_; map-equiv; is-equiv-htpy-equiv; inv-equiv; isretr-map-inv-equiv)
+    is-equiv; is-emb-is-equiv; map-inv-is-equiv; issec-map-inv-is-equiv;
+    is-equiv-map-inv-is-equiv; is-property-is-equiv; _≃_; map-equiv;
+    is-equiv-htpy-equiv; inv-equiv; isretr-map-inv-equiv)
 open import foundation.identity-types using
   ( ap; concat'; concat; is-equiv-concat; is-equiv-concat'; ap-comp;
     _＝_; refl; _∙_; inv)

--- a/src/foundation/equivalences.lagda.md
+++ b/src/foundation/equivalences.lagda.md
@@ -464,7 +464,7 @@ equiv-precomp-equiv e C =
     ( is-equiv-Prop)
     ( λ g →
       pair
-        ( is-equiv-comp' g (map-equiv e) (is-equiv-map-equiv e))
+        ( is-equiv-comp g (map-equiv e) (is-equiv-map-equiv e))
         ( λ is-equiv-eg →
           is-equiv-left-factor'
             g (map-equiv e) is-equiv-eg (is-equiv-map-equiv e)))

--- a/src/foundation/fiber-inclusions.lagda.md
+++ b/src/foundation/fiber-inclusions.lagda.md
@@ -161,10 +161,8 @@ module _
       is-pullback (pr1 {B = B}) (pt a) cone-fiber-fam
     is-pullback-cone-fiber-fam =
       is-equiv-comp
-        ( gap (pr1 {B = B}) (pt a) cone-fiber-fam)
         ( gap (pr1 {B = B}) (pt a) (cone-fiber (pr1 {B = B}) a))
         ( map-inv-fib-pr1 B a)
-        ( refl-htpy)
         ( is-equiv-map-inv-fib-pr1 B a)
         ( is-pullback-cone-fiber pr1 a)
 ```

--- a/src/foundation/functoriality-dependent-function-types.lagda.md
+++ b/src/foundation/functoriality-dependent-function-types.lagda.md
@@ -17,7 +17,7 @@ open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2)
 open import foundation.equivalences using
   ( _≃_; _∘e_; is-fiberwise-equiv; is-equiv; map-equiv; is-equiv-map-equiv;
     issec-map-inv-equiv; map-inv-equiv; coherence-map-inv-equiv;
-    isretr-map-inv-equiv; is-equiv-comp'; issec-map-inv-is-equiv;
+    isretr-map-inv-equiv; is-equiv-comp; issec-map-inv-is-equiv;
     map-inv-is-equiv; is-equiv-map-inv-is-equiv;
     id-equiv; equiv-ap; ind-htpy-equiv;
     comp-htpy-equiv)
@@ -103,7 +103,7 @@ module _
   abstract
     is-equiv-map-equiv-Π : is-equiv map-equiv-Π
     is-equiv-map-equiv-Π =
-      is-equiv-comp'
+      is-equiv-comp
         ( map-Π (λ a →
           ( tr B (issec-map-inv-is-equiv (is-equiv-map-equiv e) a)) ∘
           ( map-equiv (f (map-inv-is-equiv (is-equiv-map-equiv e) a)))))
@@ -113,7 +113,7 @@ module _
           ( is-equiv-map-inv-is-equiv (is-equiv-map-equiv e))
           ( B'))
         ( is-equiv-map-Π _
-          ( λ a → is-equiv-comp'
+          ( λ a → is-equiv-comp
             ( tr B (issec-map-inv-is-equiv (is-equiv-map-equiv e) a))
             ( map-equiv (f (map-inv-is-equiv (is-equiv-map-equiv e) a)))
             ( is-equiv-map-equiv
@@ -281,7 +281,7 @@ abstract
     ( e : A ≃ A) (f : (a : A) → B a ≃ B (map-equiv e a)) →
     is-equiv (map-automorphism-Π e f)
   is-equiv-map-automorphism-Π {B = B} e f =
-    is-equiv-comp' _ _
+    is-equiv-comp _ _
       ( is-equiv-precomp-Π-is-equiv _ (is-equiv-map-equiv e) B)
       ( is-equiv-map-Π _
         ( λ a → is-equiv-map-inv-is-equiv (is-equiv-map-equiv (f a))))

--- a/src/foundation/functoriality-dependent-pair-types.lagda.md
+++ b/src/foundation/functoriality-dependent-pair-types.lagda.md
@@ -101,21 +101,16 @@ module _
     is-equiv map-canonical-pullback-tot-cone-cone-family
   is-equiv-map-canonical-pullback-tot-cone-cone-family =
     is-equiv-comp
-      ( map-canonical-pullback-tot-cone-cone-family)
       ( tot (λ aa' →
         ( tot (λ bb' → eq-pair-Σ')) ∘
         ( map-canonical-pullback-tot-cone-cone-fam-left-factor aa')))
       ( map-canonical-pullback-tot-cone-cone-fam-right-factor)
-      ( refl-htpy)
       ( is-equiv-map-interchange-Σ-Σ
         ( λ a bα a' → Σ (PB (pr1 bα))
           ( λ b' → Id (tr PX (pr2 bα) (f' a a')) (g' (pr1 bα) b'))))
       ( is-equiv-tot-is-fiberwise-equiv (λ aa' → is-equiv-comp
-        ( ( tot (λ bb' → eq-pair-Σ')) ∘
-          ( map-canonical-pullback-tot-cone-cone-fam-left-factor aa'))
         ( tot (λ bb' → eq-pair-Σ'))
         ( map-canonical-pullback-tot-cone-cone-fam-left-factor aa')
-        ( refl-htpy)
         ( is-equiv-map-interchange-Σ-Σ _)
         ( is-equiv-tot-is-fiberwise-equiv (λ bb' → is-equiv-eq-pair-Σ
           ( pair (f (pr1 aa')) (f' (pr1 aa') (pr2 aa')))
@@ -173,7 +168,7 @@ module _
     is-pullback
       (map-Σ PX f f') (map-Σ PX g g') tot-cone-cone-family
   is-pullback-tot-is-pullback-family is-pb-c is-pb-c' =
-    is-equiv-comp
+    is-equiv-comp-htpy
       ( gap (map-Σ PX f f') (map-Σ PX g g') tot-cone-cone-family)
       ( map-canonical-pullback-tot-cone-cone-family)
       ( map-Σ _

--- a/src/foundation/identity-types.lagda.md
+++ b/src/foundation/identity-types.lagda.md
@@ -15,7 +15,7 @@ open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2)
 open import foundation.universe-levels using (UU; Level)
 
 open import foundation-core.equivalences using
-  ( is-equiv; is-equiv-has-inverse; _≃_; _∘e_; is-equiv-id; is-equiv-comp';
+  ( is-equiv; is-equiv-has-inverse; _≃_; _∘e_; is-equiv-id; is-equiv-comp;
     map-equiv)
 open import foundation-core.functions using (_∘_; id)
 open import foundation-core.function-extensionality using (eq-htpy)
@@ -159,7 +159,7 @@ module _
     is-equiv-con-inv :
       (p : x ＝ y) (q : y ＝ z) (r : x ＝ z) → is-equiv (con-inv p q r)
     is-equiv-con-inv p refl r =
-      is-equiv-comp'
+      is-equiv-comp
         ( concat' p (inv right-unit))
         ( concat (inv right-unit) r)
         ( is-equiv-concat (inv right-unit) r)

--- a/src/foundation/pullbacks.lagda.md
+++ b/src/foundation/pullbacks.lagda.md
@@ -18,10 +18,7 @@ open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2; triple)
 open import foundation.descent-equivalences using (descent-is-equiv)
 open import foundation.diagonal-maps-of-types using (diagonal)
 open import foundation.equality-dependent-pair-types using (eq-pair-Σ)
-open import foundation.equivalences using
-  ( is-equiv-comp; _∘e_; is-equiv; map-inv-is-equiv; _≃_; id-equiv;
-    map-inv-equiv; is-equiv-has-inverse; is-equiv-right-factor;
-    is-equiv-left-factor; is-pullback-is-equiv'; is-pullback-is-equiv)
+open import foundation.equivalences
 open import foundation.function-extensionality using
   ( htpy-eq; issec-eq-htpy; isretr-eq-htpy; funext)
 open import foundation.functions using (_∘_; id; map-Π)
@@ -136,7 +133,7 @@ abstract
     is-pullback f g c
   is-pullback-is-pullback-exponent f g c is-pb-exp =
     is-pullback-universal-property-pullback f g c
-      ( λ T → is-equiv-comp
+      ( λ T → is-equiv-comp-htpy
         ( cone-map f g c)
         ( map-canonical-pullback-exponent f g T)
         ( gap (_∘_ f) (_∘_ g) (exponent-cone T f g c))
@@ -249,10 +246,8 @@ module _
       is-equiv-tot-is-fiberwise-equiv (λ a →
         is-equiv-tot-is-fiberwise-equiv (λ b →
           is-equiv-comp
-            ( (concat' (f a) (inv (Hg b))) ∘ (concat (Hf a) (g' b)))
             ( concat' (f a) (inv (Hg b)))
             ( concat (Hf a) (g' b))
-            ( refl-htpy)
             ( is-equiv-concat (Hf a) (g' b))
             ( is-equiv-concat' (f a) (inv (Hg b)))))
 
@@ -298,7 +293,7 @@ module _
     is-pullback-htpy
       {c = pair p (pair q H)} (pair p' (pair q' H'))
       (pair Hp (pair Hq HH)) is-pb-c' =
-      is-equiv-comp
+      is-equiv-comp-htpy
         ( gap f g (triple p q H))
         ( map-equiv-canonical-pullback-htpy Hf Hg)
         ( gap f' g' (triple p' q' H'))
@@ -364,16 +359,12 @@ abstract
     is-equiv-tot-is-fiberwise-equiv
       ( λ K → is-equiv-tot-is-fiberwise-equiv
         ( λ L → is-equiv-comp
-          ( λ M → ( ap-concat-htpy H _ _ right-unit-htpy) ∙h
-            ( M ∙h
-              ( ap-concat-htpy' _ _ H' (inv-htpy right-unit-htpy))))
           ( concat-htpy
             ( ap-concat-htpy H _ _ right-unit-htpy)
             ( ((f ·l K) ∙h refl-htpy) ∙h H'))
           ( concat-htpy'
             ( H ∙h (g ·l L))
             ( ap-concat-htpy' _ _ H' (inv-htpy right-unit-htpy)))
-          ( refl-htpy)
           ( is-equiv-concat-htpy'
             ( H ∙h (g ·l L))
             ( λ x → ap (λ z → z ∙ H' x) (inv right-unit)))

--- a/src/foundation/retractions.lagda.md
+++ b/src/foundation/retractions.lagda.md
@@ -88,4 +88,3 @@ abstract
     is-injective f
   is-injective-retr f (pair h H) {x} {y} p = (inv (H x)) ∙ (ap h p ∙ H y)
 ```
-   

--- a/src/foundation/retractions.lagda.md
+++ b/src/foundation/retractions.lagda.md
@@ -48,13 +48,13 @@ module _
 
 ```agda
 isretr-retraction-comp :
-  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
-  (f : A → B) (g : B → C) (h : A → C) (H : h ~ (g ∘ f)) (retr-g : retr g) →
-  ((retraction-right-factor-htpy f g h H) ∘ (λ retr-f → retraction-comp-htpy f g h H retr-f retr-g)) ~ id
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
+  (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) (retr-g : retr g) →
+  ((retraction-right-factor-htpy f g h H) ∘ (retraction-comp-htpy f g h H retr-g)) ~ id
 isretr-retraction-comp f g h H (pair l L) (pair k K) =
   eq-htpy-retr
     ( ( retraction-right-factor-htpy f g h H
-        ( retraction-comp-htpy f g h H (pair k K) (pair l L)
+        ( retraction-comp-htpy f g h H (pair l L) (pair k K)
           )))
     ( pair k K)
     ( k ·l L)
@@ -62,21 +62,19 @@ isretr-retraction-comp f g h H (pair l L) (pair k K) =
         ( assoc-htpy
           ( inv-htpy ((k ∘ l) ·l H))
           ( (k ∘ l) ·l H)
-          ( (k ·l (L ·r f)) ∙h K))) ∙h
+          ( (k ·l (L ·r h)) ∙h K))) ∙h
       ( ap-concat-htpy'
         ( (inv-htpy ((k ∘ l) ·l H)) ∙h ((k ∘ l) ·l H))
         ( refl-htpy)
-        ( (k ·l (L ·r f)) ∙h K)
+        ( (k ·l (L ·r h)) ∙h K)
         ( left-inv-htpy ((k ∘ l) ·l H))))
-  
-
 
 retr-right-factor-retract-of-retr-left-factor :
-  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
-  (f : A → B) (g : B → C) (h : A → C) (H : h ~ (g ∘ f)) →
-  retr g → (retr f) retract-of (retr h)
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
+  (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
+  retr g → (retr h) retract-of (retr f)
 pr1 (retr-right-factor-retract-of-retr-left-factor f g h H retr-g) =
-  λ retr-f → retraction-comp-htpy f g h H retr-f retr-g
+  retraction-comp-htpy f g h H retr-g
 pr1 (pr2 (retr-right-factor-retract-of-retr-left-factor f g h H retr-g)) =
   retraction-right-factor-htpy f g h H
 pr2 (pr2 (retr-right-factor-retract-of-retr-left-factor f g h H retr-g)) =

--- a/src/foundation/retractions.lagda.md
+++ b/src/foundation/retractions.lagda.md
@@ -13,8 +13,7 @@ open import foundation.coslice using
   ( htpy-hom-coslice; extensionality-hom-coslice; eq-htpy-hom-coslice)
 open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2)
 open import foundation.functions using (_∘_; id)
-open import foundation.equivalences using
-  ( retraction-comp; retraction-comp'; _≃_)
+open import foundation.equivalences using (_≃_)
 open import foundation.identity-types using (inv; _∙_; ap)
 open import foundation.injective-maps using (is-injective)
 open import foundation.homotopies using
@@ -45,39 +44,41 @@ module _
   eq-htpy-retr g h = eq-htpy-hom-coslice g h 
 ```
 
-### If the left factor in a commuting traingle has a retraction, then the type of retractions of the right factor is a retract of the type of retractions of the composite
+### If the left factor of a composite has a retraction, then the type of retractions of the right factor is a retract of the type of retractions of the composite.
 
 ```agda
 isretr-retraction-comp :
-  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
-  (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) (retr-g : retr g) →
-  ((retraction-comp f g h H retr-g) ∘ (retraction-comp' f g h H retr-g)) ~ id
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
+  (f : A → B) (g : B → C) (h : A → C) (H : h ~ (g ∘ f)) (retr-g : retr g) →
+  ((retraction-right-factor-htpy f g h H) ∘ (λ retr-f → retraction-comp-htpy f g h H retr-f retr-g)) ~ id
 isretr-retraction-comp f g h H (pair l L) (pair k K) =
   eq-htpy-retr
-    ( ( retraction-comp f g h H (pair l L)
-        ( retraction-comp' f g h H (pair l L)
-          ( pair k K))))
+    ( ( retraction-right-factor-htpy f g h H
+        ( retraction-comp-htpy f g h H (pair k K) (pair l L)
+          )))
     ( pair k K)
     ( k ·l L)
     ( ( inv-htpy
         ( assoc-htpy
           ( inv-htpy ((k ∘ l) ·l H))
           ( (k ∘ l) ·l H)
-          ( (k ·l (L ·r h)) ∙h K))) ∙h
+          ( (k ·l (L ·r f)) ∙h K))) ∙h
       ( ap-concat-htpy'
         ( (inv-htpy ((k ∘ l) ·l H)) ∙h ((k ∘ l) ·l H))
         ( refl-htpy)
-        ( (k ·l (L ·r h)) ∙h K)
+        ( (k ·l (L ·r f)) ∙h K)
         ( left-inv-htpy ((k ∘ l) ·l H))))
   
+
+
 retr-right-factor-retract-of-retr-left-factor :
-  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
-  (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
-  retr g → (retr h) retract-of (retr f)
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
+  (f : A → B) (g : B → C) (h : A → C) (H : h ~ (g ∘ f)) →
+  retr g → (retr f) retract-of (retr h)
 pr1 (retr-right-factor-retract-of-retr-left-factor f g h H retr-g) =
-  retraction-comp' f g h H retr-g
+  λ retr-f → retraction-comp-htpy f g h H retr-f retr-g
 pr1 (pr2 (retr-right-factor-retract-of-retr-left-factor f g h H retr-g)) =
-  retraction-comp f g h H retr-g
+  retraction-right-factor-htpy f g h H
 pr2 (pr2 (retr-right-factor-retract-of-retr-left-factor f g h H retr-g)) =
   isretr-retraction-comp f g h H retr-g
 ```
@@ -89,3 +90,4 @@ abstract
     is-injective f
   is-injective-retr f (pair h H) {x} {y} p = (inv (H x)) ∙ (ap h p ∙ H y)
 ```
+   

--- a/src/foundation/retractions.lagda.md
+++ b/src/foundation/retractions.lagda.md
@@ -47,11 +47,11 @@ module _
 ### If the left factor of a composite has a retraction, then the type of retractions of the right factor is a retract of the type of retractions of the composite.
 
 ```agda
-isretr-retraction-comp :
+isretr-retraction-comp-htpy :
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
   (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) (retr-g : retr g) →
   ((retraction-right-factor-htpy f g h H) ∘ (retraction-comp-htpy f g h H retr-g)) ~ id
-isretr-retraction-comp f g h H (pair l L) (pair k K) =
+isretr-retraction-comp-htpy f g h H (pair l L) (pair k K) =
   eq-htpy-retr
     ( ( retraction-right-factor-htpy f g h H
         ( retraction-comp-htpy f g h H (pair l L) (pair k K)
@@ -78,7 +78,7 @@ pr1 (retr-right-factor-retract-of-retr-left-factor f g h H retr-g) =
 pr1 (pr2 (retr-right-factor-retract-of-retr-left-factor f g h H retr-g)) =
   retraction-right-factor-htpy f g h H
 pr2 (pr2 (retr-right-factor-retract-of-retr-left-factor f g h H retr-g)) =
-  isretr-retraction-comp f g h H retr-g
+  isretr-retraction-comp-htpy f g h H retr-g
 ```
 
 ```agda

--- a/src/foundation/sections.lagda.md
+++ b/src/foundation/sections.lagda.md
@@ -133,6 +133,8 @@ module _
       ( λ s → id-equiv))
 ```
 
+### Extensionality of sections
+
 ```agda
 module _
   {l1 l2 : Level} {A : UU l1} {B : UU l2} {f : A → B}
@@ -186,10 +188,10 @@ sec-left-factor-retract-of-sec-composition :
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
   (f : A → B) (g : B → C) (h : A → C) (H : h ~ (g ∘ f)) →
   sec f → (sec g) retract-of (sec h)
-pr1 (sec-left-factor-retract-of-sec-composition {C = C} f g h H sec-f) =
+pr1 (sec-left-factor-retract-of-sec-composition f g h H sec-f) =
   section-comp-htpy f g h H sec-f
-pr1 (pr2 (sec-left-factor-retract-of-sec-composition {C = C} f g h H sec-f)) =
+pr1 (pr2 (sec-left-factor-retract-of-sec-composition f g h H sec-f)) =
   section-left-factor-htpy f g h H
-pr2 (pr2 (sec-left-factor-retract-of-sec-composition {C = C} f g h H sec-f)) =
+pr2 (pr2 (sec-left-factor-retract-of-sec-composition f g h H sec-f)) =
   isretr-section-comp f g h H sec-f
 ```

--- a/src/foundation/sections.lagda.md
+++ b/src/foundation/sections.lagda.md
@@ -161,13 +161,13 @@ module _
 
 ```agda
 isretr-section-comp :
-  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
-  (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) (sec-h : sec h) →
-  ((section-comp f g h H sec-h) ∘ (section-comp' f g h H sec-h)) ~ id
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
+  (f : A → B) (g : B → C) (h : A → C) (H : h ~ (g ∘ f)) (sec-f : sec f) →
+  ((section-left-factor-htpy f g h H) ∘ (section-comp-htpy f g h H sec-f)) ~ id
 isretr-section-comp f g h H (pair k K) (pair l L) =
   eq-htpy-sec
-    ( ( section-comp f g h H (pair k K) ∘
-        section-comp' f g h H (pair k K))
+    ( ( section-left-factor-htpy f g h H ∘
+        section-comp-htpy f g h H (pair k K))
       ( pair l L))
     ( pair l L)
     ( K ·r l)
@@ -183,13 +183,13 @@ isretr-section-comp f g h H (pair k K) (pair l L) =
         ( left-inv-htpy (H ·r (k ∘ l)))))
 
 sec-left-factor-retract-of-sec-composition :
-  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
-  (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
-  sec h → (sec g) retract-of (sec f)
-pr1 (sec-left-factor-retract-of-sec-composition {X = X} f g h H sec-h) =
-  section-comp' f g h H sec-h
-pr1 (pr2 (sec-left-factor-retract-of-sec-composition {X = X} f g h H sec-h)) =
-  section-comp f g h H sec-h
-pr2 (pr2 (sec-left-factor-retract-of-sec-composition {X = X} f g h H sec-h)) =
-  isretr-section-comp f g h H sec-h
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
+  (f : A → B) (g : B → C) (h : A → C) (H : h ~ (g ∘ f)) →
+  sec f → (sec g) retract-of (sec h)
+pr1 (sec-left-factor-retract-of-sec-composition {C = C} f g h H sec-f) =
+  section-comp-htpy f g h H sec-f
+pr1 (pr2 (sec-left-factor-retract-of-sec-composition {C = C} f g h H sec-f)) =
+  section-left-factor-htpy f g h H
+pr2 (pr2 (sec-left-factor-retract-of-sec-composition {C = C} f g h H sec-f)) =
+  isretr-section-comp f g h H sec-f
 ```

--- a/src/foundation/sections.lagda.md
+++ b/src/foundation/sections.lagda.md
@@ -1,5 +1,5 @@
 ---
-title: Sections of type families
+title: Sections
 ---
 
 ```agda

--- a/src/foundation/sections.lagda.md
+++ b/src/foundation/sections.lagda.md
@@ -162,11 +162,11 @@ module _
 ### If the right factor of a composite has a section, then the type of sections of the left factor is a retract of the type of sections of the composite.
 
 ```agda
-isretr-section-comp :
+isretr-section-comp-htpy :
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
   (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) (sec-h : sec h) →
   ((section-left-factor-htpy f g h H) ∘ (section-comp-htpy f g h H sec-h)) ~ id
-isretr-section-comp f g h H (pair k K) (pair l L) =
+isretr-section-comp-htpy f g h H (pair k K) (pair l L) =
   eq-htpy-sec
     ( ( section-left-factor-htpy f g h H ∘
         section-comp-htpy f g h H (pair k K))
@@ -193,5 +193,5 @@ pr1 (sec-left-factor-retract-of-sec-composition f g h H sec-h) =
 pr1 (pr2 (sec-left-factor-retract-of-sec-composition f g h H sec-h)) =
   section-left-factor-htpy f g h H
 pr2 (pr2 (sec-left-factor-retract-of-sec-composition f g h H sec-h)) =
-  isretr-section-comp f g h H sec-h
+  isretr-section-comp-htpy f g h H sec-h
 ```

--- a/src/foundation/sections.lagda.md
+++ b/src/foundation/sections.lagda.md
@@ -16,7 +16,7 @@ open import foundation.contractible-types using
 open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2)
 open import foundation.equivalences using
   ( is-equiv; is-equiv-right-factor; is-equiv-id; _≃_; is-equiv-left-factor;
-    _∘e_; id-equiv; map-inv-equiv; section-comp; section-comp')
+    _∘e_; id-equiv; map-inv-equiv)
 open import foundation.function-extensionality using (equiv-funext)
 open import foundation.functions using (_∘_; id)
 open import foundation.homotopies using

--- a/src/foundation/sections.lagda.md
+++ b/src/foundation/sections.lagda.md
@@ -163,9 +163,9 @@ module _
 
 ```agda
 isretr-section-comp :
-  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
-  (f : A → B) (g : B → C) (h : A → C) (H : h ~ (g ∘ f)) (sec-f : sec f) →
-  ((section-left-factor-htpy f g h H) ∘ (section-comp-htpy f g h H sec-f)) ~ id
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
+  (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) (sec-h : sec h) →
+  ((section-left-factor-htpy f g h H) ∘ (section-comp-htpy f g h H sec-h)) ~ id
 isretr-section-comp f g h H (pair k K) (pair l L) =
   eq-htpy-sec
     ( ( section-left-factor-htpy f g h H ∘
@@ -185,13 +185,13 @@ isretr-section-comp f g h H (pair k K) (pair l L) =
         ( left-inv-htpy (H ·r (k ∘ l)))))
 
 sec-left-factor-retract-of-sec-composition :
-  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
-  (f : A → B) (g : B → C) (h : A → C) (H : h ~ (g ∘ f)) →
-  sec f → (sec g) retract-of (sec h)
-pr1 (sec-left-factor-retract-of-sec-composition f g h H sec-f) =
-  section-comp-htpy f g h H sec-f
-pr1 (pr2 (sec-left-factor-retract-of-sec-composition f g h H sec-f)) =
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
+  (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
+  sec h → (sec g) retract-of (sec f)
+pr1 (sec-left-factor-retract-of-sec-composition f g h H sec-h) =
+  section-comp-htpy f g h H sec-h
+pr1 (pr2 (sec-left-factor-retract-of-sec-composition f g h H sec-h)) =
   section-left-factor-htpy f g h H
-pr2 (pr2 (sec-left-factor-retract-of-sec-composition f g h H sec-f)) =
-  isretr-section-comp f g h H sec-f
+pr2 (pr2 (sec-left-factor-retract-of-sec-composition f g h H sec-h)) =
+  isretr-section-comp f g h H sec-h
 ```

--- a/src/foundation/set-truncations.lagda.md
+++ b/src/foundation/set-truncations.lagda.md
@@ -20,7 +20,7 @@ open import foundation.equality-coproduct-types using
   ( coprod-Set)
 open import foundation.equivalences using
   ( _≃_; is-equiv; map-inv-equiv; map-equiv; is-equiv-right-factor';
-    is-equiv-comp'; is-equiv-htpy-equiv; _∘e_; issec-map-inv-equiv)
+    is-equiv-comp; is-equiv-htpy-equiv; _∘e_; issec-map-inv-equiv)
 open import foundation.function-extensionality using (htpy-eq)
 open import foundation.functions using (_∘_; id)
 open import foundation.functoriality-cartesian-product-types using
@@ -468,7 +468,7 @@ module _
             ( ev-inl-inr (λ x → type-Set C))
             ( precomp-Set (map-coprod unit-trunc-Set unit-trunc-Set) C)
             ( universal-property-coprod (type-Set C))
-            ( is-equiv-comp'
+            ( is-equiv-comp
               ( map-prod
                 ( precomp-Set unit-trunc-Set C)
                 ( precomp-Set unit-trunc-Set C))

--- a/src/foundation/surjective-maps.lagda.md
+++ b/src/foundation/surjective-maps.lagda.md
@@ -17,7 +17,7 @@ open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2)
 open import foundation.embeddings using
   ( _↪_; map-emb; is-emb; emb-Σ; id-emb; equiv-ap-emb)
 open import foundation.equivalences using
-  ( is-equiv; map-inv-is-equiv; is-equiv-comp'; _≃_; map-equiv; _∘e_; inv-equiv;
+  ( is-equiv; map-inv-is-equiv; is-equiv-comp; _≃_; map-equiv; _∘e_; inv-equiv;
     map-inv-equiv; id-equiv; is-equiv-map-equiv)
 open import foundation.fibers-of-maps using
   ( fib; is-equiv-map-reduce-Π-fib; reduce-Π-fib)
@@ -280,11 +280,11 @@ abstract
     is-surjective f →
     ({l : Level} → dependent-universal-property-surj l f)
   dependent-universal-property-surj-is-surjective f is-surj-f P =
-    is-equiv-comp'
+    is-equiv-comp
       ( λ h x → h (f x) (pair x refl))
       ( ( λ h y → (h y) ∘ unit-trunc-Prop) ∘
         ( λ h y → const (type-trunc-Prop (fib f y)) (type-Prop (P y)) (h y)))
-      ( is-equiv-comp'
+      ( is-equiv-comp
         ( λ h y → (h y) ∘ unit-trunc-Prop)
         ( λ h y → const (type-trunc-Prop (fib f y)) (type-Prop (P y)) (h y))
         ( is-equiv-map-Π

--- a/src/foundation/uniqueness-image.lagda.md
+++ b/src/foundation/uniqueness-image.lagda.md
@@ -12,7 +12,7 @@ open import foundation.contractible-types using
 open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2)
 open import foundation.embeddings using (_↪_; map-emb)
 open import foundation.equivalences using
-  ( is-equiv; map-inv-is-equiv; triangle-section; issec-map-inv-is-equiv; _∘e_;
+  ( is-equiv; map-inv-is-equiv; issec-map-inv-is-equiv; _∘e_;
     id-equiv; is-property-is-equiv; is-equiv-map-equiv; _≃_)
 open import foundation.functions using (_∘_; id)
 open import foundation.functoriality-dependent-pair-types using
@@ -20,6 +20,7 @@ open import foundation.functoriality-dependent-pair-types using
 open import foundation.homotopies using (_~_; _∙h_; _·r_; _·l_)
 open import foundation.images using (inclusion-im; unit-im; emb-im; im)
 open import foundation.propositions using (is-proof-irrelevant-is-prop)
+open import foundation.sections using (triangle-section)
 open import foundation.slice using
   ( hom-slice; map-hom-slice; is-equiv-hom-slice-emb; comp-hom-slice;
     triangle-hom-slice; equiv-slice; htpy-hom-slice; hom-equiv-slice)

--- a/src/foundation/uniqueness-set-quotients.lagda.md
+++ b/src/foundation/uniqueness-set-quotients.lagda.md
@@ -10,7 +10,7 @@ module foundation.uniqueness-set-quotients where
 open import foundation.contractible-types using (is-contr; center)
 open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2)
 open import foundation.equivalences using
-  ( is-equiv; is-equiv-has-inverse; is-equiv-comp; is-equiv-precomp-is-equiv;
+  ( is-equiv; is-equiv-has-inverse; is-equiv-comp-htpy; is-equiv-precomp-is-equiv;
     is-equiv-left-factor; _≃_; map-equiv; is-property-is-equiv)
 open import foundation.function-extensionality using (htpy-eq)
 open import foundation.functions using  (_∘_; id; precomp)
@@ -114,7 +114,7 @@ module _
       is-equiv h → ({l : Level} → is-set-quotient l R B f) →
       {l : Level} → is-set-quotient l R C g
     is-set-quotient-is-set-quotient-is-equiv E Uf {l} X =
-      is-equiv-comp
+      is-equiv-comp-htpy
         ( precomp-Set-Quotient R C g X)
         ( precomp-Set-Quotient R B f X)
         ( precomp h (type-Set X))

--- a/src/foundation/universal-property-coproduct-types.lagda.md
+++ b/src/foundation/universal-property-coproduct-types.lagda.md
@@ -87,10 +87,8 @@ module _
         is-equiv (λ (s : X → Y) → pair' (s ∘ i) (s ∘ j))
     universal-property-coprod-is-equiv-ind-coprod X i j H l Y =
       is-equiv-comp
-        ( λ s → pair (s ∘ i) (s ∘ j))
         ( ev-inl-inr (λ t → Y))
         ( precomp (ind-coprod (λ t → X) i j) Y)
-        ( λ s → refl)
         ( is-equiv-precomp-is-equiv
           ( ind-coprod (λ t → X) i j)
           ( H)

--- a/src/foundation/universal-property-image.lagda.md
+++ b/src/foundation/universal-property-image.lagda.md
@@ -14,7 +14,7 @@ open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2)
 open import foundation.embeddings using
   ( _↪_; map-emb; id-emb; is-emb; is-emb-comp'; is-emb-map-emb)
 open import foundation.equivalences using
-  ( is-equiv; map-inv-is-equiv; triangle-section; issec-map-inv-is-equiv; _∘e_;
+  ( is-equiv; map-inv-is-equiv; issec-map-inv-is-equiv; _∘e_;
     id-equiv; is-property-is-equiv; is-equiv-map-equiv; _≃_; map-equiv;
     inv-equiv)
 open import foundation.fibers-of-maps using (fib; reduce-Π-fib)

--- a/src/foundation/universal-property-propositional-truncation.lagda.md
+++ b/src/foundation/universal-property-propositional-truncation.lagda.md
@@ -15,7 +15,7 @@ open import foundation.equivalences using
   ( is-equiv; map-inv-is-equiv; map-equiv; is-property-is-equiv;
     is-equiv-top-is-equiv-bottom-square; is-equiv-precomp-is-equiv;
     is-equiv-map-equiv; is-equiv-is-equiv-precomp-Prop; is-equiv-id;
-    is-equiv-comp')
+    is-equiv-comp)
 open import foundation.function-extensionality using (equiv-funext)
 open import foundation.functions using (_∘_; precomp-Π; precomp; id)
 open import foundation.functoriality-cartesian-product-types using (map-prod)
@@ -349,7 +349,7 @@ abstract
       ( refl-htpy)
       ( is-equiv-ev-pair)
       ( is-equiv-ev-pair)
-      ( is-equiv-comp'
+      ( is-equiv-comp
         ( λ h a a' → h a (f' a'))
         ( λ h a p' → h (f a) p')
         ( is-ptr-f (pair (type-hom-Prop P' Q) (is-prop-type-hom-Prop P' Q)))

--- a/src/foundation/universal-property-pullbacks.lagda.md
+++ b/src/foundation/universal-property-pullbacks.lagda.md
@@ -14,7 +14,7 @@ open import foundation.contractible-types using (is-contr; is-contr-equiv')
 open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2; triple)
 open import foundation.equivalences using
   ( is-equiv; is-property-is-equiv; map-inv-is-equiv; issec-map-inv-is-equiv;
-    _≃_; is-equiv-right-factor; is-equiv-comp; is-equiv-left-factor; map-equiv;
+    _≃_; is-equiv-right-factor; is-equiv-left-factor; map-equiv;
     id-equiv; _∘e_; map-inv-equiv; is-equiv-map-equiv)
 open import foundation.function-extensionality using (equiv-funext)
 open import foundation.functions using (_∘_)

--- a/src/foundation/universal-property-set-quotients.lagda.md
+++ b/src/foundation/universal-property-set-quotients.lagda.md
@@ -25,7 +25,7 @@ open import foundation.equivalence-classes using
     quotient-reflecting-map-equivalence-class;
     is-surjective-and-effective-class)
 open import foundation.equivalences using
-  ( is-equiv; _≃_; map-inv-is-equiv; is-equiv-has-inverse; is-equiv-comp;
+  ( is-equiv; _≃_; map-inv-is-equiv; is-equiv-has-inverse;
     is-equiv-precomp-is-equiv; is-equiv-left-factor; map-equiv;
     is-property-is-equiv; _∘e_; inv-equiv; map-inv-equiv;
     issec-map-inv-is-equiv)

--- a/src/foundation/universal-property-set-truncation.lagda.md
+++ b/src/foundation/universal-property-set-truncation.lagda.md
@@ -201,14 +201,12 @@ abstract
     is-set-truncation l3 B f
   is-set-truncation-is-set-quotient {A = A} B f H X =
     is-equiv-comp
-      ( precomp-Set f X)
       ( pr1)
       ( precomp-Set-Quotient
         ( mere-eq-Eq-Rel A)
         ( B)
         ( reflecting-map-mere-eq B f)
         ( X))
-      ( refl-htpy)
       ( H X)
       ( is-equiv-pr1-is-contr
         ( λ h →

--- a/src/foundation/universal-property-truncation.lagda.md
+++ b/src/foundation/universal-property-truncation.lagda.md
@@ -492,7 +492,7 @@ module _
             ( ev-inl-inr (λ x → type-Set C))
             ( precomp-Set (map-coprod unit-trunc-Set unit-trunc-Set) C)
             ( universal-property-coprod (type-Set C))
-            ( is-equiv-comp'
+            ( is-equiv-comp
               ( map-prod
                 ( precomp-Set unit-trunc-Set C)
                 ( precomp-Set unit-trunc-Set C))
@@ -664,7 +664,7 @@ abstract
         is-equiv-left-factor'
           ( precomp (map-Π (λ x → unit-trunc-Set)) (type-Set B))
           ( precomp (ev-Maybe {B = type-trunc-Set ∘ A}) (type-Set B))
-          ( is-equiv-comp'
+          ( is-equiv-comp
             ( precomp ev-Maybe (type-Set B))
             ( precomp
               ( map-prod (map-Π (λ x → unit-trunc-Set)) unit-trunc-Set)

--- a/src/foundation/universal-property-unit-type.lagda.md
+++ b/src/foundation/universal-property-unit-type.lagda.md
@@ -91,10 +91,8 @@ abstract
     ({l2 : Level} (Y : UU l2) → is-equiv (λ (f : X → Y) → f x))
   universal-property-unit-is-equiv-pt x is-equiv-pt Y =
     is-equiv-comp
-      ( λ f → f x)
       ( ev-star' Y)
       ( precomp (pt x) Y)
-      ( λ f → refl)
       ( is-equiv-precomp-is-equiv (pt x) is-equiv-pt Y)
       ( universal-property-unit Y)
 

--- a/src/structured-types/pointed-equivalences.lagda.md
+++ b/src/structured-types/pointed-equivalences.lagda.md
@@ -16,7 +16,7 @@ open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2)
 open import foundation.equivalences using
   ( is-equiv; is-contr-sec-is-equiv; map-inv-is-equiv; issec-map-inv-is-equiv;
     _∘e_; is-emb-is-equiv; is-contr-retr-is-equiv; isretr-map-inv-is-equiv;
-    is-equiv-comp'; _≃_; is-property-is-equiv; map-equiv; id-equiv;
+    is-equiv-comp; _≃_; is-property-is-equiv; map-equiv; id-equiv;
     map-inv-equiv; is-equiv-has-inverse; is-equiv-map-equiv)
 open import foundation.fibers-of-maps using (fib)
 open import foundation.function-extensionality using (htpy-eq)
@@ -253,7 +253,7 @@ module _
           ( isretr-map-inv-is-equiv H (pt-Pointed-Type A)))
         ( equiv-tot (λ p → equiv-inv _ _))
         ( is-contr-map-is-equiv
-          ( is-equiv-comp'
+          ( is-equiv-comp
             ( λ q → q ∙ refl)
             ( λ p →
               ( ap

--- a/src/synthetic-homotopy-theory/26-descent.lagda.md
+++ b/src/synthetic-homotopy-theory/26-descent.lagda.md
@@ -416,7 +416,7 @@ dependent-universal-property-dependent-pullback-property-pushout :
 dependent-universal-property-dependent-pullback-property-pushout
   f g (pair i (pair j H)) dpullback-c l P =
   let c = (pair i (pair j H)) in
-  is-equiv-comp
+  is-equiv-comp-htpy
     ( dep-cocone-map f g c P)
     ( tot (λ h → tot λ h' → htpy-eq))
     ( gap
@@ -1052,7 +1052,7 @@ is-equiv-desc-fam :
   ((l' : Level) → universal-property-pushout l' f g c) →
   is-equiv (desc-fam {l = l} {f = f} {g} c)
 is-equiv-desc-fam {l = l} {f = f} {g} c up-c =
-  is-equiv-comp
+  is-equiv-comp-htpy
     ( desc-fam c)
     ( Fam-pushout-cocone-UU l)
     ( cocone-map f g c)

--- a/src/synthetic-homotopy-theory/26-id-pushout.lagda.md
+++ b/src/synthetic-homotopy-theory/26-id-pushout.lagda.md
@@ -180,7 +180,7 @@ is-equiv-square-path-over-fam-maps :
   { x x' : A} (p : Id x x') (f : B x → C x) (f' : B x' → C x') →
   is-equiv (square-path-over-fam-maps p f f')
 is-equiv-square-path-over-fam-maps refl f f' =
-  is-equiv-comp' htpy-eq inv (is-equiv-inv f f') (funext f' f)
+  is-equiv-comp htpy-eq inv (is-equiv-inv f f') (funext f' f)
   
 is-equiv-hom-Fam-pushout-dep-cocone :
   { l1 l2 l3 l4 l5 l6 : Level} {S : UU l1} {A : UU l2} {B : UU l3} {X : UU l4}
@@ -240,7 +240,7 @@ is-equiv-hom-Fam-pushout-map :
   ( P : X → UU l5) (Q : X → UU l6) →
   is-equiv (hom-Fam-pushout-map c P Q)
 is-equiv-hom-Fam-pushout-map {l5 = l5} {l6} {f = f} {g} c up-X P Q =
-  is-equiv-comp
+  is-equiv-comp-htpy
     ( hom-Fam-pushout-map c P Q)
     ( hom-Fam-pushout-dep-cocone c P Q)
     ( dep-cocone-map f g c (λ x → P x → Q x))

--- a/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
@@ -144,7 +144,7 @@ is-equiv-ev-suspension :
   ( up-Y : universal-property-suspension' l3 X Y susp-str-Y) → 
   ( Z : UU l3) → is-equiv (ev-suspension susp-str-Y Z)
 is-equiv-ev-suspension {X = X} susp-str-Y up-Y Z =
-  is-equiv-comp
+  is-equiv-comp-htpy
     ( ev-suspension susp-str-Y Z)
     ( map-comparison-suspension-cocone X Z)
     ( cocone-map

--- a/src/synthetic-homotopy-theory/universal-cover-circle.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-cover-circle.lagda.md
@@ -121,7 +121,7 @@ abstract
     ( up-circle : universal-property-circle (lsuc l2) l) →
     is-equiv (ev-fam-circle {l2 = l2} l)
   is-equiv-ev-fam-circle-universal-property-circle {l2 = l2} l up-circle =
-    is-equiv-comp
+    is-equiv-comp-htpy
       ( ev-fam-circle l)
       ( comparison-fam-circle l2)
       ( ev-free-loop l (UU l2))
@@ -146,7 +146,7 @@ abstract
       ( tot (λ P → (Eq-Fam-circle-eq Q (ev-fam-circle l P)) ∘ inv))
       ( is-equiv-tot-is-fiberwise-equiv
         ( λ P →
-          is-equiv-comp' _ _
+          is-equiv-comp _ _
             ( is-equiv-inv _ _)
             ( is-equiv-Eq-Fam-circle-eq Q (ev-fam-circle l P))))
       ( is-contr-map-is-equiv
@@ -238,7 +238,7 @@ abstract
       ( _)
       ( is-equiv-f x)
       ( λ p₀ →
-        is-equiv-comp'
+        is-equiv-comp
           ( concat
             ( naturality-tr-fiberwise-transformation f l p₀)
             ( f x p₀))

--- a/src/synthetic-homotopy-theory/universal-property-pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-pushouts.lagda.md
@@ -157,7 +157,7 @@ module _
     ( up-c : {l : Level} → universal-property-pushout l f g c) →
     {l : Level} → universal-property-pushout l f g d
   up-pushout-up-pushout-is-equiv is-equiv-h up-c Z =
-    is-equiv-comp
+    is-equiv-comp-htpy
       ( cocone-map f g d)
       ( cocone-map f g c)
       ( precomp h Z)
@@ -243,7 +243,7 @@ universal-property-pushout-pullback-property-pushout :
   pullback-property-pushout l f g c → universal-property-pushout l f g c
 universal-property-pushout-pullback-property-pushout
   l f g c pb-c Y =
-  is-equiv-comp
+  is-equiv-comp-htpy
     ( cocone-map f g c)
     ( tot (λ i' → tot (λ j' p → htpy-eq p)))
     ( gap (λ h → h ∘ f) (λ h → h ∘ g) (cone-pullback-property-pushout f g c Y))

--- a/src/univalent-combinatorics/2-element-types.lagda.md
+++ b/src/univalent-combinatorics/2-element-types.lagda.md
@@ -310,11 +310,8 @@ module _
             ( ev-zero-equiv-Fin-two-ℕ)
             ( map-equiv (equiv-postcomp-equiv α (Fin 2)))
             ( is-equiv-comp
-              ( ( ev-zero-equiv-Fin-two-ℕ) ∘
-                ( map-equiv (equiv-postcomp-equiv α (Fin 2))))
               ( map-equiv α)
               ( ev-zero-equiv-Fin-two-ℕ)
-              ( refl-htpy)
               ( is-equiv-ev-zero-aut-Fin-two-ℕ)
               ( is-equiv-map-equiv α))
             ( is-equiv-comp-equiv α (Fin 2)))

--- a/src/univalent-combinatorics/distributivity-of-set-truncation-over-finite-products.lagda.md
+++ b/src/univalent-combinatorics/distributivity-of-set-truncation-over-finite-products.lagda.md
@@ -19,7 +19,7 @@ open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2; ev-pair)
 open import foundation.empty-types using (empty-Set)
 open import foundation.equivalences using
   ( _≃_; map-equiv; is-equiv-precomp-is-equiv; is-equiv-left-factor';
-    is-equiv-comp'; is-equiv-right-factor'; is-equiv-htpy-equiv;
+    is-equiv-comp; is-equiv-right-factor'; is-equiv-htpy-equiv;
     is-equiv-map-equiv; _∘e_; equiv-postcomp-equiv;
     inv-equiv; equiv-precomp-equiv; id-equiv)
 open import foundation.function-extensionality using (equiv-funext; eq-htpy)
@@ -86,7 +86,7 @@ abstract
         is-equiv-left-factor'
           ( precomp (map-Π (λ x → unit-trunc-Set)) (type-Set B))
           ( precomp (ev-Maybe {B = type-trunc-Set ∘ A}) (type-Set B))
-          ( is-equiv-comp'
+          ( is-equiv-comp
             ( precomp ev-Maybe (type-Set B))
             ( precomp
               ( map-prod (map-Π (λ x → unit-trunc-Set)) unit-trunc-Set)


### PR DESCRIPTION
### Summary
- Move `section-comp` and its variants from `foundation-core.equivalences` to their rightful home, `foundation-core.sections` (and similar for retractions).
- Rename `section-comp` to `section-left-factor-htpy` and add a non-homotopy variant (and similar for retractions).
- Rename `section-comp'` to `section-comp-htpy` and add a non-homotopy variant (and similar for retractions).
- Change the title of the `foundation.sections` files from "Sections of type families" to just "Sections".
- Rename `is-equiv-comp` to `is-equiv-comp-htpy` and change to using the non-homotopy variant where possible. In my opinion, it is clear from the usage of `is-equiv-comp` in the library that its name was misleading.

I hope my pull requests don't come across as pointlessly nitpicky.