### PR TITLE
`.md`-references

### DIFF
--- a/src/elementary-number-theory/integers.lagda.md
+++ b/src/elementary-number-theory/integers.lagda.md
@@ -431,5 +431,5 @@ is-zero-is-zero-neg-ℤ (inr (inl star)) H = refl
 
 ## See also
 
-1. We show in [`structured-types.initial-pointed-type-equipped-with-automorphism`](structured-types.initial-pointed-type-equipped-with-automorphism.html) that ℤ is the initial pointed type equipped with an automorphism.
-2. The group of integers is constructed in [`elementary-number-theory.group-of-integers`](elementary-number-theory.group-of-integers.html).
+1. We show in [`structured-types.initial-pointed-type-equipped-with-automorphism`](structured-types.initial-pointed-type-equipped-with-automorphism.md) that ℤ is the initial pointed type equipped with an automorphism.
+2. The group of integers is constructed in [`elementary-number-theory.group-of-integers`](elementary-number-theory.group-of-integers.md).

--- a/src/foundation-core/coherently-invertible-maps.lagda.md
+++ b/src/foundation-core/coherently-invertible-maps.lagda.md
@@ -134,8 +134,8 @@ module _
 ## See also
 
 - For the notion of biinvertible maps see
-  [`foundation.equivalences`](foundation.equivalences.html).
+  [`foundation.equivalences`](foundation.equivalences.md).
 - For the notion of maps with contractible fibers see
-  [`foundation.contractible-maps`](foundation.contractible-maps.html).
+  [`foundation.contractible-maps`](foundation.contractible-maps.md).
 - For the notion of path-split maps see
-  [`foundation.path-split-maps`](foundation.path-split-maps.html).
+  [`foundation.path-split-maps`](foundation.path-split-maps.md).

--- a/src/foundation-core/contractible-maps.lagda.md
+++ b/src/foundation-core/contractible-maps.lagda.md
@@ -114,8 +114,8 @@ module _
 ## See also
 
 - For the notion of biinvertible maps see
-  [`foundation.equivalences`](foundation.equivalences.html).
+  [`foundation.equivalences`](foundation.equivalences.md).
 - For the notions of inverses and coherently invertible maps, also known as half-adjoint equivalences, see
-  [`foundation.coherently-invertible-maps`](foundation.coherently-invertible-maps.html).
+  [`foundation.coherently-invertible-maps`](foundation.coherently-invertible-maps.md).
 - For the notion of path-split maps see
-  [`foundation.path-split-maps`](foundation.path-split-maps.html).
+  [`foundation.path-split-maps`](foundation.path-split-maps.md).

--- a/src/foundation-core/endomorphisms.lagda.md
+++ b/src/foundation-core/endomorphisms.lagda.md
@@ -58,4 +58,4 @@ pr2 (endo-Truncated-Type k A) = is-trunc-endo k (is-trunc-type-Truncated-Type A)
 ## See also
 
 - For endomorphisms in a category see
-  [`category-theory.endomorphisms-of-objects-categories`](category-theory.endomorphisms-of-objects-categories.html).
+  [`category-theory.endomorphisms-of-objects-categories`](category-theory.endomorphisms-of-objects-categories.md).

--- a/src/foundation-core/equality-cartesian-product-types.lagda.md
+++ b/src/foundation-core/equality-cartesian-product-types.lagda.md
@@ -131,8 +131,8 @@ ap-pr2-eq-pair refl refl = refl
 ## See also
 
 - Equality proofs in dependent pair types are characterized in
-  [`foundation.equality-dependent-pair-types`](foundation.equality-dependent-pair-types.html).
+  [`foundation.equality-dependent-pair-types`](foundation.equality-dependent-pair-types.md).
 - Equality proofs in dependent product types are characterized in
-  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.html).
+  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.md).
 - Equality proofs in coproduct types are characterized in
-  [`foundation.equality-coproduct-types`](foundation.equality-coproduct-types.html).
+  [`foundation.equality-coproduct-types`](foundation.equality-coproduct-types.md).

--- a/src/foundation-core/equality-dependent-pair-types.lagda.md
+++ b/src/foundation-core/equality-dependent-pair-types.lagda.md
@@ -87,8 +87,8 @@ module _
 ## See also
 
 - Equality proofs in cartesian product types are characterized in
-  [`foundation.equality-cartesian-product-types`](foundation.equality-cartesian-product-types.html).
+  [`foundation.equality-cartesian-product-types`](foundation.equality-cartesian-product-types.md).
 - Equality proofs in dependent function types are characterized in
-  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.html).
+  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.md).
 - Equality proofs in the fiber of a map are characterized in
-  [`foundation.equality-fibers-of-maps`](foundation.equality-equality-fibers-of-maps.html).
+  [`foundation.equality-fibers-of-maps`](foundation.equality-equality-fibers-of-maps.md).

--- a/src/foundation-core/equality-fibers-of-maps.lagda.md
+++ b/src/foundation-core/equality-fibers-of-maps.lagda.md
@@ -17,7 +17,7 @@ open import foundation.identity-types
 
 ## Idea
 
-In the file [`foundation-core.fibers-of-maps`](foundation-core.fibers-of-maps.html) we already gave one characterization of the identity type of `fib f b`, for an arbitrary map `f : A → B`. Here we give a second characterization, using the fibers of the action on identifications of `f`.
+In the file [`foundation-core.fibers-of-maps`](foundation-core.fibers-of-maps.md) we already gave one characterization of the identity type of `fib f b`, for an arbitrary map `f : A → B`. Here we give a second characterization, using the fibers of the action on identifications of `f`.
 
 ## Theorem
 
@@ -104,6 +104,6 @@ module _
 ## See also
 
 - Equality proofs in dependent pair types are characterized in
-  [`foundation.equality-dependent-pair-types`](foundation.equality-dependent-pair-types.html).
+  [`foundation.equality-dependent-pair-types`](foundation.equality-dependent-pair-types.md).
 - Equality proofs in dependent function types are characterized in
-  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.html).
+  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.md).

--- a/src/foundation-core/equivalences.lagda.md
+++ b/src/foundation-core/equivalences.lagda.md
@@ -510,8 +510,8 @@ module _
 ## See also
 
 - For the notions of inverses and coherently invertible maps, also known as half-adjoint equivalences, see
-  [`foundation.coherently-invertible-maps`](foundation.coherently-invertible-maps.html).
+  [`foundation.coherently-invertible-maps`](foundation.coherently-invertible-maps.md).
 - For the notion of maps with contractible fibers see
-  [`foundation.contractible-maps`](foundation.contractible-maps.html).
+  [`foundation.contractible-maps`](foundation.contractible-maps.md).
 - For the notion of path-split maps see
