### PR TITLE
Remove blank lines at the start and end of code blocks

### DIFF
--- a/scripts/fix_imports.py
+++ b/scripts/fix_imports.py
@@ -140,7 +140,8 @@ if __name__ == "__main__":
             pretty_imports_block + \
             contents[end:]
 
-        with open(fpath, 'w') as file:
-            file.write(new_content)
+        if contents != new_content:
+            with open(fpath, 'w') as file:
+                file.write(new_content)
 
     sys.exit(status)

--- a/scripts/generate_main_index_file.py
+++ b/scripts/generate_main_index_file.py
@@ -87,7 +87,7 @@ summary_template = """
     - [Design principles](DESIGN-PRINCIPLES.md)
   - [Everything](everything.md)
 
-MODULE_INDEX
+{module_index}
 """
 
 if __name__ == "__main__":
@@ -99,8 +99,7 @@ if __name__ == "__main__":
 
     index_content, status = generate_index(root, index_header)
     if status == 0:
-        summary_contents = summary_template.replace(
-            "MODULE_INDEX", index_content)
+        summary_contents = summary_template.format(module_index=index_content)
         with open(summary_path, "w") as summary_file:
             summary_file.write(summary_contents)
     sys.exit(status)

--- a/scripts/remove_extra_blank_lines.py
+++ b/scripts/remove_extra_blank_lines.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
         # Remove blank lines after a code block starts, and blank lines before a code block ends
         if not has_well_formed_blocks(output):
             print(
-                f"Error! File '{fpath}' does not have well formed code blocks. Please check if there is an opening or closing code block tag (```) without a corresponding closing/opening tag.")
+                f"Error! File '{fpath}' has ill-formed code blocks. Please check if there is an opening or closing code block tag (```) without a corresponding closing/opening tag.")
 
             status |= STATUS_FILES_WITH_UNEVEN_BLOCKS
         else:

--- a/scripts/remove_extra_blank_lines.py
+++ b/scripts/remove_extra_blank_lines.py
@@ -57,10 +57,10 @@ if __name__ == "__main__":
             status |= STATUS_FILES_WITH_UNEVEN_BLOCKS
         else:
 
-            output = recursive_sub(r"\n\n```$", "\n```\n", output)
+            output = recursive_sub(r"\n\n```\n", "\n```\n", output)
             output = recursive_sub(r"\n```(\S+)\n\n", r"\n```\1\n", output)
             # Empty blocks should have an empty line
-            output = recursive_sub(r"\n```(\S+)\n```$",
+            output = recursive_sub(r"\n```(\S+)\n```\n",
                                    r"\n```\1\n\n```\n", output)
 
         with open(fpath, "w") as f:

--- a/scripts/remove_extra_blank_lines.py
+++ b/scripts/remove_extra_blank_lines.py
@@ -51,13 +51,6 @@ def has_well_formed_blocks(mdcode, pos=0):
     return has_well_formed_blocks(mdcode, close_match.end())
 
 
-def len_iter(it):
-    i = -1
-    for i, el in enumerate(it):
-        pass
-    return i + 1
-
-
 if __name__ == "__main__":
 
     STATUS_FILES_WITH_UNEVEN_BLOCKS = 1

--- a/scripts/remove_extra_blank_lines.py
+++ b/scripts/remove_extra_blank_lines.py
@@ -6,14 +6,64 @@ import sys
 import utils
 import re
 
+
+def recursive_sub(pattern, repl, string, flags=0):
+    while re.search(pattern, string, flags=flags):
+        string = re.sub(pattern, repl, string, flags=flags)
+    return string
+
+
+def recursive_replace(string, old, new):
+    while old in string:
+        string = string.replace(old, new)
+    return string
+
+
+def len_iter(it):
+    i = -1
+    for i, el in enumerate(it):
+        pass
+    return i + 1
+
+
 if __name__ == "__main__":
+
+    STATUS_FILES_WITH_UNEVEN_BLOCKS = 1
+
+    files_with_uneven_blocks = []
+    status = 0
 
     for fpath in utils.get_agda_files(sys.argv[1:]):
         with open(fpath, "r") as f:
             inputText = f.read()
-        output = re.sub(r"[ \t]+$", "", inputText, flags=re.MULTILINE)
-        output = re.sub(r"\n\s*\n\s*\n", "\n\n", output)
+        output = recursive_sub(r"[ \t]+$", "", inputText, flags=re.MULTILINE)
+        output = recursive_sub(r"\n\s*\n\s*\n", "\n\n", output)
+
+        # Remove blank lines after a code block starts, and blank lines before a code block ends
+
+        # Check if file starts/ends more blocks than it ends/starts
+        block_starts = len_iter(re.finditer(r"\n```\S+\n", output))
+        block_ends = len_iter(re.finditer(r"\n```\n", output))
+
+        if block_starts != block_ends:
+            if block_starts > block_ends:
+                print(
+                    f"Error! File '{fpath}' opens {block_starts} blocks but ends only {block_ends}.")
+            else:
+                print(
+                    f"Error! File '{fpath}' opens only {block_starts} blocks but ends {block_ends}.")
+
+            files_with_uneven_blocks.append(fpath)
+            status |= STATUS_FILES_WITH_UNEVEN_BLOCKS
+        else:
+
+            output = recursive_sub(r"\n\n```$", "\n```\n", output)
+            output = recursive_sub(r"\n```(\S+)\n\n", r"\n```\1\n", output)
+            # Empty blocks should have an empty line
+            output = recursive_sub(r"\n```(\S+)\n```$",
+                                   r"\n```\1\n\n```\n", output)
+
         with open(fpath, "w") as f:
             f.write(output)
 
-    sys.exit(0)
+    sys.exit(status)

--- a/src/category-theory/discrete-precategories.lagda.md
+++ b/src/category-theory/discrete-precategories.lagda.md
@@ -23,7 +23,6 @@ Any set induces a discrete category whose objects are elements of the set and
 which contains no-nonidentity morphisms.
 
 ```agda
-
 module _
   {l : Level} (X : Set l)
   where
@@ -42,5 +41,4 @@ module _
       pr1 id-struct x = refl
       pr1 (pr2 id-struct) refl = refl
       pr2 (pr2 id-struct) refl = refl
-
 ```

--- a/src/category-theory/isomorphisms-precategories.lagda.md
+++ b/src/category-theory/isomorphisms-precategories.lagda.md
@@ -190,7 +190,6 @@ Let `f : hom x y` and suppose `g g' : hom y x` are both two-sided inverses to
 module _
   {l1 l2 : Level} (C : Precat l1 l2)
   where
-
 ```
 
 ### The type of isomorphisms form a set

--- a/src/category-theory/precategory-of-functors.lagda.md
+++ b/src/category-theory/precategory-of-functors.lagda.md
@@ -24,7 +24,6 @@ introduce a new precategory whose identity map and composition structure are
 inherited pointwise from the codomain precategory.
 
 ```agda
-
 module _
   {l1 l2 l3 l4 : Level} (C : Precat l1 l2) (D : Precat l3 l4)
   where

--- a/src/elementary-number-theory/absolute-value-integers.lagda.md
+++ b/src/elementary-number-theory/absolute-value-integers.lagda.md
@@ -26,7 +26,7 @@ open import foundation.unit-type
 
 # The absolute value of integers
 
-```
+```agda
 abs-ℤ : ℤ → ℕ
 abs-ℤ (inl x) = succ-ℕ x
 abs-ℤ (inr (inl star)) = zero-ℕ
@@ -127,7 +127,6 @@ is-positive-abs-ℤ (inr (inr x)) H = star
 is-nonzero-abs-ℤ :
   (x : ℤ) → is-positive-ℤ x → is-nonzero-ℕ (abs-ℤ x)
 is-nonzero-abs-ℤ (inr (inr x)) H = is-nonzero-succ-ℕ x
-
 ```
 
 ### Absolute value is multiplicative
@@ -201,5 +200,4 @@ multiplicative-abs-ℤ (inr (inr x)) (inr (inl star)) = equational-reasoning
   ＝ mul-ℕ (abs-ℤ (inr (inr x))) zero-ℕ by (inv (right-zero-law-mul-ℕ (abs-ℤ (inr (inr x)))))
 multiplicative-abs-ℤ (inr (inr x)) (inr (inr y)) = is-injective-int-ℕ
   (int-ℕ-abs-ℤ-mult-positive-ints x y)
-
 ```

--- a/src/elementary-number-theory/bezouts-lemma.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma.lagda.md
@@ -225,7 +225,6 @@ div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
           ＝ int-ℕ z
           by isretr-add-neg-ℤ' (mul-ℤ (int-ℕ l) (int-ℕ y)) (int-ℕ z))
        ＝ mod-ℕ x z by mod-int-ℕ x z))
