### PR TITLE
Use monospaced font for module references

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,13 @@ Egbert Rijke
 The `agda-unimath` library is a library of formalized in basic agda. Throughout our library we assume the `--without-K` and `--exact-split` flags of Agda. Furthermore, we assume some postulates.
 1. We make full use of Agda's `data` types for introducing inductive types.
 2. We make full use of Agda's universe levels, including `ω`. However, it should be noted that most of the type constructors only define types of universe levels below `ω`, so a lot of the theory developed in this library does not apply to universe level `ω` and beyond.
-3. The **function extensionality axiom** is postulated in [foundation-core.function-extensionality](https://unimath.github.io/agda-unimath/foundation-core.function-extensionality.html).
-4. The **univalence axiom** is postulated in [foundation-core.univalence](https://unimath.github.io/agda-unimath/foundation-core.univalence.html).
-5. The type theoretic **replacement axiom** is postulated in [foundation.replacement](https://unimath.github.io/agda-unimath/foundation.replacement.html)
-6. The **truncation operations** are postulated in [foundation.truncations](https://unimath.github.io/agda-unimath/foundation.truncations.html)
-7. The **interval** is postulated in [synthetic-homotopy-theory.interval-type](https://unimath.github.io/agda-unimath/synthetic-homotopy-theory.interval-type.html)
-8. The **circle** is postulated in [synthetic-homotopy-theory.circle](https://unimath.github.io/agda-unimath/synthetic-homotopy-theory.circle.html)
-9. **Pushouts** are postulated in [synthetic-homotopy-theory.pushouts](https://unimath.github.io/agda-unimath/synthetic-homotopy-theory.pushouts.html)
+3. The **function extensionality axiom** is postulated in [`foundation-core.function-extensionality`](https://unimath.github.io/agda-unimath/foundation-core.function-extensionality.html).
+4. The **univalence axiom** is postulated in [`foundation-core.univalence`](https://unimath.github.io/agda-unimath/foundation-core.univalence.html).
+5. The type theoretic **replacement axiom** is postulated in [`foundation.replacement`](https://unimath.github.io/agda-unimath/foundation.replacement.html)
+6. The **truncation operations** are postulated in [`foundation.truncations`](https://unimath.github.io/agda-unimath/foundation.truncations.html)
+7. The **interval** is postulated in [`synthetic-homotopy-theory.interval-type`](https://unimath.github.io/agda-unimath/synthetic-homotopy-theory.interval-type.html)
+8. The **circle** is postulated in [`synthetic-homotopy-theory.circle`](https://unimath.github.io/agda-unimath/synthetic-homotopy-theory.circle.html)
+9. **Pushouts** are postulated in [`synthetic-homotopy-theory.pushouts`](https://unimath.github.io/agda-unimath/synthetic-homotopy-theory.pushouts.html)
 
 Note that there is some redundancy in the postulates we assume. For example, the [univalence axiom implies function extensionality](https://unimath.github.io/agda-unimath/foundation.univalence-implies-function-extensionality.html), but we still assume function extensionality separately. Furthermore, The interval type is contractible, so there is no need at all to postulate it. The circle can be constructed as the type of `ℤ`-torsors, and the replacement axiom can be used to prove there is a circle in `UU lzero`. Finally, the replacement axiom can be proven by the join construction, which only uses pushouts.
 

--- a/src/elementary-number-theory/integers.lagda.md
+++ b/src/elementary-number-theory/integers.lagda.md
@@ -433,5 +433,5 @@ is-zero-is-zero-neg-ℤ (inr (inl star)) H = refl
 
 ## See also
 
-1. We show in [structured-types.initial-pointed-type-equipped-with-automorphism](structured-types.initial-pointed-type-equipped-with-automorphism.html) that ℤ is the initial pointed type equipped with an automorphism.
-2. The group of integers is constructed in [elementary-number-theory.group-of-integers](elementary-number-theory.group-of-integers.html).
+1. We show in [`structured-types.initial-pointed-type-equipped-with-automorphism`](structured-types.initial-pointed-type-equipped-with-automorphism.html) that ℤ is the initial pointed type equipped with an automorphism.
+2. The group of integers is constructed in [`elementary-number-theory.group-of-integers`](elementary-number-theory.group-of-integers.html).

--- a/src/foundation-core/coherently-invertible-maps.lagda.md
+++ b/src/foundation-core/coherently-invertible-maps.lagda.md
@@ -134,8 +134,8 @@ module _
 ## See also
 
 - For the notion of biinvertible maps see
-  [foundation.equivalences](foundation.equivalences.html).
+  [`foundation.equivalences`](foundation.equivalences.html).
 - For the notion of maps with contractible fibers see
-  [foundation.contractible-maps](foundation.contractible-maps.html).
+  [`foundation.contractible-maps`](foundation.contractible-maps.html).
 - For the notion of path-split maps see
-  [foundation.path-split-maps](foundation.path-split-maps.html).
+  [`foundation.path-split-maps`](foundation.path-split-maps.html).

--- a/src/foundation-core/contractible-maps.lagda.md
+++ b/src/foundation-core/contractible-maps.lagda.md
@@ -116,8 +116,8 @@ module _
 ## See also
 
 - For the notion of biinvertible maps see
-  [foundation.equivalences](foundation.equivalences.html).
+  [`foundation.equivalences`](foundation.equivalences.html).
 - For the notions of inverses and coherently invertible maps, also known as half-adjoint equivalences, see
-  [foundation.coherently-invertible-maps](foundation.coherently-invertible-maps.html).
+  [`foundation.coherently-invertible-maps`](foundation.coherently-invertible-maps.html).
 - For the notion of path-split maps see
-  [foundation.path-split-maps](foundation.path-split-maps.html).
+  [`foundation.path-split-maps`](foundation.path-split-maps.html).

--- a/src/foundation-core/endomorphisms.lagda.md
+++ b/src/foundation-core/endomorphisms.lagda.md
@@ -60,4 +60,4 @@ pr2 (endo-Truncated-Type k A) = is-trunc-endo k (is-trunc-type-Truncated-Type A)
 ## See also
 
 - For endomorphisms in a category see
-  [category-theory.endomorphisms-of-objects-categories](category-theory.endomorphisms-of-objects-categories.html).
+  [`category-theory.endomorphisms-of-objects-categories`](category-theory.endomorphisms-of-objects-categories.html).

--- a/src/foundation-core/equality-cartesian-product-types.lagda.md
+++ b/src/foundation-core/equality-cartesian-product-types.lagda.md
@@ -133,8 +133,8 @@ ap-pr2-eq-pair refl refl = refl
 ## See also
 
 - Equality proofs in dependent pair types are characterized in
-  [foundation.equality-dependent-pair-types](foundation.equality-dependent-pair-types.html).
+  [`foundation.equality-dependent-pair-types`](foundation.equality-dependent-pair-types.html).
 - Equality proofs in dependent product types are characterized in
-  [foundation.equality-dependent-function-types](foundation.equality-dependent-function-types.html).
+  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.html).
 - Equality proofs in coproduct types are characterized in
-  [foundation.equality-coproduct-types](foundation.equality-coproduct-types.html).
+  [`foundation.equality-coproduct-types`](foundation.equality-coproduct-types.html).

--- a/src/foundation-core/equality-dependent-pair-types.lagda.md
+++ b/src/foundation-core/equality-dependent-pair-types.lagda.md
@@ -89,8 +89,8 @@ module _
 ## See also
 
 - Equality proofs in cartesian product types are characterized in
-  [foundation.equality-cartesian-product-types](foundation.equality-cartesian-product-types.html).
+  [`foundation.equality-cartesian-product-types`](foundation.equality-cartesian-product-types.html).
 - Equality proofs in dependent function types are characterized in
-  [foundation.equality-dependent-function-types](foundation.equality-dependent-function-types.html).
+  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.html).
 - Equality proofs in the fiber of a map are characterized in
-  [foundation.equality-fibers-of-maps](foundation.equality-equality-fibers-of-maps.html).
+  [`foundation.equality-fibers-of-maps`](foundation.equality-equality-fibers-of-maps.html).

--- a/src/foundation-core/equality-fibers-of-maps.lagda.md
+++ b/src/foundation-core/equality-fibers-of-maps.lagda.md
@@ -19,7 +19,7 @@ open import foundation.identity-types
 
 ## Idea
 
-In the file [foundation-core.fibers-of-maps](foundation-core.fibers-of-maps.html) we already gave one characterization of the identity type of `fib f b`, for an arbitrary map `f : A → B`. Here we give a second characterization, using the fibers of the action on identifications of `f`.
+In the file [`foundation-core.fibers-of-maps`](foundation-core.fibers-of-maps.html) we already gave one characterization of the identity type of `fib f b`, for an arbitrary map `f : A → B`. Here we give a second characterization, using the fibers of the action on identifications of `f`.
 
 ## Theorem
 
@@ -106,6 +106,6 @@ module _
 ## See also
 
 - Equality proofs in dependent pair types are characterized in
-  [foundation.equality-dependent-pair-types](foundation.equality-dependent-pair-types.html).
+  [`foundation.equality-dependent-pair-types`](foundation.equality-dependent-pair-types.html).
 - Equality proofs in dependent function types are characterized in
-  [foundation.equality-dependent-function-types](foundation.equality-dependent-function-types.html).
+  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.html).

--- a/src/foundation-core/equivalences.lagda.md
+++ b/src/foundation-core/equivalences.lagda.md
@@ -512,8 +512,8 @@ module _
 ## See also
 
 - For the notions of inverses and coherently invertible maps, also known as half-adjoint equivalences, see
-  [foundation.coherently-invertible-maps](foundation.coherently-invertible-maps.html).
+  [`foundation.coherently-invertible-maps`](foundation.coherently-invertible-maps.html).
 - For the notion of maps with contractible fibers see
-  [foundation.contractible-maps](foundation.contractible-maps.html).
+  [`foundation.contractible-maps`](foundation.contractible-maps.html).
 - For the notion of path-split maps see
-  [foundation.path-split-maps](foundation.path-split-maps.html).
+  [`foundation.path-split-maps`](foundation.path-split-maps.html).

--- a/src/foundation-core/function-extensionality.lagda.md
+++ b/src/foundation-core/function-extensionality.lagda.md
@@ -18,7 +18,7 @@ open import foundation-core.universe-levels
 
 The function extensionality axiom asserts that identifications of (dependent) functions are equivalently described as pointwise equalities between them. In other words, a function is completely determined by its values.
 
-In this file, we define the statement of the axiom. The axiom itself is postulated in [foundation.function-extensionality](foundation.function-extensionality.html) as `funext`.
+In this file, we define the statement of the axiom. The axiom itself is postulated in [`foundation.function-extensionality`](foundation.function-extensionality.html) as `funext`.
 
 ## Definition
 
@@ -57,6 +57,6 @@ ap-ev a refl = refl
 ## See also
 
 - That the univalence axiom implies function extensionality is proven in
-  [foundation.univalence-implies-function-extensionality](foundation.univalence-implies-function-extensionality.html).
+  [`foundation.univalence-implies-function-extensionality`](foundation.univalence-implies-function-extensionality.html).
 - Weak function extensionality is defined in
-  [foundation.weak-function-extensionality](foundation.weak-function-extensionality.html).
+  [`foundation.weak-function-extensionality`](foundation.weak-function-extensionality.html).

--- a/src/foundation-core/functoriality-dependent-function-types.lagda.md
+++ b/src/foundation-core/functoriality-dependent-function-types.lagda.md
@@ -159,13 +159,13 @@ pr2 (equiv-precomp-Π e C) =
 ## See also
 
 - Arithmetical laws involving dependent function types are recorded in
-  [foundation.type-arithmetic-dependent-function-types](foundation.type-arithmetic-dependent-function-types.html).
+  [`foundation.type-arithmetic-dependent-function-types`](foundation.type-arithmetic-dependent-function-types.html).
 - Equality proofs in dependent function types are characterized in
-  [foundation.equality-dependent-function-types](foundation.equality-dependent-function-types.html).
+  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.html).
 
 - Functorial properties of function types are recorded in
-  [foundation.functoriality-function-types](foundation.functoriality-function-types.html).
+  [`foundation.functoriality-function-types`](foundation.functoriality-function-types.html).
 - Functorial properties of dependent pair types are recorded in
-  [foundation.functoriality-dependent-pair-types](foundation.functoriality-dependent-pair-types.html).
+  [`foundation.functoriality-dependent-pair-types`](foundation.functoriality-dependent-pair-types.html).
 - Functorial properties of cartesian product types are recorded in
-  [foundation.functoriality-cartesian-product-types](foundation.functoriality-cartesian-product-types.html).
+  [`foundation.functoriality-cartesian-product-types`](foundation.functoriality-cartesian-product-types.html).

--- a/src/foundation-core/functoriality-dependent-pair-types.lagda.md
+++ b/src/foundation-core/functoriality-dependent-pair-types.lagda.md
@@ -403,13 +403,13 @@ module _
 ## See also
 
 - Arithmetical laws involving dependent pair types are recorded in
-  [foundation.type-arithmetic-dependent-pair-types](foundation.type-arithmetic-dependent-pair-types.html).
+  [`foundation.type-arithmetic-dependent-pair-types`](foundation.type-arithmetic-dependent-pair-types.html).
 - Equality proofs in dependent pair types are characterized in
-  [foundation.equality-dependent-pair-types](foundation.equality-dependent-pair-types.html).
+  [`foundation.equality-dependent-pair-types`](foundation.equality-dependent-pair-types.html).
 - The universal property of dependent pair types is treated in
-  [foundation.universal-property-dependent-pair-types](foundation.universal-property-dependent-pair-types.html).
+  [`foundation.universal-property-dependent-pair-types`](foundation.universal-property-dependent-pair-types.html).
 
 - Functorial properties of cartesian product types are recorded in
-  [foundation.functoriality-cartesian-product-types](foundation.functoriality-cartesian-product-types.html).
+  [`foundation.functoriality-cartesian-product-types`](foundation.functoriality-cartesian-product-types.html).
 - Functorial properties of dependent product types are recorded in
-  [foundation.functoriality-dependent-function-types](foundation.functoriality-dependent-function-types.html).
+  [`foundation.functoriality-dependent-function-types`](foundation.functoriality-dependent-function-types.html).

--- a/src/foundation-core/functoriality-fibers-of-maps.lagda.md
+++ b/src/foundation-core/functoriality-fibers-of-maps.lagda.md
@@ -113,4 +113,4 @@ module _
 ## See also
 
 - Equality proofs in the fiber of a map are characterized in
-  [foundation.equality-fibers-of-maps](foundation.equality-fibers-of-maps.html).
+  [`foundation.equality-fibers-of-maps`](foundation.equality-fibers-of-maps.html).

--- a/src/foundation-core/functoriality-function-types.lagda.md
+++ b/src/foundation-core/functoriality-function-types.lagda.md
@@ -101,8 +101,8 @@ pr2 (equiv-postcomp A e) =
 ## See also
 
 - Functorial properties of dependent function types are recorded in
-  [foundation.functoriality-dependent-function-types](foundation.functoriality-dependent-function-types.html).
+  [`foundation.functoriality-dependent-function-types`](foundation.functoriality-dependent-function-types.html).
 - Arithmetical laws involving dependent function types are recorded in
-  [foundation.type-arithmetic-dependent-function-types](foundation.type-arithmetic-dependent-function-types.html).
+  [`foundation.type-arithmetic-dependent-function-types`](foundation.type-arithmetic-dependent-function-types.html).
 - Equality proofs in dependent function types are characterized in
-  [foundation.equality-dependent-function-types](foundation.equality-dependent-function-types.html).
+  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.html).

--- a/src/foundation-core/homotopies.lagda.md
+++ b/src/foundation-core/homotopies.lagda.md
@@ -316,6 +316,6 @@ module _
 ## See also
 
 - We postulate that homotopy is equivalent to identity of functions in
-  [foundation-core.function-extensionality](foundation-core.function-extensionality.html).
+  [`foundation-core.function-extensionality`](foundation-core.function-extensionality.html).
 - We define an equational reasoning syntax for homotopies in
-  [foundation.equational-reasoning](foundation.equational-reasoning.html).
+  [`foundation.equational-reasoning`](foundation.equational-reasoning.html).

--- a/src/foundation-core/path-split-maps.lagda.md
+++ b/src/foundation-core/path-split-maps.lagda.md
@@ -66,8 +66,8 @@ module _
 ## See also
 
 - For the notion of biinvertible maps see
-  [foundation.equivalences](foundation.equivalences.html).
+  [`foundation.equivalences`](foundation.equivalences.html).
 - For the notions of inverses and coherently invertible maps, also known as half-adjoint equivalences, see
-  [foundation.coherently-invertible-maps](foundation.coherently-invertible-maps.html).
+  [`foundation.coherently-invertible-maps`](foundation.coherently-invertible-maps.html).
 - For the notion of maps with contractible fibers see
-  [foundation.contractible-maps](foundation.contractible-maps.html).
+  [`foundation.contractible-maps`](foundation.contractible-maps.html).

--- a/src/foundation-core/type-arithmetic-cartesian-product-types.lagda.md
+++ b/src/foundation-core/type-arithmetic-cartesian-product-types.lagda.md
@@ -117,19 +117,19 @@ module _
 ## See also
 
 - Functorial properties of cartesian products are recorded in
-  [foundation.functoriality-cartesian-product-types](foundation.functoriality-cartesian-product-types.html).
+  [`foundation.functoriality-cartesian-product-types`](foundation.functoriality-cartesian-product-types.html).
 - Equality proofs in cartesian product types are characterized in
-  [foundation.equality-cartesian-product-types](foundation.equality-cartesian-product-types.html).
+  [`foundation.equality-cartesian-product-types`](foundation.equality-cartesian-product-types.html).
 - The universal property of cartesian product types is treated in
-  [foundation.universal-property-cartesian-product-types](foundation.universal-property-cartesian-product-types.html).
+  [`foundation.universal-property-cartesian-product-types`](foundation.universal-property-cartesian-product-types.html).
 
 - Arithmetical laws involving dependent pair types are recorded in
-  [foundation.type-arithmetic-dependent-pair-types](foundation.type-arithmetic-dependent-pair-types.html).
+  [`foundation.type-arithmetic-dependent-pair-types`](foundation.type-arithmetic-dependent-pair-types.html).
   - Arithmetical laws involving dependent product types are recorded in
-  [foundation.type-arithmetic-dependent-function-types](foundation.type-arithmetic-dependent-function-types.html).
+  [`foundation.type-arithmetic-dependent-function-types`](foundation.type-arithmetic-dependent-function-types.html).
 - Arithmetical laws involving coproduct types are recorded in
-  [foundation.type-arithmetic-coproduct-types](foundation.type-arithmetic-coproduct-types.html).
+  [`foundation.type-arithmetic-coproduct-types`](foundation.type-arithmetic-coproduct-types.html).
 - Arithmetical laws involving the unit type are recorded in
-  [foundation.type-arithmetic-unit-type](foundation.type-arithmetic-unit-type.html).
+  [`foundation.type-arithmetic-unit-type`](foundation.type-arithmetic-unit-type.html).
 - Arithmetical laws involving the empty type are recorded in
-  [foundation.type-arithmetic-empty-type](foundation.type-arithmetic-empty-type.html).
+  [`foundation.type-arithmetic-empty-type`](foundation.type-arithmetic-empty-type.html).

--- a/src/foundation-core/type-arithmetic-dependent-pair-types.lagda.md
+++ b/src/foundation-core/type-arithmetic-dependent-pair-types.lagda.md
@@ -334,19 +334,19 @@ module _
 ## See also
 
 - Functorial properties of dependent pair types are recorded in
-  [foundation.functoriality-dependent-pair-types](foundation.functoriality-dependent-pair-types.html).
+  [`foundation.functoriality-dependent-pair-types`](foundation.functoriality-dependent-pair-types.html).
 - Equality proofs in dependent pair types are characterized in
-  [foundation.equality-dependent-pair-types](foundation.equality-dependent-pair-types.html).
+  [`foundation.equality-dependent-pair-types`](foundation.equality-dependent-pair-types.html).
 - The universal property of dependent pair types is treated in
-  [foundation.universal-property-dependent-pair-types](foundation.universal-property-dependent-pair-types.html).
+  [`foundation.universal-property-dependent-pair-types`](foundation.universal-property-dependent-pair-types.html).
 
 - Arithmetical laws involving cartesian product types are recorded in
-  [foundation.type-arithmetic-cartesian-product-types](foundation.type-arithmetic-cartesian-product-types.html).
+  [`foundation.type-arithmetic-cartesian-product-types`](foundation.type-arithmetic-cartesian-product-types.html).
 - Arithmetical laws involving dependent product types are recorded in
-  [foundation.type-arithmetic-dependent-function-types](foundation.type-arithmetic-dependent-function-types.html).
+  [`foundation.type-arithmetic-dependent-function-types`](foundation.type-arithmetic-dependent-function-types.html).
 - Arithmetical laws involving coproduct types are recorded in
-  [foundation.type-arithmetic-coproduct-types](foundation.type-arithmetic-coproduct-types.html).
+  [`foundation.type-arithmetic-coproduct-types`](foundation.type-arithmetic-coproduct-types.html).
 - Arithmetical laws involving the unit type are recorded in
-  [foundation.type-arithmetic-unit-type](foundation.type-arithmetic-unit-type.html).
+  [`foundation.type-arithmetic-unit-type`](foundation.type-arithmetic-unit-type.html).
 - Arithmetical laws involving the empty type are recorded in
-  [foundation.type-arithmetic-empty-type](foundation.type-arithmetic-empty-type.html).
+  [`foundation.type-arithmetic-empty-type`](foundation.type-arithmetic-empty-type.html).

--- a/src/foundation-core/univalence.lagda.md
+++ b/src/foundation-core/univalence.lagda.md
@@ -18,7 +18,7 @@ open import foundation-core.universe-levels
 
 The univalence axiom characterizes the identity types of universes. It asserts that the map `Id A B → A ≃ B` is an equivalence.
 
-In this file, we define the statement of the axiom. The axiom itself is postulated in [foundation.univalence](foundation.univalence.html) as `univalence`.
+In this file, we define the statement of the axiom. The axiom itself is postulated in [`foundation.univalence`](foundation.univalence.html) as `univalence`.
 
 ## Definition
 

--- a/src/foundation/coherently-invertible-maps.lagda.md
+++ b/src/foundation/coherently-invertible-maps.lagda.md
@@ -120,8 +120,8 @@ abstract
 ## See also
 
 - For the notion of biinvertible maps see
-  [foundation.equivalences](foundation.equivalences.html).
+  [`foundation.equivalences`](foundation.equivalences.html).
 - For the notion of maps with contractible fibers see
-  [foundation.contractible-maps](foundation.contractible-maps.html).
+  [`foundation.contractible-maps`](foundation.contractible-maps.html).
 - For the notion of path-split maps see
-  [foundation.path-split-maps](foundation.path-split-maps.html).
+  [`foundation.path-split-maps`](foundation.path-split-maps.html).

--- a/src/foundation/contractible-maps.lagda.md
+++ b/src/foundation/contractible-maps.lagda.md
@@ -61,8 +61,8 @@ module _
 ## See also
 
 - For the notion of biinvertible maps see
-  [foundation.equivalences](foundation.equivalences.html).
+  [`foundation.equivalences`](foundation.equivalences.html).
 - For the notions of inverses and coherently invertible maps, also known as half-adjoint equivalences, see
-  [foundation.coherently-invertible-maps](foundation.coherently-invertible-maps.html).
+  [`foundation.coherently-invertible-maps`](foundation.coherently-invertible-maps.html).
 - For the notion of path-split maps see
-  [foundation.path-split-maps](foundation.path-split-maps.html).
+  [`foundation.path-split-maps`](foundation.path-split-maps.html).

--- a/src/foundation/endomorphisms.lagda.md
+++ b/src/foundation/endomorphisms.lagda.md
@@ -56,4 +56,4 @@ pr2 (pr2 (pr2 (endo-Monoid A))) f = refl
 ## See also
 
 - For endomorphisms in a category see
-  [category-theory.endomorphisms-of-objects-categories](category-theory.endomorphisms-of-objects-categories.html).
+  [`category-theory.endomorphisms-of-objects-categories`](category-theory.endomorphisms-of-objects-categories.html).

--- a/src/foundation/equality-coproduct-types.lagda.md
+++ b/src/foundation/equality-coproduct-types.lagda.md
@@ -324,6 +324,6 @@ pr2 (coprod-Set (pair A is-set-A) (pair B is-set-B)) =
 ## See also
 
 - Equality proofs in coproduct types are characterized in
-  [foundation.equality-coproduct-types](foundation.equality-coproduct-types.html).
+  [`foundation.equality-coproduct-types`](foundation.equality-coproduct-types.html).
 - Equality proofs in dependent pair types are characterized in
-  [foundation.equality-dependent-pair-types](foundation.equality-dependent-pair-types.html).
+  [`foundation.equality-dependent-pair-types`](foundation.equality-dependent-pair-types.html).

--- a/src/foundation/equality-dependent-function-types.lagda.md
+++ b/src/foundation/equality-dependent-function-types.lagda.md
@@ -70,11 +70,11 @@ module _
 ## See also
 
 - Equality proofs in the fiber of a map are characterized in
-  [foundation.equality-fibers-of-maps](foundation.equality-equality-fibers-of-maps.html).
+  [`foundation.equality-fibers-of-maps`](foundation.equality-equality-fibers-of-maps.html).
 - Equality proofs in cartesian product types are characterized in
-  [foundation.equality-cartesian-product-types](foundation.equality-cartesian-product-types.html).
+  [`foundation.equality-cartesian-product-types`](foundation.equality-cartesian-product-types.html).
 - Equality proofs in dependent pair types are characterized in
-  [foundation.equality-dependent-pair-types](foundation.equality-dependent-pair-types.html).
+  [`foundation.equality-dependent-pair-types`](foundation.equality-dependent-pair-types.html).
 
 - Function extensionality is postulated in
-  [foundation.function-extensionality](foundation.function-extensionality.html).
+  [`foundation.function-extensionality`](foundation.function-extensionality.html).

--- a/src/foundation/equality-dependent-pair-types.lagda.md
+++ b/src/foundation/equality-dependent-pair-types.lagda.md
@@ -58,8 +58,8 @@ module _
 ## See also
 
 - Equality proofs in cartesian product types are characterized in
-  [foundation.equality-cartesian-product-types](foundation.equality-cartesian-product-types.html).
+  [`foundation.equality-cartesian-product-types`](foundation.equality-cartesian-product-types.html).
 - Equality proofs in dependent function types are characterized in
-  [foundation.equality-dependent-function-types](foundation.equality-dependent-function-types.html).
+  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.html).
 - Equality proofs in the fiber of a map are characterized in
-  [foundation.equality-fibers-of-maps](foundation.equality-equality-fibers-of-maps.html).
+  [`foundation.equality-fibers-of-maps`](foundation.equality-equality-fibers-of-maps.html).

--- a/src/foundation/equivalences.lagda.md
+++ b/src/foundation/equivalences.lagda.md
@@ -508,8 +508,8 @@ equiv-fiberwise-equiv-fam-equiv B C = distributive-Π-Σ
 ## See also
 
 - For the notions of inverses and coherently invertible maps, also known as half-adjoint equivalences, see
-  [foundation.coherently-invertible-maps](foundation.coherently-invertible-maps.html).
+  [`foundation.coherently-invertible-maps`](foundation.coherently-invertible-maps.html).
 - For the notion of maps with contractible fibers see
-  [foundation.contractible-maps](foundation.contractible-maps.html).
+  [`foundation.contractible-maps`](foundation.contractible-maps.html).
 - For the notion of path-split maps see
-  [foundation.path-split-maps](foundation.path-split-maps.html).
+  [`foundation.path-split-maps`](foundation.path-split-maps.html).

--- a/src/foundation/function-extensionality.lagda.md
+++ b/src/foundation/function-extensionality.lagda.md
@@ -19,7 +19,7 @@ open import foundation-core.universe-levels
 
 The function extensionality axiom asserts that identifications of (dependent) functions are equivalently described as pointwise equalities between them. In other words, a function is completely determined by its values.
 
-In this file we postulate the function extensionality axiom. Its statement is defined in [foundation-core.function-extensionality](foundation-core.function-extensionality.html).
+In this file we postulate the function extensionality axiom. Its statement is defined in [`foundation-core.function-extensionality`](foundation-core.function-extensionality.html).
 
 ## Postulate
 
@@ -62,6 +62,6 @@ module _
 ## See also
  
 - That the univalence axiom implies function extensionality is proven in
-  [foundation.univalence-implies-function-extensionality](foundation.univalence-implies-function-extensionality.html).
+  [`foundation.univalence-implies-function-extensionality`](foundation.univalence-implies-function-extensionality.html).
 - Weak function extensionality is defined in
-  [foundation.weak-function-extensionality](foundation.weak-function-extensionality.html).
+  [`foundation.weak-function-extensionality`](foundation.weak-function-extensionality.html).

--- a/src/foundation/functoriality-cartesian-product-types.lagda.md
+++ b/src/foundation/functoriality-cartesian-product-types.lagda.md
@@ -187,15 +187,15 @@ module _
 ## See also
 
 - Arithmetical laws involving cartesian product types are recorded in
-  [foundation.type-arithmetic-cartesian-product-types](foundation.type-arithmetic-cartesian-product-types.html).
+  [`foundation.type-arithmetic-cartesian-product-types`](foundation.type-arithmetic-cartesian-product-types.html).
 - Equality proofs in cartesian product types are characterized in
-  [foundation.equality-cartesian-product-types](foundation.equality-cartesian-product-types.html).
+  [`foundation.equality-cartesian-product-types`](foundation.equality-cartesian-product-types.html).
 - The universal property of cartesian product types is treated in
-  [foundation.universal-property-cartesian-product-types](foundation.universal-property-cartesian-product-types.html).
+  [`foundation.universal-property-cartesian-product-types`](foundation.universal-property-cartesian-product-types.html).
 
 - Functorial properties of dependent pair types are recorded in
-  [foundation.functoriality-dependent-pair-types](foundation.functoriality-dependent-pair-types.html).
+  [`foundation.functoriality-dependent-pair-types`](foundation.functoriality-dependent-pair-types.html).
 - Functorial properties of dependent product types are recorded in
-  [foundation.functoriality-dependent-function-types](foundation.functoriality-dependent-function-types.html).
+  [`foundation.functoriality-dependent-function-types`](foundation.functoriality-dependent-function-types.html).
 - Functorial properties of coproduct types are recorded in
-  [foundation.functoriality-coproduct-types](foundation.functoriality-coproduct-types.html).
+  [`foundation.functoriality-coproduct-types`](foundation.functoriality-coproduct-types.html).

--- a/src/foundation/functoriality-coproduct-types.lagda.md
+++ b/src/foundation/functoriality-coproduct-types.lagda.md
@@ -492,13 +492,13 @@ module _ {i j k l : Level}
 ## See also
 
 - Arithmetical laws involving coproduct types are recorded in
-  [foundation.type-arithmetic-coproduct-types](foundation.type-arithmetic-coproduct-types.html).
+  [`foundation.type-arithmetic-coproduct-types`](foundation.type-arithmetic-coproduct-types.html).
 - Equality proofs in coproduct types are characterized in
-  [foundation.equality-coproduct-types](foundation.equality-coproduct-types.html).
+  [`foundation.equality-coproduct-types`](foundation.equality-coproduct-types.html).
 - The universal property of coproducts is treated in
-  [foundation.universal-property-coproduct-types](foundation.universal-property-coproduct-types.html).
+  [`foundation.universal-property-coproduct-types`](foundation.universal-property-coproduct-types.html).
 
 - Functorial properties of cartesian product types are recorded in
-  [foundation.functoriality-cartesian-product-types](foundation.functoriality-cartesian-product-types.html).
+  [`foundation.functoriality-cartesian-product-types`](foundation.functoriality-cartesian-product-types.html).
 - Functorial properties of dependent pair types are recorded in
-  [foundation.functoriality-dependent-pair-types](foundation.functoriality-dependent-pair-types.html).
+  [`foundation.functoriality-dependent-pair-types`](foundation.functoriality-dependent-pair-types.html).

--- a/src/foundation/functoriality-dependent-function-types.lagda.md
+++ b/src/foundation/functoriality-dependent-function-types.lagda.md
@@ -307,13 +307,13 @@ is-trunc-map-succ-precomp-Π {k = k} {f = f} {C = C} H =
 ## See also
 
 - Arithmetical laws involving dependent function types are recorded in
-  [foundation.type-arithmetic-dependent-function-types](foundation.type-arithmetic-dependent-function-types.html).
+  [`foundation.type-arithmetic-dependent-function-types`](foundation.type-arithmetic-dependent-function-types.html).
 - Equality proofs in dependent function types are characterized in
-  [foundation.equality-dependent-function-types](foundation.equality-dependent-function-types.html).
+  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.html).
 
 - Functorial properties of function types are recorded in
-  [foundation.functoriality-function-types](foundation.functoriality-function-types.html).
+  [`foundation.functoriality-function-types`](foundation.functoriality-function-types.html).
 - Functorial properties of dependent pair types are recorded in
-  [foundation.functoriality-dependent-pair-types](foundation.functoriality-dependent-pair-types.html).
+  [`foundation.functoriality-dependent-pair-types`](foundation.functoriality-dependent-pair-types.html).
 - Functorial properties of cartesian product types are recorded in
-  [foundation.functoriality-cartesian-product-types](foundation.functoriality-cartesian-product-types.html).
+  [`foundation.functoriality-cartesian-product-types`](foundation.functoriality-cartesian-product-types.html).

--- a/src/foundation/functoriality-dependent-pair-types.lagda.md
+++ b/src/foundation/functoriality-dependent-pair-types.lagda.md
@@ -189,13 +189,13 @@ module _
 ## See also
 
 - Arithmetical laws involving dependent pair types are recorded in
-  [foundation.type-arithmetic-dependent-pair-types](foundation.type-arithmetic-dependent-pair-types.html).
+  [`foundation.type-arithmetic-dependent-pair-types`](foundation.type-arithmetic-dependent-pair-types.html).
 - Equality proofs in dependent pair types are characterized in
-  [foundation.equality-dependent-pair-types](foundation.equality-dependent-pair-types.html).
+  [`foundation.equality-dependent-pair-types`](foundation.equality-dependent-pair-types.html).
 - The universal property of dependent pair types is treated in
-  [foundation.universal-property-dependent-pair-types](foundation.universal-property-dependent-pair-types.html).
+  [`foundation.universal-property-dependent-pair-types`](foundation.universal-property-dependent-pair-types.html).
 
 - Functorial properties of cartesian product types are recorded in
-  [foundation.functoriality-cartesian-product-types](foundation.functoriality-cartesian-product-types.html).
+  [`foundation.functoriality-cartesian-product-types`](foundation.functoriality-cartesian-product-types.html).
 - Functorial properties of dependent product types are recorded in
-  [foundation.functoriality-dependent-function-types](foundation.functoriality-dependent-function-types.html).
+  [`foundation.functoriality-dependent-function-types`](foundation.functoriality-dependent-function-types.html).

--- a/src/foundation/functoriality-function-types.lagda.md
+++ b/src/foundation/functoriality-function-types.lagda.md
@@ -50,8 +50,8 @@ is-trunc-map-is-trunc-map-postcomp k {X} {Y} f is-trunc-post-f =
 ## See also
 
 - Functorial properties of dependent function types are recorded in
-  [foundation.functoriality-dependent-function-types](foundation.functoriality-dependent-function-types.html).
+  [`foundation.functoriality-dependent-function-types`](foundation.functoriality-dependent-function-types.html).
 - Arithmetical laws involving dependent function types are recorded in
-  [foundation.type-arithmetic-dependent-function-types](foundation.type-arithmetic-dependent-function-types.html).
+  [`foundation.type-arithmetic-dependent-function-types`](foundation.type-arithmetic-dependent-function-types.html).
 - Equality proofs in dependent function types are characterized in
-  [foundation.equality-dependent-function-types](foundation.equality-dependent-function-types.html).
+  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.html).

--- a/src/foundation/homotopies.lagda.md
+++ b/src/foundation/homotopies.lagda.md
@@ -209,6 +209,6 @@ module _
 ## See also
 
 - We postulate that homotopy is equivalent to identity of functions in
-  [foundation-core.function-extensionality](foundation-core.function-extensionality.html).
+  [`foundation-core.function-extensionality`](foundation-core.function-extensionality.html).
 - We define an equational reasoning syntax for homotopies in
-  [foundation.equational-reasoning](foundation.equational-reasoning.html).
+  [`foundation.equational-reasoning`](foundation.equational-reasoning.html).

--- a/src/foundation/inhabited-types.lagda.md
+++ b/src/foundation/inhabited-types.lagda.md
@@ -153,8 +153,8 @@ module _
 ## See also
 
 - The notion of *nonempty types* is treated in
-  [foundation.empty-types](foundation.empty-types.html).
+  [`foundation.empty-types`](foundation.empty-types.html).
   In particular, every inhabited type is nonempty.
 
 - For the notion of *pointed types*, see
-  [structured-types.pointed-types](structured-types.pointed-types.html).
+  [`structured-types.pointed-types`](structured-types.pointed-types.html).

--- a/src/foundation/path-split-maps.lagda.md
+++ b/src/foundation/path-split-maps.lagda.md
@@ -64,8 +64,8 @@ module _
 ## See also
 
 - For the notion of biinvertible maps see
-  [foundation.equivalences](foundation.equivalences.html).
+  [`foundation.equivalences`](foundation.equivalences.html).
 - For the notions of inverses and coherently invertible maps, also known as half-adjoint equivalences, see
-  [foundation.coherently-invertible-maps](foundation.coherently-invertible-maps.html).
+  [`foundation.coherently-invertible-maps`](foundation.coherently-invertible-maps.html).
 - For the notion of maps with contractible fibers see
-  [foundation.contractible-maps](foundation.contractible-maps.html).
+  [`foundation.contractible-maps`](foundation.contractible-maps.html).

--- a/src/foundation/slice.lagda.md
+++ b/src/foundation/slice.lagda.md
@@ -359,8 +359,8 @@ module _
 ## See also
 
 - For the formally dual notion see
-  [foundation.coslice](foundation.coslice.html).
+  [`foundation.coslice`](foundation.coslice.html).
 - For slices in the context of category theory see
-  [category-theory.slice-precategories](category-theory.slice-precategories.html).
+  [`category-theory.slice-precategories`](category-theory.slice-precategories.html).
 - For fibered maps see
-  [foundation.fibered-maps](foundation.fibered-maps.html).
+  [`foundation.fibered-maps`](foundation.fibered-maps.html).

--- a/src/foundation/type-arithmetic-coproduct-types.lagda.md
+++ b/src/foundation/type-arithmetic-coproduct-types.lagda.md
@@ -323,17 +323,17 @@ module _
 
 
 - Functorial properties of coproducts are recorded in
-  [foundation.functoriality-coproduct-types](foundation.functoriality-coproduct-types.html).
+  [`foundation.functoriality-coproduct-types`](foundation.functoriality-coproduct-types.html).
 - Equality proofs in coproduct types are characterized in
-  [foundation.equality-coproduct-types](foundation.equality-coproduct-types.html).
+  [`foundation.equality-coproduct-types`](foundation.equality-coproduct-types.html).
 - The universal property of coproducts is treated in
-  [foundation.universal-property-coproduct-types](foundation.universal-property-coproduct-types.html).
+  [`foundation.universal-property-coproduct-types`](foundation.universal-property-coproduct-types.html).
 
 - Arithmetical laws involving dependent pair types are recorded in
-  [foundation.type-arithmetic-dependent-pair-types](foundation.type-arithmetic-dependent-pair-types.html).
+  [`foundation.type-arithmetic-dependent-pair-types`](foundation.type-arithmetic-dependent-pair-types.html).
 - Arithmetical laws involving cartesian-product types are recorded in
-  [foundation.type-arithmetic-cartesian-product-types](foundation.type-arithmetic-cartesian-product-types.html).
+  [`foundation.type-arithmetic-cartesian-product-types`](foundation.type-arithmetic-cartesian-product-types.html).
 - Arithmetical laws involving the unit type are recorded in
-  [foundation.type-arithmetic-unit-type](foundation.type-arithmetic-unit-type.html).
+  [`foundation.type-arithmetic-unit-type`](foundation.type-arithmetic-unit-type.html).
 - Arithmetical laws involving the empty type are recorded in
-  [foundation.type-arithmetic-empty-type](foundation.type-arithmetic-empty-type.html).
+  [`foundation.type-arithmetic-empty-type`](foundation.type-arithmetic-empty-type.html).

--- a/src/foundation/type-arithmetic-dependent-function-types.lagda.md
+++ b/src/foundation/type-arithmetic-dependent-function-types.lagda.md
@@ -38,24 +38,24 @@ module _
 ## See also
 
 - Functorial properties of dependent function types are recorded in
-  [foundation.functoriality-dependent-function-types](foundation.functoriality-dependent-function-types.html).
+  [`foundation.functoriality-dependent-function-types`](foundation.functoriality-dependent-function-types.html).
 - Equality proofs in dependent function types are characterized in
-  [foundation.equality-dependent-function-types](foundation.equality-dependent-function-types.html).
+  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.html).
 
 - Arithmetical laws involving cartesian product types are recorded in
-  [foundation.type-arithmetic-cartesian-product-types](foundation.type-arithmetic-cartesian-product-types.html).
+  [`foundation.type-arithmetic-cartesian-product-types`](foundation.type-arithmetic-cartesian-product-types.html).
 - Arithmetical laws involving dependent pair types are recorded in
-  [foundation.type-arithmetic-dependent-pair-types](foundation.type-arithmetic-dependent-pair-types.html).
+  [`foundation.type-arithmetic-dependent-pair-types`](foundation.type-arithmetic-dependent-pair-types.html).
 - Arithmetical laws involving coproduct types are recorded in
-  [foundation.type-arithmetic-coproduct-types](foundation.type-arithmetic-coproduct-types.html).
+  [`foundation.type-arithmetic-coproduct-types`](foundation.type-arithmetic-coproduct-types.html).
 - Arithmetical laws involving the unit type are recorded in
-  [foundation.type-arithmetic-unit-type](foundation.type-arithmetic-unit-type.html).
+  [`foundation.type-arithmetic-unit-type`](foundation.type-arithmetic-unit-type.html).
 - Arithmetical laws involving the empty type are recorded in
-  [foundation.type-arithmetic-empty-type](foundation.type-arithmetic-empty-type.html).
+  [`foundation.type-arithmetic-empty-type`](foundation.type-arithmetic-empty-type.html).
 
-- In [foundation.universal-property-empty-type](foundation.universal-property-empty-type.html)
+- In [`foundation.universal-property-empty-type`](foundation.universal-property-empty-type.html)
   we show that `empty` is the initial type, which can be considered a
   *left zero law for function types* (`(empty → A) ≃ unit`).
 - That `unit` is the terminal type is a corollary of `is-contr-Π`, which may be found in
-  [foundation-core.contractible-types](foundation-core.contractible-types.html).
+  [`foundation-core.contractible-types`](foundation-core.contractible-types.html).
   This can be considered a *right zero law for function types* (`(A → unit) ≃ unit`).

--- a/src/foundation/type-arithmetic-dependent-pair-types.lagda.md
+++ b/src/foundation/type-arithmetic-dependent-pair-types.lagda.md
@@ -15,19 +15,19 @@ We prove laws for the manipulation of dependent pair types with respect to thems
 ## See also
 
 - Functorial properties of dependent pair types are recorded in
-  [foundation.functoriality-dependent-pair-types](foundation.functoriality-dependent-pair-types.html).
+  [`foundation.functoriality-dependent-pair-types`](foundation.functoriality-dependent-pair-types.html).
 - Equality proofs in dependent pair types are characterized in
-  [foundation.equality-dependent-pair-types](foundation.equality-dependent-pair-types.html).
+  [`foundation.equality-dependent-pair-types`](foundation.equality-dependent-pair-types.html).
 - The universal property of dependent pair types is treated in
-  [foundation.universal-property-dependent-pair-types](foundation.universal-property-dependent-pair-types.html).
+  [`foundation.universal-property-dependent-pair-types`](foundation.universal-property-dependent-pair-types.html).
 
 - Arithmetical laws involving cartesian product types are recorded in
-  [foundation.type-arithmetic-cartesian-product-types](foundation.type-arithmetic-cartesian-product-types.html).
+  [`foundation.type-arithmetic-cartesian-product-types`](foundation.type-arithmetic-cartesian-product-types.html).
 - Arithmetical laws involving dependent product types are recorded in
-  [foundation.type-arithmetic-dependent-function-types](foundation.type-arithmetic-dependent-function-types.html).
+  [`foundation.type-arithmetic-dependent-function-types`](foundation.type-arithmetic-dependent-function-types.html).
 - Arithmetical laws involving coproduct types are recorded in
-  [foundation.type-arithmetic-coproduct-types](foundation.type-arithmetic-coproduct-types.html).
+  [`foundation.type-arithmetic-coproduct-types`](foundation.type-arithmetic-coproduct-types.html).
 - Arithmetical laws involving the unit type are recorded in
-  [foundation.type-arithmetic-unit-type](foundation.type-arithmetic-unit-type.html).
+  [`foundation.type-arithmetic-unit-type`](foundation.type-arithmetic-unit-type.html).
 - Arithmetical laws involving the empty type are recorded in
-  [foundation.type-arithmetic-empty-type](foundation.type-arithmetic-empty-type.html).
+  [`foundation.type-arithmetic-empty-type`](foundation.type-arithmetic-empty-type.html).

--- a/src/foundation/type-arithmetic-empty-type.lagda.md
+++ b/src/foundation/type-arithmetic-empty-type.lagda.md
@@ -386,6 +386,6 @@ module _
 
 ## See also
 
-- In [foundation.universal-property-empty-type](foundation.universal-property-empty-type.html)
+- In [`foundation.universal-property-empty-type`](foundation.universal-property-empty-type.html)
   we show that `empty` is the initial type, which can be considered a
   *left zero law for function types* (`(empty → A) ≃ unit`).

--- a/src/foundation/type-arithmetic-unit-type.lagda.md
+++ b/src/foundation/type-arithmetic-unit-type.lagda.md
@@ -205,5 +205,5 @@ module _
 ## See also
 
 - That `unit` is the terminal type is a corollary of `is-contr-Π`, which may be found in
-  [foundation-core.contractible-types](foundation-core.contractible-types.html).
+  [`foundation-core.contractible-types`](foundation-core.contractible-types.html).
   This can be considered a *right zero law for function types* (`(A → unit) ≃ unit`).

--- a/src/foundation/univalence.lagda.md
+++ b/src/foundation/univalence.lagda.md
@@ -23,7 +23,7 @@ open import foundation.equivalences
 
 The univalence axiom characterizes the identity types of universes. It asserts that the map `Id A B → A ≃ B` is an equivalence.
 
-In this file we postulate the univalence axiom. Its statement is defined in [foundation-core.univalence](foundation-core.univalence.html).
+In this file we postulate the univalence axiom. Its statement is defined in [`foundation-core.univalence`](foundation-core.univalence.html).
 
 ## Postulates
 

--- a/src/structured-types/central-h-spaces.lagda.md
+++ b/src/structured-types/central-h-spaces.lagda.md
@@ -13,7 +13,7 @@ open import structured-types.pointed-types
 
 ## Idea
 
-In [coherent-h-spaces](coherent-h-spaces.html) we saw that the type of coherent H-space structures on a pointed type `A` is equivalently described as the type of pointed sections of the pointed evaluation map `(A → A) →* A`. If the type `A` is connected, then the section maps to the connected component of `(A ≃ A)` at the identity equivalence. An evaluative H-space is a pointed type such that the map `ev_pt : (A ≃ A)_{(id)} → A` is an equivalence.
+In [`structured-types.coherent-h-spaces`](structured-types.coherent-h-spaces.html) we saw that the type of coherent H-space structures on a pointed type `A` is equivalently described as the type of pointed sections of the pointed evaluation map `(A → A) →* A`. If the type `A` is connected, then the section maps to the connected component of `(A ≃ A)` at the identity equivalence. An evaluative H-space is a pointed type such that the map `ev_pt : (A ≃ A)_{(id)} → A` is an equivalence.
 
 
 ## Definition

--- a/src/structured-types/pointed-types.lagda.md
+++ b/src/structured-types/pointed-types.lagda.md
@@ -44,7 +44,7 @@ ev-pt-Pointed-Type A f = f (pt-Pointed-Type A)
 ## See also
 
 - The notion of *nonempty types* is treated in
-  [foundation.empty-types](foundation.empty-types.html).
+  [`foundation.empty-types`](foundation.empty-types.html).
 
 - The notion of *inhabited types* is treated in
-  [foundation.inhabited-types](foundation.inhabited-types.html).
+  [`foundation.inhabited-types`](foundation.inhabited-types.html).

--- a/src/univalent-combinatorics/ferrers-diagrams.lagda.md
+++ b/src/univalent-combinatorics/ferrers-diagrams.lagda.md
@@ -253,4 +253,4 @@ module _
 
 ## See also
 
-- [Integer partitions](elementary-number-theory.integer-partitions.html)
+- Integer partitions in [`elementary-number-theory.integer-partitions`](elementary-number-theory.integer-partitions.html)


### PR DESCRIPTION
This changes module references in the docs to using the monospaced font, which in my opinion looks a little better.
Also fixes a broken link in `structured-types.central-h-spaces`.