### PR TITLE
Patch Coherence

### DIFF
--- a/src/synthetic-homotopy-theory/cocones-pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/cocones-pushouts.lagda.md
@@ -56,9 +56,9 @@ module _
   vertical-map-cocone : B → X
   vertical-map-cocone = pr1 (pr2 c)
 
-  coherence-square-maps-comp-horizontalcocone :
+  coherence-square-cocone :
     coherence-square-maps g f vertical-map-cocone horizontal-map-cocone
-  coherence-square-maps-comp-horizontalcocone = pr2 (pr2 c)
+  coherence-square-cocone = pr2 (pr2 c)
 ```
 
 ### Homotopies of cocones
@@ -71,8 +71,8 @@ coherence-htpy-cocone :
   (L : (vertical-map-cocone f g c) ~ (vertical-map-cocone f g c')) →
   UU (l1 ⊔ l4)
 coherence-htpy-cocone f g c c' K L =
-  ((coherence-square-maps-comp-horizontalcocone f g c) ∙h (L ·r g)) ~
-  ((K ·r f) ∙h (coherence-square-maps-comp-horizontalcocone f g c'))
+  ((coherence-square-cocone f g c) ∙h (L ·r g)) ~
+  ((K ·r f) ∙h (coherence-square-cocone f g c'))
 
 htpy-cocone :
   {l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3}
@@ -118,10 +118,10 @@ is-contr-total-htpy-cocone f g c =
       ( is-contr-is-equiv'
         ( Σ ( ( horizontal-map-cocone f g c ∘ f) ~
               ( vertical-map-cocone f g c ∘ g))
-            ( λ H' → coherence-square-maps-comp-horizontalcocone f g c ~ H'))
+            ( λ H' → coherence-square-cocone f g c ~ H'))
         ( tot (λ H' M → right-unit-htpy ∙h M))
         ( is-equiv-tot-is-fiberwise-equiv (λ H' → is-equiv-concat-htpy _ _))
-        ( is-contr-total-htpy (coherence-square-maps-comp-horizontalcocone f g c))))
+        ( is-contr-total-htpy (coherence-square-cocone f g c))))
 
 is-equiv-htpy-cocone-eq :
   {l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3}
@@ -148,7 +148,7 @@ cocone-map :
   cocone f g X → (X → Y) → cocone f g Y
 pr1 (cocone-map f g c h) = h ∘ horizontal-map-cocone f g c
 pr1 (pr2 (cocone-map f g c h)) = h ∘ vertical-map-cocone f g c
-pr2 (pr2 (cocone-map f g c h)) = h ·l coherence-square-maps-comp-horizontalcocone f g c
+pr2 (pr2 (cocone-map f g c h)) = h ·l coherence-square-cocone f g c
 
 cocone-map-id :
   {l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3}
@@ -156,7 +156,7 @@ cocone-map-id :
   Id (cocone-map f g c id) c
 cocone-map-id f g c =
   eq-pair-Σ refl
-    ( eq-pair-Σ refl (eq-htpy (λ s → ap-id (coherence-square-maps-comp-horizontalcocone f g c s))))
+    ( eq-pair-Σ refl (eq-htpy (λ s → ap-id (coherence-square-cocone f g c s))))
 
 cocone-map-comp :
   {l1 l2 l3 l4 l5 l6 : Level} {S : UU l1} {A : UU l2} {B : UU l3}
@@ -182,6 +182,6 @@ pr1 (pr2 (cocone-compose-horizontal f i k c d)) =
   vertical-map-cocone (vertical-map-cocone f i c) k d
 pr2 (pr2 (cocone-compose-horizontal f i k c d)) =
   ( ( horizontal-map-cocone (vertical-map-cocone f i c) k d) ·l
-    ( coherence-square-maps-comp-horizontalcocone f i c)) ∙h
-  ( coherence-square-maps-comp-horizontalcocone (vertical-map-cocone f i c) k d ·r i)
+    ( coherence-square-cocone f i c)) ∙h
+  ( coherence-square-cocone (vertical-map-cocone f i c) k d ·r i)
 ```

--- a/src/synthetic-homotopy-theory/universal-cover-circle.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-cover-circle.lagda.md
@@ -198,14 +198,14 @@ functor-free-dependent-loop l {P} {Q} f =
       ( naturality-tr-fiberwise-transformation f (loop-free-loop l) p₀) ∙
       ( ap (f (base-free-loop l)) α))
 