-
 ```
 
 ### If `[y] | [z]` in `ℤ-Mod x`, then `z = dist-ℕ (kx, ly)` for some `k` and `l`
@@ -541,7 +540,6 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
             (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)) (int-ℕ z)
             (cong-div-mod-ℤ (succ-ℕ x) y z (u , p)))))
         z-uy) (is-nonnegative-int-ℕ (succ-ℕ x)))
-
 ```
 
 ### The type `is-distance-between-multiples-ℕ x y z` is decidable
@@ -562,7 +560,6 @@ is-decidable-is-distance-between-multiples-ℕ x y z =
   decidable-div-ℤ-case-split (inr neg-div-Mod) =
     inr (λ dist → neg-div-Mod
       (div-mod-is-distance-between-multiples-ℕ x y z dist))
-
 ```
 
 ## Theorem

--- a/src/elementary-number-theory/congruence-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/congruence-natural-numbers.lagda.md
@@ -121,7 +121,7 @@ eq-cong-le-dist-ℕ k x y H K =
   eq-dist-ℕ x y (is-zero-div-ℕ k (dist-ℕ x y) H K)
 ```
 
-```
+```agda
 eq-cong-le-ℕ :
   (k x y : ℕ) → le-ℕ x k → le-ℕ y k → cong-ℕ k x y → x ＝ y
 eq-cong-le-ℕ k x y H K =

--- a/src/elementary-number-theory/difference-integers.lagda.md
+++ b/src/elementary-number-theory/difference-integers.lagda.md
@@ -23,7 +23,7 @@ derive their basic properties relative to `succ-ℤ`, `neg-ℤ`, and `add-ℤ`. 
 file `multiplication-integers` imports `difference-integers` and more properties
 are derived there.
 
-```
+```agda
 diff-ℤ : ℤ → ℤ → ℤ
 diff-ℤ x y = add-ℤ x (neg-ℤ y)
 

--- a/src/elementary-number-theory/divisibility-integers.lagda.md
+++ b/src/elementary-number-theory/divisibility-integers.lagda.md
@@ -372,7 +372,7 @@ is-unit-right-factor-ℤ x y (pair d p) =
 
 ### We introduce the equivalence relation `ux = y`, where `u` is a unit
 
-```
+```agda
 {- The relation presim-unit-ℤ would be an equivalence relation, except it is not
    valued in the propositions. Indeed presim-unit-ℤ zero-ℤ zero-ℤ is not a
    proposition. -}

--- a/src/elementary-number-theory/fractions.lagda.md
+++ b/src/elementary-number-theory/fractions.lagda.md
@@ -152,5 +152,4 @@ eq-rel-sim-fraction-ℤ = pair (sim-fraction-ℤ-Prop)
   ( pair' (λ {x} → refl-sim-fraction-ℤ x)
     ( pair' (λ {x y} → symm-sim-fraction-ℤ x y)
       (λ {x y z} → trans-sim-fraction-ℤ x y z)))
-
 ```

--- a/src/elementary-number-theory/greatest-common-divisor-integers.lagda.md
+++ b/src/elementary-number-theory/greatest-common-divisor-integers.lagda.md
@@ -155,7 +155,6 @@ pr2 (pr2 (is-gcd-gcd-ℤ x y) k) =
   ( div-sim-unit-ℤ
     ( symm-sim-unit-ℤ (sim-unit-abs-ℤ k))
     ( refl-sim-unit-ℤ (gcd-ℤ x y)))
-
 ```
 
 ### The gcd of `x` and `y` divides both `x` and `y`
