### PR TITLE
Unsort the autosorted public imports in `foundation`

### DIFF
--- a/src/finite-group-theory/cartier-delooping-sign-homomorphism.lagda.md
+++ b/src/finite-group-theory/cartier-delooping-sign-homomorphism.lagda.md
@@ -1,8 +1,11 @@
 # Cartier's delooping of the sign homomorphism
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --lossy-unification #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module finite-group-theory.cartier-delooping-sign-homomorphism where
 open import elementary-number-theory.natural-numbers
 open import finite-group-theory.delooping-sign-homomorphism

--- a/src/finite-group-theory/delooping-sign-homomorphism.lagda.md
+++ b/src/finite-group-theory/delooping-sign-homomorphism.lagda.md
@@ -1,8 +1,11 @@
 # Deloopings of the sign homomorphism
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --lossy-unification #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module finite-group-theory.delooping-sign-homomorphism where
 open import elementary-number-theory.inequality-natural-numbers
 open import elementary-number-theory.natural-numbers

--- a/src/finite-group-theory/finite-type-groups.lagda.md
+++ b/src/finite-group-theory/finite-type-groups.lagda.md
@@ -1,8 +1,11 @@
 # The group of n-element types
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --lossy-unification #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module finite-group-theory.finite-type-groups where
 open import elementary-number-theory.natural-numbers
 open import foundation.0-connected-types

--- a/src/finite-group-theory/groups-of-order-2.lagda.md
+++ b/src/finite-group-theory/groups-of-order-2.lagda.md
@@ -1,8 +1,11 @@
 # Groups of order 2
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --lossy-unification #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module finite-group-theory.groups-of-order-2 where
 open import elementary-number-theory.groups-of-modular-arithmetic
 open import finite-group-theory.finite-groups

--- a/src/finite-group-theory/orbits-permutations.lagda.md
+++ b/src/finite-group-theory/orbits-permutations.lagda.md
@@ -1,8 +1,11 @@
 # Orbits of permutations
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --lossy-unification #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module finite-group-theory.orbits-permutations where
 open import elementary-number-theory.addition-natural-numbers
 open import elementary-number-theory.decidable-types

--- a/src/finite-group-theory/permutations.lagda.md
+++ b/src/finite-group-theory/permutations.lagda.md
@@ -1,8 +1,11 @@
 # Permutations
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --lossy-unification #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module finite-group-theory.permutations where
 open import elementary-number-theory.modular-arithmetic-standard-finite-types
 open import elementary-number-theory.natural-numbers

--- a/src/finite-group-theory/simpson-delooping-sign-homomorphism.lagda.md
+++ b/src/finite-group-theory/simpson-delooping-sign-homomorphism.lagda.md
@@ -1,8 +1,11 @@
 # Simpson's delooping of the sign homomorphism
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --lossy-unification #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module finite-group-theory.simpson-delooping-sign-homomorphism where
 open import elementary-number-theory.addition-natural-numbers
 open import elementary-number-theory.congruence-natural-numbers

--- a/src/foundation-core/cartesian-product-types.lagda.md
+++ b/src/foundation-core/cartesian-product-types.lagda.md
@@ -1,8 +1,11 @@
 # Cartesian product types
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --safe #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation-core.cartesian-product-types where
 open import foundation-core.dependent-pair-types
 open import foundation-core.universe-levels

--- a/src/foundation-core/coherently-invertible-maps.lagda.md
+++ b/src/foundation-core/coherently-invertible-maps.lagda.md
@@ -1,8 +1,11 @@
 # Coherently invertible maps
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --safe #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation-core.coherently-invertible-maps where
 open import foundation-core.cartesian-product-types
 open import foundation-core.dependent-pair-types

--- a/src/foundation-core/commuting-3-simplices-of-homotopies.lagda.md
+++ b/src/foundation-core/commuting-3-simplices-of-homotopies.lagda.md
@@ -1,8 +1,11 @@
 # Commuting 3-simplices of homotopies
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --safe #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation-core.commuting-3-simplices-of-homotopies where
 open import foundation-core.commuting-triangles-of-homotopies
 open import foundation-core.homotopies