-  [`foundation.path-split-maps`](foundation.path-split-maps.html).
+  [`foundation.path-split-maps`](foundation.path-split-maps.md).

--- a/src/foundation-core/function-extensionality.lagda.md
+++ b/src/foundation-core/function-extensionality.lagda.md
@@ -16,7 +16,7 @@ open import foundation-core.universe-levels
 
 The function extensionality axiom asserts that identifications of (dependent) functions are equivalently described as pointwise equalities between them. In other words, a function is completely determined by its values.
 
-In this file, we define the statement of the axiom. The axiom itself is postulated in [`foundation.function-extensionality`](foundation.function-extensionality.html) as `funext`.
+In this file, we define the statement of the axiom. The axiom itself is postulated in [`foundation.function-extensionality`](foundation.function-extensionality.md) as `funext`.
 
 ## Definition
 
@@ -55,6 +55,6 @@ ap-ev a refl = refl
 ## See also
 
 - That the univalence axiom implies function extensionality is proven in
-  [`foundation.univalence-implies-function-extensionality`](foundation.univalence-implies-function-extensionality.html).
+  [`foundation.univalence-implies-function-extensionality`](foundation.univalence-implies-function-extensionality.md).
 - Weak function extensionality is defined in
-  [`foundation.weak-function-extensionality`](foundation.weak-function-extensionality.html).
+  [`foundation.weak-function-extensionality`](foundation.weak-function-extensionality.md).

--- a/src/foundation-core/functoriality-dependent-function-types.lagda.md
+++ b/src/foundation-core/functoriality-dependent-function-types.lagda.md
@@ -157,13 +157,13 @@ pr2 (equiv-precomp-Π e C) =
 ## See also
 
 - Arithmetical laws involving dependent function types are recorded in
-  [`foundation.type-arithmetic-dependent-function-types`](foundation.type-arithmetic-dependent-function-types.html).
+  [`foundation.type-arithmetic-dependent-function-types`](foundation.type-arithmetic-dependent-function-types.md).
 - Equality proofs in dependent function types are characterized in
-  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.html).
+  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.md).
 
 - Functorial properties of function types are recorded in
-  [`foundation.functoriality-function-types`](foundation.functoriality-function-types.html).
+  [`foundation.functoriality-function-types`](foundation.functoriality-function-types.md).
 - Functorial properties of dependent pair types are recorded in
-  [`foundation.functoriality-dependent-pair-types`](foundation.functoriality-dependent-pair-types.html).
+  [`foundation.functoriality-dependent-pair-types`](foundation.functoriality-dependent-pair-types.md).
 - Functorial properties of cartesian product types are recorded in
-  [`foundation.functoriality-cartesian-product-types`](foundation.functoriality-cartesian-product-types.html).
+  [`foundation.functoriality-cartesian-product-types`](foundation.functoriality-cartesian-product-types.md).

--- a/src/foundation-core/functoriality-dependent-pair-types.lagda.md
+++ b/src/foundation-core/functoriality-dependent-pair-types.lagda.md
@@ -401,13 +401,13 @@ module _
 ## See also
 
 - Arithmetical laws involving dependent pair types are recorded in
-  [`foundation.type-arithmetic-dependent-pair-types`](foundation.type-arithmetic-dependent-pair-types.html).
+  [`foundation.type-arithmetic-dependent-pair-types`](foundation.type-arithmetic-dependent-pair-types.md).
 - Equality proofs in dependent pair types are characterized in
-  [`foundation.equality-dependent-pair-types`](foundation.equality-dependent-pair-types.html).
+  [`foundation.equality-dependent-pair-types`](foundation.equality-dependent-pair-types.md).
 - The universal property of dependent pair types is treated in
-  [`foundation.universal-property-dependent-pair-types`](foundation.universal-property-dependent-pair-types.html).
+  [`foundation.universal-property-dependent-pair-types`](foundation.universal-property-dependent-pair-types.md).
 
 - Functorial properties of cartesian product types are recorded in
-  [`foundation.functoriality-cartesian-product-types`](foundation.functoriality-cartesian-product-types.html).
+  [`foundation.functoriality-cartesian-product-types`](foundation.functoriality-cartesian-product-types.md).
 - Functorial properties of dependent product types are recorded in
-  [`foundation.functoriality-dependent-function-types`](foundation.functoriality-dependent-function-types.html).
+  [`foundation.functoriality-dependent-function-types`](foundation.functoriality-dependent-function-types.md).

--- a/src/foundation-core/functoriality-fibers-of-maps.lagda.md
+++ b/src/foundation-core/functoriality-fibers-of-maps.lagda.md
@@ -111,4 +111,4 @@ module _
 ## See also
 
 - Equality proofs in the fiber of a map are characterized in
-  [`foundation.equality-fibers-of-maps`](foundation.equality-fibers-of-maps.html).
+  [`foundation.equality-fibers-of-maps`](foundation.equality-fibers-of-maps.md).

--- a/src/foundation-core/functoriality-function-types.lagda.md
+++ b/src/foundation-core/functoriality-function-types.lagda.md
@@ -99,8 +99,8 @@ pr2 (equiv-postcomp A e) =
 ## See also
 
 - Functorial properties of dependent function types are recorded in
-  [`foundation.functoriality-dependent-function-types`](foundation.functoriality-dependent-function-types.html).
+  [`foundation.functoriality-dependent-function-types`](foundation.functoriality-dependent-function-types.md).
 - Arithmetical laws involving dependent function types are recorded in
-  [`foundation.type-arithmetic-dependent-function-types`](foundation.type-arithmetic-dependent-function-types.html).
+  [`foundation.type-arithmetic-dependent-function-types`](foundation.type-arithmetic-dependent-function-types.md).
 - Equality proofs in dependent function types are characterized in
-  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.html).
+  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.md).

--- a/src/foundation-core/homotopies.lagda.md
+++ b/src/foundation-core/homotopies.lagda.md
@@ -320,6 +320,6 @@ module _
 ## See also
 
 - We postulate that homotopy is equivalent to identity of functions in
-  [`foundation-core.function-extensionality`](foundation-core.function-extensionality.html).
+  [`foundation-core.function-extensionality`](foundation-core.function-extensionality.md).
 - We define an equational reasoning syntax for homotopies in
-  [`foundation.equational-reasoning`](foundation.equational-reasoning.html).
+  [`foundation.equational-reasoning`](foundation.equational-reasoning.md).

--- a/src/foundation-core/path-split-maps.lagda.md
+++ b/src/foundation-core/path-split-maps.lagda.md
@@ -64,8 +64,8 @@ module _
 ## See also
 
 - For the notion of biinvertible maps see
-  [`foundation.equivalences`](foundation.equivalences.html).
+  [`foundation.equivalences`](foundation.equivalences.md).
 - For the notions of inverses and coherently invertible maps, also known as half-adjoint equivalences, see