@@ -289,7 +288,6 @@ is-id-is-gcd-zero-ℤ {inr (inr b)} {x} H with (is-plus-or-minus-sim-unit-ℤ (i
   gcd-is-nonneg = is-nonnegative-int-ℕ (gcd-ℕ 0 (succ-ℕ b))
   lem : (y : ℤ) → is-nonnegative-ℤ y → Σ (unit + ℕ) (λ z → y ＝ inr z)
   lem (inr z) H = pair z refl
-
 ```
 
 ### `gcd-ℤ a 0 ＝ abs-ℤ a`

--- a/src/elementary-number-theory/greatest-common-divisor-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/greatest-common-divisor-natural-numbers.lagda.md
@@ -392,5 +392,4 @@ is-id-is-gcd-zero-ℕ {b} {x} H = antisymmetric-div-ℕ x b
 is-id-is-gcd-zero-ℕ' : {a x : ℕ} → gcd-ℕ a 0 ＝ x → x ＝ a
 is-id-is-gcd-zero-ℕ' {a} {x} H = is-id-is-gcd-zero-ℕ {a} {x}
   ((is-commutative-gcd-ℕ 0 a) ∙ H)
-
 ```

--- a/src/elementary-number-theory/inequality-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/inequality-natural-numbers.lagda.md
@@ -234,7 +234,7 @@ reflects-order-add-ℕ (succ-ℕ k) m n = reflects-order-add-ℕ k m n
 
 ### Multiplication preserves the ordering on ℕ
 
-```
+```agda
 preserves-order-mul-ℕ :
   (k m n : ℕ) → m ≤-ℕ n → (mul-ℕ m k) ≤-ℕ (mul-ℕ n k)
 preserves-order-mul-ℕ k zero-ℕ n p = star

--- a/src/elementary-number-theory/modular-arithmetic.lagda.md
+++ b/src/elementary-number-theory/modular-arithmetic.lagda.md
@@ -189,7 +189,7 @@ pr2 (equiv-pred-ℤ-Mod k) = is-equiv-pred-ℤ-Mod k
 
 ## Addition on the integers modulo k
 
-```
+```agda
 add-ℤ-Mod : (k : ℕ) → ℤ-Mod k → ℤ-Mod k → ℤ-Mod k
 add-ℤ-Mod zero-ℕ = add-ℤ
 add-ℤ-Mod (succ-ℕ k) = add-Fin (succ-ℕ k)

--- a/src/elementary-number-theory/rational-numbers.lagda.md
+++ b/src/elementary-number-theory/rational-numbers.lagda.md
@@ -272,7 +272,6 @@ reduce-preserves-sim-ℤ x y H =
     (trans-sim-fraction-ℤ (reduce-fraction-ℤ x) x y
       (symm-sim-fraction-ℤ x (reduce-fraction-ℤ x) (sim-reduced-fraction-ℤ x)) H)
     (sim-reduced-fraction-ℤ y)
-
 ```
 
 ### Inclusion of fractions

--- a/src/finite-group-theory/sign-homomorphism.lagda.md
+++ b/src/finite-group-theory/sign-homomorphism.lagda.md
@@ -350,5 +350,4 @@ module _
       ( equiv-succ-Fin 2)
   eq-sign-homomorphism-transposition Y =
     ap aut-point-Fin-two-ℕ (eq-sign-homomorphism-Fin-two-transposition n X Y)
-
 ```

--- a/src/foundation-core/equality-dependent-pair-types.lagda.md
+++ b/src/foundation-core/equality-dependent-pair-types.lagda.md
@@ -30,7 +30,6 @@ is equivalently described as a pair `pair α β` consisting of an identification
 ## Definition
 
 ```agda
-
 module _
   {l1 l2 : Level} {A : UU l1} {B : A → UU l2}
   where

--- a/src/foundation-core/fibers-of-maps.lagda.md
+++ b/src/foundation-core/fibers-of-maps.lagda.md
@@ -243,7 +243,7 @@ module _
 
 ### The total space of fibers
 
-```
+```agda
 module _
   {l1 l2 : Level} {A : UU l1} {B : UU l2} (f : A → B)
   where

--- a/src/foundation-core/homotopies.lagda.md
+++ b/src/foundation-core/homotopies.lagda.md
@@ -65,7 +65,7 @@ module _
 
 ### Reflexivity
 
-```
+```agda
 refl-htpy :
   {l1 l2 : Level} {A : UU l1} {B : A → UU l2} {f : (x : A) → B x} → f ~ f
 refl-htpy x = refl

--- a/src/foundation-core/identity-systems.lagda.md
+++ b/src/foundation-core/identity-systems.lagda.md
@@ -40,7 +40,7 @@ module _
 
 ### A type family over `A` is an identity system if and only if it is equivalent to the identity type
 
-```
+```agda
 module _
   {l1 l2 : Level} {A : UU l1} {B : A → UU l2} (a : A) (b : B a)
   where

--- a/src/foundation-core/propositions.lagda.md
+++ b/src/foundation-core/propositions.lagda.md
@@ -64,7 +64,7 @@ foundation.unit-type
 
 ### To show that a type is a proposition, we may assume it is inhabited
 
-```
+```agda
 abstract
   is-prop-is-inhabited :
     {l1 : Level} {X : UU l1} → (X → is-prop X) → is-prop X

--- a/src/foundation-core/sets.lagda.md
+++ b/src/foundation-core/sets.lagda.md
@@ -82,7 +82,7 @@ module _
 
 ### If a reflexive binary relation maps into the identity type of A, then A is a set
 
-```
+```agda
 module _
   {l1 l2 : Level} {A : UU l1} (R : A → A → UU l2)
   (p : (x y : A) → is-prop (R x y)) (ρ : (x : A) → R x x)

--- a/src/foundation-core/subtypes.lagda.md
+++ b/src/foundation-core/subtypes.lagda.md
@@ -132,7 +132,7 @@ module _
 
 ### Restriction of an embedding to an embedding into a subtype
 
-```
+```agda
 module _
   {l1 l2 : Level} {A : UU l1} (B : subtype l2 A)
   where

--- a/src/foundation-core/type-arithmetic-dependent-pair-types.lagda.md
+++ b/src/foundation-core/type-arithmetic-dependent-pair-types.lagda.md
@@ -96,7 +96,7 @@ module _
 
 ### Right unit law for dependent pair types
 
-```
+```agda
 module _
   {l1 l2 : Level} {A : UU l1} {B : A → UU l2}
   where
@@ -219,7 +219,7 @@ module _
 
 ### The interchange law
 
-```
+```agda
 module _
   { l1 l2 l3 l4 : Level} { A : UU l1} {B : A → UU l2} {C : A → UU l3}
   ( D : (x : A) → B x → C x → UU l4)

--- a/src/foundation-core/universal-property-truncation.lagda.md
+++ b/src/foundation-core/universal-property-truncation.lagda.md
@@ -75,7 +75,7 @@ universal-property-truncation l {k = k} {A} B f =
 
 ### The dependent universal property of truncations
 
-```
+```agda
 precomp-Π-Truncated-Type :
   {l1 l2 l3 : Level} {k : 𝕋} {A : UU l1} {B : UU l2} (f : A → B)
   (C : B → Truncated-Type l3 k) →

--- a/src/foundation/2-types.lagda.md
+++ b/src/foundation/2-types.lagda.md
@@ -19,7 +19,7 @@ open import foundation-core.universe-levels
 
 A 2-type is a type that is 2-truncated
 
-```
+```agda
 is-2-type : {l : Level} → UU l → UU l
 is-2-type = is-trunc (two-𝕋)
 

--- a/src/foundation/conjunction.lagda.md
+++ b/src/foundation/conjunction.lagda.md
@@ -52,7 +52,7 @@ pr2 (pr2 (conj-decidable-Prop P Q)) =
 
 ### Introduction rule for conjunction
 
-```
+```agda
 intro-conj-Prop :
   {l1 l2 : Level} (P : Prop l1) (Q : Prop l2) →
   type-Prop P → type-Prop Q → type-conj-Prop P Q

--- a/src/foundation/connected-components.lagda.md
+++ b/src/foundation/connected-components.lagda.md
@@ -95,5 +95,4 @@ is-trunc-connected-component :
   is-trunc (succ-𝕋 k) A → is-trunc (succ-𝕋 k) (connected-component A a)
 is-trunc-connected-component {l} {k} A a H =
   is-trunc-Σ H (λ x → is-trunc-is-prop k is-prop-type-trunc-Prop)
-
 ```

--- a/src/foundation/decidable-embeddings.lagda.md
+++ b/src/foundation/decidable-embeddings.lagda.md
@@ -66,7 +66,7 @@ is-decidable-map-is-decidable-emb H = pr2 H
 
 ### Decidably propositional maps
 
-```
+```agda
 is-decidable-prop-map :
   {l1 l2 : Level} {X : UU l1} {Y : UU l2} → (X → Y) → UU (l1 ⊔ l2)
 is-decidable-prop-map {Y = Y} f = (y : Y) → is-decidable-prop (fib f y)

--- a/src/foundation/decidable-types.lagda.md
+++ b/src/foundation/decidable-types.lagda.md
@@ -71,7 +71,7 @@ is-merely-decidable A = type-trunc-Prop (is-decidable A)
 
 ### The unit type and the empty type are decidable
 
-```
+```agda
 is-decidable-unit : is-decidable unit
 is-decidable-unit = inl star
 

--- a/src/foundation/dependent-paths.lagda.md
+++ b/src/foundation/dependent-paths.lagda.md
@@ -132,7 +132,6 @@ Too bad I thought of this only after writing everything out...oops -}
   is-equiv-tr-path-over-path-over² =
     is-equiv-has-inverse path-over²-tr-path-over
     issec-path-over²-tr-path-over isretr-path-over²-tr-path-over
-
 ```
 
 Definition: Groupoidal operators on dependent paths.

--- a/src/foundation/embeddings.lagda.md
+++ b/src/foundation/embeddings.lagda.md
@@ -80,7 +80,7 @@ module _
 
 ### Any map between propositions is an embedding
 
-```
+```agda
 is-emb-is-prop :
   {l1 l2 : Level} {A : UU l1} {B : UU l2} {f : A → B} →
   is-prop A → is-prop B → is-emb f

--- a/src/foundation/fiber-inclusions.lagda.md
+++ b/src/foundation/fiber-inclusions.lagda.md
@@ -64,7 +64,7 @@ module _
 
 ### The fiber inclusions are truncated maps for any type family B if and only if A is truncated
 
-```
+```agda
 module _
   {l1 l2 : Level} (k : 𝕋) {A : UU l1}
   where

--- a/src/foundation/functoriality-set-truncation.lagda.md
+++ b/src/foundation/functoriality-set-truncation.lagda.md
@@ -92,7 +92,7 @@ comp-map-trunc-Set = comp-map-trunc zero-𝕋
 
 ### The functorial action of set truncations preserves homotopies
 
-```
+```agda
 htpy-trunc-Set :
   {l1 l2 : Level} {A : UU l1} {B : UU l2} {f g : A → B} →
   (f ~ g) → (map-trunc-Set f ~ map-trunc-Set g)
@@ -206,7 +206,7 @@ module _
 
 ### If the set truncation of a map `f` is surjective, then `f` is surjective
 
-```
+```agda
   abstract
     is-surjective-is-surjective-map-trunc-Set :
       is-surjective (map-trunc-Set f) → is-surjective f

--- a/src/foundation/pairs-of-distinct-elements.lagda.md
+++ b/src/foundation/pairs-of-distinct-elements.lagda.md
@@ -107,7 +107,6 @@ module _
     p ＝ q
   eq-Eq-pair-of-distinct-elements {p} {q} α β =
     map-inv-is-equiv (is-equiv-Eq-eq-pair-of-distinct-elements p q) (pair α β)
-
 ```
 
 ### Equivalences map pairs of distinct elements to pairs of distinct elements

--- a/src/foundation/partitions.lagda.md
+++ b/src/foundation/partitions.lagda.md
@@ -96,7 +96,7 @@ We introduce the type of blocks of a partition. However, we will soon be able to
 reduce the universe level of this type. Therefore we call this type of blocks
 `large`.
 
-```
+```agda
   block-partition-Large-Type : UU (l1 ⊔ lsuc l2 ⊔ l3)
   block-partition-Large-Type = type-subtype subtype-partition
 
@@ -669,34 +669,36 @@ pr2 (partition-Set-Indexed-Σ-Decomposition D) =
 
 #### The partition obtained from the set-indexed Σ-decomposition induced by a partition has the same blocks as the original partition
 
--- ```agda -- module \_ -- {l1 l2 l3 : Level} {A : UU l1} (P : partition (l1 ⊔
-l2) l3 A) -- where
+```agda
+-- -- module \_ -- {l1 l2 l3 : Level} {A : UU l1} (P : partition (l1 ⊔
+-- l2) l3 A) -- where
 
--- is-block-is-block-partition-set-indexed-Σ-decomposition-partition : -- ( Q :
-inhabited-subtype (l1 ⊔ l2) A) → -- is-block-partition -- (
-partition-Set-Indexed-Σ-Decomposition -- ( set-indexed-Σ-decomposition-partition
-P)) -- ( Q) → -- is-block-partition P Q --
-is-block-is-block-partition-set-indexed-Σ-decomposition-partition Q (i , H) = --
-apply-universal-property-trunc-Prop -- ( is-inhabited-subtype-inhabited-subtype
-Q) -- ( subtype-partition P Q) -- ( λ (a , q) → -- {!!})
+-- -- is-block-is-block-partition-set-indexed-Σ-decomposition-partition : -- ( Q :
+-- inhabited-subtype (l1 ⊔ l2) A) → -- is-block-partition -- (
+-- partition-Set-Indexed-Σ-Decomposition -- ( set-indexed-Σ-decomposition-partition
+-- P)) -- ( Q) → -- is-block-partition P Q --
+-- is-block-is-block-partition-set-indexed-Σ-decomposition-partition Q (i , H) = --
+-- apply-universal-property-trunc-Prop -- ( is-inhabited-subtype-inhabited-subtype
+-- Q) -- ( subtype-partition P Q) -- ( λ (a , q) → -- {!!})
 
--- {- -- i : X -- H : (x : A) → Q x ≃ (pr1 (inv-equiv
-(compute-total-block-partition P) x) ＝ i) -- a : A -- q : Q a
+-- -- {- -- i : X -- H : (x : A) → Q x ≃ (pr1 (inv-equiv
+-- (compute-total-block-partition P) x) ＝ i) -- a : A -- q : Q a
 
--- H a q : pr1 (inv-equiv (compute-total-block-partition P) a) ＝ i
+-- -- H a q : pr1 (inv-equiv (compute-total-block-partition P) a) ＝ i
 
--- H' : (B : block) -- -}
+-- -- H' : (B : block) -- -}
 
--- is-block-partition-set-indexed-Σ-decomposition-is-block-partition : -- ( Q :
-inhabited-subtype (l1 ⊔ l2) A) → -- is-block-partition P Q → --
-is-block-partition -- ( partition-Set-Indexed-Σ-Decomposition -- (
-set-indexed-Σ-decomposition-partition P)) -- ( Q) --
-is-block-partition-set-indexed-Σ-decomposition-is-block-partition Q H = -- {!!}
+-- -- is-block-partition-set-indexed-Σ-decomposition-is-block-partition : -- ( Q :
+-- inhabited-subtype (l1 ⊔ l2) A) → -- is-block-partition P Q → --
+-- is-block-partition -- ( partition-Set-Indexed-Σ-Decomposition -- (
+-- set-indexed-Σ-decomposition-partition P)) -- ( Q) --
+-- is-block-partition-set-indexed-Σ-decomposition-is-block-partition Q H = -- {!!}
 
--- has-same-blocks-partition-set-indexed-Σ-decomposition-partition : --
-has-same-blocks-partition -- ( partition-Set-Indexed-Σ-Decomposition -- (
-set-indexed-Σ-decomposition-partition P)) -- ( P) -- pr1
-(has-same-blocks-partition-set-indexed-Σ-decomposition-partition B) = --
-is-block-is-block-partition-set-indexed-Σ-decomposition-partition B -- pr2
-(has-same-blocks-partition-set-indexed-Σ-decomposition-partition B) = --
-is-block-partition-set-indexed-Σ-decomposition-is-block-partition B -- ```
+-- -- has-same-blocks-partition-set-indexed-Σ-decomposition-partition : --
+-- has-same-blocks-partition -- ( partition-Set-Indexed-Σ-Decomposition -- (
+-- set-indexed-Σ-decomposition-partition P)) -- ( P) -- pr1
+-- (has-same-blocks-partition-set-indexed-Σ-decomposition-partition B) = --
+-- is-block-is-block-partition-set-indexed-Σ-decomposition-partition B -- pr2
+-- (has-same-blocks-partition-set-indexed-Σ-decomposition-partition B) = --
+-- is-block-partition-set-indexed-Σ-decomposition-is-block-partition B
+```

--- a/src/foundation/partitions.lagda.md
+++ b/src/foundation/partitions.lagda.md
@@ -670,35 +670,46 @@ pr2 (partition-Set-Indexed-Σ-Decomposition D) =
 #### The partition obtained from the set-indexed Σ-decomposition induced by a partition has the same blocks as the original partition
 
 ```agda
--- -- module \_ -- {l1 l2 l3 : Level} {A : UU l1} (P : partition (l1 ⊔
--- l2) l3 A) -- where
+-- module _
+--   {l1 l2 l3 : Level} {A : UU l1} (P : partition (l1 ⊔ l2) l3 A)
+--   where
 
--- -- is-block-is-block-partition-set-indexed-Σ-decomposition-partition : -- ( Q :
--- inhabited-subtype (l1 ⊔ l2) A) → -- is-block-partition -- (
--- partition-Set-Indexed-Σ-Decomposition -- ( set-indexed-Σ-decomposition-partition
--- P)) -- ( Q) → -- is-block-partition P Q --
--- is-block-is-block-partition-set-indexed-Σ-decomposition-partition Q (i , H) = --
--- apply-universal-property-trunc-Prop -- ( is-inhabited-subtype-inhabited-subtype
--- Q) -- ( subtype-partition P Q) -- ( λ (a , q) → -- {!!})
+--   is-block-is-block-partition-set-indexed-Σ-decomposition-partition :
+--     ( Q : inhabited-subtype (l1 ⊔ l2) A) →
+--     is-block-partition
+--       ( partition-Set-Indexed-Σ-Decomposition
+--         ( set-indexed-Σ-decomposition-partition P))
+--       ( Q) →
+--     is-block-partition P Q 
+--   is-block-is-block-partition-set-indexed-Σ-decomposition-partition Q (i , H) = 
+--     apply-universal-property-trunc-Prop
+--       ( is-inhabited-subtype-inhabited-subtype Q)
+--       ( subtype-partition P Q)
+--       ( λ (a , q) → {!  !})
 
--- -- {- -- i : X -- H : (x : A) → Q x ≃ (pr1 (inv-equiv
--- (compute-total-block-partition P) x) ＝ i) -- a : A -- q : Q a
+{-  i : X  H : (x : A) → Q x ≃ (pr1 (inv-equiv
+(compute-total-block-partition P) x) ＝ i)  a : A  q : Q a
 
--- -- H a q : pr1 (inv-equiv (compute-total-block-partition P) a) ＝ i
+ H a q : pr1 (inv-equiv (compute-total-block-partition P) a) ＝ i
 
--- -- H' : (B : block) -- -}
+ H' : (B : block)  -}
 
--- -- is-block-partition-set-indexed-Σ-decomposition-is-block-partition : -- ( Q :
--- inhabited-subtype (l1 ⊔ l2) A) → -- is-block-partition P Q → --
--- is-block-partition -- ( partition-Set-Indexed-Σ-Decomposition -- (
--- set-indexed-Σ-decomposition-partition P)) -- ( Q) --
--- is-block-partition-set-indexed-Σ-decomposition-is-block-partition Q H = -- {!!}
-
--- -- has-same-blocks-partition-set-indexed-Σ-decomposition-partition : --
--- has-same-blocks-partition -- ( partition-Set-Indexed-Σ-Decomposition -- (
--- set-indexed-Σ-decomposition-partition P)) -- ( P) -- pr1
--- (has-same-blocks-partition-set-indexed-Σ-decomposition-partition B) = --
--- is-block-is-block-partition-set-indexed-Σ-decomposition-partition B -- pr2
--- (has-same-blocks-partition-set-indexed-Σ-decomposition-partition B) = --
--- is-block-partition-set-indexed-Σ-decomposition-is-block-partition B
+--   is-block-partition-set-indexed-Σ-decomposition-is-block-partition :
+--     ( Q : inhabited-subtype (l1 ⊔ l2) A) →
+--     is-block-partition P Q → 
+--     is-block-partition
+--       ( partition-Set-Indexed-Σ-Decomposition
+--         ( set-indexed-Σ-decomposition-partition P))
+--       ( Q) 
+--   is-block-partition-set-indexed-Σ-decomposition-is-block-partition Q H = {!  !}
+-- 
+--   has-same-blocks-partition-set-indexed-Σ-decomposition-partition : 
+--     has-same-blocks-partition
+--       ( partition-Set-Indexed-Σ-Decomposition
+--         ( set-indexed-Σ-decomposition-partition P))
+--       ( P)
+--   pr1 (has-same-blocks-partition-set-indexed-Σ-decomposition-partition B) = 
+--     is-block-is-block-partition-set-indexed-Σ-decomposition-partition B
+--   pr2 (has-same-blocks-partition-set-indexed-Σ-decomposition-partition B) = 
+--     is-block-partition-set-indexed-Σ-decomposition-is-block-partition B
 ```

--- a/src/foundation/partitions.lagda.md
+++ b/src/foundation/partitions.lagda.md
@@ -680,8 +680,8 @@ pr2 (partition-Set-Indexed-Σ-Decomposition D) =
 --       ( partition-Set-Indexed-Σ-Decomposition
 --         ( set-indexed-Σ-decomposition-partition P))
 --       ( Q) →
---     is-block-partition P Q 
---   is-block-is-block-partition-set-indexed-Σ-decomposition-partition Q (i , H) = 
+--     is-block-partition P Q
+--   is-block-is-block-partition-set-indexed-Σ-decomposition-partition Q (i , H) =
 --     apply-universal-property-trunc-Prop
 --       ( is-inhabited-subtype-inhabited-subtype Q)
 --       ( subtype-partition P Q)
@@ -696,20 +696,20 @@ pr2 (partition-Set-Indexed-Σ-Decomposition D) =
 
 --   is-block-partition-set-indexed-Σ-decomposition-is-block-partition :
 --     ( Q : inhabited-subtype (l1 ⊔ l2) A) →
---     is-block-partition P Q → 
+--     is-block-partition P Q →
 --     is-block-partition
 --       ( partition-Set-Indexed-Σ-Decomposition
 --         ( set-indexed-Σ-decomposition-partition P))
---       ( Q) 
+--       ( Q)
 --   is-block-partition-set-indexed-Σ-decomposition-is-block-partition Q H = {!  !}
--- 
---   has-same-blocks-partition-set-indexed-Σ-decomposition-partition : 
+--
+--   has-same-blocks-partition-set-indexed-Σ-decomposition-partition :
 --     has-same-blocks-partition
 --       ( partition-Set-Indexed-Σ-Decomposition
 --         ( set-indexed-Σ-decomposition-partition P))
 --       ( P)
---   pr1 (has-same-blocks-partition-set-indexed-Σ-decomposition-partition B) = 
+--   pr1 (has-same-blocks-partition-set-indexed-Σ-decomposition-partition B) =
 --     is-block-is-block-partition-set-indexed-Σ-decomposition-partition B
---   pr2 (has-same-blocks-partition-set-indexed-Σ-decomposition-partition B) = 
+--   pr2 (has-same-blocks-partition-set-indexed-Σ-decomposition-partition B) =
 --     is-block-partition-set-indexed-Σ-decomposition-is-block-partition B
 ```

--- a/src/foundation/sets.lagda.md
+++ b/src/foundation/sets.lagda.md
@@ -32,7 +32,7 @@ open import foundation-core.universe-levels
 
 ### The type of all sets in a universe is a 1-type
 
-```
+```agda
 is-1-type-Set : {l : Level}  → is-1-type (Set l)
 is-1-type-Set = is-trunc-Truncated-Type zero-𝕋
 

--- a/src/foundation/sigma-decompositions.lagda.md
+++ b/src/foundation/sigma-decompositions.lagda.md
@@ -791,7 +791,6 @@ module _
 #### Equivalence between fibered double Σ-Decompositions and displayed double Σ-Decompositions
 
 ```agda
-
 module _
   {l1 l2 l3 l4 l5 : Level} {A : UU l1}
   (fib-D : fibered-Σ-Decomposition l2 l3 l4 l5 A)

--- a/src/foundation/surjective-maps.lagda.md
+++ b/src/foundation/surjective-maps.lagda.md
@@ -227,7 +227,7 @@ is-surjective-map-equiv e = is-surjective-is-equiv (is-equiv-map-equiv e)
 
 ### The dependent universal property of surjective maps
 
-```
+```agda
 dependent-universal-property-surj :
   (l : Level) {l1 l2 : Level} {A : UU l1} {B : UU l2} (f : A → B) →
   UU ((lsuc l) ⊔ l1 ⊔ l2)

--- a/src/foundation/symmetric-difference.lagda.md
+++ b/src/foundation/symmetric-difference.lagda.md
@@ -51,7 +51,7 @@ module _
 
 ### The coproduct of two decidable subtypes is equivalent to their symmetric difference plus two times their intersection
 
-```
+```agda
 module _
   {l l1 l2 : Level} {X : UU l}
   where

--- a/src/foundation/type-arithmetic-coproduct-types.lagda.md
+++ b/src/foundation/type-arithmetic-coproduct-types.lagda.md
@@ -246,7 +246,7 @@ module _
 
 ### Left distributivity of products over coproducts
 
-```
+```agda
 module _
   {l1 l2 l3 : Level} (A : UU l1) (B : UU l2) (C : UU l3)
   where

--- a/src/foundation/unit-type.lagda.md
+++ b/src/foundation/unit-type.lagda.md
@@ -48,7 +48,7 @@ pr2 unit-Pointed-Type = star
 
 ### The induction principle of the unit type
 
-```
+```agda
 ind-unit : {l : Level} {P : unit → UU l} → P star → ((x : unit) → P x)
 ind-unit p star = p
 ```

--- a/src/foundation/universal-property-pullbacks.lagda.md
+++ b/src/foundation/universal-property-pullbacks.lagda.md
@@ -79,7 +79,7 @@ module _
 
 ### The homotopy of cones obtained from the universal property of pullbacks
 
-```
+```agda
 module _
   {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
   (f : A → X) (g : B → X) {C : UU l4}

--- a/src/foundation/unordered-pairs.lagda.md
+++ b/src/foundation/unordered-pairs.lagda.md
@@ -47,7 +47,7 @@ a map `X → A`.
 
 ### The definition of unordered pairs
 
-```
+```agda
 unordered-pair : {l : Level} (A : UU l) → UU (lsuc lzero ⊔ l)
 unordered-pair A = Σ (2-Element-Type lzero) (λ X → type-2-Element-Type X → A)
 ```

--- a/src/graph-theory/directed-graphs.lagda.md
+++ b/src/graph-theory/directed-graphs.lagda.md
@@ -121,7 +121,7 @@ $$
 $$
 
 <!--
-```
+```agda
 module directed-graph-defs-equivalence
   {l1 l2 : Level} where
   -- is-equiv-htpy-equiv

--- a/src/graph-theory/embeddings-directed-graphs.lagda.md
+++ b/src/graph-theory/embeddings-directed-graphs.lagda.md
@@ -12,7 +12,8 @@ open import foundation.embeddings
 open import foundation.propositions
 open import foundation.universe-levels
 
-open import graph-theory.directed-graphs open import
+open import graph-theory.directed-graphs
+open import graph-theory.morphisms-directed-graphs
 ```
 
 </details>

--- a/src/graph-theory/embeddings-directed-graphs.lagda.md
+++ b/src/graph-theory/embeddings-directed-graphs.lagda.md
@@ -1,16 +1,21 @@
 # Embeddings of directed graphs
 
-```
+```agda
 module graph-theory.embeddings-directed-graphs where
+```
 
+<details><summary>Imports</summary>
+
+```agda
 open import foundation.dependent-pair-types
 open import foundation.embeddings
 open import foundation.propositions
 open import foundation.universe-levels
 
-open import graph-theory.directed-graphs
-open import graph-theory.morphisms-directed-graphs
+open import graph-theory.directed-graphs open import
 ```
+
+</details>
 
 ## Idea
 

--- a/src/graph-theory/enriched-undirected-graphs.lagda.md
+++ b/src/graph-theory/enriched-undirected-graphs.lagda.md
@@ -187,5 +187,4 @@ module _
                 ( ∞-group-vertex-Enriched-Undirected-Graph v)
                 ( action-∞-group-vertex-Enriched-Undirected-Graph v) h
                 ( map-inv-equiv-neighbor-Enriched-Undirected-Graph v x))))))