--- a/src/foundation-core/commuting-3-simplices-of-maps.lagda.md
+++ b/src/foundation-core/commuting-3-simplices-of-maps.lagda.md
@@ -1,8 +1,11 @@
 # Commuting 3-simplices of maps
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --safe #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation-core.commuting-3-simplices-of-maps where
 open import foundation-core.commuting-triangles-of-maps
 open import foundation-core.homotopies

--- a/src/foundation-core/commuting-squares-of-maps.lagda.md
+++ b/src/foundation-core/commuting-squares-of-maps.lagda.md
@@ -1,8 +1,11 @@
 # Commuting squares of maps
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --safe #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation-core.commuting-squares-of-maps where
 open import foundation-core.functions
 open import foundation-core.homotopies

--- a/src/foundation-core/commuting-triangles-of-homotopies.lagda.md
+++ b/src/foundation-core/commuting-triangles-of-homotopies.lagda.md
@@ -1,8 +1,11 @@
 # Commuting triangles of homotopies
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --safe #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation-core.commuting-triangles-of-homotopies where
 open import foundation-core.functions
 open import foundation-core.homotopies

--- a/src/foundation-core/commuting-triangles-of-maps.lagda.md
+++ b/src/foundation-core/commuting-triangles-of-maps.lagda.md
@@ -1,8 +1,11 @@
 # Commuting triangles of maps
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --safe #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation-core.commuting-triangles-of-maps where
 open import foundation-core.functions
 open import foundation-core.homotopies

--- a/src/foundation-core/constant-maps.lagda.md
+++ b/src/foundation-core/constant-maps.lagda.md
@@ -1,8 +1,11 @@
 # Constant maps
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --safe #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation-core.constant-maps where
 open import foundation-core.universe-levels
 ```

--- a/src/foundation-core/coproduct-types.lagda.md
+++ b/src/foundation-core/coproduct-types.lagda.md
@@ -1,8 +1,11 @@
 # Coproduct types
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --safe #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation-core.coproduct-types where
 open import foundation.universe-levels
 ```

--- a/src/foundation-core/dependent-pair-types.lagda.md
+++ b/src/foundation-core/dependent-pair-types.lagda.md
@@ -1,8 +1,11 @@
 # Dependent pair types
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --safe #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation-core.dependent-pair-types where
 open import foundation-core.universe-levels
 ```

--- a/src/foundation-core/embeddings.lagda.md
+++ b/src/foundation-core/embeddings.lagda.md
@@ -1,8 +1,11 @@
 # Embeddings
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --safe #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation-core.embeddings where
 open import foundation-core.dependent-pair-types
 open import foundation-core.equivalences

--- a/src/foundation-core/equality-cartesian-product-types.lagda.md
+++ b/src/foundation-core/equality-cartesian-product-types.lagda.md
@@ -1,8 +1,11 @@
 # Equality of cartesian product types
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --safe #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation-core.equality-cartesian-product-types where
 open import foundation-core.cartesian-product-types
 open import foundation-core.dependent-pair-types

--- a/src/foundation-core/equality-dependent-pair-types.lagda.md
+++ b/src/foundation-core/equality-dependent-pair-types.lagda.md
@@ -1,8 +1,11 @@
 # Equality of dependent pair types
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --safe #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation-core.equality-dependent-pair-types where
 open import foundation-core.dependent-pair-types
 open import foundation-core.equivalences

--- a/src/foundation-core/equivalences.lagda.md
+++ b/src/foundation-core/equivalences.lagda.md
@@ -1,8 +1,11 @@
 # Equivalences
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --safe #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation-core.equivalences where
 open import foundation-core.cartesian-product-types
 open import foundation-core.coherently-invertible-maps

--- a/src/foundation-core/function-extensionality.lagda.md
+++ b/src/foundation-core/function-extensionality.lagda.md
@@ -1,8 +1,11 @@
 # Function extensionality
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --safe #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation-core.function-extensionality where
 open import foundation-core.equivalences
 open import foundation-core.functions

--- a/src/foundation-core/functions.lagda.md
+++ b/src/foundation-core/functions.lagda.md
@@ -1,8 +1,11 @@
 # Functions
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --safe #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation-core.functions where
 open import foundation-core.universe-levels
 ```

