### PR TITLE
Remove non-existant reference from SUMMARY

### DIFF
--- a/src/SUMMARY.lagda.md
+++ b/src/SUMMARY.lagda.md
@@ -226,7 +226,7 @@
   - [Commuting 3-simplices of homotopies](foundation.commuting-3-simplices-of-homotopies.md)
   - [Commuting 3-simplices of maps](foundation.commuting-3-simplices-of-maps.md)
   - [Commuting cubes of maps](foundation.commuting-cubes-of-maps.md)
-  - [Commuting squares of identifications](foundation.commuting-squares-of-identifications.md) 
+  - [Commuting squares of identifications](foundation.commuting-squares-of-identifications.md)
   - [Commuting squares of maps](foundation.commuting-squares-of-maps.md)
   - [Commuting triangles of homotopies](foundation.commuting-triangles-of-homotopies.md)
   - [Commuting triangles of maps](foundation.commuting-triangles-of-maps.md)
@@ -517,7 +517,6 @@
   - [Sets](foundation-core.sets.md)
   - [Singleton induction](foundation-core.singleton-induction.md)
   - [Small types](foundation-core.small-types.md)
-  - [Squares of identifications](foundation-core.squares-of-identifications)
   - [Subtype identity principle](foundation-core.subtype-identity-principle.md)
   - [Subtypes](foundation-core.subtypes.md)
   - [Truncated maps](foundation-core.truncated-maps.md)
@@ -923,7 +922,7 @@
   - [W-type of natural numbers](trees.w-type-of-natural-numbers.md)
   - [W-type of propositions](trees.w-type-of-propositions.md)
   - [W-types](trees.w-types.md)
-  
+
 
 - [Type theories](type-theories.md)
   - [Comprehension type theories](type-theories.comprehension-type-theories.md)


### PR DESCRIPTION
`foundation-core.squares-of-identifications` was a leftover from a
previous PR, it was moved to
`foundation.commuting-squares-of-identifications`.

Currently, clicking on "Foundation core" in the sidebar on the website shows "Squares of identifications", and also highlights that section in the sidebar, but its empty.
Removing the incorrect reference at least show an empty page with the title "Foundation core" and correctly highlights it in the sidebar.

Should there also be a file `src/foundation-core.lagda.md` with a summary of `foundation-core`?