### PR TITLE
Higher modalities

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -767,6 +767,7 @@
   - [Modal operators](orthogonal-factorization-systems.modal-operators.md)
   - [Orthogonal maps](orthogonal-factorization-systems.orthogonal-maps.md)
   - [Pullback-hom](orthogonal-factorization-systems.pullback-hom.md)
+  - [Uniquely eliminating modalities](orthogonal-factorization-systems.uniquely-eliminating-modalities.md)
 
 - [Polytopes](polytopes.md)
   - [Abstract polytopes](polytopes.abstract-polytopes.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -768,6 +768,7 @@
   - [Modal operators](orthogonal-factorization-systems.modal-operators.md)
   - [Orthogonal maps](orthogonal-factorization-systems.orthogonal-maps.md)
   - [Pullback-hom](orthogonal-factorization-systems.pullback-hom.md)
+  - [Reflective subuniverses](orthogonal-factorization-systems.reflective-subuniverses.md)
   - [Uniquely eliminating modalities](orthogonal-factorization-systems.uniquely-eliminating-modalities.md)
 
 - [Polytopes](polytopes.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -759,6 +759,7 @@
 
 - [Orthogonal factorization systems](orthogonal-factorization-systems.md)
   - [Extensions of maps](orthogonal-factorization-systems.extensions-of-maps.md)
+  - [Higher modalities](orthogonal-factorization-systems.higher-modalities.md)
   - [Lifting operations](orthogonal-factorization-systems.lifting-operations.md)
   - [Lifting squares](orthogonal-factorization-systems.lifting-squares.md)
   - [Lifts of maps](orthogonal-factorization-systems.lifts-of-maps.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -764,6 +764,7 @@
   - [Lifts of maps](orthogonal-factorization-systems.lifts-of-maps.md)
   - [Local types](orthogonal-factorization-systems.local-types.md)
   - [Mere lifting properties](orthogonal-factorization-systems.mere-lifting-properties.md)
+  - [Modal operators](orthogonal-factorization-systems.modal-operators.md)
   - [Orthogonal maps](orthogonal-factorization-systems.orthogonal-maps.md)
   - [Pullback-hom](orthogonal-factorization-systems.pullback-hom.md)
 

--- a/src/orthogonal-factorization-systems.lagda.md
+++ b/src/orthogonal-factorization-systems.lagda.md
@@ -12,4 +12,5 @@ open import orthogonal-factorization-systems.mere-lifting-properties public
 open import orthogonal-factorization-systems.modal-operators public
 open import orthogonal-factorization-systems.orthogonal-maps public
 open import orthogonal-factorization-systems.pullback-hom public
+open import orthogonal-factorization-systems.uniquely-eliminating-modalities public
 ```

--- a/src/orthogonal-factorization-systems.lagda.md
+++ b/src/orthogonal-factorization-systems.lagda.md
@@ -9,6 +9,7 @@ open import orthogonal-factorization-systems.lifting-squares public
 open import orthogonal-factorization-systems.lifts-of-maps public
 open import orthogonal-factorization-systems.local-types public
 open import orthogonal-factorization-systems.mere-lifting-properties public
+open import orthogonal-factorization-systems.modal-operators public
 open import orthogonal-factorization-systems.orthogonal-maps public
 open import orthogonal-factorization-systems.pullback-hom public
 ```

--- a/src/orthogonal-factorization-systems.lagda.md
+++ b/src/orthogonal-factorization-systems.lagda.md
@@ -4,6 +4,7 @@
 module orthogonal-factorization-systems where
 
 open import orthogonal-factorization-systems.extensions-of-maps public
+open import orthogonal-factorization-systems.higher-modalities public
 open import orthogonal-factorization-systems.lifting-operations public
 open import orthogonal-factorization-systems.lifting-squares public
 open import orthogonal-factorization-systems.lifts-of-maps public

--- a/src/orthogonal-factorization-systems.lagda.md
+++ b/src/orthogonal-factorization-systems.lagda.md
@@ -13,5 +13,6 @@ open import orthogonal-factorization-systems.mere-lifting-properties public
 open import orthogonal-factorization-systems.modal-operators public
 open import orthogonal-factorization-systems.orthogonal-maps public
 open import orthogonal-factorization-systems.pullback-hom public
+open import orthogonal-factorization-systems.reflective-subuniverses public
 open import orthogonal-factorization-systems.uniquely-eliminating-modalities public
 ```

--- a/src/orthogonal-factorization-systems/higher-modalities.lagda.md
+++ b/src/orthogonal-factorization-systems/higher-modalities.lagda.md
@@ -1,0 +1,313 @@
+# Higher modalities
+
+<details><summary>Imports</summary>
+```agda
+module orthogonal-factorization-systems.higher-modalities where
+
+open import foundation.cartesian-product-types
+open import foundation.dependent-pair-types
+open import foundation.equational-reasoning
+open import foundation.equivalences
+open import foundation.function-extensionality
+open import foundation.functions
+open import foundation.homotopies
+open import foundation.identity-types
+open import foundation.propositions
+open import foundation.propositions
+open import foundation.sections
+open import foundation.small-types
+open import foundation.subuniverses
+open import foundation.universe-levels
+
+open import orthogonal-factorization-systems.modal-operators
+open import orthogonal-factorization-systems.uniquely-eliminating-modalities
+```
+</details>
+
+## Idea
+
+## Definition
+
+### The universal property of higher modalities
+
+```agda
+module _
+  {l1 l2 : Level}
+  {○ : modal-operator l1 l2}
+  (unit-○ : modal-unit ○)
+  where
+
+  modal-ind : UU (lsuc l1 ⊔ l2)
+  modal-ind =
+    (X : UU l1) (P : ○ X → UU l1) →
+    ((x : X) → ○ (P (unit-○ x))) →
+    (x' : ○ X) → ○ (P x')
+
+  modal-rec : UU (lsuc l1 ⊔ l2)
+  modal-rec = (X Y : UU l1) → (X → ○ Y) → ○ X → ○ Y
+
+  modal-comp : modal-ind → UU (lsuc l1 ⊔ l2)
+  modal-comp ind-○ = 
+    (X : UU l1) (P : ○ X → UU l1) →
+    (f : (x : X) → ○ (P (unit-○ x))) →
+    (x : X) → ind-○ X P f (unit-○ x) ＝ f x
+
+  modal-universal-property : UU (lsuc l1 ⊔ l2)
+  modal-universal-property =
+    Σ modal-ind modal-comp
+
+  modal-rec-modal-ind : modal-ind → modal-rec
+  modal-rec-modal-ind ind X Y = ind X (λ _ → Y)
+```
+
+### Closure under identity type formers
+
+We say that the identity types of a locally small type are modal if their
+small equivalent is modal.
+We say that a modality is closed under identity type formation if for every
+modal type, their identity types are also modal.
+
+
+```agda
+module _
+  {l1 l2 : Level}
+  ((○ , is-locally-small-○) : locally-small-modal-operator l1 l2 l1)
+  (unit-○ : modal-unit ○)
+  where
+
+  is-modal-identity-types : UU (lsuc l1 ⊔ l2)
+  is-modal-identity-types =
+    (X : UU l1) (x y : ○ X) →
+    is-modal (unit-○) (type-is-small (is-locally-small-○ X x y))
+```
+
+### The `is-higher-modality` predicate
+
+```agda
+  is-higher-modality : UU (lsuc l1 ⊔ l2)
+  is-higher-modality =
+    modal-universal-property (unit-○) × is-modal-identity-types
+```
+
+### Projections for the `is-higher-modality` predicate
+
+```agda
+  modal-ind-is-higher-modality : is-higher-modality → modal-ind unit-○
+  modal-ind-is-higher-modality = pr1 ∘ pr1
+
+  modal-rec-is-higher-modality : is-higher-modality → modal-rec unit-○
+  modal-rec-is-higher-modality =
+    modal-rec-modal-ind unit-○ ∘ modal-ind-is-higher-modality
+
+  modal-comp-is-higher-modality :
+    (h : is-higher-modality) →
+    modal-comp unit-○ (modal-ind-is-higher-modality h)
+  modal-comp-is-higher-modality = pr2 ∘ pr1
+
+  is-modal-identity-types-is-higher-modality :
+    is-higher-modality → is-modal-identity-types
+  is-modal-identity-types-is-higher-modality = pr2
+```
+
+### The structure of a higher modality
+
+```agda
+higher-modality : (l1 l2 : Level) → UU (lsuc l1 ⊔ lsuc l2)
+higher-modality l1 l2 =
+  Σ ( locally-small-modal-operator l1 l2 l1)
+    ( λ ○ →
+      Σ ( modal-unit (pr1 ○))
+        ( is-higher-modality ○))
+```
+
+### Projections for `higher-modality`
+
+```agda
+module _
+  {l1 l2 : Level} (h : higher-modality l1 l2)
+    where
+
+  locally-small-modal-operator-higher-modality :
+    locally-small-modal-operator l1 l2 l1
+  locally-small-modal-operator-higher-modality = pr1 h
+
+  modal-operator-higher-modality : modal-operator l1 l2
+  modal-operator-higher-modality =
+    modal-operator-locally-small-modal-operator
+      ( locally-small-modal-operator-higher-modality)
+
+  is-locally-small-modal-operator-higher-modality :
+    is-locally-small-modal-operator (modal-operator-higher-modality)
+  is-locally-small-modal-operator-higher-modality =
+    is-locally-small-locally-small-modal-operator
+      ( locally-small-modal-operator-higher-modality)
+
+  modal-unit-higher-modality :
+    modal-unit (modal-operator-higher-modality)
+  modal-unit-higher-modality = pr1 (pr2 h)
+
+  is-higher-modality-higher-modality :
+    is-higher-modality
+      ( locally-small-modal-operator-higher-modality)
+      ( modal-unit-higher-modality)
+  is-higher-modality-higher-modality = pr2 (pr2 h)
+
+  modal-ind-higher-modality :
+    modal-ind (modal-unit-higher-modality)
+  modal-ind-higher-modality =
+    modal-ind-is-higher-modality
+      ( locally-small-modal-operator-higher-modality)
+      ( modal-unit-higher-modality)
+      ( is-higher-modality-higher-modality)
+
+  modal-rec-higher-modality :
+    modal-rec (modal-unit-higher-modality)
+  modal-rec-higher-modality =
+    modal-rec-modal-ind
+      ( modal-unit-higher-modality)
+      ( modal-ind-higher-modality)
+
+  modal-comp-higher-modality :
+    modal-comp
+      ( modal-unit-higher-modality)
+      ( modal-ind-higher-modality)
+  modal-comp-higher-modality =
+    modal-comp-is-higher-modality
+      ( locally-small-modal-operator-higher-modality)
+      ( modal-unit-higher-modality)
+      ( is-higher-modality-higher-modality)
+
+  is-modal-identity-types-higher-modality :
+    is-modal-identity-types
+      ( locally-small-modal-operator-higher-modality)
+      ( modal-unit-higher-modality)
+  is-modal-identity-types-higher-modality =
+    ( is-modal-identity-types-is-higher-modality)
+    ( locally-small-modal-operator-higher-modality)
+    ( modal-unit-higher-modality)
+    ( is-higher-modality-higher-modality)
+```
+
+## Properties
+
+### The modal operator's action on maps
+
+```agda
+module _
+  {l : Level}
+  {○ : modal-operator l l} (unit-○ : modal-unit ○)
+  where
+
+  map-modal-rec : (rec-○ : modal-rec unit-○) {X Y : UU l} → (X → Y) → ○ X → ○ Y
+  map-modal-rec rec-○ {X} {Y} f = rec-○ X Y (unit-○ ∘ f)
+```
+
+### Modal identity elimination
+
+```agda
+module _
+  {l1 l2 : Level}
+  ((○ , is-locally-small-○) : locally-small-modal-operator l1 l2 l1)
+  (unit-○ : modal-unit ○)
+  (Id-○ : is-modal-identity-types (○ , is-locally-small-○) unit-○)
+  where
+
+  id-elim-higher-modality :
+    {X : UU l1} {x' y' : ○ X} →
+    ○ (type-is-small (is-locally-small-○ X x' y')) → x' ＝ y'
+  id-elim-higher-modality {X} {x'} {y'} =
+    map-inv-unit-is-modal-is-small unit-○
+      ( x' ＝ y')
+      ( is-locally-small-○ X x' y')
+      ( Id-○ X x' y')
+```
+
+Homogenous higher modalities are closed under identity formation in the usual sense
+
+```agda
+module _
+  {l : Level}
+  (((○ , is-locally-small-○) , unit-○ , (ind-○ , comp-○) , Id-○) : higher-modality l l)
+  where
+
+  map-inv-unit-id-higher-modality :
+    {X : UU l} {x' y' : ○ X} → ○ (x' ＝ y') → x' ＝ y'
+  map-inv-unit-id-higher-modality {X} {x'} {y'} =
+    map-inv-unit-is-modal-is-small unit-○
+      ( x' ＝ y')
+      ( is-locally-small-○ X x' y')
+      ( Id-○ X x' y') ∘
+      ( map-modal-rec unit-○
+        ( modal-rec-modal-ind unit-○ ind-○)
+        ( map-equiv-is-small ( is-locally-small-○ X x' y')))
+```
+
+### `○ X` is modal
+
+```agda
+module _
+  {l : Level}
+  (((○ , is-locally-small-○) , unit-○ , (ind-○ , comp-○) , Id-○) : higher-modality l l)
+  (X : UU l)
+  where
+
+  map-inv-modal-unit : ○ (○ X) → ○ X
+  map-inv-modal-unit = ind-○ (○ X) (λ _ → X) id
+
+  isretr-map-inv-modal-unit : (map-inv-modal-unit ∘ unit-○) ~ id
+  isretr-map-inv-modal-unit = comp-○ (○ X) (λ _ → X) id
+
+  issec-map-inv-modal-unit : (unit-○ ∘ map-inv-modal-unit) ~ id
+  issec-map-inv-modal-unit x'' =
+    map-inv-unit-id-higher-modality
+      ( (○ , is-locally-small-○) , unit-○ , (ind-○ , comp-○) , Id-○)
+      ( ind-○ (○ X)
+        ( λ x'' → unit-○ (map-inv-modal-unit x'') ＝ x'')
+        ( unit-○ ∘ (ap unit-○ ∘ isretr-map-inv-modal-unit)) x'')
+
+  is-modal-○ : is-modal unit-○ (○ X)
+  pr1 (pr1 is-modal-○) = map-inv-modal-unit
+  pr2 (pr1 is-modal-○) = issec-map-inv-modal-unit
+  pr1 (pr2 is-modal-○) = map-inv-modal-unit
+  pr2 (pr2 is-modal-○) = isretr-map-inv-modal-unit
+```
+
+## Higher modalities are uniquely eliminating modalities
+
+```agda
+module _
+  {l : Level}
+  (((○ , is-locally-small-○) , unit-○ , (ind-○ , comp-○) , Id-○) : higher-modality l l)
+  where
+
+  isretr-modal-ind :
+    {X : UU l} {P : ○ X → UU l} → (precomp-Π unit-○ (○ ∘ P) ∘ ind-○ X P) ~ id
+  isretr-modal-ind {X} {P} = eq-htpy ∘ comp-○ X P
+
+  issec-modal-ind :
+    {X : UU l} {P : ○ X → UU l} → (ind-○ X P ∘ precomp-Π unit-○ (○ ∘ P)) ~ id
+  issec-modal-ind {X} {P} s =
+    eq-htpy
+      ( map-inv-unit-id-higher-modality
+        ( (○ , is-locally-small-○) , unit-○ , (ind-○ , comp-○) , Id-○) ∘
+        ( ind-○ X
+          ( λ x' → (ind-○ X P ∘ precomp-Π (unit-○) (○ ∘ P)) s x' ＝ s x')
+          ( unit-○ ∘ comp-○ X P (s ∘ unit-○))))
+
+  is-equiv-modal-ind : (X : UU l) (P : ○ X → UU l) → is-equiv (ind-○ X P)
+  pr1 (pr1 (is-equiv-modal-ind X P)) = precomp-Π unit-○ (○ ∘ P)
+  pr2 (pr1 (is-equiv-modal-ind X P)) = issec-modal-ind
+  pr1 (pr2 (is-equiv-modal-ind X P)) = precomp-Π unit-○ (○ ∘ P)
+  pr2 (pr2 (is-equiv-modal-ind X P)) = isretr-modal-ind
+
+  equiv-modal-ind :
+    (X : UU l) (P : ○ X → UU l) →
+    ((x : X) → ○ (P (unit-○ x))) ≃ ((x' : ○ X) → ○ (P x'))
+  pr1 (equiv-modal-ind X P) = ind-○ X P
+  pr2 (equiv-modal-ind X P) = is-equiv-modal-ind X P
+
+  is-uniquely-eliminating-modality-higher-modality :
+    is-uniquely-eliminating-modality unit-○
+  is-uniquely-eliminating-modality-higher-modality X P =
+    is-equiv-map-inv-is-equiv (is-equiv-modal-ind X P)
+```

--- a/src/orthogonal-factorization-systems/modal-operators.lagda.md
+++ b/src/orthogonal-factorization-systems/modal-operators.lagda.md
@@ -1,0 +1,141 @@
+# Modal operators
+
+<details><summary>Imports</summary>
+```agda
+module orthogonal-factorization-systems.modal-operators where
+
+open import foundation.dependent-pair-types
+open import foundation.equivalences
+open import foundation.functions
+open import foundation.locally-small-types
+open import foundation.propositions
+open import foundation.subuniverses
+open import foundation.small-types
+open import foundation.universe-levels
+```
+</details>
+
+## Idea
+
+## Definitions
+
+```agda
+modal-operator : (l1 l2 : Level) → UU (lsuc l1 ⊔ lsuc l2)
+modal-operator l1 l2 = UU l1 → UU l2
+
+modal-unit : {l1 l2 : Level} → modal-operator l1 l2 → UU (lsuc l1 ⊔ l2)
+modal-unit {l1} ○ = {X : UU l1} → X → ○ X
+```
+
+## The subuniverse of modal types
+
+```agda
+module _
+  {l1 l2 : Level} {○ : modal-operator l1 l2} (unit-○ : modal-unit ○)
+  where
+
+  is-modal : (X : UU l1) → UU (l1 ⊔ l2)
+  is-modal X = is-equiv (unit-○ {X})
+
+  modal-types : UU (lsuc l1 ⊔ l2)
+  modal-types = Σ (UU l1) (is-modal)
+
+  is-property-is-modal : (X : UU l1) → is-prop (is-modal X)
+  is-property-is-modal X = is-property-is-equiv (unit-○ {X})
+
+  is-modal-Prop : (X : UU l1) → Prop (l1 ⊔ l2)
+  pr1 (is-modal-Prop X) = is-modal X
+  pr2 (is-modal-Prop X) = is-property-is-modal X
+
+  is-subuniverse-is-modal : is-subuniverse is-modal
+  is-subuniverse-is-modal = is-property-is-modal
+
+  modal-types-subuniverse : subuniverse l1 (l1 ⊔ l2)
+  modal-types-subuniverse = is-modal-Prop
+```
+
+## Modal small types
+
+A small type is said to be modal if its small equivalent is modal.
+
+```agda
+module _
+  {l1 l2 l3 : Level} {○ : modal-operator l1 l2} (unit-○ : modal-unit ○)
+  (X : UU l3) (is-small-X : is-small l1 X)
+  where
+
+  is-modal-is-small : UU (l1 ⊔ l2)
+  is-modal-is-small = is-modal unit-○ (type-is-small is-small-X)
+
+  is-equiv-unit-is-modal-is-small :
+    is-modal-is-small →
+    is-equiv (unit-○ ∘ map-equiv-is-small is-small-X)
+  is-equiv-unit-is-modal-is-small =
+    is-equiv-comp _ _ (is-equiv-map-equiv (equiv-is-small is-small-X))
+
+  equiv-unit-is-modal-is-small :
+    is-modal-is-small → X ≃ ○ (type-is-small is-small-X)
+  pr1 (equiv-unit-is-modal-is-small m) = unit-○ ∘ map-equiv-is-small is-small-X
+  pr2 (equiv-unit-is-modal-is-small m) = is-equiv-unit-is-modal-is-small m
+
+  map-inv-unit-is-modal-is-small :
+    is-modal-is-small → ○ (type-is-small is-small-X) → X
+  map-inv-unit-is-modal-is-small =
+    map-inv-equiv ∘ equiv-unit-is-modal-is-small
+
+module _
+  {l1 l2 l3 : Level} {○ : modal-operator l1 l2} (unit-○ : modal-unit ○)
+  (X : Small-Type l1 l3)
+  where
+
+  is-modal-small-type : UU (l1 ⊔ l2)
+  is-modal-small-type =
+    is-modal-is-small unit-○ (type-Small-Type X) (is-small-type-Small-Type X)
+
+  is-equiv-unit-is-modal-small-type :
+    is-modal-small-type →
+    is-equiv (unit-○ ∘ map-equiv (equiv-is-small-type-Small-Type X))
+  is-equiv-unit-is-modal-small-type =
+    is-equiv-unit-is-modal-is-small unit-○
+      ( type-Small-Type X)
+      ( is-small-type-Small-Type X)
+
+  equiv-unit-is-modal-small-type :
+    is-modal-small-type → type-Small-Type X ≃ ○ (small-type-Small-Type X)
+  equiv-unit-is-modal-small-type =
+    equiv-unit-is-modal-is-small unit-○
+      ( type-Small-Type X)
+      ( is-small-type-Small-Type X)
+
+  map-inv-unit-is-modal-small-type :
+    is-modal-small-type → ○ (small-type-Small-Type X) → type-Small-Type X
+  map-inv-unit-is-modal-small-type =
+    map-inv-equiv ∘ equiv-unit-is-modal-small-type
+```
+
+## Locally small modal operators
+
+We say a modal operator is _locally small_ if it maps small types to
+locally small types.
+
+```agda
+is-locally-small-modal-operator :
+  {l1 l2 l3 : Level} (○ : modal-operator l1 l2) → UU (lsuc l1 ⊔ l2 ⊔ lsuc l3)
+is-locally-small-modal-operator {l1} {l2} {l3} ○ =
+  (X : UU l1) → is-locally-small l3 (○ X)
+
+locally-small-modal-operator :
+  (l1 l2 l3 : Level) → UU (lsuc l1 ⊔ lsuc l2 ⊔ lsuc l3)
+locally-small-modal-operator l1 l2 l3 =
+  Σ (modal-operator l1 l2) (is-locally-small-modal-operator {l1} {l2} {l3})
+
+modal-operator-locally-small-modal-operator :
+  {l1 l2 l3 : Level} →
+  locally-small-modal-operator l1 l2 l3 → modal-operator l1 l2
+modal-operator-locally-small-modal-operator = pr1
+
+is-locally-small-locally-small-modal-operator :
+  {l1 l2 l3 : Level} (○ : locally-small-modal-operator l1 l2 l3) →
+  is-locally-small-modal-operator (modal-operator-locally-small-modal-operator ○)
+is-locally-small-locally-small-modal-operator = pr2
+```

--- a/src/orthogonal-factorization-systems/modal-operators.lagda.md
+++ b/src/orthogonal-factorization-systems/modal-operators.lagda.md
@@ -139,3 +139,15 @@ is-locally-small-locally-small-modal-operator :
   is-locally-small-modal-operator (modal-operator-locally-small-modal-operator ○)
 is-locally-small-locally-small-modal-operator = pr2
 ```
+
+## Σ-closed modal operators
+
+We say a modal operator `○` is Σ-closed if for every type `X` such that for
+every term of `○ X` and for every family `P` over `X` equipped with a section
+of `○ ∘ P`, there is also a term of `○ (Σ X P)`.
+
+```agda
+is-Σ-closed-modal-operator : {l1 l2 : Level} (○ : modal-operator l1 l2) → UU (lsuc l1 ⊔ l2)
+is-Σ-closed-modal-operator {l1} ○ =
+  (X : UU l1) → ○ X → (P : X → UU l1) → ((x : X) → ○ (P x)) → ○ (Σ X P)
+```

--- a/src/orthogonal-factorization-systems/reflective-subuniverses.lagda.md
+++ b/src/orthogonal-factorization-systems/reflective-subuniverses.lagda.md
@@ -1,0 +1,56 @@
+# Reflective subuniverses
+
+<details><summary>Imports</summary>
+```agda
+module orthogonal-factorization-systems.reflective-subuniverses where
+
+open import foundation.cartesian-product-types
+open import foundation.dependent-pair-types
+open import foundation.equivalences
+open import foundation.functions
+open import foundation.propositions
+open import foundation.raising-universe-levels
+open import foundation.universe-levels
+
+open import orthogonal-factorization-systems.local-types
+open import orthogonal-factorization-systems.modal-operators
+```
+</details>
+
+## Idea
+
+## Definition
+
+```agda
+module _
+  {l1 l2 l3 : Level} {○ : modal-operator (l1 ⊔ l2) l1} (unit-○ : modal-unit ○)
+  (is-modal' : UU (l1 ⊔ l2) → Prop l3)
+  where
+
+  is-reflective-subuniverse : UU (lsuc l1 ⊔ lsuc l2 ⊔ l3)
+  is-reflective-subuniverse =
+    ( (X : UU (l1 ⊔ l2)) → type-Prop (is-modal' (raise (l1 ⊔ l2) (○ X)))) ×
+    ( (X : UU (l1 ⊔ l2)) → type-Prop (is-modal' X) →
+      (Y : UU (l1 ⊔ l2)) → is-local-type (unit-○ {Y}) X)
+
+reflective-subuniverse : (l1 l2 l3 : Level) → UU (lsuc l1 ⊔ lsuc l2 ⊔ lsuc l3)
+reflective-subuniverse l1 l2 l3 =
+  Σ ( modal-operator (l1 ⊔ l2) l1)
+    ( λ ○ →
+      Σ ( modal-unit ○)
+        ( λ unit-○ →
+          Σ ( UU (l1 ⊔ l2) → Prop l3)
+            ( is-reflective-subuniverse {l1} {l2} {l3} unit-○)))
+
+is-Σ-closed-reflective-subuniverse :
+  {l1 l2 l3 : Level}
+  (U : reflective-subuniverse l1 l2 l3) → UU (lsuc l1 ⊔ lsuc l2 ⊔ l3)
+is-Σ-closed-reflective-subuniverse (○ , unit-○ , is-modal' , _) =
+  is-Σ-closed-modal-operator (type-Prop ∘ is-modal')
+
+Σ-closed-reflective-subuniverse :
+  (l1 l2 l3 : Level) → UU (lsuc l1 ⊔ lsuc l2 ⊔ lsuc l3)
+Σ-closed-reflective-subuniverse l1 l2 l3 =
+  Σ ( reflective-subuniverse l1 l2 l3)
+    ( is-Σ-closed-reflective-subuniverse {l1} {l2} {l3})
+```

--- a/src/orthogonal-factorization-systems/uniquely-eliminating-modalities.lagda.md
+++ b/src/orthogonal-factorization-systems/uniquely-eliminating-modalities.lagda.md
@@ -1,0 +1,72 @@
+# Uniquely eliminating modalities
+
+<details><summary>Imports</summary>
+```agda
+module orthogonal-factorization-systems.uniquely-eliminating-modalities where
+
+open import foundation.dependent-pair-types
+open import foundation.equivalences
+open import foundation.function-extensionality
+open import foundation.functions
+open import foundation.homotopies
+open import foundation.identity-types
+open import foundation.universe-levels
+
+open import orthogonal-factorization-systems.local-types
+open import orthogonal-factorization-systems.modal-operators
+```
+</details>
+
+## Idea
+
+## Definition
+
+```agda
+is-uniquely-eliminating-modality :
+  {l1 l2 : Level} {○ : modal-operator l1 l2} → modal-unit ○ → UU (lsuc l1 ⊔ l2)
+is-uniquely-eliminating-modality {l1} {l2} {○} unit-○ =
+  (X : UU l1) (P : ○ X → UU l1) → is-local-family (unit-○) (○ ∘ P)
+
+uniquely-eliminating-modality : (l1 l2 : Level) → UU (lsuc l1 ⊔ lsuc l2)
+uniquely-eliminating-modality l1 l2 =
+  Σ ( modal-operator l1 l2)
+    ( λ ○ →
+      Σ ( modal-unit ○)
+        ( is-uniquely-eliminating-modality))
+```
+
+### Projections for uniquely eliminating modalities
+
+```agda
+module _
+  {l1 l2 : Level} {○ : modal-operator l1 l2} {unit-○ : modal-unit ○}
+  (is-uem-○ : is-uniquely-eliminating-modality unit-○)
+  where
+
+  modal-ind-is-uniquely-eliminating-modality :
+    (X : UU l1) (P : ○ X → UU l1) →
+    ((x : X) → ○ (P (unit-○ x))) → (x' : ○ X) → ○ (P x')
+  modal-ind-is-uniquely-eliminating-modality X P =
+    map-inv-is-equiv (is-uem-○ X P)
+
+  modal-comp-is-uniquely-eliminating-modality :
+    (X : UU l1) (P : ○ X → UU l1) (f : (x : X) → ○ (P (unit-○ x))) →
+    (pr1 (pr1 (is-uem-○ X P)) f ∘ unit-○) ~ f
+  modal-comp-is-uniquely-eliminating-modality X P =
+    htpy-eq ∘ pr2 (pr1 (is-uem-○ X P))
+
+module _
+  {l1 l2 : Level}
+  ((○ , unit-○ , is-uem-○) : uniquely-eliminating-modality l1 l2)
+  where
+
+  modal-operator-uniquely-eliminating-modality : modal-operator l1 l2
+  modal-operator-uniquely-eliminating-modality = ○
+
+  modal-unit-uniquely-eliminating-modality : modal-unit ○
+  modal-unit-uniquely-eliminating-modality = unit-○
+
+  is-uniquely-eliminating-modality-uniquely-eliminating-modality :
+    is-uniquely-eliminating-modality unit-○
+  is-uniquely-eliminating-modality-uniquely-eliminating-modality = is-uem-○
+```


### PR DESCRIPTION
Defines
- Modal operators and units
- Reflective subuniverses
- Uniquely eliminating modalities
- Higher modalities

Proves that higher modalities are uniquely eliminating and that types of the form `○ X` are modal when `○` is a higher modality.