-  [`foundation.coherently-invertible-maps`](foundation.coherently-invertible-maps.html).
+  [`foundation.coherently-invertible-maps`](foundation.coherently-invertible-maps.md).
 - For the notion of maps with contractible fibers see
-  [`foundation.contractible-maps`](foundation.contractible-maps.html).
+  [`foundation.contractible-maps`](foundation.contractible-maps.md).

--- a/src/foundation-core/type-arithmetic-cartesian-product-types.lagda.md
+++ b/src/foundation-core/type-arithmetic-cartesian-product-types.lagda.md
@@ -115,19 +115,19 @@ module _
 ## See also
 
 - Functorial properties of cartesian products are recorded in
-  [`foundation.functoriality-cartesian-product-types`](foundation.functoriality-cartesian-product-types.html).
+  [`foundation.functoriality-cartesian-product-types`](foundation.functoriality-cartesian-product-types.md).
 - Equality proofs in cartesian product types are characterized in
-  [`foundation.equality-cartesian-product-types`](foundation.equality-cartesian-product-types.html).
+  [`foundation.equality-cartesian-product-types`](foundation.equality-cartesian-product-types.md).
 - The universal property of cartesian product types is treated in
-  [`foundation.universal-property-cartesian-product-types`](foundation.universal-property-cartesian-product-types.html).
+  [`foundation.universal-property-cartesian-product-types`](foundation.universal-property-cartesian-product-types.md).
 
 - Arithmetical laws involving dependent pair types are recorded in
-  [`foundation.type-arithmetic-dependent-pair-types`](foundation.type-arithmetic-dependent-pair-types.html).
+  [`foundation.type-arithmetic-dependent-pair-types`](foundation.type-arithmetic-dependent-pair-types.md).
   - Arithmetical laws involving dependent product types are recorded in
-  [`foundation.type-arithmetic-dependent-function-types`](foundation.type-arithmetic-dependent-function-types.html).
+  [`foundation.type-arithmetic-dependent-function-types`](foundation.type-arithmetic-dependent-function-types.md).
 - Arithmetical laws involving coproduct types are recorded in
-  [`foundation.type-arithmetic-coproduct-types`](foundation.type-arithmetic-coproduct-types.html).
+  [`foundation.type-arithmetic-coproduct-types`](foundation.type-arithmetic-coproduct-types.md).
 - Arithmetical laws involving the unit type are recorded in
-  [`foundation.type-arithmetic-unit-type`](foundation.type-arithmetic-unit-type.html).
+  [`foundation.type-arithmetic-unit-type`](foundation.type-arithmetic-unit-type.md).
 - Arithmetical laws involving the empty type are recorded in
-  [`foundation.type-arithmetic-empty-type`](foundation.type-arithmetic-empty-type.html).
+  [`foundation.type-arithmetic-empty-type`](foundation.type-arithmetic-empty-type.md).

--- a/src/foundation-core/type-arithmetic-dependent-pair-types.lagda.md
+++ b/src/foundation-core/type-arithmetic-dependent-pair-types.lagda.md
@@ -332,19 +332,19 @@ module _
 ## See also
 
 - Functorial properties of dependent pair types are recorded in
-  [`foundation.functoriality-dependent-pair-types`](foundation.functoriality-dependent-pair-types.html).
+  [`foundation.functoriality-dependent-pair-types`](foundation.functoriality-dependent-pair-types.md).
 - Equality proofs in dependent pair types are characterized in
-  [`foundation.equality-dependent-pair-types`](foundation.equality-dependent-pair-types.html).
+  [`foundation.equality-dependent-pair-types`](foundation.equality-dependent-pair-types.md).
 - The universal property of dependent pair types is treated in
-  [`foundation.universal-property-dependent-pair-types`](foundation.universal-property-dependent-pair-types.html).
+  [`foundation.universal-property-dependent-pair-types`](foundation.universal-property-dependent-pair-types.md).
 
 - Arithmetical laws involving cartesian product types are recorded in
-  [`foundation.type-arithmetic-cartesian-product-types`](foundation.type-arithmetic-cartesian-product-types.html).
+  [`foundation.type-arithmetic-cartesian-product-types`](foundation.type-arithmetic-cartesian-product-types.md).
 - Arithmetical laws involving dependent product types are recorded in
-  [`foundation.type-arithmetic-dependent-function-types`](foundation.type-arithmetic-dependent-function-types.html).
+  [`foundation.type-arithmetic-dependent-function-types`](foundation.type-arithmetic-dependent-function-types.md).
 - Arithmetical laws involving coproduct types are recorded in
-  [`foundation.type-arithmetic-coproduct-types`](foundation.type-arithmetic-coproduct-types.html).
+  [`foundation.type-arithmetic-coproduct-types`](foundation.type-arithmetic-coproduct-types.md).
 - Arithmetical laws involving the unit type are recorded in
-  [`foundation.type-arithmetic-unit-type`](foundation.type-arithmetic-unit-type.html).
+  [`foundation.type-arithmetic-unit-type`](foundation.type-arithmetic-unit-type.md).
 - Arithmetical laws involving the empty type are recorded in
-  [`foundation.type-arithmetic-empty-type`](foundation.type-arithmetic-empty-type.html).
+  [`foundation.type-arithmetic-empty-type`](foundation.type-arithmetic-empty-type.md).

--- a/src/foundation-core/univalence.lagda.md
+++ b/src/foundation-core/univalence.lagda.md
@@ -16,7 +16,7 @@ open import foundation-core.universe-levels
 
 The univalence axiom characterizes the identity types of universes. It asserts that the map `Id A B → A ≃ B` is an equivalence.
 
-In this file, we define the statement of the axiom. The axiom itself is postulated in [`foundation.univalence`](foundation.univalence.html) as `univalence`.
+In this file, we define the statement of the axiom. The axiom itself is postulated in [`foundation.univalence`](foundation.univalence.md) as `univalence`.
 
 ## Definition
 

--- a/src/foundation.lagda.md
+++ b/src/foundation.lagda.md
@@ -29,9 +29,11 @@ open import foundation.cantors-diagonal-argument public
 open import foundation.cartesian-product-types public
 open import foundation.choice-of-representatives-equivalence-relation public
 open import foundation.coherently-invertible-maps public
+open import foundation.commuting-3-simplices-of-homotopies public
 open import foundation.commuting-3-simplices public
 open import foundation.commuting-cubes public
 open import foundation.commuting-squares public
+open import foundation.commuting-triangles-of-homotopies public
 open import foundation.commuting-triangles public
 open import foundation.complements public
 open import foundation.complements-subtypes public