-coherence-square-maps-comp-horizontalfunctor-free-dependent-loop :
+coherence-square-functor-free-dependent-loop :
   { l1 l2 l3 : Level} {X : UU l1} {P : X → UU l2} {Q : X → UU l3}
   ( f : (x : X) → P x → Q x) {x y : X} (α : Id x y)
   ( h : (x : X) → P x) →
   Id ( ( naturality-tr-fiberwise-transformation f α (h x)) ∙
        ( ap (f y) (apd h α)))
      ( apd (map-Π f h) α)
-coherence-square-maps-comp-horizontalfunctor-free-dependent-loop f refl h = refl
+coherence-square-functor-free-dependent-loop f refl h = refl
   
 square-functor-free-dependent-loop :
   { l1 l2 l3 : Level} {X : UU l1} (l : free-loop X)
@@ -218,7 +218,7 @@ square-functor-free-dependent-loop (pair x l) {P} {Q} f h =
       ( ev-free-loop-Π (pair x l) P h))
     ( ev-free-loop-Π (pair x l) Q (map-Π f h))
     ( pair refl
-      ( right-unit ∙ (coherence-square-maps-comp-horizontalfunctor-free-dependent-loop f l h)))
+      ( right-unit ∙ (coherence-square-functor-free-dependent-loop f l h)))
 
 abstract
   is-equiv-functor-free-dependent-loop-is-fiberwise-equiv :

--- a/src/synthetic-homotopy-theory/universal-property-pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-pushouts.lagda.md
@@ -100,7 +100,7 @@ pr1 (cone-pullback-property-pushout f g {X} c Y) =
 pr1 (pr2 (cone-pullback-property-pushout f g {X} c Y)) =
   precomp (vertical-map-cocone f g c) Y
 pr2 (pr2 (cone-pullback-property-pushout f g {X} c Y)) =
-  htpy-precomp (coherence-square-maps-comp-horizontalcocone f g c) Y
+  htpy-precomp (coherence-square-cocone f g c) Y
 
 pullback-property-pushout :
   {l1 l2 l3 l4 : Level} (l : Level) {S : UU l1} {A : UU l2} {B : UU l3}
@@ -217,7 +217,7 @@ triangle-pullback-property-pushout-universal-property-pushout
   {S = S} {A = A} {B = B} f g c Y h =
     eq-pair-Σ refl
       ( eq-pair-Σ refl
-        ( inv (issec-eq-htpy (h ·l coherence-square-maps-comp-horizontalcocone f g c))))
+        ( inv (issec-eq-htpy (h ·l coherence-square-cocone f g c))))
 
 pullback-property-pushout-universal-property-pushout :
   {l1 l2 l3 l4 : Level} (l : Level) {S : UU l1} {A : UU l2}

--- a/src/univalent-combinatorics/cyclic-types.lagda.md
+++ b/src/univalent-combinatorics/cyclic-types.lagda.md
@@ -140,14 +140,14 @@ module _
   map-equiv-Cyclic-Type e =
     map-equiv-Endo (endo-Cyclic-Type k X) (endo-Cyclic-Type k Y) e
 
-  coherence-square-maps-comp-horizontalequiv-Cyclic-Type :
+  coherence-square-equiv-Cyclic-Type :
     (e : equiv-Cyclic-Type) →
     coherence-square-maps
       ( map-equiv-Cyclic-Type e)
       ( endomorphism-Cyclic-Type k X)
       ( endomorphism-Cyclic-Type k Y)
       ( map-equiv-Cyclic-Type e)
-  coherence-square-maps-comp-horizontalequiv-Cyclic-Type e = pr2 e
+  coherence-square-equiv-Cyclic-Type e = pr2 e
 
 module _
   {l : Level} (k : ℕ) (X : Cyclic-Type l k)