--- a/src/foundation-core/homotopies.lagda.md
+++ b/src/foundation-core/homotopies.lagda.md
@@ -1,8 +1,11 @@
 # Homotopies
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --safe #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation-core.homotopies where
 open import foundation-core.functions
 open import foundation-core.identity-types

--- a/src/foundation-core/identity-types.lagda.md
+++ b/src/foundation-core/identity-types.lagda.md
@@ -1,8 +1,11 @@
 # Identity types
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --safe #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation-core.identity-types where
 open import foundation-core.constant-maps
 open import foundation-core.dependent-pair-types

--- a/src/foundation-core/morphisms-cospans.lagda.md
+++ b/src/foundation-core/morphisms-cospans.lagda.md
@@ -1,8 +1,11 @@
 # Morphisms of cospans
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --safe #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation-core.morphisms-cospans where
 open import foundation-core.cartesian-product-types
 open import foundation-core.dependent-pair-types

--- a/src/foundation-core/retractions.lagda.md
+++ b/src/foundation-core/retractions.lagda.md
@@ -1,8 +1,11 @@
 # Retractions
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --safe #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation-core.retractions where
 open import foundation-core.dependent-pair-types
 open import foundation-core.functions

--- a/src/foundation-core/sections.lagda.md
+++ b/src/foundation-core/sections.lagda.md
@@ -1,8 +1,11 @@
 # Sections
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --safe #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation-core.sections where
 open import foundation-core.dependent-pair-types
 open import foundation-core.functions