--- a/src/foundation/cantor-schroder-bernstein-escardo.lagda.md
+++ b/src/foundation/cantor-schroder-bernstein-escardo.lagda.md
@@ -164,4 +164,4 @@ module _
 
 ## References
 
-[1] The idea and the proof is given by Martin Escardo in his paper ["The Cantor–Schröder–Bernstein Theorem for ∞-groupoids"](https://doi.org/10.1007/s40062-021-00284-6). Also, the proof is formalized in Agda ([Link 1](https://www.cs.bham.ac.uk/~mhe/TypeTopology/CantorSchroederBernstein.html), [Link 2](https://github.com/martinescardo/TypeTopology)). 
+[1] The idea and the proof is given by Martin Escardo in his paper ["The Cantor–Schröder–Bernstein Theorem for ∞-groupoids"](https://doi.org/10.1007/s40062-021-00284-6). Also, the proof is formalized in Agda ([Link 1](https://www.cs.bham.ac.uk/~mhe/TypeTopology/CantorSchroederBernstein.md), [Link 2](https://github.com/martinescardo/TypeTopology)). 

--- a/src/foundation/coherently-invertible-maps.lagda.md
+++ b/src/foundation/coherently-invertible-maps.lagda.md
@@ -118,8 +118,8 @@ abstract
 ## See also
 
 - For the notion of biinvertible maps see
-  [`foundation.equivalences`](foundation.equivalences.html).
+  [`foundation.equivalences`](foundation.equivalences.md).
 - For the notion of maps with contractible fibers see
-  [`foundation.contractible-maps`](foundation.contractible-maps.html).
+  [`foundation.contractible-maps`](foundation.contractible-maps.md).
 - For the notion of path-split maps see
-  [`foundation.path-split-maps`](foundation.path-split-maps.html).
+  [`foundation.path-split-maps`](foundation.path-split-maps.md).

--- a/src/foundation/contractible-maps.lagda.md
+++ b/src/foundation/contractible-maps.lagda.md
@@ -59,8 +59,8 @@ module _
 ## See also
 
 - For the notion of biinvertible maps see
-  [`foundation.equivalences`](foundation.equivalences.html).
+  [`foundation.equivalences`](foundation.equivalences.md).
 - For the notions of inverses and coherently invertible maps, also known as half-adjoint equivalences, see
-  [`foundation.coherently-invertible-maps`](foundation.coherently-invertible-maps.html).
+  [`foundation.coherently-invertible-maps`](foundation.coherently-invertible-maps.md).
 - For the notion of path-split maps see
-  [`foundation.path-split-maps`](foundation.path-split-maps.html).
+  [`foundation.path-split-maps`](foundation.path-split-maps.md).

--- a/src/foundation/endomorphisms.lagda.md
+++ b/src/foundation/endomorphisms.lagda.md
@@ -54,4 +54,4 @@ pr2 (pr2 (pr2 (endo-Monoid A))) f = refl
 ## See also
 
 - For endomorphisms in a category see
-  [`category-theory.endomorphisms-of-objects-categories`](category-theory.endomorphisms-of-objects-categories.html).
+  [`category-theory.endomorphisms-of-objects-categories`](category-theory.endomorphisms-of-objects-categories.md).

--- a/src/foundation/equality-coproduct-types.lagda.md
+++ b/src/foundation/equality-coproduct-types.lagda.md
@@ -322,6 +322,6 @@ pr2 (coprod-Set (pair A is-set-A) (pair B is-set-B)) =
 ## See also
 
 - Equality proofs in coproduct types are characterized in
-  [`foundation.equality-coproduct-types`](foundation.equality-coproduct-types.html).
+  [`foundation.equality-coproduct-types`](foundation.equality-coproduct-types.md).
 - Equality proofs in dependent pair types are characterized in
-  [`foundation.equality-dependent-pair-types`](foundation.equality-dependent-pair-types.html).
+  [`foundation.equality-dependent-pair-types`](foundation.equality-dependent-pair-types.md).

--- a/src/foundation/equality-dependent-function-types.lagda.md
+++ b/src/foundation/equality-dependent-function-types.lagda.md
@@ -68,11 +68,11 @@ module _
 ## See also
 
 - Equality proofs in the fiber of a map are characterized in
-  [`foundation.equality-fibers-of-maps`](foundation.equality-equality-fibers-of-maps.html).
+  [`foundation.equality-fibers-of-maps`](foundation.equality-equality-fibers-of-maps.md).
 - Equality proofs in cartesian product types are characterized in
-  [`foundation.equality-cartesian-product-types`](foundation.equality-cartesian-product-types.html).
+  [`foundation.equality-cartesian-product-types`](foundation.equality-cartesian-product-types.md).
 - Equality proofs in dependent pair types are characterized in
-  [`foundation.equality-dependent-pair-types`](foundation.equality-dependent-pair-types.html).
+  [`foundation.equality-dependent-pair-types`](foundation.equality-dependent-pair-types.md).
 
 - Function extensionality is postulated in
-  [`foundation.function-extensionality`](foundation.function-extensionality.html).
+  [`foundation.function-extensionality`](foundation.function-extensionality.md).

--- a/src/foundation/equality-dependent-pair-types.lagda.md
+++ b/src/foundation/equality-dependent-pair-types.lagda.md
@@ -56,8 +56,8 @@ module _
 ## See also
 
 - Equality proofs in cartesian product types are characterized in
-  [`foundation.equality-cartesian-product-types`](foundation.equality-cartesian-product-types.html).
+  [`foundation.equality-cartesian-product-types`](foundation.equality-cartesian-product-types.md).
 - Equality proofs in dependent function types are characterized in
-  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.html).
+  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.md).
 - Equality proofs in the fiber of a map are characterized in
-  [`foundation.equality-fibers-of-maps`](foundation.equality-equality-fibers-of-maps.html).
+  [`foundation.equality-fibers-of-maps`](foundation.equality-equality-fibers-of-maps.md).

--- a/src/foundation/equivalences.lagda.md
+++ b/src/foundation/equivalences.lagda.md
@@ -506,8 +506,8 @@ equiv-fiberwise-equiv-fam-equiv B C = distributive-Π-Σ
 ## See also
 
 - For the notions of inverses and coherently invertible maps, also known as half-adjoint equivalences, see
-  [`foundation.coherently-invertible-maps`](foundation.coherently-invertible-maps.html).
+  [`foundation.coherently-invertible-maps`](foundation.coherently-invertible-maps.md).
 - For the notion of maps with contractible fibers see
-  [`foundation.contractible-maps`](foundation.contractible-maps.html).
+  [`foundation.contractible-maps`](foundation.contractible-maps.md).
 - For the notion of path-split maps see
-  [`foundation.path-split-maps`](foundation.path-split-maps.html).
+  [`foundation.path-split-maps`](foundation.path-split-maps.md).

