### PR TITLE
Define the smash product of pointed types and refactor pointed types

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,7 +21,7 @@
       "label": "imports",
       "detail": "Search for and remove unused imports. Warning: very slow!",
       "type": "shell",
-      "command": "python scripts/demote_foundation_imports.py && python scripts/remove_unused_imports.py",
+      "command": "python scripts/remove_unused_imports.py && python scripts/demote_foundation_imports.py",
       "problemMatcher": []
     }
   ]

--- a/CODINGSTYLE.md
+++ b/CODINGSTYLE.md
@@ -54,8 +54,7 @@ improve the readability.
   words.
 - The readability of the code has high priority. Therefore, we try to avoid
   subtly different variations of the same symbol. The only exception to this
-  rule is the use of the
-  [full width equals sign](https://www.fileformat.info/info/unicode/char/ff1d/index.htm)
+  rule is the use of the [full width equals sign](https://codepoints.net/U+ff1d)
   for identity type formation, as the standard equals sign is a reserved symbol
   in Agda.
 

--- a/HOWTO-INSTALL.md
+++ b/HOWTO-INSTALL.md
@@ -173,11 +173,11 @@ mistakes, ensuring a smoother coding experience.
 
 This library relies heavily on Unicode characters, so it's important to use a
 font family with comprehensive Unicode support in your editor. For instance, the
-library utilizes the [middle dot](https://www.compart.com/en/unicode/U+00B7)
-symbol `·` and the [bullet operator](https://www.compart.com/en/unicode/U+2219)
-symbol `∙`. In some fonts, these two symbols appear identical. If you find it
-difficult to distinguish between these symbols in your editor, we recommend
-switching to a different font.
+library utilizes the [middle dot](https://www.compart.com/en/unicode/U+00B7) `·`
+and the [bullet operator](https://www.compart.com/en/unicode/U+2219) `∙`. In
+some fonts, these two symbols appear identical. If you find it difficult to
+distinguish between these symbols in your editor, we recommend switching to a
+different font.
 
 ## After the setup
 

--- a/HOWTO-INSTALL.md
+++ b/HOWTO-INSTALL.md
@@ -94,11 +94,10 @@ files with the `.lagda.md` extension:
 The `agda-unimath` library employs two notations for the identity type:
 Martin-Löf's original notation `Id` and an infix notation `_＝_`. The infix
 notation's equals sign is not the standard one, but rather the
-[full width equals sign](https://www.fileformat.info/info/unicode/char/ff1d/index.htm).
-Observe that the full width equals sign is slightly wider, and is highlighted in
-blue just like all the other defined constructions in Agda. To type the full
-width equals sign in Agda's Emacs Mode, you need to add it to your Agda input
-method as follows:
+[full width equals sign](https://codepoints.net/U+ff1d). Observe that the full
+width equals sign is slightly wider, and is highlighted in blue just like all
+the other defined constructions in Agda. To type the full width equals sign in
+Agda's Emacs Mode, you need to add it to your Agda input method as follows:
 
 - Type `M-x customize-variable` and press enter.
 - Type `agda-input-user-translations` and press enter.

--- a/scripts/remove_unused_imports.py
+++ b/scripts/remove_unused_imports.py
@@ -99,8 +99,9 @@ if __name__ == '__main__':
     def filter_agda_files(f): return utils.is_agda_file(
         pathlib.Path(f)) and os.path.dirname(f) != root
 
+    # Sort the files by most recently changed
     agda_files = sorted(
-        filter(filter_agda_files, utils.get_files_recursive(root)))
+        filter(filter_agda_files, utils.get_files_recursive(root)), key=lambda t: -os.stat(t).st_mtime)
 
     with ThreadPoolExecutor() as executor:
         executor.map(lambda file: process_agda_file(

--- a/src/foundation-core/equivalence-induction.lagda.md
+++ b/src/foundation-core/equivalence-induction.lagda.md
@@ -43,7 +43,7 @@ module _
   triangle-ev-id :
     { l : Level}
     ( P : (Σ (UU l1) (λ X → A ≃ X)) → UU l) →
-    ( ev-point (pair A id-equiv) P) ~
+    ( ev-point (pair A id-equiv) {P}) ~
     ( ( ev-id (λ X e → P (pair X e))) ∘
       ( ev-pair {A = UU l1} {B = λ X → A ≃ X} {C = P}))
   triangle-ev-id P f = refl

--- a/src/foundation-core/equivalence-induction.lagda.md
+++ b/src/foundation-core/equivalence-induction.lagda.md
@@ -43,7 +43,7 @@ module _
   triangle-ev-id :
     { l : Level}
     ( P : (Σ (UU l1) (λ X → A ≃ X)) → UU l) →
-    ( ev-pt (pair A id-equiv) P) ~
+    ( ev-point (pair A id-equiv) P) ~
     ( ( ev-id (λ X e → P (pair X e))) ∘
       ( ev-pair {A = UU l1} {B = λ X → A ≃ X} {C = P}))
   triangle-ev-id P f = refl

--- a/src/foundation-core/functions.lagda.md
+++ b/src/foundation-core/functions.lagda.md
@@ -41,12 +41,16 @@ _∘_ :
 (g ∘ f) a = g (f a)
 ```
 
-### Evaluating at a point
+### Evaluation at a point
 
 ```agda
 ev-point :
-  {l1 l2 : Level} {A : UU l1} (a : A) (B : A → UU l2) → ((x : A) → B x) → B a
-ev-point a B f = f a
+  {l1 l2 : Level} {A : UU l1} (a : A) {P : A → UU l2} → ((x : A) → P x) → P a
+ev-point a f = f a
+
+ev-point' :
+  {l1 l2 : Level} {A : UU l1} (a : A) {X : UU l2} → (A → X) → X
+ev-point' a f = f a
 ```
 
 ### Precomposition functions

--- a/src/foundation-core/functions.lagda.md
+++ b/src/foundation-core/functions.lagda.md
@@ -44,9 +44,9 @@ _∘_ :
 ### Evaluating at a point
 
 ```agda
-ev-pt :
+ev-point :
   {l1 l2 : Level} {A : UU l1} (a : A) (B : A → UU l2) → ((x : A) → B x) → B a
-ev-pt a B f = f a
+ev-point a B f = f a
 ```
 
 ### Precomposition functions

--- a/src/foundation-core/homotopies.lagda.md
+++ b/src/foundation-core/homotopies.lagda.md
@@ -130,12 +130,12 @@ htpy-right-whisk H f x = H (f x)
 _·r_ = htpy-right-whisk
 ```
 
-**Warning**: The infix whiskering operators `_·l_` and `_·r_` use the symbol `·`
-("MIDDLE DOT", codepoint #xb7) (agda-input: `\cdot` or `\centerdot`) as opposed
-to the infix homotopy concatenation operator `_∙h_` which uses the symbol `∙`
-("BULLET OPERATOR", codepoint #x2219) (agda-input: `\.`). If these look the same
-in your editor, we suggest that you change your font. For a reference, see
-[How to install](HOWTO-INSTALL.md).
+**Note**: The infix whiskering operators `_·l_` and `_·r_` use the
+"[middle dot](https://codepoints.net/U+00B7)" symbol `·` (agda-input: `\cdot` or
+`\centerdot`), as opposed to the infix homotopy concatenation operator `_∙h_`
+which uses the "[bullet operator](https://codepoints.net/U+2219)" symbol `∙`
+(agda-input: `\.`). If these look the same in your editor, we suggest that you
+change your font. For a reference, see [How to install](HOWTO-INSTALL.md).
 
 ### Horizontal composition of homotopies
 

--- a/src/foundation-core/homotopies.lagda.md
+++ b/src/foundation-core/homotopies.lagda.md
@@ -131,9 +131,9 @@ _·r_ = htpy-right-whisk
 ```
 
 **Note**: The infix whiskering operators `_·l_` and `_·r_` use the
-"[middle dot](https://codepoints.net/U+00B7)" symbol `·` (agda-input: `\cdot` or
+[middle dot](https://codepoints.net/U+00B7) symbol `·` (agda-input: `\cdot`
 `\centerdot`), as opposed to the infix homotopy concatenation operator `_∙h_`
-which uses the "[bullet operator](https://codepoints.net/U+2219)" symbol `∙`
+which uses the [bullet operator](https://codepoints.net/U+2219) symbol `∙`
 (agda-input: `\.`). If these look the same in your editor, we suggest that you
 change your font. For a reference, see [How to install](HOWTO-INSTALL.md).
 

--- a/src/foundation-core/homotopies.lagda.md
+++ b/src/foundation-core/homotopies.lagda.md
@@ -131,11 +131,11 @@ _·r_ = htpy-right-whisk
 ```
 
 **Note**: The infix whiskering operators `_·l_` and `_·r_` use the
-[middle dot](https://codepoints.net/U+00B7) symbol `·` (agda-input: `\cdot`
+[middle dot](https://codepoints.net/U+00B7) `·` (agda-input: `\cdot`
 `\centerdot`), as opposed to the infix homotopy concatenation operator `_∙h_`
-which uses the [bullet operator](https://codepoints.net/U+2219) symbol `∙`
-(agda-input: `\.`). If these look the same in your editor, we suggest that you
-change your font. For a reference, see [How to install](HOWTO-INSTALL.md).
+which uses the [bullet operator](https://codepoints.net/U+2219) `∙` (agda-input:
+`\.`). If these look the same in your editor, we suggest that you change your
+font. For a reference, see [How to install](HOWTO-INSTALL.md).
 
 ### Horizontal composition of homotopies
 

--- a/src/foundation-core/identity-types.lagda.md
+++ b/src/foundation-core/identity-types.lagda.md
@@ -31,11 +31,10 @@ option the infix notation `_＝_`.
 
 **Note**: The equals sign in the infix notation is not the standard equals sign
 on your keyboard, but it is the
-[full width equals sign](https://www.fileformat.info/info/unicode/char/ff1d/index.htm).
-Note that the full width equals sign is slightly wider, and it is highlighted in
-blue just like all the other defined constructions in Agda. In order to type the
-full width equals sign in Agda's Emacs Mode, you need to add it to your agda
-input method as follows:
+[full width equals sign](https://codepoints.net/U+ff1d). Note that the full
+width equals sign is slightly wider, and it is highlighted like all the other
+defined constructions in Agda. In order to type the full width equals sign in
+Agda's Emacs Mode, you need to add it to your agda input method as follows:
 
 - Type `M-x customize-variable` and press enter.
 - Type `agda-input-user-translations` and press enter.

--- a/src/foundation-core/singleton-induction.lagda.md
+++ b/src/foundation-core/singleton-induction.lagda.md
@@ -29,7 +29,7 @@ singleton induction if and only if it is contractible.
 ```agda
 is-singleton :
   (l1 : Level) {l2 : Level} (A : UU l2) → A → UU (lsuc l1 ⊔ l2)
-is-singleton l A a = (B : A → UU l) → sec (ev-point a B)
+is-singleton l A a = (B : A → UU l) → sec (ev-point a {B})
 
 ind-is-singleton :
   {l1 l2 : Level} {A : UU l1} (a : A) →
@@ -39,7 +39,7 @@ ind-is-singleton a is-sing-A B = pr1 (is-sing-A B)
 
 compute-ind-is-singleton :
   {l1 l2 : Level} {A : UU l1} (a : A) (H : {l : Level} → is-singleton l A a) →
-  (B : A → UU l2) → (ev-point a B ∘ ind-is-singleton a H B) ~ id
+  (B : A → UU l2) → (ev-point a {B} ∘ ind-is-singleton a H B) ~ id
 compute-ind-is-singleton a H B = pr2 (H B)
 ```
 
@@ -57,7 +57,7 @@ ind-singleton-is-contr a is-contr-A B b x =
 compute-ind-singleton-is-contr :
   {l1 l2 : Level} {A : UU l1} (a : A) (is-contr-A : is-contr A)
   (B : A → UU l2) →
-  ((ev-point a B) ∘ (ind-singleton-is-contr a is-contr-A B)) ~ id
+  ((ev-point a {B}) ∘ (ind-singleton-is-contr a is-contr-A B)) ~ id
 compute-ind-singleton-is-contr a is-contr-A B b =
   ap (λ ω → tr B ω b) (left-inv (contraction is-contr-A a))
 

--- a/src/foundation-core/singleton-induction.lagda.md
+++ b/src/foundation-core/singleton-induction.lagda.md
@@ -29,7 +29,7 @@ singleton induction if and only if it is contractible.
 ```agda
 is-singleton :
   (l1 : Level) {l2 : Level} (A : UU l2) → A → UU (lsuc l1 ⊔ l2)
-is-singleton l A a = (B : A → UU l) → sec (ev-pt a B)
+is-singleton l A a = (B : A → UU l) → sec (ev-point a B)
 
 ind-is-singleton :
   {l1 l2 : Level} {A : UU l1} (a : A) →
@@ -39,7 +39,7 @@ ind-is-singleton a is-sing-A B = pr1 (is-sing-A B)
 
 compute-ind-is-singleton :
   {l1 l2 : Level} {A : UU l1} (a : A) (H : {l : Level} → is-singleton l A a) →
-  (B : A → UU l2) → (ev-pt a B ∘ ind-is-singleton a H B) ~ id
+  (B : A → UU l2) → (ev-point a B ∘ ind-is-singleton a H B) ~ id
 compute-ind-is-singleton a H B = pr2 (H B)
 ```
 
@@ -56,7 +56,8 @@ ind-singleton-is-contr a is-contr-A B b x =
 
 compute-ind-singleton-is-contr :
   {l1 l2 : Level} {A : UU l1} (a : A) (is-contr-A : is-contr A)
-  (B : A → UU l2) → ((ev-pt a B) ∘ (ind-singleton-is-contr a is-contr-A B)) ~ id
+  (B : A → UU l2) →
+  ((ev-point a B) ∘ (ind-singleton-is-contr a is-contr-A B)) ~ id
 compute-ind-singleton-is-contr a is-contr-A B b =
   ap (λ ω → tr B ω b) (left-inv (contraction is-contr-A a))
 

--- a/src/foundation/0-connected-types.lagda.md
+++ b/src/foundation/0-connected-types.lagda.md
@@ -74,10 +74,10 @@ abstract
         ( λ x → set-Prop (Id-Prop (trunc-Set A) (unit-trunc-Set a) x))
         ( λ x → apply-effectiveness-unit-trunc-Set' (e x)))
 
-is-0-connected-is-surjective-pt :
+is-0-connected-is-surjective-point :
   {l1 : Level} {A : UU l1} (a : A) →
-  is-surjective (pt a) → is-0-connected A
-is-0-connected-is-surjective-pt a H =
+  is-surjective (point a) → is-0-connected A
+is-0-connected-is-surjective-point a H =
   is-0-connected-mere-eq a
     ( λ x →
       apply-universal-property-trunc-Prop
@@ -85,27 +85,27 @@ is-0-connected-is-surjective-pt a H =
         ( mere-eq-Prop a x)
         ( λ u → unit-trunc-Prop (pr2 u)))
 
-is-surjective-pt-is-0-connected :
+is-surjective-point-is-0-connected :
   {l1 : Level} {A : UU l1} (a : A) →
-  is-0-connected A → is-surjective (pt a)
-is-surjective-pt-is-0-connected a H x =
+  is-0-connected A → is-surjective (point a)
+is-surjective-point-is-0-connected a H x =
   apply-universal-property-trunc-Prop
     ( mere-eq-is-0-connected H a x)
-    ( trunc-Prop (fib (pt a) x))
+    ( trunc-Prop (fib (point a) x))
     ( λ {refl → unit-trunc-Prop (pair star refl)})
 
-is-trunc-map-ev-pt-is-connected :
+is-trunc-map-ev-point-is-connected :
   {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} (a : A) →
   is-0-connected A → is-trunc (succ-𝕋 k) B →
-  is-trunc-map k (ev-pt a (λ _ → B))
-is-trunc-map-ev-pt-is-connected k {A} {B} a H K =
+  is-trunc-map k (ev-point a (λ _ → B))
+is-trunc-map-ev-point-is-connected k {A} {B} a H K =
   is-trunc-map-comp k
-    ( ev-pt star (λ _ → B))
-    ( precomp (pt a) B)
+    ( ev-point star (λ _ → B))
+    ( precomp (point a) B)
     ( is-trunc-map-is-equiv k
       ( universal-property-contr-is-contr star is-contr-unit B))
     ( is-trunc-map-precomp-Π-is-surjective k
-      ( is-surjective-pt-is-0-connected a H)
+      ( is-surjective-point-is-0-connected a H)
       ( λ _ → pair B K))
 
 equiv-dependent-universal-property-is-0-connected :
@@ -115,8 +115,8 @@ equiv-dependent-universal-property-is-0-connected :
 equiv-dependent-universal-property-is-0-connected a H P =
   ( equiv-universal-property-unit (type-Prop (P a))) ∘e
   ( equiv-dependent-universal-property-surj-is-surjective
-    ( pt a)
-    ( is-surjective-pt-is-0-connected a H)
+    ( point a)
+    ( is-surjective-point-is-0-connected a H)
     ( P))
 
 apply-dependent-universal-property-is-0-connected :

--- a/src/foundation/0-connected-types.lagda.md
+++ b/src/foundation/0-connected-types.lagda.md
@@ -97,10 +97,10 @@ is-surjective-point-is-0-connected a H x =
 is-trunc-map-ev-point-is-connected :
   {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} (a : A) →
   is-0-connected A → is-trunc (succ-𝕋 k) B →
-  is-trunc-map k (ev-point a (λ _ → B))
+  is-trunc-map k (ev-point' a {B})
 is-trunc-map-ev-point-is-connected k {A} {B} a H K =
   is-trunc-map-comp k
-    ( ev-point star (λ _ → B))
+    ( ev-point' star {B})
     ( precomp (point a) B)
     ( is-trunc-map-is-equiv k
       ( universal-property-contr-is-contr star is-contr-unit B))

--- a/src/foundation/conjunction.lagda.md
+++ b/src/foundation/conjunction.lagda.md
@@ -28,7 +28,13 @@ and `Q` hold.
 conj-Prop = prod-Prop
 
 _∧_ = conj-Prop
+```
 
+The symbol used for the conjunction `_∧_` is the
+"[logical and](https://codepoints.net/U+2227)" symbol `∧` (agda-input: `\wedge`
+or `\and`).
+
+```agda
 type-conj-Prop : {l1 l2 : Level} → Prop l1 → Prop l2 → UU (l1 ⊔ l2)
 type-conj-Prop P Q = type-Prop (conj-Prop P Q)
 

--- a/src/foundation/conjunction.lagda.md
+++ b/src/foundation/conjunction.lagda.md
@@ -31,8 +31,7 @@ _∧_ = conj-Prop
 ```
 
 **Note**: The symbol used for the conjunction `_∧_` is the
-[logical and](https://codepoints.net/U+2227) symbol `∧` (agda-input: `\wedge`
-`\and`).
+[logical and](https://codepoints.net/U+2227) `∧` (agda-input: `\wedge` `\and`).
 
 ```agda
 type-conj-Prop : {l1 l2 : Level} → Prop l1 → Prop l2 → UU (l1 ⊔ l2)

--- a/src/foundation/conjunction.lagda.md
+++ b/src/foundation/conjunction.lagda.md
@@ -30,9 +30,9 @@ conj-Prop = prod-Prop
 _∧_ = conj-Prop
 ```
 
-The symbol used for the conjunction `_∧_` is the
-"[logical and](https://codepoints.net/U+2227)" symbol `∧` (agda-input: `\wedge`
-or `\and`).
+**Note**: The symbol used for the conjunction `_∧_` is the
+[logical and](https://codepoints.net/U+2227) symbol `∧` (agda-input: `\wedge`
+`\and`).
 
 ```agda
 type-conj-Prop : {l1 l2 : Level} → Prop l1 → Prop l2 → UU (l1 ⊔ l2)

--- a/src/foundation/contractible-types.lagda.md
+++ b/src/foundation/contractible-types.lagda.md
@@ -169,12 +169,6 @@ module _
   {l1 : Level} {A : UU l1}
   where
 
-  ev-point : {l2 : Level} (a : A) {P : A → UU l2} → ((x : A) → P x) → P a
-  ev-point a f = f a
-
-  ev-point' : {l2 : Level} (a : A) {X : UU l2} → (A → X) → X
-  ev-point' a f = f a
-
   dependent-universal-property-contr : (l : Level) (a : A) → UU (l1 ⊔ lsuc l)
   dependent-universal-property-contr l a =
     (P : A → UU l) → is-equiv (ev-point a {P})
@@ -199,7 +193,7 @@ module _
 
   abstract
     is-contr-is-equiv-ev-point :
-      (a : A) → is-equiv (ev-point' a {X = A}) → is-contr A
+      (a : A) → is-equiv (ev-point' a {A}) → is-contr A
     pr1 (is-contr-is-equiv-ev-point a H) = a
     pr2 (is-contr-is-equiv-ev-point a H) =
       htpy-eq

--- a/src/foundation/disjunction.lagda.md
+++ b/src/foundation/disjunction.lagda.md
@@ -37,8 +37,8 @@ _∨_ = disj-Prop
 ```
 
 **Note**: The symbol used for the disjunction `_∨_` is the
-"[logical or](https://codepoints.net/U+2228)" symbol `∨` (agda-input: `\vee` or
-`\or`), and not the latin letter `v`.
+[logical or](https://codepoints.net/U+2228) symbol `∨` (agda-input: `\vee`
+`\or`), and not the latin small letter v `v`.
 
 ```agda
 type-disj-Prop : {l1 l2 : Level} → Prop l1 → Prop l2 → UU (l1 ⊔ l2)

--- a/src/foundation/disjunction.lagda.md
+++ b/src/foundation/disjunction.lagda.md
@@ -34,7 +34,13 @@ disj-Prop : {l1 l2 : Level} → Prop l1 → Prop l2 → Prop (l1 ⊔ l2)
 disj-Prop P Q = trunc-Prop (type-Prop P + type-Prop Q)
 
 _∨_ = disj-Prop
+```
 
+**Note**: The symbol used for the disjunction `_∨_` is the
+"[logical or](https://codepoints.net/U+2228)" symbol `∨` (agda-input: `\vee` or
+`\or`), and not the latin letter `v`.
+
+```agda
 type-disj-Prop : {l1 l2 : Level} → Prop l1 → Prop l2 → UU (l1 ⊔ l2)
 type-disj-Prop P Q = type-Prop (disj-Prop P Q)
 

--- a/src/foundation/disjunction.lagda.md
+++ b/src/foundation/disjunction.lagda.md
@@ -37,8 +37,8 @@ _∨_ = disj-Prop
 ```
 
 **Note**: The symbol used for the disjunction `_∨_` is the
-[logical or](https://codepoints.net/U+2228) symbol `∨` (agda-input: `\vee`
-`\or`), and not the latin small letter v `v`.
+[logical or](https://codepoints.net/U+2228) `∨` (agda-input: `\vee` `\or`), and
+not the [latin small letter v](https://codepoints.net/U+0076) `v`.
 
 ```agda
 type-disj-Prop : {l1 l2 : Level} → Prop l1 → Prop l2 → UU (l1 ⊔ l2)

--- a/src/foundation/fiber-inclusions.lagda.md
+++ b/src/foundation/fiber-inclusions.lagda.md
@@ -143,17 +143,17 @@ module _
   {l1 l2 : Level} {A : UU l1} (B : A → UU l2) (a : A)
   where
 
-  cone-fiber-fam : cone (pr1 {B = B}) (pt a) (B a)
+  cone-fiber-fam : cone (pr1 {B = B}) (point a) (B a)
   pr1 cone-fiber-fam = fiber-inclusion B a
   pr1 (pr2 cone-fiber-fam) = terminal-map
   pr2 (pr2 cone-fiber-fam) = refl-htpy
 
   abstract
     is-pullback-cone-fiber-fam :
-      is-pullback (pr1 {B = B}) (pt a) cone-fiber-fam
+      is-pullback (pr1 {B = B}) (point a) cone-fiber-fam
     is-pullback-cone-fiber-fam =
       is-equiv-comp
-        ( gap (pr1 {B = B}) (pt a) (cone-fiber (pr1 {B = B}) a))
+        ( gap (pr1 {B = B}) (point a) (cone-fiber (pr1 {B = B}) a))
         ( map-inv-fib-pr1 B a)
         ( is-equiv-map-inv-fib-pr1 B a)
         ( is-pullback-cone-fiber pr1 a)

--- a/src/foundation/singleton-induction.lagda.md
+++ b/src/foundation/singleton-induction.lagda.md
@@ -29,7 +29,7 @@ singleton induction if and only if it is contractible.
 ```agda
 is-singleton :
   (l1 : Level) {l2 : Level} (A : UU l2) → A → UU (lsuc l1 ⊔ l2)
-is-singleton l A a = (B : A → UU l) → sec (ev-pt a B)
+is-singleton l A a = (B : A → UU l) → sec (ev-point a B)
 
 ind-is-singleton :
   {l1 l2 : Level} {A : UU l1} (a : A) →
@@ -39,7 +39,7 @@ ind-is-singleton a is-sing-A B = pr1 (is-sing-A B)
 
 compute-ind-is-singleton :
   {l1 l2 : Level} {A : UU l1} (a : A) (H : {l : Level} → is-singleton l A a) →
-  (B : A → UU l2) → (ev-pt a B ∘ ind-is-singleton a H B) ~ id
+  (B : A → UU l2) → (ev-point a B ∘ ind-is-singleton a H B) ~ id
 compute-ind-is-singleton a H B = pr2 (H B)
 ```
 
@@ -58,7 +58,7 @@ abstract
   compute-ind-singleton-is-contr :
     {l1 l2 : Level} {A : UU l1}
     (a : A) (is-contr-A : is-contr A) (B : A → UU l2) →
-    ((ev-pt a B) ∘ (ind-singleton-is-contr a is-contr-A B)) ~ id
+    ((ev-point a B) ∘ (ind-singleton-is-contr a is-contr-A B)) ~ id
   compute-ind-singleton-is-contr a is-contr-A B b =
     ap (λ ω → tr B ω b) (left-inv (contraction is-contr-A a))
 

--- a/src/foundation/singleton-induction.lagda.md
+++ b/src/foundation/singleton-induction.lagda.md
@@ -29,7 +29,7 @@ singleton induction if and only if it is contractible.
 ```agda
 is-singleton :
   (l1 : Level) {l2 : Level} (A : UU l2) → A → UU (lsuc l1 ⊔ l2)
-is-singleton l A a = (B : A → UU l) → sec (ev-point a B)
+is-singleton l A a = (B : A → UU l) → sec (ev-point a {B})
 
 ind-is-singleton :
   {l1 l2 : Level} {A : UU l1} (a : A) →
@@ -39,7 +39,7 @@ ind-is-singleton a is-sing-A B = pr1 (is-sing-A B)
 
 compute-ind-is-singleton :
   {l1 l2 : Level} {A : UU l1} (a : A) (H : {l : Level} → is-singleton l A a) →
-  (B : A → UU l2) → (ev-point a B ∘ ind-is-singleton a H B) ~ id
+  (B : A → UU l2) → (ev-point a {B} ∘ ind-is-singleton a H B) ~ id
 compute-ind-is-singleton a H B = pr2 (H B)
 ```
 
@@ -58,7 +58,7 @@ abstract
   compute-ind-singleton-is-contr :
     {l1 l2 : Level} {A : UU l1}
     (a : A) (is-contr-A : is-contr A) (B : A → UU l2) →
-    ((ev-point a B) ∘ (ind-singleton-is-contr a is-contr-A B)) ~ id
+    ((ev-point a {B}) ∘ (ind-singleton-is-contr a is-contr-A B)) ~ id
   compute-ind-singleton-is-contr a is-contr-A B b =
     ap (λ ω → tr B ω b) (left-inv (contraction is-contr-A a))
 

--- a/src/foundation/unit-type.lagda.md
+++ b/src/foundation/unit-type.lagda.md
@@ -40,14 +40,6 @@ record unit : UU lzero where
 {-# BUILTIN UNIT unit #-}
 ```
 
-### The unit type as a pointed type
-
-```agda
-unit-Pointed-Type : Pointed-Type lzero
-pr1 unit-Pointed-Type = unit
-pr2 unit-Pointed-Type = star
-```
-
 ### The induction principle of the unit type
 
 ```agda

--- a/src/foundation/unit-type.lagda.md
+++ b/src/foundation/unit-type.lagda.md
@@ -65,8 +65,8 @@ terminal-map = const _ unit star
 ### Points as maps out of the unit type
 
 ```agda
-pt : {l : Level} {A : UU l} → A → (unit → A)
-pt a = const unit _ a
+point : {l : Level} {A : UU l} → A → (unit → A)
+point a = const unit _ a
 ```
 
 ### Raising the universe level of the unit type

--- a/src/foundation/universal-property-unit-type.lagda.md
+++ b/src/foundation/universal-property-unit-type.lagda.md
@@ -63,36 +63,36 @@ pr1 (equiv-universal-property-unit Y) = ev-star' Y
 pr2 (equiv-universal-property-unit Y) = universal-property-unit Y
 
 abstract
-  is-equiv-pt-is-contr :
+  is-equiv-point-is-contr :
     {l1 : Level} {X : UU l1} (x : X) →
-    is-contr X → is-equiv (pt x)
-  is-equiv-pt-is-contr x is-contr-X =
-    is-equiv-is-contr (pt x) is-contr-unit is-contr-X
+    is-contr X → is-equiv (point x)
+  is-equiv-point-is-contr x is-contr-X =
+    is-equiv-is-contr (point x) is-contr-unit is-contr-X
 
 abstract
-  is-equiv-pt-universal-property-unit :
+  is-equiv-point-universal-property-unit :
     {l1 : Level} (X : UU l1) (x : X) →
     ((l2 : Level) (Y : UU l2) → is-equiv (λ (f : X → Y) → f x)) →
-    is-equiv (pt x)
-  is-equiv-pt-universal-property-unit X x H =
+    is-equiv (point x)
+  is-equiv-point-universal-property-unit X x H =
     is-equiv-is-equiv-precomp
-      ( pt x)
+      ( point x)
       ( λ l Y → is-equiv-right-factor
         ( ev-star' Y)
-        ( precomp (pt x) Y)
+        ( precomp (point x) Y)
         ( universal-property-unit Y)
         ( H _ Y))
 
 abstract
-  universal-property-unit-is-equiv-pt :
+  universal-property-unit-is-equiv-point :
     {l1 : Level} {X : UU l1} (x : X) →
-    is-equiv (pt x) →
+    is-equiv (point x) →
     ({l2 : Level} (Y : UU l2) → is-equiv (λ (f : X → Y) → f x))
-  universal-property-unit-is-equiv-pt x is-equiv-pt Y =
+  universal-property-unit-is-equiv-point x is-equiv-point Y =
     is-equiv-comp
       ( ev-star' Y)
-      ( precomp (pt x) Y)
-      ( is-equiv-precomp-is-equiv (pt x) is-equiv-pt Y)
+      ( precomp (point x) Y)
+      ( is-equiv-precomp-is-equiv (point x) is-equiv-point Y)
       ( universal-property-unit Y)
 
 abstract
@@ -101,16 +101,16 @@ abstract
     is-contr X →
     ({l2 : Level} (Y : UU l2) → is-equiv (λ (f : X → Y) → f x))
   universal-property-unit-is-contr x is-contr-X =
-    universal-property-unit-is-equiv-pt x
-      ( is-equiv-pt-is-contr x is-contr-X)
+    universal-property-unit-is-equiv-point x
+      ( is-equiv-point-is-contr x is-contr-X)
 
 abstract
-  is-equiv-diagonal-is-equiv-pt :
+  is-equiv-diagonal-is-equiv-point :
     {l1 : Level} {X : UU l1} (x : X) →
-    is-equiv (pt x) →
+    is-equiv (point x) →
     ({l2 : Level} (Y : UU l2) → is-equiv (λ y → const X Y y))
-  is-equiv-diagonal-is-equiv-pt {X = X} x is-equiv-pt Y =
+  is-equiv-diagonal-is-equiv-point {X = X} x is-equiv-point Y =
     is-equiv-is-section
-      ( universal-property-unit-is-equiv-pt x is-equiv-pt Y)
+      ( universal-property-unit-is-equiv-point x is-equiv-point Y)
       ( refl-htpy)
 ```

--- a/src/group-theory/group-solver.lagda.md
+++ b/src/group-theory/group-solver.lagda.md
@@ -7,7 +7,21 @@ module group-theory.group-solver where
 <details><summary>Imports</summary>
 
 ```agda
+open import elementary-number-theory.natural-numbers
 
+open import foundation.coproduct-types
+open import foundation.decidable-types
+open import foundation.identity-types
+open import foundation.universe-levels
+
+open import group-theory.groups
+
+open import linear-algebra.vectors
+
+open import lists.concatenation-lists
+open import lists.functoriality-lists
+open import lists.lists
+open import lists.reversing-lists
 ```
 
 </details>
@@ -19,67 +33,95 @@ way and removes units and inverses next to the original.
 
 The main entry-point is `solveExpr` below
 
-data Fin : ℕ → UU where zero-Fin : ∀ {n} → Fin (succ-ℕ n) succ-Fin : ∀ {n} → Fin
-n → Fin (succ-ℕ n)
+```agda
+data Fin : ℕ → UU lzero where
+  zero-Fin : ∀ {n} → Fin (succ-ℕ n)
+  succ-Fin : ∀ {n} → Fin n → Fin (succ-ℕ n)
 
-finEq : ∀ {n} → (a b : Fin n) → is-decidable (Id a b) finEq zero-Fin zero-Fin =
-inl refl finEq zero-Fin (succ-Fin b) = inr (λ ()) finEq (succ-Fin a) zero-Fin =
-inr (λ ()) finEq (succ-Fin a) (succ-Fin b) with finEq a b ... | inl eq = inl (ap
-succ-Fin eq) ... | inr neq = inr (λ { refl → neq refl})
+finEq : ∀ {n} → (a b : Fin n) → is-decidable (Id a b)
+finEq zero-Fin zero-Fin = inl refl
+finEq zero-Fin (succ-Fin b) = inr (λ ())
+finEq (succ-Fin a) zero-Fin = inr (λ ())
+finEq (succ-Fin a) (succ-Fin b) with finEq a b
+... | inl eq = inl (ap succ-Fin eq)
+... | inr neq = inr (λ { refl → neq refl})
 
-getVec : ∀ {n} {l} {A : UU l} → vec A n → Fin n → A getVec (x ∷ v) zero-Fin = x
+getVec : ∀ {n} {l} {A : UU l} → vec A n → Fin n → A
+getVec (x ∷ v) zero-Fin = x
 getVec (x ∷ v) (succ-Fin k) = getVec v k
 
-data GroupSyntax (n : ℕ) : UU where gUnit : GroupSyntax n gMul : GroupSyntax n →
-GroupSyntax n → GroupSyntax n gInv : GroupSyntax n → GroupSyntax n inner : Fin n
-→ GroupSyntax n
+data GroupSyntax (n : ℕ) : UU where
+  gUnit : GroupSyntax n
+  gMul : GroupSyntax n → GroupSyntax n → GroupSyntax n
+  gInv : GroupSyntax n → GroupSyntax n
+  inner : Fin n → GroupSyntax n
 
-data SimpleElem (n : ℕ) : UU where inv-SE : Fin n → SimpleElem n pure-SE : Fin n
-→ SimpleElem n
+data SimpleElem (n : ℕ) : UU where
+  inv-SE : Fin n → SimpleElem n
+  pure-SE : Fin n → SimpleElem n
 
-inv-SE' : ∀ {n} → SimpleElem n → SimpleElem n inv-SE' (inv-SE k) = pure-SE k
+inv-SE' : ∀ {n} → SimpleElem n → SimpleElem n
+inv-SE' (inv-SE k) = pure-SE k
 inv-SE' (pure-SE k) = inv-SE k
 
-Simple : (n : ℕ) → UU Simple n = list (SimpleElem n)
+Simple : (n : ℕ) → UU
+Simple n = list (SimpleElem n)
 
-module \_ {n : ℕ} where unquoteSimpleElem : SimpleElem n → GroupSyntax n
-unquoteSimpleElem (inv-SE x) = gInv (inner x) unquoteSimpleElem (pure-SE x) =
-inner x
+module _ {n : ℕ} where
+  unquoteSimpleElem : SimpleElem n → GroupSyntax n
+  unquoteSimpleElem (inv-SE x) = gInv (inner x)
+  unquoteSimpleElem (pure-SE x) = inner x
 
-unquoteSimpleNonEmpty : Simple n → GroupSyntax n → GroupSyntax n
-unquoteSimpleNonEmpty nil x = x unquoteSimpleNonEmpty (cons y xs) x = gMul
-(unquoteSimpleNonEmpty xs (unquoteSimpleElem y)) x
+  unquoteSimpleNonEmpty : Simple n → GroupSyntax n → GroupSyntax n
+  unquoteSimpleNonEmpty nil x = x
+  unquoteSimpleNonEmpty (cons y xs) x =
+    gMul (unquoteSimpleNonEmpty xs (unquoteSimpleElem y)) x
 
-unquoteSimple : Simple n → GroupSyntax n unquoteSimple nil = gUnit unquoteSimple
-(cons x xs) = unquoteSimpleNonEmpty xs (unquoteSimpleElem x)
+  unquoteSimple : Simple n → GroupSyntax n
+  unquoteSimple nil = gUnit
+  unquoteSimple (cons x xs) = unquoteSimpleNonEmpty xs (unquoteSimpleElem x)
 
-elim-inverses : SimpleElem n → Simple n → Simple n elim-inverses x nil = cons x
-nil elim-inverses xi@(inv-SE x) yxs@(cons (inv-SE y) xs) = cons xi yxs
-elim-inverses xi@(inv-SE x) yxs@(cons (pure-SE y) xs) with finEq x y ... | inl
-eq = xs ... | inr neq = cons xi yxs elim-inverses xi@(pure-SE x) yxs@(cons
-(inv-SE y) xs) with finEq x y ... | inl eq = xs ... | inr neq = cons xi yxs
-elim-inverses xi@(pure-SE x) yxs@(cons (pure-SE y) xs) = cons xi yxs
+  elim-inverses : SimpleElem n → Simple n → Simple n
+  elim-inverses x nil = cons x nil
+  elim-inverses xi@(inv-SE x) yxs@(cons (inv-SE y) xs) = cons xi yxs
+  elim-inverses xi@(inv-SE x) yxs@(cons (pure-SE y) xs) with finEq x y
+  ... | inl eq = xs
+  ... | inr neq = cons xi yxs
+  elim-inverses xi@(pure-SE x) yxs@(cons (inv-SE y) xs) with finEq x y
+  ... | inl eq = xs
+  ... | inr neq = cons xi yxs
+  elim-inverses xi@(pure-SE x) yxs@(cons (pure-SE y) xs) = cons xi yxs
 
-concat-simplify : Simple n → Simple n → Simple n concat-simplify nil b = b
-concat-simplify (cons x a) b = elim-inverses x (concat-simplify a b)
+  concat-simplify : Simple n → Simple n → Simple n
+  concat-simplify nil b = b
+  concat-simplify (cons x a) b = elim-inverses x (concat-simplify a b)
 
-simplifyGS : GroupSyntax n → Simple n simplifyGS gUnit = nil simplifyGS (gMul a
-b) = concat-simplify (simplifyGS b) (simplifyGS a) simplifyGS (gInv a) =
-reverse-list (map-list inv-SE' (simplifyGS a)) -- simplifyGS (gInv a) = map-list
-inv-SE' (reverse-list (simplifyGS a)) simplifyGS (inner n) = cons (pure-SE n)
-nil
+  simplifyGS : GroupSyntax n → Simple n
+  simplifyGS gUnit = nil
+  simplifyGS (gMul a b) = concat-simplify (simplifyGS b) (simplifyGS a)
+  simplifyGS (gInv a) = reverse-list (map-list inv-SE' (simplifyGS a))
+  -- simplifyGS (gInv a) = map-list inv-SE' (reverse-list (simplifyGS a))
+  simplifyGS (inner n) = cons (pure-SE n) nil
 
-data GroupEqualityElem : GroupSyntax n → GroupSyntax n → UU where -- equivalence
-relation xsym-GE : ∀ {x} {y} → GroupEqualityElem x y → GroupEqualityElem y x
+  data GroupEqualityElem : GroupSyntax n → GroupSyntax n → UU where
+    -- equivalence relation
+    xsym-GE : ∀ {x} {y} → GroupEqualityElem x y → GroupEqualityElem y x
 
     -- Variations on ap
     -- xap-gMul : ∀ {x} {y} {z} {w} → GroupEqualityElem x y → GroupEqualityElem z w → GroupEqualityElem (gMul x z) (gMul y w)
-    xap-gMul-l : ∀ {x} {y} {z} → GroupEqualityElem x y → GroupEqualityElem (gMul x z) (gMul y z)
-    xap-gMul-r : ∀ {x} {y} {z} → GroupEqualityElem y z → GroupEqualityElem (gMul x y) (gMul x z)
-    xap-gInv : ∀ {x} {y} → GroupEqualityElem x y → GroupEqualityElem (gInv x) (gInv y)
+    xap-gMul-l :
+      ∀ {x} {y} {z} →
+      GroupEqualityElem x y → GroupEqualityElem (gMul x z) (gMul y z)
+    xap-gMul-r :
+      ∀ {x} {y} {z} →
+      GroupEqualityElem y z → GroupEqualityElem (gMul x y) (gMul x z)
+    xap-gInv :
+      ∀ {x} {y} →
+      GroupEqualityElem x y → GroupEqualityElem (gInv x) (gInv y)
 
     -- Group laws
-    xassoc-GE : ∀ x y z → GroupEqualityElem (gMul (gMul x y) z) (gMul x (gMul y z))
+    xassoc-GE :
+      ∀ x y z → GroupEqualityElem (gMul (gMul x y) z) (gMul x (gMul y z))
     xl-unit : ∀ x → GroupEqualityElem (gMul gUnit x) x
     xr-unit : ∀ x → GroupEqualityElem (gMul x gUnit) x
     xl-inv : ∀ x → GroupEqualityElem (gMul (gInv x) x) gUnit
@@ -88,18 +130,23 @@ relation xsym-GE : ∀ {x} {y} → GroupEqualityElem x y → GroupEqualityElem y
     -- Theorems that are provable from the others
     xinv-unit-GE : GroupEqualityElem (gInv gUnit) gUnit
     xinv-inv-GE : ∀ x → GroupEqualityElem (gInv (gInv x)) x
-    xdistr-inv-mul-GE : ∀ x y → GroupEqualityElem (gInv (gMul x y)) (gMul (gInv y) (gInv x))
+    xdistr-inv-mul-GE :
+      ∀ x y → GroupEqualityElem (gInv (gMul x y)) (gMul (gInv y) (gInv x))
+  data GroupEquality : GroupSyntax n → GroupSyntax n → UU where
+    refl-GE : ∀ {x} → GroupEquality x x
+    _∷GE_ :
+      ∀ {x} {y} {z} →
+      GroupEqualityElem x y → GroupEquality y z → GroupEquality x z
 
-data GroupEquality : GroupSyntax n → GroupSyntax n → UU where refl-GE : ∀ {x} →
-GroupEquality x x _∷GE_ : ∀ {x} {y} {z} → GroupEqualityElem x y → GroupEquality
-y z → GroupEquality x z
+  infixr 5 _∷GE_
 
-infixr 5 _∷GE_
+  module _ where
+    -- equivalence relation
+    singleton-GE : ∀ {x y} → GroupEqualityElem x y → GroupEquality x y
+    singleton-GE x = x ∷GE refl-GE
 
-module \_ where -- equivalence relation singleton-GE : ∀ {x y} →
-GroupEqualityElem x y → GroupEquality x y singleton-GE x = x ∷GE refl-GE
-
-    _∙GE_ : ∀ {x} {y} {z} → GroupEquality x y → GroupEquality y z → GroupEquality x z
+    _∙GE_ :
+      ∀ {x} {y} {z} → GroupEquality x y → GroupEquality y z → GroupEquality x z
     refl-GE ∙GE b = b
     (x ∷GE a) ∙GE b = x ∷GE (a ∙GE b)
     infixr 20 _∙GE_
@@ -112,18 +159,23 @@ GroupEqualityElem x y → GroupEquality x y singleton-GE x = x ∷GE refl-GE
     ap-gInv : ∀ {x} {y} → GroupEquality x y → GroupEquality (gInv x) (gInv y)
     ap-gInv refl-GE = refl-GE
     ap-gInv (a ∷GE as) = xap-gInv a ∷GE ap-gInv as
-    ap-gMul-l : ∀ {x} {y} {z} → GroupEquality x y → GroupEquality (gMul x z) (gMul y z)
+    ap-gMul-l :
+      ∀ {x} {y} {z} → GroupEquality x y → GroupEquality (gMul x z) (gMul y z)
     ap-gMul-l refl-GE = refl-GE
     ap-gMul-l (x ∷GE xs) = xap-gMul-l x ∷GE ap-gMul-l xs
-    ap-gMul-r : ∀ {x} {y} {z} → GroupEquality y z → GroupEquality (gMul x y) (gMul x z)
+    ap-gMul-r :
+      ∀ {x} {y} {z} → GroupEquality y z → GroupEquality (gMul x y) (gMul x z)
     ap-gMul-r refl-GE = refl-GE
     ap-gMul-r (x ∷GE xs) = xap-gMul-r x ∷GE ap-gMul-r xs
-    ap-gMul : ∀ {x} {y} {z} {w} → GroupEquality x y → GroupEquality z w → GroupEquality (gMul x z) (gMul y w)
+    ap-gMul :
+      ∀ {x} {y} {z} {w} →
+      GroupEquality x y → GroupEquality z w →
+      GroupEquality (gMul x z) (gMul y w)
     ap-gMul p q = ap-gMul-l p ∙GE ap-gMul-r q
 
     -- Group laws
-    associative-GE : ∀ x y z → GroupEquality (gMul (gMul x y) z) (gMul x (gMul y z))
-    associative-GE x y z = singleton-GE (xassoc-GE x y z)
+    assoc-GE : ∀ x y z → GroupEquality (gMul (gMul x y) z) (gMul x (gMul y z))
+    assoc-GE x y z = singleton-GE (xassoc-GE x y z)
     l-unit : ∀ x → GroupEquality (gMul gUnit x) x
     l-unit x = singleton-GE (xl-unit x)
     r-unit : ∀ x → GroupEquality (gMul x gUnit) x
@@ -138,86 +190,125 @@ GroupEqualityElem x y → GroupEquality x y singleton-GE x = x ∷GE refl-GE
     inv-unit-GE = singleton-GE (xinv-unit-GE)
     inv-inv-GE : ∀ x → GroupEquality (gInv (gInv x)) x
     inv-inv-GE x = singleton-GE (xinv-inv-GE x)
-    distr-inv-mul-GE : ∀ x y → GroupEquality (gInv (gMul x y)) (gMul (gInv y) (gInv x))
+    distr-inv-mul-GE :
+      ∀ x y → GroupEquality (gInv (gMul x y)) (gMul (gInv y) (gInv x))
     distr-inv-mul-GE x y = singleton-GE (xdistr-inv-mul-GE x y)
 
-associative-GE' : ∀ x y z → GroupEquality (gMul x (gMul y z)) (gMul (gMul x y)
-z) associative-GE' x y z = sym-GE (associative-GE x y z)
+  assoc-GE' : ∀ x y z → GroupEquality (gMul x (gMul y z)) (gMul (gMul x y) z)
+  assoc-GE' x y z = sym-GE (assoc-GE x y z)
 
-elim-inverses-remove-valid : ∀ (b : list (SimpleElem n)) (w u : GroupSyntax n) →
-GroupEquality (gMul w u) gUnit → GroupEquality (gMul (unquoteSimpleNonEmpty b w)
-u) (unquoteSimple b) elim-inverses-remove-valid nil w u eq = eq
-elim-inverses-remove-valid (cons x b) w u eq = associative-GE \_ \_ _ ∙GE
-ap-gMul-r eq ∙GE r-unit _
+  elim-inverses-remove-valid :
+    (b : list (SimpleElem n)) (w u : GroupSyntax n) →
+    GroupEquality (gMul w u) gUnit →
+    GroupEquality
+      ( gMul (unquoteSimpleNonEmpty b w) u)
+      ( unquoteSimple b)
+  elim-inverses-remove-valid nil w u eq = eq
+  elim-inverses-remove-valid (cons x b) w u eq =
+    assoc-GE _ _ _ ∙GE
+    ap-gMul-r eq ∙GE
+    r-unit _
 
-elim-inverses-valid : ∀ (x : SimpleElem n) (b : Simple n) → GroupEquality (gMul
-(unquoteSimple b) (unquoteSimpleElem x)) (unquoteSimple (elim-inverses x b))
-elim-inverses-valid x nil = l-unit (unquoteSimpleElem x) elim-inverses-valid
-(inv-SE x) (cons (inv-SE y) b) = refl-GE elim-inverses-valid (inv-SE x) (cons
-(pure-SE y) b) with finEq x y ... | inl refl = elim-inverses-remove-valid b
-(inner x) (gInv (inner x)) (r-inv (inner x)) ... | inr neq = refl-GE
-elim-inverses-valid (pure-SE x) (cons (inv-SE y) b) with finEq x y ... | inl
-refl = elim-inverses-remove-valid b (gInv (inner x)) (inner x) (l-inv (inner x))
-... | inr neq = refl-GE elim-inverses-valid (pure-SE x) (cons (pure-SE y) b) =
-refl-GE
+  elim-inverses-valid :
+    (x : SimpleElem n) (b : Simple n) →
+    GroupEquality
+      ( gMul (unquoteSimple b) (unquoteSimpleElem x))
+      ( unquoteSimple (elim-inverses x b))
+  elim-inverses-valid x nil = l-unit (unquoteSimpleElem x)
+  elim-inverses-valid (inv-SE x) (cons (inv-SE y) b) = refl-GE
+  elim-inverses-valid (inv-SE x) (cons (pure-SE y) b) with finEq x y
+  ... | inl refl =
+    elim-inverses-remove-valid b (inner x) (gInv (inner x)) (r-inv (inner x))
+  ... | inr neq = refl-GE
+  elim-inverses-valid (pure-SE x) (cons (inv-SE y) b) with finEq x y
+  ... | inl refl =
+    elim-inverses-remove-valid b (gInv (inner x)) (inner x) (l-inv (inner x))
+  ... | inr neq = refl-GE
+  elim-inverses-valid (pure-SE x) (cons (pure-SE y) b) = refl-GE
 
-concat-simplify-nonempty-valid : ∀ (x : SimpleElem n) (a : list (SimpleElem n))
-(b : Simple n) → GroupEquality (gMul (unquoteSimple b) (unquoteSimple (cons x
-a))) (unquoteSimple (concat-simplify (cons x a) b))
-concat-simplify-nonempty-valid x nil b = elim-inverses-valid x b
-concat-simplify-nonempty-valid x (cons y a) b = associative-GE' \_ \_ \_ ∙GE
-ap-gMul-l (concat-simplify-nonempty-valid y a b) ∙GE elim-inverses-valid x
-(elim-inverses y (concat-simplify a b))
+  concat-simplify-nonempty-valid :
+    (x : SimpleElem n) (a : list (SimpleElem n)) (b : Simple n) →
+    GroupEquality
+      ( gMul (unquoteSimple b) (unquoteSimple (cons x a)))
+      ( unquoteSimple (concat-simplify (cons x a) b))
+  concat-simplify-nonempty-valid x nil b = elim-inverses-valid x b
+  concat-simplify-nonempty-valid x (cons y a) b =
+    assoc-GE' _ _ _ ∙GE
+    ap-gMul-l (concat-simplify-nonempty-valid y a b) ∙GE
+    elim-inverses-valid x (elim-inverses y (concat-simplify a b))
 
-concat-simplify-valid : ∀ (u w : Simple n) → GroupEquality (gMul (unquoteSimple
-w) (unquoteSimple u)) (unquoteSimple (concat-simplify u w))
-concat-simplify-valid nil b = r-unit (unquoteSimple b) concat-simplify-valid
-(cons x a) b = concat-simplify-nonempty-valid x a b
+  concat-simplify-valid :
+    ∀ (u w : Simple n) →
+    GroupEquality
+      ( gMul (unquoteSimple w) (unquoteSimple u))
+      ( unquoteSimple (concat-simplify u w))
+  concat-simplify-valid nil b = r-unit (unquoteSimple b)
+  concat-simplify-valid (cons x a) b = concat-simplify-nonempty-valid x a b
 
-inv-single-valid : ∀ w → GroupEquality (gInv (unquoteSimpleElem w))
-(unquoteSimpleElem (inv-SE' w)) inv-single-valid (inv-SE x) = inv-inv-GE (inner
-x) inv-single-valid (pure-SE x) = refl-GE
+  inv-single-valid :
+    ∀ w →
+    GroupEquality
+      ( gInv (unquoteSimpleElem w))
+      ( unquoteSimpleElem (inv-SE' w))
+  inv-single-valid (inv-SE x) = inv-inv-GE (inner x)
+  inv-single-valid (pure-SE x) = refl-GE
 
-gMul-concat-nonempty : ∀ (w : GroupSyntax n) (as b : Simple n) → GroupEquality
-(gMul (unquoteSimple b) (unquoteSimpleNonEmpty as w)) (unquoteSimpleNonEmpty
-(concat-list as b) w) gMul-concat-nonempty w nil nil = l-unit w
-gMul-concat-nonempty w nil (cons x b) = refl-GE gMul-concat-nonempty w (cons x
-as) b = associative-GE' \_ \_ \_ ∙GE ap-gMul-l (gMul-concat-nonempty
-(unquoteSimpleElem x) as b)
+  gMul-concat-nonempty :
+    (w : GroupSyntax n) (as b : Simple n) →
+    GroupEquality
+      ( gMul (unquoteSimple b) (unquoteSimpleNonEmpty as w))
+      ( unquoteSimpleNonEmpty (concat-list as b) w)
+  gMul-concat-nonempty w nil nil = l-unit w
+  gMul-concat-nonempty w nil (cons x b) = refl-GE
+  gMul-concat-nonempty w (cons x as) b =
+    assoc-GE' _ _ _ ∙GE
+    ap-gMul-l (gMul-concat-nonempty (unquoteSimpleElem x) as b)
 
-gMul-concat' : ∀ (xs : Simple n) (ys : Simple n) → GroupEquality (gMul
-(unquoteSimple ys) (unquoteSimple xs)) (unquoteSimple (concat-list xs ys))
-gMul-concat' nil bs = r-unit \_ gMul-concat' (cons x as) b =
-gMul-concat-nonempty (unquoteSimpleElem x) as b
+  gMul-concat' :
+    (xs : Simple n) (ys : Simple n) →
+    GroupEquality
+      ( gMul (unquoteSimple ys) (unquoteSimple xs))
+      ( unquoteSimple (concat-list xs ys))
+  gMul-concat' nil bs = r-unit _
+  gMul-concat' (cons x as) b = gMul-concat-nonempty (unquoteSimpleElem x) as b
 
-gMul-concat-1 : ∀ (xs : Simple n) (x : SimpleElem n) → GroupEquality (gMul
-(unquoteSimpleElem x) (unquoteSimple xs)) (unquoteSimple (concat-list xs (cons x
-nil))) gMul-concat-1 xs a = gMul-concat' xs (cons a nil)
+  gMul-concat-1 :
+    (xs : Simple n) (x : SimpleElem n) →
+    GroupEquality
+      ( gMul (unquoteSimpleElem x) (unquoteSimple xs))
+      ( unquoteSimple (concat-list xs (cons x nil)))
+  gMul-concat-1 xs a = gMul-concat' xs (cons a nil)
 
-inv-simplify-valid'-nonempty : ∀ (x : SimpleElem n) (xs : list (SimpleElem n)) →
-GroupEquality (gInv (unquoteSimple (cons x xs))) (unquoteSimple (reverse-list
-(map-list inv-SE' (cons x xs)))) inv-simplify-valid'-nonempty x nil =
-inv-single-valid x inv-simplify-valid'-nonempty x (cons y xs) = distr-inv-mul-GE
-(unquoteSimple (cons y xs)) (unquoteSimpleElem x) ∙GE ap-gMul (inv-single-valid
-x) (inv-simplify-valid'-nonempty y xs) ∙GE gMul-concat-1 ( snoc (reverse-list
-(map-list inv-SE' xs)) (inv-SE' y)) ( inv-SE' x) ∙GE {!!} -- gMul-concat-1
-(concat-list (reverse-list (map-list inv-SE' xs)) (unit-list (inv-SE' y)))
-(inv-SE' x)
+  -- inv-simplify-valid'-nonempty : ∀ (x : SimpleElem n) (xs : list (SimpleElem n)) →
+  --                               GroupEquality (gInv (unquoteSimple (cons x xs)))
+  --                               (unquoteSimple (reverse-list (map-list inv-SE' (cons x xs))))
+  -- inv-simplify-valid'-nonempty x nil = inv-single-valid x
+  -- inv-simplify-valid'-nonempty x (cons y xs) =
+  --   distr-inv-mul-GE (unquoteSimple (cons y xs)) (unquoteSimpleElem x) ∙GE
+  --   ap-gMul (inv-single-valid x) (inv-simplify-valid'-nonempty y xs) ∙GE
+  --   gMul-concat-1 (concat-list (reverse-list (map-list inv-SE' xs)) (in-list (inv-SE' y))) (inv-SE' x)
 
-inv-simplify-valid' : ∀ (w : list (SimpleElem n)) → GroupEquality (gInv
-(unquoteSimple w)) (unquoteSimple (reverse-list (map-list inv-SE' w)))
-inv-simplify-valid' nil = inv-unit-GE inv-simplify-valid' (cons x xs) =
-inv-simplify-valid'-nonempty x xs
+  -- inv-simplify-valid' : ∀ (w : list (SimpleElem n)) →
+  --                     GroupEquality (gInv (unquoteSimple w))
+  --                     (unquoteSimple (reverse-list (map-list inv-SE' w)))
+  -- inv-simplify-valid' nil = inv-unit-GE
+  -- inv-simplify-valid' (cons x xs) =
+  --   inv-simplify-valid'-nonempty x xs
 
-simplifyValid : ∀ (g : GroupSyntax n) → GroupEquality g (unquoteSimple
-(simplifyGS g)) simplifyValid gUnit = refl-GE simplifyValid (gMul a b) =
-(ap-gMul (simplifyValid a) (simplifyValid b)) ∙GE (concat-simplify-valid
-(simplifyGS b) (simplifyGS a)) simplifyValid (gInv g) = ap-gInv (simplifyValid
-g) ∙GE inv-simplify-valid' (simplifyGS g) simplifyValid (inner \_) = refl-GE
+  -- simplifyValid : ∀ (g : GroupSyntax n) → GroupEquality g (unquoteSimple (simplifyGS g))
+  -- simplifyValid gUnit = refl-GE
+  -- simplifyValid (gMul a b) =
+  --   (ap-gMul (simplifyValid a) (simplifyValid b)) ∙GE
+  --   (concat-simplify-valid (simplifyGS b) (simplifyGS a))
+  -- simplifyValid (gInv g) = ap-gInv (simplifyValid g) ∙GE inv-simplify-valid' (simplifyGS g)
+  -- simplifyValid (inner _) = refl-GE
 
-Env : ∀ {l} → ℕ → UU l → UU l Env n A = vec A n
+  Env : ∀ {l} → ℕ → UU l → UU l
+  Env n A = vec A n
 
-module \_ {l : Level} (G : Group l) where
+  module _
+    {l : Level} (G : Group l)
+    where
 
     unQuoteGS : ∀ {n} → GroupSyntax n → Env n (type-Group G) → type-Group G
     unQuoteGS gUnit e = unit-Group G
@@ -233,15 +324,19 @@ module \_ {l : Level} (G : Group l) where
       infix 40 _⁻¹
       unit = unit-Group G
 
-    useGroupEqualityElem : ∀ {x y : GroupSyntax n} (env : Env n (type-Group G))
-                          → GroupEqualityElem x y → unQuoteGS x env ＝ unQuoteGS y env
+    useGroupEqualityElem :
+      {x y : GroupSyntax n} (env : Env n (type-Group G)) →
+      GroupEqualityElem x y → unQuoteGS x env ＝ unQuoteGS y env
     useGroupEqualityElem env (xsym-GE ge) = inv (useGroupEqualityElem env ge)
-    useGroupEqualityElem env (xap-gMul-l {z = z} ge') = ap (_* unQuoteGS z env) (useGroupEqualityElem env ge')
-    useGroupEqualityElem env (xap-gMul-r {x = x} ge') = ap (unQuoteGS x env *_) (useGroupEqualityElem env ge')
+    useGroupEqualityElem env (xap-gMul-l {z = z} ge') =
+      ap (_* unQuoteGS z env) (useGroupEqualityElem env ge')
+    useGroupEqualityElem env (xap-gMul-r {x = x} ge') =
+      ap (unQuoteGS x env *_) (useGroupEqualityElem env ge')
     -- useGroupEqualityElem env (xap-gMul {y = y} {z = z} ge ge') =
     --                              ap (_* (unQuoteGS z env)) (useGroupEqualityElem env ge)
     --                              ∙ ap (unQuoteGS y env *_) (useGroupEqualityElem env ge')
-    useGroupEqualityElem env (xap-gInv ge) = ap (inv-Group G) (useGroupEqualityElem env ge)
+    useGroupEqualityElem env (xap-gInv ge) =
+      ap (inv-Group G) (useGroupEqualityElem env ge)
     useGroupEqualityElem env (xassoc-GE x y z) = associative-mul-Group G _ _ _
     useGroupEqualityElem env (xl-unit _) = left-unit-law-mul-Group G _
     useGroupEqualityElem env (xr-unit _) = right-unit-law-mul-Group G _
@@ -249,40 +344,45 @@ module \_ {l : Level} (G : Group l) where
     useGroupEqualityElem env (xr-inv x) = right-inverse-law-mul-Group G _
     useGroupEqualityElem env xinv-unit-GE = inv-unit-Group G
     useGroupEqualityElem env (xinv-inv-GE x) = inv-inv-Group G (unQuoteGS x env)
-    useGroupEqualityElem env (xdistr-inv-mul-GE x y) = distributive-inv-mul-Group G (unQuoteGS x env) (unQuoteGS y env)
+    useGroupEqualityElem env (xdistr-inv-mul-GE x y) =
+      distributive-inv-mul-Group G (unQuoteGS x env) (unQuoteGS y env)
 
-    useGroupEquality
-      : ∀ {x y : GroupSyntax n} (env : Env n (type-Group G))
-      → GroupEquality x y → unQuoteGS x env ＝ unQuoteGS y env
+    useGroupEquality :
+      {x y : GroupSyntax n} (env : Env n (type-Group G)) →
+      GroupEquality x y → unQuoteGS x env ＝ unQuoteGS y env
     useGroupEquality env refl-GE = refl
     useGroupEquality env (x ∷GE refl-GE) = useGroupEqualityElem env x
-    useGroupEquality env (x ∷GE xs@(_ ∷GE _)) = useGroupEqualityElem env x ∙ useGroupEquality env xs
+    useGroupEquality env (x ∷GE xs@(_ ∷GE _)) =
+      useGroupEqualityElem env x ∙ useGroupEquality env xs
 
-    simplifyExpression :
-      ∀ (g : GroupSyntax n) (env : Env n (type-Group G)) →
-      unQuoteGS g env ＝ unQuoteGS (unquoteSimple (simplifyGS g)) env
-    simplifyExpression g env = useGroupEquality env (simplifyValid g)
+    -- simplifyExpression :
+    --   ∀ (g : GroupSyntax n) (env : Env n (type-Group G)) →
+    --   unQuoteGS g env ＝ unQuoteGS (unquoteSimple (simplifyGS g)) env
+    -- simplifyExpression g env = useGroupEquality env (simplifyValid g)
 
     -- Variadic functions
     n-args : (n : ℕ) (A B : UU) → UU
     n-args zero-ℕ A B = B
     n-args (succ-ℕ n) A B = A → n-args n A B
-    map-n-args : ∀ {A A' B : UU} (n : ℕ) → (A' → A) → n-args n A B → n-args n A' B
+    map-n-args :
+      ∀ {A A' B : UU} (n : ℕ) → (A' → A) → n-args n A B → n-args n A' B
     map-n-args zero-ℕ f v = v
     map-n-args (succ-ℕ n) f v = λ x → map-n-args n f (v (f x))
     apply-n-args-fin : ∀ {B : UU} (n : ℕ) → n-args n (Fin n) B → B
     apply-n-args-fin zero-ℕ f = f
-    apply-n-args-fin (succ-ℕ n) f = apply-n-args-fin n (map-n-args n succ-Fin (f zero-Fin))
+    apply-n-args-fin (succ-ℕ n) f =
+      apply-n-args-fin n (map-n-args n succ-Fin (f zero-Fin))
     apply-n-args : ∀ {B : UU} (n : ℕ) → n-args n (GroupSyntax n) B → B
     apply-n-args n f = apply-n-args-fin n (map-n-args n inner f)
 
     -- A variation of simplifyExpression which takes a function from the free variables to expr
-    simplifyExpr :
-      ∀ (env : Env n (type-Group G)) (g : n-args n (GroupSyntax n) (GroupSyntax n)) →
-      unQuoteGS (apply-n-args n g) env ＝ unQuoteGS (unquoteSimple (simplifyGS (apply-n-args n g))) env
-    simplifyExpr env g = simplifyExpression (apply-n-args n g) env
+    -- simplifyExpr :
+    --   ∀ (env : Env n (type-Group G)) (g : n-args n (GroupSyntax n) (GroupSyntax n)) →
+    --   unQuoteGS (apply-n-args n g) env ＝ unQuoteGS (unquoteSimple (simplifyGS (apply-n-args n g))) env
+    -- simplifyExpr env g = simplifyExpression (apply-n-args n g) env
 
     open import linear-algebra.vectors using (_∷_ ; empty-vec) public
+```
 
 ```agda
 -- private _\*'_ : ∀ {n} → GroupSyntax n → GroupSyntax n → GroupSyntax n _\*'_ =

--- a/src/group-theory/homomorphisms-concrete-groups.lagda.md
+++ b/src/group-theory/homomorphisms-concrete-groups.lagda.md
@@ -34,7 +34,7 @@ module _
 
   is-set-hom-Concrete-Group : is-set hom-Concrete-Group
   is-set-hom-Concrete-Group =
-    is-trunc-map-ev-pt-is-connected
+    is-trunc-map-ev-point-is-connected
       ( zero-𝕋)
       ( shape-Concrete-Group G)
       ( is-0-connected-classifying-type-Concrete-Group G)

--- a/src/group-theory/kernels-homomorphisms-concrete-groups.lagda.md
+++ b/src/group-theory/kernels-homomorphisms-concrete-groups.lagda.md
@@ -29,7 +29,7 @@ open import structured-types.pointed-types
 
 ## Idea
 
-The kernel of a concrete group homomorphsim `Bf : BG →* BH` is the connected
+The kernel of a concrete group homomorphsim `Bf : BG →∗ BH` is the connected
 component at the base point of the fiber of `Bf`.
 
 ## Definition

--- a/src/group-theory/monomorphisms-concrete-groups.lagda.md
+++ b/src/group-theory/monomorphisms-concrete-groups.lagda.md
@@ -21,8 +21,8 @@ open import group-theory.homomorphisms-concrete-groups
 ## Idea
 
 A monomorphism of concrete groups from `G` to `H` is a faithful pointed map BH
-→* BG. Recall that a map is said to be faithful if it induces embeddings on
-identity types. In particular, any faithful pointed map BH →* BG induces an
+→∗ BG. Recall that a map is said to be faithful if it induces embeddings on
+identity types. In particular, any faithful pointed map BH →∗ BG induces an
 embedding ΩBH → ΩBG, i.e., an inclusion of the underlying groups of a concrete
 group.
 

--- a/src/group-theory/stabilizer-groups-concrete-group-actions.lagda.md
+++ b/src/group-theory/stabilizer-groups-concrete-group-actions.lagda.md
@@ -27,8 +27,8 @@ open import group-theory.transitive-concrete-group-actions
 
 ## Idea
 
-The stabilizer of an element `x : X pt` of a concrete G-set `X : BG → Set` is
-the connected component of `pair pt x` in the type of orbits of `X`. Its loop
+The stabilizer of an element `x : X point` of a concrete G-set `X : BG → Set` is
+the connected component of `pair point x` in the type of orbits of `X`. Its loop
 space is indeed the type of elements `g : G` such that `g x = x`.
 
 ## Definition

--- a/src/group-theory/subgroups-concrete-groups.lagda.md
+++ b/src/group-theory/subgroups-concrete-groups.lagda.md
@@ -130,7 +130,7 @@ module _
   preserves-shape-classifying-inclusion-subgroup-Concrete-Group = refl
 
   classifying-pointed-inclusion-subgroup-Concrete-Group :
-    classifying-pointed-type-subgroup-Concrete-Group →*
+    classifying-pointed-type-subgroup-Concrete-Group →∗
     classifying-pointed-type-Concrete-Group G
   pr1 classifying-pointed-inclusion-subgroup-Concrete-Group =
     classifying-inclusion-subgroup-Concrete-Group

--- a/src/higher-group-theory/equivalences-higher-groups.lagda.md
+++ b/src/higher-group-theory/equivalences-higher-groups.lagda.md
@@ -37,7 +37,7 @@ module _
 
   equiv-∞-Group : UU (l1 ⊔ l2)
   equiv-∞-Group =
-    classifying-pointed-type-∞-Group G ≃* classifying-pointed-type-∞-Group H
+    classifying-pointed-type-∞-Group G ≃∗ classifying-pointed-type-∞-Group H
 
   hom-equiv-∞-Group : equiv-∞-Group → hom-∞-Group G H
   hom-equiv-∞-Group =

--- a/src/higher-group-theory/homomorphisms-higher-groups.lagda.md
+++ b/src/higher-group-theory/homomorphisms-higher-groups.lagda.md
@@ -34,7 +34,7 @@ module _
 
   hom-∞-Group : UU (l1 ⊔ l2)
   hom-∞-Group =
-    classifying-pointed-type-∞-Group G →* classifying-pointed-type-∞-Group H
+    classifying-pointed-type-∞-Group G →∗ classifying-pointed-type-∞-Group H
 
   classifying-map-hom-∞-Group :
     hom-∞-Group → classifying-type-∞-Group G → classifying-type-∞-Group H

--- a/src/structured-types.lagda.md
+++ b/src/structured-types.lagda.md
@@ -31,6 +31,7 @@ open import structured-types.pointed-maps public
 open import structured-types.pointed-sections public
 open import structured-types.pointed-types public
 open import structured-types.pointed-types-equipped-with-automorphisms public
+open import structured-types.pointed-unit-type public
 open import structured-types.symmetric-elements-involutive-types public
 open import structured-types.symmetric-h-spaces public
 open import structured-types.types-equipped-with-automorphisms public

--- a/src/structured-types.lagda.md
+++ b/src/structured-types.lagda.md
@@ -5,6 +5,7 @@ module structured-types where
 
 open import structured-types.central-h-spaces public
 open import structured-types.coherent-h-spaces public
+open import structured-types.commuting-squares-of-pointed-maps public
 open import structured-types.constant-maps-pointed-types public
 open import structured-types.contractible-pointed-types public
 open import structured-types.equivalences-types-equipped-with-endomorphisms public

--- a/src/structured-types/central-h-spaces.lagda.md
+++ b/src/structured-types/central-h-spaces.lagda.md
@@ -20,7 +20,7 @@ open import structured-types.pointed-types
 In [`structured-types.coherent-h-spaces`](structured-types.coherent-h-spaces.md)
 we saw that the type of coherent H-space structures on a pointed type `A` is
 equivalently described as the type of pointed sections of the pointed evaluation
-map `(A → A) →* A`. If the type `A` is connected, then the section maps to the
+map `(A → A) →∗ A`. If the type `A` is connected, then the section maps to the
 connected component of `(A ≃ A)` at the identity equivalence. An evaluative
 H-space is a pointed type such that the map `ev_pt : (A ≃ A)_{(id)} → A` is an
 equivalence.

--- a/src/structured-types/coherent-h-spaces.lagda.md
+++ b/src/structured-types/coherent-h-spaces.lagda.md
@@ -129,7 +129,7 @@ pr2 (pr2 (coherent-h-space-H-Space A)) =
   coherent-unit-laws-unit-laws (mul-H-Space A) (unit-laws-mul-H-Space A)
 ```
 
-### The type of coherent H-space structures on `A` is equivalent to the type of sections of `ev_pt : (A → A) →* A`
+### The type of coherent H-space structures on `A` is equivalent to the type of sections of `ev_point : (A → A) →∗ A`
 
 ```agda
 module _

--- a/src/structured-types/coherent-h-spaces.lagda.md
+++ b/src/structured-types/coherent-h-spaces.lagda.md
@@ -129,7 +129,7 @@ pr2 (pr2 (coherent-h-space-H-Space A)) =
   coherent-unit-laws-unit-laws (mul-H-Space A) (unit-laws-mul-H-Space A)
 ```
 
-### The type of coherent H-space structures on `A` is equivalent to the type of sections of `ev_point : (A → A) →∗ A`
+### The type of coherent H-space structures on `A` is equivalent to the type of sections of `ev-point : (A → A) →∗ A`
 
 ```agda
 module _

--- a/src/structured-types/commuting-squares-of-pointed-maps.lagda.md
+++ b/src/structured-types/commuting-squares-of-pointed-maps.lagda.md
@@ -7,10 +7,11 @@ module structured-types.commuting-squares-of-pointed-maps where
 <details><summary>Imports</summary>
 
 ```agda
-open import structured-types.pointed-types
-open import structured-types.pointed-maps
-open import structured-types.pointed-homotopies
 open import foundation-core.universe-levels
+
+open import structured-types.pointed-homotopies
+open import structured-types.pointed-maps
+open import structured-types.pointed-types
 ```
 
 </details>

--- a/src/structured-types/commuting-squares-of-pointed-maps.lagda.md
+++ b/src/structured-types/commuting-squares-of-pointed-maps.lagda.md
@@ -1,0 +1,45 @@
+# Commuting squares of pointed maps
+
+```agda
+module structured-types.commuting-squares-of-pointed-maps where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import structured-types.pointed-types
+open import structured-types.pointed-maps
+open import structured-types.pointed-homotopies
+open import foundation-core.universe-levels
+```
+
+</details>
+
+## Idea
+
+A coherence square of pointed maps
+
+```md
+  A ------> X
+  |         |
+  |         |
+  |         |
+  V         V
+  B ------> Y
+```
+
+is a coherence of the underlying square of (unpointed) maps, plus a coherence
+between the pointedness preservation proofs.
+
+## Definition
+
+```agda
+coherence-square-pointed-maps :
+  {l1 l2 l3 l4 : Level}
+  {A : Pointed-Type l1} {B : Pointed-Type l2}
+  {C : Pointed-Type l3} {X : Pointed-Type l4}
+  (top : C →∗ B) (left : C →∗ A) (right : B →∗ X) (bottom : A →∗ X) →
+  UU (l3 ⊔ l4)
+coherence-square-pointed-maps top left right bottom =
+  (bottom ∘∗ left) ~∗ (right ∘∗ top)
+```

--- a/src/structured-types/constant-maps-pointed-types.lagda.md
+++ b/src/structured-types/constant-maps-pointed-types.lagda.md
@@ -30,7 +30,7 @@ const-Pointed-Type :
 const-Pointed-Type X A x = point-Pointed-Type A
 
 pointed-const-Pointed-Type :
-  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) → A →* B
+  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) → A →∗ B
 pr1 (pointed-const-Pointed-Type A B) =
   const-Pointed-Type (type-Pointed-Type A) B
 pr2 (pointed-const-Pointed-Type A B) = refl

--- a/src/structured-types/faithful-pointed-maps.lagda.md
+++ b/src/structured-types/faithful-pointed-maps.lagda.md
@@ -29,14 +29,14 @@ the underlying map is faithful.
 faithful-pointed-map :
   {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) → UU (l1 ⊔ l2)
 faithful-pointed-map A B =
-  Σ (A →* B) (λ f → is-faithful (map-pointed-map A B f))
+  Σ (A →∗ B) (λ f → is-faithful (map-pointed-map A B f))
 
 module _
   {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2)
   (f : faithful-pointed-map A B)
   where
 
-  pointed-map-faithful-pointed-map : A →* B
+  pointed-map-faithful-pointed-map : A →∗ B
   pointed-map-faithful-pointed-map = pr1 f
 
   map-faithful-pointed-map : type-Pointed-Type A → type-Pointed-Type B

--- a/src/structured-types/fibers-of-pointed-maps.lagda.md
+++ b/src/structured-types/fibers-of-pointed-maps.lagda.md
@@ -22,7 +22,7 @@ open import structured-types.pointed-types
 ```agda
 fib-Pointed-Type :
   {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) →
-  (A →* B) → Pointed-Type (l1 ⊔ l2)
+  (A →∗ B) → Pointed-Type (l1 ⊔ l2)
 pr1 (fib-Pointed-Type A B f) =
   fib (map-pointed-map A B f) (point-Pointed-Type B)
 pr1 (pr2 (fib-Pointed-Type A B f)) = point-Pointed-Type A

--- a/src/structured-types/h-spaces.lagda.md
+++ b/src/structured-types/h-spaces.lagda.md
@@ -20,8 +20,9 @@ open import structured-types.pointed-types
 ## Idea
 
 An H-space is a pointed type `A` equipped with a binary operation `μ` and
-homotopies `(λ x → μ pt x) ~ id` and `λ x → μ x pt ~ id`. If `A` is a connected
-H-space, then `λ x → μ a x` and `λ x → μ x a` are equivalences for each `a : A`.
+homotopies `(λ x → μ point x) ~ id` and `λ x → μ x point ~ id`. If `A` is a
+connected H-space, then `λ x → μ a x` and `λ x → μ x a` are equivalences for
+each `a : A`.
 
 ## Definitions
 
@@ -62,22 +63,22 @@ module _
   type-H-Space : UU l
   type-H-Space = type-Pointed-Type pointed-type-H-Space
 
-  pt-H-Space : type-H-Space
-  pt-H-Space = point-Pointed-Type pointed-type-H-Space
+  point-H-Space : type-H-Space
+  point-H-Space = point-Pointed-Type pointed-type-H-Space
 
   mul-H-Space : type-H-Space → type-H-Space → type-H-Space
   mul-H-Space = pr1 (pr2 A)
 
   unit-laws-mul-H-Space :
-    unit-laws mul-H-Space pt-H-Space
+    unit-laws mul-H-Space point-H-Space
   unit-laws-mul-H-Space = pr2 (pr2 A)
 
   left-unit-law-mul-H-Space :
-    (x : type-H-Space) → Id (mul-H-Space pt-H-Space x) x
+    (x : type-H-Space) → Id (mul-H-Space point-H-Space x) x
   left-unit-law-mul-H-Space = pr1 unit-laws-mul-H-Space
 
   right-unit-law-mul-H-Space :
-    (x : type-H-Space) → Id (mul-H-Space x pt-H-Space) x
+    (x : type-H-Space) → Id (mul-H-Space x point-H-Space) x
   right-unit-law-mul-H-Space = pr2 unit-laws-mul-H-Space
 ```
 

--- a/src/structured-types/morphisms-coherent-h-spaces.lagda.md
+++ b/src/structured-types/morphisms-coherent-h-spaces.lagda.md
@@ -50,7 +50,7 @@ preserves-right-unit-law-mul {A = A} {B} μ {eA} rA ν {eB} rB f p μf =
 
 preserves-coh-unit-laws-mul :
   {l1 l2 : Level} (M : Coherent-H-Space l1) (N : Coherent-H-Space l2) →
-  ( f : pointed-type-Coherent-H-Space M →* pointed-type-Coherent-H-Space N) →
+  ( f : pointed-type-Coherent-H-Space M →∗ pointed-type-Coherent-H-Space N) →
   ( μf :
     preserves-mul (mul-Coherent-H-Space M) (mul-Coherent-H-Space N) (pr1 f)) →
   preserves-left-unit-law-mul
@@ -85,7 +85,7 @@ preserves-coh-unit-laws-mul M
 ```agda
 preserves-coh-unit-laws-mul' :
   {l1 l2 : Level} (M : Coherent-H-Space l1) (N : Coherent-H-Space l2) →
-  ( f : pointed-type-Coherent-H-Space M →* pointed-type-Coherent-H-Space N) →
+  ( f : pointed-type-Coherent-H-Space M →∗ pointed-type-Coherent-H-Space N) →
   ( μf :
     preserves-mul (mul-Coherent-H-Space M) (mul-Coherent-H-Space N) (pr1 f)) →
   preserves-left-unit-law-mul
@@ -183,7 +183,7 @@ preserves-coh-unit-laws-mul' M N f μf lf rf =
 
 preserves-unital-mul :
   {l1 l2 : Level} (M : Coherent-H-Space l1) (N : Coherent-H-Space l2) →
-  (f : pointed-type-Coherent-H-Space M →* pointed-type-Coherent-H-Space N) →
+  (f : pointed-type-Coherent-H-Space M →∗ pointed-type-Coherent-H-Space N) →
   UU (l1 ⊔ l2)
 preserves-unital-mul M N f =
   Σ ( preserves-mul μM μN (pr1 f))
@@ -204,7 +204,7 @@ hom-Coherent-H-Space :
   {l1 l2 : Level} (M : Coherent-H-Space l1) (N : Coherent-H-Space l2) →
   UU (l1 ⊔ l2)
 hom-Coherent-H-Space M N =
-  Σ ( pointed-type-Coherent-H-Space M →* pointed-type-Coherent-H-Space N)
+  Σ ( pointed-type-Coherent-H-Space M →∗ pointed-type-Coherent-H-Space N)
     ( preserves-unital-mul M N)
 ```
 

--- a/src/structured-types/pointed-cartesian-product-types.lagda.md
+++ b/src/structured-types/pointed-cartesian-product-types.lagda.md
@@ -9,8 +9,15 @@ module structured-types.pointed-cartesian-product-types where
 ```agda
 open import foundation.cartesian-product-types
 open import foundation.dependent-pair-types
+open import foundation.embeddings
+open import foundation.equality-cartesian-product-types
+open import foundation.function-extensionality
+open import foundation.functions
+open import foundation.homotopies
+open import foundation.identity-types
 open import foundation.universe-levels
 
+open import structured-types.pointed-maps
 open import structured-types.pointed-types
 ```
 
@@ -18,8 +25,9 @@ open import structured-types.pointed-types
 
 ## Idea
 
-Given two pointed types `(A , a)` and `(B , b)`, their cartesian product is
-again canonically pointed `(A × B , (a , b))`.
+Given two pointed types `a : A` and `b : B`, their cartesian product is again
+canonically pointed at `(a , b) : A × B`. We call this the **pointed cartesian
+product** or **pointed product** of the two pointed types.
 
 ## Definition
 
@@ -34,4 +42,81 @@ module _
   pr2 (prod-Pointed-Type (A , a) (B , b)) = a , b
 
   _×*_ = prod-Pointed-Type
+```
+
+## Properties
+
+### The pointed projections from the pointed product `A ×* B` onto `A` and `B`
+
+```agda
+module _
+  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2)
+  where
+
+  map-pr1-prod-Pointed-Type : type-Pointed-Type (A ×* B) → type-Pointed-Type A
+  map-pr1-prod-Pointed-Type = pr1
+
+  pr1-prod-Pointed-Type : (A ×* B) →* A
+  pr1 pr1-prod-Pointed-Type = map-pr1-prod-Pointed-Type
+  pr2 pr1-prod-Pointed-Type = refl
+
+  map-pr2-prod-Pointed-Type : type-Pointed-Type (A ×* B) → type-Pointed-Type B
+  map-pr2-prod-Pointed-Type = pr2
+
+  pr2-prod-Pointed-Type : (A ×* B) →* B
+  pr1 pr2-prod-Pointed-Type = map-pr2-prod-Pointed-Type
+  pr2 pr2-prod-Pointed-Type = refl
+```
+
+### The pointed product `A ×* B` comes equipped with pointed inclusion of `A` and `B`
+
+```agda
+  map-inl-prod-Pointed-Type : type-Pointed-Type A → type-Pointed-Type (A ×* B)
+  pr1 (map-inl-prod-Pointed-Type x) = x
+  pr2 (map-inl-prod-Pointed-Type x) = point-Pointed-Type B
+
+  inl-prod-Pointed-Type : A →* (A ×* B)
+  pr1 inl-prod-Pointed-Type = map-inl-prod-Pointed-Type
+  pr2 inl-prod-Pointed-Type = refl
+
+  map-inr-prod-Pointed-Type : type-Pointed-Type B → type-Pointed-Type (A ×* B)
+  pr1 (map-inr-prod-Pointed-Type y) = point-Pointed-Type A
+  pr2 (map-inr-prod-Pointed-Type y) = y
+
+  inr-prod-Pointed-Type : B →* (A ×* B)
+  pr1 inr-prod-Pointed-Type = map-inr-prod-Pointed-Type
+  pr2 inr-prod-Pointed-Type = refl
+```
+
+### The pointed inclusions into `A ×* B` are sections to the pointed projections
+
+```agda
+  issec-map-inl-prod-Pointed-Type :
+    (map-pr1-prod-Pointed-Type ∘ map-inl-prod-Pointed-Type) ~ id
+  issec-map-inl-prod-Pointed-Type = refl-htpy
+
+  issec-map-inr-prod-Pointed-Type :
+    (map-pr2-prod-Pointed-Type ∘ map-inr-prod-Pointed-Type) ~ id
+  issec-map-inr-prod-Pointed-Type = refl-htpy
+```
+
+### The pointed gap map for the pointed product
+
+```agda
+  map-gap-prod-Pointed-Type :
+    {l3 : Level} (S : Pointed-Type l3)
+    (f : S →* A) (g : S →* B) →
+    type-Pointed-Type S → type-Pointed-Type (A ×* B)
+  pr1 (map-gap-prod-Pointed-Type S f g x) = map-pointed-map S A f x
+  pr2 (map-gap-prod-Pointed-Type S f g x) = map-pointed-map S B g x
+
+  gap-prod-Pointed-Type :
+    {l3 : Level} (S : Pointed-Type l3)
+    (f : S →* A) (g : S →* B) → S →* (A ×* B)
+  pr1 (gap-prod-Pointed-Type S f g) =
+    map-gap-prod-Pointed-Type S f g
+  pr2 (gap-prod-Pointed-Type S f g) =
+     eq-pair
+      ( preserves-point-pointed-map S A f)
+      ( preserves-point-pointed-map S B g)
 ```

--- a/src/structured-types/pointed-cartesian-product-types.lagda.md
+++ b/src/structured-types/pointed-cartesian-product-types.lagda.md
@@ -39,54 +39,54 @@ module _
   pr1 (prod-Pointed-Type (A , a) (B , b)) = A × B
   pr2 (prod-Pointed-Type (A , a) (B , b)) = a , b
 
-  _×*_ = prod-Pointed-Type
+  _×∗_ = prod-Pointed-Type
 ```
 
 ## Properties
 
-### The pointed projections from the pointed product `A ×* B` onto `A` and `B`
+### The pointed projections from the pointed product `A ×∗ B` onto `A` and `B`
 
 ```agda
 module _
   {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2)
   where
 
-  map-pr1-prod-Pointed-Type : type-Pointed-Type (A ×* B) → type-Pointed-Type A
+  map-pr1-prod-Pointed-Type : type-Pointed-Type (A ×∗ B) → type-Pointed-Type A
   map-pr1-prod-Pointed-Type = pr1
 
-  pr1-prod-Pointed-Type : (A ×* B) →* A
+  pr1-prod-Pointed-Type : (A ×∗ B) →∗ A
   pr1 pr1-prod-Pointed-Type = map-pr1-prod-Pointed-Type
   pr2 pr1-prod-Pointed-Type = refl
 
-  map-pr2-prod-Pointed-Type : type-Pointed-Type (A ×* B) → type-Pointed-Type B
+  map-pr2-prod-Pointed-Type : type-Pointed-Type (A ×∗ B) → type-Pointed-Type B
   map-pr2-prod-Pointed-Type = pr2
 
-  pr2-prod-Pointed-Type : (A ×* B) →* B
+  pr2-prod-Pointed-Type : (A ×∗ B) →∗ B
   pr1 pr2-prod-Pointed-Type = map-pr2-prod-Pointed-Type
   pr2 pr2-prod-Pointed-Type = refl
 ```
 
-### The pointed product `A ×* B` comes equipped with pointed inclusion of `A` and `B`
+### The pointed product `A ×∗ B` comes equipped with pointed inclusion of `A` and `B`
 
 ```agda
-  map-inl-prod-Pointed-Type : type-Pointed-Type A → type-Pointed-Type (A ×* B)
+  map-inl-prod-Pointed-Type : type-Pointed-Type A → type-Pointed-Type (A ×∗ B)
   pr1 (map-inl-prod-Pointed-Type x) = x
   pr2 (map-inl-prod-Pointed-Type x) = point-Pointed-Type B
 
-  inl-prod-Pointed-Type : A →* (A ×* B)
+  inl-prod-Pointed-Type : A →∗ (A ×∗ B)
   pr1 inl-prod-Pointed-Type = map-inl-prod-Pointed-Type
   pr2 inl-prod-Pointed-Type = refl
 
-  map-inr-prod-Pointed-Type : type-Pointed-Type B → type-Pointed-Type (A ×* B)
+  map-inr-prod-Pointed-Type : type-Pointed-Type B → type-Pointed-Type (A ×∗ B)
   pr1 (map-inr-prod-Pointed-Type y) = point-Pointed-Type A
   pr2 (map-inr-prod-Pointed-Type y) = y
 
-  inr-prod-Pointed-Type : B →* (A ×* B)
+  inr-prod-Pointed-Type : B →∗ (A ×∗ B)
   pr1 inr-prod-Pointed-Type = map-inr-prod-Pointed-Type
   pr2 inr-prod-Pointed-Type = refl
 ```
 
-### The pointed inclusions into `A ×* B` are sections to the pointed projections
+### The pointed inclusions into `A ×∗ B` are sections to the pointed projections
 
 ```agda
   issec-map-inl-prod-Pointed-Type :
@@ -103,14 +103,14 @@ module _
 ```agda
   map-gap-prod-Pointed-Type :
     {l3 : Level} (S : Pointed-Type l3)
-    (f : S →* A) (g : S →* B) →
-    type-Pointed-Type S → type-Pointed-Type (A ×* B)
+    (f : S →∗ A) (g : S →∗ B) →
+    type-Pointed-Type S → type-Pointed-Type (A ×∗ B)
   pr1 (map-gap-prod-Pointed-Type S f g x) = map-pointed-map S A f x
   pr2 (map-gap-prod-Pointed-Type S f g x) = map-pointed-map S B g x
 
   gap-prod-Pointed-Type :
     {l3 : Level} (S : Pointed-Type l3)
-    (f : S →* A) (g : S →* B) → S →* (A ×* B)
+    (f : S →∗ A) (g : S →∗ B) → S →∗ (A ×∗ B)
   pr1 (gap-prod-Pointed-Type S f g) =
     map-gap-prod-Pointed-Type S f g
   pr2 (gap-prod-Pointed-Type S f g) =

--- a/src/structured-types/pointed-cartesian-product-types.lagda.md
+++ b/src/structured-types/pointed-cartesian-product-types.lagda.md
@@ -9,9 +9,7 @@ module structured-types.pointed-cartesian-product-types where
 ```agda
 open import foundation.cartesian-product-types
 open import foundation.dependent-pair-types
-open import foundation.embeddings
 open import foundation.equality-cartesian-product-types
-open import foundation.function-extensionality
 open import foundation.functions
 open import foundation.homotopies
 open import foundation.identity-types

--- a/src/structured-types/pointed-dependent-functions.lagda.md
+++ b/src/structured-types/pointed-dependent-functions.lagda.md
@@ -36,6 +36,15 @@ module _
       ( ev-point (point-Pointed-Type A) {fam-Pointed-Fam A B})
       ( point-Pointed-Fam A B)
 
+  Π∗ = pointed-Π
+```
+
+**Note**: the subscript asterisk symbol used for the pointed dependent function
+type `Π∗`, and pointed type constructions in general, is the
+[asterisk operator](https://codepoints.net/U+2217) `∗` (agda-input: `\ast`), not
+the [asterisk](https://codepoints.net/U+002A) `*`.
+
+```agda
   function-pointed-Π :
     pointed-Π → (x : type-Pointed-Type A) → fam-Pointed-Fam A B x
   function-pointed-Π = pr1

--- a/src/structured-types/pointed-dependent-functions.lagda.md
+++ b/src/structured-types/pointed-dependent-functions.lagda.md
@@ -33,7 +33,7 @@ module _
   pointed-Π : UU (l1 ⊔ l2)
   pointed-Π =
     fib
-      ( ev-point (point-Pointed-Type A) (fam-Pointed-Fam A B))
+      ( ev-point (point-Pointed-Type A) {fam-Pointed-Fam A B})
       ( point-Pointed-Fam A B)
 
   function-pointed-Π :

--- a/src/structured-types/pointed-dependent-functions.lagda.md
+++ b/src/structured-types/pointed-dependent-functions.lagda.md
@@ -33,8 +33,8 @@ module _
   pointed-Π : UU (l1 ⊔ l2)
   pointed-Π =
     fib
-      ( ev-pt (point-Pointed-Type A) (fam-Pointed-Fam A B))
-      ( pt-Pointed-Fam A B)
+      ( ev-point (point-Pointed-Type A) (fam-Pointed-Fam A B))
+      ( point-Pointed-Fam A B)
 
   function-pointed-Π :
     pointed-Π → (x : type-Pointed-Type A) → fam-Pointed-Fam A B x
@@ -42,6 +42,6 @@ module _
 
   preserves-point-function-pointed-Π :
     (f : pointed-Π) →
-    Id (function-pointed-Π f (point-Pointed-Type A)) (pt-Pointed-Fam A B)
+    Id (function-pointed-Π f (point-Pointed-Type A)) (point-Pointed-Fam A B)
   preserves-point-function-pointed-Π = pr2
 ```

--- a/src/structured-types/pointed-dependent-pair-types.lagda.md
+++ b/src/structured-types/pointed-dependent-pair-types.lagda.md
@@ -33,5 +33,10 @@ module _
   pr1 (Σ-Pointed-Type (A , a) (B , b)) = Σ A B
   pr2 (Σ-Pointed-Type (A , a) (B , b)) = a , b
 
-  Σ* = Σ-Pointed-Type
+  Σ∗ = Σ-Pointed-Type
 ```
+
+**Note**: the subscript asterisk symbol used for the pointed dependent pair type
+`Σ∗`, and pointed type constructions in general, is the
+[asterisk operator](https://codepoints.net/U+2217) `∗` (agda-input: `\ast`), not
+the [asterisk](https://codepoints.net/U+002A) `*`.

--- a/src/structured-types/pointed-equivalences.lagda.md
+++ b/src/structured-types/pointed-equivalences.lagda.md
@@ -47,22 +47,24 @@ module _
   {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2)
   where
 
-  is-equiv-pointed-map : (A →* B) → UU (l1 ⊔ l2)
+  is-equiv-pointed-map : (A →∗ B) → UU (l1 ⊔ l2)
   is-equiv-pointed-map f = is-equiv (map-pointed-map A B f)
 
-_≃*_ :
+pointed-equiv :
   {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) → UU (l1 ⊔ l2)
-A ≃* B =
+pointed-equiv A B =
   Σ ( type-Pointed-Type A ≃ type-Pointed-Type B)
-    ( λ e → Id (map-equiv e (point-Pointed-Type A)) (point-Pointed-Type B))
+    ( λ e → map-equiv e (point-Pointed-Type A) ＝ point-Pointed-Type B)
+
+_≃∗_ = pointed-equiv
 
 compute-pointed-equiv :
   {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) →
-  (A ≃* B) ≃ Σ (A →* B) (is-equiv-pointed-map A B)
+  (A ≃∗ B) ≃ Σ (A →∗ B) (is-equiv-pointed-map A B)
 compute-pointed-equiv A B = equiv-right-swap-Σ
 
 module _
-  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) (e : A ≃* B)
+  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) (e : A ≃∗ B)
   where
 
   equiv-pointed-equiv : type-Pointed-Type A ≃ type-Pointed-Type B
@@ -78,7 +80,7 @@ module _
     Id (map-equiv-pointed-equiv (point-Pointed-Type A)) (point-Pointed-Type B)
   preserves-point-equiv-pointed-equiv = pr2 e
 
-  pointed-map-pointed-equiv : A →* B
+  pointed-map-pointed-equiv : A →∗ B
   pr1 pointed-map-pointed-equiv = map-equiv-pointed-equiv
   pr2 pointed-map-pointed-equiv = preserves-point-equiv-pointed-equiv
 
@@ -90,7 +92,7 @@ module _
 ### The identity pointed equivalence
 
 ```agda
-id-pointed-equiv : {l : Level} (A : Pointed-Type l) → A ≃* A
+id-pointed-equiv : {l : Level} (A : Pointed-Type l) → A ≃∗ A
 pr1 (id-pointed-equiv A) = id-equiv
 pr2 (id-pointed-equiv A) = refl
 ```
@@ -100,7 +102,7 @@ pr2 (id-pointed-equiv A) = refl
 ```agda
 comp-pointed-equiv :
   {l1 l2 l3 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2)
-  (C : Pointed-Type l3) → (B ≃* C) → (A ≃* B) → (A ≃* C)
+  (C : Pointed-Type l3) → (B ≃∗ C) → (A ≃∗ B) → (A ≃∗ C)
 pr1 (comp-pointed-equiv A B C f e) =
   equiv-pointed-equiv B C f ∘e equiv-pointed-equiv A B e
 pr2 (comp-pointed-equiv A B C f e) =
@@ -113,12 +115,12 @@ pr2 (comp-pointed-equiv A B C f e) =
 
 ```agda
 module _
-  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) (f : A →* B)
+  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) (f : A →∗ B)
   where
 
   sec-pointed-map : UU (l1 ⊔ l2)
   sec-pointed-map =
-    Σ ( B →* A)
+    Σ ( B →∗ A)
       ( λ g →
         htpy-pointed-map B B
           ( comp-pointed-map B A B f g)
@@ -126,7 +128,7 @@ module _
 
   retr-pointed-map : UU (l1 ⊔ l2)
   retr-pointed-map =
-    Σ ( B →* A)
+    Σ ( B →∗ A)
       ( λ g →
         htpy-pointed-map A A
           ( comp-pointed-map A B A g f)
@@ -146,7 +148,7 @@ module _
   where
 
   is-contr-total-equiv-Pointed-Type :
-    is-contr (Σ (Pointed-Type l1) (λ B → A ≃* B))
+    is-contr (Σ (Pointed-Type l1) (λ B → A ≃∗ B))
   is-contr-total-equiv-Pointed-Type =
     is-contr-total-Eq-structure
       ( λ X x e → map-equiv e (point-Pointed-Type A) ＝ x)
@@ -154,7 +156,7 @@ module _
       ( pair (type-Pointed-Type A) id-equiv)
       ( is-contr-total-path (point-Pointed-Type A))
 
-  extensionality-Pointed-Type : (B : Pointed-Type l1) → Id A B ≃ (A ≃* B)
+  extensionality-Pointed-Type : (B : Pointed-Type l1) → Id A B ≃ (A ≃∗ B)
   extensionality-Pointed-Type =
     extensionality-Σ
       ( λ b e → Id (map-equiv e (point-Pointed-Type A)) b)
@@ -163,7 +165,7 @@ module _
       ( λ B → equiv-univalence)
       ( λ a → id-equiv)
 
-  eq-pointed-equiv : (B : Pointed-Type l1) → A ≃* B → Id A B
+  eq-pointed-equiv : (B : Pointed-Type l1) → A ≃∗ B → Id A B
   eq-pointed-equiv B = map-inv-equiv (extensionality-Pointed-Type B)
 ```
 
@@ -171,7 +173,7 @@ module _
 
 ```agda
 module _
-  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) (f : A →* B)
+  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) (f : A →∗ B)
   where
 
   is-contr-sec-is-equiv-pointed-map :
@@ -296,7 +298,7 @@ module _
 
 ```agda
 module _
-  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) (f : A →* B)
+  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) (f : A →∗ B)
   where
 
   is-equiv-is-equiv-precomp-pointed-map :
@@ -344,7 +346,7 @@ module _
                   ( left-unit-law-comp-pointed-map A B f))}))))
       ( pr1 G)
     where
-    g : B →* A
+    g : B →∗ A
     g = pr1 (center (is-contr-map-is-equiv (H A) id-pointed-map))
     G : htpy-pointed-map A A (comp-pointed-map A B A g f) id-pointed-map
     G = map-equiv
@@ -401,18 +403,18 @@ module _
     where
     I : is-iso-pointed-map A B f
     I = is-iso-is-equiv-pointed-map A B f E
-    g : B →* A
+    g : B →∗ A
     g = pr1 (pr1 I)
     G : htpy-pointed-map B B (comp-pointed-map B A B f g) id-pointed-map
     G = pr2 (pr1 I)
-    h : B →* A
+    h : B →∗ A
     h = pr1 (pr2 I)
     H : htpy-pointed-map A A (comp-pointed-map A B A h f) id-pointed-map
     H = pr2 (pr2 I)
 
 equiv-precomp-pointed-map :
   {l1 l2 l3 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2)
-  (C : Pointed-Type l3) → (A ≃* B) → (B →* C) ≃ (A →* C)
+  (C : Pointed-Type l3) → (A ≃∗ B) → (B →∗ C) ≃ (A →∗ C)
 pr1 (equiv-precomp-pointed-map A B C f) g =
   comp-pointed-map A B C g (pointed-map-pointed-equiv A B f)
 pr2 (equiv-precomp-pointed-map A B C f) =
@@ -426,7 +428,7 @@ pr2 (equiv-precomp-pointed-map A B C f) =
 
 ```agda
 module _
-  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) (f : A →* B)
+  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) (f : A →∗ B)
   where
 
   is-equiv-is-equiv-comp-pointed-map :
@@ -474,7 +476,7 @@ module _
                     ( f)
                     ( right-unit-law-comp-pointed-map A B f))}))))
     where
-    g : B →* A
+    g : B →∗ A
     g = pr1 (center (is-contr-map-is-equiv (H B) id-pointed-map))
     G : htpy-pointed-map B B (comp-pointed-map B A B f g) id-pointed-map
     G = map-equiv
@@ -533,11 +535,11 @@ module _
     where
     I : is-iso-pointed-map A B f
     I = is-iso-is-equiv-pointed-map A B f E
-    g : B →* A
+    g : B →∗ A
     g = pr1 (pr1 I)
     G : htpy-pointed-map B B (comp-pointed-map B A B f g) id-pointed-map
     G = pr2 (pr1 I)
-    h : B →* A
+    h : B →∗ A
     h = pr1 (pr2 I)
     H : htpy-pointed-map A A (comp-pointed-map A B A h f) id-pointed-map
     H = pr2 (pr2 I)

--- a/src/structured-types/pointed-families-of-types.lagda.md
+++ b/src/structured-types/pointed-families-of-types.lagda.md
@@ -37,8 +37,8 @@ module _
   fam-Pointed-Fam : type-Pointed-Type A → UU l2
   fam-Pointed-Fam = pr1 B
 
-  pt-Pointed-Fam : fam-Pointed-Fam (point-Pointed-Type A)
-  pt-Pointed-Fam = pr2 B
+  point-Pointed-Fam : fam-Pointed-Fam (point-Pointed-Type A)
+  point-Pointed-Fam = pr2 B
 ```
 
 ## Examples

--- a/src/structured-types/pointed-homotopies.lagda.md
+++ b/src/structured-types/pointed-homotopies.lagda.md
@@ -169,7 +169,7 @@ module _
             ( concat (pr2 f) (function-pointed-Π A B h (point-Pointed-Type A)))
             ( ( inv (assoc (inv (pr2 g)) (pr2 g) (inv (pr2 h)))) ∙
               ( ap
-                ( concat' (pt-Pointed-Fam A B) (inv (pr2 h)))
+                ( concat' (point-Pointed-Fam A B) (inv (pr2 h)))
                 ( left-inv (pr2 g)))))))
 
   inv-htpy-pointed-Π :
@@ -208,7 +208,7 @@ module _
             ( ( ( ( ap-inv (pr1 g) (pr2 f2)) ∙
                   ( ap
                     ( concat'
-                      ( pr1 g (pt-Pointed-Fam A (constant-Pointed-Fam A B)))
+                      ( pr1 g (point-Pointed-Fam A (constant-Pointed-Fam A B)))
                       ( inv (ap (pr1 g) (pr2 f2)))))
                   ( inv (right-inv (pr2 g)))) ∙
                 ( assoc

--- a/src/structured-types/pointed-homotopies.lagda.md
+++ b/src/structured-types/pointed-homotopies.lagda.md
@@ -66,10 +66,10 @@ module _
     (g : pointed-Π A B) → (htpy-pointed-Π g) → Id f g
   eq-htpy-pointed-Π g = map-inv-equiv (extensionality-pointed-Π g)
 
-_~*_ :
+_~∗_ :
   {l1 l2 : Level} {A : Pointed-Type l1} {B : Pointed-Fam l2 A} →
   pointed-Π A B → pointed-Π A B → UU (l1 ⊔ l2)
-_~*_ {A = A} {B} = htpy-pointed-Π A B
+_~∗_ {A = A} {B} = htpy-pointed-Π A B
 ```
 
 ## Properties
@@ -78,19 +78,19 @@ _~*_ {A = A} {B} = htpy-pointed-Π A B
 
 ```agda
 module _
-  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) (f : A →* B)
+  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) (f : A →∗ B)
   where
 
-  htpy-pointed-map : (g : A →* B) → UU (l1 ⊔ l2)
+  htpy-pointed-map : (g : A →∗ B) → UU (l1 ⊔ l2)
   htpy-pointed-map = htpy-pointed-Π A (constant-Pointed-Fam A B) f
 
   extensionality-pointed-map :
-    (g : A →* B) → Id f g ≃ (htpy-pointed-map g)
+    (g : A →∗ B) → Id f g ≃ (htpy-pointed-map g)
   extensionality-pointed-map =
     extensionality-pointed-Π A (constant-Pointed-Fam A B) f
 
   eq-htpy-pointed-map :
-    (g : A →* B) → (htpy-pointed-map g) → Id f g
+    (g : A →∗ B) → (htpy-pointed-map g) → Id f g
   eq-htpy-pointed-map g = map-inv-equiv (extensionality-pointed-map g)
 ```
 
@@ -98,7 +98,7 @@ module _
 
 ```agda
 module _
-  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) (f : A →* B)
+  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) (f : A →∗ B)
   where
 
   left-unit-law-comp-pointed-map :
@@ -128,7 +128,7 @@ module _
   associative-comp-pointed-map :
     (A : Pointed-Type l1) (B : Pointed-Type l2)
     (C : Pointed-Type l3) (D : Pointed-Type l4)
-    (h : C →* D) (g : B →* C) (f : A →* B) →
+    (h : C →∗ D) (g : B →∗ C) (f : A →∗ B) →
     htpy-pointed-map A D
       ( comp-pointed-map A B D (comp-pointed-map B C D h g) f)
       ( comp-pointed-map A C D h (comp-pointed-map A B C g f))
@@ -140,7 +140,7 @@ module _
   inv-associative-comp-pointed-map :
     (A : Pointed-Type l1) (B : Pointed-Type l2)
     (C : Pointed-Type l3) (D : Pointed-Type l4)
-    (h : C →* D) (g : B →* C) (f : A →* B) →
+    (h : C →∗ D) (g : B →∗ C) (f : A →∗ B) →
     htpy-pointed-map A D
       ( comp-pointed-map A C D h (comp-pointed-map A B C g f))
       ( comp-pointed-map A B D (comp-pointed-map B C D h g) f)
@@ -191,7 +191,7 @@ module _
   where
 
   left-whisker-htpy-pointed-map :
-    (g : B →* C) (f1 f2 : A →* B) (H : htpy-pointed-map A B f1 f2) →
+    (g : B →∗ C) (f1 f2 : A →∗ B) (H : htpy-pointed-map A B f1 f2) →
     htpy-pointed-map A C
       ( comp-pointed-map A B C g f1)
       ( comp-pointed-map A B C g f2)
@@ -236,7 +236,7 @@ module _
 
   right-whisker-htpy-pointed-map :
     (A : Pointed-Type l1) (B : Pointed-Type l2) (C : Pointed-Type l3)
-    (g1 g2 : B →* C) (H : htpy-pointed-map B C g1 g2) (f : A →* B) →
+    (g1 g2 : B →∗ C) (H : htpy-pointed-map B C g1 g2) (f : A →∗ B) →
     htpy-pointed-map A C
       ( comp-pointed-map A B C g1 f)
       ( comp-pointed-map A B C g2 f)
@@ -249,7 +249,7 @@ module _
   where
 
   concat-htpy-pointed-map :
-    (f g h : A →* B) → htpy-pointed-map A B f g → htpy-pointed-map A B g h →
+    (f g h : A →∗ B) → htpy-pointed-map A B f g → htpy-pointed-map A B g h →
     htpy-pointed-map A B f h
   concat-htpy-pointed-map = concat-htpy-pointed-Π A (constant-Pointed-Fam A B)
 ```

--- a/src/structured-types/pointed-homotopies.lagda.md
+++ b/src/structured-types/pointed-homotopies.lagda.md
@@ -81,6 +81,11 @@ module _
   {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) (f : A →∗ B)
   where
 
+  refl-htpy-pointed-map : f ~∗ f
+  pr1 refl-htpy-pointed-map = refl-htpy
+  pr2 refl-htpy-pointed-map =
+    inv (right-inv (preserves-point-pointed-map A B f))
+
   htpy-pointed-map : (g : A →∗ B) → UU (l1 ⊔ l2)
   htpy-pointed-map = htpy-pointed-Π A (constant-Pointed-Fam A B) f
 

--- a/src/structured-types/pointed-maps.lagda.md
+++ b/src/structured-types/pointed-maps.lagda.md
@@ -34,17 +34,20 @@ module _
   {l1 l2 : Level}
   where
 
-  _→*_ : Pointed-Type l1 → Pointed-Type l2 → UU (l1 ⊔ l2)
-  A →* B = pointed-Π A (constant-Pointed-Fam A B)
+  pointed-map : Pointed-Type l1 → Pointed-Type l2 → UU (l1 ⊔ l2)
+  pointed-map A B = pointed-Π A (constant-Pointed-Fam A B)
+
+  _→*_ = pointed-map
 
   constant-pointed-map : (A : Pointed-Type l1) (B : Pointed-Type l2) → A →* B
   pr1 (constant-pointed-map A B) =
     const (type-Pointed-Type A) (type-Pointed-Type B) (point-Pointed-Type B)
   pr2 (constant-pointed-map A B) = refl
 
-  [_→*_] : Pointed-Type l1 → Pointed-Type l2 → Pointed-Type (l1 ⊔ l2)
-  pr1 [ A →* B ] = A →* B
-  pr2 [ A →* B ] = constant-pointed-map A B
+  pointed-map-Pointed-Type :
+    Pointed-Type l1 → Pointed-Type l2 → Pointed-Type (l1 ⊔ l2)
+  pr1 (pointed-map-Pointed-Type A B) = pointed-map A B
+  pr2 (pointed-map-Pointed-Type A B) = constant-pointed-map A B
 
 module _
   {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2)
@@ -99,7 +102,7 @@ module _
   where
 
   map-comp-pointed-map :
-    B →* C → A →* B → (type-Pointed-Type A) → (type-Pointed-Type C)
+    B →* C → A →* B → type-Pointed-Type A → type-Pointed-Type C
   map-comp-pointed-map g f =
     map-pointed-map B C g ∘ map-pointed-map A B f
 

--- a/src/structured-types/pointed-maps.lagda.md
+++ b/src/structured-types/pointed-maps.lagda.md
@@ -59,7 +59,7 @@ module _
   preserves-point-pointed-map f = pr2 f
 ```
 
-### Precomposing pointed pointed maps
+### Precomposing pointed maps
 
 ```agda
 module _
@@ -68,27 +68,26 @@ module _
   where
 
   precomp-Pointed-Fam : Pointed-Fam l3 A
-  precomp-Pointed-Fam =
-    pair
-      ( fam-Pointed-Fam B C ∘ map-pointed-map A B f)
-      ( tr
-        ( fam-Pointed-Fam B C)
-        ( inv (preserves-point-pointed-map A B f))
-        ( pt-Pointed-Fam B C))
+  pr1 precomp-Pointed-Fam = fam-Pointed-Fam B C ∘ map-pointed-map A B f
+  pr2 precomp-Pointed-Fam =
+    tr
+      ( fam-Pointed-Fam B C)
+      ( inv (preserves-point-pointed-map A B f))
+      ( point-Pointed-Fam B C)
 
   precomp-pointed-Π : pointed-Π B C → pointed-Π A precomp-Pointed-Fam
-  precomp-pointed-Π g =
-    pair
-      ( λ x → function-pointed-Π B C g (map-pointed-map A B f x))
-      ( ( inv
-          ( apd
-            ( function-pointed-Π B C g)
-            ( inv (preserves-point-pointed-map A B f)))) ∙
-        ( ap
-          ( tr
-            ( fam-Pointed-Fam B C)
-            ( inv (preserves-point-pointed-map A B f)))
-          ( preserves-point-function-pointed-Π B C g)))
+  pr1 (precomp-pointed-Π g) x =
+    function-pointed-Π B C g (map-pointed-map A B f x)
+  pr2 (precomp-pointed-Π g) =
+    ( inv
+      ( apd
+        ( function-pointed-Π B C g)
+        ( inv (preserves-point-pointed-map A B f)))) ∙
+    ( ap
+      ( tr
+        ( fam-Pointed-Fam B C)
+        ( inv (preserves-point-pointed-map A B f)))
+      ( preserves-point-function-pointed-Π B C g))
 ```
 
 ### Composing pointed maps
@@ -133,5 +132,6 @@ module _
   where
 
   id-pointed-map : A →* A
-  id-pointed-map = pair id refl
+  pr1 id-pointed-map = id
+  pr2 id-pointed-map = refl
 ```

--- a/src/structured-types/pointed-maps.lagda.md
+++ b/src/structured-types/pointed-maps.lagda.md
@@ -37,9 +37,16 @@ module _
   pointed-map : Pointed-Type l1 → Pointed-Type l2 → UU (l1 ⊔ l2)
   pointed-map A B = pointed-Π A (constant-Pointed-Fam A B)
 
-  _→*_ = pointed-map
+  _→∗_ = pointed-map
+```
 
-  constant-pointed-map : (A : Pointed-Type l1) (B : Pointed-Type l2) → A →* B
+**Note**: the subscript asterisk symbol used for the pointed map type `_→∗_`,
+and pointed type constructions in general, is the
+[asterisk operator](https://codepoints.net/U+2217) `∗` (agda-input: `\ast`), not
+the [asterisk](https://codepoints.net/U+002A) `*`.
+
+```agda
+  constant-pointed-map : (A : Pointed-Type l1) (B : Pointed-Type l2) → A →∗ B
   pr1 (constant-pointed-map A B) =
     const (type-Pointed-Type A) (type-Pointed-Type B) (point-Pointed-Type B)
   pr2 (constant-pointed-map A B) = refl
@@ -53,11 +60,11 @@ module _
   {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2)
   where
 
-  map-pointed-map : A →* B → type-Pointed-Type A → type-Pointed-Type B
+  map-pointed-map : A →∗ B → type-Pointed-Type A → type-Pointed-Type B
   map-pointed-map = pr1
 
   preserves-point-pointed-map :
-    (f : A →* B) →
+    (f : A →∗ B) →
     map-pointed-map f (point-Pointed-Type A) ＝ point-Pointed-Type B
   preserves-point-pointed-map = pr2
 ```
@@ -67,7 +74,7 @@ module _
 ```agda
 module _
   {l1 l2 l3 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2)
-  (C : Pointed-Fam l3 B) (f : A →* B)
+  (C : Pointed-Fam l3 B) (f : A →∗ B)
   where
 
   precomp-Pointed-Fam : Pointed-Fam l3 A
@@ -102,29 +109,29 @@ module _
   where
 
   map-comp-pointed-map :
-    B →* C → A →* B → type-Pointed-Type A → type-Pointed-Type C
+    B →∗ C → A →∗ B → type-Pointed-Type A → type-Pointed-Type C
   map-comp-pointed-map g f =
     map-pointed-map B C g ∘ map-pointed-map A B f
 
   preserves-point-comp-pointed-map :
-    (g : B →* C) (f : A →* B) →
+    (g : B →∗ C) (f : A →∗ B) →
     (map-comp-pointed-map g f (point-Pointed-Type A)) ＝ point-Pointed-Type C
   preserves-point-comp-pointed-map g f =
     ( ap (map-pointed-map B C g) (preserves-point-pointed-map A B f)) ∙
     ( preserves-point-pointed-map B C g)
 
-  comp-pointed-map : B →* C → A →* B → A →* C
+  comp-pointed-map : B →∗ C → A →∗ B → A →∗ C
   pr1 (comp-pointed-map g f) = map-comp-pointed-map g f
   pr2 (comp-pointed-map g f) = preserves-point-comp-pointed-map g f
 
-  precomp-pointed-map : A →* B → B →* C → A →* C
+  precomp-pointed-map : A →∗ B → B →∗ C → A →∗ C
   precomp-pointed-map f g = comp-pointed-map g f
 
-_∘*_ :
+_∘∗_ :
   {l1 l2 l3 : Level}
   {A : Pointed-Type l1} {B : Pointed-Type l2} {C : Pointed-Type l3} →
-  B →* C → A →* B → A →* C
-_∘*_ {A = A} {B} {C} = comp-pointed-map A B C
+  B →∗ C → A →∗ B → A →∗ C
+_∘∗_ {A = A} {B} {C} = comp-pointed-map A B C
 ```
 
 ### The identity pointed map
@@ -134,7 +141,7 @@ module _
   {l1 : Level} {A : Pointed-Type l1}
   where
 
-  id-pointed-map : A →* A
+  id-pointed-map : A →∗ A
   pr1 id-pointed-map = id
   pr2 id-pointed-map = refl
 ```

--- a/src/structured-types/pointed-maps.lagda.md
+++ b/src/structured-types/pointed-maps.lagda.md
@@ -51,12 +51,12 @@ module _
   where
 
   map-pointed-map : A →* B → type-Pointed-Type A → type-Pointed-Type B
-  map-pointed-map f = pr1 f
+  map-pointed-map = pr1
 
   preserves-point-pointed-map :
     (f : A →* B) →
     map-pointed-map f (point-Pointed-Type A) ＝ point-Pointed-Type B
-  preserves-point-pointed-map f = pr2 f
+  preserves-point-pointed-map = pr2
 ```
 
 ### Precomposing pointed maps

--- a/src/structured-types/pointed-sections.lagda.md
+++ b/src/structured-types/pointed-sections.lagda.md
@@ -19,14 +19,14 @@ open import structured-types.pointed-types
 
 ## Idea
 
-A **pointed section** of a pointed map `f : A →* B` consists of a pointed map
-`g : B →* A` equipped with a pointed homotopy `H : (f ∘* g) ~* id`.
+A **pointed section** of a pointed map `f : A →∗ B` consists of a pointed map
+`g : B →∗ A` equipped with a pointed homotopy `H : (f ∘∗ g) ~∗ id`.
 
 ```agda
 pointed-section-Pointed-Type :
   {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) →
-  (A →* B) → UU (l1 ⊔ l2)
+  (A →∗ B) → UU (l1 ⊔ l2)
 pointed-section-Pointed-Type A B f =
-  Σ ( B →* A)
-    ( λ g → (f ∘* g) ~* id-pointed-map)
+  Σ ( B →∗ A)
+    ( λ g → (f ∘∗ g) ~∗ id-pointed-map)
 ```

--- a/src/structured-types/pointed-types-equipped-with-automorphisms.lagda.md
+++ b/src/structured-types/pointed-types-equipped-with-automorphisms.lagda.md
@@ -173,7 +173,7 @@ is-contr-total-htpy-hom-Pointed-Type-With-Aut X Y h1 =
     ( is-contr-total-htpy (map-hom-Pointed-Type-With-Aut X Y h1))
     ( pair (map-hom-Pointed-Type-With-Aut X Y h1) refl-htpy)
     ( is-contr-total-Eq-structure
-      ( λ ( pt-h2 :
+      ( λ ( point-h2 :
             ( map-hom-Pointed-Type-With-Aut X Y h1
               ( point-Pointed-Type-With-Aut X)) ＝
             ( point-Pointed-Type-With-Aut Y))
@@ -183,7 +183,8 @@ is-contr-total-htpy-hom-Pointed-Type-With-Aut X Y h1 =
               ( map-aut-Pointed-Type-With-Aut X x)) ＝
             ( map-aut-Pointed-Type-With-Aut Y
               ( map-hom-Pointed-Type-With-Aut X Y h1 x)))
-          ( α : preserves-point-map-hom-Pointed-Type-With-Aut X Y h1 ＝ pt-h2) →
+          ( α :
+            preserves-point-map-hom-Pointed-Type-With-Aut X Y h1 ＝ point-h2) →
           ( ( x : type-Pointed-Type-With-Aut X) →
             ( ( preserves-aut-map-hom-Pointed-Type-With-Aut X Y h1 x) ∙
               ( refl)) ＝

--- a/src/structured-types/pointed-unit-type.lagda.md
+++ b/src/structured-types/pointed-unit-type.lagda.md
@@ -33,12 +33,12 @@ pr2 unit-Pointed-Type = star
 ## Properties
 
 ```agda
-terminal-pointed-map : {l : Level} (X : Pointed-Type l) → X →* unit-Pointed-Type
+terminal-pointed-map : {l : Level} (X : Pointed-Type l) → X →∗ unit-Pointed-Type
 pr1 (terminal-pointed-map X) _ = star
 pr2 (terminal-pointed-map X) = refl
 
 inclusion-point-Pointed-Type :
-  {l : Level} (X : Pointed-Type l) → unit-Pointed-Type →* X
+  {l : Level} (X : Pointed-Type l) → unit-Pointed-Type →∗ X
 pr1 (inclusion-point-Pointed-Type X) = point (point-Pointed-Type X)
 pr2 (inclusion-point-Pointed-Type X) = refl
 ```

--- a/src/structured-types/pointed-unit-type.lagda.md
+++ b/src/structured-types/pointed-unit-type.lagda.md
@@ -25,19 +25,19 @@ The pointed unit type is the initial pointed type.
 ## Definition
 
 ```agda
-pointed-unit : Pointed-Type lzero
-pr1 pointed-unit = unit
-pr2 pointed-unit = star
+unit-Pointed-Type : Pointed-Type lzero
+pr1 unit-Pointed-Type = unit
+pr2 unit-Pointed-Type = star
 ```
 
 ## Properties
 
 ```agda
-gap-pointed-unit : {l : Level} (X : Pointed-Type l) → X →* pointed-unit
-pr1 (gap-pointed-unit X) _ = star
-pr2 (gap-pointed-unit X) = refl
+gap-unit-Pointed-Type : {l : Level} (X : Pointed-Type l) → X →* unit-Pointed-Type
+pr1 (gap-unit-Pointed-Type X) _ = star
+pr2 (gap-unit-Pointed-Type X) = refl
 
-cogap-pointed-unit : {l : Level} (X : Pointed-Type l) → pointed-unit →* X
-pr1 (cogap-pointed-unit X) _ = point-Pointed-Type X
-pr2 (cogap-pointed-unit X) = refl
+cogap-unit-Pointed-Type : {l : Level} (X : Pointed-Type l) → unit-Pointed-Type →* X
+pr1 (cogap-unit-Pointed-Type X) _ = point-Pointed-Type X
+pr2 (cogap-unit-Pointed-Type X) = refl
 ```

--- a/src/structured-types/pointed-unit-type.lagda.md
+++ b/src/structured-types/pointed-unit-type.lagda.md
@@ -1,0 +1,43 @@
+# The pointed unit type
+
+```agda
+module structured-types.pointed-unit-type where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.dependent-pair-types
+open import foundation.identity-types
+open import foundation.unit-type
+open import foundation.universe-levels
+
+open import structured-types.pointed-maps
+open import structured-types.pointed-types
+```
+
+</details>
+
+## Idea
+
+The pointed unit type is the initial pointed type.
+
+## Definition
+
+```agda
+pointed-unit : Pointed-Type lzero
+pr1 pointed-unit = unit
+pr2 pointed-unit = star
+```
+
+## Properties
+
+```agda
+gap-pointed-unit : {l : Level} (X : Pointed-Type l) → X →* pointed-unit
+pr1 (gap-pointed-unit X) _ = star
+pr2 (gap-pointed-unit X) = refl
+
+cogap-pointed-unit : {l : Level} (X : Pointed-Type l) → pointed-unit →* X
+pr1 (cogap-pointed-unit X) _ = point-Pointed-Type X
+pr2 (cogap-pointed-unit X) = refl
+```

--- a/src/structured-types/pointed-unit-type.lagda.md
+++ b/src/structured-types/pointed-unit-type.lagda.md
@@ -33,11 +33,12 @@ pr2 unit-Pointed-Type = star
 ## Properties
 
 ```agda
-gap-unit-Pointed-Type : {l : Level} (X : Pointed-Type l) → X →* unit-Pointed-Type
-pr1 (gap-unit-Pointed-Type X) _ = star
-pr2 (gap-unit-Pointed-Type X) = refl
+terminal-pointed-map : {l : Level} (X : Pointed-Type l) → X →* unit-Pointed-Type
+pr1 (terminal-pointed-map X) _ = star
+pr2 (terminal-pointed-map X) = refl
 
-cogap-unit-Pointed-Type : {l : Level} (X : Pointed-Type l) → unit-Pointed-Type →* X
-pr1 (cogap-unit-Pointed-Type X) _ = point-Pointed-Type X
-pr2 (cogap-unit-Pointed-Type X) = refl
+inclusion-point-Pointed-Type :
+  {l : Level} (X : Pointed-Type l) → unit-Pointed-Type →* X
+pr1 (inclusion-point-Pointed-Type X) = point (point-Pointed-Type X)
+pr2 (inclusion-point-Pointed-Type X) = refl
 ```

--- a/src/structured-types/wild-monoids.lagda.md
+++ b/src/structured-types/wild-monoids.lagda.md
@@ -162,7 +162,7 @@ module _
       ( wild-unital-magma-Wild-Monoid N)
 
   pointed-map-hom-Wild-Monoid :
-    hom-Wild-Monoid → pointed-type-Wild-Monoid M →* pointed-type-Wild-Monoid N
+    hom-Wild-Monoid → pointed-type-Wild-Monoid M →∗ pointed-type-Wild-Monoid N
   pointed-map-hom-Wild-Monoid f = pr1 f
 
   map-hom-Wild-Monoid :

--- a/src/synthetic-homotopy-theory.lagda.md
+++ b/src/synthetic-homotopy-theory.lagda.md
@@ -29,6 +29,7 @@ open import synthetic-homotopy-theory.plus-principle public
 open import synthetic-homotopy-theory.powers-of-loops public
 open import synthetic-homotopy-theory.prespectra public
 open import synthetic-homotopy-theory.pushouts public
+open import synthetic-homotopy-theory.smash-products-of-pointed-types public
 open import synthetic-homotopy-theory.spectra public
 open import synthetic-homotopy-theory.spheres public
 open import synthetic-homotopy-theory.suspensions-of-types public

--- a/src/synthetic-homotopy-theory.lagda.md
+++ b/src/synthetic-homotopy-theory.lagda.md
@@ -29,6 +29,7 @@ open import synthetic-homotopy-theory.plus-principle public
 open import synthetic-homotopy-theory.powers-of-loops public
 open import synthetic-homotopy-theory.prespectra public
 open import synthetic-homotopy-theory.pushouts public
+open import synthetic-homotopy-theory.pushouts-of-pointed-types public
 open import synthetic-homotopy-theory.smash-products-of-pointed-types public
 open import synthetic-homotopy-theory.spectra public
 open import synthetic-homotopy-theory.spheres public

--- a/src/synthetic-homotopy-theory.lagda.md
+++ b/src/synthetic-homotopy-theory.lagda.md
@@ -11,6 +11,7 @@ open import synthetic-homotopy-theory.acyclic-maps public
 open import synthetic-homotopy-theory.acyclic-types public
 open import synthetic-homotopy-theory.circle public
 open import synthetic-homotopy-theory.cocones-under-spans public
+open import synthetic-homotopy-theory.cocones-under-spans-of-pointed-types public
 open import synthetic-homotopy-theory.cofibers public
 open import synthetic-homotopy-theory.descent-circle public
 open import synthetic-homotopy-theory.double-loop-spaces public

--- a/src/synthetic-homotopy-theory/26-id-pushout.lagda.md
+++ b/src/synthetic-homotopy-theory/26-id-pushout.lagda.md
@@ -280,18 +280,18 @@ equiv-hom-Fam-pushout-map c up-X P Q =
 ### Definition 19.2.1 Universal families over spans
 
 ```agda
-ev-pt-hom-Fam-pushout :
+ev-point-hom-Fam-pushout :
   { l1 l2 l3 l4 l5 : Level} {S : UU l1} {A : UU l2} {B : UU l3}
   { f : S → A} {g : S → B} (P : Fam-pushout l4 f g) (Q : Fam-pushout l5 f g)
   {a : A} → (pr1 P a) → (hom-Fam-pushout P Q) → pr1 Q a
-ev-pt-hom-Fam-pushout P Q {a} p h = pr1 h a p
+ev-point-hom-Fam-pushout P Q {a} p h = pr1 h a p
 
 is-universal-Fam-pushout :
   { l1 l2 l3 l4 : Level} (l : Level) {S : UU l1} {A : UU l2} {B : UU l3}
   { f : S → A} {g : S → B} (P : Fam-pushout l4 f g) (a : A) (p : pr1 P a) →
   UU (l1 ⊔ l2 ⊔ l3 ⊔ l4 ⊔ lsuc l)
 is-universal-Fam-pushout l {f = f} {g} P a p =
-  ( Q : Fam-pushout l f g) → is-equiv (ev-pt-hom-Fam-pushout P Q p)
+  ( Q : Fam-pushout l f g) → is-equiv (ev-point-hom-Fam-pushout P Q p)
 ```
 
 ### Lemma 19.2.2 The descent data of the identity type is a universal family
@@ -302,7 +302,7 @@ triangle-is-universal-id-Fam-pushout' :
   { f : S → A} {g : S → B} (c : cocone f g X)
   (a : A) ( Q : (x : X) → UU l) →
   ( ev-refl (pr1 c a) {B = λ x p → Q x}) ~
-  ( ( ev-pt-hom-Fam-pushout
+  ( ( ev-point-hom-Fam-pushout
       ( desc-fam c (Id (pr1 c a)))
       ( desc-fam c Q)
       ( refl)) ∘
@@ -315,14 +315,14 @@ is-universal-id-Fam-pushout' :
   ( up-X : (l' : Level) → universal-property-pushout l' f g c) (a : A) →
   ( Q : (x : X) → UU l) →
   is-equiv
-    ( ev-pt-hom-Fam-pushout
+    ( ev-point-hom-Fam-pushout
       ( desc-fam c (Id (pr1 c a)))
       ( desc-fam c Q)
       ( refl))
 is-universal-id-Fam-pushout' c up-X a Q =
   is-equiv-left-factor-htpy
     ( ev-refl (pr1 c a) {B = λ x p → Q x})
-    ( ev-pt-hom-Fam-pushout
+    ( ev-point-hom-Fam-pushout
       ( desc-fam c (Id (pr1 c a)))
       ( desc-fam c Q)
       ( refl))
@@ -342,7 +342,7 @@ is-universal-id-Fam-pushout l {S = S} {A} {B} {X} {f} {g} c up-X a Q =
     ( equiv-precomp-Π
       ( equiv-desc-fam c up-X)
       ( λ (Q : Fam-pushout l f g) →
-        is-equiv (ev-pt-hom-Fam-pushout
+        is-equiv (ev-point-hom-Fam-pushout
           ( desc-fam c (Id (pr1 c a))) Q refl)))
     ( is-universal-id-Fam-pushout' c up-X a)
     ( Q)

--- a/src/synthetic-homotopy-theory/27-sequences.lagda.md
+++ b/src/synthetic-homotopy-theory/27-sequences.lagda.md
@@ -123,9 +123,9 @@ triangle-cocone-sequence A c = pr2 c
 
 ```agda
 naturality-htpy-cocone-sequence :
-  { l1 l2 : Level} (A : Sequence l1) {X : UU l2} (c c' : cocone-sequence A X) →
-  ( H : (n : ℕ) →
-    (map-cocone-sequence A c n) ~ (map-cocone-sequence A c' n)) →
+  { l1 l2 : Level} (A : Sequence l1)
+  {X : UU l2} (c c' : cocone-sequence A X) →
+  ( H : (n : ℕ) → (map-cocone-sequence A c n) ~ (map-cocone-sequence A c' n)) →
   ( n : ℕ) → UU (l1 ⊔ l2)
 naturality-htpy-cocone-sequence A c c' H n =
   ( (H n) ∙h (triangle-cocone-sequence A c' n)) ~

--- a/src/synthetic-homotopy-theory/cavallos-trick.lagda.md
+++ b/src/synthetic-homotopy-theory/cavallos-trick.lagda.md
@@ -59,5 +59,5 @@ module _
 - Cavallo's trick was originally formalized in the
   [cubical agda library](https://agda.github.io/cubical/Cubical.Foundations.Pointed.Homogeneous.html).
 - The above generalization was found by Buchholtz, Christensen, Rijke, and
-  Taxerȧs Flaten, in
+  Taxerås Flaten, in
   [Central H-spaces and banded types](https://arxiv.org/abs/2301.02636)

--- a/src/synthetic-homotopy-theory/cavallos-trick.lagda.md
+++ b/src/synthetic-homotopy-theory/cavallos-trick.lagda.md
@@ -36,8 +36,8 @@ module _
   where
 
   cavallos-trick :
-    (f g : A →* B) → sec (λ (H : id ~ id) → H (point-Pointed-Type B)) →
-    (map-pointed-map A B f ~ map-pointed-map A B g) → f ~* g
+    (f g : A →∗ B) → sec (λ (H : id ~ id) → H (point-Pointed-Type B)) →
+    (map-pointed-map A B f ~ map-pointed-map A B g) → f ~∗ g
   pr1 (cavallos-trick (f , refl) (g , q) (K , α) H) a =
     K (inv q ∙ inv (H (point-Pointed-Type A))) (f a) ∙ H a
   pr2 (cavallos-trick (f , refl) (g , q) (K , α) H) =

--- a/src/synthetic-homotopy-theory/cocones-under-spans-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/cocones-under-spans-of-pointed-types.lagda.md
@@ -22,9 +22,7 @@ open import synthetic-homotopy-theory.cocones-under-spans
 
 ## Idea
 
-## Definitions
-
-### Cocones
+## Definition
 
 ```agda
 module _
@@ -48,7 +46,11 @@ module _
   pr1 (pr2 (cocone-Pointed-Type X)) = constant-pointed-map A X
   pr1 (pr2 (pr2 (cocone-Pointed-Type X))) = constant-pointed-map B X
   pr2 (pr2 (pr2 (cocone-Pointed-Type X))) = refl-htpy
+```
 
+### Components of a cocone of pointed types
+
+```agda
 module _
   {l1 l2 l3 l4 : Level}
   {S : Pointed-Type l1} {A : Pointed-Type l2}
@@ -86,3 +88,7 @@ module _
   pr2 (pr2 cocone-type-cocone-Pointed-Type) =
     coherence-square-cocone-Pointed-Type
 ```
+
+## See also
+
+- [Pushouts of pointed types](synthetic-homotopy-theory.pushouts-of-pointed-types.md)

--- a/src/synthetic-homotopy-theory/cocones-under-spans-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/cocones-under-spans-of-pointed-types.lagda.md
@@ -29,15 +29,15 @@ module _
   {l1 l2 l3 : Level}
   {S : Pointed-Type l1} {A : Pointed-Type l2}
   {B : Pointed-Type l3}
-  (f : S →* A) (g : S →* B)
+  (f : S →∗ A) (g : S →∗ B)
   where
 
   type-cocone-Pointed-Type :
     {l4 : Level} → Pointed-Type l4 → UU (l1 ⊔ l2 ⊔ l3 ⊔ l4)
   type-cocone-Pointed-Type X =
-    Σ ( A →* X)
+    Σ ( A →∗ X)
       ( λ i →
-        Σ ( B →* X)
+        Σ ( B →∗ X)
           ( λ j → coherence-square-maps (pr1 g) (pr1 f) (pr1 j) (pr1 i)))
 
   cocone-Pointed-Type :
@@ -55,10 +55,10 @@ module _
   {l1 l2 l3 l4 : Level}
   {S : Pointed-Type l1} {A : Pointed-Type l2}
   {B : Pointed-Type l3} {X : Pointed-Type l4}
-  (f : S →* A) (g : S →* B) (c : type-cocone-Pointed-Type f g X)
+  (f : S →∗ A) (g : S →∗ B) (c : type-cocone-Pointed-Type f g X)
   where
 
-  horizontal-pointed-map-cocone-Pointed-Type : A →* X
+  horizontal-pointed-map-cocone-Pointed-Type : A →∗ X
   horizontal-pointed-map-cocone-Pointed-Type = pr1 c
 
   horizontal-map-cocone-Pointed-Type :
@@ -66,7 +66,7 @@ module _
   horizontal-map-cocone-Pointed-Type =
     pr1 horizontal-pointed-map-cocone-Pointed-Type
 
-  vertical-pointed-map-cocone-Pointed-Type : B →* X
+  vertical-pointed-map-cocone-Pointed-Type : B →∗ X
   vertical-pointed-map-cocone-Pointed-Type = pr1 (pr2 c)
 
   vertical-map-cocone-Pointed-Type :

--- a/src/synthetic-homotopy-theory/cocones-under-spans-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/cocones-under-spans-of-pointed-types.lagda.md
@@ -52,15 +52,16 @@ module _
   pr1 (pr2 (pr2 (cocone-Pointed-Type X))) = constant-pointed-map B X
   pr1 (pr2 (pr2 (pr2 (cocone-Pointed-Type X)))) = refl-htpy
   pr2 (pr2 (pr2 (pr2 (cocone-Pointed-Type X)))) =
-    ( ap
-      ( λ p → inv (p ∙ refl))
-      ( inv (ap-const (pr2 X) (preserves-point-pointed-map S B g)))) ∙
-    ( ap
-      ( λ p →
-        ( p ∙ refl) ∙
-        ( inv
-          ( preserves-point-pointed-map S X (constant-pointed-map B X ∘∗ g))))
-      ( inv (ap-const (pr2 X) (preserves-point-pointed-map S A f))))
+    inv
+    ( ( ap
+        ( λ p →
+          ( p ∙ refl) ∙
+          ( inv
+            ( preserves-point-pointed-map S X (constant-pointed-map B X ∘∗ g))))
+        ( ap-const (pr2 X) (preserves-point-pointed-map S A f))) ∙
+      ( ap
+        ( λ p → inv (p ∙ refl))
+        ( ap-const (pr2 X) (preserves-point-pointed-map S B g))))
 ```
 
 ### Components of a cocone of pointed types

--- a/src/synthetic-homotopy-theory/cocones-under-spans-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/cocones-under-spans-of-pointed-types.lagda.md
@@ -1,0 +1,97 @@
+# Cocones under spans of pointed types
+
+```agda
+module synthetic-homotopy-theory.cocones-under-spans-of-pointed-types where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.commuting-squares-of-maps
+open import foundation.contractible-types
+open import foundation.dependent-pair-types
+open import foundation.equality-dependent-pair-types
+open import foundation.equivalences
+open import foundation.function-extensionality
+open import foundation.functions
+open import foundation.functoriality-dependent-pair-types
+open import foundation.fundamental-theorem-of-identity-types
+open import foundation.homotopies
+open import foundation.identity-types
+open import foundation.structure-identity-principle
+open import foundation.universe-levels
+
+open import structured-types.pointed-maps
+open import structured-types.pointed-types
+
+open import synthetic-homotopy-theory.cocones-under-spans
+```
+
+</details>
+
+## Idea
+
+## Definitions
+
+### Cocones
+
+```agda
+module _
+  {l1 l2 l3 : Level}
+  {S : Pointed-Type l1} {A : Pointed-Type l2}
+  {B : Pointed-Type l3}
+  (f : S →* A) (g : S →* B)
+  where
+
+  type-cocone-Pointed-Type :
+    {l4 : Level} → Pointed-Type l4 → UU (l1 ⊔ l2 ⊔ l3 ⊔ l4)
+  type-cocone-Pointed-Type X =
+    Σ ( A →* X)
+      ( λ i →
+        Σ ( B →* X)
+          ( λ j → coherence-square-maps (pr1 g) (pr1 f) (pr1 j) (pr1 i)))
+
+  cocone-Pointed-Type :
+    {l4 : Level} → Pointed-Type l4 → Pointed-Type (l1 ⊔ l2 ⊔ l3 ⊔ l4)
+  pr1 (cocone-Pointed-Type X) = type-cocone-Pointed-Type X
+  pr1 (pr2 (cocone-Pointed-Type X)) = constant-pointed-map A X
+  pr1 (pr2 (pr2 (cocone-Pointed-Type X))) = constant-pointed-map B X
+  pr2 (pr2 (pr2 (cocone-Pointed-Type X))) = refl-htpy
+
+module _
+  {l1 l2 l3 l4 : Level}
+  {S : Pointed-Type l1} {A : Pointed-Type l2}
+  {B : Pointed-Type l3} {X : Pointed-Type l4}
+  (f : S →* A) (g : S →* B) (c : type-cocone-Pointed-Type f g X)
+  where
+
+  horizontal-pointed-map-cocone-Pointed-Type : A →* X
+  horizontal-pointed-map-cocone-Pointed-Type = pr1 c
+
+  horizontal-map-cocone-Pointed-Type :
+    type-Pointed-Type A → type-Pointed-Type X
+  horizontal-map-cocone-Pointed-Type =
+    pr1 horizontal-pointed-map-cocone-Pointed-Type
+
+  vertical-pointed-map-cocone-Pointed-Type : B →* X
+  vertical-pointed-map-cocone-Pointed-Type = pr1 (pr2 c)
+
+  vertical-map-cocone-Pointed-Type :
+    type-Pointed-Type B → type-Pointed-Type X
+  vertical-map-cocone-Pointed-Type =
+    pr1 vertical-pointed-map-cocone-Pointed-Type
+
+  coherence-square-cocone-Pointed-Type :
+    coherence-square-maps
+      ( pr1 g)
+      ( pr1 f)
+      ( vertical-map-cocone-Pointed-Type)
+      ( horizontal-map-cocone-Pointed-Type)
+  coherence-square-cocone-Pointed-Type = pr2 (pr2 c)
+
+  cocone-type-cocone-Pointed-Type : cocone (pr1 f) (pr1 g) (pr1 X)
+  pr1 cocone-type-cocone-Pointed-Type = horizontal-map-cocone-Pointed-Type
+  pr1 (pr2 cocone-type-cocone-Pointed-Type) = vertical-map-cocone-Pointed-Type
+  pr2 (pr2 cocone-type-cocone-Pointed-Type) =
+    coherence-square-cocone-Pointed-Type
+```

--- a/src/synthetic-homotopy-theory/cocones-under-spans-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/cocones-under-spans-of-pointed-types.lagda.md
@@ -7,11 +7,16 @@ module synthetic-homotopy-theory.cocones-under-spans-of-pointed-types where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.commuting-squares-of-maps
+open import foundation.constant-maps
 open import foundation.dependent-pair-types
+open import foundation.equational-reasoning
+open import foundation.function-extensionality
 open import foundation.homotopies
+open import foundation.identity-types
 open import foundation.universe-levels
 
+open import structured-types.commuting-squares-of-pointed-maps
+open import structured-types.pointed-homotopies
 open import structured-types.pointed-maps
 open import structured-types.pointed-types
 
@@ -38,14 +43,24 @@ module _
     Σ ( A →∗ X)
       ( λ i →
         Σ ( B →∗ X)
-          ( λ j → coherence-square-maps (pr1 g) (pr1 f) (pr1 j) (pr1 i)))
+          ( λ j → coherence-square-pointed-maps g f j i))
 
   cocone-Pointed-Type :
     {l4 : Level} → Pointed-Type l4 → Pointed-Type (l1 ⊔ l2 ⊔ l3 ⊔ l4)
   pr1 (cocone-Pointed-Type X) = type-cocone-Pointed-Type X
   pr1 (pr2 (cocone-Pointed-Type X)) = constant-pointed-map A X
   pr1 (pr2 (pr2 (cocone-Pointed-Type X))) = constant-pointed-map B X
-  pr2 (pr2 (pr2 (cocone-Pointed-Type X))) = refl-htpy
+  pr1 (pr2 (pr2 (pr2 (cocone-Pointed-Type X)))) = refl-htpy
+  pr2 (pr2 (pr2 (pr2 (cocone-Pointed-Type X)))) =
+    ( ap
+      ( λ p → inv (p ∙ refl))
+      ( inv (ap-const (pr2 X) (preserves-point-pointed-map S B g)))) ∙
+    ( ap
+      ( λ p →
+        ( p ∙ refl) ∙
+        ( inv
+          ( preserves-point-pointed-map S X (constant-pointed-map B X ∘∗ g))))
+      ( inv (ap-const (pr2 X) (preserves-point-pointed-map S A f))))
 ```
 
 ### Components of a cocone of pointed types
@@ -75,18 +90,18 @@ module _
     pr1 vertical-pointed-map-cocone-Pointed-Type
 
   coherence-square-cocone-Pointed-Type :
-    coherence-square-maps
-      ( pr1 g)
-      ( pr1 f)
-      ( vertical-map-cocone-Pointed-Type)
-      ( horizontal-map-cocone-Pointed-Type)
+    coherence-square-pointed-maps
+      ( g)
+      ( f)
+      ( vertical-pointed-map-cocone-Pointed-Type)
+      ( horizontal-pointed-map-cocone-Pointed-Type)
   coherence-square-cocone-Pointed-Type = pr2 (pr2 c)
 
   cocone-type-cocone-Pointed-Type : cocone (pr1 f) (pr1 g) (pr1 X)
   pr1 cocone-type-cocone-Pointed-Type = horizontal-map-cocone-Pointed-Type
   pr1 (pr2 cocone-type-cocone-Pointed-Type) = vertical-map-cocone-Pointed-Type
   pr2 (pr2 cocone-type-cocone-Pointed-Type) =
-    coherence-square-cocone-Pointed-Type
+    pr1 coherence-square-cocone-Pointed-Type
 ```
 
 ## See also

--- a/src/synthetic-homotopy-theory/cocones-under-spans-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/cocones-under-spans-of-pointed-types.lagda.md
@@ -57,11 +57,16 @@ module _
         ( λ p →
           ( p ∙ refl) ∙
           ( inv
-            ( preserves-point-pointed-map S X (constant-pointed-map B X ∘∗ g))))
-        ( ap-const (pr2 X) (preserves-point-pointed-map S A f))) ∙
+            ( preserves-point-pointed-map S X
+              ( constant-pointed-map B X ∘∗ g))))
+        ( ap-const
+          ( point-Pointed-Type X)
+          ( preserves-point-pointed-map S A f))) ∙
       ( ap
         ( λ p → inv (p ∙ refl))
-        ( ap-const (pr2 X) (preserves-point-pointed-map S B g))))
+        ( ap-const
+          ( point-Pointed-Type X)
+          ( preserves-point-pointed-map S B g))))
 ```
 
 ### Components of a cocone of pointed types

--- a/src/synthetic-homotopy-theory/cocones-under-spans-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/cocones-under-spans-of-pointed-types.lagda.md
@@ -8,17 +8,8 @@ module synthetic-homotopy-theory.cocones-under-spans-of-pointed-types where
 
 ```agda
 open import foundation.commuting-squares-of-maps
-open import foundation.contractible-types
 open import foundation.dependent-pair-types
-open import foundation.equality-dependent-pair-types
-open import foundation.equivalences
-open import foundation.function-extensionality
-open import foundation.functions
-open import foundation.functoriality-dependent-pair-types
-open import foundation.fundamental-theorem-of-identity-types
 open import foundation.homotopies
-open import foundation.identity-types
-open import foundation.structure-identity-principle
 open import foundation.universe-levels
 
 open import structured-types.pointed-maps

--- a/src/synthetic-homotopy-theory/cofibers.lagda.md
+++ b/src/synthetic-homotopy-theory/cofibers.lagda.md
@@ -47,13 +47,13 @@ inr-cofiber :
   {l1 l2 : Level} {A : UU l1} {B : UU l2} (f : A → B) → unit → cofiber f
 inr-cofiber f = pr1 (pr2 (cocone-cofiber f))
 
-pt-cofiber :
+point-cofiber :
   {l1 l2 : Level} {A : UU l1} {B : UU l2} (f : A → B) → cofiber f
-pt-cofiber {A = A} f = inr-cofiber f star
+point-cofiber {A = A} f = inr-cofiber f star
 
 cofiber-ptd :
   {l1 l2 : Level} {A : UU l1} {B : UU l2} (f : A → B) → Pointed-Type (l1 ⊔ l2)
-cofiber-ptd f = pair (cofiber f) (pt-cofiber f)
+cofiber-ptd f = pair (cofiber f) (point-cofiber f)
 
 up-cofiber :
   { l1 l2 : Level} {A : UU l1} {B : UU l2} (f : A → B) →

--- a/src/synthetic-homotopy-theory/descent-circle.lagda.md
+++ b/src/synthetic-homotopy-theory/descent-circle.lagda.md
@@ -383,7 +383,7 @@ module _
   compute-ev-fixpoint-descent-data-circle :
     coherence-square-maps
       ( ev-fixpoint-descent-data-circle)
-      ( ev-point (base-free-loop l) Q)
+      ( ev-point (base-free-loop l) {Q})
       ( pr1)
       ( map-inv-equiv α)
   compute-ev-fixpoint-descent-data-circle = refl-htpy

--- a/src/synthetic-homotopy-theory/descent-circle.lagda.md
+++ b/src/synthetic-homotopy-theory/descent-circle.lagda.md
@@ -383,7 +383,7 @@ module _
   compute-ev-fixpoint-descent-data-circle :
     coherence-square-maps
       ( ev-fixpoint-descent-data-circle)
-      ( ev-pt (base-free-loop l) Q)
+      ( ev-point (base-free-loop l) Q)
       ( pr1)
       ( map-inv-equiv α)
   compute-ev-fixpoint-descent-data-circle = refl-htpy

--- a/src/synthetic-homotopy-theory/functoriality-loop-spaces.lagda.md
+++ b/src/synthetic-homotopy-theory/functoriality-loop-spaces.lagda.md
@@ -25,14 +25,14 @@ open import synthetic-homotopy-theory.loop-spaces
 
 ## Idea
 
-Any pointed map `f : A →* B` induces a map `map-Ω f : Ω A →* Ω B`. Furthermore,
+Any pointed map `f : A →∗ B` induces a map `map-Ω f : Ω A →∗ Ω B`. Furthermore,
 this operation respects the groupoidal operations on loop spaces.
 
 ## Definition
 
 ```agda
 module _
-  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) (f : A →* B)
+  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) (f : A →∗ B)
   where
 
   map-Ω : type-Ω A → type-Ω B
@@ -44,7 +44,7 @@ module _
   preserves-refl-map-Ω : Id (map-Ω refl) refl
   preserves-refl-map-Ω = preserves-refl-tr-Ω (pr2 f)
 
-  pointed-map-Ω : Ω A →* Ω B
+  pointed-map-Ω : Ω A →∗ Ω B
   pointed-map-Ω = pair map-Ω preserves-refl-map-Ω
 
   preserves-mul-map-Ω :
@@ -74,7 +74,7 @@ module _
 ```agda
 is-emb-map-Ω :
   {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2)
-  (f : A →* B) → is-faithful (map-pointed-map A B f) → is-emb (map-Ω A B f)
+  (f : A →∗ B) → is-faithful (map-pointed-map A B f) → is-emb (map-Ω A B f)
 is-emb-map-Ω A B f H =
   is-emb-comp
     ( tr-type-Ω (preserves-point-pointed-map A B f))

--- a/src/synthetic-homotopy-theory/hatchers-acyclic-type.lagda.md
+++ b/src/synthetic-homotopy-theory/hatchers-acyclic-type.lagda.md
@@ -69,7 +69,7 @@ hom-algebra-Hatcher-Acyclic-Type :
   algebra-Hatcher-Acyclic-Type l2 → UU (l1 ⊔ l2)
 hom-algebra-Hatcher-Acyclic-Type
   (A , a1 , a2 , r1 , r2) (B , b1 , b2 , s1 , s2) =
-  Σ ( A →* B)
+  Σ ( A →∗ B)
     ( λ f →
       Σ ( map-Ω A B f a1 ＝ b1)
         ( λ u →

--- a/src/synthetic-homotopy-theory/infinite-complex-projective-space.lagda.md
+++ b/src/synthetic-homotopy-theory/infinite-complex-projective-space.lagda.md
@@ -25,9 +25,9 @@ open import synthetic-homotopy-theory.circle
 ℂP∞ : UU (lsuc lzero)
 ℂP∞ = Σ (UU lzero) (λ X → type-trunc-Set (𝕊¹ ≃ X))
 
-pt-ℂP∞ : ℂP∞
-pr1 pt-ℂP∞ = 𝕊¹
-pr2 pt-ℂP∞ = unit-trunc-Set id-equiv
+point-ℂP∞ : ℂP∞
+pr1 point-ℂP∞ = 𝕊¹
+pr2 point-ℂP∞ = unit-trunc-Set id-equiv
 ```
 
 ### ℂP∞ as the 2-truncation of the 2-sphere

--- a/src/synthetic-homotopy-theory/joins-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/joins-of-types.lagda.md
@@ -42,11 +42,17 @@ join :
   {l1 l2 : Level} (A : UU l1) (B : UU l2) → UU (l1 ⊔ l2)
 join A B = pushout (pr1 {A = A} {B = λ _ → B}) pr2
 
-_*_ = join
+_⋆_ = join
+```
 
+**Note**: The symbol used for the join `_⋆_` is the
+[star operator](https://codepoints.net/U+22c6) symbol `⋆` (agda-input: `\st`
+`\star` `\*`), and not the asterisk `*` or asterisk operator `∗`.
+
+```agda
 cocone-join :
   {l1 l2 : Level} (A : UU l1) (B : UU l2) →
-  cocone (pr1 {A = A} {B = λ _ → B}) pr2 (A * B)
+  cocone (pr1 {A = A} {B = λ _ → B}) pr2 (A ⋆ B)
 cocone-join A B = cocone-pushout pr1 pr2
 
 up-join :
@@ -56,11 +62,11 @@ up-join :
 up-join A B = up-pushout pr1 pr2
 
 inl-join :
-  {l1 l2 : Level} (A : UU l1) (B : UU l2) → A → A * B
+  {l1 l2 : Level} (A : UU l1) (B : UU l2) → A → A ⋆ B
 inl-join A B = pr1 (cocone-join A B)
 
 inr-join :
-  {l1 l2 : Level} (A : UU l1) (B : UU l2) → B → A * B
+  {l1 l2 : Level} (A : UU l1) (B : UU l2) → B → A ⋆ B
 inr-join A B = pr1 (pr2 (cocone-join A B))
 
 glue-join :
@@ -70,7 +76,7 @@ glue-join A B = pr2 (pr2 (cocone-join A B))
 
 cogap-join :
   {l1 l2 l3 : Level} (A : UU l1) (B : UU l2) (X : UU l3) →
-  cocone pr1 pr2 X → A * B → X
+  cocone pr1 pr2 X → A ⋆ B → X
 cogap-join A B X = map-inv-is-equiv (up-join A B X)
 ```
 
@@ -90,7 +96,7 @@ is-equiv-inr-join-empty X =
     ( up-join empty X)
 
 left-unit-law-join :
-  {l : Level} (X : UU l) → X ≃ (empty * X)
+  {l : Level} (X : UU l) → X ≃ (empty ⋆ X)
 pr1 (left-unit-law-join X) = inr-join empty X
 pr2 (left-unit-law-join X) = is-equiv-inr-join-empty X
 
@@ -107,7 +113,7 @@ is-equiv-inr-join-is-empty A B is-empty-A =
 
 left-unit-law-join-is-empty :
   {l1 l2 : Level} (A : UU l1) (B : UU l2) →
-  is-empty A → B ≃ (A * B)
+  is-empty A → B ≃ (A ⋆ B)
 pr1 (left-unit-law-join-is-empty A B is-empty-A) = inr-join A B
 pr2 (left-unit-law-join-is-empty A B is-empty-A) =
   is-equiv-inr-join-is-empty A B is-empty-A
@@ -127,7 +133,7 @@ is-equiv-inl-join-empty X =
     ( up-join X empty)
 
 right-unit-law-join :
-  {l : Level} (X : UU l) → X ≃ (X * empty)
+  {l : Level} (X : UU l) → X ≃ (X ⋆ empty)
 pr1 (right-unit-law-join X) = inl-join X empty
 pr2 (right-unit-law-join X) = is-equiv-inl-join-empty X
 
@@ -144,7 +150,7 @@ is-equiv-inl-join-is-empty A B is-empty-B =
 
 right-unit-law-join-is-empty :
   {l1 l2 : Level} (A : UU l1) (B : UU l2) →
-  is-empty B → A ≃ (A * B)
+  is-empty B → A ≃ (A ⋆ B)
 pr1 (right-unit-law-join-is-empty A B is-empty-B) = inl-join A B
 pr2 (right-unit-law-join-is-empty A B is-empty-B) =
   is-equiv-inl-join-is-empty A B is-empty-B
@@ -164,7 +170,7 @@ is-equiv-inl-join-unit X =
     ( up-join unit X)
 
 left-zero-law-join :
-  {l : Level} (X : UU l) → is-contr (unit * X)
+  {l : Level} (X : UU l) → is-contr (unit ⋆ X)
 left-zero-law-join X =
   is-contr-equiv'
     ( unit)
@@ -182,7 +188,7 @@ is-equiv-inl-join-is-contr A B is-contr-A =
     ( up-join A B)
 
 left-zero-law-join-is-contr :
-  {l1 l2 : Level} (A : UU l1) (B : UU l2) → is-contr A → is-contr (A * B)
+  {l1 l2 : Level} (A : UU l1) (B : UU l2) → is-contr A → is-contr (A ⋆ B)
 left-zero-law-join-is-contr A B is-contr-A =
   is-contr-equiv'
     ( A)
@@ -204,7 +210,7 @@ is-equiv-inr-join-unit X =
     ( up-join X unit)
 
 right-zero-law-join :
-  {l : Level} (X : UU l) → is-contr (X * unit)
+  {l : Level} (X : UU l) → is-contr (X ⋆ unit)
 right-zero-law-join X =
   is-contr-equiv'
     ( unit)
@@ -222,7 +228,7 @@ is-equiv-inr-join-is-contr A B is-contr-B =
     ( up-join A B)
 
 right-zero-law-join-is-contr :
-  {l1 l2 : Level} (A : UU l1) (B : UU l2) → is-contr B → is-contr (A * B)
+  {l1 l2 : Level} (A : UU l1) (B : UU l2) → is-contr B → is-contr (A ⋆ B)
 right-zero-law-join-is-contr A B is-contr-B =
   is-contr-equiv'
     ( B)
@@ -238,10 +244,10 @@ module _
   where
 
   is-proof-irrelevant-join-is-proof-irrelevant :
-    is-proof-irrelevant A → is-proof-irrelevant B → is-proof-irrelevant (A * B)
+    is-proof-irrelevant A → is-proof-irrelevant B → is-proof-irrelevant (A ⋆ B)
   is-proof-irrelevant-join-is-proof-irrelevant
     is-proof-irrelevant-A is-proof-irrelevant-B =
-    cogap-join A B (is-contr (A * B))
+    cogap-join A B (is-contr (A ⋆ B))
       ( pair
         ( left-zero-law-join-is-contr A B ∘ is-proof-irrelevant-A)
         ( pair
@@ -252,7 +258,7 @@ module _
               ( right-zero-law-join-is-contr A B (is-proof-irrelevant-B b))))))
 
   is-prop-join-is-prop :
-    is-prop A → is-prop B → is-prop (A * B)
+    is-prop A → is-prop B → is-prop (A ⋆ B)
   is-prop-join-is-prop is-prop-A is-prop-B =
     is-prop-is-proof-irrelevant
       ( is-proof-irrelevant-join-is-proof-irrelevant
@@ -264,7 +270,7 @@ module _
   where
 
   join-Prop : Prop (l1 ⊔ l2)
-  pr1 join-Prop = A * B
+  pr1 join-Prop = A ⋆ B
   pr2 join-Prop = is-prop-join-is-prop is-prop-A is-prop-B
 
   type-join-Prop : UU (l1 ⊔ l2)

--- a/src/synthetic-homotopy-theory/joins-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/joins-of-types.lagda.md
@@ -38,9 +38,11 @@ The join of `A` and `B` is the pushout of the span `A ← A × B → B`.
 ## Definition
 
 ```agda
-_*_ :
+join :
   {l1 l2 : Level} (A : UU l1) (B : UU l2) → UU (l1 ⊔ l2)
-A * B = pushout (pr1 {A = A} {B = λ _ → B}) pr2
+join A B = pushout (pr1 {A = A} {B = λ _ → B}) pr2
+
+_*_ = join
 
 cocone-join :
   {l1 l2 : Level} (A : UU l1) (B : UU l2) →

--- a/src/synthetic-homotopy-theory/joins-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/joins-of-types.lagda.md
@@ -40,11 +40,11 @@ The join of `A` and `B` is the pushout of the span `A ← A × B → B`.
 ```agda
 _*_ :
   {l1 l2 : Level} (A : UU l1) (B : UU l2) → UU (l1 ⊔ l2)
-A * B = pushout (pr1 {A = A} {B = λ x → B}) pr2
+A * B = pushout (pr1 {A = A} {B = λ _ → B}) pr2
 
 cocone-join :
   {l1 l2 : Level} (A : UU l1) (B : UU l2) →
-  cocone (pr1 {A = A} {B = λ x → B}) pr2 (A * B)
+  cocone (pr1 {A = A} {B = λ _ → B}) pr2 (A * B)
 cocone-join A B = cocone-pushout pr1 pr2
 
 up-join :
@@ -74,7 +74,7 @@ cogap-join A B X = map-inv-is-equiv (up-join A B X)
 
 ## Properties
 
-### Left unit law for joins
+### The left unit law for joins
 
 ```agda
 is-equiv-inr-join-empty :
@@ -89,11 +89,12 @@ is-equiv-inr-join-empty X =
 
 left-unit-law-join :
   {l : Level} (X : UU l) → X ≃ (empty * X)
-left-unit-law-join X =
-  pair (inr-join empty X) (is-equiv-inr-join-empty X)
+pr1 (left-unit-law-join X) = inr-join empty X
+pr2 (left-unit-law-join X) = is-equiv-inr-join-empty X
 
 is-equiv-inr-join-is-empty :
-  {l1 l2 : Level} (A : UU l1) (B : UU l2) → is-empty A → is-equiv (inr-join A B)
+  {l1 l2 : Level} (A : UU l1) (B : UU l2) →
+  is-empty A → is-equiv (inr-join A B)
 is-equiv-inr-join-is-empty A B is-empty-A =
   is-equiv-universal-property-pushout
     ( pr1)
@@ -103,12 +104,14 @@ is-equiv-inr-join-is-empty A B is-empty-A =
     ( up-join A B)
 
 left-unit-law-join-is-empty :
-  {l1 l2 : Level} (A : UU l1) (B : UU l2) → is-empty A → B ≃ (A * B)
-left-unit-law-join-is-empty A B is-empty-A =
-  pair (inr-join A B) (is-equiv-inr-join-is-empty A B is-empty-A)
+  {l1 l2 : Level} (A : UU l1) (B : UU l2) →
+  is-empty A → B ≃ (A * B)
+pr1 (left-unit-law-join-is-empty A B is-empty-A) = inr-join A B
+pr2 (left-unit-law-join-is-empty A B is-empty-A) =
+  is-equiv-inr-join-is-empty A B is-empty-A
 ```
 
-### Right unit law for joins
+### The right unit law for joins
 
 ```agda
 is-equiv-inl-join-empty :
@@ -123,11 +126,12 @@ is-equiv-inl-join-empty X =
 
 right-unit-law-join :
   {l : Level} (X : UU l) → X ≃ (X * empty)
-right-unit-law-join X =
-  pair (inl-join X empty) (is-equiv-inl-join-empty X)
+pr1 (right-unit-law-join X) = inl-join X empty
+pr2 (right-unit-law-join X) = is-equiv-inl-join-empty X
 
 is-equiv-inl-join-is-empty :
-  {l1 l2 : Level} (A : UU l1) (B : UU l2) → is-empty B → is-equiv (inl-join A B)
+  {l1 l2 : Level} (A : UU l1) (B : UU l2) →
+  is-empty B → is-equiv (inl-join A B)
 is-equiv-inl-join-is-empty A B is-empty-B =
   is-equiv-universal-property-pushout'
     ( pr1)
@@ -137,12 +141,14 @@ is-equiv-inl-join-is-empty A B is-empty-B =
     ( up-join A B)
 
 right-unit-law-join-is-empty :
-  {l1 l2 : Level} (A : UU l1) (B : UU l2) → is-empty B → A ≃ (A * B)
-right-unit-law-join-is-empty A B is-empty-B =
-  pair (inl-join A B) (is-equiv-inl-join-is-empty A B is-empty-B)
+  {l1 l2 : Level} (A : UU l1) (B : UU l2) →
+  is-empty B → A ≃ (A * B)
+pr1 (right-unit-law-join-is-empty A B is-empty-B) = inl-join A B
+pr2 (right-unit-law-join-is-empty A B is-empty-B) =
+  is-equiv-inl-join-is-empty A B is-empty-B
 ```
 
-### Left zero law for joins
+### The left zero law for joins
 
 ```agda
 is-equiv-inl-join-unit :
@@ -182,7 +188,7 @@ left-zero-law-join-is-contr A B is-contr-A =
     ( is-contr-A)
 ```
 
-### Right zero law for joins
+### The right zero law for joins
 
 ```agda
 is-equiv-inr-join-unit :
@@ -256,7 +262,8 @@ module _
   where
 
   join-Prop : Prop (l1 ⊔ l2)
-  join-Prop = (A * B) , is-prop-join-is-prop is-prop-A is-prop-B
+  pr1 join-Prop = A * B
+  pr2 join-Prop = is-prop-join-is-prop is-prop-A is-prop-B
 
   type-join-Prop : UU (l1 ⊔ l2)
   type-join-Prop = type-Prop join-Prop
@@ -305,7 +312,8 @@ module _
       ( map-join-disj-Prop)
 
   equiv-disj-join-Prop : (type-join-Prop A B) ≃ (type-disj-Prop A B)
-  equiv-disj-join-Prop = pair map-disj-join-Prop is-equiv-map-disj-join-Prop
+  pr1 equiv-disj-join-Prop = map-disj-join-Prop
+  pr2 equiv-disj-join-Prop = is-equiv-map-disj-join-Prop
 
   is-equiv-map-join-disj-Prop : is-equiv map-join-disj-Prop
   is-equiv-map-join-disj-Prop =
@@ -315,7 +323,8 @@ module _
       ( map-disj-join-Prop)
 
   equiv-join-disj-Prop : (type-disj-Prop A B) ≃ (type-join-Prop A B)
-  equiv-join-disj-Prop = pair map-join-disj-Prop is-equiv-map-join-disj-Prop
+  pr1 equiv-join-disj-Prop = map-join-disj-Prop
+  pr2 equiv-join-disj-Prop = is-equiv-map-join-disj-Prop
 
   up-join-disj : {l : Level} → universal-property-pushout l pr1 pr2 cocone-disj
   up-join-disj =

--- a/src/synthetic-homotopy-theory/joins-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/joins-of-types.lagda.md
@@ -42,17 +42,11 @@ join :
   {l1 l2 : Level} (A : UU l1) (B : UU l2) → UU (l1 ⊔ l2)
 join A B = pushout (pr1 {A = A} {B = λ _ → B}) pr2
 
-_⋆_ = join
-```
+_*_ = join
 
-**Note**: The symbol used for the join `_⋆_` is the
-[star operator](https://codepoints.net/U+22c6) symbol `⋆` (agda-input: `\st`
-`\star` `\*`), and not the asterisk `*` or asterisk operator `∗`.
-
-```agda
 cocone-join :
   {l1 l2 : Level} (A : UU l1) (B : UU l2) →
-  cocone (pr1 {A = A} {B = λ _ → B}) pr2 (A ⋆ B)
+  cocone (pr1 {A = A} {B = λ _ → B}) pr2 (A * B)
 cocone-join A B = cocone-pushout pr1 pr2
 
 up-join :
@@ -62,11 +56,11 @@ up-join :
 up-join A B = up-pushout pr1 pr2
 
 inl-join :
-  {l1 l2 : Level} (A : UU l1) (B : UU l2) → A → A ⋆ B
+  {l1 l2 : Level} (A : UU l1) (B : UU l2) → A → A * B
 inl-join A B = pr1 (cocone-join A B)
 
 inr-join :
-  {l1 l2 : Level} (A : UU l1) (B : UU l2) → B → A ⋆ B
+  {l1 l2 : Level} (A : UU l1) (B : UU l2) → B → A * B
 inr-join A B = pr1 (pr2 (cocone-join A B))
 
 glue-join :
@@ -76,7 +70,7 @@ glue-join A B = pr2 (pr2 (cocone-join A B))
 
 cogap-join :
   {l1 l2 l3 : Level} (A : UU l1) (B : UU l2) (X : UU l3) →
-  cocone pr1 pr2 X → A ⋆ B → X
+  cocone pr1 pr2 X → A * B → X
 cogap-join A B X = map-inv-is-equiv (up-join A B X)
 ```
 
@@ -96,7 +90,7 @@ is-equiv-inr-join-empty X =
     ( up-join empty X)
 
 left-unit-law-join :
-  {l : Level} (X : UU l) → X ≃ (empty ⋆ X)
+  {l : Level} (X : UU l) → X ≃ (empty * X)
 pr1 (left-unit-law-join X) = inr-join empty X
 pr2 (left-unit-law-join X) = is-equiv-inr-join-empty X
 
@@ -113,7 +107,7 @@ is-equiv-inr-join-is-empty A B is-empty-A =
 
 left-unit-law-join-is-empty :
   {l1 l2 : Level} (A : UU l1) (B : UU l2) →
-  is-empty A → B ≃ (A ⋆ B)
+  is-empty A → B ≃ (A * B)
 pr1 (left-unit-law-join-is-empty A B is-empty-A) = inr-join A B
 pr2 (left-unit-law-join-is-empty A B is-empty-A) =
   is-equiv-inr-join-is-empty A B is-empty-A
@@ -133,7 +127,7 @@ is-equiv-inl-join-empty X =
     ( up-join X empty)
 
 right-unit-law-join :
-  {l : Level} (X : UU l) → X ≃ (X ⋆ empty)
+  {l : Level} (X : UU l) → X ≃ (X * empty)
 pr1 (right-unit-law-join X) = inl-join X empty
 pr2 (right-unit-law-join X) = is-equiv-inl-join-empty X
 
@@ -150,7 +144,7 @@ is-equiv-inl-join-is-empty A B is-empty-B =
 
 right-unit-law-join-is-empty :
   {l1 l2 : Level} (A : UU l1) (B : UU l2) →
-  is-empty B → A ≃ (A ⋆ B)
+  is-empty B → A ≃ (A * B)
 pr1 (right-unit-law-join-is-empty A B is-empty-B) = inl-join A B
 pr2 (right-unit-law-join-is-empty A B is-empty-B) =
   is-equiv-inl-join-is-empty A B is-empty-B
@@ -170,7 +164,7 @@ is-equiv-inl-join-unit X =
     ( up-join unit X)
 
 left-zero-law-join :
-  {l : Level} (X : UU l) → is-contr (unit ⋆ X)
+  {l : Level} (X : UU l) → is-contr (unit * X)
 left-zero-law-join X =
   is-contr-equiv'
     ( unit)
@@ -188,7 +182,7 @@ is-equiv-inl-join-is-contr A B is-contr-A =
     ( up-join A B)
 
 left-zero-law-join-is-contr :
-  {l1 l2 : Level} (A : UU l1) (B : UU l2) → is-contr A → is-contr (A ⋆ B)
+  {l1 l2 : Level} (A : UU l1) (B : UU l2) → is-contr A → is-contr (A * B)
 left-zero-law-join-is-contr A B is-contr-A =
   is-contr-equiv'
     ( A)
@@ -210,7 +204,7 @@ is-equiv-inr-join-unit X =
     ( up-join X unit)
 
 right-zero-law-join :
-  {l : Level} (X : UU l) → is-contr (X ⋆ unit)
+  {l : Level} (X : UU l) → is-contr (X * unit)
 right-zero-law-join X =
   is-contr-equiv'
     ( unit)
@@ -228,7 +222,7 @@ is-equiv-inr-join-is-contr A B is-contr-B =
     ( up-join A B)
 
 right-zero-law-join-is-contr :
-  {l1 l2 : Level} (A : UU l1) (B : UU l2) → is-contr B → is-contr (A ⋆ B)
+  {l1 l2 : Level} (A : UU l1) (B : UU l2) → is-contr B → is-contr (A * B)
 right-zero-law-join-is-contr A B is-contr-B =
   is-contr-equiv'
     ( B)
@@ -244,10 +238,10 @@ module _
   where
 
   is-proof-irrelevant-join-is-proof-irrelevant :
-    is-proof-irrelevant A → is-proof-irrelevant B → is-proof-irrelevant (A ⋆ B)
+    is-proof-irrelevant A → is-proof-irrelevant B → is-proof-irrelevant (A * B)
   is-proof-irrelevant-join-is-proof-irrelevant
     is-proof-irrelevant-A is-proof-irrelevant-B =
-    cogap-join A B (is-contr (A ⋆ B))
+    cogap-join A B (is-contr (A * B))
       ( pair
         ( left-zero-law-join-is-contr A B ∘ is-proof-irrelevant-A)
         ( pair
@@ -258,7 +252,7 @@ module _
               ( right-zero-law-join-is-contr A B (is-proof-irrelevant-B b))))))
 
   is-prop-join-is-prop :
-    is-prop A → is-prop B → is-prop (A ⋆ B)
+    is-prop A → is-prop B → is-prop (A * B)
   is-prop-join-is-prop is-prop-A is-prop-B =
     is-prop-is-proof-irrelevant
       ( is-proof-irrelevant-join-is-proof-irrelevant
@@ -270,7 +264,7 @@ module _
   where
 
   join-Prop : Prop (l1 ⊔ l2)
-  pr1 join-Prop = A ⋆ B
+  pr1 join-Prop = A * B
   pr2 join-Prop = is-prop-join-is-prop is-prop-A is-prop-B
 
   type-join-Prop : UU (l1 ⊔ l2)
@@ -357,3 +351,9 @@ module _
       ( is-equiv-map-disj-join-Prop)
       ( up-join (pr1 A) (pr1 B))
 ```
+
+## References
+
+- Egbert Rijke, _The join construction_, 2017
+  ([arXiv:1701.07538](https://arxiv.org/abs/1701.07538),
+  [DOI:10.48550](https://doi.org/10.48550/arXiv.1701.07538))

--- a/src/synthetic-homotopy-theory/loop-spaces.lagda.md
+++ b/src/synthetic-homotopy-theory/loop-spaces.lagda.md
@@ -126,7 +126,7 @@ module _
   {l1 : Level} {A : UU l1} {x y : A}
   where
 
-  equiv-tr-Ω : Id x y → Ω (pair A x) ≃* Ω (pair A y)
+  equiv-tr-Ω : Id x y → Ω (pair A x) ≃∗ Ω (pair A y)
   equiv-tr-Ω refl = pair id-equiv refl
 
   equiv-tr-type-Ω : Id x y → type-Ω (pair A x) ≃ type-Ω (pair A y)

--- a/src/synthetic-homotopy-theory/multiplication-circle.lagda.md
+++ b/src/synthetic-homotopy-theory/multiplication-circle.lagda.md
@@ -57,7 +57,7 @@ htpy-id-id-base-𝕊¹ = pr1 (pr2 htpy-id-id-Π-𝕊¹)
 
 ```agda
 Mul-Π-𝕊¹ : 𝕊¹ → UU lzero
-Mul-Π-𝕊¹ x = 𝕊¹-Pointed-Type →* (pair 𝕊¹ x)
+Mul-Π-𝕊¹ x = 𝕊¹-Pointed-Type →∗ (pair 𝕊¹ x)
 
 path-over-Mul-Π-𝕊¹ :
   {x : 𝕊¹} (p : Id base-𝕊¹ x) (q : Mul-Π-𝕊¹ base-𝕊¹) (r : Mul-Π-𝕊¹ x) →

--- a/src/synthetic-homotopy-theory/powers-of-loops.lagda.md
+++ b/src/synthetic-homotopy-theory/powers-of-loops.lagda.md
@@ -123,7 +123,7 @@ power-nat-mul-Ω' m n A ω =
 ```agda
 map-power-nat-Ω :
   {l1 l2 : Level} (n : ℕ) (A : Pointed-Type l1) (B : Pointed-Type l2)
-  (f : A →* B) (ω : type-Ω A) →
+  (f : A →∗ B) (ω : type-Ω A) →
   map-Ω A B f (power-nat-Ω n A ω) ＝ power-nat-Ω n B (map-Ω A B f ω)
 map-power-nat-Ω zero-ℕ A B f ω = preserves-refl-map-Ω A B f
 map-power-nat-Ω (succ-ℕ n) A B f ω =

--- a/src/synthetic-homotopy-theory/prespectra.lagda.md
+++ b/src/synthetic-homotopy-theory/prespectra.lagda.md
@@ -23,12 +23,12 @@ open import synthetic-homotopy-theory.loop-spaces
 ## Idea
 
 A prespectrum is a sequence of pointed types `A n` equipped with pointed maps
-`ε : A n →* Ω (A (n+1))`.
+`ε : A n →∗ Ω (A (n+1))`.
 
 ## Definition
 
 ```agda
 Prespectrum : (l : Level) → UU (lsuc l)
 Prespectrum l =
-  Σ (ℕ → Pointed-Type l) (λ A → (n : ℕ) → A n →* Ω (A (succ-ℕ n)))
+  Σ (ℕ → Pointed-Type l) (λ A → (n : ℕ) → A n →∗ Ω (A (succ-ℕ n)))
 ```

--- a/src/synthetic-homotopy-theory/pushouts-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/pushouts-of-pointed-types.lagda.md
@@ -19,6 +19,7 @@ open import structured-types.pointed-maps
 open import structured-types.pointed-types
 
 open import synthetic-homotopy-theory.cocones-under-spans
+open import synthetic-homotopy-theory.cocones-under-spans-of-pointed-types
 open import synthetic-homotopy-theory.pushouts
 open import synthetic-homotopy-theory.universal-property-pushouts
 ```
@@ -98,4 +99,35 @@ module _
               ( map-pointed-map S A f)
               ( map-pointed-map S B g))
             ( preserves-point-pointed-map S A f)
+```
+
+### The cogap map for pushouts of pointed types
+
+```agda
+  map-cogap-Pointed-Type :
+    {l4 : Level}
+    (f : S →* A) (g : S →* B) →
+    {X : Pointed-Type l4} →
+    type-cocone-Pointed-Type f g X →
+    type-Pointed-Type (pushout-Pointed-Type f g) → type-Pointed-Type X
+  map-cogap-Pointed-Type f g c =
+    cogap
+      ( map-pointed-map S A f)
+      ( map-pointed-map S B g)
+      ( cocone-type-cocone-Pointed-Type f g c)
+
+  cogap-Pointed-Type :
+    {l4 : Level}
+    (f : S →* A) (g : S →* B) →
+    {X : Pointed-Type l4} →
+    type-cocone-Pointed-Type f g X → pushout-Pointed-Type f g →* X
+  pr1 (cogap-Pointed-Type f g c) = map-cogap-Pointed-Type f g c
+  pr2 (cogap-Pointed-Type f g {X} c) =
+    ( compute-inl-cogap
+      ( map-pointed-map S A f)
+      ( map-pointed-map S B g)
+      ( cocone-type-cocone-Pointed-Type f g c)
+      ( point-Pointed-Type A)) ∙
+    ( preserves-point-pointed-map A X
+      ( horizontal-pointed-map-cocone-Pointed-Type f g c))
 ```

--- a/src/synthetic-homotopy-theory/pushouts-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/pushouts-of-pointed-types.lagda.md
@@ -9,19 +9,14 @@ module synthetic-homotopy-theory.pushouts-of-pointed-types where
 ```agda
 open import foundation.dependent-pair-types
 open import foundation.equational-reasoning
-open import foundation.equivalences
-open import foundation.functions
-open import foundation.homotopies
 open import foundation.identity-types
 open import foundation.universe-levels
 
 open import structured-types.pointed-maps
 open import structured-types.pointed-types
 
-open import synthetic-homotopy-theory.cocones-under-spans
 open import synthetic-homotopy-theory.cocones-under-spans-of-pointed-types
 open import synthetic-homotopy-theory.pushouts
-open import synthetic-homotopy-theory.universal-property-pushouts
 ```
 
 </details>

--- a/src/synthetic-homotopy-theory/pushouts-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/pushouts-of-pointed-types.lagda.md
@@ -50,6 +50,11 @@ module _
 ### The pushout of a pointed map along a pointed map is pointed
 
 ```agda
+module _
+  {l1 l2 l3 : Level}
+  {S : Pointed-Type l1} {A : Pointed-Type l2} {B : Pointed-Type l3}
+  where
+
   inl-pushout-Pointed-Type :
       (f : S →∗ A) (g : S →∗ B) → A →∗ pushout-Pointed-Type f g
   pr1 (inl-pushout-Pointed-Type f g) =
@@ -61,44 +66,27 @@ module _
   pr1 (inr-pushout-Pointed-Type f g) =
     inr-pushout (map-pointed-map S A f) (map-pointed-map S B g)
   pr2 (inr-pushout-Pointed-Type f g) =
-    equational-reasoning
-      inr-pushout
-        ( map-pointed-map S A f)
-        ( map-pointed-map S B g)
-        ( point-Pointed-Type B)
-      ＝ inr-pushout
-          ( map-pointed-map S A f)
-          ( map-pointed-map S B g)
-          ( map-pointed-map S B g ( point-Pointed-Type S))
-        by
-          ap
-            ( inr-pushout (map-pointed-map S A f) (map-pointed-map S B g))
-            ( inv (preserves-point-pointed-map S B g))
-      ＝ inl-pushout
-          ( map-pointed-map S A f)
-          ( map-pointed-map S B g)
-          ( map-pointed-map S A f (point-Pointed-Type S))
-        by
-          inv
-            ( glue-pushout
-              ( map-pointed-map S A f)
-              ( map-pointed-map S B g)
-              ( point-Pointed-Type S))
-      ＝ inl-pushout
-          ( map-pointed-map S A f)
-          ( map-pointed-map S B g)
-          ( point-Pointed-Type A)
-        by
-          ap
-            ( inl-pushout
-              ( map-pointed-map S A f)
-              ( map-pointed-map S B g))
-            ( preserves-point-pointed-map S A f)
+      ( ( ap
+          ( inr-pushout (map-pointed-map S A f) (map-pointed-map S B g))
+          ( inv (preserves-point-pointed-map S B g))) ∙
+        ( inv
+          ( glue-pushout
+            ( map-pointed-map S A f)
+            ( map-pointed-map S B g)
+            ( point-Pointed-Type S)))) ∙
+      ( ap
+        ( inl-pushout (map-pointed-map S A f) (map-pointed-map S B g))
+        ( preserves-point-pointed-map S A f))
 ```
 
 ### The cogap map for pushouts of pointed types
 
 ```agda
+module _
+  {l1 l2 l3 : Level}
+  {S : Pointed-Type l1} {A : Pointed-Type l2} {B : Pointed-Type l3}
+  where
+
   map-cogap-Pointed-Type :
     {l4 : Level}
     (f : S →∗ A) (g : S →∗ B) →

--- a/src/synthetic-homotopy-theory/pushouts-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/pushouts-of-pointed-types.lagda.md
@@ -1,0 +1,101 @@
+# Pushouts of pointed types
+
+```agda
+module synthetic-homotopy-theory.pushouts-of-pointed-types where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.dependent-pair-types
+open import foundation.equational-reasoning
+open import foundation.equivalences
+open import foundation.functions
+open import foundation.homotopies
+open import foundation.identity-types
+open import foundation.universe-levels
+
+open import structured-types.pointed-maps
+open import structured-types.pointed-types
+
+open import synthetic-homotopy-theory.cocones-under-spans
+open import synthetic-homotopy-theory.pushouts
+open import synthetic-homotopy-theory.universal-property-pushouts
+```
+
+</details>
+
+## Idea
+
+Given a span of pointed maps, then the pushout is in fact a pushout diagram in
+the category of pointed types.
+
+## Definition
+
+```agda
+module _
+  {l1 l2 l3 : Level}
+  {S : Pointed-Type l1} {A : Pointed-Type l2} {B : Pointed-Type l3}
+  where
+
+  pushout-Pointed-Type :
+    (f : S →* A) (g : S →* B) → Pointed-Type (l1 ⊔ l2 ⊔ l3)
+  pr1 (pushout-Pointed-Type f g) =
+    pushout (map-pointed-map S A f) (map-pointed-map S B g)
+  pr2 (pushout-Pointed-Type f g) =
+    inl-pushout
+      ( map-pointed-map S A f)
+      ( map-pointed-map S B g)
+      ( point-Pointed-Type A)
+```
+
+## Properties
+
+### The pushout of a pointed map along a pointed map is pointed
+
+```agda
+  inl-pushout-Pointed-Type :
+      (f : S →* A) (g : S →* B) → A →* pushout-Pointed-Type f g
+  pr1 (inl-pushout-Pointed-Type f g) =
+    inl-pushout (map-pointed-map S A f) (map-pointed-map S B g)
+  pr2 (inl-pushout-Pointed-Type f g) = refl
+
+  inr-pushout-Pointed-Type :
+      (f : S →* A) (g : S →* B) → B →* pushout-Pointed-Type f g
+  pr1 (inr-pushout-Pointed-Type f g) =
+    inr-pushout (map-pointed-map S A f) (map-pointed-map S B g)
+  pr2 (inr-pushout-Pointed-Type f g) =
+    equational-reasoning
+      inr-pushout
+        ( map-pointed-map S A f)
+        ( map-pointed-map S B g)
+        ( point-Pointed-Type B)
+      ＝ inr-pushout
+          ( map-pointed-map S A f)
+          ( map-pointed-map S B g)
+          ( map-pointed-map S B g ( point-Pointed-Type S))
+        by
+          ap
+            ( inr-pushout (map-pointed-map S A f) (map-pointed-map S B g))
+            ( inv (preserves-point-pointed-map S B g))
+      ＝ inl-pushout
+          ( map-pointed-map S A f)
+          ( map-pointed-map S B g)
+          ( map-pointed-map S A f (point-Pointed-Type S))
+        by
+          inv
+            ( glue-pushout
+              ( map-pointed-map S A f)
+              ( map-pointed-map S B g)
+              ( point-Pointed-Type S))
+      ＝ inl-pushout
+          ( map-pointed-map S A f)
+          ( map-pointed-map S B g)
+          ( point-Pointed-Type A)
+        by
+          ap
+            ( inl-pushout
+              ( map-pointed-map S A f)
+              ( map-pointed-map S B g))
+            ( preserves-point-pointed-map S A f)
+```

--- a/src/synthetic-homotopy-theory/pushouts-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/pushouts-of-pointed-types.lagda.md
@@ -35,7 +35,7 @@ module _
   where
 
   pushout-Pointed-Type :
-    (f : S →* A) (g : S →* B) → Pointed-Type (l1 ⊔ l2 ⊔ l3)
+    (f : S →∗ A) (g : S →∗ B) → Pointed-Type (l1 ⊔ l2 ⊔ l3)
   pr1 (pushout-Pointed-Type f g) =
     pushout (map-pointed-map S A f) (map-pointed-map S B g)
   pr2 (pushout-Pointed-Type f g) =
@@ -51,13 +51,13 @@ module _
 
 ```agda
   inl-pushout-Pointed-Type :
-      (f : S →* A) (g : S →* B) → A →* pushout-Pointed-Type f g
+      (f : S →∗ A) (g : S →∗ B) → A →∗ pushout-Pointed-Type f g
   pr1 (inl-pushout-Pointed-Type f g) =
     inl-pushout (map-pointed-map S A f) (map-pointed-map S B g)
   pr2 (inl-pushout-Pointed-Type f g) = refl
 
   inr-pushout-Pointed-Type :
-      (f : S →* A) (g : S →* B) → B →* pushout-Pointed-Type f g
+      (f : S →∗ A) (g : S →∗ B) → B →∗ pushout-Pointed-Type f g
   pr1 (inr-pushout-Pointed-Type f g) =
     inr-pushout (map-pointed-map S A f) (map-pointed-map S B g)
   pr2 (inr-pushout-Pointed-Type f g) =
@@ -101,7 +101,7 @@ module _
 ```agda
   map-cogap-Pointed-Type :
     {l4 : Level}
-    (f : S →* A) (g : S →* B) →
+    (f : S →∗ A) (g : S →∗ B) →
     {X : Pointed-Type l4} →
     type-cocone-Pointed-Type f g X →
     type-Pointed-Type (pushout-Pointed-Type f g) → type-Pointed-Type X
@@ -113,9 +113,9 @@ module _
 
   cogap-Pointed-Type :
     {l4 : Level}
-    (f : S →* A) (g : S →* B) →
+    (f : S →∗ A) (g : S →∗ B) →
     {X : Pointed-Type l4} →
-    type-cocone-Pointed-Type f g X → pushout-Pointed-Type f g →* X
+    type-cocone-Pointed-Type f g X → pushout-Pointed-Type f g →∗ X
   pr1 (cogap-Pointed-Type f g c) = map-cogap-Pointed-Type f g c
   pr2 (cogap-Pointed-Type f g {X} c) =
     ( compute-inl-cogap

--- a/src/synthetic-homotopy-theory/pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/pushouts.lagda.md
@@ -125,7 +125,7 @@ compute-glue-cogap :
   { X : UU l4} (c : cocone f g X)
   ( s : S) →
   ( ap (cogap f g c) (glue-pushout f g s)) ＝
-  ( (compute-inl-cogap f g c (f s) ∙ coherence-square-cocone f g c s) ∙
+  ( ( compute-inl-cogap f g c (f s) ∙ coherence-square-cocone f g c s) ∙
     ( inv (compute-inr-cogap f g c (g s))))
 compute-glue-cogap f g c s =
   ( inv right-unit) ∙

--- a/src/synthetic-homotopy-theory/pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/pushouts.lagda.md
@@ -132,7 +132,7 @@ compute-glue-cogap f g c s =
     ( ap (cogap f g c) (glue-pushout f g s))
     ( compute-inr-cogap f g c (g s))
     ( compute-inl-cogap f g c (f s) ∙ coherence-square-cocone f g c s)
-    (pr2
+    ( pr2
       ( pr2
         ( htpy-cocone-map-universal-property-pushout
           ( f)

--- a/src/synthetic-homotopy-theory/pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/pushouts.lagda.md
@@ -98,11 +98,11 @@ compute-inl-cogap :
 compute-inl-cogap f g c =
   pr1
     ( htpy-cocone-map-universal-property-pushout
-        ( f)
-        ( g)
-        ( cocone-pushout f g)
-        ( up-pushout f g)
-        ( c))
+      ( f)
+      ( g)
+      ( cocone-pushout f g)
+      ( up-pushout f g)
+      ( c))
 
 compute-inr-cogap :
   { l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3}
@@ -113,9 +113,39 @@ compute-inr-cogap f g c =
   pr1
     ( pr2
       ( htpy-cocone-map-universal-property-pushout
-          ( f)
-          ( g)
-          ( cocone-pushout f g)
-          ( up-pushout f g)
-          ( c)))
+        ( f)
+        ( g)
+        ( cocone-pushout f g)
+        ( up-pushout f g)
+        ( c)))
+
+compute-glue-cogap :
+  { l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3}
+  ( f : S → A) (g : S → B) →
+  { X : UU l4} (c : cocone f g X)
+  ( s : S) →
+  ( ap (cogap f g c) (glue-pushout f g s)) ＝
+  ( (compute-inl-cogap f g c (f s) ∙ coherence-square-cocone f g c s) ∙
+    ( inv (compute-inr-cogap f g c (g s))))
+compute-glue-cogap f g c s =
+  ( inv right-unit) ∙
+  ( ( ap
+      ( ap (cogap f g c) (glue-pushout f g s) ∙_)
+      ( inv (right-inv (compute-inr-cogap f g c (g s))))) ∙
+    ( ( inv
+        ( assoc
+          ( ap (cogap f g c) (glue-pushout f g s))
+          ( compute-inr-cogap f g c (g s))
+          ( inv (compute-inr-cogap f g c (g s))))) ∙
+      ( ap
+        ( _∙ inv (compute-inr-cogap f g c (g s)))
+        ( pr2
+          ( pr2
+            ( htpy-cocone-map-universal-property-pushout
+              ( f)
+              ( g)
+              ( cocone-pushout f g)
+              ( up-pushout f g)
+              ( c)))
+          ( s)))))
 ```

--- a/src/synthetic-homotopy-theory/pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/pushouts.lagda.md
@@ -128,24 +128,17 @@ compute-glue-cogap :
   ( ( compute-inl-cogap f g c (f s) ∙ coherence-square-cocone f g c s) ∙
     ( inv (compute-inr-cogap f g c (g s))))
 compute-glue-cogap f g c s =
-  ( inv right-unit) ∙
-  ( ( ap
-      ( ap (cogap f g c) (glue-pushout f g s) ∙_)
-      ( inv (right-inv (compute-inr-cogap f g c (g s))))) ∙
-    ( ( inv
-        ( assoc
-          ( ap (cogap f g c) (glue-pushout f g s))
-          ( compute-inr-cogap f g c (g s))
-          ( inv (compute-inr-cogap f g c (g s))))) ∙
-      ( ap
-        ( _∙ inv (compute-inr-cogap f g c (g s)))
-        ( pr2
-          ( pr2
-            ( htpy-cocone-map-universal-property-pushout
-              ( f)
-              ( g)
-              ( cocone-pushout f g)
-              ( up-pushout f g)
-              ( c)))
-          ( s)))))
+  con-inv
+    ( ap (cogap f g c) (glue-pushout f g s))
+    ( compute-inr-cogap f g c (g s))
+    ( compute-inl-cogap f g c (f s) ∙ coherence-square-cocone f g c s)
+    (pr2
+      ( pr2
+        ( htpy-cocone-map-universal-property-pushout
+          ( f)
+          ( g)
+          ( cocone-pushout f g)
+          ( up-pushout f g)
+          ( c)))
+      ( s))
 ```

--- a/src/synthetic-homotopy-theory/pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/pushouts.lagda.md
@@ -11,6 +11,7 @@ open import foundation.dependent-pair-types
 open import foundation.equivalences
 open import foundation.functions
 open import foundation.homotopies
+open import foundation.identity-types
 open import foundation.universe-levels
 
 open import synthetic-homotopy-theory.cocones-under-spans
@@ -45,12 +46,9 @@ postulate
 cocone-pushout :
   {l1 l2 l3 : Level} {S : UU l1} {A : UU l2} {B : UU l3}
   (f : S → A) (g : S → B) → cocone f g (pushout f g)
-cocone-pushout f g =
-  pair
-    ( inl-pushout f g)
-    ( pair
-      ( inr-pushout f g)
-      ( glue-pushout f g))
+pr1 (cocone-pushout f g) = inl-pushout f g
+pr1 (pr2 (cocone-pushout f g)) = inr-pushout f g
+pr2 (pr2 (cocone-pushout f g)) = glue-pushout f g
 
 postulate
   up-pushout :
@@ -60,9 +58,9 @@ postulate
 
 equiv-up-pushout :
   {l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3}
-  (f : S → A) (g : S → B) (Z : UU l4) → ((pushout f g) → Z) ≃ (cocone f g Z)
-equiv-up-pushout f g Z =
-  (cocone-map f g (cocone-pushout f g)) , (up-pushout f g Z)
+  (f : S → A) (g : S → B) (X : UU l4) → (pushout f g → X) ≃ (cocone f g X)
+pr1 (equiv-up-pushout f g X) = cocone-map f g (cocone-pushout f g)
+pr2 (equiv-up-pushout f g X) = up-pushout f g X
 ```
 
 ## Definitions
@@ -73,11 +71,8 @@ equiv-up-pushout f g Z =
 cogap :
   { l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3}
   ( f : S → A) (g : S → B) →
-  { X : UU l4} (c : cocone f g X) → pushout f g → X
-cogap f g =
-  map-universal-property-pushout f g
-    ( cocone-pushout f g)
-    ( up-pushout f g)
+  { X : UU l4} → cocone f g X → pushout f g → X
+cogap f g {X} = map-inv-equiv (equiv-up-pushout f g X)
 ```
 
 ### The `is-pushout` predicate
@@ -88,4 +83,35 @@ is-pushout :
   ( f : S → A) (g : S → B) {X : UU l4} (c : cocone f g X) →
   UU (l1 ⊔ l2 ⊔ l3 ⊔ l4)
 is-pushout f g c = is-equiv (cogap f g c)
+```
+
+## Properties
+
+### Computation with the cogap map
+
+```agda
+compute-inl-cogap :
+  { l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3}
+  ( f : S → A) (g : S → B) →
+  { X : UU l4} (c : cocone f g X)
+  ( a : A) → cogap f g c (inl-pushout f g a) ＝ horizontal-map-cocone f g c a
+compute-inl-cogap f g c =
+  pr1
+    ( htpy-cocone-map-universal-property-pushout
+        ( f)
+        ( g)
+        ( cocone-pushout f g)
+        ( up-pushout f g)
+        ( c))
+
+compute-inr-cogap :
+  { l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3}
+  ( f : S → A) (g : S → B) →
+  { X : UU l4} (c : cocone f g X)
+  ( b : B) → cogap f g c (inr-pushout f g b) ＝ vertical-map-cocone f g c b
+compute-inr-cogap f g c =
+  pr1
+    ( pr2
+      ( htpy-cocone-map-universal-property-pushout
+          f g (cocone-pushout f g) (up-pushout f g) c))
 ```

--- a/src/synthetic-homotopy-theory/pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/pushouts.lagda.md
@@ -113,5 +113,9 @@ compute-inr-cogap f g c =
   pr1
     ( pr2
       ( htpy-cocone-map-universal-property-pushout
-          f g (cocone-pushout f g) (up-pushout f g) c))
+          ( f)
+          ( g)
+          ( cocone-pushout f g)
+          ( up-pushout f g)
+          ( c)))
 ```

--- a/src/synthetic-homotopy-theory/smash-products-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/smash-products-of-pointed-types.lagda.md
@@ -47,7 +47,7 @@ smash-prod-Pointed-Type :
 smash-prod-Pointed-Type A B =
   pushout-Pointed-Type
     ( pointed-map-prod-wedge-Pointed-Type A B)
-    ( gap-unit-Pointed-Type (A ∨* B))
+    ( terminal-pointed-map (A ∨* B))
 
 _∧*_ = smash-prod-Pointed-Type
 ```
@@ -62,19 +62,19 @@ cogap-smash-prod-Pointed-Type :
   {A : Pointed-Type l1} {B : Pointed-Type l2} {X : Pointed-Type l3} →
   type-cocone-Pointed-Type
     ( pointed-map-prod-wedge-Pointed-Type A B)
-    ( gap-unit-Pointed-Type (A ∨* B)) X →
+    ( terminal-pointed-map (A ∨* B)) X →
   (A ∧* B) →* X
 cogap-smash-prod-Pointed-Type {A = A} {B} =
   cogap-Pointed-Type
     ( pointed-map-prod-wedge-Pointed-Type A B)
-    ( gap-unit-Pointed-Type (A ∨* B))
+    ( terminal-pointed-map (A ∨* B))
 
 map-cogap-smash-prod-Pointed-Type :
   {l1 l2 l3 : Level}
   {A : Pointed-Type l1} {B : Pointed-Type l2} {X : Pointed-Type l3} →
   type-cocone-Pointed-Type
     ( pointed-map-prod-wedge-Pointed-Type A B)
-    ( gap-unit-Pointed-Type (A ∨* B))
+    ( terminal-pointed-map (A ∨* B))
     ( X) →
   type-Pointed-Type (A ∧* B) → type-Pointed-Type X
 map-cogap-smash-prod-Pointed-Type c =
@@ -92,7 +92,7 @@ pointed-map-smash-prod-prod-Pointed-Type :
 pointed-map-smash-prod-prod-Pointed-Type A B =
   inl-pushout-Pointed-Type
     ( pointed-map-prod-wedge-Pointed-Type A B)
-    ( gap-unit-Pointed-Type (A ∨* B))
+    ( terminal-pointed-map (A ∨* B))
 ```
 
 ### The smash product is the product in the category of pointed types

--- a/src/synthetic-homotopy-theory/smash-products-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/smash-products-of-pointed-types.lagda.md
@@ -41,13 +41,15 @@ where the map `A ∨* B → A ×* B` is the canonical inclusion
 ## Definition
 
 ```agda
-_∧*_ :
+smash-prod-Pointed-Type :
   {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) →
   Pointed-Type (l1 ⊔ l2)
-A ∧* B =
+smash-prod-Pointed-Type A B =
   pushout-Pointed-Type
     ( pointed-map-prod-wedge-Pointed-Type A B)
     ( gap-pointed-unit (A ∨* B))
+
+_∧*_ = smash-prod-Pointed-Type
 
 cogap-smash-prod-Pointed-Type :
   {l1 l2 l3 : Level}

--- a/src/synthetic-homotopy-theory/smash-products-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/smash-products-of-pointed-types.lagda.md
@@ -84,7 +84,7 @@ map-cogap-smash-prod-Pointed-Type c =
 
 ## Properties
 
-### The pointed map from the product to the smash product
+### The canonical pointed map from the product to the smash product
 
 ```agda
 pointed-map-smash-prod-prod-Pointed-Type :

--- a/src/synthetic-homotopy-theory/smash-products-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/smash-products-of-pointed-types.lagda.md
@@ -28,14 +28,14 @@ Given two pointed types `a : A` and `b : B` we may form their **smash product**
 as the following pushout
 
 ```md
- A ∨* B ----> A ×* B
+ A ∨∗ B ----> A ×∗ B
     |           |
     |           |
     v        ⌜  v
-  unit -----> A ∧* B
+  unit -----> A ∧∗ B
 ```
 
-where the map `A ∨* B → A ×* B` is the canonical inclusion
+where the map `A ∨∗ B → A ×∗ B` is the canonical inclusion
 `map-wedge-prod-Pointed-Type`.
 
 ## Definition
@@ -47,14 +47,15 @@ smash-prod-Pointed-Type :
 smash-prod-Pointed-Type A B =
   pushout-Pointed-Type
     ( pointed-map-prod-wedge-Pointed-Type A B)
-    ( terminal-pointed-map (A ∨* B))
+    ( terminal-pointed-map (A ∨∗ B))
 
-_∧*_ = smash-prod-Pointed-Type
+_∧∗_ = smash-prod-Pointed-Type
 ```
 
-**Note**: The symbol used for the smash product `_∧*_` is the
-[logical and](https://codepoints.net/U+2227) symbol `∧` (agda-input: `\wedge`
-`\and`).
+**Note**: The symbols used for the smash product `_∧∗_` are the
+[logical and](https://codepoints.net/U+2227) `∧` (agda-input: `\wedge` `\and`),
+and the [asterisk operator](https://codepoints.net/U+2217) `∗` (agda-input:
+`\ast`), not the [asterisk](https://codepoints.net/U+002A) `*`.
 
 ```agda
 cogap-smash-prod-Pointed-Type :
@@ -62,21 +63,21 @@ cogap-smash-prod-Pointed-Type :
   {A : Pointed-Type l1} {B : Pointed-Type l2} {X : Pointed-Type l3} →
   type-cocone-Pointed-Type
     ( pointed-map-prod-wedge-Pointed-Type A B)
-    ( terminal-pointed-map (A ∨* B)) X →
-  (A ∧* B) →* X
+    ( terminal-pointed-map (A ∨∗ B)) X →
+  (A ∧∗ B) →∗ X
 cogap-smash-prod-Pointed-Type {A = A} {B} =
   cogap-Pointed-Type
     ( pointed-map-prod-wedge-Pointed-Type A B)
-    ( terminal-pointed-map (A ∨* B))
+    ( terminal-pointed-map (A ∨∗ B))
 
 map-cogap-smash-prod-Pointed-Type :
   {l1 l2 l3 : Level}
   {A : Pointed-Type l1} {B : Pointed-Type l2} {X : Pointed-Type l3} →
   type-cocone-Pointed-Type
     ( pointed-map-prod-wedge-Pointed-Type A B)
-    ( terminal-pointed-map (A ∨* B))
+    ( terminal-pointed-map (A ∨∗ B))
     ( X) →
-  type-Pointed-Type (A ∧* B) → type-Pointed-Type X
+  type-Pointed-Type (A ∧∗ B) → type-Pointed-Type X
 map-cogap-smash-prod-Pointed-Type c =
   pr1 (cogap-smash-prod-Pointed-Type c)
 ```
@@ -88,11 +89,11 @@ map-cogap-smash-prod-Pointed-Type c =
 ```agda
 pointed-map-smash-prod-prod-Pointed-Type :
   {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) →
-  (A ×* B) →* (A ∧* B)
+  (A ×∗ B) →∗ (A ∧∗ B)
 pointed-map-smash-prod-prod-Pointed-Type A B =
   inl-pushout-Pointed-Type
     ( pointed-map-prod-wedge-Pointed-Type A B)
-    ( terminal-pointed-map (A ∨* B))
+    ( terminal-pointed-map (A ∨∗ B))
 ```
 
 ### The smash product is the product in the category of pointed types
@@ -101,15 +102,15 @@ pointed-map-smash-prod-prod-Pointed-Type A B =
 gap-smash-prod-Pointed-Type :
   {l1 l2 l3 : Level}
   (A : Pointed-Type l1) (B : Pointed-Type l2) (S : Pointed-Type l3) →
-  (f : S →* A) (g : S →* B) → S →* (A ∧* B)
+  (f : S →∗ A) (g : S →∗ B) → S →∗ (A ∧∗ B)
 gap-smash-prod-Pointed-Type A B S f g =
-  pointed-map-smash-prod-prod-Pointed-Type A B ∘*
+  pointed-map-smash-prod-prod-Pointed-Type A B ∘∗
   gap-prod-Pointed-Type A B S f g
 
 map-gap-smash-prod-Pointed-Type :
   {l1 l2 l3 : Level}
   (A : Pointed-Type l1) (B : Pointed-Type l2) (S : Pointed-Type l3) →
-  (f : S →* A) (g : S →* B) → type-Pointed-Type S → type-Pointed-Type (A ∧* B)
+  (f : S →∗ A) (g : S →∗ B) → type-Pointed-Type S → type-Pointed-Type (A ∧∗ B)
 map-gap-smash-prod-Pointed-Type A B S f g =
   pr1 (gap-smash-prod-Pointed-Type A B S f g)
 ```

--- a/src/synthetic-homotopy-theory/smash-products-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/smash-products-of-pointed-types.lagda.md
@@ -7,23 +7,16 @@ module synthetic-homotopy-theory.smash-products-of-pointed-types where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.cartesian-product-types
-open import foundation.constant-maps
 open import foundation.dependent-pair-types
-open import foundation.equational-reasoning
-open import foundation.equivalences
-open import foundation.function-extensionality
-open import foundation.homotopies
-open import foundation.identity-types
-open import foundation.unit-type
 open import foundation.universe-levels
 
 open import structured-types.pointed-cartesian-product-types
 open import structured-types.pointed-maps
 open import structured-types.pointed-types
+open import structured-types.pointed-unit-type
 
-open import synthetic-homotopy-theory.cofibers
-open import synthetic-homotopy-theory.pushouts
+open import synthetic-homotopy-theory.cocones-under-spans-of-pointed-types
+open import synthetic-homotopy-theory.pushouts-of-pointed-types
 open import synthetic-homotopy-theory.wedges-of-pointed-types
 ```
 
@@ -51,15 +44,33 @@ where the map `A ∨* B → A ×* B` is the canonical inclusion
 _∧*_ :
   {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) →
   Pointed-Type (l1 ⊔ l2)
-pr1 (A ∧* B) =
-  pushout
-    ( map-prod-wedge-Pointed-Type A B)
-    ( λ _ → star)
-pr2 (A ∧* B) =
-  inr-pushout
-    ( map-prod-wedge-Pointed-Type A B)
-    ( λ _ → star)
-    ( star)
+A ∧* B =
+  pushout-Pointed-Type
+    ( pointed-map-prod-wedge-Pointed-Type A B)
+    ( gap-pointed-unit (A ∨* B))
+
+cogap-smash-prod-Pointed-Type :
+  {l1 l2 l3 : Level}
+  {A : Pointed-Type l1} {B : Pointed-Type l2} {X : Pointed-Type l3} →
+  type-cocone-Pointed-Type
+    ( pointed-map-prod-wedge-Pointed-Type A B)
+    ( gap-pointed-unit (A ∨* B)) X →
+  (A ∧* B) →* X
+cogap-smash-prod-Pointed-Type {A = A} {B} =
+  cogap-Pointed-Type
+    ( pointed-map-prod-wedge-Pointed-Type A B)
+    ( gap-pointed-unit (A ∨* B))
+
+map-cogap-smash-prod-Pointed-Type :
+  {l1 l2 l3 : Level}
+  {A : Pointed-Type l1} {B : Pointed-Type l2} {X : Pointed-Type l3} →
+  type-cocone-Pointed-Type
+    ( pointed-map-prod-wedge-Pointed-Type A B)
+    ( gap-pointed-unit (A ∨* B))
+    ( X) →
+  type-Pointed-Type (A ∧* B) → type-Pointed-Type X
+map-cogap-smash-prod-Pointed-Type c =
+  pr1 (cogap-smash-prod-Pointed-Type c)
 ```
 
 ## Properties
@@ -70,37 +81,15 @@ pr2 (A ∧* B) =
 pointed-map-smash-prod-prod-Pointed-Type :
   {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) →
   (A ×* B) →* (A ∧* B)
-pr1 (pointed-map-smash-prod-prod-Pointed-Type A B) =
-  inl-pushout (map-prod-wedge-Pointed-Type A B) (λ _ → star)
-pr2 (pointed-map-smash-prod-prod-Pointed-Type A B) =
-  ( ap
-    ( inl-pushout
-      ( map-prod-wedge-Pointed-Type A B)
-      ( λ _ → star))
-    ( inv
-      ( preserves-point-pointed-map
-        (A ∨* B)
-        (A ×* B)
-        ( pointed-map-prod-wedge-Pointed-Type A B)))) ∙
-  ( glue-pushout
-    ( map-prod-wedge-Pointed-Type A B)
-    ( λ _ → star)
-    ( point-Pointed-Type (A ∨* B)))
+pointed-map-smash-prod-prod-Pointed-Type A B =
+  inl-pushout-Pointed-Type
+    ( pointed-map-prod-wedge-Pointed-Type A B)
+    ( gap-pointed-unit (A ∨* B))
 ```
 
 ### The smash product is the product in the category of pointed types
 
 ```agda
-map-gap-smash-prod-Pointed-Type :
-  {l1 l2 l3 : Level}
-  (A : Pointed-Type l1) (B : Pointed-Type l2) (S : Pointed-Type l3) →
-  (f : S →* A) (g : S →* B) → type-Pointed-Type S → type-Pointed-Type (A ∧* B)
-map-gap-smash-prod-Pointed-Type A B S f g s =
-  inl-pushout
-    ( map-prod-wedge-Pointed-Type A B)
-    ( λ _ → star)
-    ( map-pointed-map S A f s , map-pointed-map S B g s)
-
 gap-smash-prod-Pointed-Type :
   {l1 l2 l3 : Level}
   (A : Pointed-Type l1) (B : Pointed-Type l2) (S : Pointed-Type l3) →
@@ -108,6 +97,13 @@ gap-smash-prod-Pointed-Type :
 gap-smash-prod-Pointed-Type A B S f g =
   pointed-map-smash-prod-prod-Pointed-Type A B ∘*
   gap-prod-Pointed-Type A B S f g
+
+map-gap-smash-prod-Pointed-Type :
+  {l1 l2 l3 : Level}
+  (A : Pointed-Type l1) (B : Pointed-Type l2) (S : Pointed-Type l3) →
+  (f : S →* A) (g : S →* B) → type-Pointed-Type S → type-Pointed-Type (A ∧* B)
+map-gap-smash-prod-Pointed-Type A B S f g =
+  pr1 (gap-smash-prod-Pointed-Type A B S f g)
 ```
 
 It remains to show that this is the correct map, and that it is unique.

--- a/src/synthetic-homotopy-theory/smash-products-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/smash-products-of-pointed-types.lagda.md
@@ -50,7 +50,13 @@ smash-prod-Pointed-Type A B =
     ( gap-pointed-unit (A ∨* B))
 
 _∧*_ = smash-prod-Pointed-Type
+```
 
+The symbol used for the smash product `_∧*_` is the
+"[logical and](https://codepoints.net/U+2227)" symbol `∧` (agda-input: `\wedge`
+or `\and`).
+
+```agda
 cogap-smash-prod-Pointed-Type :
   {l1 l2 l3 : Level}
   {A : Pointed-Type l1} {B : Pointed-Type l2} {X : Pointed-Type l3} →

--- a/src/synthetic-homotopy-theory/smash-products-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/smash-products-of-pointed-types.lagda.md
@@ -52,9 +52,9 @@ smash-prod-Pointed-Type A B =
 _∧*_ = smash-prod-Pointed-Type
 ```
 
-The symbol used for the smash product `_∧*_` is the
-"[logical and](https://codepoints.net/U+2227)" symbol `∧` (agda-input: `\wedge`
-or `\and`).
+**Note**: The symbol used for the smash product `_∧*_` is the
+[logical and](https://codepoints.net/U+2227) symbol `∧` (agda-input: `\wedge`
+`\and`).
 
 ```agda
 cogap-smash-prod-Pointed-Type :

--- a/src/synthetic-homotopy-theory/smash-products-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/smash-products-of-pointed-types.lagda.md
@@ -1,0 +1,117 @@
+# Smash products of pointed types
+
+```agda
+module synthetic-homotopy-theory.smash-products-of-pointed-types where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.cartesian-product-types
+open import foundation.constant-maps
+open import foundation.dependent-pair-types
+open import foundation.equational-reasoning
+open import foundation.equivalences
+open import foundation.function-extensionality
+open import foundation.homotopies
+open import foundation.identity-types
+open import foundation.unit-type
+open import foundation.universe-levels
+
+open import structured-types.pointed-cartesian-product-types
+open import structured-types.pointed-maps
+open import structured-types.pointed-types
+
+open import synthetic-homotopy-theory.cofibers
+open import synthetic-homotopy-theory.pushouts
+open import synthetic-homotopy-theory.wedges-of-pointed-types
+```
+
+</details>
+
+## Idea
+
+Given two pointed types `a : A` and `b : B` we may form their **smash product**
+as the following pushout
+
+```md
+ A ∨* B ----> A ×* B
+    |           |
+    |           |
+    v        ⌜  v
+  unit -----> A ∧* B
+```
+
+where the map `A ∨* B → A ×* B` is the canonical inclusion
+`map-wedge-prod-Pointed-Type`.
+
+## Definition
+
+```agda
+_∧*_ :
+  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) →
+  Pointed-Type (l1 ⊔ l2)
+pr1 (A ∧* B) =
+  pushout
+    ( map-prod-wedge-Pointed-Type A B)
+    ( λ _ → star)
+pr2 (A ∧* B) =
+  inr-pushout
+    ( map-prod-wedge-Pointed-Type A B)
+    ( λ _ → star)
+    ( star)
+```
+
+## Properties
+
+### The pointed map from the product to the smash product
+
+```agda
+pointed-map-smash-prod-prod-Pointed-Type :
+  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) →
+  (A ×* B) →* (A ∧* B)
+pr1 (pointed-map-smash-prod-prod-Pointed-Type A B) =
+  inl-pushout (map-prod-wedge-Pointed-Type A B) (λ _ → star)
+pr2 (pointed-map-smash-prod-prod-Pointed-Type A B) =
+  ( ap
+    ( inl-pushout
+      ( map-prod-wedge-Pointed-Type A B)
+      ( λ _ → star))
+    ( inv
+      ( preserves-point-pointed-map
+        (A ∨* B)
+        (A ×* B)
+        ( pointed-map-prod-wedge-Pointed-Type A B)))) ∙
+  ( glue-pushout
+    ( map-prod-wedge-Pointed-Type A B)
+    ( λ _ → star)
+    ( point-Pointed-Type (A ∨* B)))
+```
+
+### The smash product is the product in the category of pointed types
+
+```agda
+map-gap-smash-prod-Pointed-Type :
+  {l1 l2 l3 : Level}
+  (A : Pointed-Type l1) (B : Pointed-Type l2) (S : Pointed-Type l3) →
+  (f : S →* A) (g : S →* B) → type-Pointed-Type S → type-Pointed-Type (A ∧* B)
+map-gap-smash-prod-Pointed-Type A B S f g s =
+  inl-pushout
+    ( map-prod-wedge-Pointed-Type A B)
+    ( λ _ → star)
+    ( map-pointed-map S A f s , map-pointed-map S B g s)
+
+gap-smash-prod-Pointed-Type :
+  {l1 l2 l3 : Level}
+  (A : Pointed-Type l1) (B : Pointed-Type l2) (S : Pointed-Type l3) →
+  (f : S →* A) (g : S →* B) → S →* (A ∧* B)
+gap-smash-prod-Pointed-Type A B S f g =
+  pointed-map-smash-prod-prod-Pointed-Type A B ∘*
+  gap-prod-Pointed-Type A B S f g
+```
+
+It remains to show that this is the correct map, and that it is unique.
+
+## See also
+
+- [Wedges of pointed types](synthetic-homotopy-theory.wedges-of-pointed-types.md)

--- a/src/synthetic-homotopy-theory/smash-products-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/smash-products-of-pointed-types.lagda.md
@@ -47,7 +47,7 @@ smash-prod-Pointed-Type :
 smash-prod-Pointed-Type A B =
   pushout-Pointed-Type
     ( pointed-map-prod-wedge-Pointed-Type A B)
-    ( gap-pointed-unit (A ∨* B))
+    ( gap-unit-Pointed-Type (A ∨* B))
 
 _∧*_ = smash-prod-Pointed-Type
 ```
@@ -62,19 +62,19 @@ cogap-smash-prod-Pointed-Type :
   {A : Pointed-Type l1} {B : Pointed-Type l2} {X : Pointed-Type l3} →
   type-cocone-Pointed-Type
     ( pointed-map-prod-wedge-Pointed-Type A B)
-    ( gap-pointed-unit (A ∨* B)) X →
+    ( gap-unit-Pointed-Type (A ∨* B)) X →
   (A ∧* B) →* X
 cogap-smash-prod-Pointed-Type {A = A} {B} =
   cogap-Pointed-Type
     ( pointed-map-prod-wedge-Pointed-Type A B)
-    ( gap-pointed-unit (A ∨* B))
+    ( gap-unit-Pointed-Type (A ∨* B))
 
 map-cogap-smash-prod-Pointed-Type :
   {l1 l2 l3 : Level}
   {A : Pointed-Type l1} {B : Pointed-Type l2} {X : Pointed-Type l3} →
   type-cocone-Pointed-Type
     ( pointed-map-prod-wedge-Pointed-Type A B)
-    ( gap-pointed-unit (A ∨* B))
+    ( gap-unit-Pointed-Type (A ∨* B))
     ( X) →
   type-Pointed-Type (A ∧* B) → type-Pointed-Type X
 map-cogap-smash-prod-Pointed-Type c =
@@ -92,7 +92,7 @@ pointed-map-smash-prod-prod-Pointed-Type :
 pointed-map-smash-prod-prod-Pointed-Type A B =
   inl-pushout-Pointed-Type
     ( pointed-map-prod-wedge-Pointed-Type A B)
-    ( gap-pointed-unit (A ∨* B))
+    ( gap-unit-Pointed-Type (A ∨* B))
 ```
 
 ### The smash product is the product in the category of pointed types

--- a/src/synthetic-homotopy-theory/spectra.lagda.md
+++ b/src/synthetic-homotopy-theory/spectra.lagda.md
@@ -23,12 +23,12 @@ open import synthetic-homotopy-theory.loop-spaces
 ## Idea
 
 A spectrum is an infinite sequence of pointed types `A` such that
-`A n ≃* Ω (A (n+1))` for each `n : ℕ`.
+`A n ≃∗ Ω (A (n+1))` for each `n : ℕ`.
 
 ## Definition
 
 ```agda
 Spectrum : (l : Level) → UU (lsuc l)
 Spectrum l =
-  Σ (ℕ → Pointed-Type l) (λ A → (n : ℕ) → A n ≃* Ω (A (succ-ℕ n)))
+  Σ (ℕ → Pointed-Type l) (λ A → (n : ℕ) → A n ≃∗ Ω (A (succ-ℕ n)))
 ```

--- a/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
@@ -404,7 +404,7 @@ module _
 
 Here we prove the universal property of the suspension of a pointed type: the
 suspension is left adjoint to the loop space. We do this by constructing an
-equivalence ((suspension A) →* B) ≃ (A →* Ω B) and showing this equivalences is
+equivalence ((suspension A) →∗ B) ≃ (A →∗ Ω B) and showing this equivalences is
 given by λ f → Ω(f) ∘ unit
 
 #### The unit and counit of the adjunction
@@ -418,7 +418,7 @@ module _
   shift l = l ∙ (merid-susp (point-Pointed-Type X))
 
   shift* :
-    Ω (suspension-Pointed-Type X) →*
+    Ω (suspension-Pointed-Type X) →∗
     ((N-susp ＝ S-susp) , (merid-susp (point-Pointed-Type X)))
   pr1 shift* = shift
   pr2 shift* = refl
@@ -427,7 +427,7 @@ module _
   unshift p = p ∙ inv (merid-susp (point-Pointed-Type X))
 
   unshift* :
-    ((N-susp ＝ S-susp) , (merid-susp (point-Pointed-Type X))) →*
+    ((N-susp ＝ S-susp) , (merid-susp (point-Pointed-Type X))) →∗
     Ω (suspension-Pointed-Type X)
   pr1 unshift* = unshift
   pr2 unshift* = right-inv (merid-susp (point-Pointed-Type X))
@@ -436,17 +436,17 @@ module _
   is-equiv-shift = is-equiv-concat' N-susp (merid-susp (point-Pointed-Type X))
 
   pointed-equiv-shift :
-    ( Ω (suspension-Pointed-Type X)) ≃*
+    ( Ω (suspension-Pointed-Type X)) ≃∗
     ( (N-susp ＝ S-susp) , merid-susp (point-Pointed-Type X))
   pr1 (pr1 pointed-equiv-shift) = shift
   pr2 (pr1 pointed-equiv-shift) = is-equiv-shift
   pr2 pointed-equiv-shift = preserves-point-pointed-map _ _ shift*
 
-  merid-susp* : X →* ((N-susp ＝ S-susp) , (merid-susp (point-Pointed-Type X)))
+  merid-susp* : X →∗ ((N-susp ＝ S-susp) , (merid-susp (point-Pointed-Type X)))
   pr1 merid-susp* = merid-susp
   pr2 merid-susp* = refl
 
-  unit-susp-loop-adj* : X →* Ω (suspension-Pointed-Type X)
+  unit-susp-loop-adj* : X →∗ Ω (suspension-Pointed-Type X)
   unit-susp-loop-adj* = comp-pointed-map _ _ _ unshift* merid-susp*
 
   unit-susp-loop-adj : type-Pointed-Type X → type-Ω (suspension-Pointed-Type X)
@@ -460,7 +460,7 @@ module _
         ( point-Pointed-Type X) ,
         ( id))
 
-  counit-susp-loop-adj* : ((suspension (type-Ω X)) , N-susp) →* X
+  counit-susp-loop-adj* : ((suspension (type-Ω X)) , N-susp) →∗ X
   pr1 counit-susp-loop-adj* = counit-susp-loop-adj
   pr2 counit-susp-loop-adj* =
     up-suspension-N-susp
@@ -478,7 +478,7 @@ module _
   {l1 l2 : Level} (X : Pointed-Type l1) (Y : Pointed-Type l2)
   where
 
-  equiv-susp-loop-adj : (suspension-Pointed-Type X →* Y) ≃ (X →* Ω Y)
+  equiv-susp-loop-adj : (suspension-Pointed-Type X →∗ Y) ≃ (X →∗ Ω Y)
   equiv-susp-loop-adj =
     ( left-unit-law-Σ-is-contr
       ( is-contr-total-path (point-Pointed-Type Y))

--- a/src/synthetic-homotopy-theory/universal-cover-circle.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-cover-circle.lagda.md
@@ -777,11 +777,11 @@ abstract
       ( inv-htpy
         ( pr2 (pr2 (Contraction-fundamental-cover-circle l dup-circle))))
 
-pt-fundamental-cover-circle :
+point-fundamental-cover-circle :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
   ( dup-circle : {l2 : Level} → dependent-universal-property-circle l2 l) →
   fundamental-cover-circle l dup-circle (base-free-loop l)
-pt-fundamental-cover-circle l dup-circle =
+point-fundamental-cover-circle l dup-circle =
   map-equiv (compute-fiber-fundamental-cover-circle l dup-circle) zero-ℤ
 
 fundamental-cover-circle-eq :
@@ -789,7 +789,7 @@ fundamental-cover-circle-eq :
   ( dup-circle : {l2 : Level} → dependent-universal-property-circle l2 l) →
   ( x : X) → Id (base-free-loop l) x → fundamental-cover-circle l dup-circle x
 fundamental-cover-circle-eq l dup-circle .(base-free-loop l) refl =
-  pt-fundamental-cover-circle l dup-circle
+  point-fundamental-cover-circle l dup-circle
 
 abstract
   is-equiv-fundamental-cover-circle-eq :

--- a/src/synthetic-homotopy-theory/wedges-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/wedges-of-pointed-types.lagda.md
@@ -46,8 +46,8 @@ wedge-Pointed-Type :
   Pointed-Type (l1 ⊔ l2)
 wedge-Pointed-Type A B =
   pushout-Pointed-Type
-    ( cogap-unit-Pointed-Type A)
-    ( cogap-unit-Pointed-Type B)
+    ( inclusion-point-Pointed-Type A)
+    ( inclusion-point-Pointed-Type B)
 
 _∨*_ = wedge-Pointed-Type
 ```
@@ -74,8 +74,8 @@ defined by the cogap map induced by the canonical inclusions `A → A ×* B ← 
 cocone-prod-wedge-Pointed-Type :
   {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) →
   type-cocone-Pointed-Type
-    ( cogap-unit-Pointed-Type A)
-    ( cogap-unit-Pointed-Type B)
+    ( inclusion-point-Pointed-Type A)
+    ( inclusion-point-Pointed-Type B)
     ( A ×* B)
 pr1 (cocone-prod-wedge-Pointed-Type A B) = inl-prod-Pointed-Type A B
 pr1 (pr2 (cocone-prod-wedge-Pointed-Type A B)) = inr-prod-Pointed-Type A B
@@ -87,8 +87,8 @@ pointed-map-prod-wedge-Pointed-Type :
   (A ∨* B) →* (A ×* B)
 pointed-map-prod-wedge-Pointed-Type A B =
   cogap-Pointed-Type
-    ( cogap-unit-Pointed-Type A)
-    ( cogap-unit-Pointed-Type B)
+    ( inclusion-point-Pointed-Type A)
+    ( inclusion-point-Pointed-Type B)
     ( cocone-prod-wedge-Pointed-Type A B)
 
 map-prod-wedge-Pointed-Type :

--- a/src/synthetic-homotopy-theory/wedges-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/wedges-of-pointed-types.lagda.md
@@ -53,8 +53,8 @@ _∨*_ = wedge-Pointed-Type
 ```
 
 **Note**: the symbol used for the wedge sum `_∨*_` is the
-"[logical or](https://codepoints.net/U+2228)" symbol `∨` (agda-input: `\vee` or
-`\or`), and not the latin letter `v`.
+[logical or](https://codepoints.net/U+2228) symbol `∨` (agda-input: `\vee`
+`\or`), and not the latin small letter v `v`.
 
 ```agda
 indexed-wedge :

--- a/src/synthetic-homotopy-theory/wedges-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/wedges-of-pointed-types.lagda.md
@@ -46,8 +46,8 @@ wedge-Pointed-Type :
   Pointed-Type (l1 ⊔ l2)
 wedge-Pointed-Type A B =
   pushout-Pointed-Type
-    ( cogap-pointed-unit A)
-    ( cogap-pointed-unit B)
+    ( cogap-unit-Pointed-Type A)
+    ( cogap-unit-Pointed-Type B)
 
 _∨*_ = wedge-Pointed-Type
 ```
@@ -74,8 +74,8 @@ defined by the cogap map induced by the canonical inclusions `A → A ×* B ← 
 cocone-prod-wedge-Pointed-Type :
   {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) →
   type-cocone-Pointed-Type
-    ( cogap-pointed-unit A)
-    ( cogap-pointed-unit B)
+    ( cogap-unit-Pointed-Type A)
+    ( cogap-unit-Pointed-Type B)
     ( A ×* B)
 pr1 (cocone-prod-wedge-Pointed-Type A B) = inl-prod-Pointed-Type A B
 pr1 (pr2 (cocone-prod-wedge-Pointed-Type A B)) = inr-prod-Pointed-Type A B
@@ -87,8 +87,8 @@ pointed-map-prod-wedge-Pointed-Type :
   (A ∨* B) →* (A ×* B)
 pointed-map-prod-wedge-Pointed-Type A B =
   cogap-Pointed-Type
-    ( cogap-pointed-unit A)
-    ( cogap-pointed-unit B)
+    ( cogap-unit-Pointed-Type A)
+    ( cogap-unit-Pointed-Type B)
     ( cocone-prod-wedge-Pointed-Type A B)
 
 map-prod-wedge-Pointed-Type :

--- a/src/synthetic-homotopy-theory/wedges-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/wedges-of-pointed-types.lagda.md
@@ -12,50 +12,103 @@ open import foundation.constant-maps
 open import foundation.dependent-pair-types
 open import foundation.equivalences
 open import foundation.homotopies
+open import foundation.identity-types
 open import foundation.unit-type
 open import foundation.universe-levels
 
+open import structured-types.pointed-cartesian-product-types
+open import structured-types.pointed-maps
 open import structured-types.pointed-types
 
+open import synthetic-homotopy-theory.cocones-under-spans
 open import synthetic-homotopy-theory.cofibers
 open import synthetic-homotopy-theory.pushouts
 ```
 
 </details>
 
+## Idea
+
+The **wedge** or **wedge sum** of two pointed types `a : A` and `b : B` is
+defined by the following pushout.
+
+```md
+  unit ------> A
+    |          |
+    |          |
+    v       ⌜  v
+    B -----> A ∨* B
+```
+
+The wedge sum is canonically pointed at the (identified) images of `a` and `b`.
+
+## Definition
+
 ```agda
 _∨*_ :
   {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) →
   Pointed-Type (l1 ⊔ l2)
-A ∨* B =
-  pair
-    ( pushout
-      ( const unit (pr1 A) (pr2 A))
-      ( const unit (pr1 B) (pr2 B)))
-    ( inl-pushout
-      ( const unit (pr1 A) (pr2 A))
-      ( const unit (pr1 B) (pr2 B))
-      ( pr2 A))
+pr1 (A ∨* B) =
+  pushout
+    { S = unit}
+    ( λ _ → point-Pointed-Type A)
+    ( λ _ → point-Pointed-Type B)
+pr2 (A ∨* B) =
+  inl-pushout
+    ( λ _ → point-Pointed-Type A)
+    ( λ _ → point-Pointed-Type B)
+    ( point-Pointed-Type A)
 
 indexed-wedge :
   {l1 l2 : Level} (I : UU l1) (A : I → Pointed-Type l2) → Pointed-Type (l1 ⊔ l2)
-indexed-wedge I A =
-  pair
-    ( cofiber (λ i → pair i (pr2 (A i))))
-    ( pt-cofiber (λ i → pair i (pr2 (A i))))
-
-wedge-inclusion :
-  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) →
-  pr1 (A ∨* B) → (pr1 A) × (pr1 B)
-wedge-inclusion {l1} {l2} (pair A a) (pair B b) =
-  map-inv-is-equiv
-    ( up-pushout
-      ( const unit A a)
-      ( const unit B b)
-      ( A × B))
-    ( pair
-      ( λ x → pair x b)
-      ( pair
-        ( λ y → pair a y)
-        ( refl-htpy)))
+pr1 (indexed-wedge I A) = cofiber (λ i → i , point-Pointed-Type (A i))
+pr2 (indexed-wedge I A) = point-cofiber (λ i → i , point-Pointed-Type (A i))
 ```
+
+## Properties
+
+### The canonical inclusion of the wedge sum `A ∨* B` into the pointed product `A ×* B`
+
+There is a canonical inclusion of the wedge sum into the pointed product that is
+defined by the cogap map induced by the canonical inclusions `A → A ×* B ← B`.
+
+```agda
+cocone-prod-wedge-Pointed-Type :
+  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) →
+  cocone
+    { S = unit}
+    ( λ _ → point-Pointed-Type A)
+    ( λ _ → point-Pointed-Type B)
+    ( type-Pointed-Type (A ×* B))
+pr1 (cocone-prod-wedge-Pointed-Type A B) x = x , point-Pointed-Type B
+pr1 (pr2 (cocone-prod-wedge-Pointed-Type A B)) y = point-Pointed-Type A , y
+pr2 (pr2 (cocone-prod-wedge-Pointed-Type A B)) = refl-htpy
+
+map-prod-wedge-Pointed-Type :
+  {l1 l2 : Level}
+  (A : Pointed-Type l1) (B : Pointed-Type l2) →
+  type-Pointed-Type (A ∨* B) → type-Pointed-Type (A ×* B)
+map-prod-wedge-Pointed-Type A B =
+  cogap
+    ( λ _ → point-Pointed-Type A)
+    ( λ _ → point-Pointed-Type B)
+    ( cocone-prod-wedge-Pointed-Type A B)
+
+pointed-map-prod-wedge-Pointed-Type :
+  {l1 l2 : Level}
+  (A : Pointed-Type l1) (B : Pointed-Type l2) →
+  (A ∨* B) →* (A ×* B)
+pr1 (pointed-map-prod-wedge-Pointed-Type A B) =
+  map-prod-wedge-Pointed-Type A B
+pr2 (pointed-map-prod-wedge-Pointed-Type A B) =
+  compute-inl-cogap
+    ( λ _ → point-Pointed-Type A)
+    ( λ _ → point-Pointed-Type B)
+    ( cocone-prod-wedge-Pointed-Type A B)
+    ( point-Pointed-Type A)
+```
+
+## See also
+
+- [Smash products of pointed types](synthetic-homotopy-theory.smash-products-of-pointed-types.md)
+  for a related construction.

--- a/src/synthetic-homotopy-theory/wedges-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/wedges-of-pointed-types.lagda.md
@@ -41,13 +41,15 @@ The wedge sum is canonically pointed at the (identified) images of `a` and `b`.
 ## Definition
 
 ```agda
-_∨*_ :
+wedge-Pointed-Type :
   {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) →
   Pointed-Type (l1 ⊔ l2)
-A ∨* B =
+wedge-Pointed-Type A B =
   pushout-Pointed-Type
     ( cogap-pointed-unit A)
     ( cogap-pointed-unit B)
+
+_∨*_ = wedge-Pointed-Type
 
 indexed-wedge :
   {l1 l2 : Level} (I : UU l1) (A : I → Pointed-Type l2) → Pointed-Type (l1 ⊔ l2)

--- a/src/synthetic-homotopy-theory/wedges-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/wedges-of-pointed-types.lagda.md
@@ -50,7 +50,13 @@ wedge-Pointed-Type A B =
     ( cogap-pointed-unit B)
 
 _∨*_ = wedge-Pointed-Type
+```
 
+**Note**: the symbol used for the wedge sum `_∨*_` is the
+"[logical or](https://codepoints.net/U+2228)" symbol `∨` (agda-input: `\vee` or
+`\or`), and not the latin letter `v`.
+
+```agda
 indexed-wedge :
   {l1 l2 : Level} (I : UU l1) (A : I → Pointed-Type l2) → Pointed-Type (l1 ⊔ l2)
 pr1 (indexed-wedge I A) = cofiber (λ i → i , point-Pointed-Type (A i))

--- a/src/synthetic-homotopy-theory/wedges-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/wedges-of-pointed-types.lagda.md
@@ -9,6 +9,7 @@ module synthetic-homotopy-theory.wedges-of-pointed-types where
 ```agda
 open import foundation.dependent-pair-types
 open import foundation.homotopies
+open import foundation.identity-types
 open import foundation.universe-levels
 
 open import structured-types.pointed-cartesian-product-types
@@ -81,7 +82,8 @@ cocone-prod-wedge-Pointed-Type :
     ( A ×∗ B)
 pr1 (cocone-prod-wedge-Pointed-Type A B) = inl-prod-Pointed-Type A B
 pr1 (pr2 (cocone-prod-wedge-Pointed-Type A B)) = inr-prod-Pointed-Type A B
-pr2 (pr2 (cocone-prod-wedge-Pointed-Type A B)) = refl-htpy
+pr1 (pr2 (pr2 (cocone-prod-wedge-Pointed-Type A B))) = refl-htpy
+pr2 (pr2 (pr2 (cocone-prod-wedge-Pointed-Type A B))) = refl
 
 pointed-map-prod-wedge-Pointed-Type :
   {l1 l2 : Level}

--- a/src/synthetic-homotopy-theory/wedges-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/wedges-of-pointed-types.lagda.md
@@ -33,7 +33,7 @@ defined by the following pushout.
     |          |
     |          |
     v       ⌜  v
-    B -----> A ∨* B
+    B -----> A ∨∗ B
 ```
 
 The wedge sum is canonically pointed at the (identified) images of `a` and `b`.
@@ -49,12 +49,14 @@ wedge-Pointed-Type A B =
     ( inclusion-point-Pointed-Type A)
     ( inclusion-point-Pointed-Type B)
 
-_∨*_ = wedge-Pointed-Type
+_∨∗_ = wedge-Pointed-Type
 ```
 
-**Note**: the symbol used for the wedge sum `_∨*_` is the
-[logical or](https://codepoints.net/U+2228) symbol `∨` (agda-input: `\vee`
-`\or`), and not the latin small letter v `v`.
+**Note**: the symbols used for the wedge sum `_∨∗_` are the
+[logical or](https://codepoints.net/U+2228) `∨` (agda-input: `\vee` `\or`) and
+the [asterisk operator](https://codepoints.net/U+2217) `∗` (agda-input: `\ast`),
+not the [latin small letter v](https://codepoints.net/U+0076) `v` or the
+[asterisk](https://codepoints.net/U+002A) `*`.
 
 ```agda
 indexed-wedge :
@@ -65,10 +67,10 @@ pr2 (indexed-wedge I A) = point-cofiber (λ i → i , point-Pointed-Type (A i))
 
 ## Properties
 
-### The canonical inclusion of the wedge sum `A ∨* B` into the pointed product `A ×* B`
+### The canonical inclusion of the wedge sum `A ∨∗ B` into the pointed product `A ×∗ B`
 
 There is a canonical inclusion of the wedge sum into the pointed product that is
-defined by the cogap map induced by the canonical inclusions `A → A ×* B ← B`.
+defined by the cogap map induced by the canonical inclusions `A → A ×∗ B ← B`.
 
 ```agda
 cocone-prod-wedge-Pointed-Type :
@@ -76,7 +78,7 @@ cocone-prod-wedge-Pointed-Type :
   type-cocone-Pointed-Type
     ( inclusion-point-Pointed-Type A)
     ( inclusion-point-Pointed-Type B)
-    ( A ×* B)
+    ( A ×∗ B)
 pr1 (cocone-prod-wedge-Pointed-Type A B) = inl-prod-Pointed-Type A B
 pr1 (pr2 (cocone-prod-wedge-Pointed-Type A B)) = inr-prod-Pointed-Type A B
 pr2 (pr2 (cocone-prod-wedge-Pointed-Type A B)) = refl-htpy
@@ -84,7 +86,7 @@ pr2 (pr2 (cocone-prod-wedge-Pointed-Type A B)) = refl-htpy
 pointed-map-prod-wedge-Pointed-Type :
   {l1 l2 : Level}
   (A : Pointed-Type l1) (B : Pointed-Type l2) →
-  (A ∨* B) →* (A ×* B)
+  (A ∨∗ B) →∗ (A ×∗ B)
 pointed-map-prod-wedge-Pointed-Type A B =
   cogap-Pointed-Type
     ( inclusion-point-Pointed-Type A)
@@ -94,7 +96,7 @@ pointed-map-prod-wedge-Pointed-Type A B =
 map-prod-wedge-Pointed-Type :
   {l1 l2 : Level}
   (A : Pointed-Type l1) (B : Pointed-Type l2) →
-  type-Pointed-Type (A ∨* B) → type-Pointed-Type (A ×* B)
+  type-Pointed-Type (A ∨∗ B) → type-Pointed-Type (A ×∗ B)
 map-prod-wedge-Pointed-Type A B = pr1 (pointed-map-prod-wedge-Pointed-Type A B)
 ```
 

--- a/src/synthetic-homotopy-theory/wedges-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/wedges-of-pointed-types.lagda.md
@@ -7,22 +7,18 @@ module synthetic-homotopy-theory.wedges-of-pointed-types where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.cartesian-product-types
-open import foundation.constant-maps
 open import foundation.dependent-pair-types
-open import foundation.equivalences
 open import foundation.homotopies
-open import foundation.identity-types
-open import foundation.unit-type
 open import foundation.universe-levels
 
 open import structured-types.pointed-cartesian-product-types
 open import structured-types.pointed-maps
 open import structured-types.pointed-types
+open import structured-types.pointed-unit-type
 
-open import synthetic-homotopy-theory.cocones-under-spans
+open import synthetic-homotopy-theory.cocones-under-spans-of-pointed-types
 open import synthetic-homotopy-theory.cofibers
-open import synthetic-homotopy-theory.pushouts
+open import synthetic-homotopy-theory.pushouts-of-pointed-types
 ```
 
 </details>
@@ -48,16 +44,10 @@ The wedge sum is canonically pointed at the (identified) images of `a` and `b`.
 _∨*_ :
   {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) →
   Pointed-Type (l1 ⊔ l2)
-pr1 (A ∨* B) =
-  pushout
-    { S = unit}
-    ( λ _ → point-Pointed-Type A)
-    ( λ _ → point-Pointed-Type B)
-pr2 (A ∨* B) =
-  inl-pushout
-    ( λ _ → point-Pointed-Type A)
-    ( λ _ → point-Pointed-Type B)
-    ( point-Pointed-Type A)
+A ∨* B =
+  pushout-Pointed-Type
+    ( cogap-pointed-unit A)
+    ( cogap-pointed-unit B)
 
 indexed-wedge :
   {l1 l2 : Level} (I : UU l1) (A : I → Pointed-Type l2) → Pointed-Type (l1 ⊔ l2)
@@ -75,37 +65,29 @@ defined by the cogap map induced by the canonical inclusions `A → A ×* B ← 
 ```agda
 cocone-prod-wedge-Pointed-Type :
   {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) →
-  cocone
-    { S = unit}
-    ( λ _ → point-Pointed-Type A)
-    ( λ _ → point-Pointed-Type B)
-    ( type-Pointed-Type (A ×* B))
-pr1 (cocone-prod-wedge-Pointed-Type A B) x = x , point-Pointed-Type B
-pr1 (pr2 (cocone-prod-wedge-Pointed-Type A B)) y = point-Pointed-Type A , y
+  type-cocone-Pointed-Type
+    ( cogap-pointed-unit A)
+    ( cogap-pointed-unit B)
+    ( A ×* B)
+pr1 (cocone-prod-wedge-Pointed-Type A B) = inl-prod-Pointed-Type A B
+pr1 (pr2 (cocone-prod-wedge-Pointed-Type A B)) = inr-prod-Pointed-Type A B
 pr2 (pr2 (cocone-prod-wedge-Pointed-Type A B)) = refl-htpy
-
-map-prod-wedge-Pointed-Type :
-  {l1 l2 : Level}
-  (A : Pointed-Type l1) (B : Pointed-Type l2) →
-  type-Pointed-Type (A ∨* B) → type-Pointed-Type (A ×* B)
-map-prod-wedge-Pointed-Type A B =
-  cogap
-    ( λ _ → point-Pointed-Type A)
-    ( λ _ → point-Pointed-Type B)
-    ( cocone-prod-wedge-Pointed-Type A B)
 
 pointed-map-prod-wedge-Pointed-Type :
   {l1 l2 : Level}
   (A : Pointed-Type l1) (B : Pointed-Type l2) →
   (A ∨* B) →* (A ×* B)
-pr1 (pointed-map-prod-wedge-Pointed-Type A B) =
-  map-prod-wedge-Pointed-Type A B
-pr2 (pointed-map-prod-wedge-Pointed-Type A B) =
-  compute-inl-cogap
-    ( λ _ → point-Pointed-Type A)
-    ( λ _ → point-Pointed-Type B)
+pointed-map-prod-wedge-Pointed-Type A B =
+  cogap-Pointed-Type
+    ( cogap-pointed-unit A)
+    ( cogap-pointed-unit B)
     ( cocone-prod-wedge-Pointed-Type A B)
-    ( point-Pointed-Type A)
+
+map-prod-wedge-Pointed-Type :
+  {l1 l2 : Level}
+  (A : Pointed-Type l1) (B : Pointed-Type l2) →
+  type-Pointed-Type (A ∨* B) → type-Pointed-Type (A ×* B)
+map-prod-wedge-Pointed-Type A B = pr1 (pointed-map-prod-wedge-Pointed-Type A B)
 ```
 
 ## See also

--- a/src/univalent-combinatorics/repetitions-of-values.lagda.md
+++ b/src/univalent-combinatorics/repetitions-of-values.lagda.md
@@ -19,7 +19,6 @@ open import foundation.injective-maps
 open import foundation.negation
 
 open import univalent-combinatorics.decidable-dependent-function-types
-open import univalent-combinatorics.decidable-dependent-pair-types
 open import univalent-combinatorics.decidable-propositions
 open import univalent-combinatorics.dependent-pair-types
 open import univalent-combinatorics.equality-standard-finite-types


### PR DESCRIPTION
### Summary
- Add a module on the pointed unit type.
- Add a module on pushouts of pointed types.
- Add a module on cocones under spans of pointed types.
- Define the smash product of pointed types and derive some basic properties.
- Redefine the wedge sum of pointed types in terms of pushouts of pointed types.
- Small additions to pushouts and misc.
- Replace `pt` with `point` in general.
- Remove duplicate definition of `ev-point`.
- Add an optimization to `remove_unused_imports.py` by prioritizing the files in order of most recently changed.
- Add textual names to the different pointed constructions.
- ~Change the notation for the join from `_*_` to `_⋆_`, as the asterisk is already quite heavily overloaded.~
- Add notes on symbol usage.
- Change notation for pointed type constructions to using the asterisk operator `∗` instead of the asterisk `*`.