--- a/src/foundation-core/truncation-levels.lagda.md
+++ b/src/foundation-core/truncation-levels.lagda.md
@@ -1,8 +1,11 @@
 # Truncation levels
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --safe #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation-core.truncation-levels where
 open import foundation-core.universe-levels
 ```

--- a/src/foundation/binary-functoriality-set-quotients.lagda.md
+++ b/src/foundation/binary-functoriality-set-quotients.lagda.md
@@ -1,8 +1,11 @@
 # Binary functoriality of set quotients
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --lossy-unification #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation.binary-functoriality-set-quotients where
 open import foundation.binary-homotopies
 open import foundation.binary-reflecting-maps-equivalence-relations

--- a/src/foundation/commuting-squares-of-identifications.lagda.md
+++ b/src/foundation/commuting-squares-of-identifications.lagda.md
@@ -1,8 +1,11 @@
 # Commuting squares of identifications
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --safe #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation.commuting-squares-of-identifications where
 open import foundation-core.functions
 open import foundation-core.identity-types

--- a/src/foundation/constant-maps.lagda.md
+++ b/src/foundation/constant-maps.lagda.md
@@ -3,9 +3,9 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.constant-maps where
+open import foundation-core.constant-maps public
 open import foundation-core.0-maps
 open import foundation-core.1-types
-open import foundation-core.constant-maps public
 open import foundation-core.contractible-maps
 open import foundation-core.dependent-pair-types
 open import foundation-core.equivalences

--- a/src/foundation/contractible-types.lagda.md
+++ b/src/foundation/contractible-types.lagda.md
@@ -3,9 +3,9 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.contractible-types where
+open import foundation-core.contractible-types public
 open import foundation-core.constant-maps
 open import foundation-core.contractible-maps
-open import foundation-core.contractible-types public
 open import foundation-core.dependent-pair-types
 open import foundation-core.equivalences
 open import foundation-core.functions

--- a/src/foundation/diagonal-maps-of-types.lagda.md
+++ b/src/foundation/diagonal-maps-of-types.lagda.md
@@ -3,12 +3,12 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.diagonal-maps-of-types where
+open import foundation-core.diagonal-maps-of-types public
 open import foundation-core.0-maps
 open import foundation-core.1-types
 open import foundation-core.cartesian-product-types
 open import foundation-core.contractible-maps
 open import foundation-core.dependent-pair-types
-open import foundation-core.diagonal-maps-of-types public
 open import foundation-core.embeddings
 open import foundation-core.faithful-maps
 open import foundation-core.fibers-of-maps

--- a/src/foundation/embeddings.lagda.md
+++ b/src/foundation/embeddings.lagda.md
@@ -3,10 +3,10 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.embeddings where
+open import foundation-core.embeddings public
 open import foundation-core.cartesian-product-types
 open import foundation-core.cones-pullbacks
 open import foundation-core.dependent-pair-types
-open import foundation-core.embeddings public
 open import foundation-core.functions
 open import foundation-core.functoriality-dependent-pair-types
 open import foundation-core.fundamental-theorem-of-identity-types

--- a/src/foundation/empty-types.lagda.md
+++ b/src/foundation/empty-types.lagda.md
@@ -3,8 +3,8 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.empty-types where
-open import foundation-core.dependent-pair-types
 open import foundation-core.empty-types public
+open import foundation-core.dependent-pair-types
 open import foundation-core.functions
 open import foundation-core.homotopies
 open import foundation-core.sets

--- a/src/foundation/equality-dependent-pair-types.lagda.md
+++ b/src/foundation/equality-dependent-pair-types.lagda.md
@@ -3,8 +3,8 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.equality-dependent-pair-types where
-open import foundation-core.dependent-pair-types
 open import foundation-core.equality-dependent-pair-types public
+open import foundation-core.dependent-pair-types
 open import foundation-core.functions
 open import foundation-core.homotopies
 open import foundation-core.universe-levels

--- a/src/foundation/equivalences.lagda.md
+++ b/src/foundation/equivalences.lagda.md
@@ -3,13 +3,13 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.equivalences where
+open import foundation-core.equivalences public
 open import foundation-core.cones-pullbacks
 open import foundation-core.contractible-maps
 open import foundation-core.contractible-types
 open import foundation-core.dependent-pair-types
 open import foundation-core.embeddings
 open import foundation-core.equality-dependent-pair-types
-open import foundation-core.equivalences public
 open import foundation-core.fibers-of-maps
 open import foundation-core.functions
 open import foundation-core.functoriality-dependent-function-types

--- a/src/foundation/exponents-set-quotients.lagda.md
+++ b/src/foundation/exponents-set-quotients.lagda.md
@@ -1,8 +1,11 @@
 # Exponents of set quotients
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --lossy-unification #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation.exponents-set-quotients where
 open import foundation.binary-relations
 open import foundation.commuting-triangles-of-maps

--- a/src/foundation/fibers-of-maps.lagda.md
+++ b/src/foundation/fibers-of-maps.lagda.md
@@ -3,10 +3,10 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.fibers-of-maps where
+open import foundation-core.fibers-of-maps public
 open import foundation-core.cones-pullbacks
 open import foundation-core.constant-maps
 open import foundation-core.dependent-pair-types
-open import foundation-core.fibers-of-maps public
 open import foundation-core.functions
 open import foundation-core.functoriality-dependent-pair-types
 open import foundation-core.homotopies

--- a/src/foundation/function-extensionality.lagda.md
+++ b/src/foundation/function-extensionality.lagda.md
@@ -3,9 +3,9 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.function-extensionality where
+open import foundation-core.function-extensionality public
 open import foundation-core.dependent-pair-types
 open import foundation-core.equivalences
-open import foundation-core.function-extensionality public
 open import foundation-core.functions
 open import foundation-core.homotopies
 open import foundation-core.identity-types

--- a/src/foundation/functions.lagda.md
+++ b/src/foundation/functions.lagda.md
@@ -6,6 +6,4 @@
 module foundation.functions where
 
 open import foundation-core.functions public
-
-open import foundation.universe-levels
 ```

--- a/src/foundation/functoriality-dependent-function-types.lagda.md
+++ b/src/foundation/functoriality-dependent-function-types.lagda.md
@@ -3,13 +3,13 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.functoriality-dependent-function-types where
+open import foundation-core.functoriality-dependent-function-types public
 open import foundation-core.commuting-squares-of-maps
 open import foundation-core.constant-maps
 open import foundation-core.dependent-pair-types
 open import foundation-core.embeddings
 open import foundation-core.fibers-of-maps
 open import foundation-core.functions
-open import foundation-core.functoriality-dependent-function-types public
 open import foundation-core.functoriality-dependent-pair-types
 open import foundation-core.homotopies
 open import foundation-core.propositional-maps

