### PR TITLE
Normal (commutative) submonoids and saturated congruence relations

### DIFF
--- a/src/elementary-number-theory.lagda.md
+++ b/src/elementary-number-theory.lagda.md
@@ -51,6 +51,7 @@ open import elementary-number-theory.inequality-integers public
 open import elementary-number-theory.inequality-natural-numbers public
 open import elementary-number-theory.inequality-standard-finite-types public
 open import elementary-number-theory.infinitude-of-primes public
+open import elementary-number-theory.initial-segments-natural-numbers public
 open import elementary-number-theory.integer-partitions public
 open import elementary-number-theory.integers public
 open import elementary-number-theory.kolakoski-sequence public
@@ -62,6 +63,7 @@ open import elementary-number-theory.minimum-natural-numbers public
 open import elementary-number-theory.minimum-standard-finite-types public
 open import elementary-number-theory.modular-arithmetic public
 open import elementary-number-theory.modular-arithmetic-standard-finite-types public
+open import elementary-number-theory.monoid-of-natural-numbers-with-maximum public
 open import elementary-number-theory.multiplication-integers public
 open import elementary-number-theory.multiplication-natural-numbers public
 open import elementary-number-theory.multiset-coefficients public

--- a/src/elementary-number-theory/initial-segments-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/initial-segments-natural-numbers.lagda.md
@@ -22,7 +22,8 @@ open import foundation.universe-levels
 
 ## Idea
 
-An **initial segment** of the natural numbers is a subtype `P : ℕ → Prop` such that the implication
+An **initial segment** of the natural numbers is a subtype `P : ℕ → Prop` such
+that the implication
 
 ```md
   P (n + 1) → P n

--- a/src/elementary-number-theory/initial-segments-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/initial-segments-natural-numbers.lagda.md
@@ -1,0 +1,118 @@
+# Initial segments of the natural numbers
+
+```agda
+module elementary-number-theory.initial-segments-natural-numbers where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import elementary-number-theory.maximum-natural-numbers
+open import elementary-number-theory.natural-numbers
+
+open import foundation.dependent-pair-types
+open import foundation.functions
+open import foundation.identity-types
+open import foundation.propositions
+open import foundation.subtypes
+open import foundation.universe-levels
+```
+
+</details>
+
+## Idea
+
+An **initial segment** of the natural numbers is a subtype `P : ℕ → Prop` such that the implication
+
+```md
+  P (n + 1) → P n
+```
+
+holds for every `n : ℕ`.
+
+## Definitions
+
+### Initial segments
+
+```agda
+is-initial-segment-subset-ℕ-Prop : {l : Level} (P : subtype l ℕ) → Prop l
+is-initial-segment-subset-ℕ-Prop P =
+  Π-Prop ℕ (λ n → implication-Prop (P (succ-ℕ n)) (P n))
+
+is-initial-segment-subset-ℕ : {l : Level} (P : subtype l ℕ) → UU l
+is-initial-segment-subset-ℕ P = type-Prop (is-initial-segment-subset-ℕ-Prop P)
+
+initial-segment-ℕ : (l : Level) → UU (lsuc l)
+initial-segment-ℕ l = type-subtype is-initial-segment-subset-ℕ-Prop
+
+module _
+  {l : Level} (I : initial-segment-ℕ l)
+  where
+
+  subset-initial-segment-ℕ : subtype l ℕ
+  subset-initial-segment-ℕ = pr1 I
+
+  is-initial-segment-initial-segment-ℕ :
+    is-initial-segment-subset-ℕ subset-initial-segment-ℕ
+  is-initial-segment-initial-segment-ℕ = pr2 I
+
+  is-in-initial-segment-ℕ : ℕ → UU l
+  is-in-initial-segment-ℕ = is-in-subtype subset-initial-segment-ℕ
+
+  is-closed-under-eq-initial-segment-ℕ :
+    {x y : ℕ} → is-in-initial-segment-ℕ x → x ＝ y → is-in-initial-segment-ℕ y
+  is-closed-under-eq-initial-segment-ℕ =
+    is-closed-under-eq-subtype subset-initial-segment-ℕ
+
+  is-closed-under-eq-initial-segment-ℕ' :
+    {x y : ℕ} → is-in-initial-segment-ℕ y → x ＝ y → is-in-initial-segment-ℕ x
+  is-closed-under-eq-initial-segment-ℕ' =
+    is-closed-under-eq-subtype' subset-initial-segment-ℕ
+```
+
+### Shifting initial segments
+
+```agda
+shift-initial-segment-ℕ :
+  {l : Level} → initial-segment-ℕ l → initial-segment-ℕ l
+pr1 (shift-initial-segment-ℕ I) = subset-initial-segment-ℕ I ∘ succ-ℕ
+pr2 (shift-initial-segment-ℕ I) =
+  is-initial-segment-initial-segment-ℕ I ∘ succ-ℕ
+```
+
+## Properties
+
+### Inhabited initial segments contain `0`
+
+```agda
+contains-zero-initial-segment-ℕ :
+  {l : Level} (I : initial-segment-ℕ l) →
+  (x : ℕ) → is-in-initial-segment-ℕ I x → is-in-initial-segment-ℕ I 0
+contains-zero-initial-segment-ℕ I zero-ℕ H = H
+contains-zero-initial-segment-ℕ I (succ-ℕ x) H =
+  is-initial-segment-initial-segment-ℕ I 0
+    ( contains-zero-initial-segment-ℕ (shift-initial-segment-ℕ I) x H)
+```
+
+### Initial segments that contain a successor contain `1`
+
+```agda
+contains-one-initial-segment-ℕ :
+  {l : Level} (I : initial-segment-ℕ l) →
+  (x : ℕ) → is-in-initial-segment-ℕ I (succ-ℕ x) → is-in-initial-segment-ℕ I 1
+contains-one-initial-segment-ℕ I =
+  contains-zero-initial-segment-ℕ (shift-initial-segment-ℕ I)
+```
+
+### Initial segments are closed under `max-ℕ`
+
+```agda
+max-initial-segment-ℕ :
+  {l : Level} (I : initial-segment-ℕ l) →
+  (x y : ℕ) → is-in-initial-segment-ℕ I x → is-in-initial-segment-ℕ I y →
+  is-in-initial-segment-ℕ I (max-ℕ x y)
+max-initial-segment-ℕ I zero-ℕ y H K = K
+max-initial-segment-ℕ I (succ-ℕ x) zero-ℕ H K = H
+max-initial-segment-ℕ I (succ-ℕ x) (succ-ℕ y) H K =
+  max-initial-segment-ℕ (shift-initial-segment-ℕ I) x y H K
+```

--- a/src/elementary-number-theory/maximum-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/maximum-natural-numbers.lagda.md
@@ -7,11 +7,13 @@ module elementary-number-theory.maximum-natural-numbers where
 <details><summary>Imports</summary>
 
 ```agda
+open import elementary-number-theory.addition-natural-numbers
 open import elementary-number-theory.inequality-natural-numbers
 open import elementary-number-theory.natural-numbers
 
 open import foundation.coproduct-types
 open import foundation.dependent-pair-types
+open import foundation.identity-types
 open import foundation.unit-type
 
 open import order-theory.least-upper-bounds-posets
@@ -27,12 +29,24 @@ We define the operation of maximum (least upper bound) for the natural numbers.
 
 ## Definition
 
+### Maximum of natural numbers
+
 ```agda
 max-ℕ : ℕ → (ℕ → ℕ)
 max-ℕ 0 n = n
 max-ℕ (succ-ℕ m) 0 = succ-ℕ m
 max-ℕ (succ-ℕ m) (succ-ℕ n) = succ-ℕ (max-ℕ m n)
 
+ap-max-ℕ : {x x' y y' : ℕ} → x ＝ x' → y ＝ y' → max-ℕ x y ＝ max-ℕ x' y'
+ap-max-ℕ p q = ap-binary max-ℕ p q
+
+max-ℕ' : ℕ → (ℕ → ℕ)
+max-ℕ' x y = max-ℕ y x
+```
+
+### Maximum of elements of standard finite types
+
+```agda
 max-Fin-ℕ : (n : ℕ) → (Fin n → ℕ) → ℕ
 max-Fin-ℕ zero-ℕ f = zero-ℕ
 max-Fin-ℕ (succ-ℕ n) f = max-ℕ (f (inr star)) (max-Fin-ℕ n (λ k → f (inl k)))
@@ -73,4 +87,83 @@ is-least-upper-bound-max-ℕ m n =
   ( leq-left-leq-max-ℕ (max-ℕ m n) m n (refl-leq-ℕ (max-ℕ m n)),
     leq-right-leq-max-ℕ (max-ℕ m n) m n (refl-leq-ℕ (max-ℕ m n))),
   λ x (m≤x , n≤x) → leq-max-ℕ x m n m≤x n≤x
+```
+
+### Maximum is associative
+
+```agda
+associative-max-ℕ :
+  (x y z : ℕ) → max-ℕ (max-ℕ x y) z ＝ max-ℕ x (max-ℕ y z)
+associative-max-ℕ zero-ℕ y z = refl
+associative-max-ℕ (succ-ℕ x) zero-ℕ zero-ℕ = refl
+associative-max-ℕ (succ-ℕ x) zero-ℕ (succ-ℕ z) = refl
+associative-max-ℕ (succ-ℕ x) (succ-ℕ y) zero-ℕ = refl
+associative-max-ℕ (succ-ℕ x) (succ-ℕ y) (succ-ℕ z) =
+  ap succ-ℕ (associative-max-ℕ x y z)
+```
+
+### Unit laws for `max-ℕ`
+
+```agda
+left-unit-law-max-ℕ : (x : ℕ) → max-ℕ 0 x ＝ x
+left-unit-law-max-ℕ x = refl
+
+right-unit-law-max-ℕ : (x : ℕ) → max-ℕ x 0 ＝ x
+right-unit-law-max-ℕ zero-ℕ = refl
+right-unit-law-max-ℕ (succ-ℕ x) = refl
+```
+
+### Commutativity of `max-ℕ`
+
+```agda
+commutative-max-ℕ : (x y : ℕ) → max-ℕ x y ＝ max-ℕ y x
+commutative-max-ℕ zero-ℕ zero-ℕ = refl
+commutative-max-ℕ zero-ℕ (succ-ℕ y) = refl
+commutative-max-ℕ (succ-ℕ x) zero-ℕ = refl
+commutative-max-ℕ (succ-ℕ x) (succ-ℕ y) = ap succ-ℕ (commutative-max-ℕ x y)
+```
+
+### `max-ℕ` is idempotent
+
+```agda
+idempotent-max-ℕ : (x : ℕ) → max-ℕ x x ＝ x
+idempotent-max-ℕ zero-ℕ = refl
+idempotent-max-ℕ (succ-ℕ x) = ap succ-ℕ (idempotent-max-ℕ x)
+```
+
+### Successor diagonal laws for `max-ℕ`
+
+```agda
+left-successor-diagonal-law-max-ℕ : (x : ℕ) → max-ℕ (succ-ℕ x) x ＝ succ-ℕ x
+left-successor-diagonal-law-max-ℕ zero-ℕ = refl
+left-successor-diagonal-law-max-ℕ (succ-ℕ x) =
+  ap succ-ℕ (left-successor-diagonal-law-max-ℕ x)
+
+right-successor-diagonal-law-max-ℕ : (x : ℕ) → max-ℕ x (succ-ℕ x) ＝ succ-ℕ x
+right-successor-diagonal-law-max-ℕ zero-ℕ = refl
+right-successor-diagonal-law-max-ℕ (succ-ℕ x) =
+  ap succ-ℕ (right-successor-diagonal-law-max-ℕ x)
+```
+
+### Addition distributes over max
+
+```agda
+left-distributive-add-max-ℕ :
+  (x y z : ℕ) → add-ℕ x (max-ℕ y z) ＝ max-ℕ (add-ℕ x y) (add-ℕ x z)
+left-distributive-add-max-ℕ zero-ℕ y z =
+  ( left-unit-law-add-ℕ (max-ℕ y z)) ∙
+  ( ap-max-ℕ (inv (left-unit-law-add-ℕ y)) (inv (left-unit-law-add-ℕ z)))
+left-distributive-add-max-ℕ (succ-ℕ x) y z =
+  ( left-successor-law-add-ℕ x (max-ℕ y z)) ∙
+  ( ( ap succ-ℕ (left-distributive-add-max-ℕ x y z)) ∙
+    ( ap-max-ℕ
+      ( inv (left-successor-law-add-ℕ x y))
+      ( inv (left-successor-law-add-ℕ x z))))
+
+right-distributive-add-max-ℕ :
+  (x y z : ℕ) → add-ℕ (max-ℕ x y) z ＝ max-ℕ (add-ℕ x z) (add-ℕ y z)
+right-distributive-add-max-ℕ x y z =
+  ( commutative-add-ℕ (max-ℕ x y) z) ∙
+  ( ( left-distributive-add-max-ℕ z x y) ∙
+    ( ap-max-ℕ (commutative-add-ℕ z x) (commutative-add-ℕ z y)))
 ```

--- a/src/elementary-number-theory/maximum-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/maximum-natural-numbers.lagda.md
@@ -89,7 +89,7 @@ is-least-upper-bound-max-ℕ m n =
   λ x (m≤x , n≤x) → leq-max-ℕ x m n m≤x n≤x
 ```
 
-### Maximum is associative
+### Associativity of `max-ℕ`
 
 ```agda
 associative-max-ℕ :
@@ -145,7 +145,7 @@ right-successor-diagonal-law-max-ℕ (succ-ℕ x) =
   ap succ-ℕ (right-successor-diagonal-law-max-ℕ x)
 ```
 
-### Addition distributes over max
+### Addition distributes over `max-ℕ`
 
 ```agda
 left-distributive-add-max-ℕ :

