### PR TITLE
Add formatting to the citation

### DIFF
--- a/HOME.md
+++ b/HOME.md
@@ -27,7 +27,11 @@ Great, you want to contribute something! The best way to start is to find us in 
 
 Once you've decided what you want to contribute, the best way to proceed is to make your own fork of the library. Within your fork, make a separate branch in which you will be making your contributions. Now you're ready to start your project! When you've completed your formalization you can proceed by making a pull request. Then we will review your contributions, and merge it when it is ready for the `agda-unimath` library.
 
+## Citing the Agda-UniMath library
+
+```md
 {{#include CITATION.cff}}
+```
 
 {{#include SUMMARY.md}}
 

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,7 @@
               # working on the website
               pkgs.mdbook
 	      pkgs.mdbook-katex
+	      # mdbook-toc is not included here and hence must be installed manually
             ];
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
               python
               # working on the website
               pkgs.mdbook
+	      pkgs.mdbook-katex
             ];
           };
 


### PR DESCRIPTION
PR https://github.com/UniMath/agda-unimath/pull/495 changed `CITATION.md` into `CITATION.cff` which breaks the previous citation format. I.e. from 
![image](https://user-images.githubusercontent.com/17756312/224135260-e4aefc07-8e89-492b-ba0a-47974e1e243a.png)
to 
![image](https://user-images.githubusercontent.com/17756312/224135295-05cc5b0b-7376-4305-acc9-f4974f15b789.png).

This PR adds back the formatting so it displays as it used to. 
Also adds a bit more stuff for nix flake users.


