### PR TITLE
Add nix support files

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1676928847,
+        "narHash": "sha256-FIqk+DHRICsWozlOdRxOXO/g9hCqjPYpmr8wQGrpUCA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5ab8b5ae26e6a4b781bdebdfd131c054f0b96e70",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,36 @@
+{
+  description = "agda-unimath";
+
+  inputs = {
+    # Unstable is needed for Agda 2.6.3, latest stable 22.11 only has 2.6.2.2
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          pkgs = nixpkgs.legacyPackages."${system}";
+          agda = pkgs.agda;
+          python = pkgs.python3.withPackages (p: with p; [ requests ]);
+        in
+        {
+          devShells.default = pkgs.mkShell {
+            name = "agda-unimath";
+
+            # Build tools
+            packages = [
+              agda
+              # part of `make check`
+              pkgs.time
+              # update-contributors.py
+              python
+              # working on the website
+              pkgs.mdbook
+            ];
+          };
+
+          devShell = self.devShells."${system}".default;
+        });
+}

--- a/src/HOWTO-INSTALL.lagda.md
+++ b/src/HOWTO-INSTALL.lagda.md
@@ -1,25 +1,54 @@
 # INSTALL
 
 Before you can use the `agda-unimath` library, you should have Agda
-installed on your machine and an editor that is compatible with Agda.
-We recommend `Emacs` and `VSCode`.
+installed on your machine. You can get Agda via following their
+installation instructions, or using the provided Nix flake, if you're using Nix.
+You should also have an editor capable of working with Agda file.
+We recommend either of `Emacs` and `VSCode`.
 
-### Installation guides and tutorials for Agda
+### Installation guides
 
- - Go to the [installation guide](https://agda.readthedocs.io/en/latest/getting-started/installation.html) on the Agda documentation page for instructions to install Agda.
- - Once you have Agda up and running, you can copy our library to your machine using
- ```md
- git clone git@github.com:UniMath/agda-unimath.git
- ```
- - If you're new to Agda, see the [list of tutorials](https://agda.readthedocs.io/en/latest/getting-started/tutorial-list.html) to learn how to use Agda.
+Get a copy of our library on your machine using
+```shell
+git clone git@github.com:UniMath/agda-unimath.git
+```
+then install Agda as described in the next section.
+
+#### Without Nix
+
+Go to the [installation guide](https://agda.readthedocs.io/en/latest/getting-started/installation.html) on the Agda documentation page for instructions to install Agda.
+
+#### With Nix
+
+The library comes with a development shell described in the flake.nix file. To activate the shell, open a terminal in the directory where you cloned the library, and run
+```shell
+nix develop
+```
+Then to make sure that your editor sees the Agda installation,
+start it from within that shell, i.e. run `code` or `emacs` inside the shell.
+
+To make `emacs` use the correct `agda2-mode` provided by the development environment,
+add the following snippet to your `.emacs` file:
+```elisp
+(when (executable-find "agda-mode")
+  (load-file (let ((coding-system-for-read 'utf-8))
+               (shell-command-to-string "agda-mode locate"))))
+```
+which is a modified version of the usual agda2-mode setup provided by Agda,
+except it checks if Agda is available, so that it doesn't cause errors
+when opening Emacs outside the project.
 
 ### Setting up emacs for literate Agda files
 
 The `agda-unimath` library is written in literate markdown agda. This means that all the files in the formalization have the extension `.lagda.md` and they consist of markdown text and `agda` code blocks. For your emacs to handle these files correctly, you need to add the following line to your `.emacs` file:
 
-```md
+```elisp
 (setq auto-mode-alist (cons '("\\.lagda.md$" . agda2-mode) auto-mode-alist))
 ```
+
+### Tutorials for Agda
+
+If you're new to Agda, see the [list of tutorials](https://agda.readthedocs.io/en/latest/getting-started/tutorial-list.html) to learn how to use Agda.
 
 ### Setting up emacs for special symbols
 
@@ -48,7 +77,7 @@ readability, both in your programming environment and on our website.
 Emacs has an option to display a line marking the 80th column.
 This option can be enabled by adding
 
-```md
+```elisp
 (add-hook 'prog-mode-hook #'display-fill-column-indicator-mode)
 ```
 


### PR DESCRIPTION
[Nix](https://nixos.org/) is a build tool/environment manager built with reproducibility and isolation in mind; one of its use cases is for declaratively describing a collection of programs, which should be available for working on a project (a so-called `devShell`).
For `agda-unimath`, this devShell consists of the right version of Agda and some utilities for building the website.

A new nix-enabled developer can then clone the repository, and without fiddling with any Haskell or Agda installation run `nix develop`, which drops them into a shell with all the tools available, and `make check` should just work.

The option of not depending on a system-wide implicit installation of Agda also enables developers to work on multiple projects with different version requirements for tooling.

A good complement for nix is [direnv](https://direnv.net/) - a command line tool which removes the need for manually calling `nix develop`, because when you `cd` into the project's directory (or open the project in an IDE, if it has support for direnv, e.g. see [envrc](https://github.com/purcell/envrc) for Emacs), it automatically loads the environment into the current shell session, restoring the previous state when `cd`ing out.

Further down the line, the flake.nix could provide a recipe for `agda-unimath` (a "derivation" in Nix parlance), so that projects depending on `agda-unimath` using Nix can setup their environment with `pkgs.agda.withPackages [ agda-unimath ]`, but that's out of scope for this PR. For more details on the Agda ecosystem in Nix, see the [Agda section](https://nixos.org/manual/nixpkgs/stable/#agda) in the nixpkgs manual.