@@ -230,8 +230,8 @@ module _
                   ( endomorphism-Cyclic-Type k Y
                     ( map-equiv-Cyclic-Type k X Y f x))
                   ( ( H (endomorphism-Cyclic-Type k X x)) ∙
-                    ( coherence-square-maps-comp-horizontalequiv-Cyclic-Type k X Y f x))
-                  ( ( coherence-square-maps-comp-horizontalequiv-Cyclic-Type k X Y e x) ∙
+                    ( coherence-square-equiv-Cyclic-Type k X Y f x))
+                  ( ( coherence-square-equiv-Cyclic-Type k X Y e x) ∙
                     ( ap (endomorphism-Cyclic-Type k Y) (H x)))))))
       ( is-contr-total-htpy-equiv-Endo
         ( endo-Cyclic-Type k X)
@@ -443,7 +443,7 @@ isretr-equiv-Eq-Cyclic-Type k e =
     ( compute-map-preserves-succ-map-ℤ-Mod
       ( k)
       ( map-equiv-Cyclic-Type k (ℤ-Mod-Cyclic-Type k) (ℤ-Mod-Cyclic-Type k) e)
-      ( coherence-square-maps-comp-horizontalequiv-Cyclic-Type
+      ( coherence-square-equiv-Cyclic-Type
         ( k)
         ( ℤ-Mod-Cyclic-Type k)
         ( ℤ-Mod-Cyclic-Type k)
@@ -500,7 +500,7 @@ preserves-comp-Eq-equiv-Cyclic-Type k e f =
   inv
   ( compute-map-preserves-succ-map-ℤ-Mod k
     ( map-equiv-Cyclic-Type k (ℤ-Mod-Cyclic-Type k) (ℤ-Mod-Cyclic-Type k) f)
-    ( coherence-square-maps-comp-horizontalequiv-Cyclic-Type k
+    ( coherence-square-equiv-Cyclic-Type k
       ( ℤ-Mod-Cyclic-Type k)
       ( ℤ-Mod-Cyclic-Type k)
       ( f))

--- a/src/univalent-combinatorics/set-quotients-of-index-two.lagda.md
+++ b/src/univalent-combinatorics/set-quotients-of-index-two.lagda.md
@@ -40,13 +40,13 @@ module _
        map-reflecting-map-Eq-Rel R f (h x))
   where
 
-  cases-coherence-square-maps-comp-horizontaleq-one-value-emb-is-set-quotient : is-emb h' →
+  cases-coherence-square-maps-eq-one-value-emb-is-set-quotient : is-emb h' →
     (y : A) (k k' k'' : Fin 2) → 
     map-equiv eA (h' (map-reflecting-map-Eq-Rel R f x)) ＝ k →
     map-equiv eA (h' (map-reflecting-map-Eq-Rel R f y)) ＝ k' →
     map-equiv eA (map-reflecting-map-Eq-Rel R f (h y)) ＝ k'' →
     h' (map-reflecting-map-Eq-Rel R f y) ＝ map-reflecting-map-Eq-Rel R f (h y)
-  cases-coherence-square-maps-comp-horizontaleq-one-value-emb-is-set-quotient H' y
+  cases-coherence-square-maps-eq-one-value-emb-is-set-quotient H' y
     ( inl (inr star)) (inl (inr star)) k'' p q r =
     ( is-injective-map-equiv eA (q ∙ inv p)) ∙
       ( P ∙
@@ -58,7 +58,7 @@ module _
                 ( H' ( map-reflecting-map-Eq-Rel R f x)
                      ( map-reflecting-map-Eq-Rel R f y))
                 ( is-injective-map-equiv eA (p ∙ inv q))))))
-  cases-coherence-square-maps-comp-horizontaleq-one-value-emb-is-set-quotient H' y
+  cases-coherence-square-maps-eq-one-value-emb-is-set-quotient H' y
     ( inl (inr star)) (inr star) (inl (inr star)) p q r =
     ex-falso
       ( neq-inl-inr
@@ -71,13 +71,13 @@ module _
                   ( is-effective-is-set-quotient R QR f Uf (h x) (h y))
                   ( inv P ∙ is-injective-map-equiv eA (p ∙ inv r)))))) ∙
             ( q))))
-  cases-coherence-square-maps-comp-horizontaleq-one-value-emb-is-set-quotient H' y
+  cases-coherence-square-maps-eq-one-value-emb-is-set-quotient H' y
     ( inl (inr star)) (inr star) (inr star) p q r =
     is-injective-map-equiv eA (q ∙ inv r)