--- a/src/foundation/function-extensionality.lagda.md
+++ b/src/foundation/function-extensionality.lagda.md
@@ -17,7 +17,7 @@ open import foundation-core.universe-levels
 
 The function extensionality axiom asserts that identifications of (dependent) functions are equivalently described as pointwise equalities between them. In other words, a function is completely determined by its values.
 
-In this file we postulate the function extensionality axiom. Its statement is defined in [`foundation-core.function-extensionality`](foundation-core.function-extensionality.html).
+In this file we postulate the function extensionality axiom. Its statement is defined in [`foundation-core.function-extensionality`](foundation-core.function-extensionality.md).
 
 ## Postulate
 
@@ -60,6 +60,6 @@ module _
 ## See also
  
 - That the univalence axiom implies function extensionality is proven in
-  [`foundation.univalence-implies-function-extensionality`](foundation.univalence-implies-function-extensionality.html).
+  [`foundation.univalence-implies-function-extensionality`](foundation.univalence-implies-function-extensionality.md).
 - Weak function extensionality is defined in
-  [`foundation.weak-function-extensionality`](foundation.weak-function-extensionality.html).
+  [`foundation.weak-function-extensionality`](foundation.weak-function-extensionality.md).

--- a/src/foundation/functoriality-cartesian-product-types.lagda.md
+++ b/src/foundation/functoriality-cartesian-product-types.lagda.md
@@ -185,15 +185,15 @@ module _
 ## See also
 
 - Arithmetical laws involving cartesian product types are recorded in
-  [`foundation.type-arithmetic-cartesian-product-types`](foundation.type-arithmetic-cartesian-product-types.html).
+  [`foundation.type-arithmetic-cartesian-product-types`](foundation.type-arithmetic-cartesian-product-types.md).
 - Equality proofs in cartesian product types are characterized in
-  [`foundation.equality-cartesian-product-types`](foundation.equality-cartesian-product-types.html).
+  [`foundation.equality-cartesian-product-types`](foundation.equality-cartesian-product-types.md).
 - The universal property of cartesian product types is treated in
-  [`foundation.universal-property-cartesian-product-types`](foundation.universal-property-cartesian-product-types.html).
+  [`foundation.universal-property-cartesian-product-types`](foundation.universal-property-cartesian-product-types.md).
 
 - Functorial properties of dependent pair types are recorded in
-  [`foundation.functoriality-dependent-pair-types`](foundation.functoriality-dependent-pair-types.html).
+  [`foundation.functoriality-dependent-pair-types`](foundation.functoriality-dependent-pair-types.md).
 - Functorial properties of dependent product types are recorded in
-  [`foundation.functoriality-dependent-function-types`](foundation.functoriality-dependent-function-types.html).
+  [`foundation.functoriality-dependent-function-types`](foundation.functoriality-dependent-function-types.md).
 - Functorial properties of coproduct types are recorded in
-  [`foundation.functoriality-coproduct-types`](foundation.functoriality-coproduct-types.html).
+  [`foundation.functoriality-coproduct-types`](foundation.functoriality-coproduct-types.md).

--- a/src/foundation/functoriality-coproduct-types.lagda.md
+++ b/src/foundation/functoriality-coproduct-types.lagda.md
@@ -490,13 +490,13 @@ module _ {i j k l : Level}
 ## See also
 
 - Arithmetical laws involving coproduct types are recorded in
-  [`foundation.type-arithmetic-coproduct-types`](foundation.type-arithmetic-coproduct-types.html).
+  [`foundation.type-arithmetic-coproduct-types`](foundation.type-arithmetic-coproduct-types.md).
 - Equality proofs in coproduct types are characterized in
-  [`foundation.equality-coproduct-types`](foundation.equality-coproduct-types.html).
+  [`foundation.equality-coproduct-types`](foundation.equality-coproduct-types.md).
 - The universal property of coproducts is treated in
-  [`foundation.universal-property-coproduct-types`](foundation.universal-property-coproduct-types.html).
+  [`foundation.universal-property-coproduct-types`](foundation.universal-property-coproduct-types.md).
 
 - Functorial properties of cartesian product types are recorded in
-  [`foundation.functoriality-cartesian-product-types`](foundation.functoriality-cartesian-product-types.html).
+  [`foundation.functoriality-cartesian-product-types`](foundation.functoriality-cartesian-product-types.md).
 - Functorial properties of dependent pair types are recorded in
-  [`foundation.functoriality-dependent-pair-types`](foundation.functoriality-dependent-pair-types.html).
+  [`foundation.functoriality-dependent-pair-types`](foundation.functoriality-dependent-pair-types.md).

--- a/src/foundation/functoriality-dependent-function-types.lagda.md
+++ b/src/foundation/functoriality-dependent-function-types.lagda.md
@@ -305,13 +305,13 @@ is-trunc-map-succ-precomp-Π {k = k} {f = f} {C = C} H =
 ## See also
 
 - Arithmetical laws involving dependent function types are recorded in
-  [`foundation.type-arithmetic-dependent-function-types`](foundation.type-arithmetic-dependent-function-types.html).
+  [`foundation.type-arithmetic-dependent-function-types`](foundation.type-arithmetic-dependent-function-types.md).
 - Equality proofs in dependent function types are characterized in
-  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.html).
+  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.md).
 
 - Functorial properties of function types are recorded in
-  [`foundation.functoriality-function-types`](foundation.functoriality-function-types.html).
+  [`foundation.functoriality-function-types`](foundation.functoriality-function-types.md).
 - Functorial properties of dependent pair types are recorded in
-  [`foundation.functoriality-dependent-pair-types`](foundation.functoriality-dependent-pair-types.html).
+  [`foundation.functoriality-dependent-pair-types`](foundation.functoriality-dependent-pair-types.md).
 - Functorial properties of cartesian product types are recorded in
-  [`foundation.functoriality-cartesian-product-types`](foundation.functoriality-cartesian-product-types.html).
+  [`foundation.functoriality-cartesian-product-types`](foundation.functoriality-cartesian-product-types.md).

--- a/src/foundation/functoriality-dependent-pair-types.lagda.md
+++ b/src/foundation/functoriality-dependent-pair-types.lagda.md
@@ -187,13 +187,13 @@ module _
 ## See also
 
 - Arithmetical laws involving dependent pair types are recorded in
-  [`foundation.type-arithmetic-dependent-pair-types`](foundation.type-arithmetic-dependent-pair-types.html).
+  [`foundation.type-arithmetic-dependent-pair-types`](foundation.type-arithmetic-dependent-pair-types.md).
 - Equality proofs in dependent pair types are characterized in
-  [`foundation.equality-dependent-pair-types`](foundation.equality-dependent-pair-types.html).
+  [`foundation.equality-dependent-pair-types`](foundation.equality-dependent-pair-types.md).
 - The universal property of dependent pair types is treated in
