### PR TITLE
Define binary operator notations for `mul-ℕ`, `mul-ℤ`, and `exp-ℕ`.

### DIFF
--- a/src/elementary-number-theory/absolute-value-integers.lagda.md
+++ b/src/elementary-number-theory/absolute-value-integers.lagda.md
@@ -179,19 +179,19 @@ is-nonzero-abs-ℤ (inr (inr x)) H = is-nonzero-succ-ℕ x
 
 ```agda
 multiplicative-abs-ℤ' :
-  (x y : ℤ) → abs-ℤ (explicit-mul-ℤ x y) ＝ mul-ℕ (abs-ℤ x) (abs-ℤ y)
+  (x y : ℤ) → abs-ℤ (explicit-mul-ℤ x y) ＝ (abs-ℤ x) *ℕ (abs-ℤ y)
 multiplicative-abs-ℤ' (inl x) (inl y) =
   abs-int-ℕ _
 multiplicative-abs-ℤ' (inl x) (inr (inl star)) =
   inv (right-zero-law-mul-ℕ x)
 multiplicative-abs-ℤ' (inl x) (inr (inr y)) =
-  ( abs-neg-ℤ (inl (add-ℕ (mul-ℕ x (succ-ℕ y)) y))) ∙
-  ( abs-int-ℕ (mul-ℕ (succ-ℕ x) (succ-ℕ y)))
+  ( abs-neg-ℤ (inl (add-ℕ (x *ℕ (succ-ℕ y)) y))) ∙
+  ( abs-int-ℕ ((succ-ℕ x) *ℕ (succ-ℕ y)))
 multiplicative-abs-ℤ' (inr (inl star)) (inl y) =
   refl
 multiplicative-abs-ℤ' (inr (inr x)) (inl y) =
-  ( abs-neg-ℤ (inl (add-ℕ (mul-ℕ x (succ-ℕ y)) y))) ∙
-  ( abs-int-ℕ (succ-ℕ (add-ℕ (mul-ℕ x (succ-ℕ y)) y)))
+  ( abs-neg-ℤ (inl (add-ℕ (x *ℕ (succ-ℕ y)) y))) ∙
+  ( abs-int-ℕ (succ-ℕ (add-ℕ (x *ℕ (succ-ℕ y)) y)))
 multiplicative-abs-ℤ' (inr (inl star)) (inr (inl star)) =
   refl
 multiplicative-abs-ℤ' (inr (inl star)) (inr (inr x)) =
@@ -202,7 +202,7 @@ multiplicative-abs-ℤ' (inr (inr x)) (inr (inr y)) =
   abs-int-ℕ _
 
 multiplicative-abs-ℤ :
-  (x y : ℤ) → abs-ℤ (mul-ℤ x y) ＝ mul-ℕ (abs-ℤ x) (abs-ℤ y)
+  (x y : ℤ) → abs-ℤ (mul-ℤ x y) ＝ (abs-ℤ x) *ℕ (abs-ℤ y)
 multiplicative-abs-ℤ x y =
   ap abs-ℤ (compute-mul-ℤ x y) ∙ multiplicative-abs-ℤ' x y
 ```

--- a/src/elementary-number-theory/absolute-value-integers.lagda.md
+++ b/src/elementary-number-theory/absolute-value-integers.lagda.md
@@ -111,7 +111,7 @@ successor-law-abs-ℤ (inr (inr x)) =
 
 ```agda
 subadditive-abs-ℤ :
-  (x y : ℤ) → (abs-ℤ (add-ℤ x y)) ≤-ℕ (add-ℕ (abs-ℤ x) (abs-ℤ y))
+  (x y : ℤ) → (abs-ℤ (x +ℤ y)) ≤-ℕ ((abs-ℤ x) +ℕ (abs-ℤ y))
 subadditive-abs-ℤ x (inl zero-ℕ) =
   concatenate-eq-leq-eq-ℕ
     ( ap abs-ℤ (add-neg-one-right-ℤ x))
@@ -121,11 +121,11 @@ subadditive-abs-ℤ x (inl (succ-ℕ y)) =
   concatenate-eq-leq-eq-ℕ
     ( ap abs-ℤ (right-predecessor-law-add-ℤ x (inl y)))
     ( transitive-leq-ℕ
-      ( abs-ℤ (pred-ℤ (add-ℤ x (inl y))))
-      ( succ-ℕ (abs-ℤ (add-ℤ x (inl y))))
-      ( add-ℕ (abs-ℤ x) (succ-ℕ (succ-ℕ y)))
+      ( abs-ℤ (pred-ℤ (x +ℤ (inl y))))
+      ( succ-ℕ (abs-ℤ (x +ℤ (inl y))))
+      ( (abs-ℤ x) +ℕ (succ-ℕ (succ-ℕ y)))
       ( subadditive-abs-ℤ x (inl y))
-      ( predecessor-law-abs-ℤ (add-ℤ x (inl y))))
+      ( predecessor-law-abs-ℤ (x +ℤ (inl y))))
     ( refl)
 subadditive-abs-ℤ x (inr (inl star)) =
   concatenate-eq-leq-eq-ℕ
@@ -141,11 +141,11 @@ subadditive-abs-ℤ x (inr (inr (succ-ℕ y))) =
   concatenate-eq-leq-eq-ℕ
     ( ap abs-ℤ (right-successor-law-add-ℤ x (inr (inr y))))
     ( transitive-leq-ℕ
-      ( abs-ℤ (succ-ℤ (add-ℤ x (inr (inr y)))))
-      ( succ-ℕ (abs-ℤ (add-ℤ x (inr (inr y)))))
-      ( succ-ℕ (add-ℕ (abs-ℤ x) (succ-ℕ y)))
+      ( abs-ℤ (succ-ℤ (x +ℤ (inr (inr y)))))
+      ( succ-ℕ (abs-ℤ (x +ℤ (inr (inr y)))))
+      ( succ-ℕ ((abs-ℤ x) +ℕ (succ-ℕ y)))
       ( subadditive-abs-ℤ x (inr (inr y)))
-      ( successor-law-abs-ℤ (add-ℤ x (inr (inr y)))))
+      ( successor-law-abs-ℤ (x +ℤ (inr (inr y)))))
     ( refl)
 ```
 
@@ -185,13 +185,13 @@ multiplicative-abs-ℤ' (inl x) (inl y) =
 multiplicative-abs-ℤ' (inl x) (inr (inl star)) =
   inv (right-zero-law-mul-ℕ x)
 multiplicative-abs-ℤ' (inl x) (inr (inr y)) =
-  ( abs-neg-ℤ (inl (add-ℕ (x *ℕ (succ-ℕ y)) y))) ∙
+  ( abs-neg-ℤ (inl ((x *ℕ (succ-ℕ y)) +ℕ y))) ∙
   ( abs-int-ℕ ((succ-ℕ x) *ℕ (succ-ℕ y)))
 multiplicative-abs-ℤ' (inr (inl star)) (inl y) =
   refl
 multiplicative-abs-ℤ' (inr (inr x)) (inl y) =
-  ( abs-neg-ℤ (inl (add-ℕ (x *ℕ (succ-ℕ y)) y))) ∙
-  ( abs-int-ℕ (succ-ℕ (add-ℕ (x *ℕ (succ-ℕ y)) y)))
+  ( abs-neg-ℤ (inl ((x *ℕ (succ-ℕ y)) +ℕ y))) ∙
+  ( abs-int-ℕ (succ-ℕ ((x *ℕ (succ-ℕ y)) +ℕ y)))
 multiplicative-abs-ℤ' (inr (inl star)) (inr (inl star)) =
   refl
 multiplicative-abs-ℤ' (inr (inl star)) (inr (inr x)) =
@@ -202,7 +202,7 @@ multiplicative-abs-ℤ' (inr (inr x)) (inr (inr y)) =
   abs-int-ℕ _
 
 multiplicative-abs-ℤ :
-  (x y : ℤ) → abs-ℤ (mul-ℤ x y) ＝ (abs-ℤ x) *ℕ (abs-ℤ y)
+  (x y : ℤ) → abs-ℤ (x *ℤ y) ＝ (abs-ℤ x) *ℕ (abs-ℤ y)
 multiplicative-abs-ℤ x y =
   ap abs-ℤ (compute-mul-ℤ x y) ∙ multiplicative-abs-ℤ' x y
 ```
@@ -211,13 +211,13 @@ multiplicative-abs-ℤ x y =
 
 ```agda
 left-negative-law-mul-abs-ℤ :
-  (x y : ℤ) → abs-ℤ (mul-ℤ x y) ＝ abs-ℤ (mul-ℤ (neg-ℤ x) y)
+  (x y : ℤ) → abs-ℤ (x *ℤ y) ＝ abs-ℤ ((neg-ℤ x) *ℤ y)
 left-negative-law-mul-abs-ℤ x y =
   equational-reasoning
-    abs-ℤ (mul-ℤ x y)
-    ＝ abs-ℤ (neg-ℤ (mul-ℤ x y))
-      by (inv (negative-law-abs-ℤ (mul-ℤ x y)))
-    ＝ abs-ℤ (mul-ℤ (neg-ℤ x) y)
+    abs-ℤ (x *ℤ y)
+    ＝ abs-ℤ (neg-ℤ (x *ℤ y))
+      by (inv (negative-law-abs-ℤ (x *ℤ y)))
+    ＝ abs-ℤ ((neg-ℤ x) *ℤ y)
       by (ap abs-ℤ (inv (left-negative-law-mul-ℤ x y)))
 ```
 
@@ -225,13 +225,13 @@ left-negative-law-mul-abs-ℤ x y =
 
 ```agda
 right-negative-law-mul-abs-ℤ :
-  (x y : ℤ) → abs-ℤ (mul-ℤ x y) ＝ abs-ℤ (mul-ℤ x (neg-ℤ y))
+  (x y : ℤ) → abs-ℤ (x *ℤ y) ＝ abs-ℤ (x *ℤ (neg-ℤ y))
 right-negative-law-mul-abs-ℤ x y =
   equational-reasoning
-    abs-ℤ (mul-ℤ x y)
-    ＝ abs-ℤ (neg-ℤ (mul-ℤ x y))
-      by (inv (negative-law-abs-ℤ (mul-ℤ x y)))
-    ＝ abs-ℤ (mul-ℤ x (neg-ℤ y))
+    abs-ℤ (x *ℤ y)
+    ＝ abs-ℤ (neg-ℤ (x *ℤ y))
+      by (inv (negative-law-abs-ℤ (x *ℤ y)))
+    ＝ abs-ℤ (x *ℤ (neg-ℤ y))
       by (ap abs-ℤ (inv (right-negative-law-mul-ℤ x y)))
 ```
 
@@ -239,7 +239,7 @@ right-negative-law-mul-abs-ℤ x y =
 
 ```agda
 double-negative-law-mul-abs-ℤ :
-  (x y : ℤ) → abs-ℤ (mul-ℤ x y) ＝ abs-ℤ (mul-ℤ (neg-ℤ x) (neg-ℤ y))
+  (x y : ℤ) → abs-ℤ (x *ℤ y) ＝ abs-ℤ ((neg-ℤ x) *ℤ (neg-ℤ y))
 double-negative-law-mul-abs-ℤ x y =
   (right-negative-law-mul-abs-ℤ x y) ∙ (left-negative-law-mul-abs-ℤ x (neg-ℤ y))
 ```

--- a/src/elementary-number-theory/exponentiation-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/exponentiation-natural-numbers.lagda.md
@@ -45,39 +45,39 @@ power-ℕ = power-Commutative-Semiring ℕ-Commutative-Semiring
 ### Tarski's high school arithmetic laws for exponentiation
 
 ```agda
-annihilation-law-exp-ℕ : (n : ℕ) → exp-ℕ 1 n ＝ 1
+annihilation-law-exp-ℕ : (n : ℕ) → 1 ^ℕ n ＝ 1
 annihilation-law-exp-ℕ zero-ℕ = refl
 annihilation-law-exp-ℕ (succ-ℕ n) =