--- a/src/foundation/functoriality-dependent-pair-types.lagda.md
+++ b/src/foundation/functoriality-dependent-pair-types.lagda.md
@@ -3,12 +3,12 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.functoriality-dependent-pair-types where
+open import foundation-core.functoriality-dependent-pair-types public
 open import foundation-core.cones-pullbacks
 open import foundation-core.dependent-pair-types
 open import foundation-core.equality-dependent-pair-types
 open import foundation-core.equivalences
 open import foundation-core.functions
-open import foundation-core.functoriality-dependent-pair-types public
 open import foundation-core.homotopies
 open import foundation-core.identity-types
 open import foundation-core.pullbacks

--- a/src/foundation/functoriality-function-types.lagda.md
+++ b/src/foundation/functoriality-function-types.lagda.md
@@ -3,10 +3,10 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.functoriality-function-types where
+open import foundation-core.functoriality-function-types public
 open import foundation-core.contractible-maps
 open import foundation-core.equivalences
 open import foundation-core.function-extensionality
-open import foundation-core.functoriality-function-types public
 open import foundation-core.truncated-maps
 open import foundation-core.truncation-levels
 open import foundation.constant-maps

--- a/src/foundation/functoriality-set-quotients.lagda.md
+++ b/src/foundation/functoriality-set-quotients.lagda.md
@@ -1,8 +1,11 @@
 # Functoriality of set quotients
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --lossy-unification #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation.functoriality-set-quotients where
 open import foundation-core.equivalence-relations
 open import foundation.commuting-squares-of-maps

--- a/src/foundation/homotopies.lagda.md
+++ b/src/foundation/homotopies.lagda.md
@@ -3,13 +3,13 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.homotopies where
+open import foundation-core.homotopies public
 open import foundation-core.contractible-types
 open import foundation-core.dependent-pair-types
 open import foundation-core.equivalences
 open import foundation-core.functions
 open import foundation-core.functoriality-dependent-function-types
 open import foundation-core.functoriality-dependent-pair-types
-open import foundation-core.homotopies public
 open import foundation-core.identity-systems
 open import foundation-core.sections
 open import foundation-core.universe-levels

--- a/src/foundation/identity-types.lagda.md
+++ b/src/foundation/identity-types.lagda.md
@@ -3,10 +3,10 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.identity-types where
+open import foundation-core.identity-types public
 open import foundation-core.equivalences
 open import foundation-core.functions
 open import foundation-core.homotopies
-open import foundation-core.identity-types public
 open import foundation.binary-equivalences
 open import foundation.dependent-pair-types
 open import foundation.equivalence-extensionality

--- a/src/foundation/injective-maps.lagda.md
+++ b/src/foundation/injective-maps.lagda.md
@@ -3,8 +3,8 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.injective-maps where
-open import foundation-core.empty-types
 open import foundation-core.injective-maps public
+open import foundation-core.empty-types
 open import foundation-core.universe-levels
 ```
 </details>

--- a/src/foundation/involutions.lagda.md
+++ b/src/foundation/involutions.lagda.md
@@ -3,12 +3,12 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.involutions where
+open import foundation-core.involutions public
 open import foundation-core.automorphisms
 open import foundation-core.functions
 open import foundation-core.homotopies
 open import foundation-core.identity-types
 open import foundation-core.injective-maps
-open import foundation-core.involutions public
 open import foundation-core.universe-levels
 open import foundation.equivalence-extensionality
 open import foundation.equivalences

--- a/src/foundation/logical-equivalences.lagda.md
+++ b/src/foundation/logical-equivalences.lagda.md
@@ -3,11 +3,11 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.logical-equivalences where
+open import foundation-core.logical-equivalences public
 open import foundation-core.dependent-pair-types
 open import foundation-core.equivalences
 open import foundation-core.functions
 open import foundation-core.identity-types
-open import foundation-core.logical-equivalences public
 open import foundation-core.universe-levels
 open import foundation.propositions
 ```

--- a/src/foundation/negation.lagda.md
+++ b/src/foundation/negation.lagda.md
@@ -3,8 +3,8 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.negation where
-open import foundation-core.empty-types
 open import foundation-core.negation public
+open import foundation-core.empty-types
 open import foundation.cartesian-product-types
 open import foundation.dependent-pair-types
 open import foundation.equivalences

