### PR TITLE
Deploy gh-pages using Github artifacts and action/deploy-pages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,6 +73,13 @@ jobs:
       matrix:
         agda: [ '2.6.3' ]
     needs: typecheck
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
     steps:
       - name: Checkout our repository
         uses: actions/checkout@v3
@@ -101,11 +108,16 @@ jobs:
         run: |
           cd main
           make agda-html
-
-      - name: Deploy HTML to github pages
+      - name: Setup Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: actions/configure-pages@v3
+        
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: main/docs
-          enable_jekyll: true
+          path: 'main/docs'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
It takes hours to deploy the gh-pages due to the action in use. This Pr proposes to use a different rather faster strategy recently suggested by Github. After merging this, it should take about 10s after generating the HTML files.