--- a/src/elementary-number-theory/minimum-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/minimum-natural-numbers.lagda.md
@@ -46,7 +46,7 @@ min-Fin-ℕ (succ-ℕ n) f = min-ℕ (f (inr star)) (min-Fin-ℕ n (λ k → f (
 
 ## Properties
 
-### Minimum is a greatest lower bound
+### The minimum of two natural numbers is a greatest lower bound
 
 ```agda
 leq-min-ℕ :
@@ -83,7 +83,7 @@ is-greatest-lower-bound-min-ℕ l m =
   λ x (x≤l , x≤m) → leq-min-ℕ x l m x≤l x≤m
 ```
 
-### Minimum is associative
+### Associativity of `min-ℕ`
 
 ```agda
 associative-min-ℕ :
@@ -125,7 +125,7 @@ idempotent-min-ℕ zero-ℕ = refl
 idempotent-min-ℕ (succ-ℕ x) = ap succ-ℕ (idempotent-min-ℕ x)
 ```
 
-### Addition distributes over min
+### Addition distributes over `min-ℕ`
 
 ```agda
 left-distributive-add-min-ℕ :

--- a/src/elementary-number-theory/minimum-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/minimum-natural-numbers.lagda.md
@@ -7,11 +7,13 @@ module elementary-number-theory.minimum-natural-numbers where
 <details><summary>Imports</summary>
 
 ```agda
+open import elementary-number-theory.addition-natural-numbers
 open import elementary-number-theory.inequality-natural-numbers
 open import elementary-number-theory.natural-numbers
 
 open import foundation.coproduct-types
 open import foundation.dependent-pair-types
+open import foundation.identity-types
 open import foundation.unit-type
 
 open import order-theory.greatest-lower-bounds-posets
@@ -33,6 +35,9 @@ min-ℕ : ℕ → (ℕ → ℕ)
 min-ℕ 0 n = 0
 min-ℕ (succ-ℕ m) 0 = 0
 min-ℕ (succ-ℕ m) (succ-ℕ n) = succ-ℕ (min-ℕ m n)
+
+ap-min-ℕ : {x x' y y' : ℕ} → x ＝ x' → y ＝ y' → min-ℕ x y ＝ min-ℕ x' y'
+ap-min-ℕ p q = ap-binary min-ℕ p q
 
 min-Fin-ℕ : (n : ℕ) → (Fin (succ-ℕ n) → ℕ) → ℕ
 min-Fin-ℕ zero-ℕ f = f (inr star)
@@ -76,4 +81,69 @@ is-greatest-lower-bound-min-ℕ l m =
   ( leq-left-leq-min-ℕ (min-ℕ l m) l m (refl-leq-ℕ (min-ℕ l m)),
     leq-right-leq-min-ℕ (min-ℕ l m) l m (refl-leq-ℕ (min-ℕ l m))),
   λ x (x≤l , x≤m) → leq-min-ℕ x l m x≤l x≤m
+```
+
+### Minimum is associative
+
+```agda
+associative-min-ℕ :
+  (x y z : ℕ) → min-ℕ (min-ℕ x y) z ＝ min-ℕ x (min-ℕ y z)
+associative-min-ℕ zero-ℕ y z = refl
+associative-min-ℕ (succ-ℕ x) zero-ℕ zero-ℕ = refl
+associative-min-ℕ (succ-ℕ x) zero-ℕ (succ-ℕ z) = refl
+associative-min-ℕ (succ-ℕ x) (succ-ℕ y) zero-ℕ = refl
+associative-min-ℕ (succ-ℕ x) (succ-ℕ y) (succ-ℕ z) =
+  ap succ-ℕ (associative-min-ℕ x y z)
+```
+
+### Zero laws for `min-ℕ`
+
+```agda
+left-zero-law-min-ℕ : (x : ℕ) → min-ℕ 0 x ＝ 0
+left-zero-law-min-ℕ x = refl
+
+right-zero-law-min-ℕ : (x : ℕ) → min-ℕ x 0 ＝ 0
+right-zero-law-min-ℕ zero-ℕ = refl
+right-zero-law-min-ℕ (succ-ℕ x) = refl
+```
+
+### Commutativity of `min-ℕ`
+
+```agda
+commutative-min-ℕ : (x y : ℕ) → min-ℕ x y ＝ min-ℕ y x
+commutative-min-ℕ zero-ℕ zero-ℕ = refl
+commutative-min-ℕ zero-ℕ (succ-ℕ y) = refl
+commutative-min-ℕ (succ-ℕ x) zero-ℕ = refl
+commutative-min-ℕ (succ-ℕ x) (succ-ℕ y) = ap succ-ℕ (commutative-min-ℕ x y)
+```
+
+### `min-ℕ` is idempotent
+
+```agda
+idempotent-min-ℕ : (x : ℕ) → min-ℕ x x ＝ x
+idempotent-min-ℕ zero-ℕ = refl
+idempotent-min-ℕ (succ-ℕ x) = ap succ-ℕ (idempotent-min-ℕ x)
+```
+
+### Addition distributes over min
+
+```agda
+left-distributive-add-min-ℕ :
+  (x y z : ℕ) → add-ℕ x (min-ℕ y z) ＝ min-ℕ (add-ℕ x y) (add-ℕ x z)
+left-distributive-add-min-ℕ zero-ℕ y z =
+  ( left-unit-law-add-ℕ (min-ℕ y z)) ∙
+  ( ap-min-ℕ (inv (left-unit-law-add-ℕ y)) (inv (left-unit-law-add-ℕ z)))
+left-distributive-add-min-ℕ (succ-ℕ x) y z =
+  ( left-successor-law-add-ℕ x (min-ℕ y z)) ∙
+  ( ( ap succ-ℕ (left-distributive-add-min-ℕ x y z)) ∙
+    ( ap-min-ℕ
+      ( inv (left-successor-law-add-ℕ x y))
+      ( inv (left-successor-law-add-ℕ x z))))
+
+right-distributive-add-min-ℕ :
+  (x y z : ℕ) → add-ℕ (min-ℕ x y) z ＝ min-ℕ (add-ℕ x z) (add-ℕ y z)
+right-distributive-add-min-ℕ x y z =
+  ( commutative-add-ℕ (min-ℕ x y) z) ∙
+  ( ( left-distributive-add-min-ℕ z x y) ∙
+    ( ap-min-ℕ (commutative-add-ℕ z x) (commutative-add-ℕ z y)))
 ```

--- a/src/elementary-number-theory/monoid-of-natural-numbers-with-maximum.lagda.md
+++ b/src/elementary-number-theory/monoid-of-natural-numbers-with-maximum.lagda.md
@@ -28,7 +28,10 @@ open import group-theory.subsets-monoids
 
 ## Idea
 
-The type `ℕ` of natural numbers equipped with `0` and `max-ℕ` forms a monoid. Normal submonoids of this monoid are initial segments of the natural numbers. Furthermore, the identity relation is a nonsaturated congruence relation on `ℕ-Max`.
+The type `ℕ` of natural numbers equipped with `0` and `max-ℕ` forms a monoid.
+Normal submonoids of this monoid are initial segments of the natural numbers.
+Furthermore, the identity relation is a nonsaturated congruence relation on
+`ℕ-Max`.
 
 ## Definition
 

--- a/src/elementary-number-theory/monoid-of-natural-numbers-with-maximum.lagda.md
+++ b/src/elementary-number-theory/monoid-of-natural-numbers-with-maximum.lagda.md
@@ -1,0 +1,111 @@
+# The monoid of the natural numbers with maximum
+
+```agda
+module elementary-number-theory.monoid-of-natural-numbers-with-maximum where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import elementary-number-theory.initial-segments-natural-numbers
+open import elementary-number-theory.maximum-natural-numbers
+open import elementary-number-theory.natural-numbers
+
+open import foundation.dependent-pair-types
+open import foundation.identity-types
+open import foundation.logical-equivalences
+open import foundation.universe-levels
+
+open import group-theory.commutative-monoids
+open import group-theory.monoids
+open import group-theory.normal-submonoids-commutative-monoids
+open import group-theory.semigroups
+open import group-theory.submonoids-commutative-monoids
+open import group-theory.subsets-monoids
+```
+
+</details>
+
+## Idea
+
+The type `ℕ` of natural numbers equipped with `0` and `max-ℕ` forms a monoid. Normal submonoids of this monoid are initial segments of the natural numbers. Furthermore, the identity relation is a nonsaturated congruence relation on `ℕ-Max`.
+
+## Definition
+
+```agda
+semigroup-ℕ-Max : Semigroup lzero
+pr1 semigroup-ℕ-Max = ℕ-Set
+pr1 (pr2 semigroup-ℕ-Max) = max-ℕ
+pr2 (pr2 semigroup-ℕ-Max) = associative-max-ℕ
+
+monoid-ℕ-Max : Monoid lzero
+pr1 monoid-ℕ-Max = semigroup-ℕ-Max
+pr1 (pr2 monoid-ℕ-Max) = 0
+pr1 (pr2 (pr2 monoid-ℕ-Max)) = left-unit-law-max-ℕ
+pr2 (pr2 (pr2 monoid-ℕ-Max)) = right-unit-law-max-ℕ
+
+ℕ-Max : Commutative-Monoid lzero
+pr1 ℕ-Max = monoid-ℕ-Max
+pr2 ℕ-Max = commutative-max-ℕ
+```
+
+## Properties
+
+### Normal Submonoids of `ℕ-Max` are initial segments of the natural numbers
+
+```agda
+module _
+  {l : Level} (N : Normal-Commutative-Submonoid l ℕ-Max)
+  where
+
+  is-initial-segment-Normal-Commutative-Submonoid-ℕ-Max :
+    is-initial-segment-subset-ℕ
+      ( subset-Normal-Commutative-Submonoid ℕ-Max N)
+  is-initial-segment-Normal-Commutative-Submonoid-ℕ-Max x H =
+      ( is-normal-Normal-Commutative-Submonoid ℕ-Max N x
+        ( succ-ℕ x)
+        ( H))
+      ( is-closed-under-eq-Normal-Commutative-Submonoid'
+        ( ℕ-Max)
+        ( N)
+        ( H)
+        ( right-successor-diagonal-law-max-ℕ x))
+
+  initial-segment-Normal-Submonoid-ℕ-Max : initial-segment-ℕ l
+  pr1 initial-segment-Normal-Submonoid-ℕ-Max =
+    subset-Normal-Commutative-Submonoid ℕ-Max N
+  pr2 initial-segment-Normal-Submonoid-ℕ-Max =
+    is-initial-segment-Normal-Commutative-Submonoid-ℕ-Max
+```
+
+### Initial segments of the natural numbers are normal submonoids of `ℕ-Max`
+
+```agda
+submonoid-initial-segment-ℕ-Max :
+  {l : Level} (I : initial-segment-ℕ l) (i0 : is-in-initial-segment-ℕ I 0) →
+  Commutative-Submonoid l ℕ-Max
+pr1 (submonoid-initial-segment-ℕ-Max I i0) = subset-initial-segment-ℕ I
+pr1 (pr2 (submonoid-initial-segment-ℕ-Max I i0)) = i0
+pr2 (pr2 (submonoid-initial-segment-ℕ-Max I i0)) = max-initial-segment-ℕ I
+
+is-normal-submonoid-initial-segment-ℕ-Max :
+  {l : Level} (I : initial-segment-ℕ l) (i0 : is-in-initial-segment-ℕ I 0) →
+  is-normal-Commutative-Submonoid
+    ℕ-Max
+    (submonoid-initial-segment-ℕ-Max I i0)
+is-normal-submonoid-initial-segment-ℕ-Max I i0 u zero-ℕ H K =
+  is-closed-under-eq-Commutative-Submonoid
+    ( ℕ-Max)
+    ( submonoid-initial-segment-ℕ-Max I i0)
+    ( K)
+    ( right-unit-law-max-ℕ u)
+is-normal-submonoid-initial-segment-ℕ-Max I i0 zero-ℕ (succ-ℕ x) H K = i0
+is-normal-submonoid-initial-segment-ℕ-Max I i0 (succ-ℕ u) (succ-ℕ x) H K =
+  is-normal-submonoid-initial-segment-ℕ-Max
+    ( shift-initial-segment-ℕ I)
+    ( contains-one-initial-segment-ℕ I (max-ℕ u x) K)
+    ( u)
+    ( x)
+    ( H)
+    ( K)
+```

--- a/src/group-theory.lagda.md
+++ b/src/group-theory.lagda.md
@@ -25,6 +25,7 @@ open import group-theory.commutators-groups public
 open import group-theory.concrete-group-actions public
 open import group-theory.concrete-groups public
 open import group-theory.congruence-relations-abelian-groups public
+open import group-theory.congruence-relations-commutative-monoids public
 open import group-theory.congruence-relations-groups public
 open import group-theory.congruence-relations-monoids public
 open import group-theory.congruence-relations-semigroups public
@@ -65,6 +66,7 @@ open import group-theory.groups public
 open import group-theory.higher-group-actions public
 open import group-theory.higher-groups public
 open import group-theory.homomorphisms-abelian-groups public
+open import group-theory.homomorphisms-commutative-monoids public
 open import group-theory.homomorphisms-concrete-group-actions public
 open import group-theory.homomorphisms-concrete-groups public
 open import group-theory.homomorphisms-generated-subgroups public
@@ -94,6 +96,7 @@ open import group-theory.monomorphisms-groups public
 open import group-theory.normal-subgroups public
 open import group-theory.normal-subgroups-concrete-groups public
 open import group-theory.normal-submonoids public
+open import group-theory.normal-submonoids-commutative-monoids public
 open import group-theory.opposite-groups public
 open import group-theory.orbit-stabilizer-theorem-concrete-groups public
 open import group-theory.orbits-concrete-group-actions public
@@ -112,6 +115,8 @@ open import group-theory.quotient-groups public
 open import group-theory.quotient-groups-concrete-groups public
 open import group-theory.quotients-abelian-groups public
 open import group-theory.representations-monoids public
+open import group-theory.saturated-congruence-relations-commutative-monoids public
+open import group-theory.saturated-congruence-relations-monoids public
 open import group-theory.semigroups public
 open import group-theory.sheargroups public
 open import group-theory.shriek-concrete-group-actions public
@@ -123,7 +128,10 @@ open import group-theory.subgroups-concrete-groups public
 open import group-theory.subgroups-generated-by-subsets-groups public
 open import group-theory.subgroups-higher-groups public
 open import group-theory.submonoids public
+open import group-theory.submonoids-commutative-monoids public
 open import group-theory.subsemigroups public
+open import group-theory.subsets-commutative-monoids public
+open import group-theory.subsets-monoids public
 open import group-theory.substitution-functor-concrete-group-actions public
 open import group-theory.substitution-functor-group-actions public
 open import group-theory.symmetric-concrete-groups public

--- a/src/group-theory/congruence-relations-commutative-monoids.lagda.md
+++ b/src/group-theory/congruence-relations-commutative-monoids.lagda.md
@@ -1,0 +1,188 @@
+# Congruence relations on commutative monoids
+
+```agda
+module group-theory.congruence-relations-commutative-monoids where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.binary-relations
+open import foundation.contractible-types
+open import foundation.dependent-pair-types
+open import foundation.equivalence-relations
+open import foundation.equivalences
+open import foundation.identity-types
+open import foundation.propositions
+open import foundation.structure-identity-principle
+open import foundation.subtype-identity-principle
+open import foundation.universe-levels
+
+open import group-theory.commutative-monoids
+open import group-theory.congruence-relations-monoids
+open import group-theory.monoids
+```
+
+</details>
+
+## Idea
+
+A congruence relation on a commutative monoid `M` is a congruence relation on the underlying monoid of `M`.
+
+## Definition
+
+```agda
+is-congruence-commutative-monoid-Prop :
+  {l1 l2 : Level} (M : Commutative-Monoid l1) →
+  Eq-Rel l2 (type-Commutative-Monoid M) → Prop (l1 ⊔ l2)
+is-congruence-commutative-monoid-Prop M =
+  is-congruence-monoid-Prop (monoid-Commutative-Monoid M)
+
+is-congruence-Commutative-Monoid :
+  {l1 l2 : Level} (M : Commutative-Monoid l1) →
+  Eq-Rel l2 (type-Commutative-Monoid M) → UU (l1 ⊔ l2)
+is-congruence-Commutative-Monoid M =
+  is-congruence-Monoid (monoid-Commutative-Monoid M)
+
+is-prop-is-congruence-Commutative-Monoid :
+  {l1 l2 : Level} (M : Commutative-Monoid l1)
+  (R : Eq-Rel l2 (type-Commutative-Monoid M)) →
+  is-prop (is-congruence-Commutative-Monoid M R)
+is-prop-is-congruence-Commutative-Monoid M =
+  is-prop-is-congruence-Monoid (monoid-Commutative-Monoid M)
+
+congruence-Commutative-Monoid :
+  {l : Level} (l2 : Level) (M : Commutative-Monoid l) → UU (l ⊔ lsuc l2)
+congruence-Commutative-Monoid l2 M =
+  congruence-Monoid l2 (monoid-Commutative-Monoid M)
+
+module _
+  {l1 l2 : Level} (M : Commutative-Monoid l1)
+  (R : congruence-Commutative-Monoid l2 M)
+  where
+
+  eq-rel-congruence-Commutative-Monoid : Eq-Rel l2 (type-Commutative-Monoid M)
+  eq-rel-congruence-Commutative-Monoid =
+    eq-rel-congruence-Monoid (monoid-Commutative-Monoid M) R
+
+  prop-congruence-Commutative-Monoid : Rel-Prop l2 (type-Commutative-Monoid M)
+  prop-congruence-Commutative-Monoid =
+    prop-congruence-Monoid (monoid-Commutative-Monoid M) R
+
+  sim-congruence-Commutative-Monoid : (x y : type-Commutative-Monoid M) → UU l2
+  sim-congruence-Commutative-Monoid =
+    sim-congruence-Monoid (monoid-Commutative-Monoid M) R
+
+  is-prop-sim-congruence-Commutative-Monoid :
+    (x y : type-Commutative-Monoid M) →
+    is-prop (sim-congruence-Commutative-Monoid x y)
+  is-prop-sim-congruence-Commutative-Monoid =
+    is-prop-sim-congruence-Monoid (monoid-Commutative-Monoid M) R
+
+  concatenate-sim-eq-congruence-Commutative-Monoid :
+    {x y z : type-Commutative-Monoid M} →
+    sim-congruence-Commutative-Monoid x y → y ＝ z →
+    sim-congruence-Commutative-Monoid x z
+  concatenate-sim-eq-congruence-Commutative-Monoid =
+    concatenate-sim-eq-congruence-Monoid (monoid-Commutative-Monoid M) R
+
+  concatenate-eq-sim-congruence-Commutative-Monoid :
+    {x y z : type-Commutative-Monoid M} → x ＝ y →
+    sim-congruence-Commutative-Monoid y z →
+    sim-congruence-Commutative-Monoid x z
+  concatenate-eq-sim-congruence-Commutative-Monoid =
+    concatenate-eq-sim-congruence-Monoid (monoid-Commutative-Monoid M) R
+
+  concatenate-eq-sim-eq-congruence-Commutative-Monoid :
+    {x y z w : type-Commutative-Monoid M} → x ＝ y →
+    sim-congruence-Commutative-Monoid y z →
+    z ＝ w → sim-congruence-Commutative-Monoid x w
+  concatenate-eq-sim-eq-congruence-Commutative-Monoid =
+    concatenate-eq-sim-eq-congruence-Monoid (monoid-Commutative-Monoid M) R
+
+  refl-congruence-Commutative-Monoid :
+    is-reflexive-Rel-Prop prop-congruence-Commutative-Monoid
+  refl-congruence-Commutative-Monoid =
+    refl-congruence-Monoid (monoid-Commutative-Monoid M) R
+
+  symm-congruence-Commutative-Monoid :
+    is-symmetric-Rel-Prop prop-congruence-Commutative-Monoid
+  symm-congruence-Commutative-Monoid =
+    symm-congruence-Monoid (monoid-Commutative-Monoid M) R
+
+  equiv-symm-congruence-Commutative-Monoid :
+    (x y : type-Commutative-Monoid M) →
+    sim-congruence-Commutative-Monoid x y ≃
+    sim-congruence-Commutative-Monoid y x
+  equiv-symm-congruence-Commutative-Monoid =
+    equiv-symm-congruence-Monoid (monoid-Commutative-Monoid M) R
+
+  trans-congruence-Commutative-Monoid :
+    is-transitive-Rel-Prop prop-congruence-Commutative-Monoid
+  trans-congruence-Commutative-Monoid =
+    trans-congruence-Monoid (monoid-Commutative-Monoid M) R
+
+  mul-congruence-Commutative-Monoid :
+    is-congruence-Commutative-Monoid M eq-rel-congruence-Commutative-Monoid
+  mul-congruence-Commutative-Monoid =
+    mul-congruence-Monoid (monoid-Commutative-Monoid M) R
+```
+
+## Properties
+
+### Extensionality of the type of congruence relations on a monoid
+
+```agda
+relate-same-elements-congruence-Commutative-Monoid :
+  {l1 l2 l3 : Level} (M : Commutative-Monoid l1)
+  (R : congruence-Commutative-Monoid l2 M)
+  (S : congruence-Commutative-Monoid l3 M) → UU (l1 ⊔ l2 ⊔ l3)
+relate-same-elements-congruence-Commutative-Monoid M =
+  relate-same-elements-congruence-Monoid (monoid-Commutative-Monoid M)
+
+refl-relate-same-elements-congruence-Commutative-Monoid :
+  {l1 l2 : Level} (M : Commutative-Monoid l1)
+  (R : congruence-Commutative-Monoid l2 M) →
+  relate-same-elements-congruence-Commutative-Monoid M R R
+refl-relate-same-elements-congruence-Commutative-Monoid M =
+  refl-relate-same-elements-congruence-Monoid (monoid-Commutative-Monoid M)
+
+is-contr-total-relate-same-elements-congruence-Commutative-Monoid :
+  {l1 l2 : Level} (M : Commutative-Monoid l1)
+  (R : congruence-Commutative-Monoid l2 M) →
+  is-contr
+    ( Σ ( congruence-Commutative-Monoid l2 M)
+        ( relate-same-elements-congruence-Commutative-Monoid M R))
+is-contr-total-relate-same-elements-congruence-Commutative-Monoid M =
+  is-contr-total-relate-same-elements-congruence-Monoid
+    ( monoid-Commutative-Monoid M)
+
+relate-same-elements-eq-congruence-Commutative-Monoid :
+  {l1 l2 : Level} (M : Commutative-Monoid l1)
+  (R S : congruence-Commutative-Monoid l2 M) →
+  R ＝ S → relate-same-elements-congruence-Commutative-Monoid M R S
+relate-same-elements-eq-congruence-Commutative-Monoid M =
+  relate-same-elements-eq-congruence-Monoid (monoid-Commutative-Monoid M)
+
+is-equiv-relate-same-elements-eq-congruence-Commutative-Monoid :
+  {l1 l2 : Level} (M : Commutative-Monoid l1)
+  (R S : congruence-Commutative-Monoid l2 M) →
+  is-equiv (relate-same-elements-eq-congruence-Commutative-Monoid M R S)
+is-equiv-relate-same-elements-eq-congruence-Commutative-Monoid M =
+  is-equiv-relate-same-elements-eq-congruence-Monoid
+    ( monoid-Commutative-Monoid M)
+
+extensionality-congruence-Commutative-Monoid :
+  {l1 l2 : Level} (M : Commutative-Monoid l1)
+  (R S : congruence-Commutative-Monoid l2 M) →
+  (R ＝ S) ≃ relate-same-elements-congruence-Commutative-Monoid M R S
+extensionality-congruence-Commutative-Monoid M =
+  extensionality-congruence-Monoid (monoid-Commutative-Monoid M)
+
+eq-relate-same-elements-congruence-Commutative-Monoid :
+  {l1 l2 : Level} (M : Commutative-Monoid l1)
+  (R S : congruence-Commutative-Monoid l2 M) →
+  relate-same-elements-congruence-Commutative-Monoid M R S → R ＝ S
+eq-relate-same-elements-congruence-Commutative-Monoid M =
+  eq-relate-same-elements-congruence-Monoid (monoid-Commutative-Monoid M)
+```

--- a/src/group-theory/congruence-relations-commutative-monoids.lagda.md
+++ b/src/group-theory/congruence-relations-commutative-monoids.lagda.md
@@ -27,7 +27,8 @@ open import group-theory.monoids
 
 ## Idea
 
-A congruence relation on a commutative monoid `M` is a congruence relation on the underlying monoid of `M`.
+A congruence relation on a commutative monoid `M` is a congruence relation on
+the underlying monoid of `M`.
 
 ## Definition
 

--- a/src/group-theory/congruence-relations-monoids.lagda.md
+++ b/src/group-theory/congruence-relations-monoids.lagda.md
@@ -8,10 +8,14 @@ module group-theory.congruence-relations-monoids where
 
 ```agda
 open import foundation.binary-relations
+open import foundation.contractible-types
 open import foundation.dependent-pair-types
 open import foundation.equivalence-relations
 open import foundation.equivalences
+open import foundation.identity-types
 open import foundation.propositions
+open import foundation.structure-identity-principle
+open import foundation.subtype-identity-principle
 open import foundation.universe-levels
 
 open import group-theory.congruence-relations-semigroups
@@ -28,10 +32,20 @@ semigroup of `M`.
 ## Definition
 
 ```agda
+is-congruence-monoid-Prop :
+  {l1 l2 : Level} (M : Monoid l1) → Eq-Rel l2 (type-Monoid M) → Prop (l1 ⊔ l2)
+is-congruence-monoid-Prop M = is-congruence-semigroup-Prop (semigroup-Monoid M)
+
 is-congruence-Monoid :
   {l1 l2 : Level} (M : Monoid l1) → Eq-Rel l2 (type-Monoid M) → UU (l1 ⊔ l2)
 is-congruence-Monoid M R =
   is-congruence-Semigroup (semigroup-Monoid M) R
+
+is-prop-is-congruence-Monoid :
+  {l1 l2 : Level} (M : Monoid l1) (R : Eq-Rel l2 (type-Monoid M)) →
+  is-prop (is-congruence-Monoid M R)
+is-prop-is-congruence-Monoid M =
+  is-prop-is-congruence-Semigroup (semigroup-Monoid M)
 
 congruence-Monoid : {l : Level} (l2 : Level) (M : Monoid l) → UU (l ⊔ lsuc l2)
 congruence-Monoid l2 M =
@@ -54,6 +68,21 @@ module _
     (x y : type-Monoid M) → is-prop (sim-congruence-Monoid x y)
   is-prop-sim-congruence-Monoid = is-prop-sim-Eq-Rel eq-rel-congruence-Monoid
 
+  concatenate-sim-eq-congruence-Monoid :
+    {x y z : type-Monoid M} → sim-congruence-Monoid x y → y ＝ z →
+    sim-congruence-Monoid x z
+  concatenate-sim-eq-congruence-Monoid H refl = H
+
+  concatenate-eq-sim-congruence-Monoid :
+    {x y z : type-Monoid M} → x ＝ y → sim-congruence-Monoid y z →
+    sim-congruence-Monoid x z
+  concatenate-eq-sim-congruence-Monoid refl H = H
+
+  concatenate-eq-sim-eq-congruence-Monoid :
+    {x y z w : type-Monoid M} → x ＝ y → sim-congruence-Monoid y z →
+    z ＝ w → sim-congruence-Monoid x w
+  concatenate-eq-sim-eq-congruence-Monoid refl H refl = H
+
   refl-congruence-Monoid : is-reflexive-Rel-Prop prop-congruence-Monoid
   refl-congruence-Monoid = refl-Eq-Rel eq-rel-congruence-Monoid
 
@@ -71,4 +100,55 @@ module _
   mul-congruence-Monoid :
     is-congruence-Monoid M eq-rel-congruence-Monoid
   mul-congruence-Monoid = pr2 R
+```
+
+## Properties
+
+### Extensionality of the type of congruence relations on a monoid
+
+```agda
+relate-same-elements-congruence-Monoid :
+  {l1 l2 l3 : Level} (M : Monoid l1) (R : congruence-Monoid l2 M)
+  (S : congruence-Monoid l3 M) → UU (l1 ⊔ l2 ⊔ l3)
+relate-same-elements-congruence-Monoid M =
+  relate-same-elements-congruence-Semigroup
+    ( semigroup-Monoid M)
+
+refl-relate-same-elements-congruence-Monoid :
+  {l1 l2 : Level} (M : Monoid l1) (R : congruence-Monoid l2 M) →
+  relate-same-elements-congruence-Monoid M R R
+refl-relate-same-elements-congruence-Monoid M =
+  refl-relate-same-elements-congruence-Semigroup (semigroup-Monoid M)
+
+is-contr-total-relate-same-elements-congruence-Monoid :
+  {l1 l2 : Level} (M : Monoid l1) (R : congruence-Monoid l2 M) →
+  is-contr
+    ( Σ ( congruence-Monoid l2 M)
+        ( relate-same-elements-congruence-Monoid M R))
+is-contr-total-relate-same-elements-congruence-Monoid M =
+  is-contr-total-relate-same-elements-congruence-Semigroup (semigroup-Monoid M)
+
+relate-same-elements-eq-congruence-Monoid :
+  {l1 l2 : Level} (M : Monoid l1) (R S : congruence-Monoid l2 M) →
+  R ＝ S → relate-same-elements-congruence-Monoid M R S
+relate-same-elements-eq-congruence-Monoid M =
+  relate-same-elements-eq-congruence-Semigroup (semigroup-Monoid M)
+
+is-equiv-relate-same-elements-eq-congruence-Monoid :
+  {l1 l2 : Level} (M : Monoid l1) (R S : congruence-Monoid l2 M) →
+  is-equiv (relate-same-elements-eq-congruence-Monoid M R S)
+is-equiv-relate-same-elements-eq-congruence-Monoid M =
+  is-equiv-relate-same-elements-eq-congruence-Semigroup (semigroup-Monoid M)
+
+extensionality-congruence-Monoid :
+  {l1 l2 : Level} (M : Monoid l1) (R S : congruence-Monoid l2 M) →
+  (R ＝ S) ≃ relate-same-elements-congruence-Monoid M R S
+extensionality-congruence-Monoid M =
+  extensionality-congruence-Semigroup (semigroup-Monoid M)
+
+eq-relate-same-elements-congruence-Monoid :
+  {l1 l2 : Level} (M : Monoid l1) (R S : congruence-Monoid l2 M) →
+  relate-same-elements-congruence-Monoid M R S → R ＝ S
+eq-relate-same-elements-congruence-Monoid M =
+  eq-relate-same-elements-congruence-Semigroup (semigroup-Monoid M)
 ```

--- a/src/group-theory/congruence-relations-semigroups.lagda.md
+++ b/src/group-theory/congruence-relations-semigroups.lagda.md
@@ -32,10 +32,10 @@ such that for every `x1 x2 y1 y2 : G` such that `x1 ≡ x2` and `y1 ≡ y2` we h
 ## Definition
 
 ```agda
-is-congruence-Semigroup-Prop :
+is-congruence-semigroup-Prop :
   {l1 l2 : Level} (G : Semigroup l1) →
   Eq-Rel l2 (type-Semigroup G) → Prop (l1 ⊔ l2)
-is-congruence-Semigroup-Prop G R =
+is-congruence-semigroup-Prop G R =
   Π-Prop'
     ( type-Semigroup G)
     ( λ x1 →
@@ -60,13 +60,13 @@ is-congruence-Semigroup :
   {l1 l2 : Level} (G : Semigroup l1) →
   Eq-Rel l2 (type-Semigroup G) → UU (l1 ⊔ l2)
 is-congruence-Semigroup G R =
-  type-Prop (is-congruence-Semigroup-Prop G R)
+  type-Prop (is-congruence-semigroup-Prop G R)
 
 is-prop-is-congruence-Semigroup :
   {l1 l2 : Level} (G : Semigroup l1) (R : Eq-Rel l2 (type-Semigroup G)) →
   is-prop (is-congruence-Semigroup G R)
 is-prop-is-congruence-Semigroup G R =
-  is-prop-type-Prop (is-congruence-Semigroup-Prop G R)
+  is-prop-type-Prop (is-congruence-semigroup-Prop G R)
 
 congruence-Semigroup :
   {l : Level} (l2 : Level) (G : Semigroup l) → UU (l ⊔ lsuc l2)

--- a/src/group-theory/homomorphisms-commutative-monoids.lagda.md
+++ b/src/group-theory/homomorphisms-commutative-monoids.lagda.md
@@ -14,16 +14,17 @@ open import foundation.sets
 open import foundation.subtypes
 open import foundation.universe-levels
 
+open import group-theory.commutative-monoids
 open import group-theory.homomorphisms-monoids
 open import group-theory.homomorphisms-semigroups
-open import group-theory.commutative-monoids
 ```
 
 </details>
 
 ## Idea
 
-Homomorphisms between two commutative monoids are homomorphisms between their underlying monoids.
+Homomorphisms between two commutative monoids are homomorphisms between their
+underlying monoids.
 
 ## Definition
 

--- a/src/group-theory/homomorphisms-commutative-monoids.lagda.md
+++ b/src/group-theory/homomorphisms-commutative-monoids.lagda.md
@@ -1,0 +1,99 @@
+# Homomorphisms of commutative monoids
+
+```agda
+module group-theory.homomorphisms-commutative-monoids where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.dependent-pair-types
+open import foundation.identity-types
+open import foundation.propositions
+open import foundation.sets
+open import foundation.subtypes
+open import foundation.universe-levels
+
+open import group-theory.homomorphisms-monoids
+open import group-theory.homomorphisms-semigroups
+open import group-theory.commutative-monoids
+```
+
+</details>
+
+## Idea
+
+Homomorphisms between two commutative monoids are homomorphisms between their underlying monoids.
+
+## Definition
+
+### Homomorphisms of commutative monoids
+
+```agda
+module _
+  {l1 l2 : Level} (M1 : Commutative-Monoid l1) (M2 : Commutative-Monoid l2)
+  where
+
+  hom-Commutative-Monoid : Set (l1 ⊔ l2)
+  hom-Commutative-Monoid =
+    hom-Monoid (monoid-Commutative-Monoid M1) (monoid-Commutative-Monoid M2)
+
+  type-hom-Commutative-Monoid : UU (l1 ⊔ l2)
+  type-hom-Commutative-Monoid =
+    type-hom-Monoid
+      ( monoid-Commutative-Monoid M1)
+      ( monoid-Commutative-Monoid M2)
+
+module _
+  {l1 l2 : Level} (M : Commutative-Monoid l1) (N : Commutative-Monoid l2)
+  (f : type-hom-Commutative-Monoid M N)
+  where
+
+  hom-semigroup-hom-Commutative-Monoid :
+    type-hom-Semigroup
+      ( semigroup-Commutative-Monoid M)
+      ( semigroup-Commutative-Monoid N)
+  hom-semigroup-hom-Commutative-Monoid =
+    hom-semigroup-hom-Monoid
+      ( monoid-Commutative-Monoid M)
+      ( monoid-Commutative-Monoid N)
+      ( f)
+
+  map-hom-Commutative-Monoid :
+    type-Commutative-Monoid M → type-Commutative-Monoid N
+  map-hom-Commutative-Monoid =
+    map-hom-Monoid
+      ( monoid-Commutative-Monoid M)
+      ( monoid-Commutative-Monoid N)
+      ( f)
+
+  preserves-mul-hom-Commutative-Monoid :
+    preserves-mul-Semigroup
+      ( semigroup-Commutative-Monoid M)
+      ( semigroup-Commutative-Monoid N)
+      ( map-hom-Commutative-Monoid)
+  preserves-mul-hom-Commutative-Monoid =
+    preserves-mul-hom-Monoid
+      ( monoid-Commutative-Monoid M)
+      ( monoid-Commutative-Monoid N)
+      ( f)
+
+  preserves-unit-hom-Commutative-Monoid :
+    preserves-unit-hom-Semigroup
+      ( monoid-Commutative-Monoid M)
+      ( monoid-Commutative-Monoid N)
+      ( hom-semigroup-hom-Commutative-Monoid)
+  preserves-unit-hom-Commutative-Monoid =
+    preserves-unit-hom-Monoid
+      ( monoid-Commutative-Monoid M)
+      ( monoid-Commutative-Monoid N)
+      ( f)
+```
+
+### The identity homomorphism of monoids
+
+```agda
+id-hom-Commutative-Monoid :
+  {l : Level} (M : Commutative-Monoid l) → type-hom-Commutative-Monoid M M
+id-hom-Commutative-Monoid M = id-hom-Monoid (monoid-Commutative-Monoid M)
+```

--- a/src/group-theory/normal-submonoids-commutative-monoids.lagda.md
+++ b/src/group-theory/normal-submonoids-commutative-monoids.lagda.md
@@ -1,0 +1,610 @@
+# Normal submonoids of commutative monoids
+
+```agda
+module group-theory.normal-submonoids-commutative-monoids where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.binary-relations
+open import foundation.binary-transport
+open import foundation.dependent-pair-types
+open import foundation.equivalence-relations
+open import foundation.equivalences
+open import foundation.functions
+open import foundation.identity-types
+open import foundation.logical-equivalences
+open import foundation.propositions
+open import foundation.retractions
+open import foundation.sets
+open import foundation.subtype-identity-principle
+open import foundation.subtypes
+open import foundation.universe-levels
+
+open import group-theory.commutative-monoids
+open import group-theory.congruence-relations-commutative-monoids
+open import group-theory.monoids
+open import group-theory.saturated-congruence-relations-commutative-monoids
+open import group-theory.semigroups
+open import group-theory.submonoids-commutative-monoids
+open import group-theory.subsets-commutative-monoids
+```
+
+</details>
+
+## Idea
+
+A normal submonoid `N` of of a commutative monoid `M` is a monoid that corresponds uniquely to a saturated congruence relation ~ on `M` consisting of the elements congruent to `1`. This is the case if and only if for all `x : M` and `u : N` we have
+
+```md
+  xu ∈ N → x ∈ N
+```
+
+## Definitions
+
+### Normal submonoids of commutative monoids
+
+```agda
+module _
+  {l1 l2 : Level} (M : Commutative-Monoid l1) (N : Commutative-Submonoid l2 M)
+  where
+
+  is-normal-commutative-submonoid-Prop : Prop (l1 ⊔ l2)
+  is-normal-commutative-submonoid-Prop =
+    Π-Prop
+      ( type-Commutative-Monoid M)
+      ( λ x →
+        Π-Prop
+          ( type-Commutative-Monoid M)
+          ( λ u →
+            function-Prop
+              ( is-in-Commutative-Submonoid M N u)
+              ( function-Prop
+                ( is-in-Commutative-Submonoid M N
+                  ( mul-Commutative-Monoid M x u))
+                ( subset-Commutative-Submonoid M N x))))
+
+  is-normal-Commutative-Submonoid : UU (l1 ⊔ l2)
+  is-normal-Commutative-Submonoid =
+    type-Prop is-normal-commutative-submonoid-Prop
+
+  is-prop-is-normal-Commutative-Submonoid :
+    is-prop is-normal-Commutative-Submonoid
+  is-prop-is-normal-Commutative-Submonoid =
+    is-prop-type-Prop is-normal-commutative-submonoid-Prop
+
+Normal-Commutative-Submonoid :
+  {l1 : Level} (l2 : Level) → Commutative-Monoid l1 → UU (l1 ⊔ lsuc l2)
+Normal-Commutative-Submonoid l2 M =
+  Σ (Commutative-Submonoid l2 M) (is-normal-Commutative-Submonoid M)
+
+module _
+  {l1 l2 : Level} (M : Commutative-Monoid l1)
+  (N : Normal-Commutative-Submonoid l2 M)
+  where
+
+  submonoid-Normal-Commutative-Submonoid : Commutative-Submonoid l2 M
+  submonoid-Normal-Commutative-Submonoid = pr1 N
+
+  is-normal-Normal-Commutative-Submonoid :
+    is-normal-Commutative-Submonoid M submonoid-Normal-Commutative-Submonoid
+  is-normal-Normal-Commutative-Submonoid = pr2 N
+
+  subset-Normal-Commutative-Submonoid : subtype l2 (type-Commutative-Monoid M)
+  subset-Normal-Commutative-Submonoid =
+    subset-Commutative-Submonoid M submonoid-Normal-Commutative-Submonoid
+
+  is-submonoid-Normal-Commutative-Submonoid :
+    is-submonoid-Commutative-Monoid M subset-Normal-Commutative-Submonoid
+  is-submonoid-Normal-Commutative-Submonoid =
+    is-submonoid-Commutative-Submonoid M submonoid-Normal-Commutative-Submonoid
+
+  is-in-Normal-Commutative-Submonoid : type-Commutative-Monoid M → UU l2
+  is-in-Normal-Commutative-Submonoid =
+    is-in-Commutative-Submonoid M submonoid-Normal-Commutative-Submonoid
+
+  is-prop-is-in-Normal-Commutative-Submonoid :
+    (x : type-Commutative-Monoid M) →
+    is-prop (is-in-Normal-Commutative-Submonoid x)
+  is-prop-is-in-Normal-Commutative-Submonoid =
+    is-prop-is-in-Commutative-Submonoid M
+      submonoid-Normal-Commutative-Submonoid
+
+  is-closed-under-eq-Normal-Commutative-Submonoid :
+    {x y : type-Commutative-Monoid M} →
+    is-in-Normal-Commutative-Submonoid x → (x ＝ y) →
+    is-in-Normal-Commutative-Submonoid y
+  is-closed-under-eq-Normal-Commutative-Submonoid =
+    is-closed-under-eq-subtype subset-Normal-Commutative-Submonoid
+
+  is-closed-under-eq-Normal-Commutative-Submonoid' :
+    {x y : type-Commutative-Monoid M} → is-in-Normal-Commutative-Submonoid y →
+    (x ＝ y) → is-in-Normal-Commutative-Submonoid x
+  is-closed-under-eq-Normal-Commutative-Submonoid' =
+    is-closed-under-eq-subtype' subset-Normal-Commutative-Submonoid
+
+  type-Normal-Commutative-Submonoid : UU (l1 ⊔ l2)
+  type-Normal-Commutative-Submonoid =
+    type-Commutative-Submonoid M submonoid-Normal-Commutative-Submonoid
+
+  is-set-type-Normal-Commutative-Submonoid :
+    is-set type-Normal-Commutative-Submonoid
+  is-set-type-Normal-Commutative-Submonoid =
+    is-set-type-Commutative-Submonoid M submonoid-Normal-Commutative-Submonoid
+
+  set-Normal-Commutative-Submonoid : Set (l1 ⊔ l2)
+  set-Normal-Commutative-Submonoid =
+    set-Commutative-Submonoid M submonoid-Normal-Commutative-Submonoid
+
+  inclusion-Normal-Commutative-Submonoid :
+    type-Normal-Commutative-Submonoid → type-Commutative-Monoid M
+  inclusion-Normal-Commutative-Submonoid =
+    inclusion-Commutative-Submonoid M submonoid-Normal-Commutative-Submonoid
+
+  ap-inclusion-Normal-Commutative-Submonoid :
+    (x y : type-Normal-Commutative-Submonoid) → x ＝ y →
+    inclusion-Normal-Commutative-Submonoid x ＝
+    inclusion-Normal-Commutative-Submonoid y
+  ap-inclusion-Normal-Commutative-Submonoid =
+    ap-inclusion-Commutative-Submonoid M submonoid-Normal-Commutative-Submonoid
+
+  is-in-submonoid-inclusion-Normal-Commutative-Submonoid :
+    (x : type-Normal-Commutative-Submonoid) →
+    is-in-Normal-Commutative-Submonoid
+      ( inclusion-Normal-Commutative-Submonoid x)
+  is-in-submonoid-inclusion-Normal-Commutative-Submonoid =
+    is-in-submonoid-inclusion-Commutative-Submonoid M
+      submonoid-Normal-Commutative-Submonoid
+
+  contains-unit-Normal-Commutative-Submonoid :
+    is-in-Normal-Commutative-Submonoid (unit-Commutative-Monoid M)
+  contains-unit-Normal-Commutative-Submonoid =
+    contains-unit-Commutative-Submonoid M submonoid-Normal-Commutative-Submonoid
+
+  unit-Normal-Commutative-Submonoid : type-Normal-Commutative-Submonoid
+  unit-Normal-Commutative-Submonoid =
+    unit-Commutative-Submonoid M submonoid-Normal-Commutative-Submonoid
+
+  is-closed-under-mul-Normal-Commutative-Submonoid :
+    {x y : type-Commutative-Monoid M} →
+    is-in-Normal-Commutative-Submonoid x →
+    is-in-Normal-Commutative-Submonoid y →
+    is-in-Normal-Commutative-Submonoid (mul-Commutative-Monoid M x y)
+  is-closed-under-mul-Normal-Commutative-Submonoid =
+    is-closed-under-mul-Commutative-Submonoid M
+      submonoid-Normal-Commutative-Submonoid
+
+  mul-Normal-Commutative-Submonoid :
+    (x y : type-Normal-Commutative-Submonoid) →
+    type-Normal-Commutative-Submonoid
+  mul-Normal-Commutative-Submonoid =
+    mul-Commutative-Submonoid M submonoid-Normal-Commutative-Submonoid
+
+  associative-mul-Normal-Commutative-Submonoid :
+    (x y z : type-Normal-Commutative-Submonoid) →
+    ( mul-Normal-Commutative-Submonoid
+      ( mul-Normal-Commutative-Submonoid x y)
+      ( z)) ＝
+    ( mul-Normal-Commutative-Submonoid x
+      ( mul-Normal-Commutative-Submonoid y z))
+  associative-mul-Normal-Commutative-Submonoid =
+    associative-mul-Commutative-Submonoid M
+      submonoid-Normal-Commutative-Submonoid
+
+  semigroup-Normal-Commutative-Submonoid : Semigroup (l1 ⊔ l2)
+  semigroup-Normal-Commutative-Submonoid =
+    semigroup-Commutative-Submonoid M submonoid-Normal-Commutative-Submonoid
+
+  left-unit-law-mul-Normal-Commutative-Submonoid :
+    (x : type-Normal-Commutative-Submonoid) →
+    mul-Normal-Commutative-Submonoid unit-Normal-Commutative-Submonoid x ＝ x
+  left-unit-law-mul-Normal-Commutative-Submonoid =
+    left-unit-law-mul-Commutative-Submonoid M
+      submonoid-Normal-Commutative-Submonoid
+
+  right-unit-law-mul-Normal-Commutative-Submonoid :
+    (x : type-Normal-Commutative-Submonoid) →
+    mul-Normal-Commutative-Submonoid x unit-Normal-Commutative-Submonoid ＝ x
+  right-unit-law-mul-Normal-Commutative-Submonoid =
+    right-unit-law-mul-Commutative-Submonoid M
+      submonoid-Normal-Commutative-Submonoid
+
+  commutative-mul-Normal-Commutative-Submonoid :
+    (x y : type-Normal-Commutative-Submonoid) →
+    mul-Normal-Commutative-Submonoid x y ＝
+    mul-Normal-Commutative-Submonoid y x
+  commutative-mul-Normal-Commutative-Submonoid =
+    commutative-mul-Commutative-Submonoid M
+      submonoid-Normal-Commutative-Submonoid
+
+  monoid-Normal-Commutative-Submonoid : Monoid (l1 ⊔ l2)
+  monoid-Normal-Commutative-Submonoid =
+    monoid-Commutative-Submonoid M submonoid-Normal-Commutative-Submonoid
+
+  commutative-monoid-Normal-Commutative-Submonoid :
+    Commutative-Monoid (l1 ⊔ l2)
+  commutative-monoid-Normal-Commutative-Submonoid =
+    commutative-monoid-Commutative-Submonoid M
+      submonoid-Normal-Commutative-Submonoid
+```
+
+## Properties
+
+### Extensionality of the type of all normal submonoids
+
+```agda
+module _
+  {l1 l2 : Level} (M : Commutative-Monoid l1)
+  (N : Normal-Commutative-Submonoid l2 M)
+  where
+
+  has-same-elements-Normal-Commutative-Submonoid :
+    {l3 : Level} → Normal-Commutative-Submonoid l3 M → UU (l1 ⊔ l2 ⊔ l3)
+  has-same-elements-Normal-Commutative-Submonoid K =
+    has-same-elements-Commutative-Submonoid M
+      ( submonoid-Normal-Commutative-Submonoid M N)
+      ( submonoid-Normal-Commutative-Submonoid M K)
+
+  extensionality-Normal-Commutative-Submonoid :
+    (K : Normal-Commutative-Submonoid l2 M) →
+    (N ＝ K) ≃ has-same-elements-Normal-Commutative-Submonoid K
+  extensionality-Normal-Commutative-Submonoid =
+    extensionality-type-subtype
+      ( is-normal-commutative-submonoid-Prop M)
+      ( is-normal-Normal-Commutative-Submonoid M N)
+      ( λ x → (id , id))
+      ( extensionality-Commutative-Submonoid M
+        ( submonoid-Normal-Commutative-Submonoid M N))
+
+  eq-has-same-elements-Normal-Commutative-Submonoid :
+    (K : Normal-Commutative-Submonoid l2 M) →
+    has-same-elements-Normal-Commutative-Submonoid K → N ＝ K
+  eq-has-same-elements-Normal-Commutative-Submonoid K =
+    map-inv-equiv (extensionality-Normal-Commutative-Submonoid K)
+```
+
+### The congruence relation of a normal submonoid
+
+```agda
+module _
+  {l1 l2 : Level} (M : Commutative-Monoid l1) (N : Normal-Commutative-Submonoid l2 M)
+  where
+
+  rel-congruence-Normal-Commutative-Submonoid :
+    Rel-Prop (l1 ⊔ l2) (type-Commutative-Monoid M)
+  rel-congruence-Normal-Commutative-Submonoid x y =
+    Π-Prop
+      ( type-Commutative-Monoid M)
+      ( λ u →
+        iff-Prop
+          ( subset-Normal-Commutative-Submonoid M N
+            ( mul-Commutative-Monoid M u x))
+          ( subset-Normal-Commutative-Submonoid M N
+            ( mul-Commutative-Monoid M u y)))
+
+  sim-congruence-Normal-Commutative-Submonoid :
+    (x y : type-Commutative-Monoid M) → UU (l1 ⊔ l2)
+  sim-congruence-Normal-Commutative-Submonoid x y =
+    type-Prop (rel-congruence-Normal-Commutative-Submonoid x y)
+
+  refl-congruence-Normal-Commutative-Submonoid :
+    is-reflexive-Rel-Prop rel-congruence-Normal-Commutative-Submonoid
+  pr1 (refl-congruence-Normal-Commutative-Submonoid u) = id
+  pr2 (refl-congruence-Normal-Commutative-Submonoid u) = id
+
+  symmetric-congruence-Normal-Commutative-Submonoid :
+    is-symmetric-Rel-Prop rel-congruence-Normal-Commutative-Submonoid
+  pr1 (symmetric-congruence-Normal-Commutative-Submonoid H u) = pr2 (H u)
+  pr2 (symmetric-congruence-Normal-Commutative-Submonoid H u) = pr1 (H u)
+
+  transitive-congruence-Normal-Commutative-Submonoid :
+    is-transitive-Rel-Prop rel-congruence-Normal-Commutative-Submonoid
+  transitive-congruence-Normal-Commutative-Submonoid H K u = (K u) ∘iff (H u)
+
+  eq-rel-congruence-Normal-Commutative-Submonoid :
+    Eq-Rel (l1 ⊔ l2) (type-Commutative-Monoid M)
+  pr1 eq-rel-congruence-Normal-Commutative-Submonoid =
+    rel-congruence-Normal-Commutative-Submonoid
+  pr1 (pr2 eq-rel-congruence-Normal-Commutative-Submonoid) =
+    refl-congruence-Normal-Commutative-Submonoid
+  pr1 (pr2 (pr2 eq-rel-congruence-Normal-Commutative-Submonoid)) =
+    symmetric-congruence-Normal-Commutative-Submonoid
+  pr2 (pr2 (pr2 eq-rel-congruence-Normal-Commutative-Submonoid)) =
+    transitive-congruence-Normal-Commutative-Submonoid
+
+  is-congruence-congruence-Normal-Commutative-Submonoid :
+    is-congruence-Commutative-Monoid M
+      eq-rel-congruence-Normal-Commutative-Submonoid
+  pr1
+    ( is-congruence-congruence-Normal-Commutative-Submonoid
+      {x} {x'} {y} {y'} H K u)
+    ( L) =
+    is-closed-under-eq-Normal-Commutative-Submonoid M N
+      ( forward-implication
+        ( K (mul-Commutative-Monoid M u x'))
+        ( is-closed-under-eq-Normal-Commutative-Submonoid M N
+          ( forward-implication
+            ( H (mul-Commutative-Monoid M u y))
+            ( is-closed-under-eq-Normal-Commutative-Submonoid M N L
+              ( ( inv (associative-mul-Commutative-Monoid M u x y)) ∙
+                ( right-swap-mul-Commutative-Monoid M u x y))))
+          ( right-swap-mul-Commutative-Monoid M u y x')))
+      ( associative-mul-Commutative-Monoid M u x' y')
+  pr2
+    ( is-congruence-congruence-Normal-Commutative-Submonoid
+      {x} {x'} {y} {y'} H K u)
+    ( L) =
+    is-closed-under-eq-Normal-Commutative-Submonoid M N
+      ( backward-implication
+        ( K (mul-Commutative-Monoid M u x))
+        ( is-closed-under-eq-Normal-Commutative-Submonoid M N
+          ( backward-implication
+            ( H (mul-Commutative-Monoid M u y'))
+            ( is-closed-under-eq-Normal-Commutative-Submonoid M N L
+              ( ( inv (associative-mul-Commutative-Monoid M u x' y')) ∙
+                ( right-swap-mul-Commutative-Monoid M u x' y'))))
+          ( right-swap-mul-Commutative-Monoid M u y' x)))
+      ( associative-mul-Commutative-Monoid M u x y)
+
+  congruence-Normal-Commutative-Submonoid :
+    congruence-Commutative-Monoid (l1 ⊔ l2) M
+  pr1 congruence-Normal-Commutative-Submonoid =
+    eq-rel-congruence-Normal-Commutative-Submonoid
+  pr2 congruence-Normal-Commutative-Submonoid =
+    is-congruence-congruence-Normal-Commutative-Submonoid
+```
+
+### The normal submonoid obtained from a congruence relation
+
+```agda
+module _
+  {l1 l2 : Level} (M : Commutative-Monoid l1)
+  (R : congruence-Commutative-Monoid l2 M)
+  where
+
+  subset-normal-submonoid-congruence-Commutative-Monoid :
+    subtype l2 (type-Commutative-Monoid M)
+  subset-normal-submonoid-congruence-Commutative-Monoid x =
+    prop-congruence-Commutative-Monoid M R x (unit-Commutative-Monoid M)
+
+  is-in-normal-submonoid-congruence-Commutative-Monoid :
+    type-Commutative-Monoid M → UU l2
+  is-in-normal-submonoid-congruence-Commutative-Monoid =
+    is-in-subtype subset-normal-submonoid-congruence-Commutative-Monoid
+
+  contains-unit-normal-submonoid-congruence-Commutative-Monoid :
+    is-in-normal-submonoid-congruence-Commutative-Monoid
+      ( unit-Commutative-Monoid M)
+  contains-unit-normal-submonoid-congruence-Commutative-Monoid =
+    refl-congruence-Commutative-Monoid M R
+
+  is-closed-under-multiplication-normal-submonoid-congruence-Commutative-Monoid :
+    is-closed-under-multiplication-subset-Commutative-Monoid M
+      subset-normal-submonoid-congruence-Commutative-Monoid
+  is-closed-under-multiplication-normal-submonoid-congruence-Commutative-Monoid
+    x y H K =
+    concatenate-sim-eq-congruence-Commutative-Monoid M R
+      ( mul-congruence-Commutative-Monoid M R H K)
+      ( left-unit-law-mul-Commutative-Monoid M (unit-Commutative-Monoid M))
+
+  submonoid-congruence-Commutative-Monoid : Commutative-Submonoid l2 M
+  pr1 submonoid-congruence-Commutative-Monoid =
+    subset-normal-submonoid-congruence-Commutative-Monoid
+  pr1 (pr2 submonoid-congruence-Commutative-Monoid) =
+    contains-unit-normal-submonoid-congruence-Commutative-Monoid
+  pr2 (pr2 submonoid-congruence-Commutative-Monoid) =
+    is-closed-under-multiplication-normal-submonoid-congruence-Commutative-Monoid
+
+  is-normal-submonoid-congruence-Commutative-Monoid :
+    is-normal-Commutative-Submonoid M submonoid-congruence-Commutative-Monoid
+  is-normal-submonoid-congruence-Commutative-Monoid x u H =
+    trans-congruence-Commutative-Monoid M R
+      ( symm-congruence-Commutative-Monoid M R
+        ( concatenate-sim-eq-congruence-Commutative-Monoid M R
+          ( mul-congruence-Commutative-Monoid M R
+            ( refl-congruence-Commutative-Monoid M R)
+            ( H))
+          ( right-unit-law-mul-Commutative-Monoid M x)))
+
+  normal-submonoid-congruence-Commutative-Monoid :
+    Normal-Commutative-Submonoid l2 M
+  pr1 normal-submonoid-congruence-Commutative-Monoid =
+    submonoid-congruence-Commutative-Monoid
+  pr2 normal-submonoid-congruence-Commutative-Monoid =
+    is-normal-submonoid-congruence-Commutative-Monoid
+```
+
+### The normal submonoid obtained from the congruence relation of a normal submonoid has the same elements as the original normal submonoid
+
+```agda
+module _
+  {l1 l2 : Level} (M : Commutative-Monoid l1) (N : Normal-Commutative-Submonoid l2 M)
+  where
+
+  has-same-elements-normal-submonoid-congruence-Normal-Commutative-Submonoid :
+    has-same-elements-Normal-Commutative-Submonoid M
+      ( normal-submonoid-congruence-Commutative-Monoid M
+        ( congruence-Normal-Commutative-Submonoid M N))
+      ( N)
+  pr1
+    ( has-same-elements-normal-submonoid-congruence-Normal-Commutative-Submonoid
+      x)
+    ( H) =
+    is-closed-under-eq-Normal-Commutative-Submonoid M N
+      ( backward-implication
+        ( H (unit-Commutative-Monoid M))
+        ( is-closed-under-eq-Normal-Commutative-Submonoid' M N
+          ( contains-unit-Normal-Commutative-Submonoid M N)
+          ( left-unit-law-mul-Commutative-Monoid M
+            ( unit-Commutative-Monoid M))))
+      ( left-unit-law-mul-Commutative-Monoid M x)
+  pr1
+    ( pr2
+      ( has-same-elements-normal-submonoid-congruence-Normal-Commutative-Submonoid
+        ( x))
+      ( H)
+      ( u))
+    ( K)=
+    is-closed-under-eq-Normal-Commutative-Submonoid' M N
+      ( is-normal-Normal-Commutative-Submonoid M N u x H K)
+      ( right-unit-law-mul-Commutative-Monoid M u)
+  pr2
+    ( pr2
+      ( has-same-elements-normal-submonoid-congruence-Normal-Commutative-Submonoid
+        ( x))
+      ( H)
+      ( u))
+    ( K) =
+    is-closed-under-mul-Normal-Commutative-Submonoid M N
+      ( is-closed-under-eq-Normal-Commutative-Submonoid M N K
+        ( right-unit-law-mul-Commutative-Monoid M u))
+      ( H)
+```
+
+### The congruence relation of a normal submonoid is saturated
+
+```agda
+module _
+  {l1 l2 : Level} (M : Commutative-Monoid l1) (N : Normal-Commutative-Submonoid l2 M)
+  where
+  
+  is-saturated-congruence-Normal-Commutative-Submonoid :
+    is-saturated-congruence-Commutative-Monoid M
+      ( congruence-Normal-Commutative-Submonoid M N)
+  is-saturated-congruence-Normal-Commutative-Submonoid x y H u =
+    ( ( has-same-elements-normal-submonoid-congruence-Normal-Commutative-Submonoid M N
+        ( mul-Commutative-Monoid M u y)) ∘iff
+      ( H u)) ∘iff
+    ( inv-iff
+      ( has-same-elements-normal-submonoid-congruence-Normal-Commutative-Submonoid M N
+        ( mul-Commutative-Monoid M u x)))
+
+  saturated-congruence-Normal-Commutative-Submonoid :
+    saturated-congruence-Commutative-Monoid (l1 ⊔ l2) M
+  pr1 saturated-congruence-Normal-Commutative-Submonoid = congruence-Normal-Commutative-Submonoid M N
+  pr2 saturated-congruence-Normal-Commutative-Submonoid =
+    is-saturated-congruence-Normal-Commutative-Submonoid
+```
+
+### The congruence relation of the normal submonoid associated to a congruence relation relates the same elements as the original congruence relation
+
+```agda
+module _
+  {l1 l2 : Level} (M : Commutative-Monoid l1) (R : saturated-congruence-Commutative-Monoid l2 M)
+  where
+
+  normal-submonoid-saturated-congruence-Commutative-Monoid :
+    Normal-Commutative-Submonoid l2 M
+  normal-submonoid-saturated-congruence-Commutative-Monoid =
+    normal-submonoid-congruence-Commutative-Monoid M
+      ( congruence-saturated-congruence-Commutative-Monoid M R)
+
+  relate-same-elements-congruence-normal-submonoid-saturated-congruence-Commutative-Monoid :
+    relate-same-elements-saturated-congruence-Commutative-Monoid M
+      ( saturated-congruence-Normal-Commutative-Submonoid M
+        ( normal-submonoid-saturated-congruence-Commutative-Monoid))
+      ( R)
+  pr1 (relate-same-elements-congruence-normal-submonoid-saturated-congruence-Commutative-Monoid x y) H =
+    is-saturated-saturated-congruence-Commutative-Monoid M R x y H
+  pr1
+    ( pr2
+      ( relate-same-elements-congruence-normal-submonoid-saturated-congruence-Commutative-Monoid x y)
+      ( H)
+      ( u)) =
+    trans-saturated-congruence-Commutative-Monoid M R
+      ( mul-saturated-congruence-Commutative-Monoid M R
+        ( refl-saturated-congruence-Commutative-Monoid M R)
+        ( symm-saturated-congruence-Commutative-Monoid M R H))
+  pr2
+    ( pr2
+      ( relate-same-elements-congruence-normal-submonoid-saturated-congruence-Commutative-Monoid x y)
+      ( H)
+      ( u)) =
+    trans-saturated-congruence-Commutative-Monoid M R
+      ( mul-saturated-congruence-Commutative-Monoid M R
+        ( refl-saturated-congruence-Commutative-Monoid M R)
+        ( H))
+```
+
+### The type of normal submonoids of `M` is a retract of the type of congruence relations of `M`
+
+```agda
+issec-congruence-Normal-Commutative-Submonoid :
+  {l1 : Level} (l2 : Level) (M : Commutative-Monoid l1)
+  (N : Normal-Commutative-Submonoid (l1 ⊔ l2) M) →
+  ( normal-submonoid-congruence-Commutative-Monoid M
+    ( congruence-Normal-Commutative-Submonoid M N)) ＝
+  ( N)
+issec-congruence-Normal-Commutative-Submonoid l2 M N =
+  eq-has-same-elements-Normal-Commutative-Submonoid M
+    ( normal-submonoid-congruence-Commutative-Monoid M
+      ( congruence-Normal-Commutative-Submonoid M N))
+    ( N)
+    ( has-same-elements-normal-submonoid-congruence-Normal-Commutative-Submonoid
+      M N)
+
+normal-submonoid-retract-of-congruence-Commutative-Monoid :
+  {l1 : Level} (l2 : Level) (M : Commutative-Monoid l1) →
+  ( Normal-Commutative-Submonoid (l1 ⊔ l2) M) retract-of
+  ( congruence-Commutative-Monoid (l1 ⊔ l2) M)
+pr1 (normal-submonoid-retract-of-congruence-Commutative-Monoid l2 M) =
+  congruence-Normal-Commutative-Submonoid M
+pr1 (pr2 (normal-submonoid-retract-of-congruence-Commutative-Monoid l2 M)) =
+  normal-submonoid-congruence-Commutative-Monoid M
+pr2 (pr2 (normal-submonoid-retract-of-congruence-Commutative-Monoid l2 M)) =
+  issec-congruence-Normal-Commutative-Submonoid l2 M
+```
+
+### The type of normal submonoids of `M` is equivalent to the type of saturated congruence relations on `M`
+
+```agda
+issec-saturated-congruence-Normal-Commutative-Submonoid :
+  {l1 : Level} (l2 : Level) (M : Commutative-Monoid l1)
+  (N : Normal-Commutative-Submonoid (l1 ⊔ l2) M) →
+  ( normal-submonoid-saturated-congruence-Commutative-Monoid M
+    ( saturated-congruence-Normal-Commutative-Submonoid M N)) ＝
+  ( N)
+issec-saturated-congruence-Normal-Commutative-Submonoid l2 M N =
+  eq-has-same-elements-Normal-Commutative-Submonoid M
+    ( normal-submonoid-saturated-congruence-Commutative-Monoid M
+      ( saturated-congruence-Normal-Commutative-Submonoid M N))
+    ( N)
+    ( has-same-elements-normal-submonoid-congruence-Normal-Commutative-Submonoid
+      M N)
+
+isretr-saturated-congruence-Normal-Commutative-Submonoid :
+  {l1 : Level} (l2 : Level) (M : Commutative-Monoid l1)
+  (R : saturated-congruence-Commutative-Monoid (l1 ⊔ l2) M) →
+  ( saturated-congruence-Normal-Commutative-Submonoid M
+    ( normal-submonoid-saturated-congruence-Commutative-Monoid M R)) ＝
+  ( R)
+isretr-saturated-congruence-Normal-Commutative-Submonoid l2 M R =
+  eq-relate-same-elements-saturated-congruence-Commutative-Monoid M
+    ( saturated-congruence-Normal-Commutative-Submonoid M
+      ( normal-submonoid-saturated-congruence-Commutative-Monoid M R))
+    ( R)
+    ( relate-same-elements-congruence-normal-submonoid-saturated-congruence-Commutative-Monoid
+      ( M)
+      ( R))
+
+is-equiv-normal-submonoid-saturated-congruence-Commutative-Monoid :
+  {l1 : Level} (l2 : Level) (M : Commutative-Monoid l1) →
+  is-equiv
+    ( normal-submonoid-saturated-congruence-Commutative-Monoid {l2 = l1 ⊔ l2} M)
+is-equiv-normal-submonoid-saturated-congruence-Commutative-Monoid l2 M =
+  is-equiv-has-inverse
+    ( saturated-congruence-Normal-Commutative-Submonoid M)
+    ( issec-saturated-congruence-Normal-Commutative-Submonoid l2 M)
+    ( isretr-saturated-congruence-Normal-Commutative-Submonoid l2 M)
+
+equiv-normal-submonoid-saturated-congruence-Commutative-Monoid :
+  {l1 : Level} (l2 : Level) (M : Commutative-Monoid l1) →
+  saturated-congruence-Commutative-Monoid (l1 ⊔ l2) M ≃
+  Normal-Commutative-Submonoid (l1 ⊔ l2) M
+pr1 (equiv-normal-submonoid-saturated-congruence-Commutative-Monoid l2 M) =
+  normal-submonoid-saturated-congruence-Commutative-Monoid M
+pr2 (equiv-normal-submonoid-saturated-congruence-Commutative-Monoid l2 M) =
+  is-equiv-normal-submonoid-saturated-congruence-Commutative-Monoid l2 M
+```
+

--- a/src/group-theory/normal-submonoids-commutative-monoids.lagda.md
+++ b/src/group-theory/normal-submonoids-commutative-monoids.lagda.md
@@ -35,7 +35,10 @@ open import group-theory.subsets-commutative-monoids
 
 ## Idea
 
-A normal submonoid `N` of of a commutative monoid `M` is a monoid that corresponds uniquely to a saturated congruence relation ~ on `M` consisting of the elements congruent to `1`. This is the case if and only if for all `x : M` and `u : N` we have
+A normal submonoid `N` of of a commutative monoid `M` is a monoid that
+corresponds uniquely to a saturated congruence relation ~ on `M` consisting of
+the elements congruent to `1`. This is the case if and only if for all `x : M`
+and `u : N` we have
 
 ```md
   xu ∈ N → x ∈ N
@@ -468,7 +471,7 @@ module _
 module _
   {l1 l2 : Level} (M : Commutative-Monoid l1) (N : Normal-Commutative-Submonoid l2 M)
   where
-  
+
   is-saturated-congruence-Normal-Commutative-Submonoid :
     is-saturated-congruence-Commutative-Monoid M
       ( congruence-Normal-Commutative-Submonoid M N)
@@ -607,4 +610,3 @@ pr1 (equiv-normal-submonoid-saturated-congruence-Commutative-Monoid l2 M) =
 pr2 (equiv-normal-submonoid-saturated-congruence-Commutative-Monoid l2 M) =
   is-equiv-normal-submonoid-saturated-congruence-Commutative-Monoid l2 M
 ```
-

--- a/src/group-theory/normal-submonoids-commutative-monoids.lagda.md
+++ b/src/group-theory/normal-submonoids-commutative-monoids.lagda.md
@@ -35,8 +35,8 @@ open import group-theory.subsets-commutative-monoids
 
 ## Idea
 
-A normal submonoid `N` of of a commutative monoid `M` is a monoid that
-corresponds uniquely to a saturated congruence relation ~ on `M` consisting of
+A normal submonoid `N` of of a commutative monoid `M` is a submonoid that
+corresponds uniquely to a saturated congruence relation `~` on `M` consisting of
 the elements congruent to `1`. This is the case if and only if for all `x : M`
 and `u : N` we have
 

--- a/src/group-theory/normal-submonoids.lagda.md
+++ b/src/group-theory/normal-submonoids.lagda.md
@@ -34,9 +34,15 @@ open import group-theory.subsets-monoids
 
 ## Idea
 
-A normal submonoid `N` of `M` is a monoid for which there exists a congruence relation `~` on `M` such that the elements of `N` are precisely the elements `x ~ 1`. Such a congruence relation is rarely unique. However, one can show that the normal submonoids form a retract of the type of congruence relations on `M`, and that the normal submonoids correspond uniquely to *saturated* congruence relations.
+A normal submonoid `N` of `M` is a monoid for which there exists a congruence
+relation `~` on `M` such that the elements of `N` are precisely the elements
+`x ~ 1`. Such a congruence relation is rarely unique. However, one can show that
+the normal submonoids form a retract of the type of congruence relations on `M`,
+and that the normal submonoids correspond uniquely to _saturated_ congruence
+relations.
 
-A submonoid `N` of `M` is normal if and only if for all `x y : M` and `u : N` we have
+A submonoid `N` of `M` is normal if and only if for all `x y : M` and `u : N` we
+have
 
 ```md
   xuy ∈ N ⇔ xy ∈ N.
@@ -409,7 +415,7 @@ module _
 module _
   {l1 l2 : Level} (M : Monoid l1) (N : Normal-Submonoid l2 M)
   where
-  
+
   is-saturated-congruence-Normal-Submonoid :
     is-saturated-congruence-Monoid M (congruence-Normal-Submonoid M N)
   is-saturated-congruence-Normal-Submonoid x y H u v =

--- a/src/group-theory/normal-submonoids.lagda.md
+++ b/src/group-theory/normal-submonoids.lagda.md
@@ -16,6 +16,7 @@ open import foundation.functions
 open import foundation.identity-types
 open import foundation.logical-equivalences
 open import foundation.propositions
+open import foundation.retractions
 open import foundation.sets
 open import foundation.subtype-identity-principle
 open import foundation.subtypes
@@ -23,6 +24,7 @@ open import foundation.universe-levels
 
 open import group-theory.congruence-relations-monoids
 open import group-theory.monoids
+open import group-theory.saturated-congruence-relations-monoids
 open import group-theory.semigroups
 open import group-theory.submonoids
 open import group-theory.subsets-monoids
@@ -32,15 +34,17 @@ open import group-theory.subsets-monoids
 
 ## Idea
 
-A normal submonoid `N` of `M` is a monoid that corresponds uniquely to a
-congruence relation ~ on `M` consisting of the elements congruent to `1`. This
-is the case if and only if for all `x y : M` and `u : N` we have
+A normal submonoid `N` of `M` is a monoid for which there exists a congruence relation `~` on `M` such that the elements of `N` are precisely the elements `x ~ 1`. Such a congruence relation is rarely unique. However, one can show that the normal submonoids form a retract of the type of congruence relations on `M`, and that the normal submonoids correspond uniquely to *saturated* congruence relations.
+
+A submonoid `N` of `M` is normal if and only if for all `x y : M` and `u : N` we have
 
 ```md
-  xuy ∈ N ⇔ xy ∈ N
+  xuy ∈ N ⇔ xy ∈ N.
 ```
 
-## Definition
+## Definitions
+
+### Normal submonoids
 
 ```agda
 module _
@@ -191,7 +195,8 @@ module _
   {l1 l2 : Level} (M : Monoid l1) (N : Normal-Submonoid l2 M)
   where
 
-  has-same-elements-Normal-Submonoid : Normal-Submonoid l2 M → UU (l1 ⊔ l2)
+  has-same-elements-Normal-Submonoid :
+    {l3 : Level} → Normal-Submonoid l3 M → UU (l1 ⊔ l2 ⊔ l3)
   has-same-elements-Normal-Submonoid K =
     has-same-elements-Submonoid M
       ( submonoid-Normal-Submonoid M N)
@@ -206,6 +211,12 @@ module _
       ( is-normal-Normal-Submonoid M N)
       ( λ x → (id , id))
       ( extensionality-Submonoid M (submonoid-Normal-Submonoid M N))
+
+  eq-has-same-elements-Normal-Submonoid :
+    (K : Normal-Submonoid l2 M) →
+    has-same-elements-Normal-Submonoid K → N ＝ K
+  eq-has-same-elements-Normal-Submonoid K =
+    map-inv-equiv (extensionality-Normal-Submonoid K)
 ```
 
 ### The congruence relation of a normal submonoid
@@ -312,9 +323,221 @@ module _
   is-closed-under-multiplication-normal-submonoid-congruence-Monoid :
     is-closed-under-multiplication-subset-Monoid M
       subset-normal-submonoid-congruence-Monoid
-  is-closed-under-multiplication-normal-submonoid-congruence-Monoid =
-    {!!}
-    
+  is-closed-under-multiplication-normal-submonoid-congruence-Monoid x y H K =
+    concatenate-sim-eq-congruence-Monoid M R
+      ( mul-congruence-Monoid M R H K)
+      ( left-unit-law-mul-Monoid M (unit-Monoid M))
+
+  submonoid-congruence-Monoid : Submonoid l2 M
+  pr1 submonoid-congruence-Monoid = subset-normal-submonoid-congruence-Monoid
+  pr1 (pr2 submonoid-congruence-Monoid) =
+    contains-unit-normal-submonoid-congruence-Monoid
+  pr2 (pr2 submonoid-congruence-Monoid) =
+    is-closed-under-multiplication-normal-submonoid-congruence-Monoid
+
+  is-normal-submonoid-congruence-Monoid :
+    is-normal-Submonoid M submonoid-congruence-Monoid
+  pr1 (is-normal-submonoid-congruence-Monoid x y u H) =
+    trans-congruence-Monoid M R
+      ( symm-congruence-Monoid M R
+        ( mul-congruence-Monoid M R
+          ( concatenate-sim-eq-congruence-Monoid M R
+            ( mul-congruence-Monoid M R (refl-congruence-Monoid M R) H)
+            ( right-unit-law-mul-Monoid M x))
+          ( refl-congruence-Monoid M R)))
+  pr2 (is-normal-submonoid-congruence-Monoid x y u H) =
+    trans-congruence-Monoid M R
+      ( mul-congruence-Monoid M R
+        ( concatenate-sim-eq-congruence-Monoid M R
+          ( mul-congruence-Monoid M R (refl-congruence-Monoid M R) H)
+          ( right-unit-law-mul-Monoid M x))
+        ( refl-congruence-Monoid M R))
+
+  normal-submonoid-congruence-Monoid : Normal-Submonoid l2 M
+  pr1 normal-submonoid-congruence-Monoid = submonoid-congruence-Monoid
+  pr2 normal-submonoid-congruence-Monoid = is-normal-submonoid-congruence-Monoid
+```
+
+### The normal submonoid obtained from the congruence relation of a normal submonoid has the same elements as the original normal submonoid
+
+```agda
+module _
+  {l1 l2 : Level} (M : Monoid l1) (N : Normal-Submonoid l2 M)
+  where
+
+  has-same-elements-normal-submonoid-congruence-Normal-Submonoid :
+    has-same-elements-Normal-Submonoid M
+      ( normal-submonoid-congruence-Monoid M
+        ( congruence-Normal-Submonoid M N))
+      ( N)
+  pr1 (has-same-elements-normal-submonoid-congruence-Normal-Submonoid x) H =
+    is-closed-under-eq-Normal-Submonoid M N
+      ( backward-implication
+        ( H (unit-Monoid M) (unit-Monoid M))
+        ( is-closed-under-eq-Normal-Submonoid' M N
+          ( contains-unit-Normal-Submonoid M N)
+          ( ( right-unit-law-mul-Monoid M
+              ( mul-Monoid M (unit-Monoid M) (unit-Monoid M))) ∙
+            ( left-unit-law-mul-Monoid M (unit-Monoid M)))))
+      ( right-unit-law-mul-Monoid M _ ∙ left-unit-law-mul-Monoid M _)
+  pr1
+    ( pr2
+      ( has-same-elements-normal-submonoid-congruence-Normal-Submonoid x)
+      ( H)
+      ( u)
+      ( v))
+    ( K) =
+    is-closed-under-eq-Normal-Submonoid' M N
+      ( forward-implication (is-normal-Normal-Submonoid M N u v x H) K)
+      ( ap (mul-Monoid' M v) (right-unit-law-mul-Monoid M u))
+  pr2
+    ( pr2
+      ( has-same-elements-normal-submonoid-congruence-Normal-Submonoid x)
+      ( H)
+      ( u)
+      ( v))
+    ( K) =
+    backward-implication
+      ( is-normal-Normal-Submonoid M N u v x H)
+      ( is-closed-under-eq-Normal-Submonoid M N K
+        ( ap (mul-Monoid' M v) (right-unit-law-mul-Monoid M u)))
+```
+
+### The congruence relation of a normal submonoid is saturated
+
+```agda
+module _
+  {l1 l2 : Level} (M : Monoid l1) (N : Normal-Submonoid l2 M)
+  where
+  
+  is-saturated-congruence-Normal-Submonoid :
+    is-saturated-congruence-Monoid M (congruence-Normal-Submonoid M N)
+  is-saturated-congruence-Normal-Submonoid x y H u v =
+    ( ( has-same-elements-normal-submonoid-congruence-Normal-Submonoid M N
+        ( mul-Monoid M (mul-Monoid M u y) v)) ∘iff
+      ( H u v)) ∘iff
+    ( inv-iff
+      ( has-same-elements-normal-submonoid-congruence-Normal-Submonoid M N
+        ( mul-Monoid M (mul-Monoid M u x) v)))
+
+  saturated-congruence-Normal-Submonoid :
+    saturated-congruence-Monoid (l1 ⊔ l2) M
+  pr1 saturated-congruence-Normal-Submonoid = congruence-Normal-Submonoid M N
+  pr2 saturated-congruence-Normal-Submonoid =
+    is-saturated-congruence-Normal-Submonoid
+```
+
+### The congruence relation of the normal submonoid associated to a congruence relation relates the same elements as the original congruence relation
+
+```agda
+module _
+  {l1 l2 : Level} (M : Monoid l1) (R : saturated-congruence-Monoid l2 M)
+  where
+
+  normal-submonoid-saturated-congruence-Monoid :
+    Normal-Submonoid l2 M
+  normal-submonoid-saturated-congruence-Monoid =
+    normal-submonoid-congruence-Monoid M
+      ( congruence-saturated-congruence-Monoid M R)
+
+  relate-same-elements-congruence-normal-submonoid-saturated-congruence-Monoid :
+    relate-same-elements-saturated-congruence-Monoid M
+      ( saturated-congruence-Normal-Submonoid M
+        ( normal-submonoid-saturated-congruence-Monoid))
+      ( R)
+  pr1
+    ( relate-same-elements-congruence-normal-submonoid-saturated-congruence-Monoid x y) H =
+    is-saturated-saturated-congruence-Monoid M R x y H
+  pr1
+    ( pr2
+      ( relate-same-elements-congruence-normal-submonoid-saturated-congruence-Monoid x y) H u v) =
+    trans-saturated-congruence-Monoid M R
+      ( mul-saturated-congruence-Monoid M R
+        ( mul-saturated-congruence-Monoid M R
+          ( refl-saturated-congruence-Monoid M R)
+          ( symm-saturated-congruence-Monoid M R H))
+        ( refl-saturated-congruence-Monoid M R))
+  pr2
+    ( pr2
+      ( relate-same-elements-congruence-normal-submonoid-saturated-congruence-Monoid x y) H u v) =
+    trans-saturated-congruence-Monoid M R
+      ( mul-saturated-congruence-Monoid M R
+        ( mul-saturated-congruence-Monoid M R
+          ( refl-saturated-congruence-Monoid M R)
+          ( H))
+        ( refl-saturated-congruence-Monoid M R))
+```
+
+### The type of normal submonoids of `M` is a retract of the type of congruence relations of `M`
+
+```agda
+issec-congruence-Normal-Submonoid :
+  {l1 : Level} (l2 : Level) (M : Monoid l1) (N : Normal-Submonoid (l1 ⊔ l2) M) →
+  ( normal-submonoid-congruence-Monoid M (congruence-Normal-Submonoid M N)) ＝
+  ( N)
+issec-congruence-Normal-Submonoid l2 M N =
+  eq-has-same-elements-Normal-Submonoid M
+    ( normal-submonoid-congruence-Monoid M (congruence-Normal-Submonoid M N))
+    ( N)
+    ( has-same-elements-normal-submonoid-congruence-Normal-Submonoid M N)
+
+normal-submonoid-retract-of-congruence-Monoid :
+  {l1 : Level} (l2 : Level) (M : Monoid l1) →
+  (Normal-Submonoid (l1 ⊔ l2) M) retract-of (congruence-Monoid (l1 ⊔ l2) M)
+pr1 (normal-submonoid-retract-of-congruence-Monoid l2 M) =
+  congruence-Normal-Submonoid M
+pr1 (pr2 (normal-submonoid-retract-of-congruence-Monoid l2 M)) =
+  normal-submonoid-congruence-Monoid M
+pr2 (pr2 (normal-submonoid-retract-of-congruence-Monoid l2 M)) =
+  issec-congruence-Normal-Submonoid l2 M
+```
+
+### The type of normal submonoids of `M` is equivalent to the type of saturated congruence relations on `M`
+
+```agda
+issec-saturated-congruence-Normal-Submonoid :
+  {l1 : Level} (l2 : Level) (M : Monoid l1) (N : Normal-Submonoid (l1 ⊔ l2) M) →
+  ( normal-submonoid-saturated-congruence-Monoid M
+    ( saturated-congruence-Normal-Submonoid M N)) ＝
+  ( N)
+issec-saturated-congruence-Normal-Submonoid l2 M N =
+  eq-has-same-elements-Normal-Submonoid M
+    ( normal-submonoid-saturated-congruence-Monoid M
+      ( saturated-congruence-Normal-Submonoid M N))
+    ( N)
+    ( has-same-elements-normal-submonoid-congruence-Normal-Submonoid M N)
+
+isretr-saturated-congruence-Normal-Submonoid :
+  {l1 : Level} (l2 : Level) (M : Monoid l1)
+  (R : saturated-congruence-Monoid (l1 ⊔ l2) M) →
+  ( saturated-congruence-Normal-Submonoid M
+    ( normal-submonoid-saturated-congruence-Monoid M R)) ＝
+  ( R)
+isretr-saturated-congruence-Normal-Submonoid l2 M R =
+  eq-relate-same-elements-saturated-congruence-Monoid M
+    ( saturated-congruence-Normal-Submonoid M
+      ( normal-submonoid-saturated-congruence-Monoid M R))
+    ( R)
+    ( relate-same-elements-congruence-normal-submonoid-saturated-congruence-Monoid
+      ( M)
+      ( R))
+
+is-equiv-normal-submonoid-saturated-congruence-Monoid :
+  {l1 : Level} (l2 : Level) (M : Monoid l1) →
+  is-equiv (normal-submonoid-saturated-congruence-Monoid {l2 = l1 ⊔ l2} M)
+is-equiv-normal-submonoid-saturated-congruence-Monoid l2 M =
+  is-equiv-has-inverse
+    ( saturated-congruence-Normal-Submonoid M)
+    ( issec-saturated-congruence-Normal-Submonoid l2 M)
+    ( isretr-saturated-congruence-Normal-Submonoid l2 M)
+
+equiv-normal-submonoid-saturated-congruence-Monoid :
+  {l1 : Level} (l2 : Level) (M : Monoid l1) →
+  saturated-congruence-Monoid (l1 ⊔ l2) M ≃ Normal-Submonoid (l1 ⊔ l2) M
+pr1 (equiv-normal-submonoid-saturated-congruence-Monoid l2 M) =
+  normal-submonoid-saturated-congruence-Monoid M
+pr2 (equiv-normal-submonoid-saturated-congruence-Monoid l2 M) =
+  is-equiv-normal-submonoid-saturated-congruence-Monoid l2 M
 ```
 
 ## References

--- a/src/group-theory/normal-submonoids.lagda.md
+++ b/src/group-theory/normal-submonoids.lagda.md
@@ -7,7 +7,10 @@ module group-theory.normal-submonoids where
 <details><summary>Imports</summary>
 
 ```agda
+open import foundation.binary-relations
+open import foundation.binary-transport
 open import foundation.dependent-pair-types
+open import foundation.equivalence-relations
 open import foundation.equivalences
 open import foundation.functions
 open import foundation.identity-types
@@ -18,9 +21,11 @@ open import foundation.subtype-identity-principle
 open import foundation.subtypes
 open import foundation.universe-levels
 
+open import group-theory.congruence-relations-monoids
 open import group-theory.monoids
 open import group-theory.semigroups
 open import group-theory.submonoids
+open import group-theory.subsets-monoids
 ```
 
 </details>
@@ -96,6 +101,18 @@ module _
   is-prop-is-in-Normal-Submonoid =
     is-prop-is-in-Submonoid M submonoid-Normal-Submonoid
 
+  is-closed-under-eq-Normal-Submonoid :
+    {x y : type-Monoid M} → is-in-Normal-Submonoid x → (x ＝ y) →
+    is-in-Normal-Submonoid y
+  is-closed-under-eq-Normal-Submonoid =
+    is-closed-under-eq-subtype subset-Normal-Submonoid
+
+  is-closed-under-eq-Normal-Submonoid' :
+    {x y : type-Monoid M} → is-in-Normal-Submonoid y →
+    (x ＝ y) → is-in-Normal-Submonoid x
+  is-closed-under-eq-Normal-Submonoid' =
+    is-closed-under-eq-subtype' subset-Normal-Submonoid
+
   type-Normal-Submonoid : UU (l1 ⊔ l2)
   type-Normal-Submonoid = type-Submonoid M submonoid-Normal-Submonoid
 
@@ -167,7 +184,7 @@ module _
 
 ## Properties
 
-### Extensionality of the type of all submonoids
+### Extensionality of the type of all normal submonoids
 
 ```agda
 module _
@@ -189,6 +206,115 @@ module _
       ( is-normal-Normal-Submonoid M N)
       ( λ x → (id , id))
       ( extensionality-Submonoid M (submonoid-Normal-Submonoid M N))
+```
+
+### The congruence relation of a normal submonoid
+
+```agda
+module _
+  {l1 l2 : Level} (M : Monoid l1) (N : Normal-Submonoid l2 M)
+  where
+
+  rel-congruence-Normal-Submonoid : Rel-Prop (l1 ⊔ l2) (type-Monoid M)
+  rel-congruence-Normal-Submonoid x y =
+    Π-Prop
+      ( type-Monoid M)
+      ( λ u →
+        Π-Prop
+          ( type-Monoid M)
+          ( λ v →
+            iff-Prop
+              ( subset-Normal-Submonoid M N
+                ( mul-Monoid M (mul-Monoid M u x) v))
+              ( subset-Normal-Submonoid M N
+                ( mul-Monoid M (mul-Monoid M u y) v))))
+
+  sim-congruence-Normal-Submonoid : (x y : type-Monoid M) → UU (l1 ⊔ l2)
+  sim-congruence-Normal-Submonoid x y =
+    type-Prop (rel-congruence-Normal-Submonoid x y)
+
+  refl-congruence-Normal-Submonoid :
+    is-reflexive-Rel-Prop rel-congruence-Normal-Submonoid
+  pr1 (refl-congruence-Normal-Submonoid u v) = id
+  pr2 (refl-congruence-Normal-Submonoid u v) = id
+
+  symmetric-congruence-Normal-Submonoid :
+    is-symmetric-Rel-Prop rel-congruence-Normal-Submonoid
+  pr1 (symmetric-congruence-Normal-Submonoid H u v) = pr2 (H u v)
+  pr2 (symmetric-congruence-Normal-Submonoid H u v) = pr1 (H u v)
+
+  transitive-congruence-Normal-Submonoid :
+    is-transitive-Rel-Prop rel-congruence-Normal-Submonoid
+  transitive-congruence-Normal-Submonoid H K u v = (K u v) ∘iff (H u v)
+
+  eq-rel-congruence-Normal-Submonoid : Eq-Rel (l1 ⊔ l2) (type-Monoid M)
+  pr1 eq-rel-congruence-Normal-Submonoid = rel-congruence-Normal-Submonoid
+  pr1 (pr2 eq-rel-congruence-Normal-Submonoid) =
+    refl-congruence-Normal-Submonoid
+  pr1 (pr2 (pr2 eq-rel-congruence-Normal-Submonoid)) =
+    symmetric-congruence-Normal-Submonoid
+  pr2 (pr2 (pr2 eq-rel-congruence-Normal-Submonoid)) =
+    transitive-congruence-Normal-Submonoid
+
+  is-congruence-congruence-Normal-Submonoid :
+    is-congruence-Monoid M eq-rel-congruence-Normal-Submonoid
+  pr1 (is-congruence-congruence-Normal-Submonoid {x} {x'} {y} {y'} H K u v) L =
+    is-closed-under-eq-Normal-Submonoid M N
+      ( forward-implication
+        ( H u (mul-Monoid M y' v))
+        ( is-closed-under-eq-Normal-Submonoid M N
+          ( forward-implication
+            ( K (mul-Monoid M u x) v)
+            ( is-closed-under-eq-Normal-Submonoid M N L
+              ( ap (mul-Monoid' M v) (inv (associative-mul-Monoid M u x y)))))
+          ( associative-mul-Monoid M (mul-Monoid M u x) y' v)))
+      ( ( inv (associative-mul-Monoid M (mul-Monoid M u x') y' v)) ∙
+        ( ap (mul-Monoid' M v) (associative-mul-Monoid M u x' y')))
+  pr2 (is-congruence-congruence-Normal-Submonoid {x} {x'} {y} {y'} H K u v) L =
+    is-closed-under-eq-Normal-Submonoid M N
+      ( backward-implication
+        ( H u (mul-Monoid M y v))
+        ( is-closed-under-eq-Normal-Submonoid M N
+          ( backward-implication
+            ( K (mul-Monoid M u x') v)
+            ( is-closed-under-eq-Normal-Submonoid M N L
+              ( ap (mul-Monoid' M v) (inv (associative-mul-Monoid M u x' y')))))
+          ( associative-mul-Monoid M (mul-Monoid M u x') y v)))
+      ( ( inv (associative-mul-Monoid M (mul-Monoid M u x) y v)) ∙
+        ( ap (mul-Monoid' M v) (associative-mul-Monoid M u x y)))
+
+  congruence-Normal-Submonoid : congruence-Monoid (l1 ⊔ l2) M
+  pr1 congruence-Normal-Submonoid = eq-rel-congruence-Normal-Submonoid
+  pr2 congruence-Normal-Submonoid = is-congruence-congruence-Normal-Submonoid
+```
+
+### The normal submonoid obtained from a congruence relation
+
+```agda
+module _
+  {l1 l2 : Level} (M : Monoid l1) (R : congruence-Monoid l2 M)
+  where
+
+  subset-normal-submonoid-congruence-Monoid :
+    subtype l2 (type-Monoid M)
+  subset-normal-submonoid-congruence-Monoid x =
+    prop-congruence-Monoid M R x (unit-Monoid M)
+
+  is-in-normal-submonoid-congruence-Monoid : type-Monoid M → UU l2
+  is-in-normal-submonoid-congruence-Monoid =
+    is-in-subtype subset-normal-submonoid-congruence-Monoid
+
+  contains-unit-normal-submonoid-congruence-Monoid :
+    is-in-normal-submonoid-congruence-Monoid (unit-Monoid M)
+  contains-unit-normal-submonoid-congruence-Monoid =
+    refl-congruence-Monoid M R
+
+  is-closed-under-multiplication-normal-submonoid-congruence-Monoid :
+    is-closed-under-multiplication-subset-Monoid M
+      subset-normal-submonoid-congruence-Monoid
+  is-closed-under-multiplication-normal-submonoid-congruence-Monoid =
+    {!!}
+    
 ```
 
 ## References

--- a/src/group-theory/saturated-congruence-relations-commutative-monoids.lagda.md
+++ b/src/group-theory/saturated-congruence-relations-commutative-monoids.lagda.md
@@ -1,0 +1,248 @@
+# Saturated congruences on commutative monoids
+
+```agda
+module group-theory.saturated-congruence-relations-commutative-monoids where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.binary-relations
+open import foundation.contractible-types
+open import foundation.dependent-pair-types
+open import foundation.equivalence-relations
+open import foundation.equivalences
+open import foundation.fundamental-theorem-of-identity-types
+open import foundation.identity-types
+open import foundation.logical-equivalences
+open import foundation.propositions
+open import foundation.subtype-identity-principle
+open import foundation.subtypes
+open import foundation.universe-levels
+
+open import group-theory.commutative-monoids
+open import group-theory.congruence-relations-commutative-monoids
+open import group-theory.congruence-relations-monoids
+open import group-theory.monoids
+```
+
+</details>
+
+## Idea
+
+For any commutative monoid `M`, the type of normal submonoids is a retract of the type of congruence relations on `M`. A congruence relation on `M` is said to be **saturated** if it is in the image of the inclusion of the normal submonoids of `M` into the congruence relations on `M`.
+
+## Definition
+
+```agda
+module _
+  {l1 l2 : Level} (M : Commutative-Monoid l1)
+  (R : congruence-Commutative-Monoid l2 M)
+  where
+  
+  is-saturated-congruence-commutative-monoid-Prop : Prop (l1 ⊔ l2)
+  is-saturated-congruence-commutative-monoid-Prop =
+    Π-Prop
+      ( type-Commutative-Monoid M)
+      ( λ x →
+        Π-Prop
+          ( type-Commutative-Monoid M)
+          ( λ y →
+            function-Prop
+              ( (u : type-Commutative-Monoid M) →
+                ( sim-congruence-Commutative-Monoid M R
+                  ( mul-Commutative-Monoid M u x)
+                  ( unit-Commutative-Monoid M)) ↔
+                ( sim-congruence-Commutative-Monoid M R
+                  ( mul-Commutative-Monoid M u y)
+                  ( unit-Commutative-Monoid M)))
+              ( prop-congruence-Commutative-Monoid M R x y)))
+
+  is-saturated-congruence-Commutative-Monoid : UU (l1 ⊔ l2)
+  is-saturated-congruence-Commutative-Monoid =
+    type-Prop is-saturated-congruence-commutative-monoid-Prop
+
+  is-prop-is-saturated-congruence-Commutative-Monoid :
+    is-prop is-saturated-congruence-Commutative-Monoid
+  is-prop-is-saturated-congruence-Commutative-Monoid =
+    is-prop-type-Prop is-saturated-congruence-commutative-monoid-Prop
+
+saturated-congruence-Commutative-Monoid :
+  {l1 : Level} (l2 : Level) (M : Commutative-Monoid l1) → UU (l1 ⊔ lsuc l2)
+saturated-congruence-Commutative-Monoid l2 M =
+  Σ ( congruence-Commutative-Monoid l2 M)
+    ( is-saturated-congruence-Commutative-Monoid M)
+
+module _
+  {l1 l2 : Level} (M : Commutative-Monoid l1)
+  (R : saturated-congruence-Commutative-Monoid l2 M)
+  where
+
+  congruence-saturated-congruence-Commutative-Monoid :
+    congruence-Commutative-Monoid l2 M
+  congruence-saturated-congruence-Commutative-Monoid = pr1 R
+
+  is-saturated-saturated-congruence-Commutative-Monoid :
+    is-saturated-congruence-Commutative-Monoid M
+      congruence-saturated-congruence-Commutative-Monoid
+  is-saturated-saturated-congruence-Commutative-Monoid = pr2 R
+
+  eq-rel-saturated-congruence-Commutative-Monoid :
+    Eq-Rel l2 (type-Commutative-Monoid M)
+  eq-rel-saturated-congruence-Commutative-Monoid =
+    eq-rel-congruence-Commutative-Monoid M
+      congruence-saturated-congruence-Commutative-Monoid
+
+  prop-saturated-congruence-Commutative-Monoid :
+    Rel-Prop l2 (type-Commutative-Monoid M)
+  prop-saturated-congruence-Commutative-Monoid =
+    prop-congruence-Commutative-Monoid M
+      congruence-saturated-congruence-Commutative-Monoid
+
+  sim-saturated-congruence-Commutative-Monoid :
+    (x y : type-Commutative-Monoid M) → UU l2
+  sim-saturated-congruence-Commutative-Monoid =
+    sim-congruence-Commutative-Monoid M
+      congruence-saturated-congruence-Commutative-Monoid
+
+  is-prop-sim-saturated-congruence-Commutative-Monoid :
+    (x y : type-Commutative-Monoid M) →
+      is-prop (sim-saturated-congruence-Commutative-Monoid x y)
+  is-prop-sim-saturated-congruence-Commutative-Monoid =
+    is-prop-sim-congruence-Commutative-Monoid M
+      congruence-saturated-congruence-Commutative-Monoid
+
+  concatenate-sim-eq-saturated-congruence-Commutative-Monoid :
+    {x y z : type-Commutative-Monoid M} →
+    sim-saturated-congruence-Commutative-Monoid x y → y ＝ z →
+    sim-saturated-congruence-Commutative-Monoid x z
+  concatenate-sim-eq-saturated-congruence-Commutative-Monoid =
+    concatenate-sim-eq-congruence-Commutative-Monoid M
+      congruence-saturated-congruence-Commutative-Monoid
+
+  concatenate-eq-sim-saturated-congruence-Commutative-Monoid :
+    {x y z : type-Commutative-Monoid M} → x ＝ y →
+    sim-saturated-congruence-Commutative-Monoid y z →
+    sim-saturated-congruence-Commutative-Monoid x z
+  concatenate-eq-sim-saturated-congruence-Commutative-Monoid =
+    concatenate-eq-sim-congruence-Commutative-Monoid M
+      congruence-saturated-congruence-Commutative-Monoid
+
+  concatenate-eq-sim-eq-saturated-congruence-Commutative-Monoid :
+    {x y z w : type-Commutative-Monoid M} → x ＝ y →
+    sim-saturated-congruence-Commutative-Monoid y z →
+    z ＝ w → sim-saturated-congruence-Commutative-Monoid x w
+  concatenate-eq-sim-eq-saturated-congruence-Commutative-Monoid =
+    concatenate-eq-sim-eq-congruence-Commutative-Monoid M
+      congruence-saturated-congruence-Commutative-Monoid
+
+  refl-saturated-congruence-Commutative-Monoid :
+    is-reflexive-Rel-Prop prop-saturated-congruence-Commutative-Monoid
+  refl-saturated-congruence-Commutative-Monoid =
+    refl-congruence-Commutative-Monoid M
+    congruence-saturated-congruence-Commutative-Monoid
+
+  symm-saturated-congruence-Commutative-Monoid :
+    is-symmetric-Rel-Prop prop-saturated-congruence-Commutative-Monoid
+  symm-saturated-congruence-Commutative-Monoid =
+    symm-congruence-Commutative-Monoid M
+    congruence-saturated-congruence-Commutative-Monoid
+
+  equiv-symm-saturated-congruence-Commutative-Monoid :
+    (x y : type-Commutative-Monoid M) →
+    sim-saturated-congruence-Commutative-Monoid x y ≃
+    sim-saturated-congruence-Commutative-Monoid y x
+  equiv-symm-saturated-congruence-Commutative-Monoid =
+    equiv-symm-congruence-Commutative-Monoid M
+    congruence-saturated-congruence-Commutative-Monoid
+
+  trans-saturated-congruence-Commutative-Monoid :
+    is-transitive-Rel-Prop prop-saturated-congruence-Commutative-Monoid
+  trans-saturated-congruence-Commutative-Monoid =
+    trans-congruence-Commutative-Monoid M
+      congruence-saturated-congruence-Commutative-Monoid
+
+  mul-saturated-congruence-Commutative-Monoid :
+    is-congruence-Commutative-Monoid M
+      eq-rel-saturated-congruence-Commutative-Monoid
+  mul-saturated-congruence-Commutative-Monoid =
+    mul-congruence-Commutative-Monoid M
+      congruence-saturated-congruence-Commutative-Monoid
+```
+
+## Properties
+
+### Extensionality of the type of saturated congruence relations on a monoid
+
+```agda
+relate-same-elements-saturated-congruence-Commutative-Monoid :
+  {l1 l2 l3 : Level} (M : Commutative-Monoid l1)
+  (R : saturated-congruence-Commutative-Monoid l2 M)
+  (S : saturated-congruence-Commutative-Monoid l3 M) → UU (l1 ⊔ l2 ⊔ l3)
+relate-same-elements-saturated-congruence-Commutative-Monoid M R S =
+  relate-same-elements-congruence-Commutative-Monoid M
+    ( congruence-saturated-congruence-Commutative-Monoid M R)
+    ( congruence-saturated-congruence-Commutative-Monoid M S)
+
+refl-relate-same-elements-saturated-congruence-Commutative-Monoid :
+  {l1 l2 : Level} (M : Commutative-Monoid l1)
+  (R : saturated-congruence-Commutative-Monoid l2 M) →
+  relate-same-elements-saturated-congruence-Commutative-Monoid M R R
+refl-relate-same-elements-saturated-congruence-Commutative-Monoid M R =
+  refl-relate-same-elements-congruence-Commutative-Monoid M
+    ( congruence-saturated-congruence-Commutative-Monoid M R)
+
+is-contr-total-relate-same-elements-saturated-congruence-Commutative-Monoid :
+  {l1 l2 : Level} (M : Commutative-Monoid l1)
+  (R : saturated-congruence-Commutative-Monoid l2 M) →
+  is-contr
+    ( Σ ( saturated-congruence-Commutative-Monoid l2 M)
+        ( relate-same-elements-saturated-congruence-Commutative-Monoid M R))
+is-contr-total-relate-same-elements-saturated-congruence-Commutative-Monoid
+  M R =
+  is-contr-total-Eq-subtype
+    ( is-contr-total-relate-same-elements-congruence-Commutative-Monoid M
+      ( congruence-saturated-congruence-Commutative-Monoid M R))
+    ( is-prop-is-saturated-congruence-Commutative-Monoid M)
+    ( congruence-saturated-congruence-Commutative-Monoid M R)
+    ( refl-relate-same-elements-congruence-Commutative-Monoid M
+      ( congruence-saturated-congruence-Commutative-Monoid M R))
+    ( is-saturated-saturated-congruence-Commutative-Monoid M R)
+
+relate-same-elements-eq-saturated-congruence-Commutative-Monoid :
+  {l1 l2 : Level} (M : Commutative-Monoid l1)
+  (R S : saturated-congruence-Commutative-Monoid l2 M) →
+  R ＝ S → relate-same-elements-saturated-congruence-Commutative-Monoid M R S
+relate-same-elements-eq-saturated-congruence-Commutative-Monoid M R .R refl =
+  refl-relate-same-elements-saturated-congruence-Commutative-Monoid M R
+
+is-equiv-relate-same-elements-eq-saturated-congruence-Commutative-Monoid :
+  {l1 l2 : Level} (M : Commutative-Monoid l1)
+  (R S : saturated-congruence-Commutative-Monoid l2 M) →
+  is-equiv
+    ( relate-same-elements-eq-saturated-congruence-Commutative-Monoid M R S)
+is-equiv-relate-same-elements-eq-saturated-congruence-Commutative-Monoid M R =
+  fundamental-theorem-id
+    ( is-contr-total-relate-same-elements-saturated-congruence-Commutative-Monoid M R)
+    ( relate-same-elements-eq-saturated-congruence-Commutative-Monoid M R)
+
+extensionality-saturated-congruence-Commutative-Monoid :
+  {l1 l2 : Level} (M : Commutative-Monoid l1)
+  (R S : saturated-congruence-Commutative-Monoid l2 M) →
+  (R ＝ S) ≃ relate-same-elements-saturated-congruence-Commutative-Monoid M R S
+pr1 (extensionality-saturated-congruence-Commutative-Monoid M R S) =
+  relate-same-elements-eq-saturated-congruence-Commutative-Monoid M R S
+pr2 (extensionality-saturated-congruence-Commutative-Monoid M R S) =
+  is-equiv-relate-same-elements-eq-saturated-congruence-Commutative-Monoid M R S
+
+eq-relate-same-elements-saturated-congruence-Commutative-Monoid :
+  {l1 l2 : Level} (M : Commutative-Monoid l1)
+  (R S : saturated-congruence-Commutative-Monoid l2 M) →
+  relate-same-elements-saturated-congruence-Commutative-Monoid M R S → R ＝ S
+eq-relate-same-elements-saturated-congruence-Commutative-Monoid M R S =
+  map-inv-equiv (extensionality-saturated-congruence-Commutative-Monoid M R S)
+```
+
+## See also
+
+- Not every congruence relation on a commutative monoid is saturated. For an example, see the commutative monoid [`ℕ-Max`](elementary-number-theory.monoid-of-natural-numbers-with-maximum.md).

--- a/src/group-theory/saturated-congruence-relations-commutative-monoids.lagda.md
+++ b/src/group-theory/saturated-congruence-relations-commutative-monoids.lagda.md
@@ -30,7 +30,10 @@ open import group-theory.monoids
 
 ## Idea
 
-For any commutative monoid `M`, the type of normal submonoids is a retract of the type of congruence relations on `M`. A congruence relation on `M` is said to be **saturated** if it is in the image of the inclusion of the normal submonoids of `M` into the congruence relations on `M`.
+For any commutative monoid `M`, the type of normal submonoids is a retract of
+the type of congruence relations on `M`. A congruence relation on `M` is said to
+be **saturated** if it is in the image of the inclusion of the normal submonoids
+of `M` into the congruence relations on `M`.
 
 ## Definition
 
@@ -39,7 +42,7 @@ module _
   {l1 l2 : Level} (M : Commutative-Monoid l1)
   (R : congruence-Commutative-Monoid l2 M)
   where
-  
+
   is-saturated-congruence-commutative-monoid-Prop : Prop (l1 ⊔ l2)
   is-saturated-congruence-commutative-monoid-Prop =
     Π-Prop
@@ -245,4 +248,6 @@ eq-relate-same-elements-saturated-congruence-Commutative-Monoid M R S =
 
 ## See also
 
-- Not every congruence relation on a commutative monoid is saturated. For an example, see the commutative monoid [`ℕ-Max`](elementary-number-theory.monoid-of-natural-numbers-with-maximum.md).
+- Not every congruence relation on a commutative monoid is saturated. For an
+  example, see the commutative monoid
+  [`ℕ-Max`](elementary-number-theory.monoid-of-natural-numbers-with-maximum.md).

--- a/src/group-theory/saturated-congruence-relations-commutative-monoids.lagda.md
+++ b/src/group-theory/saturated-congruence-relations-commutative-monoids.lagda.md
@@ -1,4 +1,4 @@
-# Saturated congruences on commutative monoids
+# Saturated congruence relations on commutative monoids
 
 ```agda
 module group-theory.saturated-congruence-relations-commutative-monoids where
@@ -175,7 +175,7 @@ module _
 
 ## Properties
 
-### Extensionality of the type of saturated congruence relations on a monoid
+### Extensionality of the type of saturated congruence relations on a commutative monoid
 
 ```agda
 relate-same-elements-saturated-congruence-Commutative-Monoid :

--- a/src/group-theory/saturated-congruence-relations-monoids.lagda.md
+++ b/src/group-theory/saturated-congruence-relations-monoids.lagda.md
@@ -28,7 +28,10 @@ open import group-theory.monoids
 
 ## Idea
 
-For any monoid `M`, the type of normal submonoids is a retract of the type of congruence relations on `M`. A congruence relation on `M` is said to be **saturated** if it is in the image of the inclusion of the normal submonoids of `M` into the congruence relations on `M`.
+For any monoid `M`, the type of normal submonoids is a retract of the type of
+congruence relations on `M`. A congruence relation on `M` is said to be
+**saturated** if it is in the image of the inclusion of the normal submonoids of
+`M` into the congruence relations on `M`.
 
 ## Definition
 
@@ -36,7 +39,7 @@ For any monoid `M`, the type of normal submonoids is a retract of the type of co
 module _
   {l1 l2 : Level} (M : Monoid l1) (R : congruence-Monoid l2 M)
   where
-  
+
   is-saturated-congruence-monoid-Prop : Prop (l1 ⊔ l2)
   is-saturated-congruence-monoid-Prop =
     Π-Prop
@@ -211,4 +214,6 @@ eq-relate-same-elements-saturated-congruence-Monoid M R S =
 
 ## See also
 
-- Not every congruence relation on a monoid is saturated. For an example, see the monoid [`ℕ-Max`](elementary-number-theory.monoid-of-natural-numbers-with-maximum.md).
+- Not every congruence relation on a monoid is saturated. For an example, see
+  the monoid
+  [`ℕ-Max`](elementary-number-theory.monoid-of-natural-numbers-with-maximum.md).

--- a/src/group-theory/saturated-congruence-relations-monoids.lagda.md
+++ b/src/group-theory/saturated-congruence-relations-monoids.lagda.md
@@ -1,4 +1,4 @@
-# Saturated congruences on monoids
+# Saturated congruence relations on monoids
 
 ```agda
 module group-theory.saturated-congruence-relations-monoids where

--- a/src/group-theory/saturated-congruence-relations-monoids.lagda.md
+++ b/src/group-theory/saturated-congruence-relations-monoids.lagda.md
@@ -1,0 +1,214 @@
+# Saturated congruences on monoids
+
+```agda
+module group-theory.saturated-congruence-relations-monoids where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.binary-relations
+open import foundation.contractible-types
+open import foundation.dependent-pair-types
+open import foundation.equivalence-relations
+open import foundation.equivalences
+open import foundation.fundamental-theorem-of-identity-types
+open import foundation.identity-types
+open import foundation.logical-equivalences
+open import foundation.propositions
+open import foundation.subtype-identity-principle
+open import foundation.subtypes
+open import foundation.universe-levels
+
+open import group-theory.congruence-relations-monoids
+open import group-theory.monoids
+```
+
+</details>
+
+## Idea
+
+For any monoid `M`, the type of normal submonoids is a retract of the type of congruence relations on `M`. A congruence relation on `M` is said to be **saturated** if it is in the image of the inclusion of the normal submonoids of `M` into the congruence relations on `M`.
+
+## Definition
+
+```agda
+module _
+  {l1 l2 : Level} (M : Monoid l1) (R : congruence-Monoid l2 M)
+  where
+  
+  is-saturated-congruence-monoid-Prop : Prop (l1 ⊔ l2)
+  is-saturated-congruence-monoid-Prop =
+    Π-Prop
+      ( type-Monoid M)
+      ( λ x →
+        Π-Prop
+          ( type-Monoid M)
+          ( λ y →
+            function-Prop
+              ( (u v : type-Monoid M) →
+                ( sim-congruence-Monoid M R
+                  ( mul-Monoid M (mul-Monoid M u x) v)
+                  ( unit-Monoid M)) ↔
+                ( sim-congruence-Monoid M R
+                  ( mul-Monoid M (mul-Monoid M u y) v)
+                  ( unit-Monoid M)))
+              ( prop-congruence-Monoid M R x y)))
+
+  is-saturated-congruence-Monoid : UU (l1 ⊔ l2)
+  is-saturated-congruence-Monoid = type-Prop is-saturated-congruence-monoid-Prop
+
+  is-prop-is-saturated-congruence-Monoid :
+    is-prop is-saturated-congruence-Monoid
+  is-prop-is-saturated-congruence-Monoid =
+    is-prop-type-Prop is-saturated-congruence-monoid-Prop
+
+saturated-congruence-Monoid :
+  {l1 : Level} (l2 : Level) (M : Monoid l1) → UU (l1 ⊔ lsuc l2)
+saturated-congruence-Monoid l2 M =
+  Σ ( congruence-Monoid l2 M)
+    ( is-saturated-congruence-Monoid M)
+
+module _
+  {l1 l2 : Level} (M : Monoid l1) (R : saturated-congruence-Monoid l2 M)
+  where
+
+  congruence-saturated-congruence-Monoid : congruence-Monoid l2 M
+  congruence-saturated-congruence-Monoid = pr1 R
+
+  is-saturated-saturated-congruence-Monoid :
+    is-saturated-congruence-Monoid M congruence-saturated-congruence-Monoid
+  is-saturated-saturated-congruence-Monoid = pr2 R
+
+  eq-rel-saturated-congruence-Monoid : Eq-Rel l2 (type-Monoid M)
+  eq-rel-saturated-congruence-Monoid =
+    eq-rel-congruence-Monoid M congruence-saturated-congruence-Monoid
+
+  prop-saturated-congruence-Monoid : Rel-Prop l2 (type-Monoid M)
+  prop-saturated-congruence-Monoid =
+    prop-congruence-Monoid M congruence-saturated-congruence-Monoid
+
+  sim-saturated-congruence-Monoid : (x y : type-Monoid M) → UU l2
+  sim-saturated-congruence-Monoid =
+    sim-congruence-Monoid M congruence-saturated-congruence-Monoid
+
+  is-prop-sim-saturated-congruence-Monoid :
+    (x y : type-Monoid M) → is-prop (sim-saturated-congruence-Monoid x y)
+  is-prop-sim-saturated-congruence-Monoid =
+    is-prop-sim-congruence-Monoid M congruence-saturated-congruence-Monoid
+
+  concatenate-sim-eq-saturated-congruence-Monoid :
+    {x y z : type-Monoid M} → sim-saturated-congruence-Monoid x y → y ＝ z →
+    sim-saturated-congruence-Monoid x z
+  concatenate-sim-eq-saturated-congruence-Monoid =
+    concatenate-sim-eq-congruence-Monoid M
+      congruence-saturated-congruence-Monoid
+
+  concatenate-eq-sim-saturated-congruence-Monoid :
+    {x y z : type-Monoid M} → x ＝ y → sim-saturated-congruence-Monoid y z →
+    sim-saturated-congruence-Monoid x z
+  concatenate-eq-sim-saturated-congruence-Monoid =
+    concatenate-eq-sim-congruence-Monoid M
+      congruence-saturated-congruence-Monoid
+
+  concatenate-eq-sim-eq-saturated-congruence-Monoid :
+    {x y z w : type-Monoid M} → x ＝ y → sim-saturated-congruence-Monoid y z →
+    z ＝ w → sim-saturated-congruence-Monoid x w
+  concatenate-eq-sim-eq-saturated-congruence-Monoid =
+    concatenate-eq-sim-eq-congruence-Monoid M
+      congruence-saturated-congruence-Monoid
+
+  refl-saturated-congruence-Monoid :
+    is-reflexive-Rel-Prop prop-saturated-congruence-Monoid
+  refl-saturated-congruence-Monoid =
+    refl-congruence-Monoid M congruence-saturated-congruence-Monoid
+
+  symm-saturated-congruence-Monoid :
+    is-symmetric-Rel-Prop prop-saturated-congruence-Monoid
+  symm-saturated-congruence-Monoid =
+    symm-congruence-Monoid M congruence-saturated-congruence-Monoid
+
+  equiv-symm-saturated-congruence-Monoid :
+    (x y : type-Monoid M) →
+    sim-saturated-congruence-Monoid x y ≃ sim-saturated-congruence-Monoid y x
+  equiv-symm-saturated-congruence-Monoid =
+    equiv-symm-congruence-Monoid M congruence-saturated-congruence-Monoid
+
+  trans-saturated-congruence-Monoid :
+    is-transitive-Rel-Prop prop-saturated-congruence-Monoid
+  trans-saturated-congruence-Monoid =
+    trans-congruence-Monoid M congruence-saturated-congruence-Monoid
+
+  mul-saturated-congruence-Monoid :
+    is-congruence-Monoid M eq-rel-saturated-congruence-Monoid
+  mul-saturated-congruence-Monoid =
+    mul-congruence-Monoid M congruence-saturated-congruence-Monoid
+```
+
+## Properties
+
+### Extensionality of the type of saturated congruence relations on a monoid
+
+```agda
+relate-same-elements-saturated-congruence-Monoid :
+  {l1 l2 l3 : Level} (M : Monoid l1) (R : saturated-congruence-Monoid l2 M)
+  (S : saturated-congruence-Monoid l3 M) → UU (l1 ⊔ l2 ⊔ l3)
+relate-same-elements-saturated-congruence-Monoid M R S =
+  relate-same-elements-congruence-Monoid M
+    ( congruence-saturated-congruence-Monoid M R)
+    ( congruence-saturated-congruence-Monoid M S)
+
+refl-relate-same-elements-saturated-congruence-Monoid :
+  {l1 l2 : Level} (M : Monoid l1) (R : saturated-congruence-Monoid l2 M) →
+  relate-same-elements-saturated-congruence-Monoid M R R
+refl-relate-same-elements-saturated-congruence-Monoid M R =
+  refl-relate-same-elements-congruence-Monoid M
+    ( congruence-saturated-congruence-Monoid M R)
+
+is-contr-total-relate-same-elements-saturated-congruence-Monoid :
+  {l1 l2 : Level} (M : Monoid l1) (R : saturated-congruence-Monoid l2 M) →
+  is-contr
+    ( Σ ( saturated-congruence-Monoid l2 M)
+        ( relate-same-elements-saturated-congruence-Monoid M R))
+is-contr-total-relate-same-elements-saturated-congruence-Monoid M R =
+  is-contr-total-Eq-subtype
+    ( is-contr-total-relate-same-elements-congruence-Monoid M
+      ( congruence-saturated-congruence-Monoid M R))
+    ( is-prop-is-saturated-congruence-Monoid M)
+    ( congruence-saturated-congruence-Monoid M R)
+    ( refl-relate-same-elements-congruence-Monoid M
+      ( congruence-saturated-congruence-Monoid M R))
+    ( is-saturated-saturated-congruence-Monoid M R)
+
+relate-same-elements-eq-saturated-congruence-Monoid :
+  {l1 l2 : Level} (M : Monoid l1) (R S : saturated-congruence-Monoid l2 M) →
+  R ＝ S → relate-same-elements-saturated-congruence-Monoid M R S
+relate-same-elements-eq-saturated-congruence-Monoid M R .R refl =
+  refl-relate-same-elements-saturated-congruence-Monoid M R
+
+is-equiv-relate-same-elements-eq-saturated-congruence-Monoid :
+  {l1 l2 : Level} (M : Monoid l1) (R S : saturated-congruence-Monoid l2 M) →
+  is-equiv (relate-same-elements-eq-saturated-congruence-Monoid M R S)
+is-equiv-relate-same-elements-eq-saturated-congruence-Monoid M R =
+  fundamental-theorem-id
+    ( is-contr-total-relate-same-elements-saturated-congruence-Monoid M R)
+    ( relate-same-elements-eq-saturated-congruence-Monoid M R)
+
+extensionality-saturated-congruence-Monoid :
+  {l1 l2 : Level} (M : Monoid l1) (R S : saturated-congruence-Monoid l2 M) →
+  (R ＝ S) ≃ relate-same-elements-saturated-congruence-Monoid M R S
+pr1 (extensionality-saturated-congruence-Monoid M R S) =
+  relate-same-elements-eq-saturated-congruence-Monoid M R S
+pr2 (extensionality-saturated-congruence-Monoid M R S) =
+  is-equiv-relate-same-elements-eq-saturated-congruence-Monoid M R S
+
+eq-relate-same-elements-saturated-congruence-Monoid :
+  {l1 l2 : Level} (M : Monoid l1) (R S : saturated-congruence-Monoid l2 M) →
+  relate-same-elements-saturated-congruence-Monoid M R S → R ＝ S
+eq-relate-same-elements-saturated-congruence-Monoid M R S =
+  map-inv-equiv (extensionality-saturated-congruence-Monoid M R S)
+```
+
+## See also
+
+- Not every congruence relation on a monoid is saturated. For an example, see the monoid [`ℕ-Max`](elementary-number-theory.monoid-of-natural-numbers-with-maximum.md).

--- a/src/group-theory/submonoids-commutative-monoids.lagda.md
+++ b/src/group-theory/submonoids-commutative-monoids.lagda.md
@@ -1,0 +1,222 @@
+# Submonoids of commutative monoids
+
+```agda
+module group-theory.submonoids-commutative-monoids where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.dependent-pair-types
+open import foundation.equivalences
+open import foundation.functions
+open import foundation.identity-types
+open import foundation.propositions
+open import foundation.sets
+open import foundation.subtype-identity-principle
+open import foundation.subtypes
+open import foundation.universe-levels
+
+open import group-theory.commutative-monoids
+open import group-theory.homomorphisms-commutative-monoids
+open import group-theory.monoids
+open import group-theory.semigroups
+open import group-theory.submonoids
+open import group-theory.subsets-commutative-monoids
+```
+
+</details>
+
+## Idea
+
+A submonoid of a commutative monoid `M` is a subset of `M` that contains the unit of `M` and is closed under multiplication.
+
+## Definitions
+
+### Submonoids of commutative monoids
+
+```agda
+is-submonoid-commutative-monoid-Prop :
+  {l1 l2 : Level} (M : Commutative-Monoid l1)
+  (P : subset-Commutative-Monoid l2 M) → Prop (l1 ⊔ l2)
+is-submonoid-commutative-monoid-Prop M =
+  is-submonoid-monoid-Prop (monoid-Commutative-Monoid M)
+
+is-submonoid-Commutative-Monoid :
+  {l1 l2 : Level} (M : Commutative-Monoid l1)
+  (P : subset-Commutative-Monoid l2 M) → UU (l1 ⊔ l2)
+is-submonoid-Commutative-Monoid M =
+  is-submonoid-Monoid (monoid-Commutative-Monoid M)
+
+Commutative-Submonoid :
+  {l1 : Level} (l2 : Level) (M : Commutative-Monoid l1) → UU (l1 ⊔ lsuc l2)
+Commutative-Submonoid l2 M =
+  Submonoid l2 (monoid-Commutative-Monoid M)
+
+module _
+  {l1 l2 : Level} (M : Commutative-Monoid l1) (P : Commutative-Submonoid l2 M)
+  where
+
+  subset-Commutative-Submonoid : subtype l2 (type-Commutative-Monoid M)
+  subset-Commutative-Submonoid =
+    subset-Submonoid (monoid-Commutative-Monoid M) P
+
+  is-submonoid-Commutative-Submonoid :
+    is-submonoid-Commutative-Monoid M subset-Commutative-Submonoid
+  is-submonoid-Commutative-Submonoid =
+    is-submonoid-Submonoid (monoid-Commutative-Monoid M) P
+
+  is-in-Commutative-Submonoid : type-Commutative-Monoid M → UU l2
+  is-in-Commutative-Submonoid =
+    is-in-Submonoid (monoid-Commutative-Monoid M) P
+
+  is-prop-is-in-Commutative-Submonoid :
+    (x : type-Commutative-Monoid M) → is-prop (is-in-Commutative-Submonoid x)
+  is-prop-is-in-Commutative-Submonoid =
+    is-prop-is-in-Submonoid (monoid-Commutative-Monoid M) P
+
+  is-closed-under-eq-Commutative-Submonoid :
+    {x y : type-Commutative-Monoid M} →
+    is-in-Commutative-Submonoid x → (x ＝ y) → is-in-Commutative-Submonoid y
+  is-closed-under-eq-Commutative-Submonoid =
+    is-closed-under-eq-Submonoid (monoid-Commutative-Monoid M) P
+
+  is-closed-under-eq-Commutative-Submonoid' :
+    {x y : type-Commutative-Monoid M} →
+    is-in-Commutative-Submonoid y → (x ＝ y) → is-in-Commutative-Submonoid x
+  is-closed-under-eq-Commutative-Submonoid' =
+    is-closed-under-eq-Submonoid' (monoid-Commutative-Monoid M) P
+
+  type-Commutative-Submonoid : UU (l1 ⊔ l2)
+  type-Commutative-Submonoid =
+    type-Submonoid (monoid-Commutative-Monoid M) P
+
+  is-set-type-Commutative-Submonoid : is-set type-Commutative-Submonoid
+  is-set-type-Commutative-Submonoid =
+    is-set-type-Submonoid (monoid-Commutative-Monoid M) P
+
+  set-Commutative-Submonoid : Set (l1 ⊔ l2)
+  set-Commutative-Submonoid = set-Submonoid (monoid-Commutative-Monoid M) P
+
+  inclusion-Commutative-Submonoid :
+    type-Commutative-Submonoid → type-Commutative-Monoid M
+  inclusion-Commutative-Submonoid =
+    inclusion-Submonoid (monoid-Commutative-Monoid M) P
+
+  ap-inclusion-Commutative-Submonoid :
+    (x y : type-Commutative-Submonoid) → x ＝ y →
+    inclusion-Commutative-Submonoid x ＝ inclusion-Commutative-Submonoid y
+  ap-inclusion-Commutative-Submonoid =
+    ap-inclusion-Submonoid (monoid-Commutative-Monoid M) P
+
+  is-in-submonoid-inclusion-Commutative-Submonoid :
+    (x : type-Commutative-Submonoid) →
+    is-in-Commutative-Submonoid (inclusion-Commutative-Submonoid x)
+  is-in-submonoid-inclusion-Commutative-Submonoid =
+    is-in-submonoid-inclusion-Submonoid (monoid-Commutative-Monoid M) P
+
+  contains-unit-Commutative-Submonoid :
+    is-in-Commutative-Submonoid (unit-Commutative-Monoid M)
+  contains-unit-Commutative-Submonoid =
+    contains-unit-Submonoid (monoid-Commutative-Monoid M) P
+
+  unit-Commutative-Submonoid : type-Commutative-Submonoid
+  unit-Commutative-Submonoid =
+    unit-Submonoid (monoid-Commutative-Monoid M) P
+
+  is-closed-under-mul-Commutative-Submonoid :
+    {x y : type-Commutative-Monoid M} →
+    is-in-Commutative-Submonoid x → is-in-Commutative-Submonoid y →
+    is-in-Commutative-Submonoid (mul-Commutative-Monoid M x y)
+  is-closed-under-mul-Commutative-Submonoid =
+    is-closed-under-mul-Submonoid (monoid-Commutative-Monoid M) P
+
+  mul-Commutative-Submonoid :
+    (x y : type-Commutative-Submonoid) → type-Commutative-Submonoid
+  mul-Commutative-Submonoid = mul-Submonoid (monoid-Commutative-Monoid M) P
+
+  associative-mul-Commutative-Submonoid :
+    (x y z : type-Commutative-Submonoid) →
+    (mul-Commutative-Submonoid (mul-Commutative-Submonoid x y) z) ＝
+    (mul-Commutative-Submonoid x (mul-Commutative-Submonoid y z))
+  associative-mul-Commutative-Submonoid =
+    associative-mul-Submonoid (monoid-Commutative-Monoid M) P
+
+  semigroup-Commutative-Submonoid : Semigroup (l1 ⊔ l2)
+  semigroup-Commutative-Submonoid =
+    semigroup-Submonoid (monoid-Commutative-Monoid M) P
+
+  left-unit-law-mul-Commutative-Submonoid :
+    (x : type-Commutative-Submonoid) →
+    mul-Commutative-Submonoid unit-Commutative-Submonoid x ＝ x
+  left-unit-law-mul-Commutative-Submonoid =
+    left-unit-law-mul-Submonoid (monoid-Commutative-Monoid M) P
+
+  right-unit-law-mul-Commutative-Submonoid :
+    (x : type-Commutative-Submonoid) →
+    mul-Commutative-Submonoid x unit-Commutative-Submonoid ＝ x
+  right-unit-law-mul-Commutative-Submonoid =
+    right-unit-law-mul-Submonoid (monoid-Commutative-Monoid M) P
+
+  commutative-mul-Commutative-Submonoid :
+    (x y : type-Commutative-Submonoid) →
+    mul-Commutative-Submonoid x y ＝ mul-Commutative-Submonoid y x
+  commutative-mul-Commutative-Submonoid x y =
+    eq-type-subtype
+      ( subset-Commutative-Submonoid)
+      ( commutative-mul-Commutative-Monoid M
+        ( inclusion-Commutative-Submonoid x)
+        ( inclusion-Commutative-Submonoid y))
+
+  monoid-Commutative-Submonoid : Monoid (l1 ⊔ l2)
+  monoid-Commutative-Submonoid =
+    monoid-Submonoid (monoid-Commutative-Monoid M) P
+
+  commutative-monoid-Commutative-Submonoid : Commutative-Monoid (l1 ⊔ l2)
+  pr1 commutative-monoid-Commutative-Submonoid =
+    monoid-Commutative-Submonoid
+  pr2 commutative-monoid-Commutative-Submonoid =
+    commutative-mul-Commutative-Submonoid
+
+  preserves-unit-inclusion-Commutative-Submonoid :
+    inclusion-Commutative-Submonoid unit-Commutative-Submonoid ＝
+    unit-Commutative-Monoid M
+  preserves-unit-inclusion-Commutative-Submonoid =
+    preserves-unit-inclusion-Submonoid (monoid-Commutative-Monoid M) P
+
+  preserves-mul-inclusion-Commutative-Submonoid :
+    (x y : type-Commutative-Submonoid) →
+    inclusion-Commutative-Submonoid (mul-Commutative-Submonoid x y) ＝
+    mul-Commutative-Monoid M
+      ( inclusion-Commutative-Submonoid x)
+      ( inclusion-Commutative-Submonoid y)
+  preserves-mul-inclusion-Commutative-Submonoid =
+    preserves-mul-inclusion-Submonoid (monoid-Commutative-Monoid M) P
+
+  hom-inclusion-Commutative-Submonoid :
+    type-hom-Commutative-Monoid commutative-monoid-Commutative-Submonoid M
+  hom-inclusion-Commutative-Submonoid =
+    hom-inclusion-Submonoid (monoid-Commutative-Monoid M) P
+```
+
+## Properties
+
+### Extensionality of the type of all submonoids
+
+```agda
+module _
+  {l1 l2 : Level} (M : Commutative-Monoid l1) (N : Commutative-Submonoid l2 M)
+  where
+
+  has-same-elements-Commutative-Submonoid :
+    {l3 : Level} → Commutative-Submonoid l3 M → UU (l1 ⊔ l2 ⊔ l3)
+  has-same-elements-Commutative-Submonoid =
+    has-same-elements-Submonoid (monoid-Commutative-Monoid M) N
+
+  extensionality-Commutative-Submonoid :
+    (K : Commutative-Submonoid l2 M) →
+    (N ＝ K) ≃ has-same-elements-Commutative-Submonoid K
+  extensionality-Commutative-Submonoid =
+    extensionality-Submonoid (monoid-Commutative-Monoid M) N
+```
+

--- a/src/group-theory/submonoids-commutative-monoids.lagda.md
+++ b/src/group-theory/submonoids-commutative-monoids.lagda.md
@@ -29,7 +29,8 @@ open import group-theory.subsets-commutative-monoids
 
 ## Idea
 
-A submonoid of a commutative monoid `M` is a subset of `M` that contains the unit of `M` and is closed under multiplication.
+A submonoid of a commutative monoid `M` is a subset of `M` that contains the
+unit of `M` and is closed under multiplication.
 
 ## Definitions
 
@@ -219,4 +220,3 @@ module _
   extensionality-Commutative-Submonoid =
     extensionality-Submonoid (monoid-Commutative-Monoid M) N
 ```
-

--- a/src/group-theory/submonoids.lagda.md
+++ b/src/group-theory/submonoids.lagda.md
@@ -20,6 +20,7 @@ open import foundation.universe-levels
 open import group-theory.homomorphisms-monoids
 open import group-theory.monoids
 open import group-theory.semigroups
+open import group-theory.subsets-monoids
 ```
 
 </details>
@@ -31,49 +32,6 @@ is closed under multiplication.
 
 ## Definitions
 
-### Subsets of monoids
-
-```agda
-subset-Monoid :
-  {l1 : Level} (l2 : Level) (M : Monoid l1) → UU (l1 ⊔ lsuc l2)
-subset-Monoid l2 M = subtype l2 (type-Monoid M)
-
-module _
-  {l1 l2 : Level} (M : Monoid l1) (P : subset-Monoid l2 M)
-  where
-
-  is-in-subset-Monoid : type-Monoid M → UU l2
-  is-in-subset-Monoid = is-in-subtype P
-
-  is-prop-is-in-subset-Monoid :
-    (x : type-Monoid M) → is-prop (is-in-subset-Monoid x)
-  is-prop-is-in-subset-Monoid = is-prop-is-in-subtype P
-
-  type-subset-Monoid : UU (l1 ⊔ l2)
-  type-subset-Monoid = type-subtype P
-
-  is-set-type-subset-Monoid : is-set type-subset-Monoid
-  is-set-type-subset-Monoid =
-    is-set-type-subtype P (is-set-type-Monoid M)
-
-  set-subset-Monoid : Set (l1 ⊔ l2)
-  set-subset-Monoid = set-subset (set-Monoid M) P
-
-  inclusion-subset-Monoid : type-subset-Monoid → type-Monoid M
-  inclusion-subset-Monoid = inclusion-subtype P
-
-  ap-inclusion-subset-Monoid :
-    (x y : type-subset-Monoid) →
-    x ＝ y → (inclusion-subset-Monoid x ＝ inclusion-subset-Monoid y)
-  ap-inclusion-subset-Monoid = ap-inclusion-subtype P
-
-  is-in-subset-inclusion-subset-Monoid :
-    (x : type-subset-Monoid) →
-    is-in-subset-Monoid (inclusion-subset-Monoid x)
-  is-in-subset-inclusion-subset-Monoid =
-    is-in-subtype-inclusion-subtype P
-```
-
 ### Submonoids
 
 ```agda
@@ -82,13 +40,8 @@ is-submonoid-monoid-Prop :
   Prop (l1 ⊔ l2)
 is-submonoid-monoid-Prop M P =
   prod-Prop
-    ( P (unit-Monoid M))
-    ( Π-Prop
-      ( type-Monoid M)
-      ( λ x →
-        Π-Prop
-          ( type-Monoid M)
-          ( λ y → hom-Prop (P x) (hom-Prop (P y) (P (mul-Monoid M x y))))))
+    ( contains-unit-subset-monoid-Prop M P)
+    ( is-closed-under-multiplication-subset-monoid-Prop M P)
 
 is-submonoid-Monoid :
   {l1 l2 : Level} (M : Monoid l1) (P : subset-Monoid l2 M) → UU (l1 ⊔ l2)
@@ -118,6 +71,14 @@ module _
     (x : type-Monoid M) → is-prop (is-in-Submonoid x)
   is-prop-is-in-Submonoid =
     is-prop-is-in-subtype subset-Submonoid
+
+  is-closed-under-eq-Submonoid :
+    {x y : type-Monoid M} → is-in-Submonoid x → (x ＝ y) → is-in-Submonoid y
+  is-closed-under-eq-Submonoid = is-closed-under-eq-subtype subset-Submonoid
+
+  is-closed-under-eq-Submonoid' :
+    {x y : type-Monoid M} → is-in-Submonoid y → (x ＝ y) → is-in-Submonoid x
+  is-closed-under-eq-Submonoid' = is-closed-under-eq-subtype' subset-Submonoid
 
   type-Submonoid : UU (l1 ⊔ l2)
   type-Submonoid = type-subtype subset-Submonoid

--- a/src/group-theory/submonoids.lagda.md
+++ b/src/group-theory/submonoids.lagda.md
@@ -192,7 +192,8 @@ module _
   {l1 l2 : Level} (M : Monoid l1) (N : Submonoid l2 M)
   where
 
-  has-same-elements-Submonoid : Submonoid l2 M → UU (l1 ⊔ l2)
+  has-same-elements-Submonoid :
+    {l3 : Level} → Submonoid l3 M → UU (l1 ⊔ l2 ⊔ l3)
   has-same-elements-Submonoid K =
     has-same-elements-subtype (subset-Submonoid M N) (subset-Submonoid M K)
 

--- a/src/group-theory/subsets-commutative-monoids.lagda.md
+++ b/src/group-theory/subsets-commutative-monoids.lagda.md
@@ -1,0 +1,106 @@
+# Subsets of commutative monoids
+
+```agda
+module group-theory.subsets-commutative-monoids where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.identity-types
+open import foundation.propositions
+open import foundation.sets
+open import foundation.subtypes
+open import foundation.universe-levels
+
+open import group-theory.commutative-monoids
+open import group-theory.subsets-monoids
+```
+
+</details>
+
+## Idea
+
+A subset of a commutative monoid `M` is a subset of the underlying type of `M`.
+
+## Definitions
+
+### Subsets of commutative monoids
+
+```agda
+subset-Commutative-Monoid :
+  {l1 : Level} (l2 : Level) (M : Commutative-Monoid l1) → UU (l1 ⊔ lsuc l2)
+subset-Commutative-Monoid l2 M =
+  subset-Monoid l2 (monoid-Commutative-Monoid M)
+
+module _
+  {l1 l2 : Level} (M : Commutative-Monoid l1)
+  (P : subset-Commutative-Monoid l2 M)
+  where
+
+  is-in-subset-Commutative-Monoid : type-Commutative-Monoid M → UU l2
+  is-in-subset-Commutative-Monoid =
+    is-in-subset-Monoid (monoid-Commutative-Monoid M) P
+
+  is-prop-is-in-subset-Commutative-Monoid :
+    (x : type-Commutative-Monoid M) →
+    is-prop (is-in-subset-Commutative-Monoid x)
+  is-prop-is-in-subset-Commutative-Monoid =
+    is-prop-is-in-subset-Monoid (monoid-Commutative-Monoid M) P
+
+  type-subset-Commutative-Monoid : UU (l1 ⊔ l2)
+  type-subset-Commutative-Monoid =
+    type-subset-Monoid (monoid-Commutative-Monoid M) P
+
+  is-set-type-subset-Commutative-Monoid : is-set type-subset-Commutative-Monoid
+  is-set-type-subset-Commutative-Monoid =
+    is-set-type-subset-Monoid (monoid-Commutative-Monoid M) P
+
+  set-subset-Commutative-Monoid : Set (l1 ⊔ l2)
+  set-subset-Commutative-Monoid =
+    set-subset-Monoid (monoid-Commutative-Monoid M) P
+
+  inclusion-subset-Commutative-Monoid :
+    type-subset-Commutative-Monoid → type-Commutative-Monoid M
+  inclusion-subset-Commutative-Monoid =
+    inclusion-subset-Monoid (monoid-Commutative-Monoid M) P
+
+  ap-inclusion-subset-Commutative-Monoid :
+    (x y : type-subset-Commutative-Monoid) → x ＝ y →
+    inclusion-subset-Commutative-Monoid x ＝
+    inclusion-subset-Commutative-Monoid y
+  ap-inclusion-subset-Commutative-Monoid =
+    ap-inclusion-subset-Monoid (monoid-Commutative-Monoid M) P
+
+  is-in-subset-inclusion-subset-Commutative-Monoid :
+    (x : type-subset-Commutative-Monoid) →
+    is-in-subset-Commutative-Monoid (inclusion-subset-Commutative-Monoid x)
+  is-in-subset-inclusion-subset-Commutative-Monoid =
+    is-in-subset-inclusion-subset-Monoid (monoid-Commutative-Monoid M) P
+```
+
+### The condition that a subset contains the unit
+
+```agda
+  contains-unit-subset-commutative-monoid-Prop : Prop l2
+  contains-unit-subset-commutative-monoid-Prop =
+    contains-unit-subset-monoid-Prop (monoid-Commutative-Monoid M) P
+
+  contains-unit-subset-Commutative-Monoid : UU l2
+  contains-unit-subset-Commutative-Monoid =
+    contains-unit-subset-Monoid (monoid-Commutative-Monoid M) P
+```
+
+### The condition that a subset is closed under multiplication
+
+```agda
+  is-closed-under-multiplication-subset-commutative-monoid-Prop : Prop (l1 ⊔ l2)
+  is-closed-under-multiplication-subset-commutative-monoid-Prop =
+    is-closed-under-multiplication-subset-monoid-Prop
+      ( monoid-Commutative-Monoid M)
+      ( P)
+
+  is-closed-under-multiplication-subset-Commutative-Monoid : UU (l1 ⊔ l2)
+  is-closed-under-multiplication-subset-Commutative-Monoid =
+    is-closed-under-multiplication-subset-Monoid (monoid-Commutative-Monoid M) P
+```

--- a/src/group-theory/subsets-monoids.lagda.md
+++ b/src/group-theory/subsets-monoids.lagda.md
@@ -1,0 +1,95 @@
+# Subsets of monoids
+
+```agda
+module group-theory.subsets-monoids where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.identity-types
+open import foundation.propositions
+open import foundation.sets
+open import foundation.subtypes
+open import foundation.universe-levels
+
+open import group-theory.monoids
+```
+
+</details>
+
+## Idea
+
+A subset of a monoid `M` is a subset of the underlying type of `M`.
+
+## Definitions
+
+### Subsets of monoids
+
+```agda
+subset-Monoid :
+  {l1 : Level} (l2 : Level) (M : Monoid l1) → UU (l1 ⊔ lsuc l2)
+subset-Monoid l2 M = subtype l2 (type-Monoid M)
+
+module _
+  {l1 l2 : Level} (M : Monoid l1) (P : subset-Monoid l2 M)
+  where
+
+  is-in-subset-Monoid : type-Monoid M → UU l2
+  is-in-subset-Monoid = is-in-subtype P
+
+  is-prop-is-in-subset-Monoid :
+    (x : type-Monoid M) → is-prop (is-in-subset-Monoid x)
+  is-prop-is-in-subset-Monoid = is-prop-is-in-subtype P
+
+  type-subset-Monoid : UU (l1 ⊔ l2)
+  type-subset-Monoid = type-subtype P
+
+  is-set-type-subset-Monoid : is-set type-subset-Monoid
+  is-set-type-subset-Monoid =
+    is-set-type-subtype P (is-set-type-Monoid M)
+
+  set-subset-Monoid : Set (l1 ⊔ l2)
+  set-subset-Monoid = set-subset (set-Monoid M) P
+
+  inclusion-subset-Monoid : type-subset-Monoid → type-Monoid M
+  inclusion-subset-Monoid = inclusion-subtype P
+
+  ap-inclusion-subset-Monoid :
+    (x y : type-subset-Monoid) →
+    x ＝ y → (inclusion-subset-Monoid x ＝ inclusion-subset-Monoid y)
+  ap-inclusion-subset-Monoid = ap-inclusion-subtype P
+
+  is-in-subset-inclusion-subset-Monoid :
+    (x : type-subset-Monoid) →
+    is-in-subset-Monoid (inclusion-subset-Monoid x)
+  is-in-subset-inclusion-subset-Monoid =
+    is-in-subtype-inclusion-subtype P
+```
+
+### The condition that a subset contains the unit
+
+```agda
+  contains-unit-subset-monoid-Prop : Prop l2
+  contains-unit-subset-monoid-Prop = P (unit-Monoid M)
+
+  contains-unit-subset-Monoid : UU l2
+  contains-unit-subset-Monoid = type-Prop contains-unit-subset-monoid-Prop
+```
+
+### The condition that a subset is closed under multiplication
+
+```agda
+  is-closed-under-multiplication-subset-monoid-Prop : Prop (l1 ⊔ l2)
+  is-closed-under-multiplication-subset-monoid-Prop =
+    Π-Prop
+      ( type-Monoid M)
+      ( λ x →
+        Π-Prop
+          ( type-Monoid M)
+          ( λ y → hom-Prop (P x) (hom-Prop (P y) (P (mul-Monoid M x y)))))
+
+  is-closed-under-multiplication-subset-Monoid : UU (l1 ⊔ l2)
+  is-closed-under-multiplication-subset-Monoid =
+    type-Prop is-closed-under-multiplication-subset-monoid-Prop
+```


### PR DESCRIPTION
This PR develops some theory of monoids and commutative monoids
- Submonoids
- Normal Submonoids
- Saturated congruence relations, and proof that they correspond uniquely to normal submonoids
- Submonoids of commutative monoids
- Normal submonoids of commutative monoids
- Saturated congruence relations, and proof that they correspond uniquely to norma submonoids of commutative monoids
- The example of the natural numbers with max, and a proof that its normal submonoids are initial segments of the natural numbers.