--- a/src/foundation/path-split-maps.lagda.md
+++ b/src/foundation/path-split-maps.lagda.md
@@ -3,9 +3,9 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.path-split-maps where
+open import foundation-core.path-split-maps public
 open import foundation-core.contractible-types
 open import foundation-core.dependent-pair-types
-open import foundation-core.path-split-maps public
 open import foundation-core.propositions
 open import foundation-core.universe-levels
 open import foundation.equivalences

--- a/src/foundation/propositional-maps.lagda.md
+++ b/src/foundation/propositional-maps.lagda.md
@@ -3,9 +3,9 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.propositional-maps where
+open import foundation-core.propositional-maps public
 open import foundation-core.dependent-pair-types
 open import foundation-core.equivalences
-open import foundation-core.propositional-maps public
 open import foundation-core.propositions
 open import foundation-core.truncation-levels
 open import foundation-core.universe-levels

--- a/src/foundation/propositions.lagda.md
+++ b/src/foundation/propositions.lagda.md
@@ -3,12 +3,12 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.propositions where
+open import foundation-core.propositions public
 open import foundation-core.dependent-pair-types
 open import foundation-core.equivalences
 open import foundation-core.function-extensionality
 open import foundation-core.functions
 open import foundation-core.homotopies
-open import foundation-core.propositions public
 open import foundation-core.retractions
 open import foundation-core.truncated-types
 open import foundation-core.truncation-levels

--- a/src/foundation/pullbacks.lagda.md
+++ b/src/foundation/pullbacks.lagda.md
@@ -3,6 +3,7 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.pullbacks where
+open import foundation-core.pullbacks public
 open import foundation-core.cartesian-product-types
 open import foundation-core.cones-pullbacks
 open import foundation-core.constant-maps
@@ -14,7 +15,6 @@ open import foundation-core.functions
 open import foundation-core.functoriality-dependent-function-types
 open import foundation-core.fundamental-theorem-of-identity-types
 open import foundation-core.propositions
-open import foundation-core.pullbacks public
 open import foundation-core.universe-levels
 open import foundation.commuting-cubes-of-maps
 open import foundation.descent-equivalences

--- a/src/foundation/sections.lagda.md
+++ b/src/foundation/sections.lagda.md
@@ -3,6 +3,7 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.sections where
+open import foundation-core.sections public
 open import foundation-core.contractible-types
 open import foundation-core.dependent-pair-types
 open import foundation-core.equivalences
@@ -12,7 +13,6 @@ open import foundation-core.functoriality-dependent-pair-types
 open import foundation-core.homotopies
 open import foundation-core.identity-types
 open import foundation-core.retractions
-open import foundation-core.sections public
 open import foundation-core.type-arithmetic-dependent-pair-types
 open import foundation-core.universe-levels
 open import foundation.function-extensionality

--- a/src/foundation/sets.lagda.md
+++ b/src/foundation/sets.lagda.md
@@ -3,6 +3,7 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.sets where
+open import foundation-core.sets public
 open import foundation-core.1-types
 open import foundation-core.cartesian-product-types
 open import foundation-core.dependent-pair-types
@@ -10,7 +11,6 @@ open import foundation-core.equivalences
 open import foundation-core.functions
 open import foundation-core.identity-types
 open import foundation-core.propositions
-open import foundation-core.sets public
 open import foundation-core.truncation-levels
 open import foundation-core.universe-levels
 open import foundation.contractible-types

--- a/src/foundation/subtypes.lagda.md
+++ b/src/foundation/subtypes.lagda.md
@@ -3,6 +3,7 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.subtypes where
+open import foundation-core.subtypes public
 open import foundation-core.contractible-types
 open import foundation-core.dependent-pair-types
 open import foundation-core.equivalences
@@ -13,7 +14,6 @@ open import foundation-core.identity-types
 open import foundation-core.logical-equivalences
 open import foundation-core.propositions
 open import foundation-core.sets
-open import foundation-core.subtypes public
 open import foundation-core.truncation-levels
 open import foundation-core.universe-levels
 open import foundation.embeddings

