### PR TITLE
Cleanup of composition theorems

### DIFF
--- a/src/elementary-number-theory/modular-arithmetic.lagda.md
+++ b/src/elementary-number-theory/modular-arithmetic.lagda.md
@@ -8,68 +8,38 @@ title: Modular arithmetic
 module elementary-number-theory.modular-arithmetic where
 
 open import elementary-number-theory.absolute-value-integers
-open import elementary-number-theory.addition-integers using
-  ( add-ℤ; ap-add-ℤ; is-injective-add-ℤ; is-injective-add-ℤ'; associative-add-ℤ;
-    commutative-add-ℤ; left-unit-law-add-ℤ; right-unit-law-add-ℤ;
-    left-inverse-law-add-ℤ; right-inverse-law-add-ℤ;
-    left-successor-law-add-ℤ; right-successor-law-add-ℤ;
-    left-predecessor-law-add-ℤ; right-predecessor-law-add-ℤ;
-    is-add-one-succ-ℤ; is-add-one-succ-ℤ'; is-add-neg-one-pred-ℤ;
-    is-add-neg-one-pred-ℤ'; is-equiv-add-ℤ; is-equiv-add-ℤ')
-open import elementary-number-theory.congruence-integers using
-  ( cong-ℤ; refl-cong-ℤ; cong-int-cong-ℕ; concatenate-eq-cong-ℤ;
-    transitive-cong-ℤ; concatenate-cong-eq-cong-ℤ; symmetric-cong-ℤ;
-    is-discrete-cong-ℤ; cong-cong-int-ℕ; concatenate-cong-cong-cong-ℤ;
-    is-cong-zero-div-ℤ; div-is-cong-zero-ℤ; is-unit-cong-succ-ℤ)
-open import elementary-number-theory.congruence-natural-numbers using
-  ( refl-cong-ℕ; congruence-mul-ℕ; eq-cong-nat-Fin)
-open import elementary-number-theory.divisibility-integers using
-  ( div-ℤ; is-zero-div-zero-ℤ; refl-div-ℤ; is-one-is-unit-int-ℕ; div-neg-ℤ; neg-div-ℤ; div-div-int-abs-ℤ; div-int-abs-div-ℤ)
-open import elementary-number-theory.equality-integers using
-  ( has-decidable-equality-ℤ; ℤ-Discrete-Type)
+open import elementary-number-theory.addition-integers
+open import elementary-number-theory.congruence-integers
+open import elementary-number-theory.congruence-natural-numbers
+open import elementary-number-theory.divisibility-integers
+open import elementary-number-theory.equality-integers
 open import elementary-number-theory.inequality-integers
-open import elementary-number-theory.integers using
-  ( ℤ; zero-ℤ; neg-one-ℤ; one-ℤ; int-ℕ; is-injective-int-ℕ; is-zero-ℤ; succ-ℤ;
-    pred-ℤ; issec-pred-ℤ; isretr-pred-ℤ; neg-ℤ; succ-int-ℕ; is-equiv-succ-ℤ;
-    is-equiv-pred-ℤ; is-equiv-neg-ℤ; is-set-ℤ; is-nonnegative-succ-ℤ; is-nonnegative-eq-ℤ; decide-is-nonnegative-ℤ; neg-neg-ℤ)
+open import elementary-number-theory.integers
 open import elementary-number-theory.modular-arithmetic-standard-finite-types
-open import elementary-number-theory.multiplication-integers using
-  ( mul-ℤ; mul-ℤ'; associative-mul-ℤ; commutative-mul-ℤ; left-zero-law-mul-ℤ;
-    right-zero-law-mul-ℤ; left-unit-law-mul-ℤ; right-unit-law-mul-ℤ;
-    left-distributive-mul-add-ℤ; right-distributive-mul-add-ℤ;
-    is-mul-neg-one-neg-ℤ; is-mul-neg-one-neg-ℤ'; mul-int-ℕ)
-open import elementary-number-theory.multiplication-natural-numbers using
-  ( mul-ℕ; left-unit-law-mul-ℕ)
-open import elementary-number-theory.natural-numbers using
-  ( ℕ; zero-ℕ; succ-ℕ; is-one-ℕ; is-not-one-ℕ; is-nonzero-ℕ)
+open import elementary-number-theory.multiplication-integers
+open import elementary-number-theory.multiplication-natural-numbers
+open import elementary-number-theory.natural-numbers
 
-open import foundation.coproduct-types using (inl; inr)
-open import foundation.decidable-types using (is-decidable; is-decidable-iff)
-open import foundation.decidable-equality using (has-decidable-equality)
-open import foundation.dependent-pair-types using (pair; pr1; pr2)
-open import foundation.discrete-types using (Discrete-Type)
-open import foundation.empty-types using (empty; ex-falso)
-open import foundation.equivalences using (is-equiv; _≃_)
-open import foundation.functions using (_∘_)
-open import foundation.identity-types using
-  ( _＝_; refl; _∙_; inv; ap; ap-binary; tr)
-open import foundation.injective-maps using
-  ( is-injective; is-injective-id; is-injective-comp')
-open import foundation.negation using (¬; map-neg)
-open import foundation.sets using (is-set; Set)
-open import foundation.unit-type using (star)
-open import foundation.universe-levels using (UU; lzero)
+open import foundation.coproduct-types
+open import foundation.decidable-types
+open import foundation.decidable-equality
+open import foundation.dependent-pair-types
+open import foundation.discrete-types
+open import foundation.empty-types
+open import foundation.equivalences
+open import foundation.functions
+open import foundation.identity-types
+open import foundation.injective-maps
+open import foundation.negation
+open import foundation.sets
+open import foundation.unit-type
+open import foundation.universe-levels
 
-open import structured-types.types-equipped-with-endomorphisms using (Endo)
+open import structured-types.types-equipped-with-endomorphisms
 
-open import univalent-combinatorics.equality-standard-finite-types using
-  ( has-decidable-equality-Fin; Fin-Discrete-Type)
-open import univalent-combinatorics.finite-types using
-  ( is-finite; is-finite-Fin; 𝔽)
-open import univalent-combinatorics.standard-finite-types using
-  ( Fin; zero-Fin; neg-one-Fin; one-Fin; nat-Fin; is-injective-nat-Fin;
-    is-zero-nat-zero-Fin; succ-Fin; pred-Fin; issec-pred-Fin; isretr-pred-Fin;
-    is-equiv-succ-Fin; is-equiv-pred-Fin; is-set-Fin; is-zero-Fin)
+open import univalent-combinatorics.equality-standard-finite-types
+open import univalent-combinatorics.finite-types
+open import univalent-combinatorics.standard-finite-types
 ```
 
 Some modular arithmetic was already defined in `modular-arithmetic-standard-finite-types`. Here we package those results together in a more convenient package that also allows congruence modulo 0.
@@ -154,22 +124,21 @@ int-ℤ-Mod (succ-ℕ k) x = int-ℕ (nat-Fin (succ-ℕ k) x)
 is-injective-int-ℤ-Mod : (k : ℕ) → is-injective (int-ℤ-Mod k)
 is-injective-int-ℤ-Mod zero-ℕ = is-injective-id
 is-injective-int-ℤ-Mod (succ-ℕ k) =
-  is-injective-comp' (is-injective-nat-Fin (succ-ℕ k)) is-injective-int-ℕ
+  is-injective-comp (is-injective-nat-Fin (succ-ℕ k)) is-injective-int-ℕ
 
 is-zero-int-zero-ℤ-Mod : (k : ℕ) → is-zero-ℤ (int-ℤ-Mod k (zero-ℤ-Mod k))
 is-zero-int-zero-ℤ-Mod (zero-ℕ) = refl
 is-zero-int-zero-ℤ-Mod (succ-ℕ k) = ap int-ℕ (is-zero-nat-zero-Fin {k})
 
-int-ℤ-Mod-bounded : (k : ℕ) → (x : ℤ-Mod (succ-ℕ k)) 
-  → leq-ℤ (int-ℤ-Mod (succ-ℕ  k) x) (int-ℕ (succ-ℕ k))  
-int-ℤ-Mod-bounded zero-ℕ (inr x) = star 
-int-ℤ-Mod-bounded (succ-ℕ k) (inl x) = is-nonnegative-succ-ℤ 
-  (add-ℤ (inr (inr k)) 
+int-ℤ-Mod-bounded : (k : ℕ) → (x : ℤ-Mod (succ-ℕ k))
+  → leq-ℤ (int-ℤ-Mod (succ-ℕ  k) x) (int-ℕ (succ-ℕ k))
+int-ℤ-Mod-bounded zero-ℕ (inr x) = star
+int-ℤ-Mod-bounded (succ-ℕ k) (inl x) = is-nonnegative-succ-ℤ
+  (add-ℤ (inr (inr k))
   (neg-ℤ (int-ℕ (nat-Fin (succ-ℕ k) x)))) (int-ℤ-Mod-bounded k x)
-int-ℤ-Mod-bounded (succ-ℕ k) (inr x) = is-nonnegative-succ-ℤ 
-  (add-ℤ (inr (inr k)) (inl k)) 
+int-ℤ-Mod-bounded (succ-ℕ k) (inr x) = is-nonnegative-succ-ℤ
+  (add-ℤ (inr (inr k)) (inl k))
   (is-nonnegative-eq-ℤ (inv (left-inverse-law-add-ℤ (inl k))) star)
-
 ```
 
 ## The successor and predecessor functions on the integers modulo k
@@ -456,7 +425,7 @@ preserves-successor-mod-ℕ (succ-ℕ k) x = refl
 
 mod-refl-ℕ : (k : ℕ) → mod-ℕ k k ＝ zero-ℤ-Mod k
 mod-refl-ℕ zero-ℕ = refl
-mod-refl-ℕ (succ-ℕ k) = is-zero-mod-succ-ℕ k (succ-ℕ k) (pair 1 (left-unit-law-mul-ℕ (succ-ℕ k))) 
+mod-refl-ℕ (succ-ℕ k) = is-zero-mod-succ-ℕ k (succ-ℕ k) (pair 1 (left-unit-law-mul-ℕ (succ-ℕ k)))
 
 mod-zero-ℤ : (k : ℕ) → mod-ℤ k zero-ℤ ＝ zero-ℤ-Mod k
 mod-zero-ℤ zero-ℕ = refl
@@ -674,7 +643,7 @@ cong-int-mod-ℤ (succ-ℕ k) (inr (inl star)) =
     ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k zero-ℕ))
     ( zero-ℕ)
     ( cong-nat-mod-succ-ℕ k zero-ℕ)
-cong-int-mod-ℤ (succ-ℕ k) (inr (inr x)) = 
+cong-int-mod-ℤ (succ-ℕ k) (inr (inr x)) =
   cong-int-cong-ℕ
     ( succ-ℕ k)
     ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k (succ-ℕ x)))
@@ -785,9 +754,9 @@ has-no-fixed-points-succ-Fin {succ-ℕ k} x =
 
 ### Divisibility is decidable
 
-```agda 
+```agda
 is-decidable-div-ℤ : (d x : ℤ) → is-decidable (div-ℤ d x)
-is-decidable-div-ℤ d x = 
+is-decidable-div-ℤ d x =
   is-decidable-iff
     ( div-div-int-abs-ℤ ∘ div-is-zero-mod-ℤ (abs-ℤ d) x)
     ( is-zero-mod-div-ℤ (abs-ℤ d) x ∘ div-int-abs-div-ℤ)
@@ -795,7 +764,4 @@ is-decidable-div-ℤ d x =
       ( abs-ℤ d)
       ( mod-ℤ (abs-ℤ d) x)
       ( zero-ℤ-Mod (abs-ℤ d)))
-
-   
 ```
-

--- a/src/foundation-core/0-maps.lagda.md
+++ b/src/foundation-core/0-maps.lagda.md
@@ -101,12 +101,12 @@ module _
   is-0-map-right-factor :
     (g : B → X) (h : A → B) →
     is-0-map g → is-0-map (g ∘ h) → is-0-map h
-  is-0-map-right-factor g h = is-trunc-map-right-factor zero-𝕋 g h
+  is-0-map-right-factor = is-trunc-map-right-factor zero-𝕋
 
   is-0-map-right-factor-htpy :
     (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
     is-0-map g → is-0-map f → is-0-map h
-  is-0-map-right-factor-htpy f g h H = is-trunc-map-right-factor-htpy zero-𝕋 f g h H
+  is-0-map-right-factor-htpy = is-trunc-map-right-factor-htpy zero-𝕋
 ```
 
 ### A family of 0-maps induces a 0-map on total spaces

--- a/src/foundation-core/0-maps.lagda.md
+++ b/src/foundation-core/0-maps.lagda.md
@@ -49,13 +49,13 @@ module _
 module _
   {l1 l2 : Level} {A : UU l1}
   where
-  
+
   abstract
     is-0-map-pr1 :
       {B : A → UU l2} → ((x : A) → is-set (B x)) → is-0-map (pr1 {B = B})
     is-0-map-pr1 {B} H x =
       is-set-equiv (B x) (equiv-fib-pr1 B x) (H x)
-                                                  
+
   pr1-0-map :
     (B : A → Set l2) → 0-map (Σ A (λ x → type-Set (B x))) A
   pr1 (pr1-0-map B) = pr1
@@ -68,10 +68,9 @@ module _
 module _
   {l1 l2 : Level} {A : UU l1} {B : UU l2} {f g : A → B} (H : f ~ g)
   where
-  
-  abstract
-    is-0-map-htpy : is-0-map g → is-0-map f
-    is-0-map-htpy = is-trunc-map-htpy zero-𝕋 H
+
+  is-0-map-htpy : is-0-map g → is-0-map f
+  is-0-map-htpy = is-trunc-map-htpy zero-𝕋 H
 ```
 
 ### 0-maps are closed under composition
@@ -81,17 +80,15 @@ module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
   where
 
-  abstract
-    is-0-map-comp :
-      (g : B → X) (h : A → B) →
-      is-0-map g → is-0-map h → is-0-map (g ∘ h)
-    is-0-map-comp = is-trunc-map-comp zero-𝕋
-  
-  abstract
-    is-0-map-comp-htpy :
-      (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
-      is-0-map g → is-0-map h → is-0-map f
-    is-0-map-comp-htpy = is-trunc-map-comp-htpy zero-𝕋
+  is-0-map-comp :
+    (g : B → X) (h : A → B) →
+    is-0-map g → is-0-map h → is-0-map (g ∘ h)
+  is-0-map-comp = is-trunc-map-comp zero-𝕋
+
+  is-0-map-comp-htpy :
+    (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
+    is-0-map g → is-0-map h → is-0-map f
+  is-0-map-comp-htpy = is-trunc-map-comp-htpy zero-𝕋
 ```
 
 ### If a composite is a 0-map, then so is its right factor
@@ -99,11 +96,17 @@ module _
 ```agda
 module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
-  (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
   where
-  
-  is-0-map-right-factor : is-0-map g → is-0-map f → is-0-map h
-  is-0-map-right-factor = is-trunc-map-right-factor zero-𝕋 f g h H
+
+  is-0-map-right-factor :
+    (g : B → X) (h : A → B) →
+    is-0-map g → is-0-map (g ∘ h) → is-0-map h
+  is-0-map-right-factor g h = is-trunc-map-right-factor zero-𝕋 g h
+
+  is-0-map-right-factor-htpy :
+    (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
+    is-0-map g → is-0-map f → is-0-map h
+  is-0-map-right-factor-htpy f g h H = is-trunc-map-right-factor-htpy zero-𝕋 f g h H
 ```
 
 ### A family of 0-maps induces a 0-map on total spaces
@@ -113,7 +116,7 @@ module _
   {l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2} {C : A → UU l3}
   {f : (x : A) → B x → C x}
   where
-  
+
   abstract
     is-0-map-tot : ((x : A) → is-0-map (f x)) → is-0-map (tot f)
     is-0-map-tot = is-trunc-map-tot zero-𝕋
@@ -127,7 +130,7 @@ In other words, 0-maps are stable under pullbacks. We will come to this point wh
 module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {f : A → B} (C : B → UU l3)
   where
-    
+
   abstract
     is-0-map-map-Σ-map-base : is-0-map f → is-0-map (map-Σ-map-base f C)
     is-0-map-map-Σ-map-base = is-trunc-map-map-Σ-map-base zero-𝕋 C