-  [`foundation.universal-property-dependent-pair-types`](foundation.universal-property-dependent-pair-types.html).
+  [`foundation.universal-property-dependent-pair-types`](foundation.universal-property-dependent-pair-types.md).
 
 - Functorial properties of cartesian product types are recorded in
-  [`foundation.functoriality-cartesian-product-types`](foundation.functoriality-cartesian-product-types.html).
+  [`foundation.functoriality-cartesian-product-types`](foundation.functoriality-cartesian-product-types.md).
 - Functorial properties of dependent product types are recorded in
-  [`foundation.functoriality-dependent-function-types`](foundation.functoriality-dependent-function-types.html).
+  [`foundation.functoriality-dependent-function-types`](foundation.functoriality-dependent-function-types.md).

--- a/src/foundation/functoriality-function-types.lagda.md
+++ b/src/foundation/functoriality-function-types.lagda.md
@@ -48,8 +48,8 @@ is-trunc-map-is-trunc-map-postcomp k {X} {Y} f is-trunc-post-f =
 ## See also
 
 - Functorial properties of dependent function types are recorded in
-  [`foundation.functoriality-dependent-function-types`](foundation.functoriality-dependent-function-types.html).
+  [`foundation.functoriality-dependent-function-types`](foundation.functoriality-dependent-function-types.md).
 - Arithmetical laws involving dependent function types are recorded in
-  [`foundation.type-arithmetic-dependent-function-types`](foundation.type-arithmetic-dependent-function-types.html).
+  [`foundation.type-arithmetic-dependent-function-types`](foundation.type-arithmetic-dependent-function-types.md).
 - Equality proofs in dependent function types are characterized in
-  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.html).
+  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.md).

--- a/src/foundation/homotopies.lagda.md
+++ b/src/foundation/homotopies.lagda.md
@@ -21,7 +21,7 @@ open import foundation.identity-types
 
 ## Idea
 
-A homotopy of identifications is a pointwise equality between dependent functions. We defined homotopies in [`foundation-core.homotopies`](foundation-core.homotopies.html). In this file, we record some properties of homotopies that require function extensionality, equivalences, or other.
+A homotopy of identifications is a pointwise equality between dependent functions. We defined homotopies in [`foundation-core.homotopies`](foundation-core.homotopies.md). In this file, we record some properties of homotopies that require function extensionality, equivalences, or other.
 
 ## Properties
 
@@ -278,6 +278,6 @@ module _
 ## See also
 
 - We postulate that homotopy is equivalent to identity of functions in
-  [`foundation-core.function-extensionality`](foundation-core.function-extensionality.html).
+  [`foundation-core.function-extensionality`](foundation-core.function-extensionality.md).
 - We define an equational reasoning syntax for homotopies in
-  [`foundation.equational-reasoning`](foundation.equational-reasoning.html).
+  [`foundation.equational-reasoning`](foundation.equational-reasoning.md).

--- a/src/foundation/inhabited-types.lagda.md
+++ b/src/foundation/inhabited-types.lagda.md
@@ -154,8 +154,8 @@ module _
 ## See also
 
 - The notion of *nonempty types* is treated in
-  [`foundation.empty-types`](foundation.empty-types.html).
+  [`foundation.empty-types`](foundation.empty-types.md).
   In particular, every inhabited type is nonempty.
 
 - For the notion of *pointed types*, see
-  [`structured-types.pointed-types`](structured-types.pointed-types.html).
+  [`structured-types.pointed-types`](structured-types.pointed-types.md).

--- a/src/foundation/path-split-maps.lagda.md
+++ b/src/foundation/path-split-maps.lagda.md
@@ -62,8 +62,8 @@ module _
 ## See also
 
 - For the notion of biinvertible maps see
-  [`foundation.equivalences`](foundation.equivalences.html).
+  [`foundation.equivalences`](foundation.equivalences.md).
 - For the notions of inverses and coherently invertible maps, also known as half-adjoint equivalences, see
-  [`foundation.coherently-invertible-maps`](foundation.coherently-invertible-maps.html).
+  [`foundation.coherently-invertible-maps`](foundation.coherently-invertible-maps.md).
 - For the notion of maps with contractible fibers see
-  [`foundation.contractible-maps`](foundation.contractible-maps.html).
+  [`foundation.contractible-maps`](foundation.contractible-maps.md).

--- a/src/foundation/projective-types.lagda.md
+++ b/src/foundation/projective-types.lagda.md
@@ -61,4 +61,4 @@ is-projective l2 l3 k X =
 
 ## See also
 
-- The natural map `(X → A)/~ → (X → A/R)` was studied in [foundation.exponents-set-quotients](foundation.exponents-set-quotients.html)
+- The natural map `(X → A)/~ → (X → A/R)` was studied in [foundation.exponents-set-quotients](foundation.exponents-set-quotients.md)

--- a/src/foundation/slice.lagda.md
+++ b/src/foundation/slice.lagda.md
@@ -357,8 +357,8 @@ module _
 ## See also
 
 - For the formally dual notion see
-  [`foundation.coslice`](foundation.coslice.html).
+  [`foundation.coslice`](foundation.coslice.md).
 - For slices in the context of category theory see
-  [`category-theory.slice-precategories`](category-theory.slice-precategories.html).
+  [`category-theory.slice-precategories`](category-theory.slice-precategories.md).
 - For fibered maps see
-  [`foundation.fibered-maps`](foundation.fibered-maps.html).
+  [`foundation.fibered-maps`](foundation.fibered-maps.md).

--- a/src/foundation/type-arithmetic-coproduct-types.lagda.md
+++ b/src/foundation/type-arithmetic-coproduct-types.lagda.md
@@ -321,17 +321,17 @@ module _
 
 
 - Functorial properties of coproducts are recorded in
-  [`foundation.functoriality-coproduct-types`](foundation.functoriality-coproduct-types.html).
+  [`foundation.functoriality-coproduct-types`](foundation.functoriality-coproduct-types.md).
 - Equality proofs in coproduct types are characterized in
-  [`foundation.equality-coproduct-types`](foundation.equality-coproduct-types.html).
+  [`foundation.equality-coproduct-types`](foundation.equality-coproduct-types.md).
 - The universal property of coproducts is treated in
-  [`foundation.universal-property-coproduct-types`](foundation.universal-property-coproduct-types.html).
+  [`foundation.universal-property-coproduct-types`](foundation.universal-property-coproduct-types.md).
 
 - Arithmetical laws involving dependent pair types are recorded in
-  [`foundation.type-arithmetic-dependent-pair-types`](foundation.type-arithmetic-dependent-pair-types.html).
+  [`foundation.type-arithmetic-dependent-pair-types`](foundation.type-arithmetic-dependent-pair-types.md).
 - Arithmetical laws involving cartesian-product types are recorded in