--- a/src/foundation/truncated-maps.lagda.md
+++ b/src/foundation/truncated-maps.lagda.md
@@ -3,13 +3,13 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.truncated-maps where
+open import foundation-core.truncated-maps public
 open import foundation-core.cones-pullbacks
 open import foundation-core.dependent-pair-types
 open import foundation-core.fibers-of-maps
 open import foundation-core.functoriality-fibers-of-maps
 open import foundation-core.propositions
 open import foundation-core.pullbacks
-open import foundation-core.truncated-maps public
 open import foundation-core.truncated-types
 open import foundation-core.truncation-levels
 open import foundation-core.universe-levels

--- a/src/foundation/truncated-types.lagda.md
+++ b/src/foundation/truncated-types.lagda.md
@@ -3,6 +3,7 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.truncated-types where
+open import foundation-core.truncated-types public
 open import foundation-core.contractible-types
 open import foundation-core.dependent-pair-types
 open import foundation-core.embeddings
@@ -10,7 +11,6 @@ open import foundation-core.equivalences
 open import foundation-core.identity-types
 open import foundation-core.sets
 open import foundation-core.subtypes
-open import foundation-core.truncated-types public
 open import foundation-core.truncation-levels
 open import foundation-core.univalence
 open import foundation-core.universe-levels

--- a/src/foundation/truncation-levels.lagda.md
+++ b/src/foundation/truncation-levels.lagda.md
@@ -3,11 +3,11 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.truncation-levels where
+open import foundation-core.truncation-levels public
 open import elementary-number-theory.addition-natural-numbers
 open import elementary-number-theory.natural-numbers
 open import foundation-core.functions
 open import foundation-core.identity-types
-open import foundation-core.truncation-levels public
 ```
 </details>
 

--- a/src/foundation/univalence.lagda.md
+++ b/src/foundation/univalence.lagda.md
@@ -3,13 +3,13 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.univalence where
+open import foundation-core.univalence public
 open import foundation-core.contractible-types
 open import foundation-core.dependent-pair-types
 open import foundation-core.functoriality-dependent-pair-types
 open import foundation-core.fundamental-theorem-of-identity-types
 open import foundation-core.identity-types
 open import foundation-core.injective-maps
-open import foundation-core.univalence public
 open import foundation-core.universe-levels
 open import foundation.equality-dependent-function-types
 open import foundation.equivalences

--- a/src/foundation/universal-property-pullbacks.lagda.md
+++ b/src/foundation/universal-property-pullbacks.lagda.md
@@ -3,12 +3,12 @@
 <details><summary>Imports</summary>
 ```agda
 module foundation.universal-property-pullbacks where
+open import foundation-core.universal-property-pullbacks public
 open import foundation-core.commuting-squares-of-maps
 open import foundation-core.cones-pullbacks
 open import foundation-core.contractible-maps
 open import foundation-core.functoriality-dependent-pair-types
 open import foundation-core.functoriality-function-types
-open import foundation-core.universal-property-pullbacks public
 open import foundation.cartesian-product-types
 open import foundation.contractible-types
 open import foundation.dependent-pair-types

--- a/src/foundation/universal-property-set-quotients.lagda.md
+++ b/src/foundation/universal-property-set-quotients.lagda.md
@@ -1,8 +1,11 @@
 # The universal property of set quotients
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --lossy-unification #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module foundation.universal-property-set-quotients where
 open import foundation-core.equivalence-relations
 open import foundation-core.univalence

--- a/src/foundation/universal-property-truncation.lagda.md
+++ b/src/foundation/universal-property-truncation.lagda.md
@@ -1,10 +1,9 @@
 # The universal property of truncations
 
+<details><summary>Imports</summary>
 ```agda
 module foundation.universal-property-truncation where
-
 open import foundation-core.universal-property-truncation public
-
 open import foundation.contractible-maps
 open import foundation.contractible-types
 open import foundation.dependent-pair-types
@@ -26,6 +25,7 @@ open import foundation.universal-property-dependent-pair-types
 open import foundation.universal-property-identity-types
 open import foundation.universe-levels
 ```
+</details>
 
 ## Properties
 

--- a/src/group-theory/quotient-groups.lagda.md
+++ b/src/group-theory/quotient-groups.lagda.md
@@ -1,8 +1,11 @@
 # Quotient groups
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --lossy-unification #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module group-theory.quotient-groups where
 open import foundation.binary-functoriality-set-quotients
 open import foundation.dependent-pair-types