@@ -140,7 +143,7 @@ module _
   {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {C : A → UU l3}
   (D : B → UU l4) {f : A → B} {g : (x : A) → C x → D (f x)}
   where
-    
+
   is-0-map-map-Σ :
     is-0-map f → ((x : A) → is-0-map (g x)) → is-0-map (map-Σ D f g)
   is-0-map-map-Σ = is-trunc-map-map-Σ zero-𝕋 D

--- a/src/foundation-core/0-maps.lagda.md
+++ b/src/foundation-core/0-maps.lagda.md
@@ -7,19 +7,15 @@ title: 0-Maps
 
 module foundation-core.0-maps where
 
-open import foundation-core.dependent-pair-types using (Σ; pair; pr1; pr2)
-open import foundation-core.fibers-of-maps using (fib; equiv-fib-pr1)
-open import foundation-core.functions using (_∘_)
-open import foundation-core.functoriality-dependent-pair-types using
-  (tot; map-Σ-map-base; map-Σ)
-open import foundation-core.homotopies using (_~_)
-open import foundation-core.sets using
-  ( is-set; is-set-equiv; Set; type-Set; is-set-type-Set)
-open import foundation-core.truncated-maps using
-  ( is-trunc-map-htpy; is-trunc-map-comp; is-trunc-map-right-factor;
-    is-trunc-map-tot; is-trunc-map-map-Σ-map-base; is-trunc-map-map-Σ)
-open import foundation-core.truncation-levels using (zero-𝕋)
-open import foundation-core.universe-levels using (Level; UU; _⊔_)
+open import foundation-core.dependent-pair-types
+open import foundation-core.fibers-of-maps
+open import foundation-core.functions
+open import foundation-core.functoriality-dependent-pair-types
+open import foundation-core.homotopies
+open import foundation-core.sets
+open import foundation-core.truncated-maps
+open import foundation-core.truncation-levels
+open import foundation-core.universe-levels
 ```
 
 ## Definition
@@ -83,12 +79,19 @@ module _
 ```agda
 module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
-  (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
   where
+
+  abstract
+    is-0-map-comp :
+      (g : B → X) (h : A → B) →
+      is-0-map g → is-0-map h → is-0-map (g ∘ h)
+    is-0-map-comp = is-trunc-map-comp zero-𝕋
   
   abstract
-    is-0-map-comp : is-0-map g → is-0-map h → is-0-map f
-    is-0-map-comp = is-trunc-map-comp zero-𝕋 f g h H
+    is-0-map-comp-htpy :
+      (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
+      is-0-map g → is-0-map h → is-0-map f
+    is-0-map-comp-htpy = is-trunc-map-comp-htpy zero-𝕋
 ```
 
 ### If a composite is a 0-map, then so is its right factor

--- a/src/foundation-core/embeddings.lagda.md
+++ b/src/foundation-core/embeddings.lagda.md
@@ -7,13 +7,11 @@ title: Embeddings
 
 module foundation-core.embeddings where
 
-open import foundation-core.dependent-pair-types using (Σ; pair; pr1; pr2)
-open import foundation-core.equivalences using
-  ( is-equiv; _≃_; is-equiv-htpy; is-equiv-id)
-open import foundation-core.functions using (id)
-open import foundation-core.identity-types using
-  ( _＝_; refl; ap; inv; _∙_; ap-id)
-open import foundation-core.universe-levels using (Level; UU; _⊔_)
+open import foundation-core.dependent-pair-types
+open import foundation-core.equivalences
+open import foundation-core.functions
+open import foundation-core.identity-types
+open import foundation-core.universe-levels
 ```
 
 ## Idea
@@ -52,7 +50,6 @@ module _
 
 ## Examples
 
-
 ### The identity map is an embedding
 
 ```agda
@@ -74,7 +71,7 @@ module _
 module _
   {l : Level} {A : UU l} {l2 : Level} {B : UU l2} {f : A → B}
   where
-  
+
   abstract
     is-emb-is-emb : (A → is-emb f) → is-emb f
     is-emb-is-emb H x y = H x x y

--- a/src/foundation-core/equivalences.lagda.md
+++ b/src/foundation-core/equivalences.lagda.md
@@ -7,20 +7,15 @@ title: Equivalences
 
 module foundation-core.equivalences where
 
-open import foundation-core.cartesian-product-types using (_×_)
-open import foundation-core.coherently-invertible-maps using
-  ( has-inverse; is-coherently-invertible; is-coherently-invertible-has-inverse;
-    issec-inv-has-inverse; isretr-inv-has-inverse; coherence-inv-has-inverse)
-open import foundation-core.dependent-pair-types using (Σ; pr1; pr2; pair)
-open import foundation-core.functions using (id; _∘_)
-open import foundation-core.homotopies using
-  ( _~_; refl-htpy; inv-htpy; _·r_; _·l_; _∙h_; htpy-right-whisk; htpy-left-whisk; nat-htpy)
-open import foundation-core.identity-types using
-  ( _＝_; refl; inv; _∙_; ap; ap-concat; ap-binary; ap-inv; ap-id; ap-comp;
-    inv-con; left-inv)
+open import foundation-core.cartesian-product-types
+open import foundation-core.coherently-invertible-maps
+open import foundation-core.dependent-pair-types
+open import foundation-core.functions
+open import foundation-core.homotopies
+open import foundation-core.identity-types
 open import foundation-core.retractions
 open import foundation-core.sections
-open import foundation-core.universe-levels using (Level; UU; _⊔_)
+open import foundation-core.universe-levels
 ```
 
 ## Idea
@@ -237,24 +232,27 @@ module _
 ```agda
 module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
-  (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
   where
-  
+
   abstract
-    is-equiv-left-factor : is-equiv f → is-equiv h → is-equiv g
-    pr1
-      ( is-equiv-left-factor
-        ( pair sec-f retr-f)
-        ( pair (pair sh issec-sh) retr-h)) =
-      section-left-factor-htpy f g h H sec-f
-    pr2
-      ( is-equiv-left-factor
-        ( pair sec-f retr-f)
-        ( pair (pair sh issec-sh) retr-h)) =
-      retraction-comp-htpy g f sh
-        ( triangle-section f g h H (pair sh issec-sh))
-        ( retr-f)
-        ( pair h issec-sh)
+    is-equiv-left-factor-htpy :
+      (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
+      is-equiv f → is-equiv h → is-equiv g
+    is-equiv-left-factor-htpy f g h H
+      ( pair sec-f retr-f)
+      ( pair (pair sh issec-sh) retr-h) =
+        ( pair
+          ( section-left-factor-htpy f g h H sec-f)
+          ( retraction-comp-htpy g f sh
+            ( triangle-section f g h H (pair sh issec-sh))
+            ( retr-f)
+            ( pair h issec-sh)))
+
+  is-equiv-left-factor :
+    (g : B → X) (h : A → B) →
+    is-equiv (g ∘ h) → is-equiv h → is-equiv g
+  is-equiv-left-factor g h is-equiv-gh is-equiv-h =
+      is-equiv-left-factor-htpy (g ∘ h) g h refl-htpy is-equiv-gh is-equiv-h
 ```
 
 #### If a composite and its left factor are equivalences, then so is its right factor
@@ -262,40 +260,27 @@ module _
 ```agda
 module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
-  (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
   where
 
   abstract
-    is-equiv-right-factor : is-equiv g → is-equiv f → is-equiv h
-    pr1
-      ( is-equiv-right-factor
+    is-equiv-right-factor-htpy :
+      (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
+      is-equiv g → is-equiv f → is-equiv h
+    is-equiv-right-factor-htpy f g h H
         ( pair sec-g (pair rg isretr-rg))
-        ( pair sec-f retr-f)) =
-      section-comp-htpy h rg f
-        ( triangle-retraction f g h H (pair rg isretr-rg))
-        ( sec-f)
-        ( pair g isretr-rg)
-    pr2
-      ( is-equiv-right-factor
-        ( pair sec-g (pair rg isretr-rg))
-        ( pair sec-f retr-f)) =
-      retraction-right-factor-htpy f g h H retr-f
-```
+        ( pair sec-f retr-f) =
+          ( pair
+            ( section-comp-htpy h rg f
+              ( triangle-retraction f g h H (pair rg isretr-rg))
+              ( sec-f)
+              ( pair g isretr-rg))
+            ( retraction-right-factor-htpy f g h H retr-f))
 
-```agda
-module _
-  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
-  where
-
-  abstract
-    is-equiv-left-factor' :
-      (g : B → X) (h : A → B) → is-equiv (g ∘ h) → is-equiv h → is-equiv g
-    is-equiv-left-factor' g h = is-equiv-left-factor (g ∘ h) g h refl-htpy
-
-  abstract
-    is-equiv-right-factor' :
-      (g : B → X) (h : A → B) → is-equiv g → is-equiv (g ∘ h) → is-equiv h
-    is-equiv-right-factor' g h = is-equiv-right-factor (g ∘ h) g h refl-htpy
+  is-equiv-right-factor :
+    (g : B → X) (h : A → B) →
+    is-equiv g → is-equiv (g ∘ h) → is-equiv h
+  is-equiv-right-factor g h is-equiv-g is-equiv-gh =
+    is-equiv-right-factor-htpy (g ∘ h) g h refl-htpy is-equiv-g is-equiv-gh
 ```
 
 ### Equivalences are closed under homotopies
@@ -347,7 +332,7 @@ abstract
     {i j : Level} {A : UU i} {B : UU j} {f : A → B} {g : B → A} →
     is-equiv f  → (g ∘ f) ~ id → is-equiv g
   is-equiv-is-retraction {A = A} {f = f} {g = g} is-equiv-f H =
-    is-equiv-left-factor id g f (inv-htpy H) is-equiv-id is-equiv-f
+    is-equiv-left-factor-htpy id g f (inv-htpy H) is-equiv-id is-equiv-f
 ```
 
 ### Any section of an equivalence is an equivalence
@@ -358,7 +343,7 @@ abstract
     {i j : Level} {A : UU i} {B : UU j} {f : A → B} {g : B → A} →
     is-equiv f → (f ∘ g) ~ id → is-equiv g
   is-equiv-is-section {B = B} {f = f} {g = g} is-equiv-f H =
-    is-equiv-right-factor id f g (inv-htpy H) is-equiv-f is-equiv-id
+    is-equiv-right-factor-htpy id f g (inv-htpy H) is-equiv-f is-equiv-id
 ```
 
 ### If a section of `f` is an equivalence, then `f` is an equivalence
@@ -389,7 +374,7 @@ is-equiv-equiv :
   {f : A → B} {g : X → Y} (i : A ≃ X) (j : B ≃ Y)
   (H : (map-equiv j ∘ f) ~ (g ∘ map-equiv i)) → is-equiv g → is-equiv f
 is-equiv-equiv {f = f} {g} i j H K =
-  is-equiv-right-factor'
+  is-equiv-right-factor
     ( map-equiv j)
     ( f)
     ( is-equiv-map-equiv j)
@@ -406,7 +391,7 @@ is-equiv-equiv' :
   {f : A → B} {g : X → Y} (i : A ≃ X) (j : B ≃ Y)
   (H : (map-equiv j ∘ f) ~ (g ∘ map-equiv i)) → is-equiv f → is-equiv g
 is-equiv-equiv' {f = f} {g} i j H K =
-  is-equiv-left-factor'
+  is-equiv-left-factor
     ( g)
     ( map-equiv i)
     ( is-equiv-comp-htpy
@@ -441,31 +426,31 @@ module _
     is-equiv-top-is-equiv-left-square :
       is-equiv i → is-equiv f → is-equiv g → is-equiv h
     is-equiv-top-is-equiv-left-square Ei Ef Eg =
-      is-equiv-right-factor (i ∘ f) g h H Eg (is-equiv-comp i f Ef Ei)
+      is-equiv-right-factor-htpy (i ∘ f) g h H Eg (is-equiv-comp i f Ef Ei)
 
   abstract
     is-equiv-top-is-equiv-bottom-square :
       is-equiv f → is-equiv g → is-equiv i → is-equiv h
     is-equiv-top-is-equiv-bottom-square Ef Eg Ei =
-      is-equiv-right-factor (i ∘ f) g h H Eg (is-equiv-comp i f Ef Ei)
+      is-equiv-right-factor-htpy (i ∘ f) g h H Eg (is-equiv-comp i f Ef Ei)
 
   abstract
     is-equiv-bottom-is-equiv-top-square :
       is-equiv f → is-equiv g → is-equiv h → is-equiv i
     is-equiv-bottom-is-equiv-top-square Ef Eg Eh = 
-      is-equiv-left-factor' i f (is-equiv-comp-htpy (i ∘ f) g h H Eh Eg) Ef
+      is-equiv-left-factor i f (is-equiv-comp-htpy (i ∘ f) g h H Eh Eg) Ef
 
   abstract
     is-equiv-left-is-equiv-right-square :
       is-equiv h → is-equiv i → is-equiv g → is-equiv f
     is-equiv-left-is-equiv-right-square Eh Ei Eg =
-      is-equiv-right-factor' i f Ei (is-equiv-comp-htpy (i ∘ f) g h H Eh Eg)
+      is-equiv-right-factor i f Ei (is-equiv-comp-htpy (i ∘ f) g h H Eh Eg)
 
   abstract
     is-equiv-right-is-equiv-left-square :
       is-equiv h → is-equiv i → is-equiv f → is-equiv g
     is-equiv-right-is-equiv-left-square Eh Ei Ef =
-      is-equiv-left-factor (i ∘ f) g h H (is-equiv-comp i f Ef Ei) Eh
+      is-equiv-left-factor-htpy (i ∘ f) g h H (is-equiv-comp i f Ef Ei) Eh
 ```
 
 ### Equivalences are embeddings

--- a/src/foundation-core/faithful-maps.lagda.md
+++ b/src/foundation-core/faithful-maps.lagda.md
@@ -83,7 +83,7 @@ module _
 module _
   {l : Level} {A : UU l}
   where
-  
+
   id-faithful-map : faithful-map A A
   id-faithful-map = faithful-map-emb id-emb
 
@@ -157,7 +157,7 @@ module _
         ( is-0-map-comp g h
           ( is-0-map-is-faithful is-faithful-g)
           ( is-0-map-is-faithful is-faithful-h))
-  
+
   abstract
     is-faithful-comp-htpy :
       (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
@@ -174,15 +174,25 @@ module _
 ```agda
 module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
-  (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
   where
-  
-  is-faithful-right-factor : is-faithful g → is-faithful f → is-faithful h
-  is-faithful-right-factor K L =
+
+  is-faithful-right-factor :
+    (g : B → X) (h : A → B) →
+    is-faithful g → is-faithful (g ∘ h) → is-faithful h
+  is-faithful-right-factor g h is-faithful-g is-faithful-gh =
     is-faithful-is-0-map
-      ( is-0-map-right-factor f g h H
-        ( is-0-map-is-faithful K)
-        ( is-0-map-is-faithful L))
+      ( is-0-map-right-factor g h
+        ( is-0-map-is-faithful is-faithful-g)
+        ( is-0-map-is-faithful is-faithful-gh))
+
+  is-faithful-right-factor-htpy :
+    (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
+    is-faithful g → is-faithful f → is-faithful h
+  is-faithful-right-factor-htpy f g h H is-faithful-g is-faithful-f =
+    is-faithful-is-0-map
+      ( is-0-map-right-factor-htpy f g h H
+        ( is-0-map-is-faithful is-faithful-g)
+        ( is-0-map-is-faithful is-faithful-f))
 ```
 
 ### The map on total spaces induced by a family of truncated maps is truncated
@@ -200,7 +210,7 @@ module _
 module _
   {l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2} {C : A → UU l3}
   where
-  
+
   tot-faithful-map :
     ((x : A) → faithful-map (B x) (C x)) → faithful-map (Σ A B) (Σ A C)
   pr1 (tot-faithful-map f) = tot (λ x → map-faithful-map (f x))
@@ -214,7 +224,7 @@ module _
   module _
     {f : A → B} (C : B → UU l3)
     where
-    
+
     abstract
       is-faithful-map-Σ-map-base :
         is-faithful f → is-faithful (map-Σ-map-base f C)

--- a/src/foundation-core/faithful-maps.lagda.md
+++ b/src/foundation-core/faithful-maps.lagda.md
@@ -7,27 +7,19 @@ title: Faithful maps
 
 module foundation-core.faithful-maps where
 
-open import foundation-core.0-maps using
-  ( is-0-map;  is-0-map-pr1; is-0-map-htpy; is-0-map-comp;
-    is-0-map-right-factor; is-0-map-tot; is-0-map-map-Σ-map-base;
-    is-0-map-map-Σ)
-open import foundation-core.dependent-pair-types using (Σ; pair; pr1; pr2)
-open import foundation-core.embeddings using
-  ( is-emb; _↪_; map-emb; is-emb-map-emb; id-emb)
-open import foundation-core.equivalences using
-  ( is-equiv; _≃_; map-equiv; is-equiv-map-equiv; is-emb-is-equiv)
-open import foundation-core.functions using (id; _∘_)
-open import foundation-core.functoriality-dependent-pair-types using
-  ( tot; map-Σ-map-base; map-Σ)
-open import foundation-core.homotopies using (_~_)
-open import foundation-core.identity-types using (_＝_; ap)
-open import foundation-core.propositional-maps using
-  ( is-prop-map-is-emb; is-emb-is-prop-map)
-open import foundation-core.sets using (is-set; Set; type-Set; is-set-type-Set)
-open import foundation-core.truncated-maps using
-  ( is-trunc-map-is-trunc-map-ap; is-trunc-map-ap-is-trunc-map)
-open import foundation-core.truncation-levels using (neg-one-𝕋)
-open import foundation-core.universe-levels using (Level; UU; _⊔_)
+open import foundation-core.0-maps
+open import foundation-core.dependent-pair-types
+open import foundation-core.embeddings
+open import foundation-core.equivalences
+open import foundation-core.functions
+open import foundation-core.functoriality-dependent-pair-types
+open import foundation-core.homotopies
+open import foundation-core.identity-types
+open import foundation-core.propositional-maps
+open import foundation-core.sets
+open import foundation-core.truncated-maps
+open import foundation-core.truncation-levels
+open import foundation-core.universe-levels
 ```
 
 ## Idea
@@ -154,16 +146,27 @@ module _
 ```agda
 module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
-  (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
   where
+
+  abstract
+    is-faithful-comp :
+      (g : B → X) (h : A → B) →
+      is-faithful g → is-faithful h → is-faithful (g ∘ h)
+    is-faithful-comp g h is-faithful-g is-faithful-h =
+      is-faithful-is-0-map
+        ( is-0-map-comp g h
+          ( is-0-map-is-faithful is-faithful-g)
+          ( is-0-map-is-faithful is-faithful-h))
   
   abstract
-    is-faithful-comp : is-faithful g → is-faithful h → is-faithful f
-    is-faithful-comp K L =
+    is-faithful-comp-htpy :
+      (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
+      is-faithful g → is-faithful h → is-faithful f
+    is-faithful-comp-htpy f g h H is-faithful-g is-faithful-h =
       is-faithful-is-0-map
-        ( is-0-map-comp f g h H
-          ( is-0-map-is-faithful K)
-          ( is-0-map-is-faithful L))
+        ( is-0-map-comp-htpy f g h H
+          ( is-0-map-is-faithful is-faithful-g)
+          ( is-0-map-is-faithful is-faithful-h))
 ```
 
 ### If a composite is faithful, then its right factor is faithful

--- a/src/foundation-core/functoriality-dependent-pair-types.lagda.md
+++ b/src/foundation-core/functoriality-dependent-pair-types.lagda.md
@@ -7,23 +7,16 @@ title: Functoriality of dependent pair types
 
 module foundation-core.functoriality-dependent-pair-types where
 
-open import foundation-core.contractible-maps using
-  ( is-equiv-is-contr-map; is-contr-map-is-equiv; is-contr-map)
-open import foundation-core.contractible-types using
-  ( is-contr-is-equiv; is-contr-equiv'; is-contr-is-equiv')
-open import foundation-core.dependent-pair-types using (Σ; pair; pr1; pr2)
-open import foundation-core.equality-dependent-pair-types using
-  ( eq-pair-Σ; eq-pair-Σ')
-open import foundation-core.equivalences using
-  ( is-equiv; is-equiv-has-inverse; _≃_; map-equiv; is-equiv-map-equiv;
-    is-equiv-comp-htpy; is-equiv-right-factor; is-fiberwise-equiv;
-    is-equiv-top-is-equiv-bottom-square; is-equiv-bottom-is-equiv-top-square)
-open import foundation-core.fibers-of-maps using
-  ( fib; map-equiv-total-fib; is-equiv-map-equiv-total-fib)
-open import foundation-core.functions using (_∘_; id)
-open import foundation-core.homotopies using (_~_)
-open import foundation-core.identity-types using (refl; inv; tr)
-open import foundation-core.universe-levels using (Level; UU; _⊔_)
+open import foundation-core.contractible-maps
+open import foundation-core.contractible-types
+open import foundation-core.dependent-pair-types
+open import foundation-core.equality-dependent-pair-types
+open import foundation-core.equivalences
+open import foundation-core.fibers-of-maps
+open import foundation-core.functions
+open import foundation-core.homotopies
+open import foundation-core.identity-types
+open import foundation-core.universe-levels
 ```
 
 ## Idea
@@ -344,7 +337,7 @@ module _
       is-equiv f → is-equiv (map-Σ D f g) → is-fiberwise-equiv g
     is-fiberwise-equiv-is-equiv-map-Σ f g H K =
       is-fiberwise-equiv-is-equiv-tot
-        ( is-equiv-right-factor
+        ( is-equiv-right-factor-htpy
           ( map-Σ D f g)
           ( map-Σ-map-base f D)
           ( tot g)

--- a/src/foundation-core/identity-types.lagda.md
+++ b/src/foundation-core/identity-types.lagda.md
@@ -7,9 +7,9 @@ title: Identity types
 
 module foundation-core.identity-types where
 
-open import foundation-core.dependent-pair-types using (Σ; pair; pr1; pr2)
-open import foundation-core.functions using (_∘_; id)
-open import foundation-core.universe-levels using (UU; Level)
+open import foundation-core.dependent-pair-types
+open import foundation-core.functions
+open import foundation-core.universe-levels
 ```
 
 ## Idea

--- a/src/foundation-core/pullbacks.lagda.md
+++ b/src/foundation-core/pullbacks.lagda.md
@@ -8,9 +8,7 @@ title: Pullbacks
 module foundation-core.pullbacks where
 
 open import foundation-core.cartesian-product-types
-open import foundation-core.commuting-cubes
-open import foundation-core.commuting-squares
-open import foundation.cones-pullbacks
+open import foundation-core.cones-pullbacks
 open import foundation-core.contractible-maps
 open import foundation-core.contractible-types
 open import foundation-core.dependent-pair-types
@@ -19,19 +17,18 @@ open import foundation-core.equality-cartesian-product-types
 open import foundation-core.equality-dependent-pair-types
 open import foundation-core.equivalences
 open import foundation-core.fibers-of-maps
-open import foundation-core.function-extensionality
 open import foundation-core.functions
 open import foundation-core.functoriality-dependent-pair-types
 open import foundation-core.functoriality-fibers-of-maps
 open import foundation-core.homotopies
 open import foundation-core.morphisms-cospans
+open import foundation-core.type-arithmetic-dependent-pair-types
 open import foundation-core.universal-property-pullbacks
 open import foundation-core.universe-levels
 
 open import foundation.functoriality-cartesian-product-types
 open import foundation.identity-types
 open import foundation.structure-identity-principle
-open import foundation.type-arithmetic-dependent-pair-types
 open import foundation.type-theoretic-principle-of-choice
 ```
 
@@ -358,7 +355,7 @@ abstract
     (f : A → X) (g : B → X) (c : cone f g C) →
     is-pullback g f (swap-cone f g c) → is-pullback f g c
   is-pullback-swap-cone' f g c is-pb-c' =
-    is-equiv-right-factor
+    is-equiv-right-factor-htpy
       ( gap g f (swap-cone f g c))
       ( map-commutative-canonical-pullback f g)
       ( gap f g c)
@@ -486,7 +483,7 @@ abstract
     is-pullback (map-prod f g) (diagonal X) (fold-cone f g c) →
     is-pullback f g c
   is-pullback-is-pullback-fold-cone f g c is-pb-fold =
-    is-equiv-right-factor
+    is-equiv-right-factor-htpy
       ( gap (map-prod f g) (diagonal _) (fold-cone f g c))
       ( map-fold-cone f g)
       ( gap f g c)
@@ -632,7 +629,7 @@ abstract
     canonical-pullback f' g' → is-pullback f g c
   is-pullback-left-factor-is-pullback-prod f g c f' g' c' is-pb-cc' t =
     is-equiv-left-factor-is-equiv-map-prod (gap f g c) (gap f' g' c') t
-      ( is-equiv-right-factor
+      ( is-equiv-right-factor-htpy
         ( gap
           ( map-prod f f')
           ( map-prod g g')
@@ -657,7 +654,7 @@ abstract
     canonical-pullback f g → is-pullback f' g' c'
   is-pullback-right-factor-is-pullback-prod f g c f' g' c' is-pb-cc' t =
     is-equiv-right-factor-is-equiv-map-prod (gap f g c) (gap f' g' c') t
-      ( is-equiv-right-factor
+      ( is-equiv-right-factor-htpy
         ( gap
           ( map-prod f f')
           ( map-prod g g')
@@ -706,10 +703,8 @@ module _
     is-fiberwise-equiv-is-pullback is-pullback-cone-map-Σ =
       is-fiberwise-equiv-is-equiv-tot
         ( is-equiv-right-factor
-          ( gap f pr1 cone-map-Σ)
           ( gap f pr1 (cone-canonical-pullback-Σ f Q))
           ( tot g)
-          ( refl-htpy)
           ( is-pullback-cone-canonical-pullback-Σ f Q)
           ( is-pullback-cone-map-Σ))
 
@@ -814,7 +809,7 @@ module _
       is-pullback-is-fiberwise-equiv-map-fib-cone i
         ( vertical-map-cone j h c)
         ( d)
-        ( λ x → is-equiv-right-factor
+        ( λ x → is-equiv-right-factor-htpy
           ( map-fib-cone (j ∘ i) h (cone-comp-horizontal i j h c d) x)
           ( map-fib-cone j h c (i x))
           ( map-fib-cone i (vertical-map-cone j h c) d x)

--- a/src/foundation-core/sections.lagda.md
+++ b/src/foundation-core/sections.lagda.md
@@ -8,7 +8,7 @@ title: Sections
 module foundation-core.sections where
 
 open import foundation-core.dependent-pair-types
-open import foundation-core.functions using (_∘_; id)
+open import foundation-core.functions
 open import foundation-core.homotopies
 open import foundation-core.universe-levels
 ```

--- a/src/foundation-core/truncated-maps.lagda.md
+++ b/src/foundation-core/truncated-maps.lagda.md
@@ -184,13 +184,11 @@ module _
   {l1 l2 : Level} {A : UU l1} {B : UU l2} {f g : A → B} (H : f ~ g)
   where
 
-  abstract
-    is-contr-map-htpy : is-contr-map g → is-contr-map f
-    is-contr-map-htpy = is-trunc-map-htpy neg-two-𝕋 H
+  is-contr-map-htpy : is-contr-map g → is-contr-map f
+  is-contr-map-htpy = is-trunc-map-htpy neg-two-𝕋 H
 
-  abstract
-    is-prop-map-htpy : is-prop-map g → is-prop-map f
-    is-prop-map-htpy = is-trunc-map-htpy neg-one-𝕋 H
+  is-prop-map-htpy : is-prop-map g → is-prop-map f
+  is-prop-map-htpy = is-trunc-map-htpy neg-one-𝕋 H
 ```
 
 ### Truncated maps are closed under composition
@@ -210,19 +208,16 @@ abstract
           ( is-trunc-g x)
           ( λ t → is-trunc-h (pr1 t)))
 
-abstract
-  is-contr-map-comp :
-    {l1 l2 l3 : Level} {A : UU l1} {B : UU l2}
-    {X : UU l3} (g : B → X) (h : A → B) →
-    is-contr-map g → is-contr-map h → is-contr-map (g ∘ h)
-  is-contr-map-comp = is-trunc-map-comp neg-two-𝕋
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
+  (g : B → X) (h : A → B)
+  where
 
-abstract
-  is-prop-map-comp :
-    {l1 l2 l3 : Level} {A : UU l1} {B : UU l2}
-    {X : UU l3} (g : B → X) (h : A → B) →
-    is-prop-map g → is-prop-map h → is-prop-map (g ∘ h)
-  is-prop-map-comp = is-trunc-map-comp neg-one-𝕋
+  is-contr-map-comp : is-contr-map g → is-contr-map h → is-contr-map (g ∘ h)
+  is-contr-map-comp = is-trunc-map-comp neg-two-𝕋 g h
+
+  is-prop-map-comp : is-prop-map g → is-prop-map h → is-prop-map (g ∘ h)
+  is-prop-map-comp = is-trunc-map-comp neg-one-𝕋 g h
 
 
 abstract
@@ -234,29 +229,29 @@ abstract
     is-trunc-map-htpy k H
       ( is-trunc-map-comp k g h is-trunc-g is-trunc-h)
 
-abstract
-  is-contr-map-comp-htpy :
-    {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
-    (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
-    is-contr-map g → is-contr-map h → is-contr-map f
-  is-contr-map-comp-htpy = is-trunc-map-comp-htpy neg-two-𝕋
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
+  (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
+  where
 
-abstract
+  is-contr-map-comp-htpy :
+    is-contr-map g → is-contr-map h → is-contr-map f
+  is-contr-map-comp-htpy = is-trunc-map-comp-htpy neg-two-𝕋 f g h H
+
   is-prop-map-comp-htpy :
-    {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
-    (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
     is-prop-map g → is-prop-map h → is-prop-map f
-  is-prop-map-comp-htpy = is-trunc-map-comp-htpy neg-one-𝕋
+  is-prop-map-comp-htpy = is-trunc-map-comp-htpy neg-one-𝕋 f g h H
 ```
 
 ### If a composite is truncated, then its right factor is truncated
 
 ```agda
 abstract
-  is-trunc-map-right-factor : {l1 l2 l3 : Level} (k : 𝕋) {A : UU l1} {B : UU l2}
-    {X : UU l3} (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
+  is-trunc-map-right-factor-htpy :
+    {l1 l2 l3 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} {X : UU l3}
+    (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
     is-trunc-map k g → is-trunc-map k f → is-trunc-map k h
-  is-trunc-map-right-factor k {A} f g h H is-trunc-g is-trunc-f b =
+  is-trunc-map-right-factor-htpy k {A} f g h H is-trunc-g is-trunc-f b =
     is-trunc-fam-is-trunc-Σ k
       ( is-trunc-g (g b))
       ( is-trunc-is-equiv' k
@@ -271,11 +266,30 @@ module _
   (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
   where
 
-  is-contr-map-right-factor : is-contr-map g → is-contr-map f → is-contr-map h
-  is-contr-map-right-factor = is-trunc-map-right-factor neg-two-𝕋 f g h H
+  is-contr-map-right-factor-htpy : is-contr-map g → is-contr-map f → is-contr-map h
+  is-contr-map-right-factor-htpy = is-trunc-map-right-factor-htpy neg-two-𝕋 f g h H
 
-  is-prop-map-right-factor : is-prop-map g → is-prop-map f → is-prop-map h
-  is-prop-map-right-factor = is-trunc-map-right-factor neg-one-𝕋 f g h H
+  is-prop-map-right-factor-htpy : is-prop-map g → is-prop-map f → is-prop-map h
+  is-prop-map-right-factor-htpy = is-trunc-map-right-factor-htpy neg-one-𝕋 f g h H
+
+
+is-trunc-map-right-factor :
+  {l1 l2 l3 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} {X : UU l3}
+  (g : B → X) (h : A → B) →
+  is-trunc-map k g → is-trunc-map k (g ∘ h) → is-trunc-map k h
+is-trunc-map-right-factor k {A} g h =
+  is-trunc-map-right-factor-htpy k (g ∘ h) g h refl-htpy
+
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
+  (g : B → X) (h : A → B)
+  where
+
+  is-contr-map-right-factor : is-contr-map g → is-contr-map (g ∘ h) → is-contr-map h
+  is-contr-map-right-factor = is-trunc-map-right-factor neg-two-𝕋 g h
+
+  is-prop-map-right-factor : is-prop-map g → is-prop-map (g ∘ h) → is-prop-map h
+  is-prop-map-right-factor = is-trunc-map-right-factor neg-one-𝕋 g h
 ```
 
 ### In a commuting square with the left and right maps equivalences, the top map is truncated if and only if the bottom map is truncated
@@ -290,7 +304,7 @@ module _
   is-trunc-map-top-is-trunc-map-bottom-is-equiv :
     is-equiv g → is-equiv h → is-trunc-map k i → is-trunc-map k f
   is-trunc-map-top-is-trunc-map-bottom-is-equiv K L M =
-    is-trunc-map-right-factor k (i ∘ g) h f H
+    is-trunc-map-right-factor-htpy k (i ∘ g) h f H
       ( is-trunc-map-is-equiv k L)
       ( is-trunc-map-comp k i g M
         ( is-trunc-map-is-equiv k K))

--- a/src/foundation-core/truncated-maps.lagda.md
+++ b/src/foundation-core/truncated-maps.lagda.md
@@ -8,34 +8,19 @@ title: Truncated maps
 module foundation-core.truncated-maps where
 
 open import foundation-core.commuting-squares
-open import foundation-core.contractible-maps using
-  ( is-contr-map; is-contr-map-is-equiv)
-open import foundation-core.dependent-pair-types using (Σ; pair; pr1; pr2)
-open import foundation-core.embeddings using (is-emb; _↪_; map-emb; is-emb-map-emb)
-open import foundation-core.equality-fibers-of-maps using
-  ( equiv-fib-ap-eq-fib; eq-fib-fib-ap; is-equiv-eq-fib-fib-ap)
-open import foundation-core.equivalences using (is-equiv-id; is-equiv)
-open import foundation-core.fibers-of-maps using
-  ( fib; equiv-fib-pr1; inv-equiv-fib-pr1; map-compute-fib-comp; is-equiv-map-compute-fib-comp)
-open import foundation-core.functions using (id; _∘_)
-open import foundation-core.functoriality-dependent-pair-types using
-  ( tot; compute-fib-tot; inv-compute-fib-tot; fib-triangle;
-    is-fiberwise-equiv-is-equiv-triangle; map-Σ-map-base;
-    equiv-fib-map-Σ-map-base-fib; map-Σ; triangle-map-Σ)
-open import foundation-core.homotopies using (_~_; inv-htpy; refl-htpy)
-open import foundation-core.identity-types using (_＝_; refl; ap; _∙_; inv)
-open import foundation-core.propositional-maps using
-  ( is-prop-map-is-emb; is-emb-is-prop-map; is-prop-map)
-open import foundation-core.propositions using (is-prop; Prop)
-open import foundation-core.sets using
-  ( is-set; is-set-equiv; Set; type-Set; is-set-type-Set)
-open import foundation-core.truncated-types using
-  ( is-trunc; is-trunc-succ-is-trunc; is-trunc-equiv; Truncated-Type;
-    is-trunc-is-equiv'; is-trunc-Σ; is-trunc-Id; is-trunc-equiv';
-    is-trunc-is-equiv)
-open import foundation-core.truncation-levels using
-  ( 𝕋; neg-two-𝕋; neg-one-𝕋; zero-𝕋; succ-𝕋)
-open import foundation-core.universe-levels using (Level; UU; _⊔_)
+open import foundation-core.contractible-maps
+open import foundation-core.dependent-pair-types
+open import foundation-core.equality-fibers-of-maps
+open import foundation-core.equivalences
+open import foundation-core.fibers-of-maps
+open import foundation-core.functions
+open import foundation-core.functoriality-dependent-pair-types
+open import foundation-core.homotopies
+open import foundation-core.identity-types
+open import foundation-core.propositional-maps
+open import foundation-core.truncated-types
+open import foundation-core.truncation-levels
+open import foundation-core.universe-levels
 ```
 
 ## Idea
@@ -51,7 +36,7 @@ module _
 
   is-trunc-map : {A : UU l1} {B : UU l2} → (A → B) → UU (l1 ⊔ l2)
   is-trunc-map f = (y : _) → is-trunc k (fib f y)
-  
+
   trunc-map : (A : UU l1) (B : UU l2) → UU (l1 ⊔ l2)
   trunc-map A B = Σ (A → B) is-trunc-map
 
@@ -108,7 +93,7 @@ is-trunc-map-is-equiv k H =
 module _
   {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} (f : A → B)
   where
-  
+
   abstract
     is-trunc-map-is-trunc-map-ap :
       ((x y : A) → is-trunc-map k (ap f {x} {y})) → is-trunc-map (succ-𝕋 k) f
@@ -116,7 +101,7 @@ module _
       is-trunc-equiv k
         ( fib (ap f) (p ∙ (inv p')))
         ( equiv-fib-ap-eq-fib f (pair x p) (pair x' p'))
-        ( is-trunc-map-ap-f x x' (p ∙ (inv p')))      
+        ( is-trunc-map-ap-f x x' (p ∙ (inv p')))
 
   abstract
     is-trunc-map-ap-is-trunc-map :
@@ -198,7 +183,7 @@ abstract
 module _
   {l1 l2 : Level} {A : UU l1} {B : UU l2} {f g : A → B} (H : f ~ g)
   where
-  
+
   abstract
     is-contr-map-htpy : is-contr-map g → is-contr-map f
     is-contr-map-htpy = is-trunc-map-htpy neg-two-𝕋 H
@@ -212,31 +197,56 @@ module _
 
 ```agda
 abstract
-  is-trunc-map-comp : {l1 l2 l3 : Level} (k : 𝕋) {A : UU l1} {B : UU l2}
-    {X : UU l3} (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
-    is-trunc-map k g → is-trunc-map k h → is-trunc-map k f
-  is-trunc-map-comp k f g h H is-trunc-g is-trunc-h =
-    is-trunc-map-htpy k H
-      ( λ x → is-trunc-is-equiv k
+  is-trunc-map-comp :
+    {l1 l2 l3 : Level} (k : 𝕋) {A : UU l1} {B : UU l2}
+    {X : UU l3} (g : B → X) (h : A → B) →
+    is-trunc-map k g → is-trunc-map k h → is-trunc-map k (g ∘ h)
+  is-trunc-map-comp k g h is-trunc-g is-trunc-h x =
+    is-trunc-is-equiv k
         ( Σ (fib g x) (λ t → fib h (pr1 t)))
         ( map-compute-fib-comp g h x)
         ( is-equiv-map-compute-fib-comp g h x)
         ( is-trunc-Σ
           ( is-trunc-g x)
-          ( λ t → is-trunc-h (pr1 t))))
+          ( λ t → is-trunc-h (pr1 t)))
 
-module _
-  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
-  (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
-  where
+abstract
+  is-contr-map-comp :
+    {l1 l2 l3 : Level} {A : UU l1} {B : UU l2}
+    {X : UU l3} (g : B → X) (h : A → B) →
+    is-contr-map g → is-contr-map h → is-contr-map (g ∘ h)
+  is-contr-map-comp = is-trunc-map-comp neg-two-𝕋
 
-  abstract
-    is-contr-map-comp : is-contr-map g → is-contr-map h → is-contr-map f
-    is-contr-map-comp = is-trunc-map-comp neg-two-𝕋 f g h H
+abstract
+  is-prop-map-comp :
+    {l1 l2 l3 : Level} {A : UU l1} {B : UU l2}
+    {X : UU l3} (g : B → X) (h : A → B) →
+    is-prop-map g → is-prop-map h → is-prop-map (g ∘ h)
+  is-prop-map-comp = is-trunc-map-comp neg-one-𝕋
 
-  abstract
-    is-prop-map-comp : is-prop-map g → is-prop-map h → is-prop-map f
-    is-prop-map-comp = is-trunc-map-comp neg-one-𝕋 f g h H
+
+abstract
+  is-trunc-map-comp-htpy :
+    {l1 l2 l3 : Level} (k : 𝕋) {A : UU l1} {B : UU l2}
+    {X : UU l3} (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
+    is-trunc-map k g → is-trunc-map k h → is-trunc-map k f
+  is-trunc-map-comp-htpy k f g h H is-trunc-g is-trunc-h =
+    is-trunc-map-htpy k H
+      ( is-trunc-map-comp k g h is-trunc-g is-trunc-h)
+
+abstract
+  is-contr-map-comp-htpy :
+    {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
+    (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
+    is-contr-map g → is-contr-map h → is-contr-map f
+  is-contr-map-comp-htpy = is-trunc-map-comp-htpy neg-two-𝕋
+
+abstract
+  is-prop-map-comp-htpy :
+    {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
+    (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
+    is-prop-map g → is-prop-map h → is-prop-map f
+  is-prop-map-comp-htpy = is-trunc-map-comp-htpy neg-one-𝕋
 ```
 
 ### If a composite is truncated, then its right factor is truncated
@@ -282,7 +292,7 @@ module _
   is-trunc-map-top-is-trunc-map-bottom-is-equiv K L M =
     is-trunc-map-right-factor k (i ∘ g) h f H
       ( is-trunc-map-is-equiv k L)
-      ( is-trunc-map-comp k (i ∘ g) i g refl-htpy M
+      ( is-trunc-map-comp k i g M
         ( is-trunc-map-is-equiv k K))
 ```
 
@@ -303,7 +313,7 @@ module _
         ( H (pr1 y) (pr2 y))
 
   abstract
-    is-trunc-map-is-trunc-map-tot : 
+    is-trunc-map-is-trunc-map-tot :
       is-trunc-map k (tot f) → ((x : A) → is-trunc-map k (f x))
     is-trunc-map-is-trunc-map-tot is-trunc-tot-f x z =
       is-trunc-equiv k
@@ -356,8 +366,8 @@ module _
     (k : 𝕋) (D : B → UU l4) {f : A → B} {g : (x : A) → C x → D (f x)} →
     is-trunc-map k f → ((x : A) → is-trunc-map k (g x)) →
     is-trunc-map k (map-Σ D f g)
-  is-trunc-map-map-Σ k D {f} {g} H K = 
-    is-trunc-map-comp k
+  is-trunc-map-map-Σ k D {f} {g} H K =
+    is-trunc-map-comp-htpy k
       ( map-Σ D f g)
       ( map-Σ-map-base f D)
       ( tot g)

--- a/src/foundation-core/truncated-types.lagda.md
+++ b/src/foundation-core/truncated-types.lagda.md
@@ -7,28 +7,20 @@ title: Truncated types
 
 module foundation-core.truncated-types where
 
-open import foundation-core.cartesian-product-types using (_×_)
-open import foundation-core.contractible-types using
-  ( is-contr; eq-is-contr; is-contr-is-equiv; is-contr-retract-of;
-    is-contr-Σ'; is-contr-left-factor-prod; is-contr-right-factor-prod;
-    is-contr-Π; is-property-is-contr; is-contr-equiv-is-contr)
-open import foundation-core.dependent-pair-types using (Σ; pair; pr1; pr2)
-open import foundation-core.embeddings using
-  ( is-emb; _↪_; map-emb; is-emb-map-emb)
-open import foundation-core.equality-cartesian-product-types using
-  ( Eq-prod; equiv-pair-eq)
-open import foundation-core.equality-dependent-pair-types using
-  ( equiv-pair-eq-Σ)
-open import foundation-core.equivalences using
-  ( is-equiv; _≃_; map-inv-is-equiv; is-equiv-map-inv-is-equiv)
+open import foundation-core.cartesian-product-types
+open import foundation-core.contractible-types
+open import foundation-core.dependent-pair-types
+open import foundation-core.embeddings
+open import foundation-core.equality-cartesian-product-types
+open import foundation-core.equality-dependent-pair-types
+open import foundation-core.equivalences
 open import foundation-core.function-extensionality using (htpy-eq; funext)
-open import foundation-core.homotopies using (_~_)
-open import foundation-core.identity-types using (_＝_; refl; left-inv; ap; tr)
-open import foundation-core.propositions using (is-prop; Π-Prop)
-open import foundation-core.retractions using (_retract-of_; retract-eq)
-open import foundation-core.truncation-levels using
-  ( 𝕋; neg-two-𝕋; neg-one-𝕋; succ-𝕋)
-open import foundation-core.universe-levels using (Level; UU; lsuc; _⊔_)
+open import foundation-core.homotopies
+open import foundation-core.identity-types
+open import foundation-core.propositions
+open import foundation-core.retractions
+open import foundation-core.truncation-levels
+open import foundation-core.universe-levels
 ```
 
 ## Idea
@@ -40,7 +32,7 @@ The truncatedness of a type is a measure of the complexity of its identity types
 ### The condition of truncatedness
 
 ```agda
-is-trunc : {i : Level} (k : 𝕋) → UU i → UU i
+is-trunc : {l : Level} (k : 𝕋) → UU l → UU l
 is-trunc neg-two-𝕋 A = is-contr A
 is-trunc (succ-𝕋 k) A = (x y : A) → is-trunc k (x ＝ y)
 
@@ -58,7 +50,7 @@ Truncated-Type l k = Σ (UU l) (is-trunc k)
 module _
   {k : 𝕋} {l : Level}
   where
-  
+
   type-Truncated-Type : Truncated-Type l k → UU l
   type-Truncated-Type = pr1
 
@@ -74,7 +66,7 @@ module _
 ```agda
 abstract
   is-trunc-succ-is-trunc :
-    (k : 𝕋) {i : Level} {A : UU i} → is-trunc k A → is-trunc (succ-𝕋 k) A
+    (k : 𝕋) {l : Level} {A : UU l} → is-trunc k A → is-trunc (succ-𝕋 k) A
   pr1 (is-trunc-succ-is-trunc neg-two-𝕋 H x y) = eq-is-contr H
   pr2 (is-trunc-succ-is-trunc neg-two-𝕋 H x .x) refl = left-inv (pr2 H x)
   is-trunc-succ-is-trunc (succ-𝕋 k) H x y = is-trunc-succ-is-trunc k (H x y)
@@ -129,21 +121,21 @@ module _
 ```agda
 abstract
   is-trunc-is-equiv :
-    {i j : Level} (k : 𝕋) {A : UU i} (B : UU j) (f : A → B) → is-equiv f →
+    {l1 l2 : Level} (k : 𝕋) {A : UU l1} (B : UU l2) (f : A → B) → is-equiv f →
     is-trunc k B → is-trunc k A
   is-trunc-is-equiv k B f is-equiv-f =
     is-trunc-retract-of (pair f (pr2 is-equiv-f))
 
 abstract
   is-trunc-equiv :
-    {i j : Level} (k : 𝕋) {A : UU i} (B : UU  j) (e : A ≃ B) →
+    {l1 l2 : Level} (k : 𝕋) {A : UU l1} (B : UU l2) (e : A ≃ B) →
     is-trunc k B → is-trunc k A
   is-trunc-equiv k B (pair f is-equiv-f) =
     is-trunc-is-equiv k B f is-equiv-f
 
 abstract
   is-trunc-is-equiv' :
-    {i j : Level} (k : 𝕋) (A : UU i) {B : UU j} (f : A → B) →
+    {l1 l2 : Level} (k : 𝕋) (A : UU l1) {B : UU l2} (f : A → B) →
     is-equiv f → is-trunc k A → is-trunc k B
   is-trunc-is-equiv' k A  f is-equiv-f is-trunc-A =
     is-trunc-is-equiv k A
@@ -153,7 +145,7 @@ abstract
 
 abstract
   is-trunc-equiv' :
-    {i j : Level} (k : 𝕋) (A : UU i) {B : UU j} (e : A ≃ B) →
+    {l1 l2 : Level} (k : 𝕋) (A : UU l1) {B : UU l2} (e : A ≃ B) →
     is-trunc k A → is-trunc k B
   is-trunc-equiv' k A (pair f is-equiv-f) =
     is-trunc-is-equiv' k A f is-equiv-f
@@ -164,14 +156,14 @@ abstract
 ```agda
 abstract
   is-trunc-is-emb :
-    {i j : Level} (k : 𝕋) {A : UU i} {B : UU j} (f : A → B) →
+    {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} (f : A → B) →
     is-emb f → is-trunc (succ-𝕋 k) B → is-trunc (succ-𝕋 k) A
   is-trunc-is-emb k f Ef H x y =
     is-trunc-is-equiv k (f x ＝ f y) (ap f {x} {y}) (Ef x y) (H (f x) (f y))
 
 abstract
   is-trunc-emb :
-    {i j : Level} (k : 𝕋) {A : UU i} {B : UU j} (f : A ↪ B) →
+    {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} (f : A ↪ B) →
     is-trunc (succ-𝕋 k) B → is-trunc (succ-𝕋 k) A
   is-trunc-emb k f = is-trunc-is-emb k (map-emb f) (is-emb-map-emb f)
 ```

--- a/src/foundation-core/type-arithmetic-dependent-pair-types.lagda.md
+++ b/src/foundation-core/type-arithmetic-dependent-pair-types.lagda.md
@@ -7,22 +7,16 @@ title: Type arithmetic for dependent pair types
 
 module foundation-core.type-arithmetic-dependent-pair-types where
 
-open import foundation-core.contractible-maps using
-  ( is-equiv-is-contr-map; is-contr-map-is-equiv)
-open import foundation-core.contractible-types using
-  ( is-contr; is-contr-equiv; center; is-contr-equiv')
-open import foundation-core.dependent-pair-types using
-  ( Σ; pair; pr1; pr2; ind-Σ; triple; triple')
-open import foundation-core.equivalences using
-  ( is-equiv; _≃_; is-equiv-has-inverse;
-    is-equiv-right-factor; is-equiv-id; is-equiv-left-factor)
-open import foundation-core.fibers-of-maps using (equiv-fib-pr1; fib)
-open import foundation-core.functions using (_∘_; id)
-open import foundation-core.homotopies using (_~_)
-open import foundation-core.identity-types using (Id; refl; ap)
-open import foundation-core.singleton-induction using
-  ( ind-singleton-is-contr; comp-singleton-is-contr)
-open import foundation-core.universe-levels using (Level; UU)
+open import foundation-core.contractible-maps
+open import foundation-core.contractible-types
+open import foundation-core.dependent-pair-types
+open import foundation-core.equivalences
+open import foundation-core.fibers-of-maps
+open import foundation-core.functions
+open import foundation-core.homotopies
+open import foundation-core.identity-types
+open import foundation-core.singleton-induction
+open import foundation-core.universe-levels
 ```
 
 ## Idea

--- a/src/foundation-core/universal-property-pullbacks.lagda.md
+++ b/src/foundation-core/universal-property-pullbacks.lagda.md
@@ -17,7 +17,6 @@ open import foundation-core.functoriality-dependent-pair-types
 open import foundation-core.functoriality-function-types
 open import foundation-core.homotopies
 open import foundation-core.identity-types
-open import foundation-core.subtype-identity-principle
 open import foundation-core.universe-levels
 ```
 
@@ -66,7 +65,7 @@ module _
       is-equiv h
     is-equiv-up-pullback-up-pullback up up' =
       is-equiv-is-equiv-postcomp h
-        ( λ D → is-equiv-right-factor
+        ( λ D → is-equiv-right-factor-htpy
           ( cone-map f g {C' = D} c')
           ( cone-map f g c)
           ( λ (k : D → C') → h ∘ k)
@@ -94,7 +93,7 @@ module _
       is-equiv h →
       ({l : Level} → universal-property-pullback l f g c)
     up-pullback-is-equiv-up-pullback up' is-equiv-h D =
-      is-equiv-left-factor
+      is-equiv-left-factor-htpy
         ( cone-map f g c')
         ( cone-map f g c)
         ( λ k → h ∘ k)

--- a/src/foundation/0-connected-types.lagda.md
+++ b/src/foundation/0-connected-types.lagda.md
@@ -7,41 +7,28 @@ title: 0-Connected types
 
 module foundation.0-connected-types where
 
-open import foundation.contractible-types using
-  ( is-contr-Prop; center; eq-is-contr; is-contr-equiv;
-    universal-property-contr-is-contr)
-open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2)
-open import foundation.equivalences using (_≃_; _∘e_; map-inv-equiv; inv-equiv)
-open import foundation.fiber-inclusions using (fiber-inclusion)
-open import foundation.fibers-of-maps using (fib)
-open import foundation.functions using (ev-pt; precomp)
-open import foundation.functoriality-set-truncation using (equiv-trunc-Set)
-open import foundation.homotopies using (refl-htpy)
-open import foundation.identity-types using (ap; refl)
-open import foundation.inhabited-types using (is-inhabited)
-open import foundation.mere-equality using (mere-eq; mere-eq-Prop)
-open import foundation.propositional-truncations using
-  ( type-trunc-Prop; trunc-Prop; unit-trunc-Prop;
-    apply-universal-property-trunc-Prop)
-open import foundation.propositions using
-  ( Prop; is-prop; type-Prop; is-prop-type-Prop)
-open import foundation.set-truncations using
-  ( type-trunc-Set; apply-universal-property-trunc-Set'; unit-trunc-Set;
-    apply-effectiveness-unit-trunc-Set; trunc-Set;
-    apply-dependent-universal-property-trunc-Set';
-    apply-effectiveness-unit-trunc-Set')
-open import foundation.sets using (set-Prop; Id-Prop)
-open import foundation.surjective-maps using
-  ( is-surjective; equiv-dependent-universal-property-surj-is-surjective;
-    is-trunc-map-precomp-Π-is-surjective)
-open import foundation.truncated-maps using
-  ( is-trunc-map; is-trunc-map-comp; is-trunc-map-is-equiv)
-open import foundation.truncated-types using (is-trunc)
-open import foundation.truncation-levels using (𝕋; succ-𝕋)
-open import foundation.unit-type using (star; unit; pt; is-contr-unit)
-open import foundation.universal-property-unit-type using
-  ( equiv-universal-property-unit)
-open import foundation.universe-levels using (Level; UU)
+open import foundation.contractible-types
+open import foundation.dependent-pair-types
+open import foundation.equivalences
+open import foundation.fiber-inclusions
+open import foundation.fibers-of-maps
+open import foundation.functions
+open import foundation.functoriality-set-truncation
+open import foundation.homotopies
+open import foundation.identity-types
+open import foundation.inhabited-types
+open import foundation.mere-equality
+open import foundation.propositional-truncations
+open import foundation.propositions
+open import foundation.set-truncations
+open import foundation.sets
+open import foundation.surjective-maps
+open import foundation.truncated-maps
+open import foundation.truncated-types
+open import foundation.truncation-levels
+open import foundation.unit-type
+open import foundation.universal-property-unit-type
+open import foundation.universe-levels
 ```
 
 ## Idea
@@ -110,10 +97,8 @@ is-trunc-map-ev-pt-is-connected :
   is-trunc-map k (ev-pt a (λ _ → B))
 is-trunc-map-ev-pt-is-connected k {A} {B} a H K =
   is-trunc-map-comp k
-    ( ev-pt a (λ _ → B))
     ( ev-pt star (λ _ → B))
     ( precomp (pt a) B)
-    ( refl-htpy)
     ( is-trunc-map-is-equiv k
       ( universal-property-contr-is-contr star is-contr-unit B))
     ( is-trunc-map-precomp-Π-is-surjective k

--- a/src/foundation/decidable-embeddings.lagda.md
+++ b/src/foundation/decidable-embeddings.lagda.md
@@ -7,32 +7,33 @@ title: Decidable embeddings
 
 module foundation.decidable-embeddings where
 
-open import foundation.cartesian-product-types
-open import foundation.coproduct-types
-open import foundation.contractible-maps
-open import foundation.contractible-types
+open import foundation-core.cartesian-product-types
+open import foundation-core.coproduct-types
+open import foundation-core.contractible-maps
+open import foundation-core.contractible-types
+open import foundation-core.decidable-propositions
+open import foundation-core.dependent-pair-types
+open import foundation-core.empty-types
+open import foundation-core.functions
+open import foundation-core.functoriality-dependent-pair-types
+open import foundation-core.fundamental-theorem-of-identity-types
+open import foundation-core.propositions
+open import foundation-core.subtype-identity-principle
+open import foundation-core.type-arithmetic-dependent-pair-types
+open import foundation-core.universe-levels
+
 open import foundation.decidable-maps
-open import foundation.decidable-propositions
 open import foundation.decidable-subtypes
 open import foundation.decidable-types
-open import foundation.dependent-pair-types
 open import foundation.embeddings
-open import foundation.empty-types
 open import foundation.equivalences
 open import foundation.fibers-of-maps
-open import foundation.functions
 open import foundation.functoriality-cartesian-product-types
-open import foundation.functoriality-dependent-pair-types
-open import foundation.fundamental-theorem-of-identity-types
 open import foundation.homotopies
 open import foundation.identity-types
 open import foundation.propositional-maps
-open import foundation.propositions
-open import foundation.subtype-identity-principle
-open import foundation.type-arithmetic-dependent-pair-types
 open import foundation.type-duality
 open import foundation.type-theoretic-principle-of-choice
-open import foundation.universe-levels
 ```
 
 ## Idea
@@ -223,8 +224,8 @@ abstract
 ```agda
 abstract
   is-decidable-emb-comp :
-    {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3} {g : B → C}
-    {f : A → B} →
+    {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
+    {g : B → C} {f : A → B} →
     is-decidable-emb f → is-decidable-emb g → is-decidable-emb (g ∘ f)
   pr1 (is-decidable-emb-comp {g = g} {f} H K) =
     is-emb-comp _ _ (pr1 K) (pr1 H)

--- a/src/foundation/decidable-embeddings.lagda.md
+++ b/src/foundation/decidable-embeddings.lagda.md
@@ -7,48 +7,32 @@ title: Decidable embeddings
 
 module foundation.decidable-embeddings where
 
-open import foundation.cartesian-product-types using (_×_)
-open import foundation.coproduct-types using (inl; inr; ind-coprod)
-open import foundation.contractible-maps using (is-contr-map-is-equiv)
-open import foundation.contractible-types using (center; is-contr)
-open import foundation.decidable-maps using (is-decidable-map)
-open import foundation.decidable-propositions using
-  ( is-decidable-prop; is-prop-is-decidable-prop; decidable-Prop;
-    is-prop-is-decidable)
-open import foundation.decidable-subtypes using (decidable-subtype)
-open import foundation.decidable-types using
-  ( is-decidable; is-decidable-equiv)
-open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2)
-open import foundation.embeddings using
-  ( is-emb; _↪_; is-emb-id; is-prop-is-emb; is-emb-comp'; is-emb-htpy)
-open import foundation.empty-types using (ex-falso; is-emb-ex-falso)
-open import foundation.equivalences using
-  ( _≃_; _∘e_; id-equiv; is-equiv; is-emb-is-equiv; map-inv-is-equiv;
-    equiv-precomp; map-equiv; issec-map-inv-equiv; is-equiv-map-inv-equiv)
-open import foundation.fibers-of-maps using (fib; fib-comp)
-open import foundation.functions using (id; _∘_)
-open import foundation.functoriality-cartesian-product-types using
-  ( equiv-prod)
-open import foundation.functoriality-dependent-pair-types using
-  ( equiv-tot; equiv-Σ)
-open import foundation.fundamental-theorem-of-identity-types using
-  ( fundamental-theorem-id)
-open import foundation.homotopies using (_~_; refl-htpy; is-contr-total-htpy)
-open import foundation.identity-types using (_＝_; refl; equiv-concat; inv; ap)
-open import foundation.propositional-maps using
-  ( is-prop-map; is-emb-is-prop-map; equiv-is-prop-map-is-emb;
-    is-prop-map-is-emb)
-open import foundation.propositions using
-  ( is-prop; is-prop-Π; is-prop-is-inhabited; is-prop-prod;
-    is-proof-irrelevant-is-prop; equiv-prop)
-open import foundation.subtype-identity-principle using
-  ( is-contr-total-Eq-subtype)
-open import foundation.type-arithmetic-dependent-pair-types using
-  ( left-unit-law-Σ-is-contr)
-open import foundation.type-duality using (equiv-Fib-structure)
-open import foundation.type-theoretic-principle-of-choice using
-  ( inv-distributive-Π-Σ)
-open import foundation.universe-levels using (Level; UU; _⊔_)
+open import foundation.cartesian-product-types
+open import foundation.coproduct-types
+open import foundation.contractible-maps
+open import foundation.contractible-types
+open import foundation.decidable-maps
+open import foundation.decidable-propositions
+open import foundation.decidable-subtypes
+open import foundation.decidable-types
+open import foundation.dependent-pair-types
+open import foundation.embeddings
+open import foundation.empty-types
+open import foundation.equivalences
+open import foundation.fibers-of-maps
+open import foundation.functions
+open import foundation.functoriality-cartesian-product-types
+open import foundation.functoriality-dependent-pair-types
+open import foundation.fundamental-theorem-of-identity-types
+open import foundation.homotopies
+open import foundation.identity-types
+open import foundation.propositional-maps
+open import foundation.propositions
+open import foundation.subtype-identity-principle
+open import foundation.type-arithmetic-dependent-pair-types
+open import foundation.type-duality
+open import foundation.type-theoretic-principle-of-choice
+open import foundation.universe-levels
 ```
 
 ## Idea
@@ -243,7 +227,7 @@ abstract
     {f : A → B} →
     is-decidable-emb f → is-decidable-emb g → is-decidable-emb (g ∘ f)
   pr1 (is-decidable-emb-comp {g = g} {f} H K) =
-    is-emb-comp' _ _ (pr1 K) (pr1 H)
+    is-emb-comp _ _ (pr1 K) (pr1 H)
   pr2 (is-decidable-emb-comp {g = g} {f} H K) x =
     ind-coprod
       ( λ t → is-decidable (fib (g ∘ f) x))

--- a/src/foundation/descent-coproduct-types.lagda.md
+++ b/src/foundation/descent-coproduct-types.lagda.md
@@ -105,7 +105,7 @@ module _
           ( map-fib-cone (ind-coprod (λ _ → X) f g) i
           ( cone-descent-coprod (triple h f' H) (triple k g' K)))
       α (inl x) =
-        is-equiv-left-factor
+        is-equiv-left-factor-htpy
           ( map-fib-cone f i (triple h f' H) x)
           ( map-fib-cone (ind-coprod _ f g) i
             ( cone-descent-coprod (triple h f' H) (triple k g' K))
@@ -117,18 +117,18 @@ module _
             ( triple h f' H) is-pb-cone-A' x)
           ( is-equiv-fib-map-coprod-inl-fib h k x)
       α (inr y) =
-        is-equiv-left-factor
+        is-equiv-left-factor-htpy
           ( map-fib-cone g i (triple k g' K) y)
           ( map-fib-cone
             ( ind-coprod _ f g) i
             ( cone-descent-coprod (triple h f' H) (triple k g' K))
             ( inr y))
-            ( fib-map-coprod-inr-fib h k y)
-            ( triangle-descent-square-fib-map-coprod-inr-fib
-              h k i f g f' g' H K y)
-            ( is-fiberwise-equiv-map-fib-cone-is-pullback g i
-              ( triple k g' K) is-pb-cone-B' y)
-            ( is-equiv-fib-map-coprod-inr-fib h k y)
+          ( fib-map-coprod-inr-fib h k y)
+          ( triangle-descent-square-fib-map-coprod-inr-fib
+            h k i f g f' g' H K y)
+          ( is-fiberwise-equiv-map-fib-cone-is-pullback g i
+            ( triple k g' K) is-pb-cone-B' y)
+          ( is-equiv-fib-map-coprod-inr-fib h k y)
 
   abstract
     descent-coprod-inl :

--- a/src/foundation/descent-dependent-pair-types.lagda.md
+++ b/src/foundation/descent-dependent-pair-types.lagda.md
@@ -51,7 +51,7 @@ module _
         ( h)
         ( cone-descent-Σ)
         ( ind-Σ
-          ( λ i a → is-equiv-left-factor
+          ( λ i a → is-equiv-left-factor-htpy
             ( map-fib-cone (f i) h (c i) a)
             ( map-fib-cone (ind-Σ f) h cone-descent-Σ (pair i a))
             ( map-inv-compute-fib-tot (λ i → pr1 (c i)) (pair i a))

--- a/src/foundation/descent-equivalences.lagda.md
+++ b/src/foundation/descent-equivalences.lagda.md
@@ -54,7 +54,7 @@ module _
         ( i)
         ( is-equiv-i)
         ( λ y → is-equiv (map-fib-cone j h c y))
-        ( λ x → is-equiv-left-factor
+        ( λ x → is-equiv-left-factor-htpy
           ( map-fib-cone (j ∘ i) h
             ( cone-comp-horizontal i j h c d) x)
           ( map-fib-cone j h c (i x))

--- a/src/foundation/embeddings.lagda.md
+++ b/src/foundation/embeddings.lagda.md
@@ -36,7 +36,7 @@ open import foundation.truncated-maps
 module _
   {l1 l2 : Level} {A : UU l1} {B : UU l2}
   where
-  
+
   is-prop-is-emb : (f : A → B) → is-prop (is-emb f)
   is-prop-is-emb f =
     is-prop-Π (λ x → is-prop-Π (λ y → is-property-is-equiv (ap f)))
@@ -69,7 +69,7 @@ module _
 module _
   {l1 l2 : Level} {A : UU l1} {B : UU l2} (f g : A → B) (H : f ~ g)
   where
-  
+
   abstract
     is-emb-htpy' : is-emb f → is-emb g
     is-emb-htpy' is-emb-f =
@@ -93,25 +93,23 @@ module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
   where
 
-  abstract
-    is-emb-comp :
-      (f : A → C) (g : B → C) (h : A → B) (H : f ~ (g ∘ h)) → is-emb g →
-      is-emb h → is-emb f
-    is-emb-comp f g h H is-emb-g is-emb-h =
-      is-emb-htpy f (g ∘ h) H
-        ( λ x y → is-equiv-comp-htpy (ap (g ∘ h)) (ap g) (ap h) (ap-comp g h)
-          ( is-emb-h x y)
-          ( is-emb-g (h x) (h y)))
+  is-emb-comp :
+    (g : B → C) (h : A → B) → is-emb g → is-emb h → is-emb (g ∘ h)
+  is-emb-comp g h is-emb-g is-emb-h x y =
+    is-equiv-comp-htpy (ap (g ∘ h)) (ap g) (ap h) (ap-comp g h)
+      ( is-emb-h x y)
+      ( is-emb-g (h x) (h y))
 
   abstract
-    is-emb-comp' :
-      (g : B → C) (h : A → B) → is-emb g → is-emb h → is-emb (g ∘ h)
-    is-emb-comp' g h = is-emb-comp (g ∘ h) g h refl-htpy
+    is-emb-comp-htpy :
+      (f : A → C) (g : B → C) (h : A → B) (H : f ~ (g ∘ h)) → is-emb g →
+      is-emb h → is-emb f
+    is-emb-comp-htpy f g h H is-emb-g is-emb-h =
+      is-emb-htpy f (g ∘ h) H (is-emb-comp g h is-emb-g is-emb-h)
 
   comp-emb :
     (B ↪ C) → (A ↪ B) → (A ↪ C)
-  pr1 (comp-emb (pair g H) (pair f K)) = g ∘ f
-  pr2 (comp-emb (pair g H) (pair f K)) = is-emb-comp' g f H K
+  comp-emb (pair g H) (pair f K) = pair (g ∘ f) (is-emb-comp g f H K)
 ```
 
 ### The map on total spaces induced by a family of embeddings is an embedding
@@ -206,7 +204,7 @@ module _
       (f : A → C) (g : B → C) (e : A → B) (H : f ~ (g ∘ e)) →
       is-equiv e → is-emb g → is-emb f
     is-emb-triangle-is-equiv f g e H is-equiv-e is-emb-g =
-      is-emb-comp f g e H is-emb-g (is-emb-is-equiv is-equiv-e)
+      is-emb-comp-htpy f g e H is-emb-g (is-emb-is-equiv is-equiv-e)
 
 module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
@@ -233,7 +231,7 @@ module _
 module _
   {l1 l2 : Level} {A : UU l1} {B : UU l2} (f : A → B)
   where
-  
+
   abstract
     is-emb-sec-ap :
       ((x y : A) → sec (ap f {x = x} {y = y})) → is-emb f
@@ -268,7 +266,7 @@ module _
   {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
   {X : UU l4} (f : A → X) (g : B → X) (c : cone f g C)
   where
-  
+
   abstract
     is-emb-is-pullback : is-pullback f g c → is-emb g → is-emb (pr1 c)
     is-emb-is-pullback pb is-emb-g =

--- a/src/foundation/embeddings.lagda.md
+++ b/src/foundation/embeddings.lagda.md
@@ -9,36 +9,23 @@ module foundation.embeddings where
 
 open import foundation-core.embeddings public
 
-open import foundation-core.cartesian-product-types using (_×_)
-open import foundation-core.cones-pullbacks using (cone)
-open import foundation-core.dependent-pair-types using (Σ; pair; pr1; pr2)
-open import foundation-core.functions using (_∘_)
-open import foundation-core.functoriality-dependent-pair-types using
-  ( tot; map-Σ-map-base; map-Σ)
-open import foundation-core.fundamental-theorem-of-identity-types using
-  ( fundamental-theorem-id-sec)
-open import foundation-core.homotopies using
-  ( _~_; nat-htpy; inv-htpy; refl-htpy)
-open import foundation-core.propositional-maps using
-  ( is-emb-is-prop-map; is-prop-map-is-emb)
-open import foundation-core.pullbacks using (is-pullback)
-open import foundation-core.sections using (sec; triangle-section)
-open import foundation-core.truncation-levels using (neg-one-𝕋)
-open import foundation-core.universe-levels using (Level; UU; _⊔_)
+open import foundation-core.cartesian-product-types
+open import foundation-core.cones-pullbacks
+open import foundation-core.dependent-pair-types
+open import foundation-core.functions
+open import foundation-core.functoriality-dependent-pair-types
+open import foundation-core.fundamental-theorem-of-identity-types
+open import foundation-core.homotopies
+open import foundation-core.propositional-maps
+open import foundation-core.propositions
+open import foundation-core.pullbacks
+open import foundation-core.sections
+open import foundation-core.truncation-levels
+open import foundation-core.universe-levels
 
-open import foundation.equivalences using
-  ( is-equiv-top-is-equiv-left-square; is-equiv-comp-htpy; is-equiv-right-factor;
-    is-equiv; is-emb-is-equiv; map-inv-is-equiv; issec-map-inv-is-equiv;
-    is-equiv-map-inv-is-equiv; is-property-is-equiv; _≃_; map-equiv;
-    is-equiv-htpy-equiv; inv-equiv; isretr-map-inv-equiv)
-open import foundation.identity-types using
-  ( ap; concat'; concat; is-equiv-concat; is-equiv-concat'; ap-comp;
-    _＝_; refl; _∙_; inv)
-open import foundation.propositions using (is-prop; is-prop-Π; Prop)
-open import foundation.truncated-maps using
-  ( is-trunc-map-is-trunc-domain-codomain; is-trunc-is-pullback;
-    is-prop-map-tot; is-prop-map-map-Σ-map-base; is-prop-map-map-Σ;
-    is-trunc-is-pullback')
+open import foundation.equivalences
+open import foundation.identity-types
+open import foundation.truncated-maps
 ```
 
 ## Properties
@@ -206,7 +193,7 @@ module _
       (f : A → C) (g : B → C) (h : A → B) (H : f ~ (g ∘ h)) → is-emb g →
       is-emb f → is-emb h
     is-emb-right-factor f g h H is-emb-g is-emb-f x y =
-      is-equiv-right-factor
+      is-equiv-right-factor-htpy
         ( ap (g ∘ h))
         ( ap g)
         ( ap h)

--- a/src/foundation/embeddings.lagda.md
+++ b/src/foundation/embeddings.lagda.md
@@ -112,6 +112,64 @@ module _
   comp-emb (pair g H) (pair f K) = pair (g ∘ f) (is-emb-comp g f H K)
 ```
 
+### The right factor of a composed embedding is an embedding
+
+```agda
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
+  where
+
+  is-emb-right-factor :
+    (g : B → C) (h : A → B) →
+    is-emb g → is-emb (g ∘ h) → is-emb h
+  is-emb-right-factor g h is-emb-g is-emb-gh x y =
+    is-equiv-right-factor-htpy
+      ( ap (g ∘ h))
+      ( ap g)
+      ( ap h)
+      ( ap-comp g h)
+      ( is-emb-g (h x) (h y))
+      ( is-emb-gh x y)
+
+  abstract
+    is-emb-right-factor-htpy :
+      (f : A → C) (g : B → C) (h : A → B) (H : f ~ (g ∘ h)) →
+      is-emb g → is-emb f → is-emb h
+    is-emb-right-factor-htpy f g h H is-emb-g is-emb-f x y =
+      is-equiv-right-factor-htpy
+        ( ap (g ∘ h))
+        ( ap g)
+        ( ap h)
+        ( ap-comp g h)
+        ( is-emb-g (h x) (h y))
+        ( is-emb-htpy (g ∘ h) f (inv-htpy H) is-emb-f x y)
+
+  abstract
+    is-emb-triangle-is-equiv :
+      (f : A → C) (g : B → C) (e : A → B) (H : f ~ (g ∘ e)) →
+      is-equiv e → is-emb g → is-emb f
+    is-emb-triangle-is-equiv f g e H is-equiv-e is-emb-g =
+      is-emb-comp-htpy f g e H is-emb-g (is-emb-is-equiv is-equiv-e)
+
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
+  where
+
+  abstract
+    is-emb-triangle-is-equiv' :
+      (f : A → C) (g : B → C) (e : A → B) (H : f ~ (g ∘ e)) →
+      is-equiv e → is-emb f → is-emb g
+    is-emb-triangle-is-equiv' f g e H is-equiv-e is-emb-f =
+      is-emb-triangle-is-equiv g f
+        ( map-inv-is-equiv is-equiv-e)
+        ( triangle-section f g e H
+          ( pair
+            ( map-inv-is-equiv is-equiv-e)
+            ( issec-map-inv-is-equiv is-equiv-e)))
+        ( is-equiv-map-inv-is-equiv is-equiv-e)
+        ( is-emb-f)
+```
+
 ### The map on total spaces induced by a family of embeddings is an embedding
 
 ```agda
@@ -177,52 +235,6 @@ module _
 
   emb-× : (A ↪ C) → (B ↪ D) → ((A × B) ↪ (C × D))
   emb-× f g = emb-Σ (λ _ → D) f (λ _ → g)
-```
-
-### The right factor of a composed embedding is an embedding
-
-```agda
-module _
-  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
-  where
-
-  abstract
-    is-emb-right-factor :
-      (f : A → C) (g : B → C) (h : A → B) (H : f ~ (g ∘ h)) → is-emb g →
-      is-emb f → is-emb h
-    is-emb-right-factor f g h H is-emb-g is-emb-f x y =
-      is-equiv-right-factor-htpy
-        ( ap (g ∘ h))
-        ( ap g)
-        ( ap h)
-        ( ap-comp g h)
-        ( is-emb-g (h x) (h y))
-        ( is-emb-htpy (g ∘ h) f (inv-htpy H) is-emb-f x y)
-
-  abstract
-    is-emb-triangle-is-equiv :
-      (f : A → C) (g : B → C) (e : A → B) (H : f ~ (g ∘ e)) →
-      is-equiv e → is-emb g → is-emb f
-    is-emb-triangle-is-equiv f g e H is-equiv-e is-emb-g =
-      is-emb-comp-htpy f g e H is-emb-g (is-emb-is-equiv is-equiv-e)
-
-module _
-  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
-  where
-
-  abstract
-    is-emb-triangle-is-equiv' :
-      (f : A → C) (g : B → C) (e : A → B) (H : f ~ (g ∘ e)) →
-      is-equiv e → is-emb f → is-emb g
-    is-emb-triangle-is-equiv' f g e H is-equiv-e is-emb-f =
-      is-emb-triangle-is-equiv g f
-        ( map-inv-is-equiv is-equiv-e)
-        ( triangle-section f g e H
-          ( pair
-            ( map-inv-is-equiv is-equiv-e)
-            ( issec-map-inv-is-equiv is-equiv-e)))
-        ( is-equiv-map-inv-is-equiv is-equiv-e)
-        ( is-emb-f)
 ```
 
 ### If the action on identifications has a section, then f is an embedding

--- a/src/foundation/equality-coproduct-types.lagda.md
+++ b/src/foundation/equality-coproduct-types.lagda.md
@@ -258,7 +258,7 @@ module _
     is-emb f → is-emb g → ((a : A) (b : B) → ¬ (f a ＝ g b)) →
     is-emb (ind-coprod (λ x → C) f g)
   is-emb-coprod H K L (inl a) (inl a') =
-    is-equiv-left-factor
+    is-equiv-left-factor-htpy
       ( ap f)
       ( ap (ind-coprod (λ x → C) f g))
       ( ap inl)
@@ -270,7 +270,7 @@ module _
   is-emb-coprod H K L (inr b) (inl a') =
     is-equiv-is-empty (ap (ind-coprod (λ x → C) f g)) (L a' b ∘ inv)
   is-emb-coprod H K L (inr b) (inr b') =
-    is-equiv-left-factor
+    is-equiv-left-factor-htpy
       ( ap g)
       ( ap (ind-coprod (λ x → C) f g))
       ( ap inr)

--- a/src/foundation/equivalences.lagda.md
+++ b/src/foundation/equivalences.lagda.md
@@ -9,61 +9,35 @@ module foundation.equivalences where
 
 open import foundation-core.equivalences public
 
-open import foundation-core.coherently-invertible-maps using
-  ( is-coherently-invertible)
-open import foundation-core.commuting-squares using (coherence-square)
-open import foundation-core.cones-pullbacks using (cone; swap-cone)
-open import foundation-core.contractible-maps using
-  ( is-contr-map-is-equiv; is-contr-map; is-equiv-is-contr-map)
-open import foundation-core.contractible-types using
-  ( center; eq-is-contr'; is-equiv-is-contr)
-open import foundation-core.dependent-pair-types using
-  ( Σ; pair; pr1; pr2; triple)
-open import foundation-core.embeddings using (is-emb; _↪_)
-open import foundation-core.fibers-of-maps using (fib)
-open import foundation-core.functions using (_∘_; id; precomp-Π; precomp)
-open import foundation-core.functoriality-dependent-function-types
-open import foundation-core.functoriality-dependent-pair-types using
-  ( tot; equiv-tot; is-equiv-tot-is-fiberwise-equiv)
-open import foundation-core.functoriality-fibers-of-maps using (map-fib-cone)
-open import foundation-core.fundamental-theorem-of-identity-types using
-  ( fundamental-theorem-id; fundamental-theorem-id')
-open import foundation-core.homotopies using (_~_; refl-htpy; _∙h_; _·r_)
-open import foundation-core.path-split-maps using
-  ( is-coherently-invertible-is-path-split; is-path-split-is-equiv)
-open import foundation-core.propositions using
-  ( Prop; type-Prop; is-prop-type-Prop; is-prop)
-open import foundation-core.pullbacks using
-  ( is-pullback; is-pullback-is-fiberwise-equiv-map-fib-cone;
-    is-pullback-swap-cone')
-open import foundation-core.retractions using (retr)
-open import foundation-core.sections using (sec)
-open import foundation-core.sets using (Set; type-Set; is-set)
-open import foundation-core.subtypes using
-  ( is-emb-inclusion-subtype; equiv-subtype-equiv)
-open import foundation-core.truncated-types using
-  ( Truncated-Type; type-Truncated-Type; is-trunc)
-open import foundation-core.truncation-levels using (𝕋; neg-two-𝕋)
-open import foundation-core.universal-property-pullbacks
-open import foundation-core.universe-levels using (Level; UU; _⊔_)
-
-open import foundation.contractible-types using
-  ( is-contr; is-contr-equiv; is-contr-equiv'; is-contr-Π; is-contr-is-equiv';
-    is-contr-prod; is-prop-is-contr)
-open import foundation.function-extensionality using
+open import foundation-core.cones-pullbacks
+open import foundation-core.contractible-maps
+open import foundation-core.contractible-types
+open import foundation-core.dependent-pair-types
+open import foundation-core.embeddings
+open import foundation-core.fibers-of-maps
+open import foundation-core.function-extensionality using
   ( htpy-eq; funext; eq-htpy; equiv-funext)
-open import foundation.identity-systems using (Ind-identity-system)
-open import foundation.identity-types using
-  ( _＝_; refl; equiv-inv; ap; equiv-concat'; inv; _∙_; concat'; assoc; concat;
-    left-inv; right-unit; distributive-inv-concat; con-inv; inv-inv; ap-inv;
-    ap-concat; ap-binary; inv-con; ap-comp; ap-id; tr; apd)
-open import foundation.subtype-identity-principle using
-  ( extensionality-type-subtype)
-open import foundation.type-theoretic-principle-of-choice using
-  ( distributive-Π-Σ)
+open import foundation-core.functions
+open import foundation-core.functoriality-dependent-function-types
+open import foundation-core.functoriality-dependent-pair-types
+open import foundation-core.functoriality-fibers-of-maps
+open import foundation-core.homotopies
+open import foundation-core.identity-systems
+open import foundation-core.propositions
+open import foundation-core.pullbacks
+open import foundation-core.retractions
+open import foundation-core.sections
+open import foundation-core.sets
+open import foundation-core.subtype-identity-principle
+open import foundation-core.subtypes
+open import foundation-core.truncated-types
+open import foundation-core.truncation-levels
+open import foundation-core.universe-levels
 
 open import foundation.equivalence-extensionality
+open import foundation.identity-types
 open import foundation.truncated-maps
+open import foundation.type-theoretic-principle-of-choice
 ```
 
 ## Properties
@@ -466,7 +440,7 @@ equiv-precomp-equiv e C =
       pair
         ( is-equiv-comp g (map-equiv e) (is-equiv-map-equiv e))
         ( λ is-equiv-eg →
-          is-equiv-left-factor'
+          is-equiv-left-factor
             g (map-equiv e) is-equiv-eg (is-equiv-map-equiv e)))
 ```
 

--- a/src/foundation/functoriality-dependent-pair-types.lagda.md
+++ b/src/foundation/functoriality-dependent-pair-types.lagda.md
@@ -17,9 +17,8 @@ open import foundation-core.functions
 open import foundation-core.homotopies
 open import foundation-core.identity-types
 open import foundation-core.pullbacks
+open import foundation-core.type-arithmetic-dependent-pair-types
 open import foundation-core.universe-levels
-
-open import foundation.type-arithmetic-dependent-pair-types
 ```
 
 ## Properties
@@ -145,7 +144,7 @@ module _
         ( g' (pr1 (pr2 c) x))
         ( c' x))
       ( is-pb-c)
-      ( is-equiv-right-factor
+      ( is-equiv-right-factor-htpy
         ( gap (map-Σ PX f f') (map-Σ PX g g') tot-cone-cone-family)
         ( map-canonical-pullback-tot-cone-cone-family)
         ( map-Σ _

--- a/src/foundation/injective-maps.lagda.md
+++ b/src/foundation/injective-maps.lagda.md
@@ -7,23 +7,18 @@ title: Injective maps
 
 module foundation.injective-maps where
 
-open import foundation-core.contractible-types using (is-contr; eq-is-contr)
-open import foundation-core.dependent-pair-types using (pair; pr1; pr2)
-open import foundation-core.embeddings using (is-emb; _↪_; map-emb; is-emb-map-emb)
-open import foundation-core.empty-types using (is-empty; ex-falso)
-open import foundation-core.equivalences using
-  ( is-equiv; isretr-map-inv-is-equiv; map-inv-is-equiv; _≃_; map-equiv;
-    map-inv-equiv; is-equiv-map-inv-equiv; is-equiv-has-inverse)
-open import foundation-core.functions using (id; _∘_)
-open import foundation-core.identity-types using (_＝_; refl; _∙_; inv; ap)
-open import foundation-core.propositional-maps using (is-prop-map; is-prop-map-is-emb)
-open import foundation-core.sections using (sec)
-open import foundation-core.sets using (is-set; is-set-prop-in-id)
-open import foundation-core.universe-levels using (UU; Level; _⊔_)
-
-open import foundation.propositions using
-  ( is-prop; is-equiv-is-prop; is-prop-Π'; is-prop-function-type; Prop)
-
+open import foundation-core.contractible-types
+open import foundation-core.dependent-pair-types
+open import foundation-core.embeddings
+open import foundation-core.empty-types
+open import foundation-core.equivalences
+open import foundation-core.functions
+open import foundation-core.identity-types
+open import foundation-core.propositional-maps
+open import foundation-core.propositions
+open import foundation-core.sections
+open import foundation-core.sets
+open import foundation-core.universe-levels
 ```
 
 ## Idea
@@ -58,7 +53,7 @@ is-injective-id p = p
 module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
   where
-  
+
   is-injective-right-factor :
     (f : A → C) (g : B → C) (h : A → B) (H : (a : A) → f a ＝ g (h a)) →
     is-injective f → is-injective h
@@ -72,18 +67,17 @@ module _
 module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
   where
-  
-  is-injective-comp :
-    (f : A → C) (g : B → C) (h : A → B) (H : (a : A) → f a ＝ g (h a)) →
-    is-injective h → is-injective g → is-injective f
-  is-injective-comp f g h H is-inj-h is-inj-g {x} {x'} p =
-    is-inj-h (is-inj-g ((inv (H x)) ∙ (p ∙ (H x'))))
 
-  is-injective-comp' :
+  is-injective-comp :
     {g : B → C} {h : A → B} →
     is-injective h → is-injective g → is-injective (g ∘ h)
-  is-injective-comp' {g} {h} H G =
-    is-injective-comp (g ∘ h) g h (λ x → refl) H G
+  is-injective-comp is-inj-h is-inj-g = is-inj-h ∘ is-inj-g
+
+  is-injective-comp-htpy :
+    (f : A → C) (g : B → C) (h : A → B) (H : (a : A) → f a ＝ g (h a)) →
+    is-injective h → is-injective g → is-injective f
+  is-injective-comp-htpy f g h H is-inj-h is-inj-g {x} {x'} p =
+    is-inj-h (is-inj-g ((inv (H x)) ∙ (p ∙ (H x'))))
 ```
 
 ### Equivalences are injective
@@ -107,7 +101,7 @@ module _
 module _
   {l1 l2 : Level} {A : UU l1} {B : UU l2}
   where
-  
+
   abstract
     is-injective-map-inv-equiv : (e : A ≃ B) → is-injective (map-inv-equiv e)
     is-injective-map-inv-equiv e =

--- a/src/foundation/injective-maps.lagda.md
+++ b/src/foundation/injective-maps.lagda.md
@@ -13,6 +13,7 @@ open import foundation-core.embeddings
 open import foundation-core.empty-types
 open import foundation-core.equivalences
 open import foundation-core.functions
+open import foundation-core.homotopies
 open import foundation-core.identity-types
 open import foundation-core.propositional-maps
 open import foundation-core.propositions
@@ -55,9 +56,14 @@ module _
   where
 
   is-injective-right-factor :
-    (f : A → C) (g : B → C) (h : A → B) (H : (a : A) → f a ＝ g (h a)) →
+    {g : B → C} {h : A → B} →
+    is-injective (g ∘ h) → is-injective h
+  is-injective-right-factor {g} is-inj-gh p = is-inj-gh (ap g p)
+
+  is-injective-right-factor-htpy :
+    (f : A → C) (g : B → C) (h : A → B) (H : f ~ (g ∘ h)) →
     is-injective f → is-injective h
-  is-injective-right-factor f g h H is-inj-f {x} {x'} p =
+  is-injective-right-factor-htpy f g h H is-inj-f {x} {x'} p =
     is-inj-f {x} {x'} ((H x) ∙ ((ap g p) ∙ (inv (H x'))))
 ```
 

--- a/src/foundation/isolated-points.lagda.md
+++ b/src/foundation/isolated-points.lagda.md
@@ -7,43 +7,32 @@ title: Isolated points
 
 module foundation.isolated-points where
 
-open import foundation.constant-maps using (const; fib-const)
-open import foundation.contractible-types using (is-contr; is-contr-equiv)
-open import foundation.coproduct-types using (inl; inr)
-open import foundation.decidable-embeddings using (_↪d_)
-open import foundation.decidable-equality using
-  ( has-decidable-equality; is-set-has-decidable-equality)
-open import foundation.decidable-maps using (is-decidable-map)
-open import foundation.decidable-propositions using
-  ( is-prop-is-decidable)
-open import foundation.decidable-types using
-  ( is-decidable; is-decidable-equiv; is-decidable-equiv';
-    is-decidable-prod; is-decidable-unit)
-open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2)
-open import foundation.embeddings using (is-emb; is-emb-comp')
-open import foundation.empty-types using (empty; is-prop-empty; ex-falso)
-open import foundation.equivalences using
-  (is-equiv; _≃_; is-equiv-has-inverse; map-equiv; _∘e_; equiv-ap)
-open import foundation.functions using (_∘_; id)
-open import foundation.functoriality-dependent-pair-types using (equiv-Σ)
-open import foundation.fundamental-theorem-of-identity-types using
-  ( fundamental-theorem-id)
-open import foundation.homotopies using (_~_)
-open import foundation.identity-types using
-  ( _＝_; refl; tr; ap; equiv-concat; inv)
-open import foundation.injective-maps using (is-emb-is-injective)
-open import foundation.maybe using (Maybe; maybe-structure)
-open import foundation.negation using (¬; equiv-neg)
-open import foundation.propositions using
-  ( is-prop; is-prop-equiv; is-proof-irrelevant-is-prop; Prop;
-    is-prop-is-inhabited; is-prop-Π; eq-is-prop)
-open import foundation.sets using (is-set)
-open import foundation.subtypes using
-  ( eq-type-subtype; is-emb-inclusion-subtype; equiv-ap-inclusion-subtype)
-open import foundation.type-arithmetic-unit-type using
-  ( left-unit-law-prod)
-open import foundation.unit-type using (unit; is-prop-unit; star)
-open import foundation.universe-levels using (Level; UU; _⊔_; lzero)
+open import foundation.constant-maps
+open import foundation.contractible-types
+open import foundation.coproduct-types
+open import foundation.decidable-embeddings
+open import foundation.decidable-equality
+open import foundation.decidable-maps
+open import foundation.decidable-propositions
+open import foundation.decidable-types
+open import foundation.dependent-pair-types
+open import foundation.embeddings
+open import foundation.empty-types
+open import foundation.equivalences
+open import foundation.functions
+open import foundation.functoriality-dependent-pair-types
+open import foundation.fundamental-theorem-of-identity-types
+open import foundation.homotopies
+open import foundation.identity-types
+open import foundation.injective-maps
+open import foundation.maybe
+open import foundation.negation
+open import foundation.propositions
+open import foundation.sets
+open import foundation.subtypes
+open import foundation.type-arithmetic-unit-type
+open import foundation.unit-type
+open import foundation.universe-levels
 ```
 
 ## Idea
@@ -250,7 +239,7 @@ decidable-emb-isolated-point {l1} {A} a =
   pair
     ( const unit A (pr1 a))
     ( pair
-      ( is-emb-comp'
+      ( is-emb-comp
         ( inclusion-isolated-point A)
         ( const unit (isolated-point A) a)
         ( is-emb-inclusion-isolated-point A)

--- a/src/foundation/partitions.lagda.md
+++ b/src/foundation/partitions.lagda.md
@@ -229,7 +229,7 @@ We will now introduce the type of blocks of a partition, and show that the type 
   is-emb-inhabited-subtype-block-partition :
     is-emb inhabited-subtype-block-partition
   is-emb-inhabited-subtype-block-partition =
-    is-emb-comp'
+    is-emb-comp
       ( inhabited-subtype-block-partition-Large-Type)
       ( map-inv-compute-block-partition)
       ( is-emb-inhabited-subtype-block-partition-Large-Type)

--- a/src/foundation/pullbacks.lagda.md
+++ b/src/foundation/pullbacks.lagda.md
@@ -9,47 +9,28 @@ module foundation.pullbacks where
 
 open import foundation-core.pullbacks public
 
-open import foundation.commuting-cubes
-open import foundation.contractible-types using
-  ( is-contr; is-contr-total-path; is-contr-equiv'; is-contr-is-equiv';
-    is-equiv-is-contr)
-open import foundation.constant-maps using (const)
-open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2; triple)
-open import foundation.descent-equivalences using (descent-is-equiv)
-open import foundation.diagonal-maps-of-types using (diagonal)
-open import foundation.equality-dependent-pair-types using (eq-pair-Σ)
-open import foundation.equivalences
-open import foundation.function-extensionality using
-  ( htpy-eq; issec-eq-htpy; isretr-eq-htpy; funext)
-open import foundation.functions using (_∘_; id; map-Π)
-open import foundation.functoriality-dependent-function-types using
-  ( map-inv-is-equiv-precomp-Π-is-equiv; htpy-map-Π;
-    isretr-map-inv-is-equiv-precomp-Π-is-equiv;
-    issec-map-inv-is-equiv-precomp-Π-is-equiv; is-equiv-map-Π)
-open import foundation.functoriality-dependent-pair-types using
-  ( tot; is-equiv-tot-is-fiberwise-equiv; equiv-tot;
-    is-pullback-family-is-pullback-tot; map-Σ; tot-cone-cone-family)
-open import foundation.fundamental-theorem-of-identity-types using
-  ( fundamental-theorem-id)
-open import foundation.homotopies
-open import foundation.identity-types using
-  ( Id; _＝_; refl; ap; _∙_; inv; right-unit; equiv-concat'; equiv-inv; concat';
-    concat; is-equiv-concat; is-equiv-concat'; assoc; inv-con; con-inv; tr;
-    ap-comp; tr-Id-right)
-open import foundation.structure-identity-principle using (extensionality-Σ)
-open import foundation.type-theoretic-principle-of-choice using
-  ( map-distributive-Π-Σ; mapping-into-Σ; is-equiv-mapping-into-Σ;
-    is-equiv-map-distributive-Π-Σ)
-open import foundation.unit-type using (unit; star)
-open import foundation.universe-levels using (Level; UU; _⊔_)
-
-open import foundation-core.cartesian-product-types using (_×_)
+open import foundation-core.cartesian-product-types
 open import foundation-core.cones-pullbacks
-open import foundation-core.function-extensionality using
-  ( eq-htpy; eq-htpy-refl-htpy)
-open import foundation-core.universal-property-pullbacks using
-  ( universal-property-pullback;
-    is-equiv-up-pullback-up-pullback; up-pullback-up-pullback-is-equiv)
+open import foundation-core.contractible-types
+open import foundation-core.constant-maps
+open import foundation-core.dependent-pair-types
+open import foundation-core.diagonal-maps-of-types
+open import foundation-core.equality-dependent-pair-types
+open import foundation-core.function-extensionality
+open import foundation-core.functions
+open import foundation-core.functoriality-dependent-function-types
+open import foundation-core.fundamental-theorem-of-identity-types
+open import foundation-core.universe-levels
+
+open import foundation.commuting-cubes
+open import foundation.descent-equivalences
+open import foundation.equivalences
+open import foundation.functoriality-dependent-pair-types
+open import foundation.homotopies
+open import foundation.identity-types
+open import foundation.structure-identity-principle
+open import foundation.type-theoretic-principle-of-choice
+open import foundation.unit-type
 ```
 
 ## Properties
@@ -110,7 +91,7 @@ abstract
       ( λ (h : T → B) → g ∘ h)
       ( exponent-cone T f g c)
   is-pullback-exponent-is-pullback f g c is-pb-c T =
-    is-equiv-right-factor
+    is-equiv-right-factor-htpy
       ( cone-map f g c)
       ( map-canonical-pullback-exponent f g T)
       ( gap (_∘_ f) (_∘_ g) (exponent-cone T f g c))
@@ -306,7 +287,7 @@ module _
     is-pullback-htpy'
       (pair p (pair q H)) {pair p' (pair q' H')}
       (pair Hp (pair Hq HH)) is-pb-c =
-      is-equiv-right-factor
+      is-equiv-right-factor-htpy
         ( gap f g (triple p q H))
         ( map-equiv-canonical-pullback-htpy Hf Hg)
         ( gap f' g' (triple p' q' H'))
@@ -551,7 +532,7 @@ abstract
             ( c : cone f g C) (c' : cone f g' C) →
               is-equiv (htpy-parallel-cone-eq refl-htpy Hg c c'))
           ( λ c c' →
-            is-equiv-left-factor
+            is-equiv-left-factor-htpy
               ( htpy-eq-square f g c c')
               ( htpy-parallel-cone-eq refl-htpy refl-htpy c c')
               ( concat (tr-tr-refl-htpy-cone f g c) c')
@@ -680,7 +661,7 @@ abstract
     ((i : I) → is-pullback (f i) (g i) (c i)) →
     is-pullback (map-Π f) (map-Π g) (cone-Π f g c)
   is-pullback-cone-Π f g c is-pb-c =
-    is-equiv-right-factor
+    is-equiv-right-factor-htpy
       ( map-Π (λ i → gap (f i) (g i) (c i)))
       ( map-canonical-pullback-Π f g)
       ( gap (map-Π f) (map-Π g) (cone-Π f g c))

--- a/src/foundation/sections.lagda.md
+++ b/src/foundation/sections.lagda.md
@@ -9,33 +9,22 @@ module foundation.sections where
 
 open import foundation-core.sections public
 
-open import foundation-core.retractions using (_retract-of_)
+open import foundation-core.contractible-types
+open import foundation-core.dependent-pair-types
+open import foundation-core.equivalences
+open import foundation-core.fibers-of-maps
+open import foundation-core.function-extensionality using (equiv-funext)
+open import foundation-core.functions
+open import foundation-core.functoriality-dependent-pair-types
+open import foundation-core.homotopies
+open import foundation-core.identity-types
+open import foundation-core.retractions
+open import foundation-core.type-arithmetic-dependent-pair-types
+open import foundation-core.universe-levels
 
-open import foundation.contractible-types using
-  ( is-contr; is-contr-equiv; is-contr-total-path'; is-contr-Π)
-open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2)
-open import foundation.equivalences using
-  ( is-equiv; is-equiv-right-factor; is-equiv-id; _≃_; is-equiv-left-factor;
-    _∘e_; id-equiv; map-inv-equiv)
-open import foundation.function-extensionality using (equiv-funext)
-open import foundation.functions using (_∘_; id)
-open import foundation.homotopies using
-  ( _~_; refl-htpy; _·l_; _∙h_; _·r_; inv-htpy; inv-htpy-assoc-htpy;
-    ap-concat-htpy'; left-inv-htpy)
-open import foundation.identity-types using (_＝_; refl; ap)
-open import foundation.injective-maps using (is-injective)
-open import foundation.structure-identity-principle using
-  ( extensionality-Σ)
-open import foundation.type-arithmetic-dependent-pair-types using
-  ( is-equiv-pr1-is-contr; is-contr-is-equiv-pr1; left-unit-law-Σ-is-contr;
-    equiv-right-swap-Σ)
-open import foundation.type-theoretic-principle-of-choice using
-  ( Π-total-fam; inv-distributive-Π-Σ; distributive-Π-Σ)
-open import foundation.universe-levels using (Level; UU; _⊔_)
-
-open import foundation-core.fibers-of-maps using (fib; equiv-total-fib)
-open import foundation-core.functoriality-dependent-pair-types using
-  ( equiv-Σ)
+open import foundation.injective-maps
+open import foundation.structure-identity-principle
+open import foundation.type-theoretic-principle-of-choice
 ```
 
 ## Idea
@@ -74,7 +63,7 @@ module _
   is-equiv-map-section :
     (b : (x : A) → B x) → ((x : A) → is-contr (B x)) → is-equiv (map-section b)
   is-equiv-map-section b C =
-    is-equiv-right-factor
+    is-equiv-right-factor-htpy
       ( id)
       ( pr1)
       ( map-section b)
@@ -90,7 +79,7 @@ module _
     (b : (x : A) → B x) → is-equiv (map-section b) → ((x : A) → is-contr (B x))
   is-contr-fam-is-equiv-map-section b H =
     is-contr-is-equiv-pr1
-      ( is-equiv-left-factor id pr1
+      ( is-equiv-left-factor-htpy id pr1
         ( map-section b)
         ( htpy-map-section b)
         ( is-equiv-id)
@@ -194,3 +183,4 @@ pr1 (pr2 (sec-left-factor-retract-of-sec-composition f g h H sec-h)) =
 pr2 (pr2 (sec-left-factor-retract-of-sec-composition f g h H sec-h)) =
   isretr-section-comp-htpy f g h H sec-h
 ```
+ 

--- a/src/foundation/set-truncations.lagda.md
+++ b/src/foundation/set-truncations.lagda.md
@@ -7,73 +7,40 @@ title: Set truncations
 
 module foundation.set-truncations where
 
-open import foundation.cartesian-product-types using (_×_)
-open import foundation.contractible-types using
-  ( is-contr; is-contr-equiv'; center)
-open import foundation.coproduct-types using (_+_; inl; inr)
-open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2; ev-pair)
-open import foundation.effective-maps-equivalence-relations using
-  ( is-surjective-and-effective; is-effective)
-open import foundation.embeddings using (_↪_; map-emb)
-open import foundation.empty-types using (empty; empty-Set; is-empty)
-open import foundation.equality-coproduct-types using
-  ( coprod-Set)
-open import foundation.equivalences using
-  ( _≃_; is-equiv; map-inv-equiv; map-equiv; is-equiv-right-factor';
-    is-equiv-comp; is-equiv-htpy-equiv; _∘e_; issec-map-inv-equiv)
+open import foundation.cartesian-product-types
+open import foundation.contractible-types
+open import foundation.coproduct-types
+open import foundation.dependent-pair-types
+open import foundation.effective-maps-equivalence-relations
+open import foundation.embeddings
+open import foundation.empty-types
+open import foundation.equality-coproduct-types
+open import foundation.equivalences
 open import foundation.function-extensionality using (htpy-eq)
-open import foundation.functions using (_∘_; id)
-open import foundation.functoriality-cartesian-product-types using
-  ( map-prod; is-equiv-map-prod)
-open import foundation.functoriality-coproduct-types using (map-coprod)
-open import foundation.functoriality-dependent-function-types using
-  ( equiv-map-Π)
-open import foundation.functoriality-dependent-pair-types using (tot)
-open import foundation.functoriality-function-types using (equiv-postcomp)
-open import foundation.homotopies using (_~_; refl-htpy; inv-htpy)
-open import foundation.identity-types using (_＝_)
-open import foundation.mere-equality using
-  ( mere-eq-Eq-Rel; reflects-mere-eq; mere-eq; mere-eq-Prop)
-open import foundation.propositions using (Prop)
-open import foundation.reflecting-maps-equivalence-relations using
-  ( reflecting-map-Eq-Rel)
-open import foundation.sets using
-  ( is-set; type-Set; Set; precomp-Set; type-hom-Set; is-set-type-Set;
-    is-set-is-contr; type-equiv-Set; prod-Set; Π-Set')
-open import foundation.slice using
-  ( hom-slice)
-open import foundation.surjective-maps using (is-surjective)
-open import foundation.truncation-levels using (zero-𝕋)
-open import foundation.truncations using
-  ( type-trunc; is-trunc-type-trunc; trunc; unit-trunc;
-    is-truncation-trunc; equiv-universal-property-trunc;
-    universal-property-trunc; map-universal-property-trunc;
-    triangle-universal-property-trunc; dependent-universal-property-trunc;
-    equiv-dependent-universal-property-trunc;
-    function-dependent-universal-property-trunc; is-equiv-unit-trunc;
-    equiv-unit-trunc; htpy-dependent-universal-property-trunc)
-open import foundation.uniqueness-set-truncations using
-  ( is-equiv-is-set-truncation-is-set-truncation;
-    is-set-truncation-is-equiv-is-set-truncation;
-    is-set-truncation-is-set-truncation-is-equiv; uniqueness-set-truncation)
-open import foundation.unit-type using (unit; unit-Set)
-open import foundation.universal-property-coproduct-types using
-  ( ev-inl-inr; universal-property-coprod)
-open import foundation.universal-property-dependent-pair-types using
-  ( is-equiv-ev-pair; equiv-ev-pair)
-open import foundation.universal-property-image using (is-image)
-open import foundation.universal-property-set-quotients using
-  ( is-set-quotient; is-surjective-and-effective-is-set-quotient;
-    emb-is-surjective-and-effective; triangle-emb-is-surjective-and-effective;
-    is-image-is-surjective-and-effective)
-open import foundation.universal-property-set-truncation using
-  ( is-set-truncation; universal-property-set-truncation;
-    universal-property-is-set-truncation; map-is-set-truncation;
-    triangle-is-set-truncation; precomp-Π-Set;
-    dependent-universal-property-set-truncation;
-    dependent-universal-property-is-set-truncation;
-    is-set-quotient-is-set-truncation; is-set-truncation-id)
-open import foundation.universe-levels using (Level; UU; _⊔_)
+open import foundation.functions
+open import foundation.functoriality-cartesian-product-types
+open import foundation.functoriality-coproduct-types
+open import foundation.functoriality-dependent-function-types
+open import foundation.functoriality-dependent-pair-types
+open import foundation.functoriality-function-types
+open import foundation.homotopies
+open import foundation.identity-types
+open import foundation.mere-equality
+open import foundation.propositions
+open import foundation.reflecting-maps-equivalence-relations
+open import foundation.sets
+open import foundation.slice
+open import foundation.surjective-maps
+open import foundation.truncation-levels
+open import foundation.truncations
+open import foundation.uniqueness-set-truncations
+open import foundation.unit-type
+open import foundation.universal-property-coproduct-types
+open import foundation.universal-property-dependent-pair-types
+open import foundation.universal-property-image
+open import foundation.universal-property-set-quotients
+open import foundation.universal-property-set-truncation
+open import foundation.universe-levels
 ```
 
 ## Idea
@@ -464,7 +431,7 @@ module _
         ( coprod-Set (trunc-Set A) (trunc-Set B))
         ( map-coprod unit-trunc-Set unit-trunc-Set)
         ( λ {l} C →
-          is-equiv-right-factor'
+          is-equiv-right-factor
             ( ev-inl-inr (λ x → type-Set C))
             ( precomp-Set (map-coprod unit-trunc-Set unit-trunc-Set) C)
             ( universal-property-coprod (type-Set C))
@@ -519,7 +486,7 @@ module _
         ( trunc-Set (Σ A (λ x → type-trunc-Set (B x))))
         ( unit-trunc-Set ∘ tot (λ x → unit-trunc-Set))
         ( λ {l} C →
-          is-equiv-right-factor'
+          is-equiv-right-factor
             ( ev-pair)
             ( precomp-Set (unit-trunc-Set ∘ tot (λ x → unit-trunc-Set)) C)
             ( is-equiv-ev-pair)
@@ -558,7 +525,7 @@ module _
         ( prod-Set (trunc-Set A) (trunc-Set B))
         ( map-prod unit-trunc-Set unit-trunc-Set)
         ( λ {l} C →
-          is-equiv-right-factor'
+          is-equiv-right-factor
             ( ev-pair)
             ( precomp-Set (map-prod unit-trunc-Set unit-trunc-Set) C)
             ( is-equiv-ev-pair)

--- a/src/foundation/surjective-maps.lagda.md
+++ b/src/foundation/surjective-maps.lagda.md
@@ -7,57 +7,34 @@ title: Surjective maps
 
 module foundation.surjective-maps where
 
+open import foundation-core.constant-maps
+open import foundation-core.contractible-maps
+open import foundation.contractible-types
+open import foundation-core.dependent-pair-types
+open import foundation-core.equivalences
+open import foundation-core.fibers-of-maps
+open import foundation-core.functions
+open import foundation-core.functoriality-dependent-function-types
+open import foundation-core.fundamental-theorem-of-identity-types
+open import foundation-core.identity-types
+open import foundation-core.propositional-maps
+open import foundation-core.propositions
+open import foundation-core.sections
+open import foundation-core.sets
+open import foundation-core.subtype-identity-principle
+open import foundation-core.truncated-maps
+open import foundation-core.truncation-levels
+open import foundation-core.univalence using
+  ( is-contr-total-equiv)
+open import foundation-core.universe-levels
+
 open import foundation.connected-maps
-open import foundation.constant-maps using (const)
-open import foundation.contractible-maps using
-  ( is-equiv-is-contr-map)
-open import foundation.contractible-types using
-  ( is-equiv-diagonal-is-contr; is-contr)
-open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2)
-open import foundation.embeddings using
-  ( _↪_; map-emb; is-emb; emb-Σ; id-emb; equiv-ap-emb)
-open import foundation.equivalences using
-  ( is-equiv; map-inv-is-equiv; is-equiv-comp; _≃_; map-equiv; _∘e_; inv-equiv;
-    map-inv-equiv; id-equiv; is-equiv-map-equiv)
-open import foundation.fibers-of-maps using
-  ( fib; is-equiv-map-reduce-Π-fib; reduce-Π-fib)
-open import foundation.functions using (_∘_; id; precomp-Π)
-open import foundation.functoriality-dependent-function-types using
-  ( is-equiv-map-Π; equiv-map-Π)
-open import foundation.functoriality-dependent-pair-types using (map-Σ)
-open import foundation.fundamental-theorem-of-identity-types
-open import foundation.homotopies using (_~_; refl-htpy; is-contr-total-htpy)
-open import foundation.identity-types using (refl; _∙_; inv; equiv-tr; _＝_)
-open import foundation.injective-maps using (is-injective-is-emb)
-open import foundation.propositional-maps using
-  ( is-prop-map-emb; is-prop-map-is-emb; fib-emb-Prop)
-open import foundation.propositional-truncations using
-  ( type-trunc-Prop; unit-trunc-Prop; trunc-Prop; is-prop-type-trunc-Prop;
-    is-propositional-truncation-trunc-Prop;
-    apply-universal-property-trunc-Prop)
-open import foundation.propositions using
-  ( Prop; type-Prop; is-proof-irrelevant-is-prop; Π-Prop; is-prop;
-    is-prop-type-Prop)
-open import foundation.sections using (sec)
-open import foundation.sets using
-  ( Set; type-Set; is-set; is-set-type-Set; emb-type-Set)
-open import foundation.slice using
-  ( hom-slice; map-hom-slice; equiv-hom-slice-fiberwise-hom;
-    equiv-fiberwise-hom-hom-slice)
-open import foundation.structure-identity-principle using
-  ( is-contr-total-Eq-structure)
-open import foundation.subtype-identity-principle using
-  ( is-contr-total-Eq-subtype)
-open import foundation.truncated-maps
-open import foundation.truncated-types using
-  ( Truncated-Type; type-Truncated-Type; is-trunc-type-Truncated-Type;
-    emb-type-Truncated-Type; is-trunc)
-open import foundation.truncation-levels using
-  (𝕋; zero-𝕋; neg-one-𝕋; neg-two-𝕋; succ-𝕋)
-open import foundation.univalence using (is-contr-total-equiv)
-open import foundation.universal-property-propositional-truncation using
-  ( dependent-universal-property-propositional-truncation)
-open import foundation.universe-levels using (Level; UU; _⊔_; lsuc)
+open import foundation.embeddings
+open import foundation.homotopies
+open import foundation.propositional-truncations
+open import foundation.structure-identity-principle
+open import foundation.truncated-types
+open import foundation.universal-property-propositional-truncation
 ```
 
 ## Idea
@@ -73,7 +50,7 @@ is-surjective-Prop :
   {l1 l2 : Level} {A : UU l1} {B : UU l2} → (A → B) → Prop (l1 ⊔ l2)
 is-surjective-Prop {B = B} f =
   Π-Prop B (λ b → trunc-Prop (fib f b))
-    
+
 is-surjective :
   {l1 l2 : Level} {A : UU l1} {B : UU l2} → (A → B) → UU (l1 ⊔ l2)
 is-surjective f = type-Prop (is-surjective-Prop f)
@@ -360,43 +337,38 @@ abstract
 ```agda
 module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
-  (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
   where
 
   abstract
-    is-surjective-comp :
+    is-surjective-comp-htpy :
+      (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
       is-surjective g → is-surjective h → is-surjective f
-    is-surjective-comp Sg Sh x =
+    is-surjective-comp-htpy f g h H is-surj-g is-surj-h x =
       apply-universal-property-trunc-Prop
-        ( Sg x)
+        ( is-surj-g x)
         ( trunc-Prop (fib f x))
         ( λ { (pair b refl) →
-              apply-universal-property-trunc-Prop
-                ( Sh b)
-                ( trunc-Prop (fib f (g b)))
-                ( λ { (pair a refl) →
-                  unit-trunc-Prop (pair a (H a))})})
+          apply-universal-property-trunc-Prop
+            ( is-surj-h b)
+            ( trunc-Prop (fib f (g b)))
+            ( λ { (pair a refl) →
+              unit-trunc-Prop (pair a (H a))})})
 
-module _
-  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
-  {g : B → X}
-  where
-
-  abstract
-    is-surjective-comp' :
-      {h : A → B} → is-surjective g → is-surjective h → is-surjective (g ∘ h)
-    is-surjective-comp' {h} =
-      is-surjective-comp (g ∘ h) g h refl-htpy
+  is-surjective-comp :
+    {g : B → X} {h : A → B} →
+    is-surjective g → is-surjective h → is-surjective (g ∘ h)
+  is-surjective-comp {g} {h} =
+    is-surjective-comp-htpy (g ∘ h) g h refl-htpy
 ```
 
 ### The composite of a surjective map with an equivalence is surjective
 
 ```agda
 is-surjective-comp-equiv :
-  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3} 
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
   (e : B ≃ C) → {f : A → B} → is-surjective f → is-surjective (map-equiv e ∘ f)
 is-surjective-comp-equiv e =
-  is-surjective-comp' (is-surjective-map-equiv e)
+  is-surjective-comp (is-surjective-map-equiv e)
 ```
 
 ### The precomposite of a surjective map with an equivalence is surjective
@@ -406,7 +378,7 @@ is-surjective-precomp-equiv :
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3} {f : B → C} →
   is-surjective f → (e : A ≃ B) → is-surjective (f ∘ map-equiv e)
 is-surjective-precomp-equiv H e =
-  is-surjective-comp' H (is-surjective-map-equiv e)
+  is-surjective-comp H (is-surjective-map-equiv e)
 ```
 
 ### If a composite is surjective, then so is its left factor
@@ -472,7 +444,7 @@ is-trunc-map-precomp-Π-is-surjective k H =
 module _
   {l1 l2 : Level} {A : UU l1} {B : UU l2} (f : A ↠ B)
   where
-  
+
   htpy-surjection : (A ↠ B) → UU (l1 ⊔ l2)
   htpy-surjection g = map-surjection f ~ map-surjection g
 

--- a/src/foundation/surjective-maps.lagda.md
+++ b/src/foundation/surjective-maps.lagda.md
@@ -386,29 +386,23 @@ is-surjective-precomp-equiv H e =
 ```agda
 module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
-  (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
   where
 
   abstract
-    is-surjective-left-factor :
+    is-surjective-left-factor-htpy :
+      (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
       is-surjective f → is-surjective g
-    is-surjective-left-factor Sf x =
+    is-surjective-left-factor-htpy f g h H is-surj-f x =
       apply-universal-property-trunc-Prop
-        ( Sf x)
+        ( is-surj-f x)
         ( trunc-Prop (fib g x))
         ( λ { (pair a refl) →
-              unit-trunc-Prop (pair (h a) (inv (H a)))})
+          unit-trunc-Prop (pair (h a) (inv (H a)))})
 
-module _
-  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
-  {g : B → X}
-  where
-
-  abstract
-    is-surjective-left-factor' :
-      (h : A → B) → is-surjective (g ∘ h) → is-surjective g
-    is-surjective-left-factor' h =
-      is-surjective-left-factor (g ∘ h) g h refl-htpy
+  is-surjective-left-factor :
+    {g : B → X} (h : A → B) → is-surjective (g ∘ h) → is-surjective g
+  is-surjective-left-factor {g} h =
+    is-surjective-left-factor-htpy (g ∘ h) g h refl-htpy
 ```
 
 ### Surjective maps are -1-connected

--- a/src/foundation/truncated-maps.lagda.md
+++ b/src/foundation/truncated-maps.lagda.md
@@ -10,17 +10,14 @@ module foundation.truncated-maps where
 open import foundation-core.truncated-maps public
 
 open import foundation-core.cones-pullbacks
-open import foundation-core.dependent-pair-types using
-  ( Σ; pair; pr1; pr2; triple)
-open import foundation-core.fibers-of-maps using (fib)
-open import foundation-core.functoriality-fibers-of-maps using (map-fib-cone)
+open import foundation-core.dependent-pair-types
+open import foundation-core.fibers-of-maps
+open import foundation-core.functoriality-fibers-of-maps
+open import foundation-core.propositions
 open import foundation-core.pullbacks
-open import foundation-core.truncated-types using
-  ( is-prop-is-trunc; is-trunc-is-equiv)
-open import foundation-core.truncation-levels using (𝕋)
-open import foundation-core.universe-levels using (Level; UU; _⊔_)
-
-open import foundation.propositions using (is-prop; is-prop-Π; Prop)
+open import foundation-core.truncated-types
+open import foundation-core.truncation-levels
+open import foundation-core.universe-levels
 ```
 
 ## Properties
@@ -31,7 +28,7 @@ open import foundation.propositions using (is-prop; is-prop-Π; Prop)
 module _
   {l1 l2 : Level} {A : UU l1} {B : UU l2}
   where
-  
+
   is-prop-is-trunc-map : (k : 𝕋) (f : A → B) → is-prop (is-trunc-map k f)
   is-prop-is-trunc-map k f = is-prop-Π (λ x → is-prop-is-trunc k (fib f x))
 
@@ -47,7 +44,7 @@ module _
   {l1 l2 l3 l4 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} {C : UU l3}
   {X : UU l4} (f : A → X) (g : B → X) (c : cone f g C)
   where
-  
+
   abstract
     is-trunc-is-pullback :
       is-pullback f g c → is-trunc-map k g → is-trunc-map k (pr1 c)

--- a/src/foundation/uniqueness-set-quotients.lagda.md
+++ b/src/foundation/uniqueness-set-quotients.lagda.md
@@ -7,31 +7,21 @@ title: The uniqueness of set quotients
 
 module foundation.uniqueness-set-quotients where
 
-open import foundation.contractible-types using (is-contr; center)
-open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2)
-open import foundation.equivalences using
-  ( is-equiv; is-equiv-has-inverse; is-equiv-comp-htpy; is-equiv-precomp-is-equiv;
-    is-equiv-left-factor; _≃_; map-equiv; is-property-is-equiv)
+open import foundation.contractible-types
+open import foundation.dependent-pair-types
+open import foundation.equivalences
 open import foundation.function-extensionality using (htpy-eq)
-open import foundation.functions using  (_∘_; id; precomp)
-open import foundation.homotopies using (_~_; refl-htpy; inv-htpy; _·l_)
-open import foundation.identity-types using (_＝_; _∙_; ap; inv)
-open import foundation.injective-maps using (is-injective-is-equiv)
-open import foundation.reflecting-maps-equivalence-relations using
-  ( reflecting-map-Eq-Rel; eq-htpy-reflecting-map-Eq-Rel;
-    map-reflecting-map-Eq-Rel)
-open import foundation.sets using (Set; type-Set; type-hom-Set)
-open import foundation.subtype-identity-principle using
-  ( is-contr-total-Eq-subtype)
-open import foundation.universal-property-set-quotients using
-  ( precomp-Set-Quotient; is-set-quotient; precomp-id-Set-Quotient;
-    universal-property-set-quotient-is-set-quotient;
-    map-universal-property-set-quotient-is-set-quotient;
-    triangle-universal-property-set-quotient-is-set-quotient)
-open import foundation.universe-levels using (Level; UU)
+open import foundation.functions
+open import foundation.homotopies
+open import foundation.identity-types
+open import foundation.injective-maps
+open import foundation.reflecting-maps-equivalence-relations
+open import foundation.sets
+open import foundation.subtype-identity-principle
+open import foundation.universal-property-set-quotients
+open import foundation.universe-levels
 
-open import foundation-core.equivalence-relations using
-  ( Eq-Rel)
+open import foundation-core.equivalence-relations
 ```
 
 ## Idea
@@ -131,7 +121,7 @@ module _
       ({l : Level} → is-set-quotient l R C g) → is-equiv h →
       {l : Level} → is-set-quotient l R B f
     is-set-quotient-is-equiv-is-set-quotient Ug E {l} X =
-      is-equiv-left-factor
+      is-equiv-left-factor-htpy
         ( precomp-Set-Quotient R C g X)
         ( precomp-Set-Quotient R B f X)
         ( precomp h (type-Set X))

--- a/src/foundation/universal-property-coproduct-types.lagda.md
+++ b/src/foundation/universal-property-coproduct-types.lagda.md
@@ -7,19 +7,15 @@ title: The universal property of coproduct types
 
 module foundation.universal-property-coproduct-types where
 
-open import foundation.cartesian-product-types using (_×_; pair')
-open import foundation.coproduct-types using (_+_; inl; inr; ind-coprod)
-open import foundation.dependent-pair-types using
-  ( Σ; pair; pr1; pr2; ind-Σ)
-open import foundation.equality-cartesian-product-types using
-  ( eq-pair)
-open import foundation.equivalences using
-  ( is-equiv; is-equiv-has-inverse; _≃_; is-equiv-is-equiv-precomp;
-    is-equiv-right-factor'; is-equiv-comp; is-equiv-precomp-is-equiv)
+open import foundation.cartesian-product-types
+open import foundation.coproduct-types
+open import foundation.dependent-pair-types
+open import foundation.equality-cartesian-product-types
+open import foundation.equivalences
 open import foundation.function-extensionality using (eq-htpy)
-open import foundation.functions using (_∘_; precomp)
-open import foundation.identity-types using (refl)
-open import foundation.universe-levels using (Level; UU)
+open import foundation.functions
+open import foundation.identity-types
+open import foundation.universe-levels
 ```
 
 ## Idea
@@ -73,7 +69,7 @@ module _
     uniqueness-coprod {Y = Y} i j H =
       is-equiv-is-equiv-precomp
         ( ind-coprod _ i j)
-        ( λ l X → is-equiv-right-factor'
+        ( λ l X → is-equiv-right-factor
           ( ev-inl-inr (λ t → X))
           ( precomp (ind-coprod (λ t → Y) i j) X)
           ( universal-property-coprod X)

--- a/src/foundation/universal-property-image.lagda.md
+++ b/src/foundation/universal-property-image.lagda.md
@@ -7,46 +7,28 @@ title: The universal property of the image of a map
 
 module foundation.universal-property-image where
 
-open import foundation.contractible-maps using (is-contr-map-is-equiv)
-open import foundation.contractible-types using
-  ( is-contr; is-contr-equiv'; center; is-contr-equiv)
-open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2)
-open import foundation.embeddings using
-  ( _↪_; map-emb; id-emb; is-emb; is-emb-comp'; is-emb-map-emb)
-open import foundation.equivalences using
-  ( is-equiv; map-inv-is-equiv; issec-map-inv-is-equiv; _∘e_;
-    id-equiv; is-property-is-equiv; is-equiv-map-equiv; _≃_; map-equiv;
-    inv-equiv)
-open import foundation.fibers-of-maps using (fib; reduce-Π-fib)
-open import foundation.functions using (_∘_; id)
-open import foundation.functoriality-dependent-function-types using
-  ( equiv-map-Π)
-open import foundation.functoriality-dependent-pair-types using
-  ( equiv-tot; equiv-Σ)
-open import foundation.homotopies using (_∙h_; _·r_; _~_; _·l_; refl-htpy)
-open import foundation.identity-types using (inv; _∙_; equiv-tr)
-open import foundation.images using
-  ( im; inclusion-im; emb-im; unit-im; map-unit-im)
-open import foundation.injective-maps using (is-injective-is-emb)
-open import foundation.propositional-maps using (fib-emb-Prop; is-prop-map-emb)
-open import foundation.propositional-truncations using
-  ( type-trunc-Prop; is-prop-type-trunc-Prop; map-universal-property-trunc-Prop;
-    trunc-Prop; unit-trunc-Prop; apply-universal-property-trunc-Prop)
-open import foundation.propositions using
-  ( is-equiv-is-prop; is-proof-irrelevant-is-prop; type-Prop)
-open import foundation.sections using (sec)
-open import foundation.slice using
-  ( hom-slice; map-hom-slice; triangle-hom-slice; is-prop-hom-slice;
-    htpy-hom-slice; comp-hom-slice; extensionality-hom-slice;
-    is-equiv-hom-slice-emb; equiv-slice; hom-equiv-slice;
-    equiv-hom-slice-fiberwise-hom; equiv-fiberwise-hom-hom-slice)
-open import foundation.subtypes using
-  ( type-subtype; is-emb-inclusion-subtype)
-open import foundation.surjective-maps using
-  ( is-surjective; equiv-dependent-universal-property-surj-is-surjective)
-open import foundation.type-arithmetic-dependent-pair-types using
-  ( left-unit-law-Σ-is-contr; equiv-right-swap-Σ)
-open import foundation.universe-levels using (Level; UU; lsuc; _⊔_)
+open import foundation.contractible-maps
+open import foundation.contractible-types
+open import foundation.dependent-pair-types
+open import foundation.embeddings
+open import foundation.equivalences
+open import foundation.fibers-of-maps
+open import foundation.functions
+open import foundation.functoriality-dependent-function-types
+open import foundation.functoriality-dependent-pair-types
+open import foundation.homotopies
+open import foundation.identity-types
+open import foundation.images
+open import foundation.injective-maps
+open import foundation.propositional-maps
+open import foundation.propositional-truncations
+open import foundation.propositions
+open import foundation.sections
+open import foundation.slice
+open import foundation.subtypes
+open import foundation.surjective-maps
+open import foundation.type-arithmetic-dependent-pair-types
+open import foundation.universe-levels
 ```
 
 ## Idea
@@ -264,7 +246,7 @@ abstract
         X
     g = map-emb i ∘ pr1
     is-emb-g : is-emb g
-    is-emb-g = is-emb-comp' (map-emb i) pr1
+    is-emb-g = is-emb-comp (map-emb i) pr1
       ( is-emb-map-emb i)
       ( is-emb-inclusion-subtype (λ x → trunc-Prop _))
     α : hom-slice (map-emb i) g

--- a/src/foundation/universal-property-pullbacks.lagda.md
+++ b/src/foundation/universal-property-pullbacks.lagda.md
@@ -9,35 +9,25 @@ module foundation.universal-property-pullbacks where
 
 open import foundation-core.universal-property-pullbacks public
 
-open import foundation.cartesian-product-types using (_×_)
-open import foundation.contractible-types using (is-contr; is-contr-equiv')
-open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2; triple)
-open import foundation.equivalences using
-  ( is-equiv; is-property-is-equiv; map-inv-is-equiv; issec-map-inv-is-equiv;
-    _≃_; is-equiv-right-factor; is-equiv-left-factor; map-equiv;
-    id-equiv; _∘e_; map-inv-equiv; is-equiv-map-equiv)
+open import foundation.cartesian-product-types
+open import foundation.contractible-types
+open import foundation.dependent-pair-types
+open import foundation.equivalences
 open import foundation.function-extensionality using (equiv-funext)
-open import foundation.functions using (_∘_)
-open import foundation.fundamental-theorem-of-identity-types using
-  ( fundamental-theorem-id')
-open import foundation.homotopies using
-  ( _·r_; _~_; _∙h_; htpy-left-whisk; refl-htpy;
-    is-contr-total-htpy; equiv-concat-htpy)
-open import foundation.identity-types using (_＝_; inv; ap; refl)
-open import foundation.propositions using (is-prop; is-prop-Π)
-open import foundation.structure-identity-principle using
-  ( extensionality-Σ)
-open import foundation.subtype-identity-principle using
-  ( is-contr-total-Eq-subtype)
-open import foundation.universe-levels using (Level; UU; _⊔_; lsuc)
+open import foundation.functions
+open import foundation.fundamental-theorem-of-identity-types
+open import foundation.homotopies
+open import foundation.identity-types
+open import foundation.propositions
+open import foundation.structure-identity-principle
+open import foundation.subtype-identity-principle
+open import foundation.universe-levels
 
-open import foundation-core.commuting-squares using (coherence-square)
-open import foundation-core.cones-pullbacks using
-  ( cone; cone-map; htpy-cone; htpy-eq-cone; extensionality-cone)
-open import foundation-core.contractible-maps using (is-contr-map-is-equiv)
-open import foundation-core.functoriality-dependent-pair-types using (equiv-tot)
-open import foundation-core.functoriality-function-types using
-  ( is-equiv-is-equiv-postcomp; is-equiv-postcomp-is-equiv)
+open import foundation-core.commuting-squares
+open import foundation-core.cones-pullbacks
+open import foundation-core.contractible-maps
+open import foundation-core.functoriality-dependent-pair-types
+open import foundation-core.functoriality-function-types
 ```
 
 ## Idea

--- a/src/foundation/universal-property-set-quotients.lagda.md
+++ b/src/foundation/universal-property-set-quotients.lagda.md
@@ -7,72 +7,38 @@ title: The universal property of set quotients
 
 module foundation.universal-property-set-quotients where
 
-open import foundation.cartesian-product-types using (_×_)
-open import foundation.contractible-maps using
-  ( is-contr-map-is-equiv; is-equiv-is-contr-map)
-open import foundation.contractible-types using
-  ( is-contr; is-contr-equiv'; center; is-contr-equiv; eq-is-contr)
-open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2)
-open import foundation.effective-maps-equivalence-relations using
-  ( is-effective; is-surjective-and-effective)
-open import foundation.embeddings using (_↪_; map-emb; equiv-ap-emb; is-emb)
-open import foundation.epimorphisms-with-respect-to-sets using
-  ( is-epimorphism-is-surjective-Set)
-open import foundation.equivalence-classes using
-  ( equivalence-class; class; emb-equivalence-class;
-    apply-effectiveness-class';
-    is-effective-class; equivalence-class-Set;
-    quotient-reflecting-map-equivalence-class;
-    is-surjective-and-effective-class)
-open import foundation.equivalences using
-  ( is-equiv; _≃_; map-inv-is-equiv; is-equiv-has-inverse;
-    is-equiv-precomp-is-equiv; is-equiv-left-factor; map-equiv;
-    is-property-is-equiv; _∘e_; inv-equiv; map-inv-equiv;
-    issec-map-inv-is-equiv)
-open import foundation.existential-quantification using (∃-Prop)
-open import foundation.fibers-of-maps using (fib)
+open import foundation.cartesian-product-types
+open import foundation.contractible-maps
+open import foundation.contractible-types
+open import foundation.dependent-pair-types
+open import foundation.effective-maps-equivalence-relations
+open import foundation.embeddings
+open import foundation.epimorphisms-with-respect-to-sets
+open import foundation.equivalence-classes
+open import foundation.equivalences
+open import foundation.existential-quantification
+open import foundation.fibers-of-maps
 open import foundation.function-extensionality using (htpy-eq; eq-htpy)
-open import foundation.functions using (_∘_; id; precomp)
-open import foundation.functoriality-dependent-pair-types using (equiv-tot)
-open import foundation.fundamental-theorem-of-identity-types using
-  ( fundamental-theorem-id)
-open import foundation.homotopies using
-  ( _~_; refl-htpy; is-contr-total-htpy; inv-htpy; _·l_; _∙h_)
-open import foundation.identity-types using
-  ( _＝_; ap; _∙_; inv; refl; convert-eq-values; tr; inv-tr)
-open import foundation.images using
-  ( emb-im; map-unit-im; is-emb-inclusion-im; triangle-unit-im; im; is-set-im;
-    inclusion-im)
-open import foundation.injective-maps using
-  ( is-injective-is-equiv; is-emb-is-injective; is-injective-is-emb)
-open import foundation.locally-small-types using (is-locally-small)
-open import foundation.propositional-extensionality using
-  ( eq-equiv-Prop; is-set-type-Prop; eq-iff; Prop-Set)
-open import foundation.propositional-maps using (is-prop-map-is-emb)
-open import foundation.propositional-truncations using
-  ( apply-universal-property-trunc-Prop; type-trunc-Prop; unit-trunc-Prop)
-open import foundation.propositions using
-  ( is-prop; is-prop-Π'; is-prop-function-type; Prop; type-Prop;
-    is-prop-equiv'; is-prop-type-Prop; all-elements-equal;
-    is-prop-all-elements-equal; is-proof-irrelevant-is-prop; is-prop-equiv)
-open import foundation.reflecting-maps-equivalence-relations using
-  ( reflecting-map-Eq-Rel; map-reflecting-map-Eq-Rel;
-    reflects-map-reflecting-map-Eq-Rel; eq-htpy-reflecting-map-Eq-Rel;
-    extensionality-reflecting-map-Eq-Rel; reflects-Eq-Rel;
-    reflecting-map-Eq-Rel-is-surjective-and-effective; is-prop-reflects-Eq-Rel;
-    reflects-Eq-Rel-Prop)
-open import foundation.sets using
-  ( Set; type-Set; is-set; is-set-type-Set; type-hom-Set; Id-Prop;
-    is-set-function-type)
-open import foundation.small-types using (is-small; is-small-Prop)
-open import foundation.subtypes using
-  ( eq-type-subtype; equiv-ap-inclusion-subtype)
-open import foundation.surjective-maps using
-  ( is-surjective; dependent-universal-property-surj-is-surjective)
+open import foundation.functions
+open import foundation.functoriality-dependent-pair-types
+open import foundation.fundamental-theorem-of-identity-types
+open import foundation.homotopies
+open import foundation.identity-types
+open import foundation.images
+open import foundation.injective-maps
+open import foundation.locally-small-types
+open import foundation.propositional-extensionality
+open import foundation.propositional-maps
+open import foundation.propositional-truncations
+open import foundation.propositions
+open import foundation.reflecting-maps-equivalence-relations
+open import foundation.sets
+open import foundation.small-types
+open import foundation.subtypes
+open import foundation.surjective-maps
 open import foundation.univalence using (equiv-eq)
-open import foundation.universal-property-image using
-  ( is-image; is-surjective-is-image; is-image-is-surjective)
-open import foundation.universe-levels using (Level; UU; _⊔_; lsuc)
+open import foundation.universal-property-image
+open import foundation.universe-levels
 
 open import foundation-core.equivalence-relations using
   ( Eq-Rel; sim-Eq-Rel; prop-Eq-Rel; trans-Eq-Rel; symm-Eq-Rel; refl-Eq-Rel)

--- a/src/foundation/universal-property-set-truncation.lagda.md
+++ b/src/foundation/universal-property-set-truncation.lagda.md
@@ -7,36 +7,25 @@ title: The universal property of set truncations
 
 module foundation.universal-property-set-truncation where
 
-open import foundation.contractible-maps using
-  ( is-equiv-is-contr-map; is-contr-map-is-equiv)
-open import foundation.contractible-types using
-  ( is-contr; is-contr-equiv'; is-contr-equiv; center)
-open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2; ind-Σ)
-open import foundation.equivalences using
-  ( is-equiv; is-equiv-precomp-is-equiv; is-equiv-id; _≃_; map-equiv;
-    is-equiv-map-equiv; is-equiv-equiv; is-equiv-comp; is-equiv-right-factor)
+open import foundation.contractible-maps
+open import foundation.contractible-types
+open import foundation.dependent-pair-types
+open import foundation.equivalences
 open import foundation.function-extensionality using (equiv-funext)
-open import foundation.functions using (_∘_; id)
-open import foundation.functoriality-dependent-pair-types using
-  ( equiv-tot; is-fiberwise-equiv-is-equiv-map-Σ)
-open import foundation.homotopies using (_~_; refl-htpy)
-open import foundation.identity-types using (_＝_; refl)
-open import foundation.mere-equality using
-  ( mere-eq-Eq-Rel; reflecting-map-mere-eq; reflects-mere-eq)
-open import foundation.propositions using (is-proof-irrelevant-is-prop)
-open import foundation.reflecting-maps-equivalence-relations using
-  ( is-prop-reflects-Eq-Rel)
-open import foundation.sets using
-  ( Set; type-Set; precomp-Set; type-hom-Set; is-set; Σ-Set)
-open import foundation.type-arithmetic-dependent-pair-types using
-  ( is-equiv-pr1-is-contr)
-open import foundation.type-theoretic-principle-of-choice using
-  ( inv-distributive-Π-Σ)
-open import foundation.universal-property-set-quotients using
-  ( is-set-quotient; precomp-Set-Quotient)
-open import foundation.universe-levels using (Level; UU; lsuc; _⊔_)
+open import foundation.functions
+open import foundation.functoriality-dependent-pair-types
+open import foundation.homotopies
+open import foundation.identity-types
+open import foundation.mere-equality
+open import foundation.propositions
+open import foundation.reflecting-maps-equivalence-relations
+open import foundation.sets
+open import foundation.type-arithmetic-dependent-pair-types
+open import foundation.type-theoretic-principle-of-choice
+open import foundation.universal-property-set-quotients
+open import foundation.universe-levels
 
-open import foundation-core.equivalence-relations using (Eq-Rel)
+open import foundation-core.equivalence-relations
 ```
 
 ## Idea
@@ -225,14 +214,12 @@ abstract
     is-set-quotient l3 (mere-eq-Eq-Rel A) B (reflecting-map-mere-eq B f)
   is-set-quotient-is-set-truncation {A = A} B f H X =
     is-equiv-right-factor
-      ( precomp-Set f X)
       ( pr1)
       ( precomp-Set-Quotient
         ( mere-eq-Eq-Rel A)
         ( B)
         ( reflecting-map-mere-eq B f)
         ( X))
-      ( refl-htpy)
       ( is-equiv-pr1-is-contr
         ( λ h →
           is-proof-irrelevant-is-prop

--- a/src/foundation/universal-property-truncation.lagda.md
+++ b/src/foundation/universal-property-truncation.lagda.md
@@ -488,7 +488,7 @@ module _
         ( coprod-Set (trunc-Set A) (trunc-Set B))
         ( map-coprod unit-trunc-Set unit-trunc-Set)
         ( λ {l} C →
-          is-equiv-right-factor'
+          is-equiv-right-factor
             ( ev-inl-inr (λ x → type-Set C))
             ( precomp-Set (map-coprod unit-trunc-Set unit-trunc-Set) C)
             ( universal-property-coprod (type-Set C))
@@ -543,7 +543,7 @@ module _
         ( trunc-Set (Σ A (λ x → type-trunc-Set (B x))))
         ( unit-trunc-Set ∘ tot (λ x → unit-trunc-Set))
         ( λ {l} C →
-          is-equiv-right-factor'
+          is-equiv-right-factor
             ( ev-pair)
             ( precomp-Set (unit-trunc-Set ∘ tot (λ x → unit-trunc-Set)) C)
             ( is-equiv-ev-pair)
@@ -605,7 +605,7 @@ module _
         ( prod-Set (trunc-Set A) (trunc-Set B))
         ( map-prod unit-trunc-Set unit-trunc-Set)
         ( λ {l} C →
-          is-equiv-right-factor'
+          is-equiv-right-factor
             ( ev-pair)
             ( precomp-Set (map-prod unit-trunc-Set unit-trunc-Set) C)
             ( is-equiv-ev-pair)
@@ -661,7 +661,7 @@ abstract
       ( Π-Set (Fin-Set (succ-ℕ k)) (λ x → trunc-Set (A x)))
       ( map-Π (λ x → unit-trunc-Set))
       ( λ {l} B →
-        is-equiv-left-factor'
+        is-equiv-left-factor
           ( precomp (map-Π (λ x → unit-trunc-Set)) (type-Set B))
           ( precomp (ev-Maybe {B = type-trunc-Set ∘ A}) (type-Set B))
           ( is-equiv-comp
@@ -669,7 +669,7 @@ abstract
             ( precomp
               ( map-prod (map-Π (λ x → unit-trunc-Set)) unit-trunc-Set)
               ( type-Set B))
-            ( is-equiv-right-factor'
+            ( is-equiv-right-factor
               ( ev-pair)
               ( precomp
                 ( map-prod (map-Π (λ x → unit-trunc-Set)) unit-trunc-Set)

--- a/src/foundation/universal-property-unit-type.lagda.md
+++ b/src/foundation/universal-property-unit-type.lagda.md
@@ -7,19 +7,16 @@ title: The universal property of the unit type
 
 module foundation.universal-property-unit-type where
 
-open import foundation-core.homotopies using (refl-htpy)
+open import foundation-core.homotopies
 
-open import foundation.constant-maps using (const)
-open import foundation.contractible-types using
-  ( dependent-universal-property-contr-is-contr; is-contr; is-equiv-is-contr)
-open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2)
-open import foundation.equivalences using
-  ( is-equiv; _≃_; is-equiv-is-equiv-precomp; is-equiv-right-factor';
-    is-equiv-comp; is-equiv-precomp-is-equiv; is-equiv-is-section)
-open import foundation.functions using (precomp)
-open import foundation.identity-types using (refl)
-open import foundation.unit-type using (unit; star; is-contr-unit; pt)
-open import foundation.universe-levels using (Level; UU)
+open import foundation.constant-maps
+open import foundation.contractible-types
+open import foundation.dependent-pair-types
+open import foundation.equivalences
+open import foundation.functions
+open import foundation.identity-types
+open import foundation.unit-type
+open import foundation.universe-levels
 ```
 
 ## Idea
@@ -78,7 +75,7 @@ abstract
   is-equiv-pt-universal-property-unit X x H =
     is-equiv-is-equiv-precomp
       ( pt x)
-      ( λ l Y → is-equiv-right-factor'
+      ( λ l Y → is-equiv-right-factor
         ( ev-star' Y)
         ( precomp (pt x) Y)
         ( universal-property-unit Y)

--- a/src/group-theory/subgroups.lagda.md
+++ b/src/group-theory/subgroups.lagda.md
@@ -7,35 +7,27 @@ title: Subgroups
 
 module group-theory.subgroups where
 
-open import foundation.binary-relations using
-  ( is-reflexive-Rel-Prop; is-symmetric-Rel-Prop; is-transitive-Rel-Prop)
-open import foundation.cartesian-product-types using (_×_)
-open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2; _,_)
-open import foundation.embeddings using (is-emb; _↪_; is-emb-comp')
-open import foundation.equality-dependent-pair-types using (eq-pair-Σ)
-open import foundation.equivalence-relations using (Eq-Rel)
-open import foundation.equivalences using (map-inv-is-equiv; _≃_)
-open import foundation.fibers-of-maps using (fib)
+open import foundation.binary-relations
+open import foundation.cartesian-product-types
+open import foundation.dependent-pair-types
+open import foundation.embeddings
+open import foundation.equality-dependent-pair-types
+open import foundation.equivalence-relations
+open import foundation.equivalences
+open import foundation.fibers-of-maps
 open import foundation.function-extensionality using (eq-htpy)
-open import foundation.functions using (id; _∘_)
+open import foundation.functions
 open import foundation.identity-types
-open import foundation.powersets using (_⊆_)
-open import foundation.propositional-extensionality using (is-set-type-Prop)
-open import foundation.propositional-maps using (is-prop-map-is-emb)
-open import foundation.propositions using
-  ( Prop; type-Prop; is-prop; is-prop-type-Prop; is-prop-Π;
-    is-prop-function-type; is-prop-prod; is-prop-is-equiv; Π-Prop; hom-Prop;
-    prod-Prop; eq-is-prop)
-open import foundation.raising-universe-levels using (raise-Prop; map-raise)
-open import foundation.sets using (is-set; is-set-function-type; Set)
-open import foundation.subtype-identity-principle using
-  ( extensionality-type-subtype)
-open import foundation.subtypes using
-  ( subtype; is-emb-inclusion-subtype; type-subtype; inclusion-subtype;
-    is-set-type-subtype; is-prop-is-in-subtype; is-in-subtype; emb-subtype;
-    has-same-elements-subtype; extensionality-subtype)
-open import foundation.unit-type using (unit-Prop; star; raise-star)
-open import foundation.universe-levels using (Level; UU; lsuc; _⊔_)
+open import foundation.powersets
+open import foundation.propositional-extensionality
+open import foundation.propositional-maps
+open import foundation.propositions
+open import foundation.raising-universe-levels
+open import foundation.sets
+open import foundation.subtype-identity-principle
+open import foundation.subtypes
+open import foundation.unit-type
+open import foundation.universe-levels
 
 open import group-theory.groups
 open import group-theory.homomorphisms-groups
@@ -380,7 +372,7 @@ module _
     (x y : type-Group G) → is-prop (right-sim-Subgroup x y)
   is-prop-right-sim-Subgroup x =
     is-prop-map-is-emb
-      ( is-emb-comp'
+      ( is-emb-comp
         ( mul-Group G x)
         ( inclusion-Subgroup G H)
         ( is-emb-mul-Group G x)
@@ -436,7 +428,7 @@ module _
     (x y : type-Group G) → is-prop (left-sim-Subgroup x y)
   is-prop-left-sim-Subgroup x =
     is-prop-map-is-emb
-      ( is-emb-comp'
+      ( is-emb-comp
         ( mul-Group' G x)
         ( inclusion-Subgroup G H)
         ( is-emb-mul-Group' G x)

--- a/src/synthetic-homotopy-theory/26-descent.lagda.md
+++ b/src/synthetic-homotopy-theory/26-descent.lagda.md
@@ -393,7 +393,7 @@ dependent-pullback-property-dependent-universal-property-pushout :
 dependent-pullback-property-dependent-universal-property-pushout
   f g (pair i (pair j H)) I l P =
   let c = (pair i (pair j H)) in
-  is-equiv-right-factor
+  is-equiv-right-factor-htpy
     ( dep-cocone-map f g c P)
     ( tot (λ h → tot λ h' → htpy-eq))
     ( gap

--- a/src/synthetic-homotopy-theory/26-id-pushout.lagda.md
+++ b/src/synthetic-homotopy-theory/26-id-pushout.lagda.md
@@ -301,7 +301,7 @@ is-universal-id-Fam-pushout' :
       ( desc-fam c Q)
       ( refl))
 is-universal-id-Fam-pushout' c up-X a Q =
-  is-equiv-left-factor
+  is-equiv-left-factor-htpy
     ( ev-refl (pr1 c a) {B = λ x p → Q x})
     ( ev-pt-hom-Fam-pushout
       ( desc-fam c (Id (pr1 c a)))

--- a/src/synthetic-homotopy-theory/functoriality-loop-spaces.lagda.md
+++ b/src/synthetic-homotopy-theory/functoriality-loop-spaces.lagda.md
@@ -76,7 +76,7 @@ is-emb-map-Ω :
   {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2)
   (f : A →* B) → is-faithful (map-pointed-map A B f) → is-emb (map-Ω A B f)
 is-emb-map-Ω A B f H =
-  is-emb-comp'
+  is-emb-comp
     ( tr-type-Ω (preserves-point-pointed-map A B f))
     ( ap (map-pointed-map A B f))
     ( is-emb-is-equiv (is-equiv-tr-type-Ω (preserves-point-pointed-map A B f)))

--- a/src/synthetic-homotopy-theory/universal-property-circle.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-circle.lagda.md
@@ -214,7 +214,7 @@ module _
       ({l : Level} → dependent-universal-property-circle l α) →
       ({l : Level} → universal-property-circle l α)
     universal-property-dependent-universal-property-circle dup-circle Y =
-      is-equiv-right-factor
+      is-equiv-right-factor-htpy
         ( ev-free-loop-Π α (λ x → Y))
         ( map-compute-free-dependent-loop-const α Y)
         ( ev-free-loop α Y)

--- a/src/synthetic-homotopy-theory/universal-property-pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-pushouts.lagda.md
@@ -144,7 +144,7 @@ module _
   is-equiv-up-pushout-up-pushout up-c up-d =
     is-equiv-is-equiv-precomp h
       ( λ l Z →
-        is-equiv-right-factor
+        is-equiv-right-factor-htpy
           ( cocone-map f g d)
           ( cocone-map f g c)
           ( precomp h Z)
@@ -170,7 +170,7 @@ module _
     is-equiv h →
     {l : Level} → universal-property-pushout l f g c
   up-pushout-is-equiv-up-pushout up-d is-equiv-h Z =
-    is-equiv-left-factor
+    is-equiv-left-factor-htpy
       ( cocone-map f g d)
       ( cocone-map f g c)
       ( precomp h Z)
@@ -227,7 +227,7 @@ pullback-property-pushout-universal-property-pushout :
   universal-property-pushout l f g c → pullback-property-pushout l f g c
 pullback-property-pushout-universal-property-pushout
   l f g c up-c Y =
-  is-equiv-right-factor
+  is-equiv-right-factor-htpy
     ( cocone-map f g c)
     ( tot (λ i' → tot (λ j' p → htpy-eq p)))
     ( gap (λ h → h ∘ f) (λ h → h ∘ g) (cone-pullback-property-pushout f g c Y))

--- a/src/univalent-combinatorics/2-element-types.lagda.md
+++ b/src/univalent-combinatorics/2-element-types.lagda.md
@@ -268,7 +268,7 @@ module _
         ( has-two-elements-type-2-Element-Type X)
         ( is-equiv-Prop (ev-zero-equiv-Fin-two-ℕ))
         ( λ α →
-          is-equiv-left-factor'
+          is-equiv-left-factor
             ( ev-zero-equiv-Fin-two-ℕ)
             ( map-equiv (equiv-postcomp-equiv α (Fin 2)))
             ( is-equiv-comp

--- a/src/univalent-combinatorics/distributivity-of-set-truncation-over-finite-products.lagda.md
+++ b/src/univalent-combinatorics/distributivity-of-set-truncation-over-finite-products.lagda.md
@@ -9,49 +9,34 @@ module
   univalent-combinatorics.distributivity-of-set-truncation-over-finite-products
   where
 
-open import elementary-number-theory.natural-numbers using (ℕ; zero-ℕ; succ-ℕ)
+open import elementary-number-theory.natural-numbers
 
-open import foundation.contractible-types using
-  ( is-contr; is-equiv-is-contr; center; is-contr-equiv; is-contr-equiv';
-    is-contr-Prop)
-open import foundation.coproduct-types using (inl; inr)
-open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2; ev-pair)
-open import foundation.empty-types using (empty-Set)
-open import foundation.equivalences using
-  ( _≃_; map-equiv; is-equiv-precomp-is-equiv; is-equiv-left-factor';
-    is-equiv-comp; is-equiv-right-factor'; is-equiv-htpy-equiv;
-    is-equiv-map-equiv; _∘e_; equiv-postcomp-equiv;
-    inv-equiv; equiv-precomp-equiv; id-equiv)
+open import foundation.contractible-types
+open import foundation.coproduct-types
+open import foundation.dependent-pair-types
+open import foundation.empty-types
+open import foundation.equivalences
 open import foundation.function-extensionality using (equiv-funext; eq-htpy)
-open import foundation.functions using (_∘_; map-Π; precomp; precomp-Π)
-open import foundation.functoriality-cartesian-product-types using (map-prod)
-open import foundation.functoriality-dependent-function-types using
-  ( equiv-map-Π; equiv-Π; map-equiv-Π; compute-map-equiv-Π; equiv-precomp-Π)
-open import foundation.functoriality-dependent-pair-types using (equiv-Σ)
-open import foundation.functoriality-function-types using (equiv-postcomp)
-open import foundation.functoriality-set-truncation using
-  ( equiv-trunc-Set; map-equiv-trunc-Set; naturality-unit-trunc-Set)
-open import foundation.homotopies using (_~_; refl-htpy)
-open import foundation.identity-types using
-  ( Id; equiv-concat; ap; _∙_; equiv-concat'; inv)
-open import foundation.propositional-truncations using
-  ( apply-universal-property-trunc-Prop)
-open import foundation.sets using (Π-Set; type-Set; Π-Set')
-open import foundation.set-truncations using
-  ( type-trunc-Set; unit-trunc-Set; uniqueness-trunc-Set; trunc-Set;
-    is-set-truncation-is-equiv; equiv-universal-property-trunc-Set)
-open import foundation.unit-type using (star)
-open import foundation.universal-property-dependent-pair-types using
-  ( is-equiv-ev-pair; equiv-ev-pair)
-open import foundation.universal-property-empty-type using
-  ( dependent-universal-property-empty')
-open import foundation.universal-property-maybe using
-  ( ev-Maybe; dependent-universal-property-Maybe)
-open import foundation.universe-levels using (Level; UU)
+open import foundation.functions
+open import foundation.functoriality-cartesian-product-types
+open import foundation.functoriality-dependent-function-types
+open import foundation.functoriality-dependent-pair-types
+open import foundation.functoriality-function-types
+open import foundation.functoriality-set-truncation
+open import foundation.homotopies
+open import foundation.identity-types
+open import foundation.propositional-truncations
+open import foundation.sets
+open import foundation.set-truncations
+open import foundation.unit-type
+open import foundation.universal-property-dependent-pair-types
+open import foundation.universal-property-empty-type
+open import foundation.universal-property-maybe
+open import foundation.universe-levels
 
-open import univalent-combinatorics.counting using (count)
-open import univalent-combinatorics.finite-types using (is-finite)
-open import univalent-combinatorics.standard-finite-types using (Fin; Fin-Set)
+open import univalent-combinatorics.counting
+open import univalent-combinatorics.finite-types
+open import univalent-combinatorics.standard-finite-types
 ```
 
 ```agda
@@ -83,7 +68,7 @@ abstract
       ( Π-Set (Fin-Set (succ-ℕ k)) (λ x → trunc-Set (A x)))
       ( map-Π (λ x → unit-trunc-Set))
       ( λ {l} B →
-        is-equiv-left-factor'
+        is-equiv-left-factor
           ( precomp (map-Π (λ x → unit-trunc-Set)) (type-Set B))
           ( precomp (ev-Maybe {B = type-trunc-Set ∘ A}) (type-Set B))
           ( is-equiv-comp
@@ -91,7 +76,7 @@ abstract
             ( precomp
               ( map-prod (map-Π (λ x → unit-trunc-Set)) unit-trunc-Set)
               ( type-Set B))
-            ( is-equiv-right-factor'
+            ( is-equiv-right-factor
               ( ev-pair)
               ( precomp
                 ( map-prod (map-Π (λ x → unit-trunc-Set)) unit-trunc-Set)

--- a/src/univalent-combinatorics/pi-finite-types.lagda.md
+++ b/src/univalent-combinatorics/pi-finite-types.lagda.md
@@ -559,7 +559,7 @@ has-finite-connected-components-Σ-is-0-connected {A = A} {B} C H K =
     ( is-inhabited-is-0-connected C)
     ( is-π-finite-Prop zero-ℕ (Σ A B))
     ( α)
-    
+
   where
   α : A → is-π-finite zero-ℕ (Σ A B)
   α a =
@@ -575,7 +575,7 @@ has-finite-connected-components-Σ-is-0-connected {A = A} {B} C H K =
               ( type-trunc-Set (Σ A B))
               ( λ y → is-decidable-Prop (Id-Prop (trunc-Set (Σ A B)) x y))))
         ( β))
-        
+
     where
     β : (x : Σ A B) (v : type-trunc-Set (Σ A B)) →
         is-decidable (Id (unit-trunc-Set x) v)
@@ -586,7 +586,7 @@ has-finite-connected-components-Σ-is-0-connected {A = A} {B} C H K =
             ( is-decidable-Prop
               ( Id-Prop (trunc-Set (Σ A B)) (unit-trunc-Set (pair x y)) u)))
         ( γ)
-        
+
       where
       γ : (v : Σ A B) →
           is-decidable (Id (unit-trunc-Set (pair x y)) (unit-trunc-Set v))
@@ -601,7 +601,7 @@ has-finite-connected-components-Σ-is-0-connected {A = A} {B} C H K =
             ( is-decidable-Prop
               ( mere-eq-Prop (pair x y) (pair x' y')))
               ( δ))
-              
+
         where
         δ : Id a x → is-decidable (mere-eq (pair x y) (pair x' y'))
         δ refl =
@@ -610,7 +610,7 @@ has-finite-connected-components-Σ-is-0-connected {A = A} {B} C H K =
             ( is-decidable-Prop
               ( mere-eq-Prop (pair a y) (pair x' y')))
             ( ε)
-            
+
           where
           ε : Id a x' → is-decidable (mere-eq (pair x y) (pair x' y'))
           ε refl =
@@ -619,7 +619,7 @@ has-finite-connected-components-Σ-is-0-connected {A = A} {B} C H K =
                 ( is-finite-Σ
                   ( pr2 H a a)
                   ( λ ω → is-finite-is-decidable-Prop (P ω) (d ω))))
-            
+
             where
             ℙ : is-contr
                 ( Σ ( type-hom-Set (trunc-Set (Id a a)) (Prop-Set _))
@@ -635,7 +635,7 @@ has-finite-connected-components-Σ-is-0-connected {A = A} {B} C H K =
             compute-P :
               ( ω : Id a a) →
               type-Prop (P (unit-trunc-Set ω)) ≃
-              type-trunc-Prop (Id (tr B ω y) y') 
+              type-trunc-Prop (Id (tr B ω y) y')
             compute-P ω = equiv-eq (ap pr1 (pr2 (center ℙ) ω))
             d : (t : type-trunc-Set (Id a a)) → is-decidable (type-Prop (P t))
             d = apply-dependent-universal-property-trunc-Set'
@@ -693,7 +693,7 @@ module _
   (f : A1 + A2 → B) (e : (A1 + A2) ≃ type-trunc-Set B)
   (H : (unit-trunc-Set ∘ f) ~ map-equiv e)
   where
-  
+
   map-is-coprod-codomain : (im (f ∘ inl) + im (f ∘ inr)) → B
   map-is-coprod-codomain = ind-coprod (λ x → B) pr1 pr1
 
@@ -798,7 +798,7 @@ is-0-connected-im-unit f =
 has-finite-connected-components-Σ' :
   {l1 l2 : Level} {A : UU l1} {B : A → UU l2} →
   (k : ℕ) → (Fin k ≃ (type-trunc-Set A)) →
-  ((x y : A) → has-finite-connected-components (Id x y)) → 
+  ((x y : A) → has-finite-connected-components (Id x y)) →
   ((x : A) → has-finite-connected-components (B x)) →
   has-finite-connected-components (Σ A B)
 has-finite-connected-components-Σ' zero-ℕ e H K =
@@ -861,7 +861,7 @@ has-finite-connected-components-Σ' {l1} {l2} {A} {B} (succ-ℕ k) e H K =
     i = unit-trunc-Set ∘ map-unit-im (f ∘ inl)
     is-surjective-i : is-surjective i
     is-surjective-i =
-      is-surjective-comp'
+      is-surjective-comp
         ( is-surjective-unit-trunc-Set _)
         ( is-surjective-map-unit-im (f ∘ inl))
     is-emb-i : is-emb i

--- a/src/univalent-combinatorics/pi-finite-types.lagda.md
+++ b/src/univalent-combinatorics/pi-finite-types.lagda.md
@@ -866,7 +866,7 @@ has-finite-connected-components-Σ' {l1} {l2} {A} {B} (succ-ℕ k) e H K =
         ( is-surjective-map-unit-im (f ∘ inl))
     is-emb-i : is-emb i
     is-emb-i =
-      is-emb-right-factor
+      is-emb-right-factor-htpy
         ( (unit-trunc-Set ∘ f) ∘ inl)
         ( inclusion-trunc-im-Set (f ∘ inl))
         ( i)

--- a/src/univalent-combinatorics/pi-finite-types.lagda.md
+++ b/src/univalent-combinatorics/pi-finite-types.lagda.md
@@ -5,127 +5,69 @@ title: π-finite types
 ```agda
 module univalent-combinatorics.pi-finite-types where
 
-open import elementary-number-theory.natural-numbers using (ℕ; zero-ℕ; succ-ℕ)
+open import elementary-number-theory.natural-numbers
 
-open import foundation.0-connected-types using
-  ( is-0-connected; mere-eq-is-0-connected; is-surjective-fiber-inclusion;
-    is-inhabited-is-0-connected)
-open import foundation.cartesian-product-types using (_×_)
-open import foundation.constant-maps using (const)
-open import foundation.contractible-types using
-  ( is-contr; is-prop-is-contr; center; is-contr-equiv'; is-contr-Prop)
-open import foundation.coproduct-types using (_+_; inl; inr; ind-coprod)
-open import foundation.decidable-equality using
-  ( has-decidable-equality)
-open import foundation.decidable-propositions using
-  ( is-finite-is-decidable-Prop; is-decidable-Prop)
-open import foundation.decidable-types using
-  ( is-decidable; is-decidable-equiv'; is-decidable-equiv)
-open import foundation.dependent-pair-types using (Σ; pair; pr1; pr2)
-open import foundation.embeddings using
-  ( is-emb; is-emb-right-factor; is-emb-comp'; equiv-ap-emb)
-open import foundation.empty-types using
-  ( is-empty; ex-falso; empty; ind-empty; empty-Prop)
-open import foundation.equality-coproduct-types using
-  ( compute-eq-coprod-inl-inl; compute-eq-coprod-inl-inr;
-    compute-eq-coprod-inr-inl; compute-eq-coprod-inr-inr; is-emb-coprod;
-    is-empty-eq-coprod-inl-inr; is-emb-inl)
-open import foundation.equality-cartesian-product-types using
-  ( equiv-eq-pair)
-open import foundation.equality-dependent-pair-types using
-  ( equiv-pair-eq-Σ; eq-pair-Σ; pair-eq-Σ)
-open import foundation.equivalences using
-  ( _≃_; equiv-ap; map-equiv; inv-equiv; map-inv-equiv;
-    is-equiv-map-equiv; issec-map-inv-equiv; is-equiv; id-equiv; _∘e_;
-    is-emb-is-equiv)
-open import foundation.fiber-inclusions using (fiber-inclusion)
-open import foundation.fibers-of-maps using (fib)
+open import foundation.0-connected-types
+open import foundation.cartesian-product-types
+open import foundation.constant-maps
+open import foundation.contractible-types
+open import foundation.coproduct-types
+open import foundation.decidable-equality
+open import foundation.decidable-propositions
+open import foundation.decidable-types
+open import foundation.dependent-pair-types
+open import foundation.embeddings
+open import foundation.empty-types
+open import foundation.equality-coproduct-types
+open import foundation.equality-cartesian-product-types
+open import foundation.equality-dependent-pair-types
+open import foundation.equivalences
+open import foundation.fiber-inclusions
+open import foundation.fibers-of-maps
 open import foundation.function-extensionality using (equiv-funext)
-open import foundation.functions using (id; _∘_)
-open import foundation.functoriality-coproduct-types using (map-coprod)
-open import foundation.functoriality-dependent-function-types using
-  ( equiv-precomp-Π)
-open import foundation.functoriality-dependent-pair-types using
-  ( equiv-Σ)
-open import foundation.functoriality-set-truncation using
-  ( equiv-trunc-Set; is-surjective-map-trunc-Set; map-trunc-Set;
-    equiv-trunc-im-Set; inclusion-trunc-im-Set; naturality-unit-trunc-Set;
-    is-emb-inclusion-trunc-im-Set)
-open import foundation.homotopies using (_~_; refl-htpy; inv-htpy; _·r_)
-open import foundation.identity-types using (Id; tr; ap; refl; inv; _∙_)
-open import foundation.images using
-  ( im; map-unit-im; im-Set; eq-Eq-im; is-surjective-map-unit-im;
-    inclusion-im; equiv-Eq-eq-im)
-open import foundation.injective-maps using (is-injective-is-equiv)
-open import foundation.logical-equivalences using (equiv-iff)
-open import foundation.maybe using (Maybe)
-open import foundation.mere-equality using (mere-eq; mere-eq-Prop)
-open import foundation.mere-equivalences using (mere-equiv)
-open import foundation.propositional-extensionality using
-  ( Prop-Set)
-open import foundation.propositional-truncations using
-  ( apply-universal-property-trunc-Prop; trunc-Prop; type-trunc-Prop;
-    unit-trunc-Prop; is-prop-type-trunc-Prop;
-    apply-dependent-universal-property-trunc-Prop)
-open import foundation.propositions using
-  ( Prop; Π-Prop; type-Prop; is-prop; is-prop-type-Prop; prod-Prop;
-    type-hom-Prop; function-Prop)
-open import foundation.set-truncations using
-  ( type-trunc-Set; equiv-unit-trunc-empty-Set; is-empty-trunc-Set;
-    is-contr-trunc-Set; equiv-distributive-trunc-coprod-Set;
-    equiv-unit-trunc-Set; unit-trunc-Set; trunc-Set;
-    universal-property-trunc-Set; apply-dependent-universal-property-trunc-Set';
-    is-effective-unit-trunc-Set; apply-effectiveness-unit-trunc-Set;
-    equiv-unit-trunc-unit-Set; is-empty-is-empty-trunc-Set;
-    is-surjective-unit-trunc-Set)
-open import foundation.sets using
-  ( is-set; type-hom-Set; set-Prop; hom-Set; Id-Prop; Set; type-Set)
-open import foundation.subtypes using (is-emb-inclusion-subtype)
-open import foundation.surjective-maps using
-  ( is-surjective; is-equiv-is-emb-is-surjective; is-surjective-comp')
-open import foundation.truncated-types using (is-trunc)
-open import foundation.truncation-levels using
-  ( 𝕋; zero-𝕋; succ-𝕋; truncation-level-ℕ)
-open import foundation.type-arithmetic-coproduct-types using
-  ( right-distributive-Σ-coprod)
-open import foundation.unit-type using (unit; is-contr-unit; star)
+open import foundation.functions
+open import foundation.functoriality-coproduct-types
+open import foundation.functoriality-dependent-function-types
+open import foundation.functoriality-dependent-pair-types
+open import foundation.functoriality-set-truncation
+open import foundation.homotopies
+open import foundation.identity-types
+open import foundation.images
+open import foundation.injective-maps
+open import foundation.logical-equivalences
+open import foundation.maybe
+open import foundation.mere-equality
+open import foundation.mere-equivalences
+open import foundation.propositional-extensionality
+open import foundation.propositional-truncations
+open import foundation.propositions
+open import foundation.set-truncations
+open import foundation.sets
+open import foundation.subtypes
+open import foundation.surjective-maps
+open import foundation.truncated-types
+open import foundation.truncation-levels
+open import foundation.type-arithmetic-coproduct-types
+open import foundation.unit-type
 open import foundation.univalence using (equiv-eq)
-open import foundation.universal-property-coproduct-types using
-  ( equiv-dependent-universal-property-coprod)
-open import foundation.universal-property-empty-type using
-  ( dependent-universal-property-empty')
-open import foundation.universal-property-unit-type using
-  ( equiv-dependent-universal-property-unit)
-open import foundation.universe-levels using (Level; UU; lsuc; lzero; _⊔_)
+open import foundation.universal-property-coproduct-types
+open import foundation.universal-property-empty-type
+open import foundation.universal-property-unit-type
+open import foundation.universe-levels
 
-open import univalent-combinatorics.cartesian-product-types using
-  ( is-finite-prod)
-open import univalent-combinatorics.coproduct-types using
-  ( is-finite-coprod)
-open import univalent-combinatorics.counting using (count)
-open import univalent-combinatorics.dependent-function-types using
-  ( is-finite-Π)
-open import univalent-combinatorics.dependent-sum-finite-types using
-  ( is-finite-Σ)
+open import univalent-combinatorics.cartesian-product-types
+open import univalent-combinatorics.coproduct-types
+open import univalent-combinatorics.counting
+open import univalent-combinatorics.dependent-function-types
+open import univalent-combinatorics.dependent-sum-finite-types
 open import
   univalent-combinatorics.distributivity-of-set-truncation-over-finite-products
-  using
-  ( equiv-distributive-trunc-Π-is-finite-Set)
-open import univalent-combinatorics.equality-finite-types using
-  ( is-finite-eq; has-decidable-equality-is-finite)
-open import univalent-combinatorics.finite-types using
-  ( is-finite-Prop; number-of-elements-is-finite; mere-equiv-is-finite;
-    is-finite-equiv'; is-finite-is-contr; is-finite-equiv; is-finite-empty;
-    is-finite-is-empty; is-finite; 𝔽; type-𝔽; is-finite-type-𝔽; UU-Fin;
-    is-0-connected-UU-Fin; equiv-equiv-eq-UU-Fin; 
-    is-finite-has-finite-cardinality; is-decidable-type-trunc-Prop-is-finite;
-    is-set-is-finite)
-open import univalent-combinatorics.finitely-presented-types using
-  ( has-presentation-of-cardinality-has-cardinality-components)
-open import univalent-combinatorics.function-types using
-  ( is-finite-≃)
-open import univalent-combinatorics.image-of-maps using (is-finite-codomain)
-open import univalent-combinatorics.standard-finite-types using (Fin)
+open import univalent-combinatorics.equality-finite-types
+open import univalent-combinatorics.finite-types
+open import univalent-combinatorics.finitely-presented-types
+open import univalent-combinatorics.function-types
+open import univalent-combinatorics.image-of-maps
+open import univalent-combinatorics.standard-finite-types
 ```
 
 ## Idea
@@ -931,7 +873,7 @@ has-finite-connected-components-Σ' {l1} {l2} {A} {B} (succ-ℕ k) e H K =
         ( ( inv-htpy (naturality-unit-trunc-Set (inclusion-im (f ∘ inl)))) ·r
           ( map-unit-im (f ∘ inl)))
         ( is-emb-inclusion-trunc-im-Set (f ∘ inl))
-        ( is-emb-comp'
+        ( is-emb-comp
           ( unit-trunc-Set ∘ f)
           ( inl)
           ( is-emb-is-equiv Eηf)


### PR DESCRIPTION
This is a follow-up to #389 giving the same treatment to all the other composition and factor theorems I could find, making their usage consistent with sections and retractions.

This includes
- injective maps
- surjective maps
- embeddings
- equivalences
- truncated maps
- contractible maps
- propositional maps
- 0-maps
- faithful maps

If my usage/removal of the `abstract` keyword is wrong please enlighten me. It is mainly used for performance reasons, correct?