### PR TITLE
Update CI with latest Github Actions and other improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,11 +29,12 @@ env:
   AGDAHTMLFLAGS: --only-scope-checking --html --html-highlight=code --html-dir=docs --css=docs/Agda.css
 
 jobs:
-  typecheck-and-docs:
+  typecheck:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ macOS-latest , ubuntu-latest ]
+        agda: [ '2.6.3' ]
     steps:
       - name: Checkout our repository
         uses: actions/checkout@v3
@@ -42,11 +43,11 @@ jobs:
       - name: Install Agda
         uses: wenkokke/setup-agda@v2.0.0
         with:
-          agda-version: '2.6.3'
+          agda-version: ${{ matrix.agda }}
 
       - uses: actions/cache/restore@v3
-        id: agda-typecheck-cache
-        name: Restore main/_build
+        id: cache-agda-formalisation
+        name: Restore Agda formalisation cache
         with:
           path: main/_build
           key: ${{ runner.os }}-agda-typecheck-cache-
@@ -60,22 +61,30 @@ jobs:
         uses: actions/cache/save@v3
         with:
           path: main/_build
-          key: '${{ steps.agda-typecheck-cache.outputs.cache-primary-key }}'
+          key: '${{ steps.cache-agda-formalisation.outputs.cache-primary-key }}'
 
+  docs:
+    runs-on: ubuntu-latest
+    needs: typecheck
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    steps:
       - uses: r-lib/actions/setup-pandoc@v2
-        if: ${{ success() }}
         with:
           pandoc-version: 2.19.2
 
+      - name: Install Agda
+        uses: wenkokke/setup-agda@v2.0.0
+        with:
+          agda-version: ${{ matrix.agda }}
+
       - name: Generate HTML
-        if: ${{ success() }}
         id: gen-html
         run: |
           cd main
           make agda-html
 
       - name: Deploy HTML to github pages
-        if: ${{ success() }} && github.event_name == 'push' && github.ref == 'refs/heads/master' && runner.os == 'Linux'
+        if: ${{ success() }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,8 +50,10 @@ jobs:
         name: Restore Agda formalisation cache
         with:
           path: main/_build
-          key: ${{ runner.os }}-agda-typecheck-cache-hash-${{ hashFiles('main/src/**') }}
-
+          key: ${{ runner.os }}-check-${{ github.ref }}-${{ matrix.agda }}-${{ hashFiles('main/src/**') }}
+          restore-keys: |
+            ${{ runner.os }}-check-${{ github.ref }}-${{ matrix.agda }}-
+            ${{ runner.os }}-check-${{ github.ref }}-
       - name: Typecheck the whole formalisation
         run: |
           cd main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,174 +1,70 @@
-# CI workflow summary:
-# - build: install haskell and agda, and make them available for other jobs
-#   0. Cancel Previous Runs
-#   1. Branch caching
-#   2. Setup Haskell
-#   3. Add .cabal/bin into PATH
-#   4. Checkout Agda repository
-#   5. Install Agda
-# - check: i) use the cache to get haskell and agda.
-#          ii) see if there some cache for typechecking `main/_build` in the branch build.
-#          iii) if so, it tries to check the agda files.
-#   6. Checkout the main repository
-#   7. Verify the whole formalisation
-# - html
-#   8. Setup Pandoc using setup-pandoc
-#   9. Generate HTML
-#   10. Deploy HTML to github pages
-
-name: CI
+name: Agda-Unimath CI
 on:
+  # To run this workflow manually
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: the repository ref to build
+        required: true
+        default: main
+
   push:
-    branches: [ master , develop ]
+    branches:
+      - master
   pull_request:
     branches:
       - master
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
+# Cancel previous runs of the same branch
+concurrency:
+  group: '${{ github.workflow }}-${{ github.head_ref || github.run_id }}'
+  cancel-in-progress: true
+
+env:
+  AGDAHTMLFLAGS: --only-scope-checking --html --html-highlight=code --html-dir=docs --css=docs/Agda.css
 
 jobs:
-  Build:
+  check-ci:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ macOS-latest , ubuntu-latest ]
-        agda: ["v2.6.3"]
-        ghc: ["9.4.4"]
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-      - uses: actions/cache@v2
-        name: Caching
-        id: cache-build
-        env:
-          cache-name: cache-haskell-agda
-        with:
-          path: |
-            ~/.cabal
-            dist-newstyle
-            agda
-          key: ${{ runner.os }}-build-${{ matrix.agda }}-${{ matrix.ghc }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ matrix.agda }}-
-            ${{ runner.os }}-build-
-      - uses: haskell/actions/setup@v1
-        name: Setup Haskell
-        with:
-          ghc-version: ${{ matrix.ghc }}
-
-      - name: Add .cabal/bin into PATH
-        run:
-          echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-        shell: bash
-
-      - uses: actions/checkout@v2
-        name: Checkout Agda repository
-        if: steps.cache-build.outputs.cache-hit != 'true'
-        with:
-          repository: agda/agda
-          path: agda
-          ref: ${{ matrix.agda }}
-
-      - name: Install Agda
-        if: steps.cache-build.outputs.cache-hit != 'true'
-        run: |
-          cd agda
-          touch doc/user-manual.pdf
-          cabal install --overwrite-policy=always --ghc-options='-O2 +RTS -M6G -RTS' -foptimise-heavily
-        shell: bash
-
-  check:
-    needs: build
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ macOS-latest , ubuntu-latest ]
-        agda: ["v2.6.3"]
-        ghc: ["9.4.4"]
-    steps:
-      - uses: actions/cache@v2
-        id: cache-build
-        with:
-          path: |
-            ~/.cabal
-            dist-newstyle
-            agda
-          key: ${{ runner.os }}-build-${{ matrix.agda }}-${{ matrix.ghc }}
-      - name: Add .cabal/bin into PATH
-        run:
-          echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-        shell: bash
-      - name: Checkout the main repository
-        uses: actions/checkout@v2
+      - name: Checkout our repository
+        uses: actions/checkout@v3
         with:
           path: main