-  [`foundation.type-arithmetic-cartesian-product-types`](foundation.type-arithmetic-cartesian-product-types.html).
+  [`foundation.type-arithmetic-cartesian-product-types`](foundation.type-arithmetic-cartesian-product-types.md).
 - Arithmetical laws involving the unit type are recorded in
-  [`foundation.type-arithmetic-unit-type`](foundation.type-arithmetic-unit-type.html).
+  [`foundation.type-arithmetic-unit-type`](foundation.type-arithmetic-unit-type.md).
 - Arithmetical laws involving the empty type are recorded in
-  [`foundation.type-arithmetic-empty-type`](foundation.type-arithmetic-empty-type.html).
+  [`foundation.type-arithmetic-empty-type`](foundation.type-arithmetic-empty-type.md).

--- a/src/foundation/type-arithmetic-dependent-function-types.lagda.md
+++ b/src/foundation/type-arithmetic-dependent-function-types.lagda.md
@@ -36,24 +36,24 @@ module _
 ## See also
 
 - Functorial properties of dependent function types are recorded in
-  [`foundation.functoriality-dependent-function-types`](foundation.functoriality-dependent-function-types.html).
+  [`foundation.functoriality-dependent-function-types`](foundation.functoriality-dependent-function-types.md).
 - Equality proofs in dependent function types are characterized in
-  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.html).
+  [`foundation.equality-dependent-function-types`](foundation.equality-dependent-function-types.md).
 
 - Arithmetical laws involving cartesian product types are recorded in
-  [`foundation.type-arithmetic-cartesian-product-types`](foundation.type-arithmetic-cartesian-product-types.html).
+  [`foundation.type-arithmetic-cartesian-product-types`](foundation.type-arithmetic-cartesian-product-types.md).
 - Arithmetical laws involving dependent pair types are recorded in
-  [`foundation.type-arithmetic-dependent-pair-types`](foundation.type-arithmetic-dependent-pair-types.html).
+  [`foundation.type-arithmetic-dependent-pair-types`](foundation.type-arithmetic-dependent-pair-types.md).
 - Arithmetical laws involving coproduct types are recorded in
-  [`foundation.type-arithmetic-coproduct-types`](foundation.type-arithmetic-coproduct-types.html).
+  [`foundation.type-arithmetic-coproduct-types`](foundation.type-arithmetic-coproduct-types.md).
 - Arithmetical laws involving the unit type are recorded in
-  [`foundation.type-arithmetic-unit-type`](foundation.type-arithmetic-unit-type.html).
+  [`foundation.type-arithmetic-unit-type`](foundation.type-arithmetic-unit-type.md).
 - Arithmetical laws involving the empty type are recorded in
-  [`foundation.type-arithmetic-empty-type`](foundation.type-arithmetic-empty-type.html).
+  [`foundation.type-arithmetic-empty-type`](foundation.type-arithmetic-empty-type.md).
 
-- In [`foundation.universal-property-empty-type`](foundation.universal-property-empty-type.html)
+- In [`foundation.universal-property-empty-type`](foundation.universal-property-empty-type.md)
   we show that `empty` is the initial type, which can be considered a
   *left zero law for function types* (`(empty → A) ≃ unit`).
 - That `unit` is the terminal type is a corollary of `is-contr-Π`, which may be found in
-  [`foundation-core.contractible-types`](foundation-core.contractible-types.html).
+  [`foundation-core.contractible-types`](foundation-core.contractible-types.md).
   This can be considered a *right zero law for function types* (`(A → unit) ≃ unit`).

--- a/src/foundation/type-arithmetic-dependent-pair-types.lagda.md
+++ b/src/foundation/type-arithmetic-dependent-pair-types.lagda.md
@@ -13,19 +13,19 @@ We prove laws for the manipulation of dependent pair types with respect to thems
 ## See also
 
 - Functorial properties of dependent pair types are recorded in
-  [`foundation.functoriality-dependent-pair-types`](foundation.functoriality-dependent-pair-types.html).
+  [`foundation.functoriality-dependent-pair-types`](foundation.functoriality-dependent-pair-types.md).
 - Equality proofs in dependent pair types are characterized in
-  [`foundation.equality-dependent-pair-types`](foundation.equality-dependent-pair-types.html).
+  [`foundation.equality-dependent-pair-types`](foundation.equality-dependent-pair-types.md).
 - The universal property of dependent pair types is treated in
-  [`foundation.universal-property-dependent-pair-types`](foundation.universal-property-dependent-pair-types.html).
+  [`foundation.universal-property-dependent-pair-types`](foundation.universal-property-dependent-pair-types.md).
 
 - Arithmetical laws involving cartesian product types are recorded in
-  [`foundation.type-arithmetic-cartesian-product-types`](foundation.type-arithmetic-cartesian-product-types.html).
+  [`foundation.type-arithmetic-cartesian-product-types`](foundation.type-arithmetic-cartesian-product-types.md).
 - Arithmetical laws involving dependent product types are recorded in
-  [`foundation.type-arithmetic-dependent-function-types`](foundation.type-arithmetic-dependent-function-types.html).
+  [`foundation.type-arithmetic-dependent-function-types`](foundation.type-arithmetic-dependent-function-types.md).
 - Arithmetical laws involving coproduct types are recorded in
-  [`foundation.type-arithmetic-coproduct-types`](foundation.type-arithmetic-coproduct-types.html).
+  [`foundation.type-arithmetic-coproduct-types`](foundation.type-arithmetic-coproduct-types.md).
 - Arithmetical laws involving the unit type are recorded in
-  [`foundation.type-arithmetic-unit-type`](foundation.type-arithmetic-unit-type.html).
+  [`foundation.type-arithmetic-unit-type`](foundation.type-arithmetic-unit-type.md).
 - Arithmetical laws involving the empty type are recorded in
-  [`foundation.type-arithmetic-empty-type`](foundation.type-arithmetic-empty-type.html).
+  [`foundation.type-arithmetic-empty-type`](foundation.type-arithmetic-empty-type.md).

--- a/src/foundation/type-arithmetic-empty-type.lagda.md
+++ b/src/foundation/type-arithmetic-empty-type.lagda.md
@@ -384,6 +384,6 @@ module _
 
 ## See also
 
-- In [`foundation.universal-property-empty-type`](foundation.universal-property-empty-type.html)
+- In [`foundation.universal-property-empty-type`](foundation.universal-property-empty-type.md)
   we show that `empty` is the initial type, which can be considered a
   *left zero law for function types* (`(empty → A) ≃ unit`).