-
 ```

--- a/src/graph-theory/morphisms-directed-graphs.lagda.md
+++ b/src/graph-theory/morphisms-directed-graphs.lagda.md
@@ -58,7 +58,6 @@ module _
 ### Composition of morphisms graphs
 
 ```agda
-
 module _
   {l1 l2 l3 l4 l5 l6 : Level}
   (G : Directed-Graph l1 l2) (H : Directed-Graph l3 l4)

--- a/src/graph-theory/walks-undirected-graphs.lagda.md
+++ b/src/graph-theory/walks-undirected-graphs.lagda.md
@@ -234,7 +234,6 @@ module _
       ( total-edge-Undirected-Graph G)
       ( is-edge-on-walk-Undirected-Graph' G w)
       ( λ z → pair p e ＝ z))
-
 ```
 
 ### Right unit law for concatenation of walks
@@ -253,7 +252,6 @@ module _
     ap
       ( cons-walk-Undirected-Graph p e)
       ( right-unit-law-concat-walk-Undirected-Graph w)
-
 ```
 
 ### For any walk `w` from `x` to `y` and any vertex `v` on `w`, we can decompose `w` into a walk `w1` from `x` to `v` and a walk `w2` from `v` to `y`.

--- a/src/group-theory/furstenberg-groups.lagda.md
+++ b/src/group-theory/furstenberg-groups.lagda.md
@@ -30,5 +30,4 @@ Furstenberg-Group l =
             ( (x y z : type-Set X) → Id (μ (μ x z) (μ y z)) (μ x y)) ×
             ( Σ ( type-Set X → type-Set X → type-Set X)
                 ( λ δ → (x y : type-Set X) → Id (μ x (δ x y)) y)))))