-      - uses: actions/cache@v2
-        if: steps.cache-agda-formalisation.outputs.cache-hit != 'true'
-        env:
-          cache-name: cache-agda-formalisation
+      - name: Install Agda
+        uses: wenkokke/setup-agda@v2.0.0
         with:
-          path: main/_build
-          key: ${{ runner.os }}-check-${{ github.ref }}-${{ matrix.agda }}-${{ matrix.ghc }}-${{ hashFiles('main/src/**') }}
-          restore-keys: |
-            ${{ runner.os }}-check-${{ github.ref }}-${{ matrix.agda }}-${{ matrix.ghc }}-
-            ${{ runner.os }}-check-${{ github.ref }}-${{ matrix.agda }}-
-            ${{ runner.os }}-check-${{ github.ref }}-
-      - name: Verify the whole formalisation
-        if: steps.cache-agda-formalisation.cache-hit != 'true'
-        id: typecheck
+          agda-version: '2.6.3'
+
+      - name: Typecheck the whole formalisation
         run: |
           cd main
           make check
 
-  website:
-    needs: check
-    runs-on: macOS-latest
-    if:  ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-    strategy:
-      matrix:
-        agda: ["v2.6.3"]
-        ghc: ["9.4.4"]
-    steps:
-      - name: Checkout the main repository
-        uses: actions/checkout@v2
-        with:
-          path: main
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cabal
-            dist-newstyle
-            agda
-          key: ${{ runner.os }}-build-${{ matrix.agda }}-${{ matrix.ghc }}
-      - name: Add .cabal/bin into PATH
-        run:
-          echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-        shell: bash
-      - uses: actions/cache@v2
-        with:
-          path: main/_build
-          key: ${{ runner.os }}-check-${{ github.ref }}-${{ matrix.agda }}-${{ matrix.ghc }}-${{ hashFiles('main/src/**')}}
-      - uses: r-lib/actions/setup-pandoc@v1
-        with:
-          pandoc-version: '3.0'
-      - run: echo "# Test" | pandoc -t html
-
       - name: Generate HTML