--- a/src/foundation/type-arithmetic-unit-type.lagda.md
+++ b/src/foundation/type-arithmetic-unit-type.lagda.md
@@ -203,5 +203,5 @@ module _
 ## See also
 
 - That `unit` is the terminal type is a corollary of `is-contr-Π`, which may be found in
-  [`foundation-core.contractible-types`](foundation-core.contractible-types.html).
+  [`foundation-core.contractible-types`](foundation-core.contractible-types.md).
   This can be considered a *right zero law for function types* (`(A → unit) ≃ unit`).

--- a/src/foundation/univalence.lagda.md
+++ b/src/foundation/univalence.lagda.md
@@ -21,7 +21,7 @@ open import foundation.equivalences
 
 The univalence axiom characterizes the identity types of universes. It asserts that the map `Id A B → A ≃ B` is an equivalence.
 
-In this file we postulate the univalence axiom. Its statement is defined in [`foundation-core.univalence`](foundation-core.univalence.html).
+In this file we postulate the univalence axiom. Its statement is defined in [`foundation-core.univalence`](foundation-core.univalence.md).
 
 ## Postulates
 

--- a/src/orthogonal-factorization-systems/extensions-of-maps.lagda.md
+++ b/src/orthogonal-factorization-systems/extensions-of-maps.lagda.md
@@ -355,4 +355,4 @@ is-extension-along-self _ = refl-htpy
 
 ## See also
 
-- [`orthogonal-factorization-systems.lifts-of-maps`](orthogonal-factorization-systems.lifts-of-maps.html) for the dual notion.
+- [`orthogonal-factorization-systems.lifts-of-maps`](orthogonal-factorization-systems.lifts-of-maps.md) for the dual notion.

--- a/src/orthogonal-factorization-systems/lifting-operations.lagda.md
+++ b/src/orthogonal-factorization-systems/lifting-operations.lagda.md
@@ -37,7 +37,7 @@ _lifting properties_. However, these are generally additional structure
 on the maps.
 
 For the proof-irrelevant notion see
-[`orthogonal-factorization-systems.mere-lifting-properties`](orthogonal-factorization-systems.mere-lifting-properties.html).
+[`orthogonal-factorization-systems.mere-lifting-properties`](orthogonal-factorization-systems.mere-lifting-properties.md).
 
 ## Definition
 

--- a/src/orthogonal-factorization-systems/lifts-of-maps.lagda.md
+++ b/src/orthogonal-factorization-systems/lifts-of-maps.lagda.md
@@ -273,4 +273,4 @@ module _
 
 ## See also
 
-- [`orthogonal-factorization-systems.extensions-of-maps`](orthogonal-factorization-systems.extensions-of-maps.html) for the dual notion.
+- [`orthogonal-factorization-systems.extensions-of-maps`](orthogonal-factorization-systems.extensions-of-maps.md) for the dual notion.

--- a/src/orthogonal-factorization-systems/mere-lifting-properties.lagda.md
+++ b/src/orthogonal-factorization-systems/mere-lifting-properties.lagda.md
@@ -13,7 +13,7 @@ open import orthogonal-factorization-systems.pullback-hom
 
 ## Idea
 
-Given two maps, `f : A → X` and `g : B → Y`, we say that `f` has the _mere left lifting property_ with respect to `g` and that `g` has the _mere right lifting property_ with respect to `f` if the pullback-hom is surjective. This means that the type of lifting operations between `f` and `g` is merely [inhabited](foundation.inhabited-types.html).
+Given two maps, `f : A → X` and `g : B → Y`, we say that `f` has the _mere left lifting property_ with respect to `g` and that `g` has the _mere right lifting property_ with respect to `f` if the pullback-hom is surjective. This means that the type of lifting operations between `f` and `g` is merely [inhabited](foundation.inhabited-types.md).
 
 ## Definition
 

--- a/src/structured-types/central-h-spaces.lagda.md
+++ b/src/structured-types/central-h-spaces.lagda.md
@@ -11,7 +11,7 @@ open import structured-types.pointed-types
 
 ## Idea
 
-In [`structured-types.coherent-h-spaces`](structured-types.coherent-h-spaces.html) we saw that the type of coherent H-space structures on a pointed type `A` is equivalently described as the type of pointed sections of the pointed evaluation map `(A → A) →* A`. If the type `A` is connected, then the section maps to the connected component of `(A ≃ A)` at the identity equivalence. An evaluative H-space is a pointed type such that the map `ev_pt : (A ≃ A)_{(id)} → A` is an equivalence.
+In [`structured-types.coherent-h-spaces`](structured-types.coherent-h-spaces.md) we saw that the type of coherent H-space structures on a pointed type `A` is equivalently described as the type of pointed sections of the pointed evaluation map `(A → A) →* A`. If the type `A` is connected, then the section maps to the connected component of `(A ≃ A)` at the identity equivalence. An evaluative H-space is a pointed type such that the map `ev_pt : (A ≃ A)_{(id)} → A` is an equivalence.
 
 
 ## Definition

--- a/src/structured-types/pointed-types.lagda.md
+++ b/src/structured-types/pointed-types.lagda.md
@@ -42,7 +42,7 @@ ev-pt-Pointed-Type A f = f (pt-Pointed-Type A)
 ## See also
 
 - The notion of *nonempty types* is treated in
-  [`foundation.empty-types`](foundation.empty-types.html).
+  [`foundation.empty-types`](foundation.empty-types.md).
 
 - The notion of *inhabited types* is treated in
-  [`foundation.inhabited-types`](foundation.inhabited-types.html).
+  [`foundation.inhabited-types`](foundation.inhabited-types.md).

--- a/src/univalent-combinatorics/ferrers-diagrams.lagda.md
+++ b/src/univalent-combinatorics/ferrers-diagrams.lagda.md
@@ -251,4 +251,4 @@ module _
 
 ## See also
 
-- Integer partitions in [`elementary-number-theory.integer-partitions`](elementary-number-theory.integer-partitions.html)
+- Integer partitions in [`elementary-number-theory.integer-partitions`](elementary-number-theory.integer-partitions.md)

--- a/src/univalent-combinatorics/unlabeled-partitions.lagda.md
+++ b/src/univalent-combinatorics/unlabeled-partitions.lagda.md
@@ -6,5 +6,5 @@ module univalent-combinatorics.unlabeled-partitions where
 
 ## Idea
 
-Unlabeled partitions are [Ferrers diagrams](univalent-combinatorics.ferrers-diagrams.html).
+Unlabeled partitions are [Ferrers diagrams](univalent-combinatorics.ferrers-diagrams.md).
 


### PR DESCRIPTION
Change `.html`-references to local files on the documentation pages to using `.md`.
Also add missing indexing to `commuting-3-simplices-of-homotopies` and `commuting-triangles-of-homotopies` in `foundation.lagda.md`.