-
 ```

--- a/src/group-theory/group-solver.lagda.md
+++ b/src/group-theory/group-solver.lagda.md
@@ -31,7 +31,6 @@ way and removes units and inverses next to the original.
 The main entry-point is `solveExpr` below
 
 ```agda
-
 data Fin : ℕ → UU where
   zero-Fin : ∀ {n} → Fin (succ-ℕ n)
   succ-Fin : ∀ {n} → Fin n → Fin (succ-ℕ n)
@@ -340,32 +339,29 @@ module _ {n : ℕ} where
     simplifyExpr env g = simplifyExpression (apply-n-args n g) env
 
     open import linear-algebra.vectors using (_∷_ ; empty-vec) public
-
 ```
 
-private _\*'_ : ∀ {n} → GroupSyntax n → GroupSyntax n → GroupSyntax n _\*'_ =
-gMul x : GroupSyntax 2 x = inner (zero-Fin) y : GroupSyntax 2 y = inner
-(succ-Fin zero-Fin)
+```agda
+-- private _\*'_ : ∀ {n} → GroupSyntax n → GroupSyntax n → GroupSyntax n _\*'_ =
+-- gMul x : GroupSyntax 2 x = inner (zero-Fin) y : GroupSyntax 2 y = inner
+-- (succ-Fin zero-Fin)
 