-        id: html
+        if: ${{ success() && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        id: gen-html
         run: |
           cd main
           make agda-html
 
+      - uses: r-lib/actions/setup-pandoc@v2
+        if: ${{ sucess() }}
+        with:
+          pandoc-version: 2.19.2
+
       - name: Deploy HTML to github pages
-        if: steps.html.outputs.cache-hit != 'true'
+        if: steps.gen-html.outputs.exit_status == 0
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: main/docs
           enable_jekyll: true
-
-# References:
-#
-# - fangyi-zhou/setup-agda-action
-# - oisdk/agda-playground/blob/master/.github/workflows/compile.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
           make agda-html
 
       - uses: r-lib/actions/setup-pandoc@v2
-        if: ${{ sucess() }}
+        if: ${{ success() }}
         with:
           pandoc-version: 2.19.2
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: main
-      - name: Install Agda
+      - name: Setup Agda
         uses: wenkokke/setup-agda@v2.0.0
         with:
           agda-version: ${{ matrix.agda }}
@@ -53,7 +53,7 @@ jobs:
           key: ${{ runner.os }}-check-${{ github.ref }}-${{ matrix.agda }}-${{ hashFiles('main/src/**') }}
           restore-keys: |
             ${{ runner.os }}-check-${{ github.ref }}-${{ matrix.agda }}-
-            ${{ runner.os }}-check-${{ github.ref }}-
+            
       - name: Typecheck the whole formalisation
         run: |
           cd main
@@ -74,7 +74,7 @@ jobs:
         with:
           pandoc-version: 2.19.2
 
-      - name: Install Agda
+      - name: Setup Agda
         uses: wenkokke/setup-agda@v2.0.0
         with:
           agda-version: ${{ matrix.agda }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,13 @@ jobs:
         with:
           agda-version: '2.6.3'
 
+      - uses: actions/cache/restore@v3
+        id: agda-typecheck-cache
+        name: Restore main/_build
+        with:
+          path: main/_build
+          key: ${{ runner.os }}-agda-typecheck-cache-
+
       - name: Typecheck the whole formalisation
         run: |
           cd main
@@ -66,5 +73,11 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Save Agda build cache
+        uses: actions/cache/save@v3
+        with:
+          path: main/_build
+          key: '${{ steps.agda-typecheck-cache.outputs.cache-primary-key }}'
           publish_dir: main/docs
           enable_jekyll: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
           pandoc-version: 2.19.2
 
       - name: Deploy HTML to github pages
-        if: steps.gen-html.outputs.exit_status == 0
+        if: ${{ success() }} && runner.os == 'Linux'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
         name: Restore Agda formalisation cache
         with:
           path: main/_build
-          key: ${{ runner.os }}-agda-typecheck-cache-
+          key: ${{ runner.os }}-agda-typecheck-cache-hash-${{ hashFiles('main/src/**') }}
 
       - name: Typecheck the whole formalisation
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ env:
   AGDAHTMLFLAGS: --only-scope-checking --html --html-highlight=code --html-dir=docs --css=docs/Agda.css
 
 jobs:
-  check-ci:
+  typecheck-and-docs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,28 +56,28 @@ jobs:
           cd main
           make check
 
+      - name: Save Agda build cache
+        uses: actions/cache/save@v3
+        with:
+          path: main/_build
+          key: '${{ steps.agda-typecheck-cache.outputs.cache-primary-key }}'
+
       - uses: r-lib/actions/setup-pandoc@v2
         if: ${{ success() }}
         with:
           pandoc-version: 2.19.2
 
       - name: Generate HTML
-        if: ${{ success() && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ success() }}
         id: gen-html
         run: |
           cd main
           make agda-html
 
       - name: Deploy HTML to github pages
-        if: ${{ success() }} && runner.os == 'Linux'
+        if: ${{ success() }} && github.event_name == 'push' && github.ref == 'refs/heads/master' && runner.os == 'Linux'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Save Agda build cache
-        uses: actions/cache/save@v3
-        with:
-          path: main/_build
-          key: '${{ steps.agda-typecheck-cache.outputs.cache-primary-key }}'
           publish_dir: main/docs
           enable_jekyll: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,17 +49,17 @@ jobs:
           cd main
           make check
 
+      - uses: r-lib/actions/setup-pandoc@v2
+        if: ${{ success() }}
+        with:
+          pandoc-version: 2.19.2
+
       - name: Generate HTML
         if: ${{ success() && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         id: gen-html
         run: |
           cd main
           make agda-html
-
-      - uses: r-lib/actions/setup-pandoc@v2
-        if: ${{ success() }}
-        with:
-          pandoc-version: 2.19.2
 
       - name: Deploy HTML to github pages
         if: ${{ success() }} && runner.os == 'Linux'

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ HTMLFILES := $(AGDAFILES:.lagda.md=.html)
 
 bar := $(foreach f,$(AGDAFILES),$(shell wc -l $(f))"\n")
 
-htmlOpts=--html --html-highlight=code --html-dir=docs --css=docs/Agda.css
+htmlOpts?=--html --html-highlight=code --html-dir=docs --css=docs/Agda.css
 AGDA ?=agda -v$(agdaVerbose)
 TIME ?=time
 


### PR DESCRIPTION
I have updated our GitHub CI pipeline by incorporating the latest GitHub Actions. The [setup-agda](https://github.com/wenkokke/setup-agda) action has been added to simplify operations. For the agda formalisation cache, we use the recently added Github restore/save actions. The key to accessing the Agda formalisation cache didn't change, so I expect similar times for type-checking the project once a PR is open. The CI should be much faster with new changes on an open PR.

Hopefully, this change will result in a smoother and more efficient user experience.