--- a/src/type-theories/comprehension-type-theories.lagda.md
+++ b/src/type-theories/comprehension-type-theories.lagda.md
@@ -1,8 +1,11 @@
 # Comprehension of fibered type theories
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --guardedness #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module type-theories.comprehension-type-theories where
 open import foundation.universe-levels
 open import type-theories.dependent-type-theories

--- a/src/type-theories/fibered-dependent-type-theories.lagda.md
+++ b/src/type-theories/fibered-dependent-type-theories.lagda.md
@@ -1,8 +1,11 @@
 # Fibered dependent type theories
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --guardedness #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module type-theories.fibered-dependent-type-theories where
 open import foundation.dependent-pair-types
 open import foundation.functions

--- a/src/type-theories/sections-dependent-type-theories.lagda.md
+++ b/src/type-theories/sections-dependent-type-theories.lagda.md
@@ -2,19 +2,20 @@
 
 ```agda
 {-# OPTIONS --guardedness #-}
+```
 
+<details><summary>Imports</summary>
+```agda
 module type-theories.sections-dependent-type-theories where
-
 open import foundation.dependent-pair-types
 open import foundation.identity-types
 open import foundation.universe-levels
-
 open import type-theories.dependent-type-theories
 open import type-theories.fibered-dependent-type-theories
-
 open dependent
 open fibered
 ```
+</details>
 
 ```agda
 module sections-dtt where

--- a/src/type-theories/simple-type-theories.lagda.md
+++ b/src/type-theories/simple-type-theories.lagda.md
@@ -2,14 +2,17 @@
 
 ```agda
 {-# OPTIONS --guardedness --allow-unsolved-metas #-}
+```
 
+<details><summary>Imports</summary>
+```agda
 module type-theories.simple-type-theories where
-
 open import foundation.functions
 open import foundation.homotopies
 open import foundation.identity-types
 open import foundation.universe-levels
 ```
+</details>
 
 ## Idea
 

--- a/src/type-theories/unityped-type-theories.lagda.md
+++ b/src/type-theories/unityped-type-theories.lagda.md
@@ -2,20 +2,21 @@
 
 ```agda
 {-# OPTIONS --guardedness --allow-unsolved-metas #-}
+```
 
+<details><summary>Imports</summary>
+```agda
 module type-theories.unityped-type-theories where
-
 open import elementary-number-theory.addition-natural-numbers
 open import elementary-number-theory.natural-numbers
-
 open import foundation.functions
 open import foundation.homotopies
 open import foundation.identity-types
 open import foundation.sets
 open import foundation.universe-levels
-
 open import type-theories.simple-type-theories
 ```
+</details>
 
 ## Idea
 

--- a/src/univalent-combinatorics/orientations-complete-undirected-graph.lagda.md
+++ b/src/univalent-combinatorics/orientations-complete-undirected-graph.lagda.md
@@ -1,8 +1,11 @@
 # Orientations of the complete undirected graph
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --lossy-unification #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module univalent-combinatorics.orientations-complete-undirected-graph where
 open import elementary-number-theory.addition-natural-numbers
 open import elementary-number-theory.congruence-natural-numbers
@@ -60,6 +63,10 @@ open import univalent-combinatorics.equality-standard-finite-types
 open import univalent-combinatorics.finite-types
 open import univalent-combinatorics.standard-finite-types
 open import univalent-combinatorics.symmetric-difference
+```
+</details>
+
+```agda
 module _
   {l : Level} (n : ℕ) (X : UU-Fin l n)
   where

--- a/src/univalent-combinatorics/set-quotients-of-index-two.lagda.md
+++ b/src/univalent-combinatorics/set-quotients-of-index-two.lagda.md
@@ -1,8 +1,11 @@
 # Set quotients of index 2
 
-<details><summary>Imports</summary>
 ```agda
 {-# OPTIONS --lossy-unification #-}
+```
+
+<details><summary>Imports</summary>
+```agda
 module univalent-combinatorics.set-quotients-of-index-two where
 open import foundation.commuting-squares-of-maps
 open import foundation.contractible-types


### PR DESCRIPTION
Moves public import statements in `foundation` before other import statements. Also moves options pragmas up before the Imports section.