-    infixl 20 _*'_
-    ex1 : GroupEquality {n = 2} (gInv (x *' y *' gInv x *' gInv y)) (y *' x *' gInv y *' gInv x)
-    ex1 = simplifyValid _
+--     infixl 20 _*'_
+--     ex1 : GroupEquality {n = 2} (gInv (x *' y *' gInv x *' gInv y)) (y *' x *' gInv y *' gInv x)
+--     ex1 = simplifyValid _
 
-    ex2 : ∀ x y → (x * y * x ⁻¹ * y ⁻¹) ⁻¹ ＝ (y * x * y ⁻¹ * x ⁻¹)
-    ex2 x' y' = simplifyExpression (gInv (x *' y *' gInv x *' gInv y)) (x' ∷ y' ∷ empty-vec)
+--     ex2 : ∀ x y → (x * y * x ⁻¹ * y ⁻¹) ⁻¹ ＝ (y * x * y ⁻¹ * x ⁻¹)
+--     ex2 x' y' = simplifyExpression (gInv (x *' y *' gInv x *' gInv y)) (x' ∷ y' ∷ empty-vec)
 
-    _ : UU
-    -- _ = {!simplifyValid (y *' (x *' (gInv y *' (gInv x *' gUnit))))!}
-    _ = {!ex1!}
+--     _ : UU
+--     -- _ = {!simplifyValid (y *' (x *' (gInv y *' (gInv x *' gUnit))))!}
+--     _ = {!ex1!}
 
-    ex3 : ∀ x y → (x * y) ⁻¹ ＝ (y ⁻¹ * x ⁻¹)
-    ex3 x' y' = {!simplifyExpression (gInv (x *' y)) (x' ∷ y' ∷ empty-vec)!}
+--     ex3 : ∀ x y → (x * y) ⁻¹ ＝ (y ⁻¹ * x ⁻¹)
+--     ex3 x' y' = {!simplifyExpression (gInv (x *' y)) (x' ∷ y' ∷ empty-vec)!}
 
-    _ : GroupEquality {n = 2} (y *' (x *' (gInv y *' (gInv x *' gUnit)))) (y *' (x *' (gInv y *' (gInv x *' gUnit))))
-    _ = {!simplifyValid (gInv x *' x *' y)!}
-    -- _ = {!simplifyValid (gUnit *' gUnit)!}
-    -- _ = {!simplifyValid (x *' gUnit)!}
-
-```
-
+--     _ : GroupEquality {n = 2} (y *' (x *' (gInv y *' (gInv x *' gUnit)))) (y *' (x *' (gInv y *' (gInv x *' gUnit))))
+--     _ = {!simplifyValid (gInv x *' x *' y)!}
+--     -- _ = {!simplifyValid (gUnit *' gUnit)!}
+--     -- _ = {!simplifyValid (x *' gUnit)!}
 ```

--- a/src/group-theory/isomorphisms-groups.lagda.md
+++ b/src/group-theory/isomorphisms-groups.lagda.md
@@ -120,7 +120,6 @@ module _
 ### Group isomorphisms are stable by composition
 
 ```agda
-
 module _
   {l1 l2 l3 : Level} (G : Group l1) (H : Group l2) (K : Group l3)
   where
@@ -133,7 +132,6 @@ module _
 ### Group isomorphisms are stable by inversion
 
 ```agda
-
 module _
   {l1 l2 : Level} (G : Group l1) (H : Group l2)
   where

--- a/src/group-theory/orbits-monoid-actions.lagda.md
+++ b/src/group-theory/orbits-monoid-actions.lagda.md
@@ -186,5 +186,4 @@ module _
     left-unit-law-comp-hom-orbit-Monoid-Action
   pr2 (pr2 (pr2 (pr2 (pr2 orbit-monoid-action-Precategory)))) =
     right-unit-law-comp-hom-orbit-Monoid-Action
-
 ```

--- a/src/group-theory/sheargroups.lagda.md
+++ b/src/group-theory/sheargroups.lagda.md
@@ -31,5 +31,4 @@ Sheargroup l =
               ( ( (x : type-Set X) → Id (m x x) e) ×
                 ( (x y z : type-Set X) →
                   Id (m x (m y z)) (m (m (m x (m y e)) e) z))))))
-
 ```

--- a/src/group-theory/symmetric-groups.lagda.md
+++ b/src/group-theory/symmetric-groups.lagda.md
@@ -155,7 +155,6 @@ module _
     is-sec-hom-inv-symmetric-group-equiv-Set
   pr2 (pr2 (pr2 iso-symmetric-group-equiv-Set)) =
     is-retr-hom-inv-symmetric-group-equiv-Set
-
 ```
 
 ### The symmetric group and the abstract automorphism group of a set are isomorphic

--- a/src/group-theory/transitive-concrete-group-actions.lagda.md
+++ b/src/group-theory/transitive-concrete-group-actions.lagda.md
@@ -130,7 +130,7 @@ module _
 
 ### Characterization of the identity type of transitive actions of a concrete group
 
-```
+```agda
 module _
   {l1 l2 : Level} (G : Concrete-Group l1)
   (X : transitive-action-Concrete-Group l2 G)

--- a/src/linear-algebra/diagonal-matrices-on-rings.lagda.md
+++ b/src/linear-algebra/diagonal-matrices-on-rings.lagda.md
@@ -39,7 +39,7 @@ module _
 
 ### Scalar matrices
 
-```
+```agda
 module _
   {l : Level} (R : Ring l)
   where

--- a/src/order-theory/decidable-subposets.lagda.md
+++ b/src/order-theory/decidable-subposets.lagda.md
@@ -23,7 +23,6 @@ open import order-theory.subposets
 ## Definition
 
 ```agda
-
 module _
   {l1 l2 l3 : Level} (X : Poset l1 l2)
   (S : element-Poset X → decidable-Prop l3)

--- a/src/order-theory/finite-preorders.lagda.md
+++ b/src/order-theory/finite-preorders.lagda.md
@@ -180,7 +180,6 @@ module _
 ### Decidable sub-preorders of finite preorders
 
 ```agda
-
 module _
   {l1 l2 l3 : Level} (X : Finite-Preorder l1 l2)
   (S : element-Finite-Preorder X → decidable-Prop l3)

--- a/src/order-theory/finitely-graded-posets.lagda.md
+++ b/src/order-theory/finitely-graded-posets.lagda.md
@@ -44,7 +44,6 @@ A finitely graded poset consists of a family of types indexed by
 `Fin (succ-Fin (inl i))` for each `i : Fin k`.
 
 ```agda
-
 Finitely-Graded-Poset : (l1 l2 : Level) (k : ℕ) → UU (lsuc l1 ⊔ lsuc l2)
 Finitely-Graded-Poset l1 l2 k =
   Σ ( Fin (succ-ℕ k) → Set l1)
@@ -272,7 +271,6 @@ module _
 ### Poset structure on element-Finitely-Graded-Poset
 
 ```agda
-
 module _
   {l1 l2 : Level} {k : ℕ} (X : Finitely-Graded-Poset l1 l2 k)
   where
@@ -464,7 +462,6 @@ module _
 ## Finitely graded subposets
 
 ```agda
-
 module _
   {l1 l2 l3 : Level} {k : ℕ} (X : Finitely-Graded-Poset l1 l2 k)
   (S : {i : Fin (succ-ℕ k)} → face-Finitely-Graded-Poset X i → Prop l3)
@@ -615,7 +612,6 @@ module _
 ### Inclusion of finitely graded subposets
 
 ```agda
-
 module _
   {l1 l2 : Level} {k : ℕ} (X : Finitely-Graded-Poset l1 l2 k)
   where
@@ -676,7 +672,6 @@ module _
 ### Chains in finitely graded posets
 
 ```agda
-
 module _
   {l1 l2 : Level} {k : ℕ} (X : Finitely-Graded-Poset l1 l2 k)
   where
@@ -738,7 +733,6 @@ module _
 ### Maximal chains in preorders
 
 ```agda
-
 module _
   {l1 l2 : Level} {k : ℕ} (X : Finitely-Graded-Poset l1 l2 k)
   where

--- a/src/order-theory/frames.lagda.md
+++ b/src/order-theory/frames.lagda.md
@@ -27,16 +27,13 @@ There are many equivalent ways to formulate this definition. Our choice here is
 simply motivated by a desire to avoid iterated sigma types.
 
 ```agda
-
 Frame : (l1 l2 l3 : Level) → UU (lsuc l1 ⊔ lsuc l2 ⊔ lsuc l3)
 Frame l1 l2 l3 = Σ (Meet-Sup-Lattice l1 l2 l3) (distributive-law-meet-sup-lattice l1 l2 l3 )
-
 ```
 
 ## Now we retrieve all the information from a frame (i.e. break up all of it's components, etc.)
 
 ```agda
-
 module _
   {l1 l2 l3 : Level} (A : Frame l1 l2 l3)
   where
@@ -117,5 +114,4 @@ module _
   frame-Frame : Frame l1 l2 l3
   pr1 frame-Frame = meet-sup-lattice-Frame
   pr2 frame-Frame = distributive-law-Frame
-
 ```

--- a/src/order-theory/homomorphisms-frames.lagda.md
+++ b/src/order-theory/homomorphisms-frames.lagda.md
@@ -27,7 +27,6 @@ A frame homomorphism is an order preserving map between posets that additionally
 preserves binary meets and arbitrary joins.
 
 ```agda
-
 module _
   {l1 l2 l3 l4 l5 l6 : Level} (A : Frame l1 l2 l3) (B : Frame l4 l5 l6)
   where
@@ -51,5 +50,4 @@ module _
 
   preserves-sups-hom-Frame : (H : hom-Frame) → preserves-sups (sup-lattice-Frame A) (sup-lattice-Frame B) (map-hom-Frame H)
   preserves-sups-hom-Frame = pr2 ∘ preserves-meets-sups-hom-Frame
-
 ```

--- a/src/order-theory/homomorphisms-meet-semilattices.lagda.md
+++ b/src/order-theory/homomorphisms-meet-semilattices.lagda.md
@@ -25,7 +25,6 @@ A meet semi-lattice homomorphism is an order preserving map between the
 underlying posets that also preserves meets.
 
 ```agda
-
 module _
   {l1 l2 l3 l4 : Level} (A : Meet-Semilattice l1 l2) (B : Meet-Semilattice l3 l4)
   where
@@ -47,5 +46,4 @@ module _
 
   preserves-meet-hom-Meet-Semilattice : (H : hom-Meet-Semilattice) → preserves-meets (map-hom-Meet-Semilattice H)
   preserves-meet-hom-Meet-Semilattice = pr2 ∘ pr2
-
 ```

--- a/src/order-theory/homomorphisms-sup-lattices.lagda.md
+++ b/src/order-theory/homomorphisms-sup-lattices.lagda.md
@@ -25,7 +25,6 @@ A sup lattice homomorphism is a order preserving map between the underlying
 posets that additionally preserves sups (or arbitrary joins of subsets).
 
 ```agda
-
 module _
   {l1 l2 l3 l4 l5 l6 : Level} (A : Sup-Lattice l1 l2 l3) (B : Sup-Lattice l4 l5 l6)
   where
@@ -46,5 +45,4 @@ module _
 
   preserves-sup-hom-Sup-Lattice : (H : hom-Sup-Lattice) → preserves-sups (map-hom-Sup-Lattice H)
   preserves-sup-hom-Sup-Lattice = pr2 ∘ pr2
-
 ```

--- a/src/order-theory/infinite-distributive-law.lagda.md
+++ b/src/order-theory/infinite-distributive-law.lagda.md
@@ -30,7 +30,6 @@ following identity holds a ∧ (‌‌‌⋁ᵢ bᵢ) ＝ ⋁ᵢ (a ∧ bᵢ) No
 about the dual infinite distributive law but it is not needed at this time.
 
 ```agda
-
 module _
   {l1 l2 : Level} (l3 : Level) (P : Poset l1 l2)
   where
@@ -48,13 +47,11 @@ module _
 Meet-Sup-Lattice : (l1 l2 l3 : Level) → UU (lsuc l1 ⊔ lsuc l2 ⊔ lsuc l3)
 Meet-Sup-Lattice l1 l2 l3 =
   Σ (Poset l1 l2) (is-meet-sup-lattice-Poset l3)
-
 ```
 
 ## We need to provide the appropriate components to state the infinite distributive law.
 
 ```agda
-
 module _
   {l1 l2 l3 : Level} (A : Meet-Sup-Lattice l1 l2 l3)
   where
@@ -130,7 +127,6 @@ module _
     (I : UU l3) → (I → element-Meet-Sup-Lattice) →
     element-Meet-Sup-Lattice
   sup-Meet-Sup-Lattice I f = pr1 (is-sup-lattice-Meet-Sup-Lattice I f)
-
 ```
 
 ## Characterize the identity type.
@@ -138,14 +134,12 @@ module _
 ## We now state the infinite distributive law
 
 ```agda
-
 distributive-law-meet-sup-lattice : (l1 l2 l3 : Level) → (Meet-Sup-Lattice l1 l2 l3) → UU (l1 ⊔ lsuc l3)
 distributive-law-meet-sup-lattice l1 l2 l3 A =
   (a : element-Meet-Sup-Lattice A) → {I : UU l3} →
   (b : I → element-Meet-Sup-Lattice A) →
   (meet-Meet-Sup-Lattice A a (sup-Meet-Sup-Lattice A I b) ＝
   sup-Meet-Sup-Lattice A I (λ i → (meet-Meet-Sup-Lattice A a (b i))))
-
 ```
 
 This notation is not easy on the eye, but recall, in more familiar notation the

--- a/src/order-theory/join-semilattices.lagda.md
+++ b/src/order-theory/join-semilattices.lagda.md
@@ -117,7 +117,6 @@ module _
       ( join-Join-Semilattice x y)
   is-least-binary-upper-bound-join-Join-Semilattice x y =
     pr2 (is-join-semilattice-Join-Semilattice x y)
-
 ```
 
 ### Algebraic join-semilattices

--- a/src/order-theory/largest-elements-preorders.lagda.md
+++ b/src/order-theory/largest-elements-preorders.lagda.md
@@ -12,7 +12,7 @@ open import order-theory.preorders
 
 ## Definition
 
-```
+```agda
 module _
   {l1 l2 : Level} (X : Preorder l1 l2)
   where

--- a/src/order-theory/maximal-chains-posets.lagda.md
+++ b/src/order-theory/maximal-chains-posets.lagda.md
@@ -20,7 +20,6 @@ open import order-theory.posets
 ## Definition
 
 ```agda
-
 module _
   {l1 l2 : Level} (X : Poset l1 l2)
   where

--- a/src/order-theory/maximal-chains-preorders.lagda.md
+++ b/src/order-theory/maximal-chains-preorders.lagda.md
@@ -20,7 +20,6 @@ open import order-theory.preorders
 ## Definition
 
 ```agda
-
 module _
   {l1 l2 : Level} (X : Preorder l1 l2)
   where

--- a/src/order-theory/subposets.lagda.md
+++ b/src/order-theory/subposets.lagda.md
@@ -24,7 +24,6 @@ open import order-theory.subpreorders
 ### Subposets
 
 ```agda
-
 module _
   {l1 l2 l3 : Level} (X : Poset l1 l2) (S : element-Poset X → Prop l3)
   where
@@ -65,7 +64,6 @@ module _
   pr1 (pr1 (pr2 (pr2 sub-Poset))) = refl-leq-sub-Poset
   pr2 (pr1 (pr2 (pr2 sub-Poset))) = transitive-leq-sub-Poset
   pr2 (pr2 (pr2 sub-Poset)) = antisymmetric-leq-sub-Poset
-
 ```
 
 ### Inclusion of sub-posets

--- a/src/order-theory/sup-lattices.lagda.md
+++ b/src/order-theory/sup-lattices.lagda.md
@@ -52,14 +52,12 @@ module _
 
 Sup-Lattice : (l1 l2 l3 : Level) → UU (lsuc l1 ⊔ lsuc l2 ⊔ lsuc l3)
 Sup-Lattice l1 l2 l3 = Σ (Poset l1 l2) (λ P → is-sup-lattice-Poset l3 P)
-
 ```
 
 We now develop the tools that allow us to work with the components of a sup
 lattice.
 
 ```agda
-
 module _
   {l1 l2 l3 : Level} (A : Sup-Lattice l1 l2 l3)
   where
@@ -119,5 +117,4 @@ module _
     is-least-upper-bound-family-Poset poset-Sup-Lattice f
       (sup-Sup-Lattice I f)
   is-least-upper-bound-family-sup-Sup-Lattice I f = pr2 (is-sup-lattice-Sup-Lattice I f)
-
 ```

--- a/src/polytopes/abstract-polytopes.lagda.md
+++ b/src/polytopes/abstract-polytopes.lagda.md
@@ -46,7 +46,6 @@ Next, we assert the diamond condition for abstract polytopes.
 ### The diamond condition
 
 ```agda
-
 diamond-condition-finitely-graded-poset-Prop :
   {l1 l2 : Level} {k : ℕ} (X : Finitely-Graded-Poset l1 l2 k) →
   Prop (l1 ⊔ l2)
@@ -95,7 +94,6 @@ with a least and a largest element, and satisfying the diamond condition. Before
 we state the remaining conditions of polytopes, we introduce some terminology
 
 ```agda
-
 Prepolytope : (l1 l2 : Level) (k : ℕ) → UU (lsuc l1 ⊔ lsuc l2)
 Prepolytope l1 l2 k =
   Σ ( Finitely-Graded-Poset l1 l2 k)
@@ -427,7 +425,6 @@ module _
       is-prop (is-on-path-face-Prepolytope p z)
     is-prop-is-on-path-face-Prepolytope p z =
       is-prop-type-Prop (is-on-path-face-prepolytope-Prop p z)
-
 ```
 
 ### Proof condition P2 of polytopes
@@ -439,7 +436,6 @@ axiom follows from our setup. Note that we didn't start with general posets, but
 with finitely graded posets.
 
 ```agda
-
 module _
   {l1 l2 : Level} (l : Level) {k : ℕ} (X : Prepolytope l1 l2 k)
   where
@@ -475,7 +471,6 @@ connects the two flags it is a subchain of.
 ### The definition of polytopes
 
 ```agda
-
 Polytope :
   (l1 l2 l3 : Level) (k : ℕ) → UU (lsuc l1 ⊔ lsuc l2 ⊔ lsuc l3)
 Polytope l1 l2 l3 k =

--- a/src/ring-theory/sums-semirings.lagda.md
+++ b/src/ring-theory/sums-semirings.lagda.md
@@ -187,7 +187,6 @@ module _
       ( interchange-add-sum-Semiring n
         ( f ∘ inl-Fin n)
         ( g ∘ inl-Fin n)))
-
 ```
 
 ### Extending a sum of elements in a semiring

--- a/src/structured-types/coherent-h-spaces.lagda.md
+++ b/src/structured-types/coherent-h-spaces.lagda.md
@@ -167,5 +167,4 @@ compute-pointed-section-ev-pt-Pointed-Type (pair A a) =
     ( λ μp →
       Σ ( (x : A) → pr1 μp x a ＝ x)
         ( λ H → H a ＝ ( ( ap (λ h → h a) (pr2 μp) ∙ refl) ∙ refl))))
-
 ```

--- a/src/structured-types/universal-property-lists-wild-monoids.lagda.md
+++ b/src/structured-types/universal-property-lists-wild-monoids.lagda.md
@@ -280,7 +280,7 @@ elim-list-Wild-Monoid M f =
 
 ### Contractibility of the type `hom (list X) M` of morphisms of wild monoids
 
-```
+```agda
 -- htpy-elim-list-Wild-Monoid :
 --   {l1 l2 : Level} {X : UU l1} (M : Wild-Monoid l2)
 --   (g h : hom-Wild-Monoid (list-Wild-Monoid X) M)

--- a/src/synthetic-homotopy-theory/cofibers.lagda.md
+++ b/src/synthetic-homotopy-theory/cofibers.lagda.md
@@ -60,7 +60,6 @@ up-cofiber :
   ( {l : Level} →
     universal-property-pushout l f (const A unit star) (cocone-cofiber f))
 up-cofiber {A = A} f = up-pushout f (const A unit star)
-
 ```
 
 ## Properties

--- a/src/synthetic-homotopy-theory/infinite-cyclic-types.lagda.md
+++ b/src/synthetic-homotopy-theory/infinite-cyclic-types.lagda.md
@@ -202,5 +202,4 @@ module _
 -- pr1 (pr1 (Infinite-Cyclic-Type-𝕊¹ x)) = Id x x
 -- pr2 (pr1 (Infinite-Cyclic-Type-𝕊¹ x)) = {!!}
 -- pr2 (Infinite-Cyclic-Type-𝕊¹ x) = {!!}
-
 ```

--- a/src/synthetic-homotopy-theory/loop-spaces.lagda.md
+++ b/src/synthetic-homotopy-theory/loop-spaces.lagda.md
@@ -121,7 +121,7 @@ module _
 
 -- We compute transport of type-Ω
 
-```
+```agda
 module _
   {l1 : Level} {A : UU l1} {x y : A}
   where
@@ -158,5 +158,4 @@ module _
     (p : Id x y) (q : type-Ω (pair A x)) →
     Id (tr-type-Ω p q) (inv p ∙ (q ∙ p))
   eq-tr-type-Ω refl q = inv right-unit
-
 ```

--- a/src/trees/inequality-w-types.lagda.md
+++ b/src/trees/inequality-w-types.lagda.md
@@ -69,7 +69,6 @@ module _
   length-Path-𝕎 : (w : 𝕎 A B) → Path-𝕎 w → ℕ
   length-Path-𝕎 w (root .w) = zero-ℕ
   length-Path-𝕎 .(tree-𝕎 a f) (cons a f b p) = succ-ℕ (length-Path-𝕎 (f b) p)
-
 ```
 
 ## Properties

--- a/src/trees/ranks-of-elements-w-types.lagda.md
+++ b/src/trees/ranks-of-elements-w-types.lagda.md
@@ -105,7 +105,7 @@ module _
 
 ### Reflexivity of rank comparison
 
-```
+```agda
 module _
   {l1 l2 : Level} {A : UU l1} {B : A → UU l2}
   where

--- a/src/univalent-combinatorics/2-element-decidable-subtypes.lagda.md
+++ b/src/univalent-combinatorics/2-element-decidable-subtypes.lagda.md
@@ -329,7 +329,6 @@ module _
           is-finite-equiv
             ( inv-equiv equiv-bool-decidable-Prop ∘e equiv-bool-Fin-two-ℕ)
             ( is-finite-Fin 2)))
-
 ```
 
 ### 2-element decidable subtypes are closed under precomposition with an equivalence

--- a/src/univalent-combinatorics/cartesian-product-types.lagda.md
+++ b/src/univalent-combinatorics/cartesian-product-types.lagda.md
@@ -49,7 +49,7 @@ operation on finite types.
 
 ### The standard finite types are closed under cartesian products
 
-```
+```agda
 prod-Fin : (k l : ℕ) → ((Fin k) × (Fin l)) ≃ Fin (mul-ℕ k l)
 prod-Fin zero-ℕ l = left-absorption-prod (Fin l)
 prod-Fin (succ-ℕ k) l =

--- a/src/univalent-combinatorics/composition-species.lagda.md
+++ b/src/univalent-combinatorics/composition-species.lagda.md
@@ -51,7 +51,6 @@ analytic-comp-species {l1} {l2} {l3} S T X =
 ```agda
 analytic-unit-species : {l1 : Level} → species l1 l1
 analytic-unit-species X = is-contr (type-𝔽 X)
-
 ```
 
 ## Properties

--- a/src/univalent-combinatorics/inhabited-finite-types.lagda.md
+++ b/src/univalent-combinatorics/inhabited-finite-types.lagda.md
@@ -73,5 +73,4 @@ module _
 
   total-Fam-Inhabited-Types-𝔽 : 𝔽 (l1 ⊔ l2)
   total-Fam-Inhabited-Types-𝔽 = Σ-𝔽 X finite-type-Fam-Inhabited-Types-𝔽
-
 ```

--- a/src/univalent-combinatorics/lists.lagda.md
+++ b/src/univalent-combinatorics/lists.lagda.md
@@ -600,7 +600,6 @@ module _
   preserves-concat-map-list nil k = refl
   preserves-concat-map-list (cons x l) k =
     ap (cons (f x)) (preserves-concat-map-list l k)
-
 ```
 
 ### Multiplication of a list of elements in a monoid


### PR DESCRIPTION
Removes blank lines directly after Agda code block opening tags and similar, and also blank lines directly before a closing "```" tag.

Also adds an error when there are more opening or closing code block tags than there are closing/opening tags, and resolves detected issues regarding this.