### PR TITLE
Gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.lagda.md linguist-language=Agda


### PR DESCRIPTION
Adds the `.gitattributes` file so that github recognizes the agda code. Other than updating the languages used info
![image](https://user-images.githubusercontent.com/17756312/224206869-c6c28b56-33b0-4c74-9394-86c345d58b14.png)
it makes the project more discoverable, I believe it is currently not appearing in a search for agda projects on github https://github.com/search?l=Agda&p=1&q=agda&type=Repositories .