-  right-unit-law-mul-ℕ (exp-ℕ 1 n) ∙ annihilation-law-exp-ℕ n
+  right-unit-law-mul-ℕ (1 ^ℕ n) ∙ annihilation-law-exp-ℕ n
 
 left-distributive-exp-add-ℕ :
-  (x y z : ℕ) → exp-ℕ x (add-ℕ y z) ＝ mul-ℕ (exp-ℕ x y) (exp-ℕ x z)
-left-distributive-exp-add-ℕ x y zero-ℕ = inv (right-unit-law-mul-ℕ (exp-ℕ x y))
+  (x y z : ℕ) → x ^ℕ (y +ℕ z) ＝ (x ^ℕ y) *ℕ (x ^ℕ z)
+left-distributive-exp-add-ℕ x y zero-ℕ = inv (right-unit-law-mul-ℕ (x ^ℕ y))
 left-distributive-exp-add-ℕ x y (succ-ℕ z) =
-  ( ap (mul-ℕ' x) (left-distributive-exp-add-ℕ x y z)) ∙
-  ( associative-mul-ℕ (exp-ℕ x y) (exp-ℕ x z) x)
+  ( ap (_*ℕ x) (left-distributive-exp-add-ℕ x y z)) ∙
+  ( associative-mul-ℕ (x ^ℕ y) (x ^ℕ z) x)
 
 right-distributive-exp-mul-ℕ :
-  (x y z : ℕ) → exp-ℕ (mul-ℕ x y) z ＝ mul-ℕ (exp-ℕ x z) (exp-ℕ y z)
+  (x y z : ℕ) → (x *ℕ y) ^ℕ z ＝ (x ^ℕ z) *ℕ (y ^ℕ z)
 right-distributive-exp-mul-ℕ x y zero-ℕ = refl
 right-distributive-exp-mul-ℕ x y (succ-ℕ z) =
-  ( ap (mul-ℕ' (mul-ℕ x y)) (right-distributive-exp-mul-ℕ x y z)) ∙
-  ( interchange-law-mul-mul-ℕ (exp-ℕ x z) (exp-ℕ y z) x y)
+  ( ap (_*ℕ (x *ℕ y)) (right-distributive-exp-mul-ℕ x y z)) ∙
+  ( interchange-law-mul-mul-ℕ (x ^ℕ z) (y ^ℕ z) x y)
 
-exp-mul-ℕ : (x y z : ℕ) → exp-ℕ x (mul-ℕ y z) ＝ exp-ℕ (exp-ℕ x y) z
+exp-mul-ℕ : (x y z : ℕ) → x ^ℕ (y *ℕ z) ＝ (x ^ℕ y) ^ℕ z
 exp-mul-ℕ x zero-ℕ z = inv (annihilation-law-exp-ℕ z)
 exp-mul-ℕ x (succ-ℕ y) z =
-  ( left-distributive-exp-add-ℕ x (mul-ℕ y z) z) ∙
-  ( ( ap (mul-ℕ' (exp-ℕ x z)) (exp-mul-ℕ x y z)) ∙
-    ( inv (right-distributive-exp-mul-ℕ (exp-ℕ x y) x z)))
+  ( left-distributive-exp-add-ℕ x (y *ℕ z) z) ∙
+  ( ( ap (_*ℕ (x ^ℕ z)) (exp-mul-ℕ x y z)) ∙
+    ( inv (right-distributive-exp-mul-ℕ (x ^ℕ y) x z)))
 ```
 
 ### The exponent `m^n` is always nonzero
 
 ```agda
 is-nonzero-exp-ℕ :
-  (m n : ℕ) → is-nonzero-ℕ m → is-nonzero-ℕ (exp-ℕ m n)
+  (m n : ℕ) → is-nonzero-ℕ m → is-nonzero-ℕ (m ^ℕ n)
 is-nonzero-exp-ℕ m zero-ℕ p = is-nonzero-one-ℕ
 is-nonzero-exp-ℕ m (succ-ℕ n) p =
-  is-nonzero-mul-ℕ (exp-ℕ m n) m (is-nonzero-exp-ℕ m n p) p
+  is-nonzero-mul-ℕ (m ^ℕ n) m (is-nonzero-exp-ℕ m n p) p
 ```

--- a/src/elementary-number-theory/exponentiation-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/exponentiation-natural-numbers.lagda.md
@@ -27,9 +27,12 @@ times.
 ## Definition
 
 ```agda
-exp-ℕ : ℕ → (ℕ → ℕ)
+exp-ℕ : ℕ → ℕ → ℕ
 exp-ℕ m 0 = 1
 exp-ℕ m (succ-ℕ n) = mul-ℕ (exp-ℕ m n) m
+
+infix 30 _^ℕ_
+_^ℕ_ = exp-ℕ
 ```
 
 ```agda

--- a/src/elementary-number-theory/multiplication-integers.lagda.md
+++ b/src/elementary-number-theory/multiplication-integers.lagda.md
@@ -85,10 +85,10 @@ is-plus-or-minus-ℤ x y = (x ＝ y) + (mul-ℤ neg-one-ℤ x ＝ y)
 ### Laws for multiplication on ℤ
 
 ```agda
-left-zero-law-mul-ℤ : (k : ℤ) → (zero-ℤ *ℤ k) ＝ zero-ℤ
+left-zero-law-mul-ℤ : (k : ℤ) → zero-ℤ *ℤ k ＝ zero-ℤ
 left-zero-law-mul-ℤ k = refl
 
-right-zero-law-mul-ℤ : (k : ℤ) → (k *ℤ zero-ℤ) ＝ zero-ℤ
+right-zero-law-mul-ℤ : (k : ℤ) → k *ℤ zero-ℤ ＝ zero-ℤ
 right-zero-law-mul-ℤ (inl zero-ℕ) = refl
 right-zero-law-mul-ℤ (inl (succ-ℕ n)) =
   right-zero-law-mul-ℤ (inl n)
@@ -97,10 +97,10 @@ right-zero-law-mul-ℤ (inr (inr zero-ℕ)) = refl
 right-zero-law-mul-ℤ (inr (inr (succ-ℕ n))) =
   right-zero-law-mul-ℤ (inr (inr n))
 
-left-unit-law-mul-ℤ : (k : ℤ) → (one-ℤ *ℤ k) ＝ k
+left-unit-law-mul-ℤ : (k : ℤ) → one-ℤ *ℤ k ＝ k
 left-unit-law-mul-ℤ k = refl
 
-right-unit-law-mul-ℤ : (k : ℤ) → (k *ℤ one-ℤ) ＝ k
+right-unit-law-mul-ℤ : (k : ℤ) → k *ℤ one-ℤ ＝ k
 right-unit-law-mul-ℤ (inl zero-ℕ) = refl
 right-unit-law-mul-ℤ (inl (succ-ℕ n)) =
   ap ((neg-one-ℤ) +ℤ_) (right-unit-law-mul-ℤ (inl n))
@@ -109,10 +109,10 @@ right-unit-law-mul-ℤ (inr (inr zero-ℕ)) = refl
 right-unit-law-mul-ℤ (inr (inr (succ-ℕ n))) =
   ap (one-ℤ +ℤ_) (right-unit-law-mul-ℤ (inr (inr n)))
 
-left-neg-unit-law-mul-ℤ : (k : ℤ) → (neg-one-ℤ *ℤ k) ＝ neg-ℤ k
+left-neg-unit-law-mul-ℤ : (k : ℤ) → neg-one-ℤ *ℤ k ＝ neg-ℤ k
 left-neg-unit-law-mul-ℤ k = refl
 
-right-neg-unit-law-mul-ℤ : (k : ℤ) → (k *ℤ neg-one-ℤ) ＝ neg-ℤ k
+right-neg-unit-law-mul-ℤ : (k : ℤ) → k *ℤ neg-one-ℤ ＝ neg-ℤ k
 right-neg-unit-law-mul-ℤ (inl zero-ℕ) = refl
 right-neg-unit-law-mul-ℤ (inl (succ-ℕ n)) =
   ap (one-ℤ +ℤ_) (right-neg-unit-law-mul-ℤ (inl n))
@@ -122,7 +122,7 @@ right-neg-unit-law-mul-ℤ (inr (inr (succ-ℕ n))) =
   ap (neg-one-ℤ +ℤ_) (right-neg-unit-law-mul-ℤ (inr (inr n)))
 
 left-successor-law-mul-ℤ :
-  (k l : ℤ) → ((succ-ℤ k) *ℤ l) ＝ (l +ℤ (k *ℤ l))
+  (k l : ℤ) → (succ-ℤ k) *ℤ l ＝ l +ℤ (k *ℤ l)
 left-successor-law-mul-ℤ (inl zero-ℕ) l =
   inv (right-inverse-law-add-ℤ l)
 left-successor-law-mul-ℤ (inl (succ-ℕ n)) l =
@@ -136,7 +136,7 @@ left-successor-law-mul-ℤ (inr (inl star)) l =
 left-successor-law-mul-ℤ (inr (inr n)) l = refl
 
 left-predecessor-law-mul-ℤ :
-  (k l : ℤ) → ((pred-ℤ k) *ℤ l) ＝ (neg-ℤ l) +ℤ (k *ℤ l)
+  (k l : ℤ) → (pred-ℤ k) *ℤ l ＝ (neg-ℤ l) +ℤ (k *ℤ l)
 left-predecessor-law-mul-ℤ (inl n) l = refl
 left-predecessor-law-mul-ℤ (inr (inl star)) l =
   ( left-neg-unit-law-mul-ℤ l) ∙
@@ -150,7 +150,7 @@ left-predecessor-law-mul-ℤ (inr (inr (succ-ℕ x))) l =
    ( associative-add-ℤ (neg-ℤ l) l ((in-pos x) *ℤ l))
 
 right-successor-law-mul-ℤ :
-  (k l : ℤ) → (k *ℤ (succ-ℤ l)) ＝ k +ℤ (k *ℤ l)
+  (k l : ℤ) → k *ℤ (succ-ℤ l) ＝ k +ℤ (k *ℤ l)
 right-successor-law-mul-ℤ (inl zero-ℕ) l = inv (pred-neg-ℤ l)
 right-successor-law-mul-ℤ (inl (succ-ℕ n)) l =
   ( left-predecessor-law-mul-ℤ (inl n) (succ-ℤ l)) ∙
@@ -188,7 +188,7 @@ right-successor-law-mul-ℤ (inr (inr (succ-ℕ n))) l =
         ( associative-add-ℤ (inr (inr (succ-ℕ n))) l ((inr (inr n)) *ℤ l)))))
 
 right-predecessor-law-mul-ℤ :
-  (k l : ℤ) → (k *ℤ (pred-ℤ l)) ＝ (neg-ℤ k) +ℤ (k *ℤ l)
+  (k l : ℤ) → k *ℤ (pred-ℤ l) ＝ (neg-ℤ k) +ℤ (k *ℤ l)
 right-predecessor-law-mul-ℤ (inl zero-ℕ) l =
   ( left-neg-unit-law-mul-ℤ (pred-ℤ l)) ∙
   ( neg-pred-ℤ l)
@@ -260,7 +260,7 @@ left-negative-law-mul-ℤ (inr (inr (succ-ℕ n))) l =
     ( inv (distributive-neg-add-ℤ l ((in-pos n) *ℤ l))))
 
 associative-mul-ℤ :
-  (k l m : ℤ) → (k *ℤ l) *ℤ m ＝ (k *ℤ (l *ℤ m))
+  (k l m : ℤ) → (k *ℤ l) *ℤ m ＝ k *ℤ (l *ℤ m)
 associative-mul-ℤ (inl zero-ℕ) l m =
   left-negative-law-mul-ℤ l m
 associative-mul-ℤ (inl (succ-ℕ n)) l m =
@@ -276,7 +276,7 @@ associative-mul-ℤ (inr (inr (succ-ℕ n))) l m =
   ( ap ((l *ℤ m) +ℤ_) (associative-mul-ℤ (inr (inr n)) l m))
 
 commutative-mul-ℤ :
-  (k l : ℤ) → (k *ℤ l) ＝ (l *ℤ k)
+  (k l : ℤ) → k *ℤ l ＝ l *ℤ k
 commutative-mul-ℤ (inl zero-ℕ) l = inv (right-neg-unit-law-mul-ℤ l)
 commutative-mul-ℤ (inl (succ-ℕ n)) l =
   ( ap ((neg-ℤ l) +ℤ_) (commutative-mul-ℤ (inl n) l)) ∙
@@ -308,14 +308,14 @@ interchange-law-mul-mul-ℤ =
     commutative-mul-ℤ
     associative-mul-ℤ
 
-is-mul-neg-one-neg-ℤ : (x : ℤ) → neg-ℤ x ＝ (neg-one-ℤ *ℤ x)
+is-mul-neg-one-neg-ℤ : (x : ℤ) → neg-ℤ x ＝ neg-one-ℤ *ℤ x
 is-mul-neg-one-neg-ℤ x = refl
 
-is-mul-neg-one-neg-ℤ' : (x : ℤ) → neg-ℤ x ＝ (x *ℤ neg-one-ℤ)
+is-mul-neg-one-neg-ℤ' : (x : ℤ) → neg-ℤ x ＝ x *ℤ neg-one-ℤ
 is-mul-neg-one-neg-ℤ' x =
   is-mul-neg-one-neg-ℤ x ∙ commutative-mul-ℤ neg-one-ℤ x
 
-double-negative-law-mul-ℤ : (k l : ℤ) → ((neg-ℤ k) *ℤ (neg-ℤ l)) ＝ (k *ℤ l)
+double-negative-law-mul-ℤ : (k l : ℤ) → (neg-ℤ k) *ℤ (neg-ℤ l) ＝ k *ℤ l
 double-negative-law-mul-ℤ k l =
   equational-reasoning
     (neg-ℤ k) *ℤ (neg-ℤ l)
@@ -341,7 +341,7 @@ is-positive-mul-ℤ {inr (inr (succ-ℕ x))} {inr (inr y)} H K =
 ### Computing multiplication of integers that come from natural numbers
 
 ```agda
-mul-int-ℕ : (x y : ℕ) → ((int-ℕ x) *ℤ (int-ℕ y)) ＝ int-ℕ (x *ℕ y)
+mul-int-ℕ : (x y : ℕ) → (int-ℕ x) *ℤ (int-ℕ y) ＝ int-ℕ (x *ℕ y)
 mul-int-ℕ zero-ℕ y = refl
 mul-int-ℕ (succ-ℕ x) y =
   ( ap (_*ℤ (int-ℕ y)) (inv (succ-int-ℕ x))) ∙
@@ -350,7 +350,7 @@ mul-int-ℕ (succ-ℕ x) y =
         ( add-int-ℕ y (x *ℕ y))) ∙
       ( ap int-ℕ (commutative-add-ℕ y (x *ℕ y)))))
 
-compute-mul-ℤ : (x y : ℤ) → (x *ℤ y) ＝ explicit-mul-ℤ x y
+compute-mul-ℤ : (x y : ℤ) → x *ℤ y ＝ explicit-mul-ℤ x y
 compute-mul-ℤ (inl zero-ℕ) (inl y) =
   inv (ap int-ℕ (left-unit-law-mul-ℕ (succ-ℕ y)))
 compute-mul-ℤ (inl (succ-ℕ x)) (inl y) =
@@ -409,13 +409,13 @@ compute-mul-ℤ (inr (inr (succ-ℕ x))) (inr (inr y)) =
 
 ```agda
 linear-diff-ℤ :
-  (z x y : ℤ) → diff-ℤ (z *ℤ x) (z *ℤ y) ＝ (z *ℤ (diff-ℤ x y))
+  (z x y : ℤ) → diff-ℤ (z *ℤ x) (z *ℤ y) ＝ z *ℤ (diff-ℤ x y)
 linear-diff-ℤ z x y =
   ( ap ((z *ℤ x) +ℤ_) (inv (right-negative-law-mul-ℤ z y))) ∙
   ( inv (left-distributive-mul-add-ℤ z x (neg-ℤ y)))
 
 linear-diff-ℤ' :
-  (x y z : ℤ) → diff-ℤ (x *ℤ z) (y *ℤ z) ＝ ((diff-ℤ x y) *ℤ z)
+  (x y z : ℤ) → diff-ℤ (x *ℤ z) (y *ℤ z) ＝ (diff-ℤ x y) *ℤ z
 linear-diff-ℤ' x y z =
   ( ap ((x *ℤ z) +ℤ_) (inv (left-negative-law-mul-ℤ y z))) ∙
   ( inv (right-distributive-mul-add-ℤ x (neg-ℤ y) z))

--- a/src/elementary-number-theory/multiplication-integers.lagda.md
+++ b/src/elementary-number-theory/multiplication-integers.lagda.md
@@ -128,7 +128,7 @@ left-successor-law-mul-ℤ (inl zero-ℕ) l =
 left-successor-law-mul-ℤ (inl (succ-ℕ n)) l =
   ( ( inv (left-unit-law-add-ℤ ((inl n) *ℤ l))) ∙
     ( ap
-      (  _+ℤ ((inl n) *ℤ l))
+      ( _+ℤ ((inl n) *ℤ l))
       ( inv (right-inverse-law-add-ℤ l)))) ∙
   ( associative-add-ℤ l (neg-ℤ l) ((inl n) *ℤ l))
 left-successor-law-mul-ℤ (inr (inl star)) l =
@@ -157,7 +157,7 @@ right-successor-law-mul-ℤ (inl (succ-ℕ n)) l =
   ( ( ap ((neg-ℤ (succ-ℤ l)) +ℤ_) (right-successor-law-mul-ℤ (inl n) l)) ∙
     ( ( inv (associative-add-ℤ (neg-ℤ (succ-ℤ l)) (inl n) ((inl n) *ℤ l))) ∙
       ( ( ap
-          (  _+ℤ ((inl n) *ℤ l))
+          ( _+ℤ ((inl n) *ℤ l))
           { x = (neg-ℤ (succ-ℤ l)) +ℤ (inl n)}
           { y = (inl (succ-ℕ n)) +ℤ (neg-ℤ l)}
           ( ( right-successor-law-add-ℤ (neg-ℤ (succ-ℤ l)) (inl (succ-ℕ n))) ∙
@@ -179,7 +179,7 @@ right-successor-law-mul-ℤ (inr (inr (succ-ℕ n))) l =
   ( ( ap ((succ-ℤ l) +ℤ_) (right-successor-law-mul-ℤ (inr (inr n)) l)) ∙
     ( ( inv (associative-add-ℤ (succ-ℤ l) (in-pos n) ((in-pos n) *ℤ l))) ∙
       ( ( ap
-          (  _+ℤ ((in-pos n) *ℤ l))
+          ( _+ℤ ((in-pos n) *ℤ l))
           { x = (succ-ℤ l) +ℤ (in-pos n)}
           { y = (in-pos (succ-ℕ n)) +ℤ l}
           ( ( left-successor-law-add-ℤ l (in-pos n)) ∙
@@ -267,7 +267,7 @@ associative-mul-ℤ (inl (succ-ℕ n)) l m =
   ( right-distributive-mul-add-ℤ (neg-ℤ l) ((inl n) *ℤ l) m) ∙
   ( ( ap (((neg-ℤ l) *ℤ m) +ℤ_) (associative-mul-ℤ (inl n) l m)) ∙
     ( ap
-      (  _+ℤ ((inl n) *ℤ (l *ℤ m)))
+      ( _+ℤ ((inl n) *ℤ (l *ℤ m)))
       ( left-negative-law-mul-ℤ l m)))
 associative-mul-ℤ (inr (inl star)) l m = refl
 associative-mul-ℤ (inr (inr zero-ℕ)) l m = refl

--- a/src/elementary-number-theory/multiplication-integers.lagda.md
+++ b/src/elementary-number-theory/multiplication-integers.lagda.md
@@ -44,6 +44,8 @@ mul-ℤ (inr (inl star)) l = zero-ℤ
 mul-ℤ (inr (inr zero-ℕ)) l = l
 mul-ℤ (inr (inr (succ-ℕ x))) l = add-ℤ l (mul-ℤ (inr (inr x)) l)
 
+_*ℤ_ = mul-ℤ
+
 mul-ℤ' : ℤ → ℤ → ℤ
 mul-ℤ' x y = mul-ℤ y x
 

--- a/src/elementary-number-theory/multiplication-integers.lagda.md
+++ b/src/elementary-number-theory/multiplication-integers.lagda.md
@@ -44,13 +44,14 @@ mul-ℤ (inr (inl star)) l = zero-ℤ
 mul-ℤ (inr (inr zero-ℕ)) l = l
 mul-ℤ (inr (inr (succ-ℕ x))) l = add-ℤ l (mul-ℤ (inr (inr x)) l)
 
+infix 30 _*ℤ_
 _*ℤ_ = mul-ℤ
 
 mul-ℤ' : ℤ → ℤ → ℤ
 mul-ℤ' x y = mul-ℤ y x
 
 ap-mul-ℤ :
-  {x y x' y' : ℤ} → x ＝ x' → y ＝ y' → mul-ℤ x y ＝ mul-ℤ x' y'
+  {x y x' y' : ℤ} → x ＝ x' → y ＝ y' → x *ℤ y ＝ x' *ℤ y'
 ap-mul-ℤ p q = ap-binary mul-ℤ p q
 ```
 
@@ -58,17 +59,15 @@ ap-mul-ℤ p q = ap-binary mul-ℤ p q
 
 ```agda
 explicit-mul-ℤ : ℤ → ℤ → ℤ
-explicit-mul-ℤ (inl x) (inl y) = int-ℕ (mul-ℕ (succ-ℕ x) (succ-ℕ y))
+explicit-mul-ℤ (inl x) (inl y) = int-ℕ ((succ-ℕ x) *ℕ (succ-ℕ y))
 explicit-mul-ℤ (inl x) (inr (inl star)) = zero-ℤ
-explicit-mul-ℤ (inl x) (inr (inr y)) =
-  neg-ℤ (int-ℕ (mul-ℕ (succ-ℕ x) (succ-ℕ y)))
+explicit-mul-ℤ (inl x) (inr (inr y)) = neg-ℤ (int-ℕ ((succ-ℕ x) *ℕ (succ-ℕ y)))
 explicit-mul-ℤ (inr (inl star)) (inl y) = zero-ℤ
-explicit-mul-ℤ (inr (inr x)) (inl y) =
-  neg-ℤ (int-ℕ (mul-ℕ (succ-ℕ x) (succ-ℕ y)))
+explicit-mul-ℤ (inr (inr x)) (inl y) = neg-ℤ (int-ℕ ((succ-ℕ x) *ℕ (succ-ℕ y)))
 explicit-mul-ℤ (inr (inl star)) (inr (inl star)) = zero-ℤ
 explicit-mul-ℤ (inr (inl star)) (inr (inr y)) = zero-ℤ
 explicit-mul-ℤ (inr (inr x)) (inr (inl star)) = zero-ℤ
-explicit-mul-ℤ (inr (inr x)) (inr (inr y)) = int-ℕ (mul-ℕ (succ-ℕ x) (succ-ℕ y))
+explicit-mul-ℤ (inr (inr x)) (inr (inr y)) = int-ℕ ((succ-ℕ x) *ℕ (succ-ℕ y))
 
 explicit-mul-ℤ' : ℤ → ℤ → ℤ
 explicit-mul-ℤ' x y = explicit-mul-ℤ y x
@@ -86,10 +85,10 @@ is-plus-or-minus-ℤ x y = (x ＝ y) + (mul-ℤ neg-one-ℤ x ＝ y)
 ### Laws for multiplication on ℤ
 
 ```agda
-left-zero-law-mul-ℤ : (k : ℤ) → mul-ℤ zero-ℤ k ＝ zero-ℤ
+left-zero-law-mul-ℤ : (k : ℤ) → (zero-ℤ *ℤ k) ＝ zero-ℤ
 left-zero-law-mul-ℤ k = refl
 
-right-zero-law-mul-ℤ : (k : ℤ) → mul-ℤ k zero-ℤ ＝ zero-ℤ
+right-zero-law-mul-ℤ : (k : ℤ) → (k *ℤ zero-ℤ) ＝ zero-ℤ
 right-zero-law-mul-ℤ (inl zero-ℕ) = refl
 right-zero-law-mul-ℤ (inl (succ-ℕ n)) =
   right-zero-law-mul-ℤ (inl n)
@@ -98,46 +97,46 @@ right-zero-law-mul-ℤ (inr (inr zero-ℕ)) = refl
 right-zero-law-mul-ℤ (inr (inr (succ-ℕ n))) =
   right-zero-law-mul-ℤ (inr (inr n))
 
-left-unit-law-mul-ℤ : (k : ℤ) → mul-ℤ one-ℤ k ＝ k
+left-unit-law-mul-ℤ : (k : ℤ) → (one-ℤ *ℤ k) ＝ k
 left-unit-law-mul-ℤ k = refl
 
-right-unit-law-mul-ℤ : (k : ℤ) → mul-ℤ k one-ℤ ＝ k
+right-unit-law-mul-ℤ : (k : ℤ) → (k *ℤ one-ℤ) ＝ k
 right-unit-law-mul-ℤ (inl zero-ℕ) = refl
 right-unit-law-mul-ℤ (inl (succ-ℕ n)) =
-  ap (add-ℤ (neg-one-ℤ)) (right-unit-law-mul-ℤ (inl n))
+  ap ((neg-one-ℤ) +ℤ_) (right-unit-law-mul-ℤ (inl n))
 right-unit-law-mul-ℤ (inr (inl star)) = refl
 right-unit-law-mul-ℤ (inr (inr zero-ℕ)) = refl
 right-unit-law-mul-ℤ (inr (inr (succ-ℕ n))) =
-  ap (add-ℤ one-ℤ) (right-unit-law-mul-ℤ (inr (inr n)))
+  ap (one-ℤ +ℤ_) (right-unit-law-mul-ℤ (inr (inr n)))
 
-left-neg-unit-law-mul-ℤ : (k : ℤ) → mul-ℤ neg-one-ℤ k ＝ neg-ℤ k
+left-neg-unit-law-mul-ℤ : (k : ℤ) → (neg-one-ℤ *ℤ k) ＝ neg-ℤ k
 left-neg-unit-law-mul-ℤ k = refl
 
-right-neg-unit-law-mul-ℤ : (k : ℤ) → mul-ℤ k neg-one-ℤ ＝ neg-ℤ k
+right-neg-unit-law-mul-ℤ : (k : ℤ) → (k *ℤ neg-one-ℤ) ＝ neg-ℤ k
 right-neg-unit-law-mul-ℤ (inl zero-ℕ) = refl
 right-neg-unit-law-mul-ℤ (inl (succ-ℕ n)) =
-  ap (add-ℤ one-ℤ) (right-neg-unit-law-mul-ℤ (inl n))
+  ap (one-ℤ +ℤ_) (right-neg-unit-law-mul-ℤ (inl n))
 right-neg-unit-law-mul-ℤ (inr (inl star)) = refl
 right-neg-unit-law-mul-ℤ (inr (inr zero-ℕ)) = refl
 right-neg-unit-law-mul-ℤ (inr (inr (succ-ℕ n))) =
-  ap (add-ℤ neg-one-ℤ) (right-neg-unit-law-mul-ℤ (inr (inr n)))
+  ap (neg-one-ℤ +ℤ_) (right-neg-unit-law-mul-ℤ (inr (inr n)))
 
 left-successor-law-mul-ℤ :
-  (k l : ℤ) → mul-ℤ (succ-ℤ k) l ＝ add-ℤ l (mul-ℤ k l)
+  (k l : ℤ) → ((succ-ℤ k) *ℤ l) ＝ (l +ℤ (k *ℤ l))
 left-successor-law-mul-ℤ (inl zero-ℕ) l =
   inv (right-inverse-law-add-ℤ l)
 left-successor-law-mul-ℤ (inl (succ-ℕ n)) l =
-  ( ( inv (left-unit-law-add-ℤ (mul-ℤ (inl n) l))) ∙
+  ( ( inv (left-unit-law-add-ℤ ((inl n) *ℤ l))) ∙
     ( ap
-      ( add-ℤ' (mul-ℤ (inl n) l))
+      (  _+ℤ ((inl n) *ℤ l))
       ( inv (right-inverse-law-add-ℤ l)))) ∙
-  ( associative-add-ℤ l (neg-ℤ l) (mul-ℤ (inl n) l))
+  ( associative-add-ℤ l (neg-ℤ l) ((inl n) *ℤ l))
 left-successor-law-mul-ℤ (inr (inl star)) l =
   inv (right-unit-law-add-ℤ l)
 left-successor-law-mul-ℤ (inr (inr n)) l = refl
 
 left-predecessor-law-mul-ℤ :
-  (k l : ℤ) → mul-ℤ (pred-ℤ k) l ＝ add-ℤ (neg-ℤ l) (mul-ℤ k l)
+  (k l : ℤ) → ((pred-ℤ k) *ℤ l) ＝ (neg-ℤ l) +ℤ (k *ℤ l)
 left-predecessor-law-mul-ℤ (inl n) l = refl
 left-predecessor-law-mul-ℤ (inr (inl star)) l =
   ( left-neg-unit-law-mul-ℤ l) ∙
@@ -146,21 +145,21 @@ left-predecessor-law-mul-ℤ (inr (inr zero-ℕ)) l =
   inv (left-inverse-law-add-ℤ l)
 left-predecessor-law-mul-ℤ (inr (inr (succ-ℕ x))) l =
    ( ap
-     ( add-ℤ' (mul-ℤ (in-pos x) l))
+     ( _+ℤ ((in-pos x) *ℤ l))
      ( inv (left-inverse-law-add-ℤ l))) ∙
-   ( associative-add-ℤ (neg-ℤ l) l (mul-ℤ (in-pos x) l))
+   ( associative-add-ℤ (neg-ℤ l) l ((in-pos x) *ℤ l))
 
 right-successor-law-mul-ℤ :
-  (k l : ℤ) → mul-ℤ k (succ-ℤ l) ＝ add-ℤ k (mul-ℤ k l)
+  (k l : ℤ) → (k *ℤ (succ-ℤ l)) ＝ k +ℤ (k *ℤ l)
 right-successor-law-mul-ℤ (inl zero-ℕ) l = inv (pred-neg-ℤ l)
 right-successor-law-mul-ℤ (inl (succ-ℕ n)) l =
   ( left-predecessor-law-mul-ℤ (inl n) (succ-ℤ l)) ∙
-  ( ( ap (add-ℤ (neg-ℤ (succ-ℤ l))) (right-successor-law-mul-ℤ (inl n) l)) ∙
-    ( ( inv (associative-add-ℤ (neg-ℤ (succ-ℤ l)) (inl n) (mul-ℤ (inl n) l))) ∙
+  ( ( ap ((neg-ℤ (succ-ℤ l)) +ℤ_) (right-successor-law-mul-ℤ (inl n) l)) ∙
+    ( ( inv (associative-add-ℤ (neg-ℤ (succ-ℤ l)) (inl n) ((inl n) *ℤ l))) ∙
       ( ( ap
-          ( add-ℤ' (mul-ℤ (inl n) l))
-          { x = add-ℤ (neg-ℤ (succ-ℤ l)) (inl n)}
-          { y = add-ℤ (inl (succ-ℕ n)) (neg-ℤ l)}
+          (  _+ℤ ((inl n) *ℤ l))
+          { x = (neg-ℤ (succ-ℤ l)) +ℤ (inl n)}
+          { y = (inl (succ-ℕ n)) +ℤ (neg-ℤ l)}
           ( ( right-successor-law-add-ℤ (neg-ℤ (succ-ℤ l)) (inl (succ-ℕ n))) ∙
             ( ( ap succ-ℤ
                 ( commutative-add-ℤ (neg-ℤ (succ-ℤ l)) (inl (succ-ℕ n)))) ∙
@@ -169,134 +168,134 @@ right-successor-law-mul-ℤ (inl (succ-ℕ n)) l =
                     ( inl (succ-ℕ n))
                     ( neg-ℤ (succ-ℤ l)))) ∙
                 ( ap
-                  ( add-ℤ (inl (succ-ℕ n)))
+                  ( (inl (succ-ℕ n)) +ℤ_)
                   ( ( ap succ-ℤ (inv (pred-neg-ℤ l))) ∙
                     ( issec-pred-ℤ (neg-ℤ l)))))))) ∙
-        ( associative-add-ℤ (inl (succ-ℕ n)) (neg-ℤ l) (mul-ℤ (inl n) l)))))
+        ( associative-add-ℤ (inl (succ-ℕ n)) (neg-ℤ l) ((inl n) *ℤ l)))))
 right-successor-law-mul-ℤ (inr (inl star)) l = refl
 right-successor-law-mul-ℤ (inr (inr zero-ℕ)) l = refl
 right-successor-law-mul-ℤ (inr (inr (succ-ℕ n))) l =
   ( left-successor-law-mul-ℤ (in-pos n) (succ-ℤ l)) ∙
-  ( ( ap (add-ℤ (succ-ℤ l)) (right-successor-law-mul-ℤ (inr (inr n)) l)) ∙
-    ( ( inv (associative-add-ℤ (succ-ℤ l) (in-pos n) (mul-ℤ (in-pos n) l))) ∙
+  ( ( ap ((succ-ℤ l) +ℤ_) (right-successor-law-mul-ℤ (inr (inr n)) l)) ∙
+    ( ( inv (associative-add-ℤ (succ-ℤ l) (in-pos n) ((in-pos n) *ℤ l))) ∙
       ( ( ap
-          ( add-ℤ' (mul-ℤ (in-pos n) l))
-          { x = add-ℤ (succ-ℤ l) (in-pos n)}
-          { y = add-ℤ (in-pos (succ-ℕ n)) l}
+          (  _+ℤ ((in-pos n) *ℤ l))
+          { x = (succ-ℤ l) +ℤ (in-pos n)}
+          { y = (in-pos (succ-ℕ n)) +ℤ l}
           ( ( left-successor-law-add-ℤ l (in-pos n)) ∙
             ( ( ap succ-ℤ (commutative-add-ℤ l (in-pos n))) ∙
               ( inv (left-successor-law-add-ℤ (in-pos n) l))))) ∙
-        ( associative-add-ℤ (inr (inr (succ-ℕ n))) l (mul-ℤ (inr (inr n)) l)))))
+        ( associative-add-ℤ (inr (inr (succ-ℕ n))) l ((inr (inr n)) *ℤ l)))))
 
 right-predecessor-law-mul-ℤ :
-  (k l : ℤ) → mul-ℤ k (pred-ℤ l) ＝ add-ℤ (neg-ℤ k) (mul-ℤ k l)
+  (k l : ℤ) → (k *ℤ (pred-ℤ l)) ＝ (neg-ℤ k) +ℤ (k *ℤ l)
 right-predecessor-law-mul-ℤ (inl zero-ℕ) l =
   ( left-neg-unit-law-mul-ℤ (pred-ℤ l)) ∙
   ( neg-pred-ℤ l)
 right-predecessor-law-mul-ℤ (inl (succ-ℕ n)) l =
   ( left-predecessor-law-mul-ℤ (inl n) (pred-ℤ l)) ∙
-  ( ( ap (add-ℤ (neg-ℤ (pred-ℤ l))) (right-predecessor-law-mul-ℤ (inl n) l)) ∙
+  ( ( ap ((neg-ℤ (pred-ℤ l)) +ℤ_) (right-predecessor-law-mul-ℤ (inl n) l)) ∙
     ( ( inv
-        ( associative-add-ℤ (neg-ℤ (pred-ℤ l)) (in-pos n) (mul-ℤ (inl n) l))) ∙
+        ( associative-add-ℤ (neg-ℤ (pred-ℤ l)) (in-pos n) ((inl n) *ℤ l))) ∙
       ( ( ap
-          ( add-ℤ' (mul-ℤ (inl n) l))
-          { x = add-ℤ (neg-ℤ (pred-ℤ l)) (inr (inr n))}
-          { y = add-ℤ (neg-ℤ (inl (succ-ℕ n))) (neg-ℤ l)}
-          ( ( ap (add-ℤ' (in-pos n)) (neg-pred-ℤ l)) ∙
+          ( _+ℤ ((inl n) *ℤ l))
+          { x = (neg-ℤ (pred-ℤ l)) +ℤ (inr (inr n))}
+          { y = (neg-ℤ (inl (succ-ℕ n))) +ℤ (neg-ℤ l)}
+          ( ( ap (_+ℤ (in-pos n)) (neg-pred-ℤ l)) ∙
             ( ( left-successor-law-add-ℤ (neg-ℤ l) (in-pos n)) ∙
               ( ( ap succ-ℤ (commutative-add-ℤ (neg-ℤ l) (in-pos n))) ∙
                 ( inv (left-successor-law-add-ℤ (in-pos n) (neg-ℤ l))))))) ∙
-        ( associative-add-ℤ (in-pos (succ-ℕ n)) (neg-ℤ l) (mul-ℤ (inl n) l)))))
+        ( associative-add-ℤ (in-pos (succ-ℕ n)) (neg-ℤ l) ((inl n) *ℤ l)))))
 right-predecessor-law-mul-ℤ (inr (inl star)) l = refl
 right-predecessor-law-mul-ℤ (inr (inr zero-ℕ)) l = refl
 right-predecessor-law-mul-ℤ (inr (inr (succ-ℕ n))) l =
   ( left-successor-law-mul-ℤ (in-pos n) (pred-ℤ l)) ∙
-  ( ( ap (add-ℤ (pred-ℤ l)) (right-predecessor-law-mul-ℤ (inr (inr n)) l)) ∙
-    ( ( inv (associative-add-ℤ (pred-ℤ l) (inl n) (mul-ℤ (inr (inr n)) l))) ∙
+  ( ( ap ((pred-ℤ l) +ℤ_) (right-predecessor-law-mul-ℤ (inr (inr n)) l)) ∙
+    ( ( inv (associative-add-ℤ (pred-ℤ l) (inl n) ((inr (inr n)) *ℤ l))) ∙
       ( ( ap
-          ( add-ℤ' (mul-ℤ (in-pos n) l))
-          { x = add-ℤ (pred-ℤ l) (inl n)}
-          { y = add-ℤ (neg-ℤ (in-pos (succ-ℕ n))) l}
+          ( _+ℤ ((in-pos n) *ℤ l))
+          { x = (pred-ℤ l) +ℤ (inl n)}
+          { y = (neg-ℤ (in-pos (succ-ℕ n))) +ℤ l}
           ( ( left-predecessor-law-add-ℤ l (inl n)) ∙
             ( ( ap pred-ℤ (commutative-add-ℤ l (inl n))) ∙
               ( inv (left-predecessor-law-add-ℤ (inl n) l))))) ∙
-        ( associative-add-ℤ (inl (succ-ℕ n)) l (mul-ℤ (inr (inr n)) l)))))
+        ( associative-add-ℤ (inl (succ-ℕ n)) l ((inr (inr n)) *ℤ l)))))
 
 right-distributive-mul-add-ℤ :
-  (k l m : ℤ) → mul-ℤ (add-ℤ k l) m ＝ add-ℤ (mul-ℤ k m) (mul-ℤ l m)
+  (k l m : ℤ) → (k +ℤ l) *ℤ m ＝ (k *ℤ m) +ℤ (l *ℤ m)
 right-distributive-mul-add-ℤ (inl zero-ℕ) l m =
   ( left-predecessor-law-mul-ℤ l m) ∙
   ( ap
-    ( add-ℤ' (mul-ℤ l m))
+    ( _+ℤ (l *ℤ m))
     ( inv
       ( ( left-predecessor-law-mul-ℤ zero-ℤ m) ∙
         ( right-unit-law-add-ℤ (neg-ℤ m)))))
 right-distributive-mul-add-ℤ (inl (succ-ℕ x)) l m =
-  ( left-predecessor-law-mul-ℤ (add-ℤ (inl x) l) m) ∙
-  ( ( ap (add-ℤ (neg-ℤ m)) (right-distributive-mul-add-ℤ (inl x) l m)) ∙
-    ( inv (associative-add-ℤ (neg-ℤ m) (mul-ℤ (inl x) m) (mul-ℤ l m))))
+  ( left-predecessor-law-mul-ℤ ((inl x) +ℤ l) m) ∙
+  ( ( ap ((neg-ℤ m) +ℤ_) (right-distributive-mul-add-ℤ (inl x) l m)) ∙
+    ( inv (associative-add-ℤ (neg-ℤ m) ((inl x) *ℤ m) (l *ℤ m))))
 right-distributive-mul-add-ℤ (inr (inl star)) l m = refl
 right-distributive-mul-add-ℤ (inr (inr zero-ℕ)) l m =
   left-successor-law-mul-ℤ l m
 right-distributive-mul-add-ℤ (inr (inr (succ-ℕ n))) l m =
-  ( left-successor-law-mul-ℤ (add-ℤ (in-pos n) l) m) ∙
-  ( ( ap (add-ℤ m) (right-distributive-mul-add-ℤ (inr (inr n)) l m)) ∙
-    ( inv (associative-add-ℤ m (mul-ℤ (in-pos n) m) (mul-ℤ l m))))
+  ( left-successor-law-mul-ℤ ((in-pos n) +ℤ l) m) ∙
+  ( ( ap (m +ℤ_) (right-distributive-mul-add-ℤ (inr (inr n)) l m)) ∙
+    ( inv (associative-add-ℤ m ((in-pos n) *ℤ m) (l *ℤ m))))
 
 left-negative-law-mul-ℤ :
-  (k l : ℤ) → mul-ℤ (neg-ℤ k) l ＝ neg-ℤ (mul-ℤ k l)
+  (k l : ℤ) → (neg-ℤ k) *ℤ l ＝ neg-ℤ (k *ℤ l)
 left-negative-law-mul-ℤ (inl zero-ℕ) l =
   ( left-unit-law-mul-ℤ l) ∙
   ( inv (neg-neg-ℤ l))
 left-negative-law-mul-ℤ (inl (succ-ℕ n)) l =
-  ( ap (mul-ℤ' l) (neg-pred-ℤ (inl n))) ∙
+  ( ap (_*ℤ l) (neg-pred-ℤ (inl n))) ∙
   ( ( left-successor-law-mul-ℤ (neg-ℤ (inl n)) l) ∙
-    ( ( ap (add-ℤ l) (left-negative-law-mul-ℤ (inl n) l)) ∙
-      ( right-negative-law-add-ℤ l (mul-ℤ (inl n) l))))
+    ( ( ap (l +ℤ_) (left-negative-law-mul-ℤ (inl n) l)) ∙
+      ( right-negative-law-add-ℤ l ((inl n) *ℤ l))))
 left-negative-law-mul-ℤ (inr (inl star)) l = refl
 left-negative-law-mul-ℤ (inr (inr zero-ℕ)) l = refl
 left-negative-law-mul-ℤ (inr (inr (succ-ℕ n))) l =
   ( left-predecessor-law-mul-ℤ (inl n) l) ∙
-  ( ( ap (add-ℤ (neg-ℤ l)) (left-negative-law-mul-ℤ (inr (inr n)) l)) ∙
-    ( inv (distributive-neg-add-ℤ l (mul-ℤ (in-pos n) l))))
+  ( ( ap ((neg-ℤ l) +ℤ_) (left-negative-law-mul-ℤ (inr (inr n)) l)) ∙
+    ( inv (distributive-neg-add-ℤ l ((in-pos n) *ℤ l))))
 
 associative-mul-ℤ :
-  (k l m : ℤ) → mul-ℤ (mul-ℤ k l) m ＝ mul-ℤ k (mul-ℤ l m)
+  (k l m : ℤ) → (k *ℤ l) *ℤ m ＝ (k *ℤ (l *ℤ m))
 associative-mul-ℤ (inl zero-ℕ) l m =
   left-negative-law-mul-ℤ l m
 associative-mul-ℤ (inl (succ-ℕ n)) l m =
-  ( right-distributive-mul-add-ℤ (neg-ℤ l) (mul-ℤ (inl n) l) m) ∙
-  ( ( ap (add-ℤ (mul-ℤ (neg-ℤ l) m)) (associative-mul-ℤ (inl n) l m)) ∙
+  ( right-distributive-mul-add-ℤ (neg-ℤ l) ((inl n) *ℤ l) m) ∙
+  ( ( ap (((neg-ℤ l) *ℤ m) +ℤ_) (associative-mul-ℤ (inl n) l m)) ∙
     ( ap
-      ( add-ℤ' (mul-ℤ (inl n) (mul-ℤ l m)))
+      (  _+ℤ ((inl n) *ℤ (l *ℤ m)))
       ( left-negative-law-mul-ℤ l m)))
 associative-mul-ℤ (inr (inl star)) l m = refl
 associative-mul-ℤ (inr (inr zero-ℕ)) l m = refl
 associative-mul-ℤ (inr (inr (succ-ℕ n))) l m =
-  ( right-distributive-mul-add-ℤ l (mul-ℤ (in-pos n) l) m) ∙
-  ( ap (add-ℤ (mul-ℤ l m)) (associative-mul-ℤ (inr (inr n)) l m))
+  ( right-distributive-mul-add-ℤ l ((in-pos n) *ℤ l) m) ∙
+  ( ap ((l *ℤ m) +ℤ_) (associative-mul-ℤ (inr (inr n)) l m))
 
 commutative-mul-ℤ :
-  (k l : ℤ) → mul-ℤ k l ＝ mul-ℤ l k
+  (k l : ℤ) → (k *ℤ l) ＝ (l *ℤ k)
 commutative-mul-ℤ (inl zero-ℕ) l = inv (right-neg-unit-law-mul-ℤ l)
 commutative-mul-ℤ (inl (succ-ℕ n)) l =
-  ( ap (add-ℤ (neg-ℤ l)) (commutative-mul-ℤ (inl n) l)) ∙
+  ( ap ((neg-ℤ l) +ℤ_) (commutative-mul-ℤ (inl n) l)) ∙
   ( inv (right-predecessor-law-mul-ℤ l (inl n)))
 commutative-mul-ℤ (inr (inl star)) l = inv (right-zero-law-mul-ℤ l)
 commutative-mul-ℤ (inr (inr zero-ℕ)) l = inv (right-unit-law-mul-ℤ l)
 commutative-mul-ℤ (inr (inr (succ-ℕ n))) l =
-  ( ap (add-ℤ l) (commutative-mul-ℤ (inr (inr n)) l)) ∙
+  ( ap (l +ℤ_) (commutative-mul-ℤ (inr (inr n)) l)) ∙
   ( inv (right-successor-law-mul-ℤ l (in-pos n)))
 
 left-distributive-mul-add-ℤ :
-  (m k l : ℤ) → mul-ℤ m (add-ℤ k l) ＝ add-ℤ (mul-ℤ m k) (mul-ℤ m l)
+  (m k l : ℤ) → m *ℤ (k +ℤ l) ＝ (m *ℤ k) +ℤ (m *ℤ l)
 left-distributive-mul-add-ℤ m k l =
-  commutative-mul-ℤ m (add-ℤ k l) ∙
+  commutative-mul-ℤ m (k +ℤ l) ∙
     ( ( right-distributive-mul-add-ℤ k l m) ∙
       ( ap-add-ℤ (commutative-mul-ℤ k m) (commutative-mul-ℤ l m)))
 
 right-negative-law-mul-ℤ :
-  (k l : ℤ) → mul-ℤ k (neg-ℤ l) ＝ neg-ℤ (mul-ℤ k l)
+  (k l : ℤ) → k *ℤ (neg-ℤ l) ＝ neg-ℤ (k *ℤ l)
 right-negative-law-mul-ℤ k l =
   ( ( commutative-mul-ℤ k (neg-ℤ l)) ∙
     ( left-negative-law-mul-ℤ l k)) ∙
@@ -309,30 +308,30 @@ interchange-law-mul-mul-ℤ =
     commutative-mul-ℤ
     associative-mul-ℤ
 
-is-mul-neg-one-neg-ℤ : (x : ℤ) → neg-ℤ x ＝ mul-ℤ neg-one-ℤ x
+is-mul-neg-one-neg-ℤ : (x : ℤ) → neg-ℤ x ＝ (neg-one-ℤ *ℤ x)
 is-mul-neg-one-neg-ℤ x = refl
 
-is-mul-neg-one-neg-ℤ' : (x : ℤ) → neg-ℤ x ＝ mul-ℤ x neg-one-ℤ
+is-mul-neg-one-neg-ℤ' : (x : ℤ) → neg-ℤ x ＝ (x *ℤ neg-one-ℤ)
 is-mul-neg-one-neg-ℤ' x =
   is-mul-neg-one-neg-ℤ x ∙ commutative-mul-ℤ neg-one-ℤ x
 
-double-negative-law-mul-ℤ : (k l : ℤ) → mul-ℤ (neg-ℤ k) (neg-ℤ l) ＝ mul-ℤ k l
+double-negative-law-mul-ℤ : (k l : ℤ) → ((neg-ℤ k) *ℤ (neg-ℤ l)) ＝ (k *ℤ l)
 double-negative-law-mul-ℤ k l =
   equational-reasoning
-    mul-ℤ (neg-ℤ k) (neg-ℤ l)
-    ＝ neg-ℤ (mul-ℤ k (neg-ℤ l))
+    (neg-ℤ k) *ℤ (neg-ℤ l)
+    ＝ neg-ℤ (k *ℤ (neg-ℤ l))
       by left-negative-law-mul-ℤ k (neg-ℤ l)
-    ＝ neg-ℤ (neg-ℤ (mul-ℤ k l))
+    ＝ neg-ℤ (neg-ℤ (k *ℤ l))
       by ap neg-ℤ (right-negative-law-mul-ℤ k l)
-    ＝ mul-ℤ k l
-      by neg-neg-ℤ (mul-ℤ k l)
+    ＝ k *ℤ l
+      by neg-neg-ℤ (k *ℤ l)
 ```
 
 ### Positivity of multiplication
 
 ```agda
 is-positive-mul-ℤ :
-  {x y : ℤ} → is-positive-ℤ x → is-positive-ℤ y → is-positive-ℤ (mul-ℤ x y)
+  {x y : ℤ} → is-positive-ℤ x → is-positive-ℤ y → is-positive-ℤ (x *ℤ y)
 is-positive-mul-ℤ {inr (inr zero-ℕ)} {inr (inr y)} H K = star
 is-positive-mul-ℤ {inr (inr (succ-ℕ x))} {inr (inr y)} H K =
   is-positive-add-ℤ {inr (inr y)} K
@@ -342,54 +341,54 @@ is-positive-mul-ℤ {inr (inr (succ-ℕ x))} {inr (inr y)} H K =
 ### Computing multiplication of integers that come from natural numbers
 
 ```agda
-mul-int-ℕ : (x y : ℕ) → mul-ℤ (int-ℕ x) (int-ℕ y) ＝ int-ℕ (mul-ℕ x y)
+mul-int-ℕ : (x y : ℕ) → ((int-ℕ x) *ℤ (int-ℕ y)) ＝ int-ℕ (x *ℕ y)
 mul-int-ℕ zero-ℕ y = refl
 mul-int-ℕ (succ-ℕ x) y =
-  ( ap (mul-ℤ' (int-ℕ y)) (inv (succ-int-ℕ x))) ∙
+  ( ap (_*ℤ (int-ℕ y)) (inv (succ-int-ℕ x))) ∙
   ( ( left-successor-law-mul-ℤ (int-ℕ x) (int-ℕ y)) ∙
-    ( ( ( ap (add-ℤ (int-ℕ y)) (mul-int-ℕ x y)) ∙
-        ( add-int-ℕ y (mul-ℕ x y))) ∙
-      ( ap int-ℕ (commutative-add-ℕ y (mul-ℕ x y)))))
+    ( ( ( ap ((int-ℕ y) +ℤ_) (mul-int-ℕ x y)) ∙
+        ( add-int-ℕ y (x *ℕ y))) ∙
+      ( ap int-ℕ (commutative-add-ℕ y (x *ℕ y)))))
 
-compute-mul-ℤ : (x y : ℤ) → mul-ℤ x y ＝ explicit-mul-ℤ x y
+compute-mul-ℤ : (x y : ℤ) → (x *ℤ y) ＝ explicit-mul-ℤ x y
 compute-mul-ℤ (inl zero-ℕ) (inl y) =
   inv (ap int-ℕ (left-unit-law-mul-ℕ (succ-ℕ y)))
 compute-mul-ℤ (inl (succ-ℕ x)) (inl y) =
-  ( ( ap (add-ℤ (int-ℕ (succ-ℕ y))) (compute-mul-ℤ (inl x) (inl y))) ∙
+  ( ( ap ((int-ℕ (succ-ℕ y)) +ℤ_) (compute-mul-ℤ (inl x) (inl y))) ∙
     ( commutative-add-ℤ
       ( int-ℕ (succ-ℕ y))
-      ( int-ℕ (mul-ℕ (succ-ℕ x) (succ-ℕ y))))) ∙
-  ( add-int-ℕ (mul-ℕ (succ-ℕ x) (succ-ℕ y)) (succ-ℕ y))
+      ( int-ℕ ((succ-ℕ x) *ℕ (succ-ℕ y))))) ∙
+  ( add-int-ℕ ((succ-ℕ x) *ℕ (succ-ℕ y)) (succ-ℕ y))
 compute-mul-ℤ (inl zero-ℕ) (inr (inl star)) = refl
 compute-mul-ℤ (inl zero-ℕ) (inr (inr x)) = ap inl (inv (left-unit-law-add-ℕ x))
 compute-mul-ℤ (inl (succ-ℕ x)) (inr (inl star)) = right-zero-law-mul-ℤ (inl x)
 compute-mul-ℤ (inl (succ-ℕ x)) (inr (inr y)) =
-  ( ( ( ap (add-ℤ (inl y)) (compute-mul-ℤ (inl x) (inr (inr y)))) ∙
+  ( ( ( ap ((inl y) +ℤ_) (compute-mul-ℤ (inl x) (inr (inr y)))) ∙
       ( inv
         ( distributive-neg-add-ℤ
           ( inr (inr y))
-          ( int-ℕ (mul-ℕ (succ-ℕ x) (succ-ℕ y)))))) ∙
+          ( int-ℕ ((succ-ℕ x) *ℕ (succ-ℕ y)))))) ∙
     ( ap
       ( neg-ℤ)
       ( commutative-add-ℤ
         ( int-ℕ (succ-ℕ y))
-        ( int-ℕ (mul-ℕ (succ-ℕ x) (succ-ℕ y)))))) ∙
-  ( ap neg-ℤ (add-int-ℕ (mul-ℕ (succ-ℕ x) (succ-ℕ y)) (succ-ℕ y)))
+        ( int-ℕ ((succ-ℕ x) *ℕ (succ-ℕ y)))))) ∙
+  ( ap neg-ℤ (add-int-ℕ ((succ-ℕ x) *ℕ (succ-ℕ y)) (succ-ℕ y)))
 compute-mul-ℤ (inr (inl star)) (inl y) = refl
 compute-mul-ℤ (inr (inr zero-ℕ)) (inl y) = ap inl (inv (left-unit-law-add-ℕ y))
 compute-mul-ℤ (inr (inr (succ-ℕ x))) (inl y) =
-  ( ap (add-ℤ (inl y)) (compute-mul-ℤ (inr (inr x)) (inl y))) ∙
+  ( ap ((inl y) +ℤ_) (compute-mul-ℤ (inr (inr x)) (inl y))) ∙
   ( ( ( inv
         ( distributive-neg-add-ℤ
           ( inr (inr y))
-          ( inr (inr (add-ℕ (mul-ℕ x (succ-ℕ y)) y))))) ∙
+          ( inr (inr ((x *ℕ (succ-ℕ y)) +ℕ y))))) ∙
       ( ap
         ( neg-ℤ)
-        ( ( add-int-ℕ (succ-ℕ y) (mul-ℕ (succ-ℕ x) (succ-ℕ y))) ∙
+        ( ( add-int-ℕ (succ-ℕ y) ((succ-ℕ x) *ℕ (succ-ℕ y))) ∙
           ( ap
             ( inr ∘ inr)
-            ( left-successor-law-add-ℕ y (add-ℕ (mul-ℕ x (succ-ℕ y)) y)))))) ∙
-    ( ap inl (commutative-add-ℕ y (mul-ℕ (succ-ℕ x) (succ-ℕ y)))))
+            ( left-successor-law-add-ℕ y ((x *ℕ (succ-ℕ y)) +ℕ y)))))) ∙
+    ( ap inl (commutative-add-ℕ y ((succ-ℕ x) *ℕ (succ-ℕ y)))))
 compute-mul-ℤ (inr (inl star)) (inr (inl star)) = refl
 compute-mul-ℤ (inr (inl star)) (inr (inr y)) = refl
 compute-mul-ℤ (inr (inr zero-ℕ)) (inr (inl star)) = refl
@@ -398,33 +397,33 @@ compute-mul-ℤ (inr (inr (succ-ℕ x))) (inr (inl star)) =
 compute-mul-ℤ (inr (inr zero-ℕ)) (inr (inr y)) =
   ap ( inr ∘ inr)
      ( inv
-       ( ( ap (add-ℕ' y) (left-zero-law-mul-ℕ (succ-ℕ y))) ∙
+       ( ( ap (_+ℕ y) (left-zero-law-mul-ℕ (succ-ℕ y))) ∙
          ( left-unit-law-add-ℕ y)))
 compute-mul-ℤ (inr (inr (succ-ℕ x))) (inr (inr y)) =
-  ( ap (add-ℤ (inr (inr y))) (compute-mul-ℤ (inr (inr x)) (inr (inr y)))) ∙
-  ( ( add-int-ℕ (succ-ℕ y) (mul-ℕ (succ-ℕ x) (succ-ℕ y))) ∙
-    ( ap int-ℕ (commutative-add-ℕ (succ-ℕ y) (mul-ℕ (succ-ℕ x) (succ-ℕ y)))))
+  ( ap ((inr (inr y)) +ℤ_) (compute-mul-ℤ (inr (inr x)) (inr (inr y)))) ∙
+  ( ( add-int-ℕ (succ-ℕ y) ((succ-ℕ x) *ℕ (succ-ℕ y))) ∙
+    ( ap int-ℕ (commutative-add-ℕ (succ-ℕ y) ((succ-ℕ x) *ℕ (succ-ℕ y)))))
 ```
 
 ### Linearity of the difference
 
 ```agda
 linear-diff-ℤ :
-  (z x y : ℤ) → diff-ℤ (mul-ℤ z x) (mul-ℤ z y) ＝ mul-ℤ z (diff-ℤ x y)
+  (z x y : ℤ) → diff-ℤ (z *ℤ x) (z *ℤ y) ＝ (z *ℤ (diff-ℤ x y))
 linear-diff-ℤ z x y =
-  ( ap (add-ℤ (mul-ℤ z x)) (inv (right-negative-law-mul-ℤ z y))) ∙
+  ( ap ((z *ℤ x) +ℤ_) (inv (right-negative-law-mul-ℤ z y))) ∙
   ( inv (left-distributive-mul-add-ℤ z x (neg-ℤ y)))
 
 linear-diff-ℤ' :
-  (x y z : ℤ) → diff-ℤ (mul-ℤ x z) (mul-ℤ y z) ＝ mul-ℤ (diff-ℤ x y) z
+  (x y z : ℤ) → diff-ℤ (x *ℤ z) (y *ℤ z) ＝ ((diff-ℤ x y) *ℤ z)
 linear-diff-ℤ' x y z =
-  ( ap (add-ℤ (mul-ℤ x z)) (inv (left-negative-law-mul-ℤ y z))) ∙
+  ( ap ((x *ℤ z) +ℤ_) (inv (left-negative-law-mul-ℤ y z))) ∙
   ( inv (right-distributive-mul-add-ℤ x (neg-ℤ y) z))
 ```
 
 ```agda
 is-zero-is-zero-mul-ℤ :
-  (x y : ℤ) → is-zero-ℤ (mul-ℤ x y) → (is-zero-ℤ x) + (is-zero-ℤ y)
+  (x y : ℤ) → is-zero-ℤ (x *ℤ y) → (is-zero-ℤ x) + (is-zero-ℤ y)
 is-zero-is-zero-mul-ℤ (inl x) (inl y) H =
   ex-falso (Eq-eq-ℤ (inv (compute-mul-ℤ (inl x) (inl y)) ∙ H))
 is-zero-is-zero-mul-ℤ (inl x) (inr (inl star)) H = inr refl
@@ -471,7 +470,7 @@ is-emb-mul-ℤ' x f = is-emb-is-injective is-set-ℤ (is-injective-mul-ℤ' x f)
 
 ```agda
 is-positive-left-factor-mul-ℤ :
-  {x y : ℤ} → is-positive-ℤ (mul-ℤ x y) → is-positive-ℤ y → is-positive-ℤ x
+  {x y : ℤ} → is-positive-ℤ (x *ℤ y) → is-positive-ℤ y → is-positive-ℤ x
 is-positive-left-factor-mul-ℤ {inl x} {inr (inr y)} H K =
   is-positive-eq-ℤ (compute-mul-ℤ (inl x) (inr (inr y))) H
 is-positive-left-factor-mul-ℤ {inr (inl star)} {inr (inr y)} H K =
@@ -479,7 +478,7 @@ is-positive-left-factor-mul-ℤ {inr (inl star)} {inr (inr y)} H K =
 is-positive-left-factor-mul-ℤ {inr (inr x)} {inr (inr y)} H K = star
 
 is-positive-right-factor-mul-ℤ :
-  {x y : ℤ} → is-positive-ℤ (mul-ℤ x y) → is-positive-ℤ x → is-positive-ℤ y
+  {x y : ℤ} → is-positive-ℤ (x *ℤ y) → is-positive-ℤ x → is-positive-ℤ y
 is-positive-right-factor-mul-ℤ {x} {y} H =
   is-positive-left-factor-mul-ℤ (is-positive-eq-ℤ (commutative-mul-ℤ x y) H)
 ```
@@ -489,7 +488,7 @@ is-positive-right-factor-mul-ℤ {x} {y} H =
 ```agda
 is-nonnegative-mul-ℤ :
   {x y : ℤ} → is-nonnegative-ℤ x → is-nonnegative-ℤ y →
-  is-nonnegative-ℤ (mul-ℤ x y)
+  is-nonnegative-ℤ (x *ℤ y)
 is-nonnegative-mul-ℤ {inr (inl star)} {y} H K = star
 is-nonnegative-mul-ℤ {inr (inr x)} {inr (inl star)} H K =
   is-nonnegative-eq-ℤ (inv (right-zero-law-mul-ℤ (inr (inr x)))) star
@@ -498,14 +497,14 @@ is-nonnegative-mul-ℤ {inr (inr x)} {inr (inr y)} H K =
 
 is-nonnegative-left-factor-mul-ℤ :
   {x y : ℤ} →
-  is-nonnegative-ℤ (mul-ℤ x y) → is-positive-ℤ y → is-nonnegative-ℤ x
+  is-nonnegative-ℤ (x *ℤ y) → is-positive-ℤ y → is-nonnegative-ℤ x
 is-nonnegative-left-factor-mul-ℤ {inl x} {inr (inr y)} H K =
   ex-falso (is-nonnegative-eq-ℤ (compute-mul-ℤ (inl x) (inr (inr y))) H)
 is-nonnegative-left-factor-mul-ℤ {inr x} {inr y} H K = star
 
 is-nonnegative-right-factor-mul-ℤ :
   {x y : ℤ} →
-  is-nonnegative-ℤ (mul-ℤ x y) → is-positive-ℤ x → is-nonnegative-ℤ y
+  is-nonnegative-ℤ (x *ℤ y) → is-positive-ℤ x → is-nonnegative-ℤ y
 is-nonnegative-right-factor-mul-ℤ {x} {y} H =
   is-nonnegative-left-factor-mul-ℤ
     ( is-nonnegative-eq-ℤ (commutative-mul-ℤ x y) H)
@@ -513,18 +512,18 @@ is-nonnegative-right-factor-mul-ℤ {x} {y} H =
 
 ```agda
 preserves-leq-mul-ℤ :
-  (x y z : ℤ) → is-nonnegative-ℤ z → leq-ℤ x y → leq-ℤ (mul-ℤ z x) (mul-ℤ z y)
+  (x y z : ℤ) → is-nonnegative-ℤ z → leq-ℤ x y → leq-ℤ (z *ℤ x) (z *ℤ y)
 preserves-leq-mul-ℤ x y (inr (inl star)) star K = star
 preserves-leq-mul-ℤ x y (inr (inr zero-ℕ)) star K = K
 preserves-leq-mul-ℤ x y (inr (inr (succ-ℕ n))) star K =
   preserves-leq-add-ℤ {x} {y}
-    { mul-ℤ (inr (inr n)) x}
-    { mul-ℤ (inr (inr n)) y}
+    { (inr (inr n)) *ℤ x}
+    { (inr (inr n)) *ℤ y}
     ( K)
     ( preserves-leq-mul-ℤ x y (inr (inr n)) star K)
 
 preserves-leq-mul-ℤ' :
-  (x y z : ℤ) → is-nonnegative-ℤ z → leq-ℤ x y → leq-ℤ (mul-ℤ x z) (mul-ℤ y z)
+  (x y z : ℤ) → is-nonnegative-ℤ z → leq-ℤ x y → leq-ℤ (x *ℤ z) (y *ℤ z)
 preserves-leq-mul-ℤ' x y z H K =
   concatenate-eq-leq-eq-ℤ
     ( commutative-mul-ℤ x z)

--- a/src/elementary-number-theory/multiplication-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/multiplication-natural-numbers.lagda.md
@@ -33,6 +33,7 @@ mul-ℕ : ℕ → ℕ → ℕ
 mul-ℕ 0 n = 0
 mul-ℕ (succ-ℕ m) n = add-ℕ (mul-ℕ m n) n
 
+infix 30 _*ℕ_
 _*ℕ_ = mul-ℕ
 
 mul-ℕ' : ℕ → ℕ → ℕ

--- a/src/elementary-number-theory/multiplication-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/multiplication-natural-numbers.lagda.md
@@ -33,6 +33,8 @@ mul-ℕ : ℕ → ℕ → ℕ
 mul-ℕ 0 n = 0
 mul-ℕ (succ-ℕ m) n = add-ℕ (mul-ℕ m n) n
 
+_*ℕ_ = mul-ℕ
+
 mul-ℕ' : ℕ → ℕ → ℕ
 mul-ℕ' x y = mul-ℕ y x
 

--- a/src/elementary-number-theory/multiplication-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/multiplication-natural-numbers.lagda.md
@@ -40,20 +40,20 @@ mul-ℕ' : ℕ → ℕ → ℕ
 mul-ℕ' x y = mul-ℕ y x
 
 ap-mul-ℕ :
-  {x y x' y' : ℕ} → x ＝ x' → y ＝ y' → mul-ℕ x y ＝ mul-ℕ x' y'
+  {x y x' y' : ℕ} → x ＝ x' → y ＝ y' → x *ℕ y ＝ x' *ℕ y'
 ap-mul-ℕ p q = ap-binary mul-ℕ p q
 
 double-ℕ : ℕ → ℕ
-double-ℕ x = mul-ℕ 2 x
+double-ℕ x = 2 *ℕ x
 
 triple-ℕ : ℕ → ℕ
-triple-ℕ x = mul-ℕ 3 x
+triple-ℕ x = 3 *ℕ x
 
 square-ℕ : ℕ → ℕ
-square-ℕ x = mul-ℕ x x
+square-ℕ x = x *ℕ x
 
 cube-ℕ : ℕ → ℕ
-cube-ℕ x = mul-ℕ (square-ℕ x) x
+cube-ℕ x = (square-ℕ x) *ℕ x
 ```
 
 ## Properties
@@ -61,97 +61,98 @@ cube-ℕ x = mul-ℕ (square-ℕ x) x
 ```agda
 abstract
   left-zero-law-mul-ℕ :
-    (x : ℕ) → mul-ℕ zero-ℕ x ＝ zero-ℕ
+    (x : ℕ) → zero-ℕ *ℕ x ＝ zero-ℕ
   left-zero-law-mul-ℕ x = refl
 
   right-zero-law-mul-ℕ :
-    (x : ℕ) → mul-ℕ x zero-ℕ ＝ zero-ℕ
+    (x : ℕ) → x *ℕ zero-ℕ ＝ zero-ℕ
   right-zero-law-mul-ℕ zero-ℕ = refl
   right-zero-law-mul-ℕ (succ-ℕ x) =
-    ( right-unit-law-add-ℕ (mul-ℕ x zero-ℕ)) ∙ (right-zero-law-mul-ℕ x)
+    ( right-unit-law-add-ℕ (x *ℕ zero-ℕ)) ∙ (right-zero-law-mul-ℕ x)
 
 abstract
   right-unit-law-mul-ℕ :
-    (x : ℕ) → mul-ℕ x 1 ＝ x
+    (x : ℕ) → x *ℕ 1 ＝ x
   right-unit-law-mul-ℕ zero-ℕ = refl
   right-unit-law-mul-ℕ (succ-ℕ x) = ap succ-ℕ (right-unit-law-mul-ℕ x)
 
   left-unit-law-mul-ℕ :
-    (x : ℕ) → mul-ℕ 1 x ＝ x
+    (x : ℕ) → 1 *ℕ x ＝ x
   left-unit-law-mul-ℕ zero-ℕ = refl
   left-unit-law-mul-ℕ (succ-ℕ x) = ap succ-ℕ (left-unit-law-mul-ℕ x)
 
 abstract
   left-successor-law-mul-ℕ :
-    (x y : ℕ) → mul-ℕ (succ-ℕ x) y ＝ add-ℕ (mul-ℕ x y) y
+    (x y : ℕ) → (succ-ℕ x) *ℕ y ＝ (x *ℕ y) +ℕ y
   left-successor-law-mul-ℕ x y = refl
 
   right-successor-law-mul-ℕ :
-    (x y : ℕ) → mul-ℕ x (succ-ℕ y) ＝ add-ℕ x (mul-ℕ x y)
+    (x y : ℕ) → x *ℕ (succ-ℕ y) ＝ x +ℕ (x *ℕ y)
   right-successor-law-mul-ℕ zero-ℕ y = refl
   right-successor-law-mul-ℕ (succ-ℕ x) y =
-    ( ( ap (λ t → succ-ℕ (add-ℕ t y)) (right-successor-law-mul-ℕ x y)) ∙
-      ( ap succ-ℕ (associative-add-ℕ x (mul-ℕ x y) y))) ∙
-    ( inv (left-successor-law-add-ℕ x (add-ℕ (mul-ℕ x y) y)))
+    ( ( ap (λ t → succ-ℕ (t +ℕ y)) (right-successor-law-mul-ℕ x y)) ∙
+      ( ap succ-ℕ (associative-add-ℕ x (x *ℕ y) y))) ∙
+    ( inv (left-successor-law-add-ℕ x ((x *ℕ y) +ℕ y)))
 
 square-succ-ℕ :
   (k : ℕ) →
-  square-ℕ (succ-ℕ k) ＝ succ-ℕ (mul-ℕ (succ-ℕ (succ-ℕ k)) k)
+  square-ℕ (succ-ℕ k) ＝ succ-ℕ ((succ-ℕ (succ-ℕ k)) *ℕ k)
 square-succ-ℕ k =
   ( right-successor-law-mul-ℕ (succ-ℕ k) k) ∙
-  ( commutative-add-ℕ (succ-ℕ k) (mul-ℕ (succ-ℕ k) k))
+  ( commutative-add-ℕ (succ-ℕ k) ((succ-ℕ k) *ℕ k))
 
 abstract
   commutative-mul-ℕ :
-    (x y : ℕ) → mul-ℕ x y ＝ mul-ℕ y x
+    (x y : ℕ) → x *ℕ y ＝ y *ℕ x
   commutative-mul-ℕ zero-ℕ y = inv (right-zero-law-mul-ℕ y)
   commutative-mul-ℕ (succ-ℕ x) y =
-    ( commutative-add-ℕ (mul-ℕ x y) y) ∙
-    ( ( ap (add-ℕ y) (commutative-mul-ℕ x y)) ∙
+    ( commutative-add-ℕ (x *ℕ y) y) ∙
+    ( ( ap (y +ℕ_) (commutative-mul-ℕ x y)) ∙
       ( inv (right-successor-law-mul-ℕ y x)))
 
 abstract
   left-distributive-mul-add-ℕ :
-    (x y z : ℕ) → mul-ℕ x (add-ℕ y z) ＝ add-ℕ (mul-ℕ x y) (mul-ℕ x z)
+    (x y z : ℕ) → x *ℕ (y +ℕ z) ＝ (x *ℕ y) +ℕ (x *ℕ z)
   left-distributive-mul-add-ℕ zero-ℕ y z = refl
   left-distributive-mul-add-ℕ (succ-ℕ x) y z =
-    ( left-successor-law-mul-ℕ x (add-ℕ y z)) ∙
-    ( ( ap (add-ℕ' (add-ℕ y z)) (left-distributive-mul-add-ℕ x y z)) ∙
-      ( ( associative-add-ℕ (mul-ℕ x y) (mul-ℕ x z) (add-ℕ y z)) ∙
-        ( ( ap ( add-ℕ (mul-ℕ x y))
-               ( ( inv (associative-add-ℕ (mul-ℕ x z) y z)) ∙
-                 ( ( ap (add-ℕ' z) (commutative-add-ℕ (mul-ℕ x z) y)) ∙
-                   ( associative-add-ℕ y (mul-ℕ x z) z)))) ∙
-          ( inv (associative-add-ℕ (mul-ℕ x y) y (add-ℕ (mul-ℕ x z) z))))))
+    ( left-successor-law-mul-ℕ x (y +ℕ z)) ∙
+    ( ( ap (_+ℕ (y +ℕ z)) (left-distributive-mul-add-ℕ x y z)) ∙
+      ( ( associative-add-ℕ (x *ℕ y) (x *ℕ z) (y +ℕ z)) ∙
+        ( ( ap
+            ( ( x *ℕ y) +ℕ_)
+            ( ( inv (associative-add-ℕ (x *ℕ z) y z)) ∙
+              ( ( ap (_+ℕ z) (commutative-add-ℕ (x *ℕ z) y)) ∙
+                ( associative-add-ℕ y (x *ℕ z) z)))) ∙
+          ( inv (associative-add-ℕ (x *ℕ y) y ((x *ℕ z) +ℕ z))))))
 
 abstract
   right-distributive-mul-add-ℕ :
-    (x y z : ℕ) → mul-ℕ (add-ℕ x y) z ＝ add-ℕ (mul-ℕ x z) (mul-ℕ y z)
+    (x y z : ℕ) → (x +ℕ y) *ℕ z ＝ (x *ℕ z) +ℕ (y *ℕ z)
   right-distributive-mul-add-ℕ x y z =
-    ( commutative-mul-ℕ (add-ℕ x y) z) ∙
+    ( commutative-mul-ℕ (x +ℕ y) z) ∙
     ( ( left-distributive-mul-add-ℕ z x y) ∙
-      ( ( ap (add-ℕ' (mul-ℕ z y)) (commutative-mul-ℕ z x)) ∙
-        ( ap (add-ℕ (mul-ℕ x z)) (commutative-mul-ℕ z y))))
+      ( ( ap (_+ℕ (z *ℕ y)) (commutative-mul-ℕ z x)) ∙
+        ( ap ((x *ℕ z) +ℕ_) (commutative-mul-ℕ z y))))
 
 abstract
   associative-mul-ℕ :
-    (x y z : ℕ) → mul-ℕ (mul-ℕ x y) z ＝ mul-ℕ x (mul-ℕ y z)
+    (x y z : ℕ) → (x *ℕ y) *ℕ z ＝ x *ℕ (y *ℕ z)
   associative-mul-ℕ zero-ℕ y z = refl
   associative-mul-ℕ (succ-ℕ x) y z =
-    ( right-distributive-mul-add-ℕ (mul-ℕ x y) y z) ∙
-    ( ap (add-ℕ' (mul-ℕ y z)) (associative-mul-ℕ x y z))
+    ( right-distributive-mul-add-ℕ (x *ℕ y) y z) ∙
+    ( ap (_+ℕ (y *ℕ z)) (associative-mul-ℕ x y z))
 
 left-two-law-mul-ℕ :
-  (x : ℕ) → mul-ℕ 2 x ＝ add-ℕ x x
+  (x : ℕ) → 2 *ℕ x ＝ x +ℕ x
 left-two-law-mul-ℕ x =
   ( left-successor-law-mul-ℕ 1 x) ∙
-  ( ap (add-ℕ' x) (left-unit-law-mul-ℕ x))
+  ( ap (_+ℕ x) (left-unit-law-mul-ℕ x))
 
 right-two-law-mul-ℕ :
-  (x : ℕ) → mul-ℕ x 2 ＝ add-ℕ x x
+  (x : ℕ) → x *ℕ 2 ＝ x +ℕ x
 right-two-law-mul-ℕ x =
   ( right-successor-law-mul-ℕ x 1) ∙
-  ( ap (add-ℕ x) (right-unit-law-mul-ℕ x))
+  ( ap (x +ℕ_) (right-unit-law-mul-ℕ x))
 
 interchange-law-mul-mul-ℕ : interchange-law mul-ℕ mul-ℕ
 interchange-law-mul-mul-ℕ =
@@ -197,16 +198,16 @@ is-emb-mul-ℕ' : (x : ℕ) → is-nonzero-ℕ x → is-emb (mul-ℕ' x)
 is-emb-mul-ℕ' x H = is-emb-is-injective is-set-ℕ (is-injective-mul-ℕ' x H)
 
 is-nonzero-mul-ℕ :
-  (x y : ℕ) → is-nonzero-ℕ x → is-nonzero-ℕ y → is-nonzero-ℕ (mul-ℕ x y)
+  (x y : ℕ) → is-nonzero-ℕ x → is-nonzero-ℕ y → is-nonzero-ℕ (x *ℕ y)
 is-nonzero-mul-ℕ x y H K p =
   K (is-injective-mul-ℕ x H (p ∙ (inv (right-zero-law-mul-ℕ x))))
 
 is-nonzero-left-factor-mul-ℕ :
-  (x y : ℕ) → is-nonzero-ℕ (mul-ℕ x y) → is-nonzero-ℕ x
+  (x y : ℕ) → is-nonzero-ℕ (x *ℕ y) → is-nonzero-ℕ x
 is-nonzero-left-factor-mul-ℕ .zero-ℕ y H refl = H (left-zero-law-mul-ℕ y)
 
 is-nonzero-right-factor-mul-ℕ :
-  (x y : ℕ) → is-nonzero-ℕ (mul-ℕ x y) → is-nonzero-ℕ y
+  (x y : ℕ) → is-nonzero-ℕ (x *ℕ y) → is-nonzero-ℕ y
 is-nonzero-right-factor-mul-ℕ x .zero-ℕ H refl = H (right-zero-law-mul-ℕ x)
 ```
 
@@ -214,43 +215,43 @@ We conclude that $y = 1$ if $(x+1)y = x+1$.
 
 ```agda
 is-one-is-right-unit-mul-ℕ :
-  (x y : ℕ) → mul-ℕ (succ-ℕ x) y ＝ succ-ℕ x → is-one-ℕ y
+  (x y : ℕ) → (succ-ℕ x) *ℕ y ＝ succ-ℕ x → is-one-ℕ y
 is-one-is-right-unit-mul-ℕ x y p =
   is-injective-mul-succ-ℕ x (p ∙ inv (right-unit-law-mul-ℕ (succ-ℕ x)))
 
 is-one-is-left-unit-mul-ℕ :
-  (x y : ℕ) → mul-ℕ x (succ-ℕ y) ＝ succ-ℕ y → is-one-ℕ x
+  (x y : ℕ) → x *ℕ (succ-ℕ y) ＝ succ-ℕ y → is-one-ℕ x
 is-one-is-left-unit-mul-ℕ x y p =
   is-injective-mul-succ-ℕ' y (p ∙ inv (left-unit-law-mul-ℕ (succ-ℕ y)))
 
 is-one-right-is-one-mul-ℕ :
-  (x y : ℕ) → is-one-ℕ (mul-ℕ x y) → is-one-ℕ y
+  (x y : ℕ) → is-one-ℕ (x *ℕ y) → is-one-ℕ y
 is-one-right-is-one-mul-ℕ zero-ℕ zero-ℕ p = p
 is-one-right-is-one-mul-ℕ zero-ℕ (succ-ℕ y) ()
 is-one-right-is-one-mul-ℕ (succ-ℕ x) zero-ℕ p =
   is-one-right-is-one-mul-ℕ x zero-ℕ p
 is-one-right-is-one-mul-ℕ (succ-ℕ x) (succ-ℕ y) p =
   ap ( succ-ℕ)
-     ( is-zero-right-is-zero-add-ℕ (mul-ℕ x (succ-ℕ y)) y
+     ( is-zero-right-is-zero-add-ℕ (x *ℕ (succ-ℕ y)) y
        ( is-injective-succ-ℕ p))
 
 is-one-left-is-one-mul-ℕ :
-  (x y : ℕ) → is-one-ℕ (mul-ℕ x y) → is-one-ℕ x
+  (x y : ℕ) → is-one-ℕ (x *ℕ y) → is-one-ℕ x
 is-one-left-is-one-mul-ℕ x y p =
   is-one-right-is-one-mul-ℕ y x (commutative-mul-ℕ y x ∙ p)
 
 neq-mul-ℕ :
-  (m n : ℕ) → ¬ (succ-ℕ m ＝ mul-ℕ (succ-ℕ m) (succ-ℕ (succ-ℕ n)))
+  (m n : ℕ) → ¬ (succ-ℕ m ＝ (succ-ℕ m) *ℕ (succ-ℕ (succ-ℕ n)))
 neq-mul-ℕ m n p =
   neq-add-ℕ
     ( succ-ℕ m)
-    ( add-ℕ (mul-ℕ m (succ-ℕ n)) n)
+    ( ( m *ℕ (succ-ℕ n)) +ℕ n)
     ( ( p) ∙
       ( ( right-successor-law-mul-ℕ (succ-ℕ m) (succ-ℕ n)) ∙
-        ( ap (add-ℕ (succ-ℕ m)) (left-successor-law-mul-ℕ m (succ-ℕ n)))))
+        ( ap ((succ-ℕ m) +ℕ_) (left-successor-law-mul-ℕ m (succ-ℕ n)))))
 ```
 
-### The multiplicative monoid ℕ\*
+### The multiplicative monoid `ℕ*`
 
 ```agda
 ℕ*-Semigroup : Semigroup lzero


### PR DESCRIPTION
They are `_*ℕ_`, `_*ℤ_`, and `_^ℕ_` respectively.

In addition to what the title says, I've also refactored the files
- `multiplication-natural-numbers`
- `multiplication-integers`
- `exponentiation-natural-numbers`
- `absolute-value-integers`

to use the binary operators where it's natural, to get a sense for how this would look. It should be possible to change most usages easily enough* with a nice enough regex, but I don't want to do this before I get some feedback on whether it is preferable.

Also, pairs like `is-injective-mul-succ-ℕ` and `is-injective-mul-succ-ℕ'` should perhaps be renamed to something like `is-injective-left-mul-succ-ℕ` and `is-injective-right-mul-succ-ℕ`.