-  cases-coherence-square-maps-comp-horizontaleq-one-value-emb-is-set-quotient H' y
+  cases-coherence-square-maps-eq-one-value-emb-is-set-quotient H' y
     ( inr star) (inl (inr star)) (inl (inr star)) p q r = 
     is-injective-map-equiv eA (q ∙ inv r)
-  cases-coherence-square-maps-comp-horizontaleq-one-value-emb-is-set-quotient H' y
+  cases-coherence-square-maps-eq-one-value-emb-is-set-quotient H' y
     ( inr star) (inl (inr star)) (inr star) p q r =
     ex-falso
       ( neq-inr-inl
@@ -90,7 +90,7 @@ module _
                   ( is-effective-is-set-quotient R QR f Uf (h x) (h y))
                   ( inv P ∙ is-injective-map-equiv eA (p ∙ inv r)))))) ∙
             ( q))))
-  cases-coherence-square-maps-comp-horizontaleq-one-value-emb-is-set-quotient H' y
+  cases-coherence-square-maps-eq-one-value-emb-is-set-quotient H' y
     ( inr star) (inr star) k'' p q r =
     ( is-injective-map-equiv eA (q ∙ inv p)) ∙
       ( P ∙
@@ -103,14 +103,14 @@ module _
                      ( map-reflecting-map-Eq-Rel R f y))
                 ( is-injective-map-equiv eA (p ∙ inv q))))))
 
-  coherence-square-maps-comp-horizontaleq-one-value-emb-is-set-quotient : is-emb h' →
+  cases-coherence-square-maps-eq-one-value-emb-is-set-quotient : is-emb h' →
     coherence-square-maps
       ( h)
       ( map-reflecting-map-Eq-Rel R f)
       ( map-reflecting-map-Eq-Rel R f)
       ( h')
-  coherence-square-maps-comp-horizontaleq-one-value-emb-is-set-quotient H' y =
-    cases-coherence-square-maps-comp-horizontaleq-one-value-emb-is-set-quotient H' y
+  cases-coherence-square-maps-eq-one-value-emb-is-set-quotient H' y =
+    cases-coherence-square-maps-eq-one-value-emb-is-set-quotient H' y
       ( map-equiv eA (h' (map-reflecting-map-Eq-Rel R f x)))
       ( map-equiv eA (h' (map-reflecting-map-Eq-Rel R f y)))
       ( map-equiv eA (map-reflecting-map-Eq-Rel R f (h y)))
@@ -126,7 +126,7 @@ module _
       { x =
         pair
           ( pair h' Q)
-          ( coherence-square-maps-comp-horizontaleq-one-value-emb-is-set-quotient
+          ( cases-coherence-square-maps-eq-one-value-emb-is-set-quotient
             ( is-emb-is-equiv Q))}
       { y =
         center

--- a/src/univalent-combinatorics/set-quotients-of-index-two.lagda.md
+++ b/src/univalent-combinatorics/set-quotients-of-index-two.lagda.md
@@ -103,13 +103,13 @@ module _
                      ( map-reflecting-map-Eq-Rel R f y))
                 ( is-injective-map-equiv eA (p ∙ inv q))))))
 
-  cases-coherence-square-maps-eq-one-value-emb-is-set-quotient : is-emb h' →
+  coherence-square-maps-eq-one-value-emb-is-set-quotient : is-emb h' →
     coherence-square-maps
       ( h)
       ( map-reflecting-map-Eq-Rel R f)
       ( map-reflecting-map-Eq-Rel R f)
       ( h')
-  cases-coherence-square-maps-eq-one-value-emb-is-set-quotient H' y =
+  coherence-square-maps-eq-one-value-emb-is-set-quotient H' y =
     cases-coherence-square-maps-eq-one-value-emb-is-set-quotient H' y
       ( map-equiv eA (h' (map-reflecting-map-Eq-Rel R f x)))
       ( map-equiv eA (h' (map-reflecting-map-Eq-Rel R f y)))
@@ -126,7 +126,7 @@ module _
       { x =
         pair
           ( pair h' Q)
-          ( cases-coherence-square-maps-eq-one-value-emb-is-set-quotient
+          ( coherence-square-maps-eq-one-value-emb-is-set-quotient
             ( is-emb-is-equiv Q))}
       { y =
         center


### PR DESCRIPTION
Patches some typing errors that were introduced with #457 due to an ill-formed search-and-replace.