### PR TITLE
Refactor to use infix binary operators for arithmetic

### DIFF
--- a/src/commutative-algebra/binomial-theorem-commutative-rings.lagda.md
+++ b/src/commutative-algebra/binomial-theorem-commutative-rings.lagda.md
@@ -164,7 +164,7 @@ is-linear-combination-power-add-Commutative-Ring :
           mul-nat-scalar-Commutative-Ring A
             ( binomial-coefficient-ℕ
               ( n +ℕ m)
-              ( add-ℕ n (nat-Fin (succ-ℕ m) i)))
+              ( n +ℕ (nat-Fin (succ-ℕ m) i)))
             ( mul-Commutative-Ring A
               ( power-Commutative-Ring A (nat-Fin (succ-ℕ m) i) x)
               ( power-Commutative-Ring A

--- a/src/commutative-algebra/binomial-theorem-commutative-rings.lagda.md
+++ b/src/commutative-algebra/binomial-theorem-commutative-rings.lagda.md
@@ -145,14 +145,14 @@ binomial-theorem-Commutative-Ring A n x y =
 is-linear-combination-power-add-Commutative-Ring :
   {l : Level} (A : Commutative-Ring l) (n m : ℕ)
   (x y : type-Commutative-Ring A) →
-  power-Commutative-Ring A (add-ℕ n m) (add-Commutative-Ring A x y) ＝
+  power-Commutative-Ring A (n +ℕ m) (add-Commutative-Ring A x y) ＝
   add-Commutative-Ring A
     ( mul-Commutative-Ring A
       ( power-Commutative-Ring A m y)
       ( sum-Commutative-Ring A n
         ( λ i →
           mul-nat-scalar-Commutative-Ring A
-            ( binomial-coefficient-ℕ (add-ℕ n m) (nat-Fin n i))
+            ( binomial-coefficient-ℕ (n +ℕ m) (nat-Fin n i))
             ( mul-Commutative-Ring A
               ( power-Commutative-Ring A (nat-Fin n i) x)
               ( power-Commutative-Ring A (dist-ℕ (nat-Fin n i) n) y)))))
@@ -163,7 +163,7 @@ is-linear-combination-power-add-Commutative-Ring :
         ( λ i →
           mul-nat-scalar-Commutative-Ring A
             ( binomial-coefficient-ℕ
-              ( add-ℕ n m)
+              ( n +ℕ m)
               ( add-ℕ n (nat-Fin (succ-ℕ m) i)))
             ( mul-Commutative-Ring A
               ( power-Commutative-Ring A (nat-Fin (succ-ℕ m) i) x)

--- a/src/commutative-algebra/binomial-theorem-commutative-semirings.lagda.md
+++ b/src/commutative-algebra/binomial-theorem-commutative-semirings.lagda.md
@@ -151,14 +151,14 @@ binomial-theorem-Commutative-Semiring A n x y =
 is-linear-combination-power-add-Commutative-Semiring :
   {l : Level} (A : Commutative-Semiring l) (n m : ℕ)
   (x y : type-Commutative-Semiring A) →
-  power-Commutative-Semiring A (add-ℕ n m) (add-Commutative-Semiring A x y) ＝
+  power-Commutative-Semiring A (n +ℕ m) (add-Commutative-Semiring A x y) ＝
   add-Commutative-Semiring A
     ( mul-Commutative-Semiring A
       ( power-Commutative-Semiring A m y)
       ( sum-Commutative-Semiring A n
         ( λ i →
           mul-nat-scalar-Commutative-Semiring A
-            ( binomial-coefficient-ℕ (add-ℕ n m) (nat-Fin n i))
+            ( binomial-coefficient-ℕ (n +ℕ m) (nat-Fin n i))
             ( mul-Commutative-Semiring A
               ( power-Commutative-Semiring A (nat-Fin n i) x)
               ( power-Commutative-Semiring A (dist-ℕ (nat-Fin n i) n) y)))))
@@ -169,7 +169,7 @@ is-linear-combination-power-add-Commutative-Semiring :
         ( λ i →
           mul-nat-scalar-Commutative-Semiring A
             ( binomial-coefficient-ℕ
-              ( add-ℕ n m)
+              ( n +ℕ m)
               ( add-ℕ n (nat-Fin (succ-ℕ m) i)))
             ( mul-Commutative-Semiring A
               ( power-Commutative-Semiring A (nat-Fin (succ-ℕ m) i) x)

--- a/src/commutative-algebra/binomial-theorem-commutative-semirings.lagda.md
+++ b/src/commutative-algebra/binomial-theorem-commutative-semirings.lagda.md
@@ -170,7 +170,7 @@ is-linear-combination-power-add-Commutative-Semiring :
           mul-nat-scalar-Commutative-Semiring A
             ( binomial-coefficient-ℕ
               ( n +ℕ m)
-              ( add-ℕ n (nat-Fin (succ-ℕ m) i)))
+              ( n +ℕ (nat-Fin (succ-ℕ m) i)))
             ( mul-Commutative-Semiring A
               ( power-Commutative-Semiring A (nat-Fin (succ-ℕ m) i) x)
               ( power-Commutative-Semiring A

--- a/src/commutative-algebra/commutative-rings.lagda.md
+++ b/src/commutative-algebra/commutative-rings.lagda.md
@@ -525,7 +525,7 @@ module _
 
   right-distributive-mul-nat-scalar-add-Commutative-Ring :
     (m n : ℕ) (x : type-Commutative-Ring) →
-    mul-nat-scalar-Commutative-Ring (add-ℕ m n) x ＝
+    mul-nat-scalar-Commutative-Ring (m +ℕ n) x ＝
     add-Commutative-Ring
       ( mul-nat-scalar-Commutative-Ring m x)
       ( mul-nat-scalar-Commutative-Ring n x)

--- a/src/commutative-algebra/commutative-semirings.lagda.md
+++ b/src/commutative-algebra/commutative-semirings.lagda.md
@@ -309,7 +309,7 @@ module _
 
   right-distributive-mul-nat-scalar-add-Commutative-Semiring :
     (m n : ℕ) (x : type-Commutative-Semiring) →
-    mul-nat-scalar-Commutative-Semiring (add-ℕ m n) x ＝
+    mul-nat-scalar-Commutative-Semiring (m +ℕ n) x ＝
     add-Commutative-Semiring
       ( mul-nat-scalar-Commutative-Semiring m x)
       ( mul-nat-scalar-Commutative-Semiring n x)

--- a/src/commutative-algebra/eisenstein-integers.lagda.md
+++ b/src/commutative-algebra/eisenstein-integers.lagda.md
@@ -300,7 +300,7 @@ associative-mul-ℤ[ω] (a , b) (c , d) (e , f) =
                         ( d *ℤ e)
                         ( (c *ℤ f) +ℤ (neg-ℤ (d *ℤ f))))) ∙
                     ( ap
-                      ( mul-ℤ b)
+                      ( b *ℤ_)
                       ( ( inv
                           ( associative-add-ℤ
                             ( d *ℤ e)
@@ -327,8 +327,8 @@ associative-mul-ℤ[ω] (a , b) (c , d) (e , f) =
                     ( ap-add-ℤ
                       ( ( commutative-mul-ℤ e ad) ∙
                         ( ( associative-mul-ℤ a d e) ∙
-                          ( ap (mul-ℤ a) (commutative-mul-ℤ d e))))
-                      ( ( ap (mul-ℤ e) (commutative-mul-ℤ c b)) ∙
+                          ( ap (a *ℤ_) (commutative-mul-ℤ d e))))
+                      ( ( ap (e *ℤ_) (commutative-mul-ℤ c b)) ∙
                         ( ( commutative-mul-ℤ e (b *ℤ c)) ∙
                           ( ( associative-mul-ℤ b c e) ∙
                             ( commutative-mul-ℤ b ce))))))
@@ -339,7 +339,7 @@ associative-mul-ℤ[ω] (a , b) (c , d) (e , f) =
                           ( associative-mul-ℤ b d e))) ∙
                       ( ap
                         ( neg-ℤ)
-                        ( ap (mul-ℤ b) (commutative-mul-ℤ d e)))))) ∙
+                        ( ap (b *ℤ_) (commutative-mul-ℤ d e)))))) ∙
                 ( associative-add-ℤ
                   ( a *ℤ ed)
                   ( ce *ℤ b)
@@ -445,7 +445,7 @@ associative-mul-ℤ[ω] (a , b) (c , d) (e , f) =
                           ( left-distributive-mul-add-ℤ b ed
                             ( cf +ℤ (neg-ℤ df)))) ∙
                         ( ap
-                          ( mul-ℤ b)
+                          ( b *ℤ_)
                           ( ( inv
                               ( associative-add-ℤ ed cf (neg-ℤ df))) ∙
                             ( ap

--- a/src/commutative-algebra/eisenstein-integers.lagda.md
+++ b/src/commutative-algebra/eisenstein-integers.lagda.md
@@ -196,7 +196,7 @@ left-unit-law-mul-ℤ[ω] (a , b) =
   eq-Eq-ℤ[ω]
     ( right-unit-law-add-ℤ a)
     ( ( right-unit-law-add-ℤ (b +ℤ (a *ℤ zero-ℤ))) ∙
-      ( ( ap (add-ℤ b) (right-zero-law-mul-ℤ a)) ∙
+      ( ( ap (b +ℤ_) (right-zero-law-mul-ℤ a)) ∙
         ( right-unit-law-add-ℤ b)))
 
 right-unit-law-mul-ℤ[ω] :
@@ -310,7 +310,7 @@ associative-mul-ℤ[ω] (a , b) (c , d) (e , f) =
                           ( add-ℤ' (neg-ℤ (d *ℤ f)))
                           ( ( commutative-add-ℤ (d *ℤ e) (c *ℤ f)) ∙
                             ( ap
-                              ( add-ℤ (c *ℤ f))
+                              ( (c *ℤ f) +ℤ_)
                               ( commutative-mul-ℤ d e))))))))))))))
     ( ( ap-add-ℤ
         ( ( ap-add-ℤ

--- a/src/commutative-algebra/eisenstein-integers.lagda.md
+++ b/src/commutative-algebra/eisenstein-integers.lagda.md
@@ -101,7 +101,7 @@ neg-ω-ℤ[ω] = pair zero-ℤ neg-one-ℤ
 
 ```agda
 add-ℤ[ω] : ℤ[ω] → ℤ[ω] → ℤ[ω]
-add-ℤ[ω] (pair a b) (pair a' b') = pair (add-ℤ a a') (add-ℤ b b')
+add-ℤ[ω] (pair a b) (pair a' b') = pair (a +ℤ a') (b +ℤ b')
 
 ap-add-ℤ[ω] :
   {x x' y y' : ℤ[ω]} → x ＝ x' → y ＝ y' → add-ℤ[ω] x y ＝ add-ℤ[ω] x' y'
@@ -124,7 +124,7 @@ mul-ℤ[ω] : ℤ[ω] → ℤ[ω] → ℤ[ω]
 mul-ℤ[ω] (pair a1 b1) (pair a2 b2) =
   pair
     ( add-ℤ (mul-ℤ a1 a2) (neg-ℤ (mul-ℤ b1 b2)))
-    ( add-ℤ (add-ℤ (mul-ℤ a1 b2) (mul-ℤ a2 b1)) (neg-ℤ (mul-ℤ b1 b2)))
+    ( add-ℤ ((mul-ℤ a1 b2) +ℤ (mul-ℤ a2 b1)) (neg-ℤ (mul-ℤ b1 b2)))
 
 ap-mul-ℤ[ω] :
   {x x' y y' : ℤ[ω]} → x ＝ x' → y ＝ y' → mul-ℤ[ω] x y ＝ mul-ℤ[ω] x' y'
@@ -137,7 +137,7 @@ The conjugate of `a + bω` is `a + bω²`, which is `(a - b) - bω`.
 
 ```agda
 conjugate-ℤ[ω] : ℤ[ω] → ℤ[ω]
-conjugate-ℤ[ω] (pair a b) = pair (add-ℤ a (neg-ℤ b)) (neg-ℤ b)
+conjugate-ℤ[ω] (pair a b) = pair (a +ℤ (neg-ℤ b)) (neg-ℤ b)
 
 conjugate-conjugate-ℤ[ω] :
   (x : ℤ[ω]) → conjugate-ℤ[ω] (conjugate-ℤ[ω] x) ＝ x
@@ -180,7 +180,7 @@ left-unit-law-mul-ℤ[ω] :
 left-unit-law-mul-ℤ[ω] (pair a b) =
   eq-Eq-ℤ[ω]
     ( right-unit-law-add-ℤ a)
-    ( ( right-unit-law-add-ℤ (add-ℤ b (mul-ℤ a zero-ℤ))) ∙
+    ( ( right-unit-law-add-ℤ (b +ℤ (mul-ℤ a zero-ℤ))) ∙
       ( ( ap (add-ℤ b) (right-zero-law-mul-ℤ a)) ∙
         ( right-unit-law-add-ℤ b)))
 
@@ -220,7 +220,7 @@ associative-mul-ℤ[ω] (pair a b) (pair c d) (pair e f) =
         ( ( ap
             ( neg-ℤ)
             ( ( right-distributive-mul-add-ℤ
-                ( add-ℤ (mul-ℤ a d) (mul-ℤ c b))
+                ( (mul-ℤ a d) +ℤ (mul-ℤ c b))
                 ( neg-ℤ (mul-ℤ b d))
                 ( f)) ∙
               ( ap-add-ℤ
@@ -306,7 +306,7 @@ associative-mul-ℤ[ω] (pair a b) (pair c d) (pair e f) =
                   ( ( ap neg-ℤ (associative-mul-ℤ b d f)) ∙
                     ( ( inv (right-negative-law-mul-ℤ b df)) ∙
                       ( commutative-mul-ℤ b (neg-ℤ df)))))))
-            ( ( left-distributive-mul-add-ℤ e (add-ℤ ad cb) (neg-ℤ bd)) ∙
+            ( ( left-distributive-mul-add-ℤ e (ad +ℤ cb) (neg-ℤ bd)) ∙
               ( ( ap-add-ℤ
                   ( ( left-distributive-mul-add-ℤ e ad cb) ∙
                     ( ap-add-ℤ
@@ -348,25 +348,25 @@ associative-mul-ℤ[ω] (pair a b) (pair c d) (pair e f) =
                         ( right-distributive-mul-add-ℤ ce (neg-ℤ df) b)))))) ∙
               ( ( inv
                   ( associative-add-ℤ
-                    ( mul-ℤ a (add-ℤ cf ed))
-                    ( mul-ℤ (add-ℤ ce (neg-ℤ df)) b)
+                    ( mul-ℤ a (cf +ℤ ed))
+                    ( mul-ℤ (ce +ℤ (neg-ℤ df)) b)
                     ( neg-ℤ (mul-ℤ b ed)))) ∙
                 ( ( ap
                     ( add-ℤ' (neg-ℤ (mul-ℤ b ed)))
                     ( commutative-add-ℤ
-                      ( mul-ℤ a (add-ℤ cf ed))
-                      ( mul-ℤ (add-ℤ ce (neg-ℤ df)) b))) ∙
+                      ( mul-ℤ a (cf +ℤ ed))
+                      ( mul-ℤ (ce +ℤ (neg-ℤ df)) b))) ∙
                   ( associative-add-ℤ
-                    ( mul-ℤ (add-ℤ ce (neg-ℤ df)) b)
-                    ( mul-ℤ a (add-ℤ cf ed))
+                    ( mul-ℤ (ce +ℤ (neg-ℤ df)) b)
+                    ( mul-ℤ a (cf +ℤ ed))
                     ( neg-ℤ (mul-ℤ b ed))))))))
-        ( ( inv (left-negative-law-mul-ℤ (add-ℤ (add-ℤ ad cb) (neg-ℤ bd)) f)) ∙
+        ( ( inv (left-negative-law-mul-ℤ ((ad +ℤ cb) +ℤ (neg-ℤ bd)) f)) ∙
           ( ( ap
               ( mul-ℤ' f)
-              ( ( distributive-neg-add-ℤ (add-ℤ ad cb) (neg-ℤ bd)) ∙
+              ( ( distributive-neg-add-ℤ (ad +ℤ cb) (neg-ℤ bd)) ∙
                 ( ap-add-ℤ (distributive-neg-add-ℤ ad cb) (neg-neg-ℤ bd)))) ∙
             ( ( right-distributive-mul-add-ℤ
-                ( add-ℤ (neg-ℤ ad) (neg-ℤ cb))
+                ( (neg-ℤ ad) +ℤ (neg-ℤ cb))
                 ( bd)
                 ( f)) ∙
               ( ( ap-add-ℤ
@@ -405,30 +405,30 @@ associative-mul-ℤ[ω] (pair a b) (pair c d) (pair e f) =
                             ( cf)
                             ( neg-ℤ df)))))))))))) ∙
       ( ( associative-add-ℤ
-          ( mul-ℤ (add-ℤ ce (neg-ℤ df)) b)
-          ( add-ℤ (mul-ℤ a (add-ℤ cf ed)) (neg-ℤ (mul-ℤ b ed)))
+          ( mul-ℤ (ce +ℤ (neg-ℤ df)) b)
+          ( add-ℤ (mul-ℤ a (cf +ℤ ed)) (neg-ℤ (mul-ℤ b ed)))
           ( add-ℤ
             ( mul-ℤ a (neg-ℤ df))
-            ( neg-ℤ (mul-ℤ b (add-ℤ cf (neg-ℤ df)))))) ∙
+            ( neg-ℤ (mul-ℤ b (cf +ℤ (neg-ℤ df)))))) ∙
         ( ( ( ap
-              ( add-ℤ (mul-ℤ (add-ℤ ce (neg-ℤ df)) b))
+              ( add-ℤ (mul-ℤ (ce +ℤ (neg-ℤ df)) b))
               ( ( interchange-law-add-add-ℤ
-                  ( mul-ℤ a (add-ℤ cf ed))
+                  ( mul-ℤ a (cf +ℤ ed))
                   ( neg-ℤ (mul-ℤ b ed))
                   ( mul-ℤ a (neg-ℤ df))
-                  ( neg-ℤ (mul-ℤ b (add-ℤ cf (neg-ℤ df))))) ∙
+                  ( neg-ℤ (mul-ℤ b (cf +ℤ (neg-ℤ df))))) ∙
                 ( ap-add-ℤ
                   ( inv
-                    ( left-distributive-mul-add-ℤ a (add-ℤ cf ed) (neg-ℤ df)))
+                    ( left-distributive-mul-add-ℤ a (cf +ℤ ed) (neg-ℤ df)))
                   ( ( inv
                       ( distributive-neg-add-ℤ
                         ( mul-ℤ b ed)
-                        ( mul-ℤ b (add-ℤ cf (neg-ℤ df))))) ∙
+                        ( mul-ℤ b (cf +ℤ (neg-ℤ df))))) ∙
                     ( ap
                       ( neg-ℤ)
                       ( ( inv
                           ( left-distributive-mul-add-ℤ b ed
-                            ( add-ℤ cf (neg-ℤ df)))) ∙
+                            ( cf +ℤ (neg-ℤ df)))) ∙
                         ( ap
                           ( mul-ℤ b)
                           ( ( inv
@@ -438,14 +438,14 @@ associative-mul-ℤ[ω] (pair a b) (pair c d) (pair e f) =
                               ( commutative-add-ℤ ed cf)))))))))) ∙
             ( inv
               ( associative-add-ℤ
-                ( mul-ℤ (add-ℤ ce (neg-ℤ df)) b)
-                ( mul-ℤ a (add-ℤ (add-ℤ cf ed) (neg-ℤ df)))
-                ( neg-ℤ (mul-ℤ b (add-ℤ (add-ℤ cf ed) (neg-ℤ df))))))) ∙
+                ( mul-ℤ (ce +ℤ (neg-ℤ df)) b)
+                ( mul-ℤ a ((cf +ℤ ed) +ℤ (neg-ℤ df)))
+                ( neg-ℤ (mul-ℤ b ((cf +ℤ ed) +ℤ (neg-ℤ df))))))) ∙
           ( ap
-            ( add-ℤ' (neg-ℤ (mul-ℤ b (add-ℤ (add-ℤ cf ed) (neg-ℤ df)))))
+            ( add-ℤ' (neg-ℤ (mul-ℤ b ((cf +ℤ ed) +ℤ (neg-ℤ df)))))
             ( commutative-add-ℤ
-              ( mul-ℤ (add-ℤ ce (neg-ℤ df)) b)
-              ( mul-ℤ a (add-ℤ (add-ℤ cf ed) (neg-ℤ df))))))))
+              ( mul-ℤ (ce +ℤ (neg-ℤ df)) b)
+              ( mul-ℤ a ((cf +ℤ ed) +ℤ (neg-ℤ df))))))))
     where
     ac = mul-ℤ a c
     bd = mul-ℤ b d
@@ -484,8 +484,8 @@ left-distributive-mul-add-ℤ[ω] (pair a b) (pair c d) (pair e f) =
         ( ( ap neg-ℤ (left-distributive-mul-add-ℤ b d f)) ∙
           ( distributive-neg-add-ℤ (mul-ℤ b d) (mul-ℤ b f)))) ∙
       ( interchange-law-add-add-ℤ
-        ( add-ℤ (mul-ℤ a d) (mul-ℤ c b))
-        ( add-ℤ (mul-ℤ a f) (mul-ℤ e b))
+        ( (mul-ℤ a d) +ℤ (mul-ℤ c b))
+        ( (mul-ℤ a f) +ℤ (mul-ℤ e b))
         ( neg-ℤ (mul-ℤ b d))
         ( neg-ℤ (mul-ℤ b f))))
 

--- a/src/commutative-algebra/eisenstein-integers.lagda.md
+++ b/src/commutative-algebra/eisenstein-integers.lagda.md
@@ -247,7 +247,7 @@ associative-mul-ℤ[ω] (a , b) (c , d) (e , f) =
                 ( ( left-negative-law-mul-ℤ (b *ℤ d) f) ∙
                   ( ap neg-ℤ (associative-mul-ℤ b d f)))))) ∙
           ( ( distributive-neg-add-ℤ
-              ( add-ℤ (a *ℤ (d *ℤ f)) (b *ℤ (c *ℤ f)))
+              ( (a *ℤ (d *ℤ f)) +ℤ (b *ℤ (c *ℤ f)))
               ( neg-ℤ (b *ℤ (d *ℤ f)))) ∙
             ( ( ap-add-ℤ
                 ( distributive-neg-add-ℤ
@@ -364,15 +364,15 @@ associative-mul-ℤ[ω] (a , b) (c , d) (e , f) =
               ( ( inv
                   ( associative-add-ℤ
                     ( a *ℤ (cf +ℤ ed))
-                    ( mul-ℤ (ce +ℤ (neg-ℤ df)) b)
+                    ( (ce +ℤ (neg-ℤ df)) *ℤ b)
                     ( neg-ℤ (b *ℤ ed)))) ∙
                 ( ( ap
                     ( add-ℤ' (neg-ℤ (b *ℤ ed)))
                     ( commutative-add-ℤ
                       ( a *ℤ (cf +ℤ ed))
-                      ( mul-ℤ (ce +ℤ (neg-ℤ df)) b))) ∙
+                      ( (ce +ℤ (neg-ℤ df)) *ℤ b))) ∙
                   ( associative-add-ℤ
-                    ( mul-ℤ (ce +ℤ (neg-ℤ df)) b)
+                    ( (ce +ℤ (neg-ℤ df)) *ℤ b)
                     ( a *ℤ (cf +ℤ ed))
                     ( neg-ℤ (b *ℤ ed))))))))
         ( ( inv (left-negative-law-mul-ℤ ((ad +ℤ cb) +ℤ (neg-ℤ bd)) f)) ∙
@@ -420,13 +420,13 @@ associative-mul-ℤ[ω] (a , b) (c , d) (e , f) =
                             ( cf)
                             ( neg-ℤ df)))))))))))) ∙
       ( ( associative-add-ℤ
-          ( mul-ℤ (ce +ℤ (neg-ℤ df)) b)
-          ( add-ℤ (a *ℤ (cf +ℤ ed)) (neg-ℤ (b *ℤ ed)))
+          ( (ce +ℤ (neg-ℤ df)) *ℤ b)
+          ( (a *ℤ (cf +ℤ ed)) +ℤ (neg-ℤ (b *ℤ ed)))
           ( add-ℤ
             ( a *ℤ (neg-ℤ df))
             ( neg-ℤ (b *ℤ (cf +ℤ (neg-ℤ df)))))) ∙
         ( ( ( ap
-              ( add-ℤ (mul-ℤ (ce +ℤ (neg-ℤ df)) b))
+              ( add-ℤ ((ce +ℤ (neg-ℤ df)) *ℤ b))
               ( ( interchange-law-add-add-ℤ
                   ( a *ℤ (cf +ℤ ed))
                   ( neg-ℤ (b *ℤ ed))
@@ -453,13 +453,13 @@ associative-mul-ℤ[ω] (a , b) (c , d) (e , f) =
                               ( commutative-add-ℤ ed cf)))))))))) ∙
             ( inv
               ( associative-add-ℤ
-                ( mul-ℤ (ce +ℤ (neg-ℤ df)) b)
+                ( (ce +ℤ (neg-ℤ df)) *ℤ b)
                 ( a *ℤ ((cf +ℤ ed) +ℤ (neg-ℤ df)))
                 ( neg-ℤ (b *ℤ ((cf +ℤ ed) +ℤ (neg-ℤ df))))))) ∙
           ( ap
             ( add-ℤ' (neg-ℤ (b *ℤ ((cf +ℤ ed) +ℤ (neg-ℤ df)))))
             ( commutative-add-ℤ
-              ( mul-ℤ (ce +ℤ (neg-ℤ df)) b)
+              ( (ce +ℤ (neg-ℤ df)) *ℤ b)
               ( a *ℤ ((cf +ℤ ed) +ℤ (neg-ℤ df))))))))
     where
     ac = a *ℤ c

--- a/src/commutative-algebra/eisenstein-integers.lagda.md
+++ b/src/commutative-algebra/eisenstein-integers.lagda.md
@@ -307,7 +307,7 @@ associative-mul-ℤ[ω] (a , b) (c , d) (e , f) =
                             ( c *ℤ f)
                             ( neg-ℤ (d *ℤ f)))) ∙
                         ( ap
-                          ( add-ℤ' (neg-ℤ (d *ℤ f)))
+                          ( _+ℤ (neg-ℤ (d *ℤ f)))
                           ( ( commutative-add-ℤ (d *ℤ e) (c *ℤ f)) ∙
                             ( ap
                               ( (c *ℤ f) +ℤ_)
@@ -357,7 +357,7 @@ associative-mul-ℤ[ω] (a , b) (c , d) (e , f) =
                       ( ce *ℤ b)
                       ( neg-ℤ (b *ℤ ed)))) ∙
                   ( ap
-                    ( add-ℤ' (neg-ℤ (b *ℤ ed)))
+                    ( _+ℤ (neg-ℤ (b *ℤ ed)))
                     ( ( commutative-add-ℤ ((neg-ℤ df) *ℤ b) (ce *ℤ b)) ∙
                       ( inv
                         ( right-distributive-mul-add-ℤ ce (neg-ℤ df) b)))))) ∙
@@ -367,7 +367,7 @@ associative-mul-ℤ[ω] (a , b) (c , d) (e , f) =
                     ( (ce +ℤ (neg-ℤ df)) *ℤ b)
                     ( neg-ℤ (b *ℤ ed)))) ∙
                 ( ( ap
-                    ( add-ℤ' (neg-ℤ (b *ℤ ed)))
+                    ( _+ℤ (neg-ℤ (b *ℤ ed)))
                     ( commutative-add-ℤ
                       ( a *ℤ (cf +ℤ ed))
                       ( (ce +ℤ (neg-ℤ df)) *ℤ b))) ∙
@@ -457,7 +457,7 @@ associative-mul-ℤ[ω] (a , b) (c , d) (e , f) =
                 ( a *ℤ ((cf +ℤ ed) +ℤ (neg-ℤ df)))
                 ( neg-ℤ (b *ℤ ((cf +ℤ ed) +ℤ (neg-ℤ df))))))) ∙
           ( ap
-            ( add-ℤ' (neg-ℤ (b *ℤ ((cf +ℤ ed) +ℤ (neg-ℤ df)))))
+            ( _+ℤ (neg-ℤ (b *ℤ ((cf +ℤ ed) +ℤ (neg-ℤ df)))))
             ( commutative-add-ℤ
               ( (ce +ℤ (neg-ℤ df)) *ℤ b)
               ( a *ℤ ((cf +ℤ ed) +ℤ (neg-ℤ df))))))))

--- a/src/commutative-algebra/eisenstein-integers.lagda.md
+++ b/src/commutative-algebra/eisenstein-integers.lagda.md
@@ -206,7 +206,7 @@ right-unit-law-mul-ℤ[ω] (a , b) =
     ( ( ap-add-ℤ (right-unit-law-mul-ℤ a) (ap neg-ℤ (right-zero-law-mul-ℤ b))) ∙
       ( right-unit-law-add-ℤ a))
     ( ( ap-add-ℤ
-        ( ap (add-ℤ' b) (right-zero-law-mul-ℤ a))
+        ( ap (_+ℤ b) (right-zero-law-mul-ℤ a))
         ( ap neg-ℤ (right-zero-law-mul-ℤ b))) ∙
       ( right-unit-law-add-ℤ b))
 
@@ -242,7 +242,7 @@ associative-mul-ℤ[ω] (a , b) (c , d) (e , f) =
                 ( ( right-distributive-mul-add-ℤ (a *ℤ d) (c *ℤ b) f) ∙
                   ( ap-add-ℤ
                     ( associative-mul-ℤ a d f)
-                    ( ( ap (mul-ℤ' f) (commutative-mul-ℤ c b)) ∙
+                    ( ( ap (_*ℤ f) (commutative-mul-ℤ c b)) ∙
                       ( associative-mul-ℤ b c f))))
                 ( ( left-negative-law-mul-ℤ (b *ℤ d) f) ∙
                   ( ap neg-ℤ (associative-mul-ℤ b d f)))))) ∙
@@ -377,7 +377,7 @@ associative-mul-ℤ[ω] (a , b) (c , d) (e , f) =
                     ( neg-ℤ (b *ℤ ed))))))))
         ( ( inv (left-negative-law-mul-ℤ ((ad +ℤ cb) +ℤ (neg-ℤ bd)) f)) ∙
           ( ( ap
-              ( mul-ℤ' f)
+              ( _*ℤ f)
               ( ( distributive-neg-add-ℤ (ad +ℤ cb) (neg-ℤ bd)) ∙
                 ( ap-add-ℤ (distributive-neg-add-ℤ ad cb) (neg-neg-ℤ bd)))) ∙
             ( ( right-distributive-mul-add-ℤ
@@ -396,7 +396,7 @@ associative-mul-ℤ[ω] (a , b) (c , d) (e , f) =
                         ( ap
                           ( neg-ℤ)
                           ( ( ap
-                              ( mul-ℤ' f)
+                              ( _*ℤ f)
                               ( commutative-mul-ℤ c b)) ∙
                             ( associative-mul-ℤ b c f))))))
                   ( ( associative-mul-ℤ b d f) ∙

--- a/src/commutative-algebra/eisenstein-integers.lagda.md
+++ b/src/commutative-algebra/eisenstein-integers.lagda.md
@@ -157,7 +157,7 @@ pr2 (conjugate-ℤ[ω] (a , b)) = neg-ℤ b
 conjugate-conjugate-ℤ[ω] :
   (x : ℤ[ω]) → conjugate-ℤ[ω] (conjugate-ℤ[ω] x) ＝ x
 conjugate-conjugate-ℤ[ω] (a , b) =
-  eq-Eq-ℤ[ω] (isretr-add-neg-ℤ' (neg-ℤ b) a) (neg-neg-ℤ b)
+  eq-Eq-ℤ[ω] (isretr-right-add-neg-ℤ (neg-ℤ b) a) (neg-neg-ℤ b)
 ```
 
 ### The Eisenstein integers form a ring with conjugation

--- a/src/commutative-algebra/eisenstein-integers.lagda.md
+++ b/src/commutative-algebra/eisenstein-integers.lagda.md
@@ -449,7 +449,7 @@ associative-mul-ℤ[ω] (a , b) (c , d) (e , f) =
                           ( ( inv
                               ( associative-add-ℤ ed cf (neg-ℤ df))) ∙
                             ( ap
-                              ( add-ℤ' (neg-ℤ df))
+                              ( _+ℤ (neg-ℤ df))
                               ( commutative-add-ℤ ed cf)))))))))) ∙
             ( inv
               ( associative-add-ℤ

--- a/src/commutative-algebra/eisenstein-integers.lagda.md
+++ b/src/commutative-algebra/eisenstein-integers.lagda.md
@@ -123,7 +123,7 @@ Note that `(a + bω)(c + dω) = (ac - bd) + (ad + cb - bd)ω`
 mul-ℤ[ω] : ℤ[ω] → ℤ[ω] → ℤ[ω]
 mul-ℤ[ω] (pair a1 b1) (pair a2 b2) =
   pair
-    ( add-ℤ (mul-ℤ a1 a2) (neg-ℤ (mul-ℤ b1 b2)))
+    ( (mul-ℤ a1 a2) +ℤ (neg-ℤ (mul-ℤ b1 b2)))
     ( add-ℤ ((mul-ℤ a1 b2) +ℤ (mul-ℤ a2 b1)) (neg-ℤ (mul-ℤ b1 b2)))
 
 ap-mul-ℤ[ω] :
@@ -283,7 +283,7 @@ associative-mul-ℤ[ω] (pair a b) (pair c d) (pair e f) =
                   ( ( inv
                       ( left-distributive-mul-add-ℤ b
                         ( mul-ℤ d e)
-                        ( add-ℤ (mul-ℤ c f) (neg-ℤ (mul-ℤ d f))))) ∙
+                        ( (mul-ℤ c f) +ℤ (neg-ℤ (mul-ℤ d f))))) ∙
                     ( ap
                       ( mul-ℤ b)
                       ( ( inv
@@ -333,7 +333,7 @@ associative-mul-ℤ[ω] (pair a b) (pair c d) (pair e f) =
               ( mul-ℤ a cf)
               ( mul-ℤ (neg-ℤ df) b)
               ( mul-ℤ a ed)
-              ( add-ℤ (mul-ℤ ce b) (neg-ℤ (mul-ℤ b ed)))) ∙
+              ( (mul-ℤ ce b) +ℤ (neg-ℤ (mul-ℤ b ed)))) ∙
             ( ( ap-add-ℤ
                 ( inv (left-distributive-mul-add-ℤ a cf ed))
                 ( ( inv

--- a/src/commutative-algebra/eisenstein-integers.lagda.md
+++ b/src/commutative-algebra/eisenstein-integers.lagda.md
@@ -50,61 +50,71 @@ Eq-ℤ[ω] : ℤ[ω] → ℤ[ω] → UU lzero
 Eq-ℤ[ω] x y = (pr1 x ＝ pr1 y) × (pr2 x ＝ pr2 y)
 
 refl-Eq-ℤ[ω] : (x : ℤ[ω]) → Eq-ℤ[ω] x x
-refl-Eq-ℤ[ω] x = pair refl refl
+pr1 (refl-Eq-ℤ[ω] x) = refl
+pr2 (refl-Eq-ℤ[ω] x) = refl
 
 Eq-eq-ℤ[ω] : {x y : ℤ[ω]} → x ＝ y → Eq-ℤ[ω] x y
 Eq-eq-ℤ[ω] {x} refl = refl-Eq-ℤ[ω] x
 
 eq-Eq-ℤ[ω]' : {x y : ℤ[ω]} → Eq-ℤ[ω] x y → x ＝ y
-eq-Eq-ℤ[ω]' {pair a b} {pair .a .b} (pair refl refl) = refl
+eq-Eq-ℤ[ω]' {a , b} {.a , .b} (refl , refl) = refl
 
 eq-Eq-ℤ[ω] : {x y : ℤ[ω]} → (pr1 x ＝ pr1 y) → (pr2 x ＝ pr2 y) → x ＝ y
-eq-Eq-ℤ[ω] {pair a b} {pair .a .b} refl refl = refl
+eq-Eq-ℤ[ω] {a , b} {.a , .b} refl refl = refl
 ```
 
 ### The Eisenstein integer zero
 
 ```agda
 zero-ℤ[ω] : ℤ[ω]
-zero-ℤ[ω] = pair zero-ℤ zero-ℤ
+pr1 zero-ℤ[ω] = zero-ℤ
+pr2 zero-ℤ[ω] = zero-ℤ
 ```
 
 ### The Eisenstein integer one
 
 ```agda
 one-ℤ[ω] : ℤ[ω]
-one-ℤ[ω] = pair one-ℤ zero-ℤ
+pr1 one-ℤ[ω] = one-ℤ
+pr2 one-ℤ[ω] = zero-ℤ
 ```
 
 ### The inclusion of the integers into the Eisenstein integers
 
 ```agda
 eisenstein-int-ℤ : ℤ → ℤ[ω]
-eisenstein-int-ℤ x = pair x zero-ℤ
+pr1 (eisenstein-int-ℤ x) = x
+pr2 (eisenstein-int-ℤ x) = zero-ℤ
 ```
 
 ### The Eisenstein integer ω
 
 ```agda
 ω-ℤ[ω] : ℤ[ω]
-ω-ℤ[ω] = pair zero-ℤ one-ℤ
+pr1 ω-ℤ[ω] = zero-ℤ
+pr2 ω-ℤ[ω] = one-ℤ
 ```
 
 ### The Eisenstein integer -ω
 
 ```agda
 neg-ω-ℤ[ω] : ℤ[ω]
-neg-ω-ℤ[ω] = pair zero-ℤ neg-one-ℤ
+pr1 neg-ω-ℤ[ω] = zero-ℤ
+pr2 neg-ω-ℤ[ω] = neg-one-ℤ
 ```
 
 ### Addition of Eisenstein integers
 
 ```agda
 add-ℤ[ω] : ℤ[ω] → ℤ[ω] → ℤ[ω]
-add-ℤ[ω] (pair a b) (pair a' b') = pair (a +ℤ a') (b +ℤ b')
+pr1 (add-ℤ[ω] (a , b) (a' , b')) = a +ℤ a'
+pr2 (add-ℤ[ω] (a , b) (a' , b')) = b +ℤ b'
+
+infix 30 _+ℤ[ω]_
+_+ℤ[ω]_ = add-ℤ[ω]
 
 ap-add-ℤ[ω] :
-  {x x' y y' : ℤ[ω]} → x ＝ x' → y ＝ y' → add-ℤ[ω] x y ＝ add-ℤ[ω] x' y'
+  {x x' y y' : ℤ[ω]} → x ＝ x' → y ＝ y' → x +ℤ[ω] y ＝ x' +ℤ[ω] y'
 ap-add-ℤ[ω] p q = ap-binary add-ℤ[ω] p q
 ```
 
@@ -112,7 +122,8 @@ ap-add-ℤ[ω] p q = ap-binary add-ℤ[ω] p q
 
 ```agda
 neg-ℤ[ω] : ℤ[ω] → ℤ[ω]
-neg-ℤ[ω] (pair a b) = pair (neg-ℤ a) (neg-ℤ b)
+pr1 (neg-ℤ[ω] (a , b)) = neg-ℤ a
+pr2 (neg-ℤ[ω] (a , b)) = neg-ℤ b
 ```
 
 ### Multiplication of Eisenstein integers
@@ -121,13 +132,16 @@ Note that `(a + bω)(c + dω) = (ac - bd) + (ad + cb - bd)ω`
 
 ```agda
 mul-ℤ[ω] : ℤ[ω] → ℤ[ω] → ℤ[ω]
-mul-ℤ[ω] (pair a1 b1) (pair a2 b2) =
-  pair
-    ( (mul-ℤ a1 a2) +ℤ (neg-ℤ (mul-ℤ b1 b2)))
-    ( add-ℤ ((mul-ℤ a1 b2) +ℤ (mul-ℤ a2 b1)) (neg-ℤ (mul-ℤ b1 b2)))
+pr1 (mul-ℤ[ω] (a1 , b1) (a2 , b2)) =
+  (a1 *ℤ a2) +ℤ (neg-ℤ (b1 *ℤ b2))
+pr2 (mul-ℤ[ω] (a1 , b1) (a2 , b2)) =
+  ((a1 *ℤ b2) +ℤ (a2 *ℤ b1)) +ℤ (neg-ℤ (b1 *ℤ b2))
+
+infix 30 _*ℤ[ω]_
+_*ℤ[ω]_ = mul-ℤ[ω]
 
 ap-mul-ℤ[ω] :
-  {x x' y y' : ℤ[ω]} → x ＝ x' → y ＝ y' → mul-ℤ[ω] x y ＝ mul-ℤ[ω] x' y'
+  {x x' y y' : ℤ[ω]} → x ＝ x' → y ＝ y' → x *ℤ[ω] y ＝ x' *ℤ[ω] y'
 ap-mul-ℤ[ω] p q = ap-binary mul-ℤ[ω] p q
 ```
 
@@ -137,56 +151,57 @@ The conjugate of `a + bω` is `a + bω²`, which is `(a - b) - bω`.
 
 ```agda
 conjugate-ℤ[ω] : ℤ[ω] → ℤ[ω]
-conjugate-ℤ[ω] (pair a b) = pair (a +ℤ (neg-ℤ b)) (neg-ℤ b)
+pr1 (conjugate-ℤ[ω] (a , b)) = a +ℤ (neg-ℤ b)
+pr2 (conjugate-ℤ[ω] (a , b)) = neg-ℤ b
 
 conjugate-conjugate-ℤ[ω] :
   (x : ℤ[ω]) → conjugate-ℤ[ω] (conjugate-ℤ[ω] x) ＝ x
-conjugate-conjugate-ℤ[ω] (pair a b) =
+conjugate-conjugate-ℤ[ω] (a , b) =
   eq-Eq-ℤ[ω] (isretr-add-neg-ℤ' (neg-ℤ b) a) (neg-neg-ℤ b)
 ```
 
 ### The Eisenstein integers form a ring with conjugation
 
 ```agda
-left-unit-law-add-ℤ[ω] : (x : ℤ[ω]) → add-ℤ[ω] zero-ℤ[ω] x ＝ x
-left-unit-law-add-ℤ[ω] (pair a b) = eq-Eq-ℤ[ω] refl refl
+left-unit-law-add-ℤ[ω] : (x : ℤ[ω]) → zero-ℤ[ω] +ℤ[ω] x ＝ x
+left-unit-law-add-ℤ[ω] (a , b) = eq-Eq-ℤ[ω] refl refl
 
-right-unit-law-add-ℤ[ω] : (x : ℤ[ω]) → add-ℤ[ω] x zero-ℤ[ω] ＝ x
-right-unit-law-add-ℤ[ω] (pair a b) =
+right-unit-law-add-ℤ[ω] : (x : ℤ[ω]) → x +ℤ[ω] zero-ℤ[ω] ＝ x
+right-unit-law-add-ℤ[ω] (a , b) =
   eq-Eq-ℤ[ω] (right-unit-law-add-ℤ a) (right-unit-law-add-ℤ b)
 
 associative-add-ℤ[ω] :
-  (x y z : ℤ[ω]) → add-ℤ[ω] (add-ℤ[ω] x y) z ＝ add-ℤ[ω] x (add-ℤ[ω] y z)
-associative-add-ℤ[ω] (pair a b) (pair c d) (pair e f) =
+  (x y z : ℤ[ω]) → (x +ℤ[ω] y) +ℤ[ω] z ＝ x +ℤ[ω] (y +ℤ[ω] z)
+associative-add-ℤ[ω] (a , b) (c , d) (e , f) =
   eq-Eq-ℤ[ω] (associative-add-ℤ a c e) (associative-add-ℤ b d f)
 
 left-inverse-law-add-ℤ[ω] :
-  (x : ℤ[ω]) → add-ℤ[ω] (neg-ℤ[ω] x) x ＝ zero-ℤ[ω]
-left-inverse-law-add-ℤ[ω] (pair a b) =
+  (x : ℤ[ω]) → (neg-ℤ[ω] x) +ℤ[ω] x ＝ zero-ℤ[ω]
+left-inverse-law-add-ℤ[ω] (a , b) =
   eq-Eq-ℤ[ω] (left-inverse-law-add-ℤ a) (left-inverse-law-add-ℤ b)
 
 right-inverse-law-add-ℤ[ω] :
-  (x : ℤ[ω]) → add-ℤ[ω] x (neg-ℤ[ω] x) ＝ zero-ℤ[ω]
-right-inverse-law-add-ℤ[ω] (pair a b) =
+  (x : ℤ[ω]) → x +ℤ[ω] (neg-ℤ[ω] x) ＝ zero-ℤ[ω]
+right-inverse-law-add-ℤ[ω] (a , b) =
   eq-Eq-ℤ[ω] (right-inverse-law-add-ℤ a) (right-inverse-law-add-ℤ b)
 
 commutative-add-ℤ[ω] :
-  (x y : ℤ[ω]) → add-ℤ[ω] x y ＝ add-ℤ[ω] y x
-commutative-add-ℤ[ω] (pair a b) (pair a' b') =
+  (x y : ℤ[ω]) → x +ℤ[ω] y ＝ y +ℤ[ω] x
+commutative-add-ℤ[ω] (a , b) (a' , b') =
   eq-Eq-ℤ[ω] (commutative-add-ℤ a a') (commutative-add-ℤ b b')
 
 left-unit-law-mul-ℤ[ω] :
-  (x : ℤ[ω]) → mul-ℤ[ω] one-ℤ[ω] x ＝ x
-left-unit-law-mul-ℤ[ω] (pair a b) =
+  (x : ℤ[ω]) → one-ℤ[ω] *ℤ[ω] x ＝ x
+left-unit-law-mul-ℤ[ω] (a , b) =
   eq-Eq-ℤ[ω]
     ( right-unit-law-add-ℤ a)
-    ( ( right-unit-law-add-ℤ (b +ℤ (mul-ℤ a zero-ℤ))) ∙
+    ( ( right-unit-law-add-ℤ (b +ℤ (a *ℤ zero-ℤ))) ∙
       ( ( ap (add-ℤ b) (right-zero-law-mul-ℤ a)) ∙
         ( right-unit-law-add-ℤ b)))
 
 right-unit-law-mul-ℤ[ω] :
-  (x : ℤ[ω]) → mul-ℤ[ω] x one-ℤ[ω] ＝ x
-right-unit-law-mul-ℤ[ω] (pair a b) =
+  (x : ℤ[ω]) → x *ℤ[ω] one-ℤ[ω] ＝ x
+right-unit-law-mul-ℤ[ω] (a , b) =
   eq-Eq-ℤ[ω]
     ( ( ap-add-ℤ (right-unit-law-mul-ℤ a) (ap neg-ℤ (right-zero-law-mul-ℤ b))) ∙
       ( right-unit-law-add-ℤ a))
@@ -196,106 +211,106 @@ right-unit-law-mul-ℤ[ω] (pair a b) =
       ( right-unit-law-add-ℤ b))
 
 commutative-mul-ℤ[ω] :
-  (x y : ℤ[ω]) → mul-ℤ[ω] x y ＝ mul-ℤ[ω] y x
-commutative-mul-ℤ[ω] (pair a b) (pair c d) =
+  (x y : ℤ[ω]) → x *ℤ[ω] y ＝ y *ℤ[ω] x
+commutative-mul-ℤ[ω] (a , b) (c , d) =
   eq-Eq-ℤ[ω]
     ( ap-add-ℤ (commutative-mul-ℤ a c) (ap neg-ℤ (commutative-mul-ℤ b d)))
     ( ap-add-ℤ
-      ( commutative-add-ℤ (mul-ℤ a d) (mul-ℤ c b))
+      ( commutative-add-ℤ (a *ℤ d) (c *ℤ b))
       ( ap neg-ℤ (commutative-mul-ℤ b d)))
 
 associative-mul-ℤ[ω] :
-  (x y z : ℤ[ω]) → mul-ℤ[ω] (mul-ℤ[ω] x y) z ＝ mul-ℤ[ω] x (mul-ℤ[ω] y z)
-associative-mul-ℤ[ω] (pair a b) (pair c d) (pair e f) =
+  (x y z : ℤ[ω]) → (x *ℤ[ω] y) *ℤ[ω] z ＝ x *ℤ[ω] (y *ℤ[ω] z)
+associative-mul-ℤ[ω] (a , b) (c , d) (e , f) =
   eq-Eq-ℤ[ω]
     ( ( ap-add-ℤ
         ( ( right-distributive-mul-add-ℤ
-            ( mul-ℤ a c)
-            ( neg-ℤ (mul-ℤ b d))
+            ( a *ℤ c)
+            ( neg-ℤ (b *ℤ d))
             ( e)) ∙
           ( ap-add-ℤ
             ( associative-mul-ℤ a c e)
-            ( ( left-negative-law-mul-ℤ (mul-ℤ b d) e) ∙
+            ( ( left-negative-law-mul-ℤ (b *ℤ d) e) ∙
               ( ap neg-ℤ (associative-mul-ℤ b d e)))))
         ( ( ap
             ( neg-ℤ)
             ( ( right-distributive-mul-add-ℤ
-                ( (mul-ℤ a d) +ℤ (mul-ℤ c b))
-                ( neg-ℤ (mul-ℤ b d))
+                ( (a *ℤ d) +ℤ (c *ℤ b))
+                ( neg-ℤ (b *ℤ d))
                 ( f)) ∙
               ( ap-add-ℤ
-                ( ( right-distributive-mul-add-ℤ (mul-ℤ a d) (mul-ℤ c b) f) ∙
+                ( ( right-distributive-mul-add-ℤ (a *ℤ d) (c *ℤ b) f) ∙
                   ( ap-add-ℤ
                     ( associative-mul-ℤ a d f)
                     ( ( ap (mul-ℤ' f) (commutative-mul-ℤ c b)) ∙
                       ( associative-mul-ℤ b c f))))
-                ( ( left-negative-law-mul-ℤ (mul-ℤ b d) f) ∙
+                ( ( left-negative-law-mul-ℤ (b *ℤ d) f) ∙
                   ( ap neg-ℤ (associative-mul-ℤ b d f)))))) ∙
           ( ( distributive-neg-add-ℤ
-              ( add-ℤ (mul-ℤ a (mul-ℤ d f)) (mul-ℤ b (mul-ℤ c f)))
-              ( neg-ℤ (mul-ℤ b (mul-ℤ d f)))) ∙
+              ( add-ℤ (a *ℤ (d *ℤ f)) (b *ℤ (c *ℤ f)))
+              ( neg-ℤ (b *ℤ (d *ℤ f)))) ∙
             ( ( ap-add-ℤ
                 ( distributive-neg-add-ℤ
-                  ( mul-ℤ a (mul-ℤ d f))
-                  ( mul-ℤ b (mul-ℤ c f)))
+                  ( a *ℤ (d *ℤ f))
+                  ( b *ℤ (c *ℤ f)))
                 ( refl
-                  { x = neg-ℤ (neg-ℤ (mul-ℤ b (mul-ℤ d f)))})) ∙
+                  { x = neg-ℤ (neg-ℤ (b *ℤ (d *ℤ f)))})) ∙
               ( associative-add-ℤ
-                ( neg-ℤ (mul-ℤ a (mul-ℤ d f)))
-                ( neg-ℤ (mul-ℤ b (mul-ℤ c f)))
-                ( neg-ℤ (neg-ℤ (mul-ℤ b (mul-ℤ d f))))))))) ∙
+                ( neg-ℤ (a *ℤ (d *ℤ f)))
+                ( neg-ℤ (b *ℤ (c *ℤ f)))
+                ( neg-ℤ (neg-ℤ (b *ℤ (d *ℤ f))))))))) ∙
       ( ( interchange-law-add-add-ℤ
-          ( mul-ℤ a (mul-ℤ c e))
-          ( neg-ℤ (mul-ℤ b (mul-ℤ d e)))
-          ( neg-ℤ (mul-ℤ a (mul-ℤ d f)))
+          ( a *ℤ (c *ℤ e))
+          ( neg-ℤ (b *ℤ (d *ℤ e)))
+          ( neg-ℤ (a *ℤ (d *ℤ f)))
           ( add-ℤ
-            ( neg-ℤ (mul-ℤ b (mul-ℤ c f)))
-            ( neg-ℤ (neg-ℤ (mul-ℤ b (mul-ℤ d f)))))) ∙
+            ( neg-ℤ (b *ℤ (c *ℤ f)))
+            ( neg-ℤ (neg-ℤ (b *ℤ (d *ℤ f)))))) ∙
         ( ap-add-ℤ
           ( ( ap
-              ( add-ℤ (mul-ℤ a (mul-ℤ c e)))
-              ( inv ( right-negative-law-mul-ℤ a (mul-ℤ d f)))) ∙
+              ( add-ℤ (a *ℤ (c *ℤ e)))
+              ( inv ( right-negative-law-mul-ℤ a (d *ℤ f)))) ∙
             ( inv
-              ( left-distributive-mul-add-ℤ a (mul-ℤ c e) (neg-ℤ (mul-ℤ d f)))))
+              ( left-distributive-mul-add-ℤ a (c *ℤ e) (neg-ℤ (d *ℤ f)))))
           ( ( ap
-              ( add-ℤ (neg-ℤ (mul-ℤ b (mul-ℤ d e))))
+              ( add-ℤ (neg-ℤ (b *ℤ (d *ℤ e))))
               ( inv
                 ( distributive-neg-add-ℤ
-                  ( mul-ℤ b (mul-ℤ c f))
-                  ( neg-ℤ (mul-ℤ b (mul-ℤ d f)))))) ∙
+                  ( b *ℤ (c *ℤ f))
+                  ( neg-ℤ (b *ℤ (d *ℤ f)))))) ∙
             ( ( inv
                 ( distributive-neg-add-ℤ
-                  ( mul-ℤ b (mul-ℤ d e))
+                  ( b *ℤ (d *ℤ e))
                   ( add-ℤ
-                    ( mul-ℤ b (mul-ℤ c f))
-                    ( neg-ℤ (mul-ℤ b (mul-ℤ d f)))))) ∙
+                    ( b *ℤ (c *ℤ f))
+                    ( neg-ℤ (b *ℤ (d *ℤ f)))))) ∙
               ( ap
                 ( neg-ℤ)
                 ( ( ap
-                    ( add-ℤ (mul-ℤ b (mul-ℤ d e)))
+                    ( add-ℤ (b *ℤ (d *ℤ e)))
                     ( ( ap
-                        ( add-ℤ (mul-ℤ b (mul-ℤ c f)))
-                        ( inv (right-negative-law-mul-ℤ b (mul-ℤ d f)))) ∙
+                        ( add-ℤ (b *ℤ (c *ℤ f)))
+                        ( inv (right-negative-law-mul-ℤ b (d *ℤ f)))) ∙
                       ( inv
                         ( left-distributive-mul-add-ℤ b
-                          ( mul-ℤ c f)
-                          ( neg-ℤ (mul-ℤ d f)))))) ∙
+                          ( c *ℤ f)
+                          ( neg-ℤ (d *ℤ f)))))) ∙
                   ( ( inv
                       ( left-distributive-mul-add-ℤ b
-                        ( mul-ℤ d e)
-                        ( (mul-ℤ c f) +ℤ (neg-ℤ (mul-ℤ d f))))) ∙
+                        ( d *ℤ e)
+                        ( (c *ℤ f) +ℤ (neg-ℤ (d *ℤ f))))) ∙
                     ( ap
                       ( mul-ℤ b)
                       ( ( inv
                           ( associative-add-ℤ
-                            ( mul-ℤ d e)
-                            ( mul-ℤ c f)
-                            ( neg-ℤ (mul-ℤ d f)))) ∙
+                            ( d *ℤ e)
+                            ( c *ℤ f)
+                            ( neg-ℤ (d *ℤ f)))) ∙
                         ( ap
-                          ( add-ℤ' (neg-ℤ (mul-ℤ d f)))
-                          ( ( commutative-add-ℤ (mul-ℤ d e) (mul-ℤ c f)) ∙
+                          ( add-ℤ' (neg-ℤ (d *ℤ f)))
+                          ( ( commutative-add-ℤ (d *ℤ e) (c *ℤ f)) ∙
                             ( ap
-                              ( add-ℤ (mul-ℤ c f))
+                              ( add-ℤ (c *ℤ f))
                               ( commutative-mul-ℤ d e))))))))))))))
     ( ( ap-add-ℤ
         ( ( ap-add-ℤ
@@ -314,7 +329,7 @@ associative-mul-ℤ[ω] (pair a b) (pair c d) (pair e f) =
                         ( ( associative-mul-ℤ a d e) ∙
                           ( ap (mul-ℤ a) (commutative-mul-ℤ d e))))
                       ( ( ap (mul-ℤ e) (commutative-mul-ℤ c b)) ∙
-                        ( ( commutative-mul-ℤ e (mul-ℤ b c)) ∙
+                        ( ( commutative-mul-ℤ e (b *ℤ c)) ∙
                           ( ( associative-mul-ℤ b c e) ∙
                             ( commutative-mul-ℤ b ce))))))
                   ( ( right-negative-law-mul-ℤ e bd) ∙
@@ -326,40 +341,40 @@ associative-mul-ℤ[ω] (pair a b) (pair c d) (pair e f) =
                         ( neg-ℤ)
                         ( ap (mul-ℤ b) (commutative-mul-ℤ d e)))))) ∙
                 ( associative-add-ℤ
-                  ( mul-ℤ a ed)
-                  ( mul-ℤ ce b)
-                  ( neg-ℤ (mul-ℤ b ed)))))) ∙
+                  ( a *ℤ ed)
+                  ( ce *ℤ b)
+                  ( neg-ℤ (b *ℤ ed)))))) ∙
           ( ( interchange-law-add-add-ℤ
-              ( mul-ℤ a cf)
-              ( mul-ℤ (neg-ℤ df) b)
-              ( mul-ℤ a ed)
-              ( (mul-ℤ ce b) +ℤ (neg-ℤ (mul-ℤ b ed)))) ∙
+              ( a *ℤ cf)
+              ( (neg-ℤ df) *ℤ b)
+              ( a *ℤ ed)
+              ( (ce *ℤ b) +ℤ (neg-ℤ (b *ℤ ed)))) ∙
             ( ( ap-add-ℤ
                 ( inv (left-distributive-mul-add-ℤ a cf ed))
                 ( ( inv
                     ( associative-add-ℤ
-                      ( mul-ℤ (neg-ℤ df) b)
-                      ( mul-ℤ ce b)
-                      ( neg-ℤ (mul-ℤ b ed)))) ∙
+                      ( (neg-ℤ df) *ℤ b)
+                      ( ce *ℤ b)
+                      ( neg-ℤ (b *ℤ ed)))) ∙
                   ( ap
-                    ( add-ℤ' (neg-ℤ (mul-ℤ b ed)))
-                    ( ( commutative-add-ℤ (mul-ℤ (neg-ℤ df) b) (mul-ℤ ce b)) ∙
+                    ( add-ℤ' (neg-ℤ (b *ℤ ed)))
+                    ( ( commutative-add-ℤ ((neg-ℤ df) *ℤ b) (ce *ℤ b)) ∙
                       ( inv
                         ( right-distributive-mul-add-ℤ ce (neg-ℤ df) b)))))) ∙
               ( ( inv
                   ( associative-add-ℤ
-                    ( mul-ℤ a (cf +ℤ ed))
+                    ( a *ℤ (cf +ℤ ed))
                     ( mul-ℤ (ce +ℤ (neg-ℤ df)) b)
-                    ( neg-ℤ (mul-ℤ b ed)))) ∙
+                    ( neg-ℤ (b *ℤ ed)))) ∙
                 ( ( ap
-                    ( add-ℤ' (neg-ℤ (mul-ℤ b ed)))
+                    ( add-ℤ' (neg-ℤ (b *ℤ ed)))
                     ( commutative-add-ℤ
-                      ( mul-ℤ a (cf +ℤ ed))
+                      ( a *ℤ (cf +ℤ ed))
                       ( mul-ℤ (ce +ℤ (neg-ℤ df)) b))) ∙
                   ( associative-add-ℤ
                     ( mul-ℤ (ce +ℤ (neg-ℤ df)) b)
-                    ( mul-ℤ a (cf +ℤ ed))
-                    ( neg-ℤ (mul-ℤ b ed))))))))
+                    ( a *ℤ (cf +ℤ ed))
+                    ( neg-ℤ (b *ℤ ed))))))))
         ( ( inv (left-negative-law-mul-ℤ ((ad +ℤ cb) +ℤ (neg-ℤ bd)) f)) ∙
           ( ( ap
               ( mul-ℤ' f)
@@ -385,18 +400,18 @@ associative-mul-ℤ[ω] (pair a b) (pair c d) (pair e f) =
                               ( commutative-mul-ℤ c b)) ∙
                             ( associative-mul-ℤ b c f))))))
                   ( ( associative-mul-ℤ b d f) ∙
-                    ( ( inv (neg-neg-ℤ (mul-ℤ b df))) ∙
+                    ( ( inv (neg-neg-ℤ (b *ℤ df))) ∙
                       ( ap neg-ℤ (inv (right-negative-law-mul-ℤ b df)))))) ∙
                 ( ( associative-add-ℤ
-                    ( mul-ℤ a ( neg-ℤ df))
-                    ( neg-ℤ (mul-ℤ b cf))
-                    ( neg-ℤ (mul-ℤ b (neg-ℤ df)))) ∙
+                    ( a *ℤ ( neg-ℤ df))
+                    ( neg-ℤ (b *ℤ cf))
+                    ( neg-ℤ (b *ℤ (neg-ℤ df)))) ∙
                   ( ap
-                    ( add-ℤ (mul-ℤ a (neg-ℤ df)))
+                    ( add-ℤ (a *ℤ (neg-ℤ df)))
                     ( ( inv
                         ( distributive-neg-add-ℤ
-                          ( mul-ℤ b cf)
-                          ( mul-ℤ b (neg-ℤ df)))) ∙
+                          ( b *ℤ cf)
+                          ( b *ℤ (neg-ℤ df)))) ∙
                       ( ap
                         ( neg-ℤ)
                         ( inv
@@ -406,24 +421,24 @@ associative-mul-ℤ[ω] (pair a b) (pair c d) (pair e f) =
                             ( neg-ℤ df)))))))))))) ∙
       ( ( associative-add-ℤ
           ( mul-ℤ (ce +ℤ (neg-ℤ df)) b)
-          ( add-ℤ (mul-ℤ a (cf +ℤ ed)) (neg-ℤ (mul-ℤ b ed)))
+          ( add-ℤ (a *ℤ (cf +ℤ ed)) (neg-ℤ (b *ℤ ed)))
           ( add-ℤ
-            ( mul-ℤ a (neg-ℤ df))
-            ( neg-ℤ (mul-ℤ b (cf +ℤ (neg-ℤ df)))))) ∙
+            ( a *ℤ (neg-ℤ df))
+            ( neg-ℤ (b *ℤ (cf +ℤ (neg-ℤ df)))))) ∙
         ( ( ( ap
               ( add-ℤ (mul-ℤ (ce +ℤ (neg-ℤ df)) b))
               ( ( interchange-law-add-add-ℤ
-                  ( mul-ℤ a (cf +ℤ ed))
-                  ( neg-ℤ (mul-ℤ b ed))
-                  ( mul-ℤ a (neg-ℤ df))
-                  ( neg-ℤ (mul-ℤ b (cf +ℤ (neg-ℤ df))))) ∙
+                  ( a *ℤ (cf +ℤ ed))
+                  ( neg-ℤ (b *ℤ ed))
+                  ( a *ℤ (neg-ℤ df))
+                  ( neg-ℤ (b *ℤ (cf +ℤ (neg-ℤ df))))) ∙
                 ( ap-add-ℤ
                   ( inv
                     ( left-distributive-mul-add-ℤ a (cf +ℤ ed) (neg-ℤ df)))
                   ( ( inv
                       ( distributive-neg-add-ℤ
-                        ( mul-ℤ b ed)
-                        ( mul-ℤ b (cf +ℤ (neg-ℤ df))))) ∙
+                        ( b *ℤ ed)
+                        ( b *ℤ (cf +ℤ (neg-ℤ df))))) ∙
                     ( ap
                       ( neg-ℤ)
                       ( ( inv
@@ -439,61 +454,61 @@ associative-mul-ℤ[ω] (pair a b) (pair c d) (pair e f) =
             ( inv
               ( associative-add-ℤ
                 ( mul-ℤ (ce +ℤ (neg-ℤ df)) b)
-                ( mul-ℤ a ((cf +ℤ ed) +ℤ (neg-ℤ df)))
-                ( neg-ℤ (mul-ℤ b ((cf +ℤ ed) +ℤ (neg-ℤ df))))))) ∙
+                ( a *ℤ ((cf +ℤ ed) +ℤ (neg-ℤ df)))
+                ( neg-ℤ (b *ℤ ((cf +ℤ ed) +ℤ (neg-ℤ df))))))) ∙
           ( ap
-            ( add-ℤ' (neg-ℤ (mul-ℤ b ((cf +ℤ ed) +ℤ (neg-ℤ df)))))
+            ( add-ℤ' (neg-ℤ (b *ℤ ((cf +ℤ ed) +ℤ (neg-ℤ df)))))
             ( commutative-add-ℤ
               ( mul-ℤ (ce +ℤ (neg-ℤ df)) b)
-              ( mul-ℤ a ((cf +ℤ ed) +ℤ (neg-ℤ df))))))))
+              ( a *ℤ ((cf +ℤ ed) +ℤ (neg-ℤ df))))))))
     where
-    ac = mul-ℤ a c
-    bd = mul-ℤ b d
-    ad = mul-ℤ a d
-    cb = mul-ℤ c b
-    ce = mul-ℤ c e
-    cf = mul-ℤ c f
-    ed = mul-ℤ e d
-    df = mul-ℤ d f
+    ac = a *ℤ c
+    bd = b *ℤ d
+    ad = a *ℤ d
+    cb = c *ℤ b
+    ce = c *ℤ e
+    cf = c *ℤ f
+    ed = e *ℤ d
+    df = d *ℤ f
 
 left-distributive-mul-add-ℤ[ω] :
   (x y z : ℤ[ω]) →
-  mul-ℤ[ω] x (add-ℤ[ω] y z) ＝ add-ℤ[ω] (mul-ℤ[ω] x y) (mul-ℤ[ω] x z)
-left-distributive-mul-add-ℤ[ω] (pair a b) (pair c d) (pair e f) =
+  x *ℤ[ω] (y +ℤ[ω] z) ＝ (x *ℤ[ω] y) +ℤ[ω] (x *ℤ[ω] z)
+left-distributive-mul-add-ℤ[ω] (a , b) (c , d) (e , f) =
   eq-Eq-ℤ[ω]
     ( ( ap-add-ℤ
         ( left-distributive-mul-add-ℤ a c e)
         ( ( ap
             ( neg-ℤ)
             ( left-distributive-mul-add-ℤ b d f)) ∙
-          ( distributive-neg-add-ℤ (mul-ℤ b d) (mul-ℤ b f)))) ∙
+          ( distributive-neg-add-ℤ (b *ℤ d) (b *ℤ f)))) ∙
       ( interchange-law-add-add-ℤ
-        ( mul-ℤ a c)
-        ( mul-ℤ a e)
-        ( neg-ℤ (mul-ℤ b d))
-        ( neg-ℤ (mul-ℤ b f))))
+        ( a *ℤ c)
+        ( a *ℤ e)
+        ( neg-ℤ (b *ℤ d))
+        ( neg-ℤ (b *ℤ f))))
     ( ( ap-add-ℤ
         ( ( ap-add-ℤ
             ( left-distributive-mul-add-ℤ a d f)
             ( right-distributive-mul-add-ℤ c e b)) ∙
           ( interchange-law-add-add-ℤ
-            ( mul-ℤ a d)
-            ( mul-ℤ a f)
-            ( mul-ℤ c b)
-            ( mul-ℤ e b)))
+            ( a *ℤ d)
+            ( a *ℤ f)
+            ( c *ℤ b)
+            ( e *ℤ b)))
         ( ( ap neg-ℤ (left-distributive-mul-add-ℤ b d f)) ∙
-          ( distributive-neg-add-ℤ (mul-ℤ b d) (mul-ℤ b f)))) ∙
+          ( distributive-neg-add-ℤ (b *ℤ d) (b *ℤ f)))) ∙
       ( interchange-law-add-add-ℤ
-        ( (mul-ℤ a d) +ℤ (mul-ℤ c b))
-        ( (mul-ℤ a f) +ℤ (mul-ℤ e b))
-        ( neg-ℤ (mul-ℤ b d))
-        ( neg-ℤ (mul-ℤ b f))))
+        ( (a *ℤ d) +ℤ (c *ℤ b))
+        ( (a *ℤ f) +ℤ (e *ℤ b))
+        ( neg-ℤ (b *ℤ d))
+        ( neg-ℤ (b *ℤ f))))
 
 right-distributive-mul-add-ℤ[ω] :
   (x y z : ℤ[ω]) →
-  mul-ℤ[ω] (add-ℤ[ω] x y) z ＝ add-ℤ[ω] (mul-ℤ[ω] x z) (mul-ℤ[ω] y z)
+  (x +ℤ[ω] y) *ℤ[ω] z ＝ (x *ℤ[ω] z) +ℤ[ω] (y *ℤ[ω] z)
 right-distributive-mul-add-ℤ[ω] x y z =
-  ( commutative-mul-ℤ[ω] (add-ℤ[ω] x y) z) ∙
+  ( commutative-mul-ℤ[ω] (x +ℤ[ω] y) z) ∙
   ( ( left-distributive-mul-add-ℤ[ω] z x y) ∙
     ( ap-add-ℤ[ω] (commutative-mul-ℤ[ω] z x) (commutative-mul-ℤ[ω] z y)))
 

--- a/src/commutative-algebra/eisenstein-integers.lagda.md
+++ b/src/commutative-algebra/eisenstein-integers.lagda.md
@@ -263,17 +263,15 @@ associative-mul-ℤ[ω] (a , b) (c , d) (e , f) =
           ( a *ℤ (c *ℤ e))
           ( neg-ℤ (b *ℤ (d *ℤ e)))
           ( neg-ℤ (a *ℤ (d *ℤ f)))
-          ( add-ℤ
-            ( neg-ℤ (b *ℤ (c *ℤ f)))
-            ( neg-ℤ (neg-ℤ (b *ℤ (d *ℤ f)))))) ∙
+          ( ( neg-ℤ (b *ℤ (c *ℤ f))) +ℤ (neg-ℤ (neg-ℤ (b *ℤ (d *ℤ f)))))) ∙
         ( ap-add-ℤ
           ( ( ap
-              ( add-ℤ (a *ℤ (c *ℤ e)))
+              ( (a *ℤ (c *ℤ e)) +ℤ_)
               ( inv ( right-negative-law-mul-ℤ a (d *ℤ f)))) ∙
             ( inv
               ( left-distributive-mul-add-ℤ a (c *ℤ e) (neg-ℤ (d *ℤ f)))))
           ( ( ap
-              ( add-ℤ (neg-ℤ (b *ℤ (d *ℤ e))))
+              ( (neg-ℤ (b *ℤ (d *ℤ e))) +ℤ_)
               ( inv
                 ( distributive-neg-add-ℤ
                   ( b *ℤ (c *ℤ f))
@@ -281,15 +279,13 @@ associative-mul-ℤ[ω] (a , b) (c , d) (e , f) =
             ( ( inv
                 ( distributive-neg-add-ℤ
                   ( b *ℤ (d *ℤ e))
-                  ( add-ℤ
-                    ( b *ℤ (c *ℤ f))
-                    ( neg-ℤ (b *ℤ (d *ℤ f)))))) ∙
+                  ( (b *ℤ (c *ℤ f)) +ℤ (neg-ℤ (b *ℤ (d *ℤ f)))))) ∙
               ( ap
                 ( neg-ℤ)
                 ( ( ap
-                    ( add-ℤ (b *ℤ (d *ℤ e)))
+                    ( (b *ℤ (d *ℤ e)) +ℤ_)
                     ( ( ap
-                        ( add-ℤ (b *ℤ (c *ℤ f)))
+                        ( (b *ℤ (c *ℤ f)) +ℤ_)
                         ( inv (right-negative-law-mul-ℤ b (d *ℤ f)))) ∙
                       ( inv
                         ( left-distributive-mul-add-ℤ b
@@ -407,7 +403,7 @@ associative-mul-ℤ[ω] (a , b) (c , d) (e , f) =
                     ( neg-ℤ (b *ℤ cf))
                     ( neg-ℤ (b *ℤ (neg-ℤ df)))) ∙
                   ( ap
-                    ( add-ℤ (a *ℤ (neg-ℤ df)))
+                    ( (a *ℤ (neg-ℤ df)) +ℤ_)
                     ( ( inv
                         ( distributive-neg-add-ℤ
                           ( b *ℤ cf)
@@ -422,11 +418,9 @@ associative-mul-ℤ[ω] (a , b) (c , d) (e , f) =
       ( ( associative-add-ℤ
           ( (ce +ℤ (neg-ℤ df)) *ℤ b)
           ( (a *ℤ (cf +ℤ ed)) +ℤ (neg-ℤ (b *ℤ ed)))
-          ( add-ℤ
-            ( a *ℤ (neg-ℤ df))
-            ( neg-ℤ (b *ℤ (cf +ℤ (neg-ℤ df)))))) ∙
+          ( (a *ℤ (neg-ℤ df)) +ℤ (neg-ℤ (b *ℤ (cf +ℤ (neg-ℤ df)))))) ∙
         ( ( ( ap
-              ( add-ℤ ((ce +ℤ (neg-ℤ df)) *ℤ b))
+              ( ((ce +ℤ (neg-ℤ df)) *ℤ b) +ℤ_)
               ( ( interchange-law-add-add-ℤ
                   ( a *ℤ (cf +ℤ ed))
                   ( neg-ℤ (b *ℤ ed))

--- a/src/commutative-algebra/euclidean-domains.lagda.md
+++ b/src/commutative-algebra/euclidean-domains.lagda.md
@@ -612,7 +612,7 @@ module _
 
   right-distributive-mul-nat-scalar-add-Euclidean-Domain :
     (m n : ℕ) (x : type-Euclidean-Domain) →
-    mul-nat-scalar-Euclidean-Domain (add-ℕ m n) x ＝
+    mul-nat-scalar-Euclidean-Domain (m +ℕ n) x ＝
     add-Euclidean-Domain
       ( mul-nat-scalar-Euclidean-Domain m x)
       ( mul-nat-scalar-Euclidean-Domain n x)

--- a/src/commutative-algebra/gaussian-integers.lagda.md
+++ b/src/commutative-algebra/gaussian-integers.lagda.md
@@ -192,7 +192,7 @@ right-unit-law-mul-ℤ[i] (a , b) =
         ( right-unit-law-mul-ℤ a)
         ( ap neg-ℤ (right-zero-law-mul-ℤ b))) ∙
       ( right-unit-law-add-ℤ a))
-    ( ap (add-ℤ' b) (right-zero-law-mul-ℤ a))
+    ( ap (_+ℤ b) (right-zero-law-mul-ℤ a))
 
 commutative-mul-ℤ[i] :
   (x y : ℤ[i]) → x *ℤ[i] y ＝ y *ℤ[i] x

--- a/src/commutative-algebra/gaussian-integers.lagda.md
+++ b/src/commutative-algebra/gaussian-integers.lagda.md
@@ -265,7 +265,7 @@ associative-mul-ℤ[i] (a , b) (c , d) (e , f) =
             ( neg-ℤ (b *ℤ d))
             ( f)) ∙
           ( ap
-            ( add-ℤ ((a *ℤ c) *ℤ f))
+            ( ((a *ℤ c) *ℤ f) +ℤ_)
             ( left-negative-law-mul-ℤ (b *ℤ d) f)))
         ( ( left-distributive-mul-add-ℤ e (a *ℤ d) (c *ℤ b)) ∙
           ( ap-add-ℤ

--- a/src/commutative-algebra/gaussian-integers.lagda.md
+++ b/src/commutative-algebra/gaussian-integers.lagda.md
@@ -214,9 +214,9 @@ associative-mul-ℤ[i] (a , b) (c , d) (e , f) =
             ( associative-mul-ℤ a c e)
             ( ( associative-mul-ℤ neg-one-ℤ (b *ℤ d) e) ∙
               ( ap
-                ( mul-ℤ neg-one-ℤ)
+                ( neg-one-ℤ *ℤ_)
                 ( ( associative-mul-ℤ b d e) ∙
-                  ( ap (mul-ℤ b) (commutative-mul-ℤ d e)))))))
+                  ( ap (b *ℤ_) (commutative-mul-ℤ d e)))))))
         ( ( ap
             ( neg-ℤ)
             ( ( right-distributive-mul-add-ℤ (a *ℤ d) (c *ℤ b) f) ∙
@@ -249,7 +249,7 @@ associative-mul-ℤ[i] (a , b) (c , d) (e , f) =
             ( ap neg-ℤ
               ( ( ap-add-ℤ
                   ( refl {x = b *ℤ (e *ℤ d)})
-                  ( ( ap (mul-ℤ c) (commutative-mul-ℤ b f)) ∙
+                  ( ( ap (c *ℤ_) (commutative-mul-ℤ b f)) ∙
                     ( ( inv (associative-mul-ℤ c f b)) ∙
                       ( commutative-mul-ℤ (c *ℤ f) b)))) ∙
                 ( ( inv
@@ -257,7 +257,7 @@ associative-mul-ℤ[i] (a , b) (c , d) (e , f) =
                       ( e *ℤ d)
                       ( c *ℤ f))) ∙
                   ( ap
-                    ( mul-ℤ b)
+                    ( b *ℤ_)
                     ( commutative-add-ℤ (e *ℤ d) (c *ℤ f))))))))))
     ( ( ap-add-ℤ
         ( ( right-distributive-mul-add-ℤ
@@ -271,7 +271,7 @@ associative-mul-ℤ[i] (a , b) (c , d) (e , f) =
           ( ap-add-ℤ
             ( ( commutative-mul-ℤ e (a *ℤ d)) ∙
               ( ( associative-mul-ℤ a d e) ∙
-                ( ap (mul-ℤ a) (commutative-mul-ℤ d e))))
+                ( ap (a *ℤ_) (commutative-mul-ℤ d e))))
             ( ( inv (associative-mul-ℤ e c b)) ∙
               ( ap (_*ℤ b) (commutative-mul-ℤ e c)))))) ∙
       ( ( interchange-law-add-add-ℤ

--- a/src/commutative-algebra/gaussian-integers.lagda.md
+++ b/src/commutative-algebra/gaussian-integers.lagda.md
@@ -273,7 +273,7 @@ associative-mul-ℤ[i] (a , b) (c , d) (e , f) =
               ( ( associative-mul-ℤ a d e) ∙
                 ( ap (mul-ℤ a) (commutative-mul-ℤ d e))))
             ( ( inv (associative-mul-ℤ e c b)) ∙
-              ( ap (mul-ℤ' b) (commutative-mul-ℤ e c)))))) ∙
+              ( ap (_*ℤ b) (commutative-mul-ℤ e c)))))) ∙
       ( ( interchange-law-add-add-ℤ
           ( (a *ℤ c) *ℤ f)
           ( neg-ℤ ((b *ℤ d) *ℤ f))
@@ -296,7 +296,7 @@ associative-mul-ℤ[i] (a , b) (c , d) (e , f) =
                     ( neg-ℤ (d *ℤ f))
                     ( c *ℤ e) b))) ∙
               ( ap
-                ( mul-ℤ' b)
+                ( _*ℤ b)
                 ( commutative-add-ℤ (neg-ℤ (d *ℤ f)) (c *ℤ e))))))))
 
 left-distributive-mul-add-ℤ[i] :

--- a/src/commutative-algebra/gaussian-integers.lagda.md
+++ b/src/commutative-algebra/gaussian-integers.lagda.md
@@ -47,20 +47,20 @@ The **Gaussian integers** are the complex numbers of the form `a + bi`, where
 
 ```agda
 Eq-ℤ[i] : ℤ[i] → ℤ[i] → UU lzero
-Eq-ℤ[i] x y = (Id (pr1 x) (pr1 y)) × (Id (pr2 x) (pr2 y))
+Eq-ℤ[i] x y = (pr1 x ＝ pr1 y) × (pr2 x ＝ pr2 y)
 
 refl-Eq-ℤ[i] : (x : ℤ[i]) → Eq-ℤ[i] x x
 pr1 (refl-Eq-ℤ[i] x) = refl
 pr2 (refl-Eq-ℤ[i] x) = refl
 
-Eq-eq-ℤ[i] : {x y : ℤ[i]} → Id x y → Eq-ℤ[i] x y
+Eq-eq-ℤ[i] : {x y : ℤ[i]} → x ＝ y → Eq-ℤ[i] x y
 Eq-eq-ℤ[i] {x} refl = refl-Eq-ℤ[i] x
 
-eq-Eq-ℤ[i]' : {x y : ℤ[i]} → Eq-ℤ[i] x y → Id x y
-eq-Eq-ℤ[i]' {pair a b} {pair .a .b} (pair refl refl) = refl
+eq-Eq-ℤ[i]' : {x y : ℤ[i]} → Eq-ℤ[i] x y → x ＝ y
+eq-Eq-ℤ[i]' {a , b} {.a , .b} (refl , refl) = refl
 
-eq-Eq-ℤ[i] : {x y : ℤ[i]} → Id (pr1 x) (pr1 y) → Id (pr2 x) (pr2 y) → Id x y
-eq-Eq-ℤ[i] {pair a b} {pair .a .b} refl refl = refl
+eq-Eq-ℤ[i] : {x y : ℤ[i]} → pr1 x ＝ pr1 y → pr2 x ＝ pr2 y → x ＝ y
+eq-Eq-ℤ[i] {a , b} {.a , .b} refl refl = refl
 ```
 
 ### The Gaussian integer zero
@@ -110,8 +110,11 @@ add-ℤ[i] : ℤ[i] → ℤ[i] → ℤ[i]
 pr1 (add-ℤ[i] (a , b) (a' , b')) = a +ℤ a'
 pr2 (add-ℤ[i] (a , b) (a' , b')) = b +ℤ b'
 
+infix 30 _+ℤ[i]_
+_+ℤ[i]_ = add-ℤ[i]
+
 ap-add-ℤ[i] :
-  {x x' y y' : ℤ[i]} → Id x x' → Id y y' → Id (add-ℤ[i] x y) (add-ℤ[i] x' y')
+  {x x' y y' : ℤ[i]} → x ＝ x' → y ＝ y' → x +ℤ[i] y ＝ x' +ℤ[i] y'
 ap-add-ℤ[i] p q = ap-binary add-ℤ[i] p q
 ```
 
@@ -127,11 +130,14 @@ pr2 (neg-ℤ[i] (a , b)) = neg-ℤ b
 
 ```agda
 mul-ℤ[i] : ℤ[i] → ℤ[i] → ℤ[i]
-pr1 (mul-ℤ[i] (a , b) (a' , b')) = diff-ℤ (mul-ℤ a a') (mul-ℤ b b')
-pr2 (mul-ℤ[i] (a , b) (a' , b')) = mul-ℤ a b' +ℤ mul-ℤ a' b
+pr1 (mul-ℤ[i] (a , b) (a' , b')) = diff-ℤ (a *ℤ a') (b *ℤ b')
+pr2 (mul-ℤ[i] (a , b) (a' , b')) = (a *ℤ b') +ℤ (a' *ℤ b)
+
+infix 30 _*ℤ[i]_
+_*ℤ[i]_ = mul-ℤ[i]
 
 ap-mul-ℤ[i] :
-  {x x' y y' : ℤ[i]} → Id x x' → Id y y' → Id (mul-ℤ[i] x y) (mul-ℤ[i] x' y')
+  {x x' y y' : ℤ[i]} → x ＝ x' → y ＝ y' → x *ℤ[i] y ＝ x' *ℤ[i] y'
 ap-mul-ℤ[i] p q = ap-binary mul-ℤ[i] p q
 ```
 
@@ -146,41 +152,41 @@ pr2 (conjugate-ℤ[i] (a , b)) = neg-ℤ b
 ### The Gaussian integers form a commutative ring
 
 ```agda
-left-unit-law-add-ℤ[i] : (x : ℤ[i]) → Id (add-ℤ[i] zero-ℤ[i] x) x
-left-unit-law-add-ℤ[i] (pair a b) = eq-Eq-ℤ[i] refl refl
+left-unit-law-add-ℤ[i] : (x : ℤ[i]) → zero-ℤ[i] +ℤ[i] x ＝ x
+left-unit-law-add-ℤ[i] (a , b) = eq-Eq-ℤ[i] refl refl
 
-right-unit-law-add-ℤ[i] : (x : ℤ[i]) → Id (add-ℤ[i] x zero-ℤ[i]) x
-right-unit-law-add-ℤ[i] (pair a b) =
+right-unit-law-add-ℤ[i] : (x : ℤ[i]) → x +ℤ[i] zero-ℤ[i] ＝ x
+right-unit-law-add-ℤ[i] (a , b) =
   eq-Eq-ℤ[i] (right-unit-law-add-ℤ a) (right-unit-law-add-ℤ b)
 
 associative-add-ℤ[i] :
-  (x y z : ℤ[i]) → Id (add-ℤ[i] (add-ℤ[i] x y) z) (add-ℤ[i] x (add-ℤ[i] y z))
-associative-add-ℤ[i] (pair a1 b1) (pair a2 b2) (pair a3 b3) =
+  (x y z : ℤ[i]) → (x +ℤ[i] y) +ℤ[i] z ＝ x +ℤ[i] (y +ℤ[i] z)
+associative-add-ℤ[i] (a1 , b1) (a2 , b2) (a3 , b3) =
   eq-Eq-ℤ[i] (associative-add-ℤ a1 a2 a3) (associative-add-ℤ b1 b2 b3)
 
 left-inverse-law-add-ℤ[i] :
-  (x : ℤ[i]) → Id (add-ℤ[i] (neg-ℤ[i] x) x) zero-ℤ[i]
-left-inverse-law-add-ℤ[i] (pair a b) =
+  (x : ℤ[i]) → (neg-ℤ[i] x) +ℤ[i] x ＝ zero-ℤ[i]
+left-inverse-law-add-ℤ[i] (a , b) =
   eq-Eq-ℤ[i] (left-inverse-law-add-ℤ a) (left-inverse-law-add-ℤ b)
 
 right-inverse-law-add-ℤ[i] :
-  (x : ℤ[i]) → Id (add-ℤ[i] x (neg-ℤ[i] x)) zero-ℤ[i]
-right-inverse-law-add-ℤ[i] (pair a b) =
+  (x : ℤ[i]) → x +ℤ[i] (neg-ℤ[i] x) ＝ zero-ℤ[i]
+right-inverse-law-add-ℤ[i] (a , b) =
   eq-Eq-ℤ[i] (right-inverse-law-add-ℤ a) (right-inverse-law-add-ℤ b)
 
 commutative-add-ℤ[i] :
-  (x y : ℤ[i]) → Id (add-ℤ[i] x y) (add-ℤ[i] y x)
-commutative-add-ℤ[i] (pair a b) (pair a' b') =
+  (x y : ℤ[i]) → x +ℤ[i] y ＝ y +ℤ[i] x
+commutative-add-ℤ[i] (a , b) (a' , b') =
   eq-Eq-ℤ[i] (commutative-add-ℤ a a') (commutative-add-ℤ b b')
 
-left-unit-law-mul-ℤ[i] : (x : ℤ[i]) → Id (mul-ℤ[i] one-ℤ[i] x) x
-left-unit-law-mul-ℤ[i] (pair a b) =
+left-unit-law-mul-ℤ[i] : (x : ℤ[i]) → one-ℤ[i] *ℤ[i] x ＝ x
+left-unit-law-mul-ℤ[i] (a , b) =
   eq-Eq-ℤ[i]
     ( right-unit-law-add-ℤ a)
     ( ap (add-ℤ b) (right-zero-law-mul-ℤ a) ∙ right-unit-law-add-ℤ b)
 
-right-unit-law-mul-ℤ[i] : (x : ℤ[i]) → Id (mul-ℤ[i] x one-ℤ[i]) x
-right-unit-law-mul-ℤ[i] (pair a b) =
+right-unit-law-mul-ℤ[i] : (x : ℤ[i]) → x *ℤ[i] one-ℤ[i] ＝ x
+right-unit-law-mul-ℤ[i] (a , b) =
   eq-Eq-ℤ[i]
     ( ( ap-add-ℤ
         ( right-unit-law-mul-ℤ a)
@@ -189,138 +195,138 @@ right-unit-law-mul-ℤ[i] (pair a b) =
     ( ap (add-ℤ' b) (right-zero-law-mul-ℤ a))
 
 commutative-mul-ℤ[i] :
-  (x y : ℤ[i]) → Id (mul-ℤ[i] x y) (mul-ℤ[i] y x)
-commutative-mul-ℤ[i] (pair a b) (pair c d) =
+  (x y : ℤ[i]) → x *ℤ[i] y ＝ y *ℤ[i] x
+commutative-mul-ℤ[i] (a , b) (c , d) =
   eq-Eq-ℤ[i]
     ( ap-add-ℤ (commutative-mul-ℤ a c) (ap neg-ℤ (commutative-mul-ℤ b d)))
-    ( commutative-add-ℤ (mul-ℤ a d) (mul-ℤ c b))
+    ( commutative-add-ℤ (a *ℤ d) (c *ℤ b))
 
 associative-mul-ℤ[i] :
-  (x y z : ℤ[i]) → Id (mul-ℤ[i] (mul-ℤ[i] x y) z) (mul-ℤ[i] x (mul-ℤ[i] y z))
-associative-mul-ℤ[i] (pair a b) (pair c d) (pair e f) =
+  (x y z : ℤ[i]) → (x *ℤ[i] y) *ℤ[i] z ＝ x *ℤ[i] (y *ℤ[i] z)
+associative-mul-ℤ[i] (a , b) (c , d) (e , f) =
   eq-Eq-ℤ[i]
     ( ( ap-add-ℤ
         ( ( right-distributive-mul-add-ℤ
-            ( mul-ℤ a c)
-            ( mul-ℤ neg-one-ℤ (mul-ℤ b d))
+            ( a *ℤ c)
+            ( neg-one-ℤ *ℤ (b *ℤ d))
             ( e)) ∙
           ( ap-add-ℤ
             ( associative-mul-ℤ a c e)
-            ( ( associative-mul-ℤ neg-one-ℤ (mul-ℤ b d) e) ∙
+            ( ( associative-mul-ℤ neg-one-ℤ (b *ℤ d) e) ∙
               ( ap
                 ( mul-ℤ neg-one-ℤ)
                 ( ( associative-mul-ℤ b d e) ∙
                   ( ap (mul-ℤ b) (commutative-mul-ℤ d e)))))))
         ( ( ap
             ( neg-ℤ)
-            ( ( right-distributive-mul-add-ℤ (mul-ℤ a d) (mul-ℤ c b) f) ∙
+            ( ( right-distributive-mul-add-ℤ (a *ℤ d) (c *ℤ b) f) ∙
               ( ap-add-ℤ
                 ( associative-mul-ℤ a d f)
                 ( associative-mul-ℤ c b f)))) ∙
           ( ( left-distributive-mul-add-ℤ
               ( neg-one-ℤ)
-              ( mul-ℤ a (mul-ℤ d f))
-              ( mul-ℤ c (mul-ℤ b f)))))) ∙
+              ( a *ℤ (d *ℤ f))
+              ( c *ℤ (b *ℤ f)))))) ∙
       ( ( interchange-law-add-add-ℤ
-          ( mul-ℤ a (mul-ℤ c e))
-          ( neg-ℤ (mul-ℤ b (mul-ℤ e d)))
-          ( neg-ℤ (mul-ℤ a (mul-ℤ d f)))
-          ( neg-ℤ (mul-ℤ c (mul-ℤ b f)))) ∙
+          ( a *ℤ (c *ℤ e))
+          ( neg-ℤ (b *ℤ (e *ℤ d)))
+          ( neg-ℤ (a *ℤ (d *ℤ f)))
+          ( neg-ℤ (c *ℤ (b *ℤ f)))) ∙
         ( ap-add-ℤ
           ( ( ap-add-ℤ
-              ( refl {x = mul-ℤ a (mul-ℤ c e)})
+              ( refl {x = a *ℤ (c *ℤ e)})
               ( inv
-                ( right-negative-law-mul-ℤ a (mul-ℤ d f)))) ∙
+                ( right-negative-law-mul-ℤ a (d *ℤ f)))) ∙
             ( inv
               ( left-distributive-mul-add-ℤ a
-                ( mul-ℤ c e)
-                ( neg-ℤ (mul-ℤ d f)))))
+                ( c *ℤ e)
+                ( neg-ℤ (d *ℤ f)))))
           ( ( inv
               ( left-distributive-mul-add-ℤ
                 ( neg-one-ℤ)
-                ( mul-ℤ b (mul-ℤ e d))
-                ( mul-ℤ c (mul-ℤ b f)))) ∙
+                ( b *ℤ (e *ℤ d))
+                ( c *ℤ (b *ℤ f)))) ∙
             ( ap neg-ℤ
               ( ( ap-add-ℤ
-                  ( refl {x = mul-ℤ b (mul-ℤ e d)})
+                  ( refl {x = b *ℤ (e *ℤ d)})
                   ( ( ap (mul-ℤ c) (commutative-mul-ℤ b f)) ∙
                     ( ( inv (associative-mul-ℤ c f b)) ∙
-                      ( commutative-mul-ℤ (mul-ℤ c f) b)))) ∙
+                      ( commutative-mul-ℤ (c *ℤ f) b)))) ∙
                 ( ( inv
                     ( left-distributive-mul-add-ℤ b
-                      ( mul-ℤ e d)
-                      ( mul-ℤ c f))) ∙
+                      ( e *ℤ d)
+                      ( c *ℤ f))) ∙
                   ( ap
                     ( mul-ℤ b)
-                    ( commutative-add-ℤ (mul-ℤ e d) (mul-ℤ c f))))))))))
+                    ( commutative-add-ℤ (e *ℤ d) (c *ℤ f))))))))))
     ( ( ap-add-ℤ
         ( ( right-distributive-mul-add-ℤ
-            ( mul-ℤ a c)
-            ( neg-ℤ (mul-ℤ b d))
+            ( a *ℤ c)
+            ( neg-ℤ (b *ℤ d))
             ( f)) ∙
           ( ap
-            ( add-ℤ (mul-ℤ (mul-ℤ a c) f))
-            ( left-negative-law-mul-ℤ (mul-ℤ b d) f)))
-        ( ( left-distributive-mul-add-ℤ e (mul-ℤ a d) (mul-ℤ c b)) ∙
+            ( add-ℤ ((a *ℤ c) *ℤ f))
+            ( left-negative-law-mul-ℤ (b *ℤ d) f)))
+        ( ( left-distributive-mul-add-ℤ e (a *ℤ d) (c *ℤ b)) ∙
           ( ap-add-ℤ
-            ( ( commutative-mul-ℤ e (mul-ℤ a d)) ∙
+            ( ( commutative-mul-ℤ e (a *ℤ d)) ∙
               ( ( associative-mul-ℤ a d e) ∙
                 ( ap (mul-ℤ a) (commutative-mul-ℤ d e))))
             ( ( inv (associative-mul-ℤ e c b)) ∙
               ( ap (mul-ℤ' b) (commutative-mul-ℤ e c)))))) ∙
       ( ( interchange-law-add-add-ℤ
-          ( mul-ℤ (mul-ℤ a c) f)
-          ( neg-ℤ (mul-ℤ (mul-ℤ b d) f))
-          ( mul-ℤ a (mul-ℤ e d))
-          ( mul-ℤ (mul-ℤ c e) b)) ∙
+          ( (a *ℤ c) *ℤ f)
+          ( neg-ℤ ((b *ℤ d) *ℤ f))
+          ( a *ℤ (e *ℤ d))
+          ( (c *ℤ e) *ℤ b)) ∙
         ( ap-add-ℤ
           ( ( ap-add-ℤ
               ( associative-mul-ℤ a c f)
               ( refl)) ∙
-            ( inv (left-distributive-mul-add-ℤ a (mul-ℤ c f) (mul-ℤ e d))))
+            ( inv (left-distributive-mul-add-ℤ a (c *ℤ f) (e *ℤ d))))
           ( ( ap-add-ℤ
               ( ( ap
                   ( neg-ℤ)
                   ( ( associative-mul-ℤ b d f) ∙
-                    ( commutative-mul-ℤ b (mul-ℤ d f)))) ∙
-                ( inv (left-negative-law-mul-ℤ (mul-ℤ d f) b)))
+                    ( commutative-mul-ℤ b (d *ℤ f)))) ∙
+                ( inv (left-negative-law-mul-ℤ (d *ℤ f) b)))
               ( refl)) ∙
             ( ( inv
                 ( ( right-distributive-mul-add-ℤ
-                    ( neg-ℤ (mul-ℤ d f))
-                    ( mul-ℤ c e) b))) ∙
+                    ( neg-ℤ (d *ℤ f))
+                    ( c *ℤ e) b))) ∙
               ( ap
                 ( mul-ℤ' b)
-                ( commutative-add-ℤ (neg-ℤ (mul-ℤ d f)) (mul-ℤ c e))))))))
+                ( commutative-add-ℤ (neg-ℤ (d *ℤ f)) (c *ℤ e))))))))
 
 left-distributive-mul-add-ℤ[i] :
   (x y z : ℤ[i]) →
-  Id (mul-ℤ[i] x (add-ℤ[i] y z)) (add-ℤ[i] (mul-ℤ[i] x y) (mul-ℤ[i] x z))
-left-distributive-mul-add-ℤ[i] (pair a b) (pair c d) (pair e f) =
+  x *ℤ[i] (y +ℤ[i] z) ＝ (x *ℤ[i] y) +ℤ[i] (x *ℤ[i] z)
+left-distributive-mul-add-ℤ[i] (a , b) (c , d) (e , f) =
   eq-Eq-ℤ[i]
     ( ( ap-add-ℤ
         ( left-distributive-mul-add-ℤ a c e)
         ( ( ap neg-ℤ (left-distributive-mul-add-ℤ b d f)) ∙
-          ( left-distributive-mul-add-ℤ neg-one-ℤ (mul-ℤ b d) (mul-ℤ b f)))) ∙
+          ( left-distributive-mul-add-ℤ neg-one-ℤ (b *ℤ d) (b *ℤ f)))) ∙
       ( interchange-law-add-add-ℤ
-        ( mul-ℤ a c)
-        ( mul-ℤ a e)
-        ( neg-ℤ (mul-ℤ b d))
-        ( neg-ℤ (mul-ℤ b f))))
+        ( a *ℤ c)
+        ( a *ℤ e)
+        ( neg-ℤ (b *ℤ d))
+        ( neg-ℤ (b *ℤ f))))
     ( ( ap-add-ℤ
         ( left-distributive-mul-add-ℤ a d f)
         ( right-distributive-mul-add-ℤ c e b)) ∙
       ( interchange-law-add-add-ℤ
-        ( mul-ℤ a d)
-        ( mul-ℤ a f)
-        ( mul-ℤ c b)
-        ( mul-ℤ e b)))
+        ( a *ℤ d)
+        ( a *ℤ f)
+        ( c *ℤ b)
+        ( e *ℤ b)))
 
 right-distributive-mul-add-ℤ[i] :
   (x y z : ℤ[i]) →
-  Id (mul-ℤ[i] (add-ℤ[i] x y) z) (add-ℤ[i] (mul-ℤ[i] x z) (mul-ℤ[i] y z))
+  (x +ℤ[i] y) *ℤ[i] z ＝ (x *ℤ[i] z) +ℤ[i] (y *ℤ[i] z)
 right-distributive-mul-add-ℤ[i] x y z =
-  ( commutative-mul-ℤ[i] (add-ℤ[i] x y) z) ∙
+  ( commutative-mul-ℤ[i] (x +ℤ[i] y) z) ∙
   ( ( left-distributive-mul-add-ℤ[i] z x y) ∙
     ( ap-add-ℤ[i] (commutative-mul-ℤ[i] z x) (commutative-mul-ℤ[i] z y)))
 

--- a/src/commutative-algebra/gaussian-integers.lagda.md
+++ b/src/commutative-algebra/gaussian-integers.lagda.md
@@ -183,7 +183,7 @@ left-unit-law-mul-ℤ[i] : (x : ℤ[i]) → one-ℤ[i] *ℤ[i] x ＝ x
 left-unit-law-mul-ℤ[i] (a , b) =
   eq-Eq-ℤ[i]
     ( right-unit-law-add-ℤ a)
-    ( ap (add-ℤ b) (right-zero-law-mul-ℤ a) ∙ right-unit-law-add-ℤ b)
+    ( ap (b +ℤ_) (right-zero-law-mul-ℤ a) ∙ right-unit-law-add-ℤ b)
 
 right-unit-law-mul-ℤ[i] : (x : ℤ[i]) → x *ℤ[i] one-ℤ[i] ＝ x
 right-unit-law-mul-ℤ[i] (a , b) =

--- a/src/commutative-algebra/integral-domains.lagda.md
+++ b/src/commutative-algebra/integral-domains.lagda.md
@@ -581,7 +581,7 @@ module _
 
   right-distributive-mul-nat-scalar-add-Integral-Domain :
     (m n : ℕ) (x : type-Integral-Domain) →
-    mul-nat-scalar-Integral-Domain (add-ℕ m n) x ＝
+    mul-nat-scalar-Integral-Domain (m +ℕ n) x ＝
     add-Integral-Domain
       ( mul-nat-scalar-Integral-Domain m x)
       ( mul-nat-scalar-Integral-Domain n x)

--- a/src/commutative-algebra/powers-of-elements-commutative-rings.lagda.md
+++ b/src/commutative-algebra/powers-of-elements-commutative-rings.lagda.md
@@ -61,7 +61,7 @@ module _
 
   power-add-Commutative-Ring :
     (m n : ℕ) {x : type-Commutative-Ring A} →
-    power-Commutative-Ring A (add-ℕ m n) x ＝
+    power-Commutative-Ring A (m +ℕ n) x ＝
     mul-Commutative-Ring A
       ( power-Commutative-Ring A m x)
       ( power-Commutative-Ring A n x)

--- a/src/commutative-algebra/powers-of-elements-commutative-semirings.lagda.md
+++ b/src/commutative-algebra/powers-of-elements-commutative-semirings.lagda.md
@@ -60,7 +60,7 @@ module _
 
   power-add-Commutative-Semiring :
     (m n : ℕ) {x : type-Commutative-Semiring A} →
-    power-Commutative-Semiring A (add-ℕ m n) x ＝
+    power-Commutative-Semiring A (m +ℕ n) x ＝
     mul-Commutative-Semiring A
       ( power-Commutative-Semiring A m x)
       ( power-Commutative-Semiring A n x)

--- a/src/commutative-algebra/radicals-of-ideals-commutative-rings.lagda.md
+++ b/src/commutative-algebra/radicals-of-ideals-commutative-rings.lagda.md
@@ -72,7 +72,7 @@ module _
             ( add-Commutative-Ring A x y))
           ( λ (m , q) →
             intro-∃
-              ( add-ℕ n m)
+              ( n +ℕ m)
               ( is-closed-under-eq-ideal-Commutative-Ring' A I
                 ( is-closed-under-addition-ideal-Commutative-Ring A I _ _
                   ( is-closed-under-right-multiplication-ideal-Commutative-Ring

--- a/src/commutative-algebra/sums-commutative-rings.lagda.md
+++ b/src/commutative-algebra/sums-commutative-rings.lagda.md
@@ -185,8 +185,8 @@ module _
 ```agda
 split-sum-Commutative-Ring :
   {l : Level} (A : Commutative-Ring l)
-  (n m : ℕ) (f : functional-vec-Commutative-Ring A (add-ℕ n m)) →
-  sum-Commutative-Ring A (add-ℕ n m) f ＝
+  (n m : ℕ) (f : functional-vec-Commutative-Ring A (n +ℕ m)) →
+  sum-Commutative-Ring A (n +ℕ m) f ＝
   add-Commutative-Ring A
     ( sum-Commutative-Ring A n (f ∘ inl-coprod-Fin n m))
     ( sum-Commutative-Ring A m (f ∘ inr-coprod-Fin n m))

--- a/src/commutative-algebra/sums-commutative-semirings.lagda.md
+++ b/src/commutative-algebra/sums-commutative-semirings.lagda.md
@@ -205,8 +205,8 @@ module _
 ```agda
 split-sum-Commutative-Semiring :
   {l : Level} (A : Commutative-Semiring l)
-  (n m : ℕ) (f : functional-vec-Commutative-Semiring A (add-ℕ n m)) →
-  sum-Commutative-Semiring A (add-ℕ n m) f ＝
+  (n m : ℕ) (f : functional-vec-Commutative-Semiring A (n +ℕ m)) →
+  sum-Commutative-Semiring A (n +ℕ m) f ＝
   add-Commutative-Semiring A
     ( sum-Commutative-Semiring A n (f ∘ inl-coprod-Fin n m))
     ( sum-Commutative-Semiring A m (f ∘ inr-coprod-Fin n m))

--- a/src/elementary-number-theory/absolute-value-integers.lagda.md
+++ b/src/elementary-number-theory/absolute-value-integers.lagda.md
@@ -114,7 +114,7 @@ subadditive-abs-ℤ :
   (x y : ℤ) → (abs-ℤ (x +ℤ y)) ≤-ℕ ((abs-ℤ x) +ℕ (abs-ℤ y))
 subadditive-abs-ℤ x (inl zero-ℕ) =
   concatenate-eq-leq-eq-ℕ
-    ( ap abs-ℤ (add-neg-one-right-ℤ x))
+    ( ap abs-ℤ (right-add-neg-one-ℤ x))
     ( predecessor-law-abs-ℤ x)
     ( refl)
 subadditive-abs-ℤ x (inl (succ-ℕ y)) =
@@ -134,7 +134,7 @@ subadditive-abs-ℤ x (inr (inl star)) =
     ( refl)
 subadditive-abs-ℤ x (inr (inr zero-ℕ)) =
   concatenate-eq-leq-eq-ℕ
-    ( ap abs-ℤ (add-one-right-ℤ x))
+    ( ap abs-ℤ (right-add-one-ℤ x))
     ( successor-law-abs-ℤ x)
     ( refl)
 subadditive-abs-ℤ x (inr (inr (succ-ℕ y))) =

--- a/src/elementary-number-theory/addition-integer-fractions.lagda.md
+++ b/src/elementary-number-theory/addition-integer-fractions.lagda.md
@@ -27,9 +27,9 @@ that the properties only hold up to fraction similarity.
 ```agda
 add-fraction-ℤ : fraction-ℤ → fraction-ℤ → fraction-ℤ
 pr1 (add-fraction-ℤ (m , n , n-pos) (m' , n' , n'-pos)) =
-  (mul-ℤ m n') +ℤ (mul-ℤ m' n)
+  (m *ℤ n') +ℤ (m' *ℤ n)
 pr1 (pr2 (add-fraction-ℤ (m , n , n-pos) (m' , n' , n'-pos))) =
-  mul-ℤ n n'
+  n *ℤ n'
 pr2 (pr2 (add-fraction-ℤ (m , n , n-pos) (m' , n' , n'-pos))) =
   is-positive-mul-ℤ n-pos n'-pos
 
@@ -59,45 +59,45 @@ sim-fraction-add-fraction-ℤ
   {(nx , dx , dxp)} {(nx' , dx' , dx'p)}
   {(ny , dy , dyp)} {(ny' , dy' , dy'p)} p q =
   equational-reasoning
-  mul-ℤ ((mul-ℤ nx dy) +ℤ (mul-ℤ ny dx)) (mul-ℤ dx' dy')
-  ＝ mul-ℤ (mul-ℤ nx dy) (mul-ℤ dx' dy') +ℤ mul-ℤ (mul-ℤ ny dx) (mul-ℤ dx' dy')
-    by right-distributive-mul-add-ℤ (mul-ℤ nx dy) (mul-ℤ ny dx) (mul-ℤ dx' dy')
-  ＝ mul-ℤ (mul-ℤ dy nx) (mul-ℤ dx' dy') +ℤ mul-ℤ (mul-ℤ dx ny) (mul-ℤ dy' dx')
-    by ap-add-ℤ (ap-mul-ℤ (commutative-mul-ℤ nx dy) refl)
-      (ap-mul-ℤ (commutative-mul-ℤ ny dx) (commutative-mul-ℤ dx' dy'))
-  ＝ mul-ℤ (mul-ℤ (mul-ℤ dy nx) dx') dy' +ℤ mul-ℤ (mul-ℤ (mul-ℤ dx ny) dy') dx'
-    by ap-add-ℤ (inv (associative-mul-ℤ (mul-ℤ dy nx) dx' dy'))
-      (inv (associative-mul-ℤ (mul-ℤ dx ny) dy' dx'))
-  ＝ mul-ℤ (mul-ℤ dy (mul-ℤ nx dx')) dy' +ℤ mul-ℤ (mul-ℤ dx (mul-ℤ ny dy')) dx'
-    by ap-add-ℤ (ap-mul-ℤ (associative-mul-ℤ dy nx dx') refl)
-      (ap-mul-ℤ (associative-mul-ℤ dx ny dy') refl)
-  ＝ mul-ℤ (mul-ℤ dy (mul-ℤ dx nx')) dy' +ℤ mul-ℤ (mul-ℤ dx (mul-ℤ dy ny')) dx'
-    by ap-add-ℤ
-      (ap-mul-ℤ (ap-mul-ℤ (refl {x = dy}) (p ∙ commutative-mul-ℤ nx' dx))
-        (refl {x = dy'}))
-      (ap-mul-ℤ (ap-mul-ℤ (refl {x = dx}) (q ∙ commutative-mul-ℤ ny' dy))
-        (refl {x = dx'}))
-  ＝ mul-ℤ (mul-ℤ (mul-ℤ dy dx) nx') dy' +ℤ mul-ℤ (mul-ℤ (mul-ℤ dx dy) ny') dx'
-    by ap-add-ℤ (ap-mul-ℤ (inv (associative-mul-ℤ dy dx nx')) refl)
-      (ap-mul-ℤ (inv (associative-mul-ℤ dx dy ny')) refl)
-  ＝ mul-ℤ (mul-ℤ nx' (mul-ℤ dy dx)) dy' +ℤ mul-ℤ (mul-ℤ ny' (mul-ℤ dx dy)) dx'
-    by ap-add-ℤ (ap-mul-ℤ (commutative-mul-ℤ (mul-ℤ dy dx) nx') refl)
-      (ap-mul-ℤ (commutative-mul-ℤ (mul-ℤ dx dy) ny') refl)
-  ＝ mul-ℤ nx' (mul-ℤ (mul-ℤ dy dx) dy') +ℤ mul-ℤ ny' (mul-ℤ (mul-ℤ dx dy) dx')
-    by ap-add-ℤ (associative-mul-ℤ nx' (mul-ℤ dy dx) dy')
-      (associative-mul-ℤ ny' (mul-ℤ dx dy) dx')
-  ＝ mul-ℤ nx' (mul-ℤ dy' (mul-ℤ dy dx)) +ℤ mul-ℤ ny' (mul-ℤ dx' (mul-ℤ dx dy))
-    by ap-add-ℤ
-      (ap-mul-ℤ (refl {x = nx'}) (commutative-mul-ℤ (mul-ℤ dy dx) dy'))
-      (ap-mul-ℤ (refl {x = ny'}) (commutative-mul-ℤ (mul-ℤ dx dy) dx'))
-  ＝ mul-ℤ (mul-ℤ nx' dy') (mul-ℤ dy dx) +ℤ mul-ℤ (mul-ℤ ny' dx') (mul-ℤ dx dy)
-    by ap-add-ℤ (inv (associative-mul-ℤ nx' dy' (mul-ℤ dy dx)))
-      (inv (associative-mul-ℤ ny' dx' (mul-ℤ dx dy)))
-  ＝ mul-ℤ (mul-ℤ nx' dy') (mul-ℤ dx dy) +ℤ mul-ℤ (mul-ℤ ny' dx') (mul-ℤ dx dy)
-    by ap-add-ℤ
-      (ap-mul-ℤ (refl {x = mul-ℤ nx' dy'}) (commutative-mul-ℤ dy dx)) refl
-  ＝ mul-ℤ ((mul-ℤ nx' dy') +ℤ (mul-ℤ ny' dx')) (mul-ℤ dx dy)
-    by inv (right-distributive-mul-add-ℤ (mul-ℤ nx' dy') _ (mul-ℤ dx dy))
+    ((nx *ℤ dy) +ℤ (ny *ℤ dx)) *ℤ (dx' *ℤ dy')
+    ＝ ((nx *ℤ dy) *ℤ (dx' *ℤ dy')) +ℤ ((ny *ℤ dx) *ℤ (dx' *ℤ dy'))
+      by right-distributive-mul-add-ℤ (nx *ℤ dy) (ny *ℤ dx) (dx' *ℤ dy')
+    ＝ ((dy *ℤ nx) *ℤ (dx' *ℤ dy')) +ℤ ((dx *ℤ ny) *ℤ (dy' *ℤ dx'))
+      by ap-add-ℤ (ap-mul-ℤ (commutative-mul-ℤ nx dy) refl)
+        (ap-mul-ℤ (commutative-mul-ℤ ny dx) (commutative-mul-ℤ dx' dy'))
+    ＝ (((dy *ℤ nx) *ℤ dx') *ℤ dy') +ℤ (((dx *ℤ ny) *ℤ dy') *ℤ dx')
+      by ap-add-ℤ (inv (associative-mul-ℤ (dy *ℤ nx) dx' dy'))
+        (inv (associative-mul-ℤ (dx *ℤ ny) dy' dx'))
+    ＝ ((dy *ℤ (nx *ℤ dx')) *ℤ dy') +ℤ ((dx *ℤ (ny *ℤ dy')) *ℤ dx')
+      by ap-add-ℤ (ap-mul-ℤ (associative-mul-ℤ dy nx dx') refl)
+        (ap-mul-ℤ (associative-mul-ℤ dx ny dy') refl)
+    ＝ ((dy *ℤ (dx *ℤ nx')) *ℤ dy') +ℤ ((dx *ℤ (dy *ℤ ny')) *ℤ dx')
+      by ap-add-ℤ
+        (ap-mul-ℤ (ap-mul-ℤ (refl {x = dy}) (p ∙ commutative-mul-ℤ nx' dx))
+          (refl {x = dy'}))
+        (ap-mul-ℤ (ap-mul-ℤ (refl {x = dx}) (q ∙ commutative-mul-ℤ ny' dy))
+          (refl {x = dx'}))
+    ＝ (((dy *ℤ dx) *ℤ nx') *ℤ dy') +ℤ (((dx *ℤ dy) *ℤ ny') *ℤ dx')
+      by ap-add-ℤ (ap-mul-ℤ (inv (associative-mul-ℤ dy dx nx')) refl)
+        (ap-mul-ℤ (inv (associative-mul-ℤ dx dy ny')) refl)
+    ＝ ((nx' *ℤ (dy *ℤ dx)) *ℤ dy') +ℤ ((ny' *ℤ (dx *ℤ dy)) *ℤ dx')
+      by ap-add-ℤ (ap-mul-ℤ (commutative-mul-ℤ (dy *ℤ dx) nx') refl)
+        (ap-mul-ℤ (commutative-mul-ℤ (dx *ℤ dy) ny') refl)
+    ＝ (nx' *ℤ ((dy *ℤ dx) *ℤ dy')) +ℤ (ny' *ℤ ((dx *ℤ dy) *ℤ dx'))
+      by ap-add-ℤ (associative-mul-ℤ nx' (dy *ℤ dx) dy')
+        (associative-mul-ℤ ny' (dx *ℤ dy) dx')
+    ＝ (nx' *ℤ (dy' *ℤ (dy *ℤ dx))) +ℤ (ny' *ℤ (dx' *ℤ (dx *ℤ dy)))
+      by ap-add-ℤ
+        (ap-mul-ℤ (refl {x = nx'}) (commutative-mul-ℤ (dy *ℤ dx) dy'))
+        (ap-mul-ℤ (refl {x = ny'}) (commutative-mul-ℤ (dx *ℤ dy) dx'))
+    ＝ ((nx' *ℤ dy') *ℤ (dy *ℤ dx)) +ℤ ((ny' *ℤ dx') *ℤ (dx *ℤ dy))
+      by ap-add-ℤ (inv (associative-mul-ℤ nx' dy' (dy *ℤ dx)))
+        (inv (associative-mul-ℤ ny' dx' (dx *ℤ dy)))
+    ＝ ((nx' *ℤ dy') *ℤ (dx *ℤ dy)) +ℤ ((ny' *ℤ dx') *ℤ (dx *ℤ dy))
+      by ap-add-ℤ
+        (ap-mul-ℤ (refl {x = nx' *ℤ dy'}) (commutative-mul-ℤ dy dx)) refl
+    ＝ ((nx' *ℤ dy') +ℤ (ny' *ℤ dx')) *ℤ (dx *ℤ dy)
+      by inv (right-distributive-mul-add-ℤ (nx' *ℤ dy') _ (dx *ℤ dy))
 ```
 
 ### Unit laws
@@ -132,42 +132,42 @@ associative-add-fraction-ℤ (nx , dx , dxp) (ny , dy , dyp) (nz , dz , dzp) =
     (inv (associative-mul-ℤ dx dy dz))
   where
     eq-num :
-      mul-ℤ ((mul-ℤ nx dy) +ℤ (mul-ℤ ny dx)) dz +ℤ mul-ℤ nz (mul-ℤ dx dy) ＝
-      mul-ℤ nx (mul-ℤ dy dz) +ℤ (mul-ℤ (mul-ℤ ny dz +ℤ mul-ℤ nz dy) dx)
+      (((nx *ℤ dy) +ℤ (ny *ℤ dx)) *ℤ dz) +ℤ (nz *ℤ (dx *ℤ dy)) ＝
+      (nx *ℤ (dy *ℤ dz)) +ℤ (((ny *ℤ dz) +ℤ (nz *ℤ dy)) *ℤ dx)
     eq-num =
       equational-reasoning
-        mul-ℤ ((mul-ℤ nx dy) +ℤ (mul-ℤ ny dx)) dz +ℤ mul-ℤ nz (mul-ℤ dx dy)
-        ＝ (mul-ℤ (mul-ℤ nx dy) dz +ℤ mul-ℤ (mul-ℤ ny dx) dz) +ℤ
-            mul-ℤ nz (mul-ℤ dx dy)
+        (((nx *ℤ dy) +ℤ (ny *ℤ dx)) *ℤ dz) +ℤ (nz *ℤ (dx *ℤ dy))
+        ＝ (((nx *ℤ dy) *ℤ dz) +ℤ ((ny *ℤ dx) *ℤ dz)) +ℤ
+            (nz *ℤ (dx *ℤ dy))
           by ap-add-ℤ
-            (right-distributive-mul-add-ℤ (mul-ℤ nx dy) (mul-ℤ ny dx) dz) refl
-        ＝ mul-ℤ (mul-ℤ nx dy) dz +ℤ
-            (mul-ℤ (mul-ℤ ny dx) dz +ℤ mul-ℤ nz (mul-ℤ dx dy))
+            (right-distributive-mul-add-ℤ (nx *ℤ dy) (ny *ℤ dx) dz) refl
+        ＝ ((nx *ℤ dy) *ℤ dz) +ℤ
+            (((ny *ℤ dx) *ℤ dz) +ℤ (nz *ℤ (dx *ℤ dy)))
           by associative-add-ℤ
-            (mul-ℤ (mul-ℤ nx dy) dz) (mul-ℤ (mul-ℤ ny dx) dz) _
-        ＝ mul-ℤ nx (mul-ℤ dy dz) +ℤ
-            (mul-ℤ (mul-ℤ ny dx) dz +ℤ mul-ℤ nz (mul-ℤ dx dy))
+            ((nx *ℤ dy) *ℤ dz) ((ny *ℤ dx) *ℤ dz) _
+        ＝ (nx *ℤ (dy *ℤ dz)) +ℤ
+            (((ny *ℤ dx) *ℤ dz) +ℤ (nz *ℤ (dx *ℤ dy)))
           by ap-add-ℤ (associative-mul-ℤ nx dy dz) refl
-        ＝ mul-ℤ nx (mul-ℤ dy dz) +ℤ
-            (mul-ℤ ny (mul-ℤ dz dx) +ℤ mul-ℤ nz (mul-ℤ dy dx))
+        ＝ (nx *ℤ (dy *ℤ dz)) +ℤ
+            ((ny *ℤ (dz *ℤ dx)) +ℤ (nz *ℤ (dy *ℤ dx)))
           by ap-add-ℤ
-            (refl {x = mul-ℤ nx (mul-ℤ dy dz)})
+            (refl {x = nx *ℤ (dy *ℤ dz)})
             (ap-add-ℤ
               (associative-mul-ℤ ny dx dz ∙ ap-mul-ℤ (refl {x = ny})
                 (commutative-mul-ℤ dx dz))
               (ap-mul-ℤ (refl {x = nz}) (commutative-mul-ℤ dx dy)))
-        ＝ mul-ℤ nx (mul-ℤ dy dz) +ℤ
-            (mul-ℤ (mul-ℤ ny dz) dx +ℤ mul-ℤ (mul-ℤ nz dy) dx)
+        ＝ (nx *ℤ (dy *ℤ dz)) +ℤ
+            (((ny *ℤ dz) *ℤ dx) +ℤ ((nz *ℤ dy) *ℤ dx))
           by ap-add-ℤ
-            (refl {x = mul-ℤ nx (mul-ℤ dy dz)})
+            (refl {x = nx *ℤ (dy *ℤ dz)})
             (inv
               (ap-add-ℤ
                 ( associative-mul-ℤ ny dz dx)
                 ( associative-mul-ℤ nz dy dx)))
-        ＝ mul-ℤ nx (mul-ℤ dy dz) +ℤ (mul-ℤ (mul-ℤ ny dz +ℤ mul-ℤ nz dy) dx)
+        ＝ (nx *ℤ (dy *ℤ dz)) +ℤ (((ny *ℤ dz) +ℤ (nz *ℤ dy)) *ℤ dx)
           by ap-add-ℤ
-            (refl {x = mul-ℤ nx (mul-ℤ dy dz)})
-            (inv (right-distributive-mul-add-ℤ (mul-ℤ ny dz) (mul-ℤ nz dy) dx))
+            (refl {x = nx *ℤ (dy *ℤ dz)})
+            (inv (right-distributive-mul-add-ℤ (ny *ℤ dz) (nz *ℤ dy) dx))
 ```
 
 ### Addition is commutative
@@ -180,6 +180,6 @@ commutative-add-fraction-ℤ :
     (y +fraction-ℤ x)
 commutative-add-fraction-ℤ (nx , dx , dxp) (ny , dy , dyp) =
   ap-mul-ℤ
-    ( commutative-add-ℤ (mul-ℤ nx dy) (mul-ℤ ny dx))
+    ( commutative-add-ℤ (nx *ℤ dy) (ny *ℤ dx))
     ( commutative-mul-ℤ dy dx)
 ```

--- a/src/elementary-number-theory/addition-integer-fractions.lagda.md
+++ b/src/elementary-number-theory/addition-integer-fractions.lagda.md
@@ -27,7 +27,7 @@ that the properties only hold up to fraction similarity.
 ```agda
 add-fraction-ℤ : fraction-ℤ → fraction-ℤ → fraction-ℤ
 pr1 (add-fraction-ℤ (m , n , n-pos) (m' , n' , n'-pos)) =
-  add-ℤ (mul-ℤ m n') (mul-ℤ m' n)
+  (mul-ℤ m n') +ℤ (mul-ℤ m' n)
 pr1 (pr2 (add-fraction-ℤ (m , n , n-pos) (m' , n' , n'-pos))) =
   mul-ℤ n n'
 pr2 (pr2 (add-fraction-ℤ (m , n , n-pos) (m' , n' , n'-pos))) =

--- a/src/elementary-number-theory/addition-integers.lagda.md
+++ b/src/elementary-number-theory/addition-integers.lagda.md
@@ -393,13 +393,13 @@ isretr-add-neg-ℤ' x y =
 
 abstract
   is-equiv-add-ℤ' : (y : ℤ) → is-equiv (_+ℤ y)
-  pr1 (pr1 (is-equiv-add-ℤ' y)) = add-ℤ' (neg-ℤ y)
+  pr1 (pr1 (is-equiv-add-ℤ' y)) = _+ℤ (neg-ℤ y)
   pr2 (pr1 (is-equiv-add-ℤ' y)) = issec-add-neg-ℤ' y
-  pr1 (pr2 (is-equiv-add-ℤ' y)) = add-ℤ' (neg-ℤ y)
+  pr1 (pr2 (is-equiv-add-ℤ' y)) = _+ℤ (neg-ℤ y)
   pr2 (pr2 (is-equiv-add-ℤ' y)) = isretr-add-neg-ℤ' y
 
 equiv-add-ℤ' : ℤ → (ℤ ≃ ℤ)
-pr1 (equiv-add-ℤ' y) = add-ℤ' y
+pr1 (equiv-add-ℤ' y) = _+ℤ y
 pr2 (equiv-add-ℤ' y) = is-equiv-add-ℤ' y
 
 is-binary-equiv-add-ℤ : is-binary-equiv add-ℤ

--- a/src/elementary-number-theory/addition-integers.lagda.md
+++ b/src/elementary-number-theory/addition-integers.lagda.md
@@ -207,7 +207,7 @@ abstract
     equational-reasoning
       (neg-one-ℤ +ℤ y) +ℤ z
       ＝ (pred-ℤ (zero-ℤ +ℤ y)) +ℤ z
-        by ap (add-ℤ' z) (left-predecessor-law-add-ℤ zero-ℤ y)
+        by ap (_+ℤ z) (left-predecessor-law-add-ℤ zero-ℤ y)
       ＝ pred-ℤ (y +ℤ z)
         by left-predecessor-law-add-ℤ y z
       ＝ neg-one-ℤ +ℤ (y +ℤ z)
@@ -216,7 +216,7 @@ abstract
     equational-reasoning
       (pred-ℤ (inl x) +ℤ y) +ℤ z
       ＝ pred-ℤ (inl x +ℤ y) +ℤ z
-        by ap (add-ℤ' z) (left-predecessor-law-add-ℤ (inl x) y)
+        by ap (_+ℤ z) (left-predecessor-law-add-ℤ (inl x) y)
       ＝ pred-ℤ ((inl x +ℤ y) +ℤ z)
         by left-predecessor-law-add-ℤ ((inl x) +ℤ y) z
       ＝ pred-ℤ (inl x +ℤ (y +ℤ z))
@@ -229,7 +229,7 @@ abstract
     equational-reasoning
       (one-ℤ +ℤ y) +ℤ z
       ＝ succ-ℤ (zero-ℤ +ℤ y) +ℤ z
-        by ap (add-ℤ' z) (left-successor-law-add-ℤ zero-ℤ y)
+        by ap (_+ℤ z) (left-successor-law-add-ℤ zero-ℤ y)
       ＝ succ-ℤ (y +ℤ z)
         by left-successor-law-add-ℤ y z
       ＝ one-ℤ +ℤ (y +ℤ z)
@@ -238,7 +238,7 @@ abstract
     equational-reasoning
       (succ-ℤ (inr (inr x)) +ℤ y) +ℤ z
       ＝ succ-ℤ (inr (inr x) +ℤ y) +ℤ z
-        by ap (add-ℤ' z) (left-successor-law-add-ℤ (inr (inr x)) y)
+        by ap (_+ℤ z) (left-successor-law-add-ℤ (inr (inr x)) y)
       ＝ succ-ℤ ((inr (inr x) +ℤ y) +ℤ z)
         by left-successor-law-add-ℤ (add-ℤ (inr (inr x)) y) z
       ＝ succ-ℤ (inr (inr x) +ℤ (y +ℤ z))
@@ -344,7 +344,7 @@ issec-add-neg-ℤ x y =
     ＝ (x +ℤ neg-ℤ x) +ℤ y
       by inv (associative-add-ℤ x (neg-ℤ x) y)
     ＝ y
-      by ap (add-ℤ' y) (right-inverse-law-add-ℤ x)
+      by ap (_+ℤ y) (right-inverse-law-add-ℤ x)
 
 isretr-add-neg-ℤ :
   (x y : ℤ) → (neg-ℤ x) +ℤ (x +ℤ y) ＝ y
@@ -354,7 +354,7 @@ isretr-add-neg-ℤ x y =
     ＝ (neg-ℤ x +ℤ x) +ℤ y
       by inv (associative-add-ℤ (neg-ℤ x) x y)
     ＝ y
-      by ap (add-ℤ' y) (left-inverse-law-add-ℤ x)
+      by ap (_+ℤ y) (left-inverse-law-add-ℤ x)
 
 abstract
   is-equiv-add-ℤ : (x : ℤ) → is-equiv (add-ℤ x)
@@ -392,7 +392,7 @@ isretr-add-neg-ℤ' x y =
       by right-unit-law-add-ℤ y
 
 abstract
-  is-equiv-add-ℤ' : (y : ℤ) → is-equiv (add-ℤ' y)
+  is-equiv-add-ℤ' : (y : ℤ) → is-equiv (_+ℤ y)
   pr1 (pr1 (is-equiv-add-ℤ' y)) = add-ℤ' (neg-ℤ y)
   pr2 (pr1 (is-equiv-add-ℤ' y)) = issec-add-neg-ℤ' y
   pr1 (pr2 (is-equiv-add-ℤ' y)) = add-ℤ' (neg-ℤ y)
@@ -416,7 +416,7 @@ is-emb-add-ℤ x =
   is-emb-is-equiv (is-equiv-add-ℤ x)
 
 is-emb-add-ℤ' :
-  (y : ℤ) → is-emb (add-ℤ' y)
+  (y : ℤ) → is-emb (_+ℤ y)
 is-emb-add-ℤ' y = is-emb-is-equiv (is-equiv-add-ℤ' y)
 
 is-binary-emb-add-ℤ : is-binary-emb add-ℤ
@@ -427,7 +427,7 @@ is-binary-emb-add-ℤ =
 ### Addition by x is injective
 
 ```agda
-is-injective-add-ℤ' : (x : ℤ) → is-injective (add-ℤ' x)
+is-injective-add-ℤ' : (x : ℤ) → is-injective (_+ℤ x)
 is-injective-add-ℤ' x = is-injective-is-emb (is-emb-add-ℤ' x)
 
 is-injective-add-ℤ : (x : ℤ) → is-injective (add-ℤ x)
@@ -490,7 +490,7 @@ distributive-neg-add-ℤ (inl (succ-ℕ n)) l =
     ＝ succ-ℤ (neg-ℤ (inl n) +ℤ neg-ℤ l)
       by ap succ-ℤ (distributive-neg-add-ℤ (inl n) l)
     ＝ neg-ℤ (pred-ℤ (inl n)) +ℤ neg-ℤ l
-      by ap (add-ℤ' (neg-ℤ l)) (inv (neg-pred-ℤ (inl n)))
+      by ap (_+ℤ (neg-ℤ l)) (inv (neg-pred-ℤ (inl n)))
 distributive-neg-add-ℤ (inr (inl star)) l =
   refl
 distributive-neg-add-ℤ (inr (inr zero-ℕ)) l =
@@ -569,7 +569,7 @@ is-zero-add-ℤ x y H =
     ＝ (x +ℤ y) +ℤ neg-ℤ y
       by inv (associative-add-ℤ x y (neg-ℤ y))
     ＝ y +ℤ neg-ℤ y
-      by ap (add-ℤ' (neg-ℤ y)) H
+      by ap (_+ℤ (neg-ℤ y)) H
     ＝ zero-ℤ
       by right-inverse-law-add-ℤ y
 

--- a/src/elementary-number-theory/addition-integers.lagda.md
+++ b/src/elementary-number-theory/addition-integers.lagda.md
@@ -83,7 +83,7 @@ abstract
   left-predecessor-law-add-ℤ (inr (inr zero-ℕ)) y =
     inv (isretr-pred-ℤ y)
   left-predecessor-law-add-ℤ (inr (inr (succ-ℕ x))) y =
-    inv (isretr-pred-ℤ (add-ℤ (inr (inr x)) y))
+    inv (isretr-pred-ℤ ((inr (inr x)) +ℤ y))
 
   right-predecessor-law-add-ℤ :
     (x y : ℤ) → x +ℤ pred-ℤ y ＝ pred-ℤ (x +ℤ y)
@@ -104,9 +104,9 @@ abstract
       ＝ succ-ℤ (pred-ℤ (inr (inr x) +ℤ n))
         by ap succ-ℤ (right-predecessor-law-add-ℤ (inr (inr x)) n)
       ＝ inr (inr x) +ℤ n
-        by issec-pred-ℤ (add-ℤ (inr (inr x)) n)
+        by issec-pred-ℤ ((inr (inr x)) +ℤ n)
       ＝ pred-ℤ (succ-ℤ (inr (inr x) +ℤ n))
-        by inv (isretr-pred-ℤ (add-ℤ (inr (inr x)) n))
+        by inv (isretr-pred-ℤ ((inr (inr x)) +ℤ n))
 ```
 
 ### Left and right successor laws
@@ -240,7 +240,7 @@ abstract
       ＝ succ-ℤ (inr (inr x) +ℤ y) +ℤ z
         by ap (_+ℤ z) (left-successor-law-add-ℤ (inr (inr x)) y)
       ＝ succ-ℤ ((inr (inr x) +ℤ y) +ℤ z)
-        by left-successor-law-add-ℤ (add-ℤ (inr (inr x)) y) z
+        by left-successor-law-add-ℤ ((inr (inr x)) +ℤ y) z
       ＝ succ-ℤ (inr (inr x) +ℤ (y +ℤ z))
         by ap succ-ℤ (associative-add-ℤ (inr (inr x)) y z)
       ＝ succ-ℤ (inr (inr x)) +ℤ (y +ℤ z)
@@ -263,7 +263,7 @@ abstract
         by inv (right-predecessor-law-add-ℤ y zero-ℤ)
   commutative-add-ℤ (inl (succ-ℕ x)) y =
     equational-reasoning
-      add-ℤ (inl (succ-ℕ x)) y
+      (inl (succ-ℕ x)) +ℤ y
       ＝ pred-ℤ (y +ℤ (inl x))
         by ap pred-ℤ (commutative-add-ℤ (inl x) y)
       ＝ y +ℤ (inl (succ-ℕ x))
@@ -279,7 +279,7 @@ abstract
         by inv (right-successor-law-add-ℤ y zero-ℤ)
   commutative-add-ℤ (inr (inr (succ-ℕ x))) y =
     equational-reasoning
-      succ-ℤ (add-ℤ (inr (inr x)) y)
+      succ-ℤ ((inr (inr x)) +ℤ y)
       ＝ succ-ℤ (y +ℤ (inr (inr x)))
         by ap succ-ℤ (commutative-add-ℤ (inr (inr x)) y)
       ＝ y +ℤ (succ-ℤ (inr (inr x)))
@@ -299,7 +299,7 @@ abstract
       ＝ succ-ℤ (pred-ℤ (inr (inr x) +ℤ inl x))
         by ap succ-ℤ (right-predecessor-law-add-ℤ (inr (inr x)) (inl x))
       ＝ inr (inr x) +ℤ inl x
-        by issec-pred-ℤ (add-ℤ (inr (inr x)) (inl x))
+        by issec-pred-ℤ ((inr (inr x)) +ℤ (inl x))
       ＝ zero-ℤ
         by left-inverse-law-add-ℤ (inl x)
   left-inverse-law-add-ℤ (inr (inl star)) = refl
@@ -515,12 +515,12 @@ is-nonnegative-add-ℤ (inr (inl star)) (inr (inr n)) p q = star
 is-nonnegative-add-ℤ (inr (inr zero-ℕ)) (inr (inl star)) p q = star
 is-nonnegative-add-ℤ (inr (inr (succ-ℕ n))) (inr (inl star)) star star =
   is-nonnegative-succ-ℤ
-    ( add-ℤ (inr (inr n)) (inr (inl star)))
+    ( (inr (inr n)) +ℤ (inr (inl star)))
     ( is-nonnegative-add-ℤ (inr (inr n)) (inr (inl star)) star star)
 is-nonnegative-add-ℤ (inr (inr zero-ℕ)) (inr (inr m)) star star = star
 is-nonnegative-add-ℤ (inr (inr (succ-ℕ n))) (inr (inr m)) star star =
   is-nonnegative-succ-ℤ
-    ( add-ℤ (inr (inr n)) (inr (inr m)))
+    ( (inr (inr n)) +ℤ (inr (inr m)))
     ( is-nonnegative-add-ℤ (inr (inr n)) (inr (inr m)) star star)
 ```
 

--- a/src/elementary-number-theory/addition-integers.lagda.md
+++ b/src/elementary-number-theory/addition-integers.lagda.md
@@ -49,7 +49,7 @@ infix 30 _+ℤ_
 _+ℤ_ = add-ℤ
 
 ap-add-ℤ :
-  {x y x' y' : ℤ} → x ＝ x' → y ＝ y' → add-ℤ x y ＝ add-ℤ x' y'
+  {x y x' y' : ℤ} → x ＝ x' → y ＝ y' → x +ℤ y ＝ x' +ℤ y'
 ap-add-ℤ p q = ap-binary add-ℤ p q
 ```
 
@@ -121,7 +121,7 @@ abstract
     equational-reasoning
       inl x +ℤ y
       ＝ succ-ℤ (pred-ℤ (inl x +ℤ y))
-        by inv (issec-pred-ℤ (add-ℤ (inl x) y))
+        by inv (issec-pred-ℤ ((inl x) +ℤ y))
       ＝ succ-ℤ (pred-ℤ (inl x) +ℤ y)
         by ap succ-ℤ (inv (left-predecessor-law-add-ℤ (inl x) y))
   left-successor-law-add-ℤ (inr (inl star)) y = refl
@@ -142,9 +142,9 @@ abstract
       ＝ pred-ℤ (succ-ℤ (inl x +ℤ y))
         by ap pred-ℤ (right-successor-law-add-ℤ (inl x) y)
       ＝ inl x +ℤ y
-        by isretr-pred-ℤ (add-ℤ (inl x) y)
+        by isretr-pred-ℤ ((inl x) +ℤ y)
       ＝ succ-ℤ (pred-ℤ (inl x +ℤ y))
-        by inv (issec-pred-ℤ (add-ℤ (inl x) y))
+        by inv (issec-pred-ℤ ((inl x) +ℤ y))
   right-successor-law-add-ℤ (inr (inl star)) y = refl
   right-successor-law-add-ℤ (inr (inr zero-ℕ)) y = refl
   right-successor-law-add-ℤ (inr (inr (succ-ℕ x))) y =
@@ -211,18 +211,18 @@ abstract
       ＝ pred-ℤ (y +ℤ z)
         by left-predecessor-law-add-ℤ y z
       ＝ neg-one-ℤ +ℤ (y +ℤ z)
-        by inv (left-predecessor-law-add-ℤ zero-ℤ (add-ℤ y z))
+        by inv (left-predecessor-law-add-ℤ zero-ℤ (y +ℤ z))
   associative-add-ℤ (inl (succ-ℕ x)) y z =
     equational-reasoning
       (pred-ℤ (inl x) +ℤ y) +ℤ z
       ＝ pred-ℤ (inl x +ℤ y) +ℤ z
         by ap (add-ℤ' z) (left-predecessor-law-add-ℤ (inl x) y)
       ＝ pred-ℤ ((inl x +ℤ y) +ℤ z)
-        by left-predecessor-law-add-ℤ (add-ℤ (inl x) y) z
+        by left-predecessor-law-add-ℤ ((inl x) +ℤ y) z
       ＝ pred-ℤ (inl x +ℤ (y +ℤ z))
         by ap pred-ℤ (associative-add-ℤ (inl x) y z)
       ＝ pred-ℤ (inl x) +ℤ (y +ℤ z)
-        by inv (left-predecessor-law-add-ℤ (inl x) (add-ℤ y z))
+        by inv (left-predecessor-law-add-ℤ (inl x) (y +ℤ z))
   associative-add-ℤ (inr (inl star)) y z =
     refl
   associative-add-ℤ (inr (inr zero-ℕ)) y z =
@@ -233,7 +233,7 @@ abstract
       ＝ succ-ℤ (y +ℤ z)
         by left-successor-law-add-ℤ y z
       ＝ one-ℤ +ℤ (y +ℤ z)
-        by inv (left-successor-law-add-ℤ zero-ℤ (add-ℤ y z))
+        by inv (left-successor-law-add-ℤ zero-ℤ (y +ℤ z))
   associative-add-ℤ (inr (inr (succ-ℕ x))) y z =
     equational-reasoning
       (succ-ℤ (inr (inr x)) +ℤ y) +ℤ z
@@ -244,7 +244,7 @@ abstract
       ＝ succ-ℤ (inr (inr x) +ℤ (y +ℤ z))
         by ap succ-ℤ (associative-add-ℤ (inr (inr x)) y z)
       ＝ succ-ℤ (inr (inr x)) +ℤ (y +ℤ z)
-        by inv (left-successor-law-add-ℤ (inr (inr x)) (add-ℤ y z))
+        by inv (left-successor-law-add-ℤ (inr (inr x)) (y +ℤ z))
 ```
 
 ### Addition is commutative
@@ -254,17 +254,17 @@ abstract
   commutative-add-ℤ : (x y : ℤ) → x +ℤ y ＝ y +ℤ x
   commutative-add-ℤ (inl zero-ℕ) y =
     equational-reasoning
-      add-ℤ neg-one-ℤ y
-      ＝ pred-ℤ (add-ℤ zero-ℤ y)
+      neg-one-ℤ +ℤ y
+      ＝ pred-ℤ (zero-ℤ +ℤ y)
         by left-predecessor-law-add-ℤ zero-ℤ y
-      ＝ pred-ℤ (add-ℤ y zero-ℤ)
+      ＝ pred-ℤ (y +ℤ zero-ℤ)
         by inv (ap pred-ℤ (right-unit-law-add-ℤ y))
-      ＝ add-ℤ y neg-one-ℤ
+      ＝ y +ℤ neg-one-ℤ
         by inv (right-predecessor-law-add-ℤ y zero-ℤ)
   commutative-add-ℤ (inl (succ-ℕ x)) y =
     equational-reasoning
       add-ℤ (inl (succ-ℕ x)) y
-      ＝ pred-ℤ (add-ℤ y (inl x))
+      ＝ pred-ℤ (y +ℤ (inl x))
         by ap pred-ℤ (commutative-add-ℤ (inl x) y)
       ＝ add-ℤ y (inl (succ-ℕ x))
         by inv (right-predecessor-law-add-ℤ y (inl x))
@@ -273,9 +273,9 @@ abstract
   commutative-add-ℤ (inr (inr zero-ℕ)) y =
     equational-reasoning
       succ-ℤ y
-      ＝ succ-ℤ (add-ℤ y zero-ℤ)
+      ＝ succ-ℤ (y +ℤ zero-ℤ)
         by inv (ap succ-ℤ (right-unit-law-add-ℤ y))
-      ＝ add-ℤ y one-ℤ
+      ＝ y +ℤ one-ℤ
         by inv (right-successor-law-add-ℤ y zero-ℤ)
   commutative-add-ℤ (inr (inr (succ-ℕ x))) y =
     equational-reasoning
@@ -347,7 +347,7 @@ issec-add-neg-ℤ x y =
       by ap (add-ℤ' y) (right-inverse-law-add-ℤ x)
 
 isretr-add-neg-ℤ :
-  (x y : ℤ) → add-ℤ (neg-ℤ x) (add-ℤ x y) ＝ y
+  (x y : ℤ) → (neg-ℤ x) +ℤ (x +ℤ y) ＝ y
 isretr-add-neg-ℤ x y =
   equational-reasoning
     neg-ℤ x +ℤ (x +ℤ y)
@@ -466,8 +466,8 @@ right-negative-law-add-ℤ (inr (inr (succ-ℕ n))) l =
       by left-successor-law-add-ℤ (in-pos n) (neg-ℤ l)
     ＝ succ-ℤ (neg-ℤ (neg-ℤ (inr (inr n)) +ℤ l))
       by ap succ-ℤ (right-negative-law-add-ℤ (inr (inr n)) l)
-    ＝ neg-ℤ (pred-ℤ (add-ℤ (inl n) l))
-      by inv (neg-pred-ℤ (add-ℤ (inl n) l))
+    ＝ neg-ℤ (pred-ℤ ((inl n) +ℤ l))
+      by inv (neg-pred-ℤ ((inl n) +ℤ l))
 ```
 
 ### Distributivity of negatives over addition
@@ -509,7 +509,7 @@ distributive-neg-add-ℤ (inr (inr (succ-ℕ n))) l =
 ```agda
 is-nonnegative-add-ℤ :
   (k l : ℤ) →
-  is-nonnegative-ℤ k → is-nonnegative-ℤ l → is-nonnegative-ℤ (add-ℤ k l)
+  is-nonnegative-ℤ k → is-nonnegative-ℤ l → is-nonnegative-ℤ (k +ℤ l)
 is-nonnegative-add-ℤ (inr (inl star)) (inr (inl star)) p q = star
 is-nonnegative-add-ℤ (inr (inl star)) (inr (inr n)) p q = star
 is-nonnegative-add-ℤ (inr (inr zero-ℕ)) (inr (inl star)) p q = star
@@ -528,7 +528,7 @@ is-nonnegative-add-ℤ (inr (inr (succ-ℕ n))) (inr (inr m)) star star =
 
 ```agda
 is-positive-add-ℤ :
-  {x y : ℤ} → is-positive-ℤ x → is-positive-ℤ y → is-positive-ℤ (add-ℤ x y)
+  {x y : ℤ} → is-positive-ℤ x → is-positive-ℤ y → is-positive-ℤ (x +ℤ y)
 is-positive-add-ℤ {inr (inr zero-ℕ)} {inr (inr y)} H K = star
 is-positive-add-ℤ {inr (inr (succ-ℕ x))} {inr (inr y)} H K =
   is-positive-succ-ℤ
@@ -539,7 +539,7 @@ is-positive-add-ℤ {inr (inr (succ-ℕ x))} {inr (inr y)} H K =
 ### The inclusion of ℕ into ℤ preserves addition
 
 ```agda
-add-int-ℕ : (x y : ℕ) → add-ℤ (int-ℕ x) (int-ℕ y) ＝ int-ℕ (add-ℕ x y)
+add-int-ℕ : (x y : ℕ) → (int-ℕ x) +ℤ (int-ℕ y) ＝ int-ℕ (x +ℕ y)
 add-int-ℕ x zero-ℕ = right-unit-law-add-ℤ (int-ℕ x)
 add-int-ℕ x (succ-ℕ y) =
   equational-reasoning
@@ -548,17 +548,17 @@ add-int-ℕ x (succ-ℕ y) =
       by ap (add-ℤ (int-ℕ x)) (inv (succ-int-ℕ y))
     ＝ succ-ℤ (int-ℕ x +ℤ int-ℕ y)
       by right-successor-law-add-ℤ (int-ℕ x) (int-ℕ y)
-    ＝ succ-ℤ (int-ℕ (add-ℕ x y))
+    ＝ succ-ℤ (int-ℕ (x +ℕ y))
       by ap succ-ℤ (add-int-ℕ x y)
-    ＝ int-ℕ (succ-ℕ (add-ℕ x y))
-      by succ-int-ℕ (add-ℕ x y)
+    ＝ int-ℕ (succ-ℕ (x +ℕ y))
+      by succ-int-ℕ (x +ℕ y)
 ```
 
 ### If `x + y = y` then `x = 0`
 
 ```agda
 is-zero-add-ℤ :
-  (x y : ℤ) → add-ℤ x y ＝ y → is-zero-ℤ x
+  (x y : ℤ) → x +ℤ y ＝ y → is-zero-ℤ x
 is-zero-add-ℤ x y H =
   equational-reasoning
     x
@@ -574,7 +574,7 @@ is-zero-add-ℤ x y H =
       by right-inverse-law-add-ℤ y
 
 is-zero-add-ℤ' :
-  (x y : ℤ) → add-ℤ x y ＝ x → is-zero-ℤ y
+  (x y : ℤ) → x +ℤ y ＝ x → is-zero-ℤ y
 is-zero-add-ℤ' x y H =
   is-zero-add-ℤ y x (commutative-add-ℤ y x ∙ H)
 ```
@@ -583,13 +583,13 @@ is-zero-add-ℤ' x y H =
 
 ```agda
 negatives-add-ℤ :
-  (x y : ℕ) → in-neg x +ℤ in-neg y ＝ in-neg (succ-ℕ (add-ℕ x y))
+  (x y : ℕ) → in-neg x +ℤ in-neg y ＝ in-neg (succ-ℕ (x +ℕ y))
 negatives-add-ℤ zero-ℕ y = ap (inl ∘ succ-ℕ) (inv (left-unit-law-add-ℕ y))
 negatives-add-ℤ (succ-ℕ x) y =
   equational-reasoning
     pred-ℤ (in-neg x +ℤ in-neg y)
-    ＝ pred-ℤ (in-neg (succ-ℕ (add-ℕ x y)))
+    ＝ pred-ℤ (in-neg (succ-ℕ (x +ℕ y)))
       by ap pred-ℤ (negatives-add-ℤ x y)
-    ＝ (inl ∘ succ-ℕ) (add-ℕ (succ-ℕ x) y)
+    ＝ (inl ∘ succ-ℕ) ((succ-ℕ x) +ℕ y)
       by ap (inl ∘ succ-ℕ) (inv (left-successor-law-add-ℕ x y))
 ```

--- a/src/elementary-number-theory/addition-integers.lagda.md
+++ b/src/elementary-number-theory/addition-integers.lagda.md
@@ -155,8 +155,8 @@ abstract
 
 ```agda
 abstract
-  is-add-one-succ-ℤ' : (x : ℤ) → succ-ℤ x ＝ x +ℤ one-ℤ
-  is-add-one-succ-ℤ' x =
+  is-right-add-one-succ-ℤ : (x : ℤ) → succ-ℤ x ＝ x +ℤ one-ℤ
+  is-right-add-one-succ-ℤ x =
     equational-reasoning
       succ-ℤ x
       ＝ succ-ℤ (x +ℤ zero-ℤ)
@@ -164,25 +164,25 @@ abstract
       ＝ x +ℤ one-ℤ
         by inv (right-successor-law-add-ℤ x zero-ℤ)
 
-  is-add-one-succ-ℤ : (x : ℤ) → succ-ℤ x ＝ one-ℤ +ℤ x
-  is-add-one-succ-ℤ x = inv (left-successor-law-add-ℤ zero-ℤ x)
+  is-left-add-one-succ-ℤ : (x : ℤ) → succ-ℤ x ＝ one-ℤ +ℤ x
+  is-left-add-one-succ-ℤ x = inv (left-successor-law-add-ℤ zero-ℤ x)
 
-  add-one-left-ℤ : (x : ℤ) → one-ℤ +ℤ x ＝ succ-ℤ x
-  add-one-left-ℤ x = refl
+  left-add-one-ℤ : (x : ℤ) → one-ℤ +ℤ x ＝ succ-ℤ x
+  left-add-one-ℤ x = refl
 
-  add-one-right-ℤ : (x : ℤ) → x +ℤ one-ℤ ＝ succ-ℤ x
-  add-one-right-ℤ x = inv (is-add-one-succ-ℤ' x)
+  right-add-one-ℤ : (x : ℤ) → x +ℤ one-ℤ ＝ succ-ℤ x
+  right-add-one-ℤ x = inv (is-right-add-one-succ-ℤ x)
 ```
 
 ### The predecessor of an integer is that integer minus one
 
 ```agda
-  is-add-neg-one-pred-ℤ : (x : ℤ) → pred-ℤ x ＝ neg-one-ℤ +ℤ x
-  is-add-neg-one-pred-ℤ x =
+  is-left-add-neg-one-pred-ℤ : (x : ℤ) → pred-ℤ x ＝ neg-one-ℤ +ℤ x
+  is-left-add-neg-one-pred-ℤ x =
     inv (left-predecessor-law-add-ℤ zero-ℤ x)
 
-  is-add-neg-one-pred-ℤ' : (x : ℤ) → pred-ℤ x ＝ x +ℤ neg-one-ℤ
-  is-add-neg-one-pred-ℤ' x =
+  is-right-add-neg-one-pred-ℤ : (x : ℤ) → pred-ℤ x ＝ x +ℤ neg-one-ℤ
+  is-right-add-neg-one-pred-ℤ x =
     equational-reasoning
       pred-ℤ x
       ＝ pred-ℤ (x +ℤ zero-ℤ)
@@ -190,11 +190,11 @@ abstract
       ＝ x +ℤ neg-one-ℤ
         by inv (right-predecessor-law-add-ℤ x zero-ℤ)
 
-  add-neg-one-left-ℤ : (x : ℤ) → neg-one-ℤ +ℤ x ＝ pred-ℤ x
-  add-neg-one-left-ℤ x = refl
+  left-add-neg-one-ℤ : (x : ℤ) → neg-one-ℤ +ℤ x ＝ pred-ℤ x
+  left-add-neg-one-ℤ x = refl
 
-  add-neg-one-right-ℤ : (x : ℤ) → x +ℤ neg-one-ℤ ＝ pred-ℤ x
-  add-neg-one-right-ℤ x = inv (is-add-neg-one-pred-ℤ' x)
+  right-add-neg-one-ℤ : (x : ℤ) → x +ℤ neg-one-ℤ ＝ pred-ℤ x
+  right-add-neg-one-ℤ x = inv (is-right-add-neg-one-pred-ℤ x)
 ```
 
 ### Addition is associative
@@ -333,12 +333,12 @@ interchange-law-add-add-ℤ =
     associative-add-ℤ
 ```
 
-### Addition by x is a binary equivalence
+### Addition by `x` is a binary equivalence
 
 ```agda
-issec-add-neg-ℤ :
+issec-left-add-neg-ℤ :
   (x y : ℤ) → x +ℤ (neg-ℤ x +ℤ y) ＝ y
-issec-add-neg-ℤ x y =
+issec-left-add-neg-ℤ x y =
   equational-reasoning
     x +ℤ (neg-ℤ x +ℤ y)
     ＝ (x +ℤ neg-ℤ x) +ℤ y
@@ -346,9 +346,9 @@ issec-add-neg-ℤ x y =
     ＝ y
       by ap (_+ℤ y) (right-inverse-law-add-ℤ x)
 
-isretr-add-neg-ℤ :
+isretr-left-add-neg-ℤ :
   (x y : ℤ) → (neg-ℤ x) +ℤ (x +ℤ y) ＝ y
-isretr-add-neg-ℤ x y =
+isretr-left-add-neg-ℤ x y =
   equational-reasoning
     neg-ℤ x +ℤ (x +ℤ y)
     ＝ (neg-ℤ x +ℤ x) +ℤ y
@@ -357,19 +357,19 @@ isretr-add-neg-ℤ x y =
       by ap (_+ℤ y) (left-inverse-law-add-ℤ x)
 
 abstract
-  is-equiv-add-ℤ : (x : ℤ) → is-equiv (x +ℤ_)
-  pr1 (pr1 (is-equiv-add-ℤ x)) = add-ℤ (neg-ℤ x)
-  pr2 (pr1 (is-equiv-add-ℤ x)) = issec-add-neg-ℤ x
-  pr1 (pr2 (is-equiv-add-ℤ x)) = add-ℤ (neg-ℤ x)
-  pr2 (pr2 (is-equiv-add-ℤ x)) = isretr-add-neg-ℤ x
+  is-equiv-left-add-ℤ : (x : ℤ) → is-equiv (x +ℤ_)
+  pr1 (pr1 (is-equiv-left-add-ℤ x)) = add-ℤ (neg-ℤ x)
+  pr2 (pr1 (is-equiv-left-add-ℤ x)) = issec-left-add-neg-ℤ x
+  pr1 (pr2 (is-equiv-left-add-ℤ x)) = add-ℤ (neg-ℤ x)
+  pr2 (pr2 (is-equiv-left-add-ℤ x)) = isretr-left-add-neg-ℤ x
 
-equiv-add-ℤ : ℤ → (ℤ ≃ ℤ)
-pr1 (equiv-add-ℤ x) = add-ℤ x
-pr2 (equiv-add-ℤ x) = is-equiv-add-ℤ x
+equiv-left-add-ℤ : ℤ → (ℤ ≃ ℤ)
+pr1 (equiv-left-add-ℤ x) = add-ℤ x
+pr2 (equiv-left-add-ℤ x) = is-equiv-left-add-ℤ x
 
-issec-add-neg-ℤ' :
+issec-right-add-neg-ℤ :
   (x y : ℤ) → (y +ℤ neg-ℤ x) +ℤ x ＝ y
-issec-add-neg-ℤ' x y =
+issec-right-add-neg-ℤ x y =
   equational-reasoning
     (y +ℤ neg-ℤ x) +ℤ x
     ＝ y +ℤ (neg-ℤ x +ℤ x)
@@ -379,9 +379,9 @@ issec-add-neg-ℤ' x y =
     ＝ y
       by right-unit-law-add-ℤ y
 
-isretr-add-neg-ℤ' :
+isretr-right-add-neg-ℤ :
   (x y : ℤ) → (y +ℤ x) +ℤ neg-ℤ x ＝ y
-isretr-add-neg-ℤ' x y =
+isretr-right-add-neg-ℤ x y =
   equational-reasoning
     (y +ℤ x) +ℤ neg-ℤ x
     ＝ y +ℤ (x +ℤ neg-ℤ x)
@@ -392,46 +392,46 @@ isretr-add-neg-ℤ' x y =
       by right-unit-law-add-ℤ y
 
 abstract
-  is-equiv-add-ℤ' : (y : ℤ) → is-equiv (_+ℤ y)
-  pr1 (pr1 (is-equiv-add-ℤ' y)) = _+ℤ (neg-ℤ y)
-  pr2 (pr1 (is-equiv-add-ℤ' y)) = issec-add-neg-ℤ' y
-  pr1 (pr2 (is-equiv-add-ℤ' y)) = _+ℤ (neg-ℤ y)
-  pr2 (pr2 (is-equiv-add-ℤ' y)) = isretr-add-neg-ℤ' y
+  is-equiv-right-add-ℤ : (y : ℤ) → is-equiv (_+ℤ y)
+  pr1 (pr1 (is-equiv-right-add-ℤ y)) = _+ℤ (neg-ℤ y)
+  pr2 (pr1 (is-equiv-right-add-ℤ y)) = issec-right-add-neg-ℤ y
+  pr1 (pr2 (is-equiv-right-add-ℤ y)) = _+ℤ (neg-ℤ y)
+  pr2 (pr2 (is-equiv-right-add-ℤ y)) = isretr-right-add-neg-ℤ y
 
-equiv-add-ℤ' : ℤ → (ℤ ≃ ℤ)
-pr1 (equiv-add-ℤ' y) = _+ℤ y
-pr2 (equiv-add-ℤ' y) = is-equiv-add-ℤ' y
+equiv-right-add-ℤ : ℤ → (ℤ ≃ ℤ)
+pr1 (equiv-right-add-ℤ y) = _+ℤ y
+pr2 (equiv-right-add-ℤ y) = is-equiv-right-add-ℤ y
 
-is-binary-equiv-add-ℤ : is-binary-equiv add-ℤ
-pr1 is-binary-equiv-add-ℤ = is-equiv-add-ℤ'
-pr2 is-binary-equiv-add-ℤ = is-equiv-add-ℤ
+is-binary-equiv-left-add-ℤ : is-binary-equiv add-ℤ
+pr1 is-binary-equiv-left-add-ℤ = is-equiv-right-add-ℤ
+pr2 is-binary-equiv-left-add-ℤ = is-equiv-left-add-ℤ
 ```
 
 ### Addition by an integer is a binary embedding
 
 ```agda
-is-emb-add-ℤ :
+is-emb-left-add-ℤ :
   (x : ℤ) → is-emb (x +ℤ_)
-is-emb-add-ℤ x =
-  is-emb-is-equiv (is-equiv-add-ℤ x)
+is-emb-left-add-ℤ x =
+  is-emb-is-equiv (is-equiv-left-add-ℤ x)
 
-is-emb-add-ℤ' :
+is-emb-right-add-ℤ :
   (y : ℤ) → is-emb (_+ℤ y)
-is-emb-add-ℤ' y = is-emb-is-equiv (is-equiv-add-ℤ' y)
+is-emb-right-add-ℤ y = is-emb-is-equiv (is-equiv-right-add-ℤ y)
 
 is-binary-emb-add-ℤ : is-binary-emb add-ℤ
 is-binary-emb-add-ℤ =
-  is-binary-emb-is-binary-equiv is-binary-equiv-add-ℤ
+  is-binary-emb-is-binary-equiv is-binary-equiv-left-add-ℤ
 ```
 
 ### Addition by x is injective
 
 ```agda
-is-injective-add-ℤ' : (x : ℤ) → is-injective (_+ℤ x)
-is-injective-add-ℤ' x = is-injective-is-emb (is-emb-add-ℤ' x)
+is-injective-right-add-ℤ : (x : ℤ) → is-injective (_+ℤ x)
+is-injective-right-add-ℤ x = is-injective-is-emb (is-emb-right-add-ℤ x)
 
 is-injective-add-ℤ : (x : ℤ) → is-injective (x +ℤ_)
-is-injective-add-ℤ x = is-injective-is-emb (is-emb-add-ℤ x)
+is-injective-add-ℤ x = is-injective-is-emb (is-emb-left-add-ℤ x)
 ```
 
 ### Negative laws for addition
@@ -557,9 +557,9 @@ add-int-ℕ x (succ-ℕ y) =
 ### If `x + y = y` then `x = 0`
 
 ```agda
-is-zero-add-ℤ :
+is-zero-left-add-ℤ :
   (x y : ℤ) → x +ℤ y ＝ y → is-zero-ℤ x
-is-zero-add-ℤ x y H =
+is-zero-left-add-ℤ x y H =
   equational-reasoning
     x
     ＝ x +ℤ zero-ℤ
@@ -573,10 +573,10 @@ is-zero-add-ℤ x y H =
     ＝ zero-ℤ
       by right-inverse-law-add-ℤ y
 
-is-zero-add-ℤ' :
+is-zero-right-add-ℤ :
   (x y : ℤ) → x +ℤ y ＝ x → is-zero-ℤ y
-is-zero-add-ℤ' x y H =
-  is-zero-add-ℤ y x (commutative-add-ℤ y x ∙ H)
+is-zero-right-add-ℤ x y H =
+  is-zero-left-add-ℤ y x (commutative-add-ℤ y x ∙ H)
 ```
 
 ### Adding negatives results in a negative

--- a/src/elementary-number-theory/addition-integers.lagda.md
+++ b/src/elementary-number-theory/addition-integers.lagda.md
@@ -357,7 +357,7 @@ isretr-add-neg-ℤ x y =
       by ap (_+ℤ y) (left-inverse-law-add-ℤ x)
 
 abstract
-  is-equiv-add-ℤ : (x : ℤ) → is-equiv (add-ℤ x)
+  is-equiv-add-ℤ : (x : ℤ) → is-equiv (x +ℤ_)
   pr1 (pr1 (is-equiv-add-ℤ x)) = add-ℤ (neg-ℤ x)
   pr2 (pr1 (is-equiv-add-ℤ x)) = issec-add-neg-ℤ x
   pr1 (pr2 (is-equiv-add-ℤ x)) = add-ℤ (neg-ℤ x)
@@ -375,7 +375,7 @@ issec-add-neg-ℤ' x y =
     ＝ y +ℤ (neg-ℤ x +ℤ x)
       by associative-add-ℤ y (neg-ℤ x) x
     ＝ y +ℤ zero-ℤ
-      by ap (add-ℤ y) (left-inverse-law-add-ℤ x)
+      by ap (y +ℤ_) (left-inverse-law-add-ℤ x)
     ＝ y
       by right-unit-law-add-ℤ y
 
@@ -387,7 +387,7 @@ isretr-add-neg-ℤ' x y =
     ＝ y +ℤ (x +ℤ neg-ℤ x)
       by associative-add-ℤ y x (neg-ℤ x)
     ＝ y +ℤ zero-ℤ
-      by ap (add-ℤ y) (right-inverse-law-add-ℤ x)
+      by ap (y +ℤ_) (right-inverse-law-add-ℤ x)
     ＝ y
       by right-unit-law-add-ℤ y
 
@@ -411,7 +411,7 @@ pr2 is-binary-equiv-add-ℤ = is-equiv-add-ℤ
 
 ```agda
 is-emb-add-ℤ :
-  (x : ℤ) → is-emb (add-ℤ x)
+  (x : ℤ) → is-emb (x +ℤ_)
 is-emb-add-ℤ x =
   is-emb-is-equiv (is-equiv-add-ℤ x)
 
@@ -430,7 +430,7 @@ is-binary-emb-add-ℤ =
 is-injective-add-ℤ' : (x : ℤ) → is-injective (_+ℤ x)
 is-injective-add-ℤ' x = is-injective-is-emb (is-emb-add-ℤ' x)
 
-is-injective-add-ℤ : (x : ℤ) → is-injective (add-ℤ x)
+is-injective-add-ℤ : (x : ℤ) → is-injective (x +ℤ_)
 is-injective-add-ℤ x = is-injective-is-emb (is-emb-add-ℤ x)
 ```
 
@@ -545,7 +545,7 @@ add-int-ℕ x (succ-ℕ y) =
   equational-reasoning
     int-ℕ x +ℤ int-ℕ (succ-ℕ y)
     ＝ int-ℕ x +ℤ succ-ℤ (int-ℕ y)
-      by ap (add-ℤ (int-ℕ x)) (inv (succ-int-ℕ y))
+      by ap ((int-ℕ x) +ℤ_) (inv (succ-int-ℕ y))
     ＝ succ-ℤ (int-ℕ x +ℤ int-ℕ y)
       by right-successor-law-add-ℤ (int-ℕ x) (int-ℕ y)
     ＝ succ-ℤ (int-ℕ (x +ℕ y))
@@ -565,7 +565,7 @@ is-zero-add-ℤ x y H =
     ＝ x +ℤ zero-ℤ
       by inv (right-unit-law-add-ℤ x)
     ＝ x +ℤ (y +ℤ neg-ℤ y)
-      by inv (ap (add-ℤ x) (right-inverse-law-add-ℤ y))
+      by inv (ap (x +ℤ_) (right-inverse-law-add-ℤ y))
     ＝ (x +ℤ y) +ℤ neg-ℤ y
       by inv (associative-add-ℤ x y (neg-ℤ y))
     ＝ y +ℤ neg-ℤ y

--- a/src/elementary-number-theory/addition-integers.lagda.md
+++ b/src/elementary-number-theory/addition-integers.lagda.md
@@ -266,7 +266,7 @@ abstract
       add-ℤ (inl (succ-ℕ x)) y
       ＝ pred-ℤ (y +ℤ (inl x))
         by ap pred-ℤ (commutative-add-ℤ (inl x) y)
-      ＝ add-ℤ y (inl (succ-ℕ x))
+      ＝ y +ℤ (inl (succ-ℕ x))
         by inv (right-predecessor-law-add-ℤ y (inl x))
   commutative-add-ℤ (inr (inl star)) y =
     inv (right-unit-law-add-ℤ y)
@@ -280,9 +280,9 @@ abstract
   commutative-add-ℤ (inr (inr (succ-ℕ x))) y =
     equational-reasoning
       succ-ℤ (add-ℤ (inr (inr x)) y)
-      ＝ succ-ℤ (add-ℤ y (inr (inr x)))
+      ＝ succ-ℤ (y +ℤ (inr (inr x)))
         by ap succ-ℤ (commutative-add-ℤ (inr (inr x)) y)
-      ＝ add-ℤ y (succ-ℤ (inr (inr x)))
+      ＝ y +ℤ (succ-ℤ (inr (inr x)))
         by inv (right-successor-law-add-ℤ y (inr (inr x)))
 ```
 

--- a/src/elementary-number-theory/addition-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/addition-natural-numbers.lagda.md
@@ -133,7 +133,7 @@ is-injective-add-ℕ' : (k : ℕ) → is-injective (_+ℕ k)
 is-injective-add-ℕ' zero-ℕ = id
 is-injective-add-ℕ' (succ-ℕ k) p = is-injective-add-ℕ' k (is-injective-succ-ℕ p)
 
-is-injective-add-ℕ : (k : ℕ) → is-injective (add-ℕ k)
+is-injective-add-ℕ : (k : ℕ) → is-injective (k +ℕ_)
 is-injective-add-ℕ k {x} {y} p =
   is-injective-add-ℕ' k (commutative-add-ℕ x k ∙ (p ∙ commutative-add-ℕ k y))
 ```
@@ -141,7 +141,7 @@ is-injective-add-ℕ k {x} {y} p =
 ### Addition by a fixed element on either side is an embedding
 
 ```agda
-is-emb-add-ℕ : (x : ℕ) → is-emb (add-ℕ x)
+is-emb-add-ℕ : (x : ℕ) → is-emb (x +ℕ_)
 is-emb-add-ℕ x = is-emb-is-injective is-set-ℕ (is-injective-add-ℕ x)
 
 is-emb-add-ℕ' : (x : ℕ) → is-emb (_+ℕ x)

--- a/src/elementary-number-theory/addition-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/addition-natural-numbers.lagda.md
@@ -32,12 +32,11 @@ add-ℕ x (succ-ℕ y) = succ-ℕ (add-ℕ x y)
 add-ℕ' : ℕ → ℕ → ℕ
 add-ℕ' m n = add-ℕ n m
 
+infix 30 _+ℕ_
 _+ℕ_ = add-ℕ
 
-infix 30 _+ℕ_
-
 ap-add-ℕ :
-  {m n m' n' : ℕ} → m ＝ m' → n ＝ n' → add-ℕ m n ＝ add-ℕ m' n'
+  {m n m' n' : ℕ} → m ＝ m' → n ＝ n' → m +ℕ n ＝ m' +ℕ n'
 ap-add-ℕ p q = ap-binary add-ℕ p q
 ```
 
@@ -47,11 +46,11 @@ ap-add-ℕ p q = ap-binary add-ℕ p q
 
 ```agda
 right-unit-law-add-ℕ :
-  (x : ℕ) → add-ℕ x zero-ℕ ＝ x
+  (x : ℕ) → x +ℕ zero-ℕ ＝ x
 right-unit-law-add-ℕ x = refl
 
 left-unit-law-add-ℕ :
-  (x : ℕ) → add-ℕ zero-ℕ x ＝ x
+  (x : ℕ) → zero-ℕ +ℕ x ＝ x
 left-unit-law-add-ℕ zero-ℕ = refl
 left-unit-law-add-ℕ (succ-ℕ x) = ap succ-ℕ (left-unit-law-add-ℕ x)
 ```
@@ -60,13 +59,13 @@ left-unit-law-add-ℕ (succ-ℕ x) = ap succ-ℕ (left-unit-law-add-ℕ x)
 
 ```agda
 left-successor-law-add-ℕ :
-  (x y : ℕ) → add-ℕ (succ-ℕ x) y ＝ succ-ℕ (add-ℕ x y)
+  (x y : ℕ) → (succ-ℕ x) +ℕ y ＝ succ-ℕ (x +ℕ y)
 left-successor-law-add-ℕ x zero-ℕ = refl
 left-successor-law-add-ℕ x (succ-ℕ y) =
   ap succ-ℕ (left-successor-law-add-ℕ x y)
 
 right-successor-law-add-ℕ :
-  (x y : ℕ) → add-ℕ x (succ-ℕ y) ＝ succ-ℕ (add-ℕ x y)
+  (x y : ℕ) → x +ℕ (succ-ℕ y) ＝ succ-ℕ (x +ℕ y)
 right-successor-law-add-ℕ x y = refl
 ```
 
@@ -74,7 +73,7 @@ right-successor-law-add-ℕ x y = refl
 
 ```agda
 associative-add-ℕ :
-  (x y z : ℕ) → add-ℕ (add-ℕ x y) z ＝ add-ℕ x (add-ℕ y z)
+  (x y z : ℕ) → (x +ℕ y) +ℕ z ＝ x +ℕ (y +ℕ z)
 associative-add-ℕ x y zero-ℕ = refl
 associative-add-ℕ x y (succ-ℕ z) = ap succ-ℕ (associative-add-ℕ x y z)
 ```
@@ -82,7 +81,7 @@ associative-add-ℕ x y (succ-ℕ z) = ap succ-ℕ (associative-add-ℕ x y z)
 ### Addition is commutative
 
 ```agda
-commutative-add-ℕ : (x y : ℕ) → add-ℕ x y ＝ add-ℕ y x
+commutative-add-ℕ : (x y : ℕ) → x +ℕ y ＝ y +ℕ x
 commutative-add-ℕ zero-ℕ y = left-unit-law-add-ℕ y
 commutative-add-ℕ (succ-ℕ x) y =
   (left-successor-law-add-ℕ x y) ∙ (ap succ-ℕ (commutative-add-ℕ x y))
@@ -92,13 +91,13 @@ commutative-add-ℕ (succ-ℕ x) y =
 
 ```agda
 left-one-law-add-ℕ :
-  (x : ℕ) → add-ℕ 1 x ＝ succ-ℕ x
+  (x : ℕ) → 1 +ℕ x ＝ succ-ℕ x
 left-one-law-add-ℕ x =
   ( left-successor-law-add-ℕ zero-ℕ x) ∙
   ( ap succ-ℕ (left-unit-law-add-ℕ x))
 
 right-one-law-add-ℕ :
-  (x : ℕ) → add-ℕ x 1 ＝ succ-ℕ x
+  (x : ℕ) → x +ℕ 1 ＝ succ-ℕ x
 right-one-law-add-ℕ x = refl
 ```
 
@@ -106,13 +105,13 @@ right-one-law-add-ℕ x = refl
 
 ```agda
 left-two-law-add-ℕ :
-  (x : ℕ) → add-ℕ 2 x ＝ succ-ℕ (succ-ℕ x)
+  (x : ℕ) → 2 +ℕ x ＝ succ-ℕ (succ-ℕ x)
 left-two-law-add-ℕ x =
   ( left-successor-law-add-ℕ 1 x) ∙
   ( ap succ-ℕ (left-one-law-add-ℕ x))
 
 right-two-law-add-ℕ :
-  (x : ℕ) → add-ℕ x 2 ＝ succ-ℕ (succ-ℕ x)
+  (x : ℕ) → x +ℕ 2 ＝ succ-ℕ (succ-ℕ x)
 right-two-law-add-ℕ x = refl
 ```
 
@@ -153,23 +152,23 @@ is-emb-add-ℕ' x = is-emb-is-injective is-set-ℕ (is-injective-add-ℕ' x)
 
 ```agda
 is-zero-right-is-zero-add-ℕ :
-  (x y : ℕ) → is-zero-ℕ (add-ℕ x y) → is-zero-ℕ y
+  (x y : ℕ) → is-zero-ℕ (x +ℕ y) → is-zero-ℕ y
 is-zero-right-is-zero-add-ℕ x zero-ℕ p = refl
 is-zero-right-is-zero-add-ℕ x (succ-ℕ y) p =
-  ex-falso (is-nonzero-succ-ℕ (add-ℕ x y) p)
+  ex-falso (is-nonzero-succ-ℕ (x +ℕ y) p)
 
 is-zero-left-is-zero-add-ℕ :
-  (x y : ℕ) → is-zero-ℕ (add-ℕ x y) → is-zero-ℕ x
+  (x y : ℕ) → is-zero-ℕ (x +ℕ y) → is-zero-ℕ x
 is-zero-left-is-zero-add-ℕ x y p =
   is-zero-right-is-zero-add-ℕ y x ((commutative-add-ℕ y x) ∙ p)
 
 is-zero-summand-is-zero-sum-ℕ :
-  (x y : ℕ) → is-zero-ℕ (add-ℕ x y) → (is-zero-ℕ x) × (is-zero-ℕ y)
+  (x y : ℕ) → is-zero-ℕ (x +ℕ y) → (is-zero-ℕ x) × (is-zero-ℕ y)
 is-zero-summand-is-zero-sum-ℕ x y p =
   pair (is-zero-left-is-zero-add-ℕ x y p) (is-zero-right-is-zero-add-ℕ x y p)
 
 is-zero-sum-is-zero-summand-ℕ :
-  (x y : ℕ) → (is-zero-ℕ x) × (is-zero-ℕ y) → is-zero-ℕ (add-ℕ x y)
+  (x y : ℕ) → (is-zero-ℕ x) × (is-zero-ℕ y) → is-zero-ℕ (x +ℕ y)
 is-zero-sum-is-zero-summand-ℕ .zero-ℕ .zero-ℕ (pair refl refl) = refl
 ```
 
@@ -177,7 +176,7 @@ is-zero-sum-is-zero-summand-ℕ .zero-ℕ .zero-ℕ (pair refl refl) = refl
 
 ```agda
 neq-add-ℕ :
-  (m n : ℕ) → ¬ (m ＝ add-ℕ m (succ-ℕ n))
+  (m n : ℕ) → ¬ (m ＝ m +ℕ (succ-ℕ n))
 neq-add-ℕ (succ-ℕ m) n p =
   neq-add-ℕ m n
     ( ( is-injective-succ-ℕ p) ∙

--- a/src/elementary-number-theory/addition-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/addition-natural-numbers.lagda.md
@@ -129,7 +129,7 @@ interchange-law-add-add-ℕ =
 ### Addition by a fixed element on either side is injective
 
 ```agda
-is-injective-add-ℕ' : (k : ℕ) → is-injective (add-ℕ' k)
+is-injective-add-ℕ' : (k : ℕ) → is-injective (_+ℕ k)
 is-injective-add-ℕ' zero-ℕ = id
 is-injective-add-ℕ' (succ-ℕ k) p = is-injective-add-ℕ' k (is-injective-succ-ℕ p)
 
@@ -144,7 +144,7 @@ is-injective-add-ℕ k {x} {y} p =
 is-emb-add-ℕ : (x : ℕ) → is-emb (add-ℕ x)
 is-emb-add-ℕ x = is-emb-is-injective is-set-ℕ (is-injective-add-ℕ x)
 
-is-emb-add-ℕ' : (x : ℕ) → is-emb (add-ℕ' x)
+is-emb-add-ℕ' : (x : ℕ) → is-emb (_+ℕ x)
 is-emb-add-ℕ' x = is-emb-is-injective is-set-ℕ (is-injective-add-ℕ' x)
 ```
 

--- a/src/elementary-number-theory/addition-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/addition-natural-numbers.lagda.md
@@ -129,23 +129,26 @@ interchange-law-add-add-ℕ =
 ### Addition by a fixed element on either side is injective
 
 ```agda
-is-injective-add-ℕ' : (k : ℕ) → is-injective (_+ℕ k)
-is-injective-add-ℕ' zero-ℕ = id
-is-injective-add-ℕ' (succ-ℕ k) p = is-injective-add-ℕ' k (is-injective-succ-ℕ p)
+is-injective-right-add-ℕ : (k : ℕ) → is-injective (_+ℕ k)
+is-injective-right-add-ℕ zero-ℕ = id
+is-injective-right-add-ℕ (succ-ℕ k) p =
+  is-injective-right-add-ℕ k (is-injective-succ-ℕ p)
 
-is-injective-add-ℕ : (k : ℕ) → is-injective (k +ℕ_)
-is-injective-add-ℕ k {x} {y} p =
-  is-injective-add-ℕ' k (commutative-add-ℕ x k ∙ (p ∙ commutative-add-ℕ k y))
+is-injective-left-add-ℕ : (k : ℕ) → is-injective (k +ℕ_)
+is-injective-left-add-ℕ k {x} {y} p =
+  is-injective-right-add-ℕ
+    ( k)
+    ( commutative-add-ℕ x k ∙ (p ∙ commutative-add-ℕ k y))
 ```
 
 ### Addition by a fixed element on either side is an embedding
 
 ```agda
-is-emb-add-ℕ : (x : ℕ) → is-emb (x +ℕ_)
-is-emb-add-ℕ x = is-emb-is-injective is-set-ℕ (is-injective-add-ℕ x)
+is-emb-left-add-ℕ : (x : ℕ) → is-emb (x +ℕ_)
+is-emb-left-add-ℕ x = is-emb-is-injective is-set-ℕ (is-injective-left-add-ℕ x)
 
-is-emb-add-ℕ' : (x : ℕ) → is-emb (_+ℕ x)
-is-emb-add-ℕ' x = is-emb-is-injective is-set-ℕ (is-injective-add-ℕ' x)
+is-emb-right-add-ℕ : (x : ℕ) → is-emb (_+ℕ x)
+is-emb-right-add-ℕ x = is-emb-is-injective is-set-ℕ (is-injective-right-add-ℕ x)
 ```
 
 ### `x + y ＝ 0` if and only if both `x` and `y` are `0`

--- a/src/elementary-number-theory/addition-rationals.lagda.md
+++ b/src/elementary-number-theory/addition-rationals.lagda.md
@@ -39,7 +39,7 @@ infix 30 _+ℚ_
 _+ℚ_ = add-ℚ
 
 ap-add-ℚ :
-  {x y x' y' : ℚ} → x ＝ x' → y ＝ y' → add-ℚ x y ＝ add-ℚ x' y'
+  {x y x' y' : ℚ} → x ＝ x' → y ＝ y' → x +ℚ y ＝ x' +ℚ y'
 ap-add-ℚ p q = ap-binary add-ℚ p q
 ```
 

--- a/src/elementary-number-theory/bezouts-lemma-integers.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma-integers.lagda.md
@@ -245,7 +245,7 @@ bezouts-lemma-pos-ints x y H K =
           by ap int-ℕ (bezouts-lemma-refactor-hypotheses x y H K)
         ＝ diff-ℤ (mul-ℤ s x) (mul-ℤ t y)
           by int-abs-is-nonnegative-ℤ (diff-ℤ (mul-ℤ s x) (mul-ℤ t y)) pos
-        ＝ add-ℤ (mul-ℤ s x) (mul-ℤ (neg-ℤ t) y)
+        ＝ (mul-ℤ s x) +ℤ (mul-ℤ (neg-ℤ t) y)
           by ap (λ M → (mul-ℤ s x) +ℤ M) (inv (left-negative-law-mul-ℤ t y)))
 
   pr1 (sx-ty-nonneg-case-split (inr neg)) = neg-ℤ s
@@ -266,7 +266,7 @@ bezouts-lemma-pos-ints x y H K =
           ＝ add-ℤ (neg-ℤ (mul-ℤ s x)) (neg-ℤ (neg-ℤ (mul-ℤ t y)))
             by distributive-neg-add-ℤ (mul-ℤ s x) (neg-ℤ (mul-ℤ t y))
           ＝ add-ℤ (mul-ℤ (neg-ℤ s) x) (neg-ℤ (neg-ℤ (mul-ℤ t y)))
-            by ap (λ M → add-ℤ M (neg-ℤ (neg-ℤ (mul-ℤ t y))))
+            by ap (λ M → M +ℤ (neg-ℤ (neg-ℤ (mul-ℤ t y))))
               (inv (left-negative-law-mul-ℤ s x))
           ＝ add-ℤ (mul-ℤ (neg-ℤ s) x) (mul-ℤ t y)
             by ap (λ M → add-ℤ (mul-ℤ (neg-ℤ s) x) M) (neg-neg-ℤ (mul-ℤ t y)))
@@ -298,7 +298,7 @@ bezouts-lemma-ℤ (inl x) (inl y) = pair (neg-ℤ s) (pair (neg-ℤ t) eqn)
       ＝ add-ℤ (mul-ℤ s (inr (inr x))) (mul-ℤ (neg-ℤ t) (neg-ℤ (inr (inr y))))
         by
           ( ap
-            ( λ M → add-ℤ M (mul-ℤ (neg-ℤ t) (neg-ℤ (inr (inr y)))))
+            ( λ M → M +ℤ (mul-ℤ (neg-ℤ t) (neg-ℤ (inr (inr y)))))
             ( double-negative-law-mul-ℤ s (inr (inr x))))
       ＝ add-ℤ (mul-ℤ s (inr (inr x))) (mul-ℤ t (inr (inr y)))
         by
@@ -322,7 +322,7 @@ bezouts-lemma-ℤ (inl x) (inr (inl star)) = pair neg-one-ℤ (pair one-ℤ eqn)
       ＝ add-ℤ (inr (inr x)) (mul-ℤ one-ℤ (inr (inl star)))
         by
           ap
-            ( λ M → add-ℤ M (mul-ℤ one-ℤ (inr (inl star))))
+            ( λ M → M +ℤ (mul-ℤ one-ℤ (inr (inl star))))
             ( inv (is-mul-neg-one-neg-ℤ (inl x)))
       ＝ add-ℤ (inr (inr x)) zero-ℤ
         by ap (add-ℤ (inr (inr x))) (right-zero-law-mul-ℤ one-ℤ)
@@ -351,7 +351,7 @@ bezouts-lemma-ℤ (inl x) (inr (inr y)) = pair (neg-ℤ s) (pair t eqn)
     equational-reasoning
       add-ℤ (mul-ℤ (neg-ℤ s) (neg-ℤ (inr (inr x)))) (mul-ℤ t (inr (inr y)))
       ＝ add-ℤ (mul-ℤ s (inr (inr x))) (mul-ℤ t (inr (inr y)))
-        by ap (λ M → add-ℤ M (mul-ℤ t (inr (inr y))))
+        by ap (λ M → M +ℤ (mul-ℤ t (inr (inr y))))
           (double-negative-law-mul-ℤ s (inr (inr x)))
       ＝ gcd-ℤ (inr (inr x)) (inr (inr y))
         by pr2 (pr2 (pos-bezout))
@@ -370,8 +370,8 @@ bezouts-lemma-ℤ (inr (inl star)) (inl y) = pair one-ℤ (pair neg-one-ℤ eqn)
           ap
             ( add-ℤ (mul-ℤ one-ℤ (inr (inl star))))
             ( inv (is-mul-neg-one-neg-ℤ (inl y)))
-      ＝ add-ℤ zero-ℤ (inr (inr y))
-        by ap (λ M → add-ℤ M (inr (inr y))) (right-zero-law-mul-ℤ one-ℤ)
+      ＝ zero-ℤ +ℤ (inr (inr y))
+        by ap (λ M → M +ℤ (inr (inr y))) (right-zero-law-mul-ℤ one-ℤ)
       ＝ int-ℕ (abs-ℤ (inl y))
         by left-unit-law-add-ℤ (inr (inr y))
       ＝ gcd-ℤ zero-ℤ (inl y)
@@ -384,10 +384,10 @@ bezouts-lemma-ℤ (inr (inl star)) (inr (inl star)) = pair one-ℤ (pair one-ℤ
   eqn =
     equational-reasoning
       add-ℤ (mul-ℤ one-ℤ (inr (inl star))) (mul-ℤ one-ℤ (inr (inl star)))
-      ＝ add-ℤ zero-ℤ (mul-ℤ one-ℤ (inr (inl star)))
+      ＝ zero-ℤ +ℤ (mul-ℤ one-ℤ (inr (inl star)))
         by
           ap
-            ( λ M → add-ℤ M (mul-ℤ one-ℤ (inr (inl star))))
+            ( λ M → M +ℤ (mul-ℤ one-ℤ (inr (inl star))))
             ( right-zero-law-mul-ℤ one-ℤ)
       ＝ zero-ℤ +ℤ zero-ℤ
         by ap (λ M → zero-ℤ +ℤ M) (right-zero-law-mul-ℤ one-ℤ)
@@ -405,8 +405,8 @@ bezouts-lemma-ℤ (inr (inl star)) (inr (inr y)) = pair one-ℤ (pair one-ℤ eq
         by ap
           ( add-ℤ (mul-ℤ one-ℤ (inr (inl star))))
           ( inv (left-unit-law-mul-ℤ (inr (inr y))))
-      ＝ add-ℤ zero-ℤ (inr (inr y))
-        by ap (λ M → add-ℤ M (inr (inr y))) (right-zero-law-mul-ℤ one-ℤ)
+      ＝ zero-ℤ +ℤ (inr (inr y))
+        by ap (λ M → M +ℤ (inr (inr y))) (right-zero-law-mul-ℤ one-ℤ)
       ＝ int-ℕ (abs-ℤ (inr (inr y)))
         by left-unit-law-add-ℤ (inr (inr y))
       ＝ gcd-ℤ zero-ℤ (inr (inr y))
@@ -454,7 +454,7 @@ bezouts-lemma-ℤ (inr (inr x)) (inr (inl star)) = pair one-ℤ (pair one-ℤ eq
       ＝ add-ℤ (inr (inr x)) (mul-ℤ one-ℤ (inr (inl star)))
         by
           ap
-            ( λ M → add-ℤ M (mul-ℤ one-ℤ (inr (inl star))))
+            ( λ M → M +ℤ (mul-ℤ one-ℤ (inr (inl star))))
             ( left-unit-law-mul-ℤ (inr (inr x)))
       ＝ add-ℤ (inr (inr x)) zero-ℤ
         by ap (λ M → add-ℤ (inr (inr x)) M) (right-zero-law-mul-ℤ one-ℤ)
@@ -501,7 +501,7 @@ div-right-factor-coprime-ℤ x y z H K = pair ((mul-ℤ s z) +ℤ (mul-ℤ t k))
       ＝ add-ℤ (mul-ℤ (mul-ℤ s z) x) (mul-ℤ (mul-ℤ t k) x)
         by right-distributive-mul-add-ℤ (mul-ℤ s z) (mul-ℤ t k) x
       ＝ add-ℤ (mul-ℤ (mul-ℤ s x) z) (mul-ℤ (mul-ℤ t k) x)
-        by ap (λ M → add-ℤ M (mul-ℤ (mul-ℤ t k) x))
+        by ap (λ M → M +ℤ (mul-ℤ (mul-ℤ t k) x))
         ( equational-reasoning
             mul-ℤ (mul-ℤ s z) x
             ＝ mul-ℤ s (mul-ℤ z x)

--- a/src/elementary-number-theory/bezouts-lemma-integers.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma-integers.lagda.md
@@ -310,7 +310,7 @@ bezouts-lemma-ℤ (inl x) (inr (inl star)) = pair neg-one-ℤ (pair one-ℤ eqn)
         by
           ap
             ( _+ℤ (one-ℤ *ℤ (inr (inl star))))
-            ( inv (is-mul-neg-one-neg-ℤ (inl x)))
+            ( inv (is-left-mul-neg-one-neg-ℤ (inl x)))
       ＝ (inr (inr x)) +ℤ zero-ℤ
         by ap ((inr (inr x)) +ℤ_) (right-zero-law-mul-ℤ one-ℤ)
       ＝ int-ℕ (abs-ℤ (inl x))
@@ -356,7 +356,7 @@ bezouts-lemma-ℤ (inr (inl star)) (inl y) = pair one-ℤ (pair neg-one-ℤ eqn)
         by
           ap
             ( (one-ℤ *ℤ (inr (inl star))) +ℤ_)
-            ( inv (is-mul-neg-one-neg-ℤ (inl y)))
+            ( inv (is-left-mul-neg-one-neg-ℤ (inl y)))
       ＝ zero-ℤ +ℤ (inr (inr y))
         by ap (_+ℤ (inr (inr y))) (right-zero-law-mul-ℤ one-ℤ)
       ＝ int-ℕ (abs-ℤ (inl y))

--- a/src/elementary-number-theory/bezouts-lemma-integers.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma-integers.lagda.md
@@ -175,12 +175,8 @@ bezouts-lemma-refactor-hypotheses x y H K =
             ( y)))
       by bezouts-lemma-eqn-to-int x y P
     ＝ dist-ℤ
-        ( mul-ℤ
-          ( int-ℕ (minimal-positive-distance-x-coeff (abs-ℤ x) (abs-ℤ y) P))
-          ( x))
-        ( mul-ℤ
-          (int-ℕ (minimal-positive-distance-y-coeff (abs-ℤ x) (abs-ℤ y) P))
-          ( y))
+        ( int-ℕ (minimal-positive-distance-x-coeff (abs-ℤ x) (abs-ℤ y) P) *ℤ x)
+        ( int-ℕ (minimal-positive-distance-y-coeff (abs-ℤ x) (abs-ℤ y) P) *ℤ y)
       by
         dist-abs-ℤ
           ( mul-ℤ
@@ -195,18 +191,14 @@ bezouts-lemma-refactor-hypotheses x y H K =
   P = (refactor-pos-cond x y H K)
   x-prod-nonneg :
     is-nonnegative-ℤ
-      ( mul-ℤ
-        ( int-ℕ (minimal-positive-distance-x-coeff (abs-ℤ x) (abs-ℤ y) P))
-        ( x))
+      ( int-ℕ (minimal-positive-distance-x-coeff (abs-ℤ x) (abs-ℤ y) P) *ℤ x)
   x-prod-nonneg = is-nonnegative-mul-ℤ
     (is-nonnegative-int-ℕ
       ( minimal-positive-distance-x-coeff (abs-ℤ x) (abs-ℤ y) P))
     (is-nonnegative-is-positive-ℤ H)
   y-prod-nonneg :
     is-nonnegative-ℤ
-      ( mul-ℤ
-        ( int-ℕ (minimal-positive-distance-y-coeff (abs-ℤ x) (abs-ℤ y) P))
-        ( y))
+      ( int-ℕ (minimal-positive-distance-y-coeff (abs-ℤ x) (abs-ℤ y) P) *ℤ y)
   y-prod-nonneg =
     is-nonnegative-mul-ℤ
       ( is-nonnegative-int-ℕ
@@ -288,9 +280,8 @@ bezouts-lemma-ℤ (inl x) (inl y) = pair (neg-ℤ s) (pair (neg-ℤ t) eqn)
     gcd-ℤ (inl x) (inl y)
   eqn =
     equational-reasoning
-      add-ℤ
-        ( (neg-ℤ s) *ℤ (neg-ℤ (inr (inr x))))
-        ( (neg-ℤ t) *ℤ (neg-ℤ (inr (inr y))))
+      ( (neg-ℤ s) *ℤ (neg-ℤ (inr (inr x)))) +ℤ
+      ( (neg-ℤ t) *ℤ (neg-ℤ (inr (inr y))))
       ＝ (s *ℤ (inr (inr x))) +ℤ ((neg-ℤ t) *ℤ (neg-ℤ (inr (inr y))))
         by
           ( ap
@@ -299,7 +290,7 @@ bezouts-lemma-ℤ (inl x) (inl y) = pair (neg-ℤ s) (pair (neg-ℤ t) eqn)
       ＝ (s *ℤ (inr (inr x))) +ℤ (t *ℤ (inr (inr y)))
         by
           ( ap
-            ( add-ℤ (s *ℤ (inr (inr x))))
+            ( (s *ℤ (inr (inr x))) +ℤ_)
             ( double-negative-law-mul-ℤ t (inr (inr y))))
       ＝ gcd-ℤ (inr (inr x)) (inr (inr y))
         by pr2 (pr2 (pos-bezout))
@@ -321,7 +312,7 @@ bezouts-lemma-ℤ (inl x) (inr (inl star)) = pair neg-one-ℤ (pair one-ℤ eqn)
             ( _+ℤ (one-ℤ *ℤ (inr (inl star))))
             ( inv (is-mul-neg-one-neg-ℤ (inl x)))
       ＝ (inr (inr x)) +ℤ zero-ℤ
-        by ap (add-ℤ (inr (inr x))) (right-zero-law-mul-ℤ one-ℤ)
+        by ap ((inr (inr x)) +ℤ_) (right-zero-law-mul-ℤ one-ℤ)
       ＝ int-ℕ (abs-ℤ (inl x))
         by right-unit-law-add-ℤ (inr (inr x))
       ＝ gcd-ℤ (inl x) zero-ℤ
@@ -364,7 +355,7 @@ bezouts-lemma-ℤ (inr (inl star)) (inl y) = pair one-ℤ (pair neg-one-ℤ eqn)
       ＝ (one-ℤ *ℤ (inr (inl star))) +ℤ (inr (inr y))
         by
           ap
-            ( add-ℤ (one-ℤ *ℤ (inr (inl star))))
+            ( (one-ℤ *ℤ (inr (inl star))) +ℤ_)
             ( inv (is-mul-neg-one-neg-ℤ (inl y)))
       ＝ zero-ℤ +ℤ (inr (inr y))
         by ap (_+ℤ (inr (inr y))) (right-zero-law-mul-ℤ one-ℤ)
@@ -399,7 +390,7 @@ bezouts-lemma-ℤ (inr (inl star)) (inr (inr y)) = pair one-ℤ (pair one-ℤ eq
       (one-ℤ *ℤ (inr (inl star))) +ℤ (one-ℤ *ℤ (inr (inr y)))
       ＝ (one-ℤ *ℤ (inr (inl star))) +ℤ (inr (inr y))
         by ap
-          ( add-ℤ (one-ℤ *ℤ (inr (inl star))))
+          ( (one-ℤ *ℤ (inr (inl star))) +ℤ_)
           ( inv (left-unit-law-mul-ℤ (inr (inr y))))
       ＝ zero-ℤ +ℤ (inr (inr y))
         by ap (_+ℤ (inr (inr y))) (right-zero-law-mul-ℤ one-ℤ)

--- a/src/elementary-number-theory/bezouts-lemma-integers.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma-integers.lagda.md
@@ -349,7 +349,7 @@ bezouts-lemma-ℤ (inl x) (inr (inr y)) = pair (neg-ℤ s) (pair t eqn)
     gcd-ℤ (inl x) (inr (inr y))
   eqn =
     equational-reasoning
-      add-ℤ ((neg-ℤ s) *ℤ (neg-ℤ (inr (inr x)))) (t *ℤ (inr (inr y)))
+      ((neg-ℤ s) *ℤ (neg-ℤ (inr (inr x)))) +ℤ (t *ℤ (inr (inr y)))
       ＝ (s *ℤ (inr (inr x))) +ℤ (t *ℤ (inr (inr y)))
         by ap (_+ℤ (t *ℤ (inr (inr y))))
           (double-negative-law-mul-ℤ s (inr (inr x)))

--- a/src/elementary-number-theory/bezouts-lemma-integers.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma-integers.lagda.md
@@ -66,7 +66,7 @@ bezouts-lemma-eqn-to-int x y H =
         ( ap
           ( λ K →
             dist-ℕ
-              ( mul-ℕ K (abs-ℤ x))
+              ( K *ℕ (abs-ℤ x))
               ( mul-ℕ
                 ( minimal-positive-distance-y-coeff (abs-ℤ x) (abs-ℤ y) H)
                 ( abs-ℤ y)))
@@ -91,7 +91,7 @@ bezouts-lemma-eqn-to-int x y H =
                   ( int-ℕ
                     ( minimal-positive-distance-x-coeff (abs-ℤ x) (abs-ℤ y) H)))
                 ( abs-ℤ x))
-              ( mul-ℕ K (abs-ℤ y)))
+              ( K *ℕ (abs-ℤ y)))
         (inv
           ( abs-int-ℕ
             ( minimal-positive-distance-y-coeff (abs-ℤ x) (abs-ℤ y) H))))
@@ -219,10 +219,10 @@ bezouts-lemma-refactor-hypotheses x y H K =
 
 bezouts-lemma-pos-ints :
   (x y : ℤ) (H : is-positive-ℤ x) (K : is-positive-ℤ y) →
-  Σ ℤ (λ s → Σ ℤ (λ t → (mul-ℤ s x) +ℤ (mul-ℤ t y) ＝ gcd-ℤ x y))
+  Σ ℤ (λ s → Σ ℤ (λ t → (s *ℤ x) +ℤ (t *ℤ y) ＝ gcd-ℤ x y))
 bezouts-lemma-pos-ints x y H K =
   sx-ty-nonneg-case-split
-    ( decide-is-nonnegative-ℤ {diff-ℤ (mul-ℤ s x) (mul-ℤ t y)})
+    ( decide-is-nonnegative-ℤ {diff-ℤ (s *ℤ x) (t *ℤ y)})
   where
   s : ℤ
   s = int-ℕ (minimal-positive-distance-x-coeff
@@ -232,21 +232,21 @@ bezouts-lemma-pos-ints x y H K =
     (abs-ℤ x) (abs-ℤ y) (refactor-pos-cond x y H K))
 
   sx-ty-nonneg-case-split :
-    ( is-nonnegative-ℤ (diff-ℤ (mul-ℤ s x) (mul-ℤ t y)) +
-      is-nonnegative-ℤ (neg-ℤ (diff-ℤ (mul-ℤ s x) (mul-ℤ t y)))) →
-    Σ ℤ (λ s → Σ ℤ (λ t → (mul-ℤ s x) +ℤ (mul-ℤ t y) ＝ gcd-ℤ x y))
+    ( is-nonnegative-ℤ (diff-ℤ (s *ℤ x) (t *ℤ y)) +
+      is-nonnegative-ℤ (neg-ℤ (diff-ℤ (s *ℤ x) (t *ℤ y)))) →
+    Σ ℤ (λ s → Σ ℤ (λ t → (s *ℤ x) +ℤ (t *ℤ y) ＝ gcd-ℤ x y))
   pr1 (sx-ty-nonneg-case-split (inl pos)) = s
   pr1 (pr2 (sx-ty-nonneg-case-split (inl pos))) = neg-ℤ t
   pr2 (pr2 (sx-ty-nonneg-case-split (inl pos))) =
     inv
     ( equational-reasoning
         gcd-ℤ x y
-        ＝ int-ℕ (abs-ℤ (diff-ℤ (mul-ℤ s x) (mul-ℤ t y)))
+        ＝ int-ℕ (abs-ℤ (diff-ℤ (s *ℤ x) (t *ℤ y)))
           by ap int-ℕ (bezouts-lemma-refactor-hypotheses x y H K)
-        ＝ diff-ℤ (mul-ℤ s x) (mul-ℤ t y)
-          by int-abs-is-nonnegative-ℤ (diff-ℤ (mul-ℤ s x) (mul-ℤ t y)) pos
-        ＝ (mul-ℤ s x) +ℤ (mul-ℤ (neg-ℤ t) y)
-          by ap (λ M → (mul-ℤ s x) +ℤ M) (inv (left-negative-law-mul-ℤ t y)))
+        ＝ diff-ℤ (s *ℤ x) (t *ℤ y)
+          by int-abs-is-nonnegative-ℤ (diff-ℤ (s *ℤ x) (t *ℤ y)) pos
+        ＝ (s *ℤ x) +ℤ ((neg-ℤ t) *ℤ y)
+          by ap (λ M → (s *ℤ x) +ℤ M) (inv (left-negative-law-mul-ℤ t y)))
 
   pr1 (sx-ty-nonneg-case-split (inr neg)) = neg-ℤ s
   pr1 (pr2 (sx-ty-nonneg-case-split (inr neg))) = t
@@ -254,25 +254,25 @@ bezouts-lemma-pos-ints x y H K =
     inv
       ( equational-reasoning
           gcd-ℤ x y
-          ＝ int-ℕ (abs-ℤ (diff-ℤ (mul-ℤ s x) (mul-ℤ t y)))
+          ＝ int-ℕ (abs-ℤ (diff-ℤ (s *ℤ x) (t *ℤ y)))
             by ap int-ℕ (bezouts-lemma-refactor-hypotheses x y H K)
-          ＝ int-ℕ (abs-ℤ (neg-ℤ (diff-ℤ (mul-ℤ s x) (mul-ℤ t y))))
-            by ap (int-ℕ) (inv (abs-neg-ℤ (diff-ℤ (mul-ℤ s x) (mul-ℤ t y))))
-          ＝ neg-ℤ (diff-ℤ (mul-ℤ s x) (mul-ℤ t y))
+          ＝ int-ℕ (abs-ℤ (neg-ℤ (diff-ℤ (s *ℤ x) (t *ℤ y))))
+            by ap (int-ℕ) (inv (abs-neg-ℤ (diff-ℤ (s *ℤ x) (t *ℤ y))))
+          ＝ neg-ℤ (diff-ℤ (s *ℤ x) (t *ℤ y))
             by
               int-abs-is-nonnegative-ℤ
-                ( neg-ℤ (diff-ℤ (mul-ℤ s x) (mul-ℤ t y)))
+                ( neg-ℤ (diff-ℤ (s *ℤ x) (t *ℤ y)))
                 ( neg)
-          ＝ add-ℤ (neg-ℤ (mul-ℤ s x)) (neg-ℤ (neg-ℤ (mul-ℤ t y)))
-            by distributive-neg-add-ℤ (mul-ℤ s x) (neg-ℤ (mul-ℤ t y))
-          ＝ add-ℤ (mul-ℤ (neg-ℤ s) x) (neg-ℤ (neg-ℤ (mul-ℤ t y)))
-            by ap (λ M → M +ℤ (neg-ℤ (neg-ℤ (mul-ℤ t y))))
+          ＝ add-ℤ (neg-ℤ (s *ℤ x)) (neg-ℤ (neg-ℤ (t *ℤ y)))
+            by distributive-neg-add-ℤ (s *ℤ x) (neg-ℤ (t *ℤ y))
+          ＝ add-ℤ ((neg-ℤ s) *ℤ x) (neg-ℤ (neg-ℤ (t *ℤ y)))
+            by ap (λ M → M +ℤ (neg-ℤ (neg-ℤ (t *ℤ y))))
               (inv (left-negative-law-mul-ℤ s x))
-          ＝ add-ℤ (mul-ℤ (neg-ℤ s) x) (mul-ℤ t y)
-            by ap (λ M → add-ℤ (mul-ℤ (neg-ℤ s) x) M) (neg-neg-ℤ (mul-ℤ t y)))
+          ＝ add-ℤ ((neg-ℤ s) *ℤ x) (t *ℤ y)
+            by ap (λ M → add-ℤ ((neg-ℤ s) *ℤ x) M) (neg-neg-ℤ (t *ℤ y)))
 
 bezouts-lemma-ℤ :
-  (x y : ℤ) → Σ ℤ (λ s → Σ ℤ (λ t → (mul-ℤ s x) +ℤ (mul-ℤ t y) ＝ gcd-ℤ x y))
+  (x y : ℤ) → Σ ℤ (λ s → Σ ℤ (λ t → (s *ℤ x) +ℤ (t *ℤ y) ＝ gcd-ℤ x y))
 bezouts-lemma-ℤ (inl x) (inl y) = pair (neg-ℤ s) (pair (neg-ℤ t) eqn)
   where
   pos-bezout :
@@ -280,7 +280,7 @@ bezouts-lemma-ℤ (inl x) (inl y) = pair (neg-ℤ s) (pair (neg-ℤ t) eqn)
       ( λ s →
         Σ ( ℤ)
           ( λ t →
-            ( add-ℤ (mul-ℤ s (inr (inr x))) (mul-ℤ t (inr (inr y)))) ＝
+            ( add-ℤ (s *ℤ (inr (inr x))) (t *ℤ (inr (inr y)))) ＝
             ( gcd-ℤ (inr (inr x)) (inr (inr y)))))
   pos-bezout = bezouts-lemma-pos-ints (inr (inr x)) (inr (inr y)) star star
   s : ℤ
@@ -288,22 +288,22 @@ bezouts-lemma-ℤ (inl x) (inl y) = pair (neg-ℤ s) (pair (neg-ℤ t) eqn)
   t : ℤ
   t = pr1 (pr2 (pos-bezout))
   eqn :
-    add-ℤ (mul-ℤ (neg-ℤ s) (inl x)) (mul-ℤ (neg-ℤ t) (inl y)) ＝
+    add-ℤ ((neg-ℤ s) *ℤ (inl x)) ((neg-ℤ t) *ℤ (inl y)) ＝
     gcd-ℤ (inl x) (inl y)
   eqn =
     equational-reasoning
       add-ℤ
-        ( mul-ℤ (neg-ℤ s) (neg-ℤ (inr (inr x))))
-        ( mul-ℤ (neg-ℤ t) (neg-ℤ (inr (inr y))))
-      ＝ add-ℤ (mul-ℤ s (inr (inr x))) (mul-ℤ (neg-ℤ t) (neg-ℤ (inr (inr y))))
+        ( (neg-ℤ s) *ℤ (neg-ℤ (inr (inr x))))
+        ( (neg-ℤ t) *ℤ (neg-ℤ (inr (inr y))))
+      ＝ add-ℤ (s *ℤ (inr (inr x))) ((neg-ℤ t) *ℤ (neg-ℤ (inr (inr y))))
         by
           ( ap
-            ( λ M → M +ℤ (mul-ℤ (neg-ℤ t) (neg-ℤ (inr (inr y)))))
+            ( λ M → M +ℤ ((neg-ℤ t) *ℤ (neg-ℤ (inr (inr y)))))
             ( double-negative-law-mul-ℤ s (inr (inr x))))
-      ＝ add-ℤ (mul-ℤ s (inr (inr x))) (mul-ℤ t (inr (inr y)))
+      ＝ add-ℤ (s *ℤ (inr (inr x))) (t *ℤ (inr (inr y)))
         by
           ( ap
-            ( add-ℤ (mul-ℤ s (inr (inr x))))
+            ( add-ℤ (s *ℤ (inr (inr x))))
             ( double-negative-law-mul-ℤ t (inr (inr y))))
       ＝ gcd-ℤ (inr (inr x)) (inr (inr y))
         by pr2 (pr2 (pos-bezout))
@@ -314,15 +314,15 @@ bezouts-lemma-ℤ (inl x) (inl y) = pair (neg-ℤ s) (pair (neg-ℤ t) eqn)
 bezouts-lemma-ℤ (inl x) (inr (inl star)) = pair neg-one-ℤ (pair one-ℤ eqn)
   where
   eqn :
-    add-ℤ (mul-ℤ neg-one-ℤ (inl x)) (mul-ℤ one-ℤ (inr (inl star))) ＝
+    add-ℤ (neg-one-ℤ *ℤ (inl x)) (one-ℤ *ℤ (inr (inl star))) ＝
     gcd-ℤ (inl x) (inr (inl star))
   eqn =
     equational-reasoning
-      add-ℤ (mul-ℤ neg-one-ℤ (inl x)) (mul-ℤ one-ℤ (inr (inl star)))
-      ＝ add-ℤ (inr (inr x)) (mul-ℤ one-ℤ (inr (inl star)))
+      add-ℤ (neg-one-ℤ *ℤ (inl x)) (one-ℤ *ℤ (inr (inl star)))
+      ＝ add-ℤ (inr (inr x)) (one-ℤ *ℤ (inr (inl star)))
         by
           ap
-            ( λ M → M +ℤ (mul-ℤ one-ℤ (inr (inl star))))
+            ( λ M → M +ℤ (one-ℤ *ℤ (inr (inl star))))
             ( inv (is-mul-neg-one-neg-ℤ (inl x)))
       ＝ add-ℤ (inr (inr x)) zero-ℤ
         by ap (add-ℤ (inr (inr x))) (right-zero-law-mul-ℤ one-ℤ)
@@ -337,7 +337,7 @@ bezouts-lemma-ℤ (inl x) (inr (inr y)) = pair (neg-ℤ s) (pair t eqn)
       ( λ s →
         Σ ( ℤ)
           ( λ t →
-            add-ℤ (mul-ℤ s (inr (inr x))) (mul-ℤ t (inr (inr y))) ＝
+            add-ℤ (s *ℤ (inr (inr x))) (t *ℤ (inr (inr y))) ＝
             gcd-ℤ (inr (inr x)) (inr (inr y))))
   pos-bezout = bezouts-lemma-pos-ints (inr (inr x)) (inr (inr y)) star star
   s : ℤ
@@ -345,13 +345,13 @@ bezouts-lemma-ℤ (inl x) (inr (inr y)) = pair (neg-ℤ s) (pair t eqn)
   t : ℤ
   t = pr1 (pr2 (pos-bezout))
   eqn :
-    add-ℤ (mul-ℤ (neg-ℤ s) (inl x)) (mul-ℤ t (inr (inr y))) ＝
+    add-ℤ ((neg-ℤ s) *ℤ (inl x)) (t *ℤ (inr (inr y))) ＝
     gcd-ℤ (inl x) (inr (inr y))
   eqn =
     equational-reasoning
-      add-ℤ (mul-ℤ (neg-ℤ s) (neg-ℤ (inr (inr x)))) (mul-ℤ t (inr (inr y)))
-      ＝ add-ℤ (mul-ℤ s (inr (inr x))) (mul-ℤ t (inr (inr y)))
-        by ap (λ M → M +ℤ (mul-ℤ t (inr (inr y))))
+      add-ℤ ((neg-ℤ s) *ℤ (neg-ℤ (inr (inr x)))) (t *ℤ (inr (inr y)))
+      ＝ add-ℤ (s *ℤ (inr (inr x))) (t *ℤ (inr (inr y)))
+        by ap (λ M → M +ℤ (t *ℤ (inr (inr y))))
           (double-negative-law-mul-ℤ s (inr (inr x)))
       ＝ gcd-ℤ (inr (inr x)) (inr (inr y))
         by pr2 (pr2 (pos-bezout))
@@ -360,15 +360,15 @@ bezouts-lemma-ℤ (inl x) (inr (inr y)) = pair (neg-ℤ s) (pair t eqn)
 bezouts-lemma-ℤ (inr (inl star)) (inl y) = pair one-ℤ (pair neg-one-ℤ eqn)
   where
   eqn :
-    add-ℤ (mul-ℤ one-ℤ (inr (inl star))) (mul-ℤ neg-one-ℤ (inl y)) ＝
+    add-ℤ (one-ℤ *ℤ (inr (inl star))) (neg-one-ℤ *ℤ (inl y)) ＝
     gcd-ℤ (inr (inl star)) (inl y)
   eqn =
     equational-reasoning
-      add-ℤ (mul-ℤ one-ℤ (inr (inl star))) (mul-ℤ neg-one-ℤ (inl y))
-      ＝ add-ℤ (mul-ℤ one-ℤ (inr (inl star))) (inr (inr y))
+      add-ℤ (one-ℤ *ℤ (inr (inl star))) (neg-one-ℤ *ℤ (inl y))
+      ＝ add-ℤ (one-ℤ *ℤ (inr (inl star))) (inr (inr y))
         by
           ap
-            ( add-ℤ (mul-ℤ one-ℤ (inr (inl star))))
+            ( add-ℤ (one-ℤ *ℤ (inr (inl star))))
             ( inv (is-mul-neg-one-neg-ℤ (inl y)))
       ＝ zero-ℤ +ℤ (inr (inr y))
         by ap (λ M → M +ℤ (inr (inr y))) (right-zero-law-mul-ℤ one-ℤ)
@@ -379,15 +379,15 @@ bezouts-lemma-ℤ (inr (inl star)) (inl y) = pair one-ℤ (pair neg-one-ℤ eqn)
 bezouts-lemma-ℤ (inr (inl star)) (inr (inl star)) = pair one-ℤ (pair one-ℤ eqn)
   where
   eqn :
-    add-ℤ (mul-ℤ one-ℤ (inr (inl star))) (mul-ℤ one-ℤ (inr (inl star))) ＝
+    add-ℤ (one-ℤ *ℤ (inr (inl star))) (one-ℤ *ℤ (inr (inl star))) ＝
     gcd-ℤ zero-ℤ zero-ℤ
   eqn =
     equational-reasoning
-      add-ℤ (mul-ℤ one-ℤ (inr (inl star))) (mul-ℤ one-ℤ (inr (inl star)))
-      ＝ zero-ℤ +ℤ (mul-ℤ one-ℤ (inr (inl star)))
+      add-ℤ (one-ℤ *ℤ (inr (inl star))) (one-ℤ *ℤ (inr (inl star)))
+      ＝ zero-ℤ +ℤ (one-ℤ *ℤ (inr (inl star)))
         by
           ap
-            ( λ M → M +ℤ (mul-ℤ one-ℤ (inr (inl star))))
+            ( λ M → M +ℤ (one-ℤ *ℤ (inr (inl star))))
             ( right-zero-law-mul-ℤ one-ℤ)
       ＝ zero-ℤ +ℤ zero-ℤ
         by ap (λ M → zero-ℤ +ℤ M) (right-zero-law-mul-ℤ one-ℤ)
@@ -396,14 +396,14 @@ bezouts-lemma-ℤ (inr (inl star)) (inr (inl star)) = pair one-ℤ (pair one-ℤ
 bezouts-lemma-ℤ (inr (inl star)) (inr (inr y)) = pair one-ℤ (pair one-ℤ eqn)
   where
   eqn :
-    add-ℤ (mul-ℤ one-ℤ (inr (inl star))) (mul-ℤ one-ℤ (inr (inr y))) ＝
+    add-ℤ (one-ℤ *ℤ (inr (inl star))) (one-ℤ *ℤ (inr (inr y))) ＝
     gcd-ℤ (inr (inl star)) (inr (inr y))
   eqn =
     equational-reasoning
-      add-ℤ (mul-ℤ one-ℤ (inr (inl star))) (mul-ℤ one-ℤ (inr (inr y)))
-      ＝ add-ℤ (mul-ℤ one-ℤ (inr (inl star))) (inr (inr y))
+      add-ℤ (one-ℤ *ℤ (inr (inl star))) (one-ℤ *ℤ (inr (inr y)))
+      ＝ add-ℤ (one-ℤ *ℤ (inr (inl star))) (inr (inr y))
         by ap
-          ( add-ℤ (mul-ℤ one-ℤ (inr (inl star))))
+          ( add-ℤ (one-ℤ *ℤ (inr (inl star))))
           ( inv (left-unit-law-mul-ℤ (inr (inr y))))
       ＝ zero-ℤ +ℤ (inr (inr y))
         by ap (λ M → M +ℤ (inr (inr y))) (right-zero-law-mul-ℤ one-ℤ)
@@ -423,7 +423,7 @@ bezouts-lemma-ℤ (inr (inr x)) (inl y) = pair s (pair (neg-ℤ t) eqn)
       ( λ s →
         Σ ( ℤ)
           ( λ t →
-            add-ℤ (mul-ℤ s (inr (inr x))) (mul-ℤ t (inr (inr y))) ＝
+            add-ℤ (s *ℤ (inr (inr x))) (t *ℤ (inr (inr y))) ＝
             gcd-ℤ (inr (inr x)) (inr (inr y))))
   pos-bezout = bezouts-lemma-pos-ints (inr (inr x)) (inr (inr y)) star star
   s : ℤ
@@ -431,13 +431,13 @@ bezouts-lemma-ℤ (inr (inr x)) (inl y) = pair s (pair (neg-ℤ t) eqn)
   t : ℤ
   t = pr1 (pr2 (pos-bezout))
   eqn :
-    add-ℤ (mul-ℤ s (inr (inr x))) (mul-ℤ (neg-ℤ t) (inl y)) ＝
+    add-ℤ (s *ℤ (inr (inr x))) ((neg-ℤ t) *ℤ (inl y)) ＝
     gcd-ℤ (inr (inr x)) (inl y)
   eqn =
     equational-reasoning
-      add-ℤ (mul-ℤ s (inr (inr x))) (mul-ℤ (neg-ℤ t) (neg-ℤ (inr (inr y))))
-      ＝ add-ℤ (mul-ℤ s (inr (inr x))) (mul-ℤ t (inr (inr y)))
-        by ap (λ M → add-ℤ (mul-ℤ s (inr (inr x))) M)
+      add-ℤ (s *ℤ (inr (inr x))) ((neg-ℤ t) *ℤ (neg-ℤ (inr (inr y))))
+      ＝ add-ℤ (s *ℤ (inr (inr x))) (t *ℤ (inr (inr y)))
+        by ap (λ M → add-ℤ (s *ℤ (inr (inr x))) M)
           (double-negative-law-mul-ℤ t (inr (inr y)))
       ＝ gcd-ℤ (inr (inr x)) (inr (inr y))
         by pr2 (pr2 (pos-bezout))
@@ -446,15 +446,15 @@ bezouts-lemma-ℤ (inr (inr x)) (inl y) = pair s (pair (neg-ℤ t) eqn)
 bezouts-lemma-ℤ (inr (inr x)) (inr (inl star)) = pair one-ℤ (pair one-ℤ eqn)
   where
   eqn :
-    add-ℤ (mul-ℤ one-ℤ (inr (inr x))) (mul-ℤ one-ℤ (inr (inl star))) ＝
+    add-ℤ (one-ℤ *ℤ (inr (inr x))) (one-ℤ *ℤ (inr (inl star))) ＝
     gcd-ℤ (inr (inr x)) (inr (inl star))
   eqn =
     equational-reasoning
-      add-ℤ (mul-ℤ one-ℤ (inr (inr x))) (mul-ℤ one-ℤ (inr (inl star)))
-      ＝ add-ℤ (inr (inr x)) (mul-ℤ one-ℤ (inr (inl star)))
+      add-ℤ (one-ℤ *ℤ (inr (inr x))) (one-ℤ *ℤ (inr (inl star)))
+      ＝ add-ℤ (inr (inr x)) (one-ℤ *ℤ (inr (inl star)))
         by
           ap
-            ( λ M → M +ℤ (mul-ℤ one-ℤ (inr (inl star))))
+            ( λ M → M +ℤ (one-ℤ *ℤ (inr (inl star))))
             ( left-unit-law-mul-ℤ (inr (inr x)))
       ＝ add-ℤ (inr (inr x)) zero-ℤ
         by ap (λ M → add-ℤ (inr (inr x)) M) (right-zero-law-mul-ℤ one-ℤ)
@@ -478,57 +478,57 @@ Bezout.
 
 ```agda
 div-right-factor-coprime-ℤ :
-  (x y z : ℤ) → (div-ℤ x (mul-ℤ y z)) → (gcd-ℤ x y ＝ one-ℤ) → div-ℤ x z
-div-right-factor-coprime-ℤ x y z H K = pair ((mul-ℤ s z) +ℤ (mul-ℤ t k)) eqn
+  (x y z : ℤ) → (div-ℤ x (y *ℤ z)) → (gcd-ℤ x y ＝ one-ℤ) → div-ℤ x z
+div-right-factor-coprime-ℤ x y z H K = pair ((s *ℤ z) +ℤ (t *ℤ k)) eqn
   where
   bezout-triple :
-    Σ ℤ (λ s → Σ ℤ (λ t → (mul-ℤ s x) +ℤ (mul-ℤ t y) ＝ gcd-ℤ x y))
+    Σ ℤ (λ s → Σ ℤ (λ t → (s *ℤ x) +ℤ (t *ℤ y) ＝ gcd-ℤ x y))
   bezout-triple = bezouts-lemma-ℤ x y
   s : ℤ
   s = pr1 bezout-triple
   t : ℤ
   t = pr1 (pr2 bezout-triple)
-  bezout-eqn : (mul-ℤ s x) +ℤ (mul-ℤ t y) ＝ gcd-ℤ x y
+  bezout-eqn : (s *ℤ x) +ℤ (t *ℤ y) ＝ gcd-ℤ x y
   bezout-eqn = pr2 (pr2 bezout-triple)
   k : ℤ
   k = pr1 H
-  div-yz : mul-ℤ k x ＝ mul-ℤ y z
+  div-yz : k *ℤ x ＝ y *ℤ z
   div-yz = pr2 H
-  eqn : mul-ℤ ((mul-ℤ s z) +ℤ (mul-ℤ t k)) x ＝ z
+  eqn : mul-ℤ ((s *ℤ z) +ℤ (t *ℤ k)) x ＝ z
   eqn =
     equational-reasoning
-      mul-ℤ ((mul-ℤ s z) +ℤ (mul-ℤ t k)) x
-      ＝ add-ℤ (mul-ℤ (mul-ℤ s z) x) (mul-ℤ (mul-ℤ t k) x)
-        by right-distributive-mul-add-ℤ (mul-ℤ s z) (mul-ℤ t k) x
-      ＝ add-ℤ (mul-ℤ (mul-ℤ s x) z) (mul-ℤ (mul-ℤ t k) x)
-        by ap (λ M → M +ℤ (mul-ℤ (mul-ℤ t k) x))
+      mul-ℤ ((s *ℤ z) +ℤ (t *ℤ k)) x
+      ＝ add-ℤ ((s *ℤ z) *ℤ x) ((t *ℤ k) *ℤ x)
+        by right-distributive-mul-add-ℤ (s *ℤ z) (t *ℤ k) x
+      ＝ add-ℤ ((s *ℤ x) *ℤ z) ((t *ℤ k) *ℤ x)
+        by ap (λ M → M +ℤ ((t *ℤ k) *ℤ x))
         ( equational-reasoning
-            mul-ℤ (mul-ℤ s z) x
-            ＝ mul-ℤ s (mul-ℤ z x)
+            (s *ℤ z) *ℤ x
+            ＝ s *ℤ (z *ℤ x)
               by associative-mul-ℤ s z x
-            ＝ mul-ℤ s (mul-ℤ x z)
-              by ap (λ P → mul-ℤ s P) (commutative-mul-ℤ z x)
-            ＝ mul-ℤ (mul-ℤ s x) z
+            ＝ s *ℤ (x *ℤ z)
+              by ap (λ P → s *ℤ P) (commutative-mul-ℤ z x)
+            ＝ (s *ℤ x) *ℤ z
               by inv (associative-mul-ℤ s x z))
-      ＝ add-ℤ (mul-ℤ (mul-ℤ s x) z) (mul-ℤ (mul-ℤ t y) z)
-        by ap (λ M → add-ℤ (mul-ℤ (mul-ℤ s x) z) M)
+      ＝ add-ℤ ((s *ℤ x) *ℤ z) ((t *ℤ y) *ℤ z)
+        by ap (λ M → add-ℤ ((s *ℤ x) *ℤ z) M)
     ( equational-reasoning
-        mul-ℤ (mul-ℤ t k) x
-        ＝ mul-ℤ t (mul-ℤ k x)
+        (t *ℤ k) *ℤ x
+        ＝ t *ℤ (k *ℤ x)
           by associative-mul-ℤ t k x
-        ＝ mul-ℤ t (mul-ℤ y z)
-          by ap (λ P → mul-ℤ t P) div-yz
-        ＝ mul-ℤ (mul-ℤ t y) z
+        ＝ t *ℤ (y *ℤ z)
+          by ap (λ P → t *ℤ P) div-yz
+        ＝ (t *ℤ y) *ℤ z
           by inv (associative-mul-ℤ t y z))
-    ＝ mul-ℤ ((mul-ℤ s x) +ℤ (mul-ℤ t y)) z
-      by inv (right-distributive-mul-add-ℤ (mul-ℤ s x) (mul-ℤ t y) z)
-    ＝ mul-ℤ one-ℤ z
-      by ap (λ M → mul-ℤ M z) (bezout-eqn ∙ K)
+    ＝ mul-ℤ ((s *ℤ x) +ℤ (t *ℤ y)) z
+      by inv (right-distributive-mul-add-ℤ (s *ℤ x) (t *ℤ y) z)
+    ＝ one-ℤ *ℤ z
+      by ap (λ M → M *ℤ z) (bezout-eqn ∙ K)
     ＝ z
       by left-unit-law-mul-ℤ z
 
 div-right-factor-coprime-ℕ :
-  (x y z : ℕ) → (div-ℕ x (mul-ℕ y z)) → (gcd-ℕ x y ＝ 1) → div-ℕ x z
+  (x y z : ℕ) → (div-ℕ x (y *ℕ z)) → (gcd-ℕ x y ＝ 1) → div-ℕ x z
 div-right-factor-coprime-ℕ x y z H K =
   div-div-int-ℕ
     ( div-right-factor-coprime-ℤ

--- a/src/elementary-number-theory/bezouts-lemma-integers.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma-integers.lagda.md
@@ -36,7 +36,7 @@ open import foundation.unit-type
 
 ```agda
 bezouts-lemma-eqn-to-int :
-  (x y : ℤ) → (H : is-nonzero-ℕ (add-ℕ (abs-ℤ x) (abs-ℤ y))) →
+  (x y : ℤ) → (H : is-nonzero-ℕ ((abs-ℤ x) +ℕ (abs-ℤ y))) →
   nat-gcd-ℤ x y ＝
   dist-ℕ
     ( abs-ℤ
@@ -142,7 +142,7 @@ bezouts-lemma-eqn-to-int x y H =
 
 refactor-pos-cond :
   (x y : ℤ) → (H : is-positive-ℤ x) → (K : is-positive-ℤ y) →
-  is-nonzero-ℕ (add-ℕ (abs-ℤ x) (abs-ℤ y))
+  is-nonzero-ℕ ((abs-ℤ x) +ℕ (abs-ℤ y))
 refactor-pos-cond x y H _ =
   is-nonzero-abs-ℤ x H ∘ is-zero-left-is-zero-add-ℕ (abs-ℤ x) (abs-ℤ y)
 
@@ -195,7 +195,7 @@ bezouts-lemma-refactor-hypotheses x y H K =
             ( y))
         x-prod-nonneg y-prod-nonneg
   where
-  P : is-nonzero-ℕ (add-ℕ (abs-ℤ x) (abs-ℤ y))
+  P : is-nonzero-ℕ ((abs-ℤ x) +ℕ (abs-ℤ y))
   P = (refactor-pos-cond x y H K)
   x-prod-nonneg :
     is-nonnegative-ℤ
@@ -219,7 +219,7 @@ bezouts-lemma-refactor-hypotheses x y H K =
 
 bezouts-lemma-pos-ints :
   (x y : ℤ) (H : is-positive-ℤ x) (K : is-positive-ℤ y) →
-  Σ ℤ (λ s → Σ ℤ (λ t → add-ℤ (mul-ℤ s x) (mul-ℤ t y) ＝ gcd-ℤ x y))
+  Σ ℤ (λ s → Σ ℤ (λ t → (mul-ℤ s x) +ℤ (mul-ℤ t y) ＝ gcd-ℤ x y))
 bezouts-lemma-pos-ints x y H K =
   sx-ty-nonneg-case-split
     ( decide-is-nonnegative-ℤ {diff-ℤ (mul-ℤ s x) (mul-ℤ t y)})
@@ -234,7 +234,7 @@ bezouts-lemma-pos-ints x y H K =
   sx-ty-nonneg-case-split :
     ( is-nonnegative-ℤ (diff-ℤ (mul-ℤ s x) (mul-ℤ t y)) +
       is-nonnegative-ℤ (neg-ℤ (diff-ℤ (mul-ℤ s x) (mul-ℤ t y)))) →
-    Σ ℤ (λ s → Σ ℤ (λ t → add-ℤ (mul-ℤ s x) (mul-ℤ t y) ＝ gcd-ℤ x y))
+    Σ ℤ (λ s → Σ ℤ (λ t → (mul-ℤ s x) +ℤ (mul-ℤ t y) ＝ gcd-ℤ x y))
   pr1 (sx-ty-nonneg-case-split (inl pos)) = s
   pr1 (pr2 (sx-ty-nonneg-case-split (inl pos))) = neg-ℤ t
   pr2 (pr2 (sx-ty-nonneg-case-split (inl pos))) =
@@ -246,7 +246,7 @@ bezouts-lemma-pos-ints x y H K =
         ＝ diff-ℤ (mul-ℤ s x) (mul-ℤ t y)
           by int-abs-is-nonnegative-ℤ (diff-ℤ (mul-ℤ s x) (mul-ℤ t y)) pos
         ＝ add-ℤ (mul-ℤ s x) (mul-ℤ (neg-ℤ t) y)
-          by ap (λ M → add-ℤ (mul-ℤ s x) M) (inv (left-negative-law-mul-ℤ t y)))
+          by ap (λ M → (mul-ℤ s x) +ℤ M) (inv (left-negative-law-mul-ℤ t y)))
 
   pr1 (sx-ty-nonneg-case-split (inr neg)) = neg-ℤ s
   pr1 (pr2 (sx-ty-nonneg-case-split (inr neg))) = t
@@ -272,7 +272,7 @@ bezouts-lemma-pos-ints x y H K =
             by ap (λ M → add-ℤ (mul-ℤ (neg-ℤ s) x) M) (neg-neg-ℤ (mul-ℤ t y)))
 
 bezouts-lemma-ℤ :
-  (x y : ℤ) → Σ ℤ (λ s → Σ ℤ (λ t → add-ℤ (mul-ℤ s x) (mul-ℤ t y) ＝ gcd-ℤ x y))
+  (x y : ℤ) → Σ ℤ (λ s → Σ ℤ (λ t → (mul-ℤ s x) +ℤ (mul-ℤ t y) ＝ gcd-ℤ x y))
 bezouts-lemma-ℤ (inl x) (inl y) = pair (neg-ℤ s) (pair (neg-ℤ t) eqn)
   where
   pos-bezout :
@@ -389,8 +389,8 @@ bezouts-lemma-ℤ (inr (inl star)) (inr (inl star)) = pair one-ℤ (pair one-ℤ
           ap
             ( λ M → add-ℤ M (mul-ℤ one-ℤ (inr (inl star))))
             ( right-zero-law-mul-ℤ one-ℤ)
-      ＝ add-ℤ zero-ℤ zero-ℤ
-        by ap (λ M → add-ℤ zero-ℤ M) (right-zero-law-mul-ℤ one-ℤ)
+      ＝ zero-ℤ +ℤ zero-ℤ
+        by ap (λ M → zero-ℤ +ℤ M) (right-zero-law-mul-ℤ one-ℤ)
       ＝ gcd-ℤ zero-ℤ zero-ℤ
         by inv (is-zero-gcd-ℤ zero-ℤ zero-ℤ refl refl)
 bezouts-lemma-ℤ (inr (inl star)) (inr (inr y)) = pair one-ℤ (pair one-ℤ eqn)
@@ -479,25 +479,25 @@ Bezout.
 ```agda
 div-right-factor-coprime-ℤ :
   (x y z : ℤ) → (div-ℤ x (mul-ℤ y z)) → (gcd-ℤ x y ＝ one-ℤ) → div-ℤ x z
-div-right-factor-coprime-ℤ x y z H K = pair (add-ℤ (mul-ℤ s z) (mul-ℤ t k)) eqn
+div-right-factor-coprime-ℤ x y z H K = pair ((mul-ℤ s z) +ℤ (mul-ℤ t k)) eqn
   where
   bezout-triple :
-    Σ ℤ (λ s → Σ ℤ (λ t → add-ℤ (mul-ℤ s x) (mul-ℤ t y) ＝ gcd-ℤ x y))
+    Σ ℤ (λ s → Σ ℤ (λ t → (mul-ℤ s x) +ℤ (mul-ℤ t y) ＝ gcd-ℤ x y))
   bezout-triple = bezouts-lemma-ℤ x y
   s : ℤ
   s = pr1 bezout-triple
   t : ℤ
   t = pr1 (pr2 bezout-triple)
-  bezout-eqn : add-ℤ (mul-ℤ s x) (mul-ℤ t y) ＝ gcd-ℤ x y
+  bezout-eqn : (mul-ℤ s x) +ℤ (mul-ℤ t y) ＝ gcd-ℤ x y
   bezout-eqn = pr2 (pr2 bezout-triple)
   k : ℤ
   k = pr1 H
   div-yz : mul-ℤ k x ＝ mul-ℤ y z
   div-yz = pr2 H
-  eqn : mul-ℤ (add-ℤ (mul-ℤ s z) (mul-ℤ t k)) x ＝ z
+  eqn : mul-ℤ ((mul-ℤ s z) +ℤ (mul-ℤ t k)) x ＝ z
   eqn =
     equational-reasoning
-      mul-ℤ (add-ℤ (mul-ℤ s z) (mul-ℤ t k)) x
+      mul-ℤ ((mul-ℤ s z) +ℤ (mul-ℤ t k)) x
       ＝ add-ℤ (mul-ℤ (mul-ℤ s z) x) (mul-ℤ (mul-ℤ t k) x)
         by right-distributive-mul-add-ℤ (mul-ℤ s z) (mul-ℤ t k) x
       ＝ add-ℤ (mul-ℤ (mul-ℤ s x) z) (mul-ℤ (mul-ℤ t k) x)
@@ -520,7 +520,7 @@ div-right-factor-coprime-ℤ x y z H K = pair (add-ℤ (mul-ℤ s z) (mul-ℤ t 
           by ap (λ P → mul-ℤ t P) div-yz
         ＝ mul-ℤ (mul-ℤ t y) z
           by inv (associative-mul-ℤ t y z))
-    ＝ mul-ℤ (add-ℤ (mul-ℤ s x) (mul-ℤ t y)) z
+    ＝ mul-ℤ ((mul-ℤ s x) +ℤ (mul-ℤ t y)) z
       by inv (right-distributive-mul-add-ℤ (mul-ℤ s x) (mul-ℤ t y) z)
     ＝ mul-ℤ one-ℤ z
       by ap (λ M → mul-ℤ M z) (bezout-eqn ∙ K)

--- a/src/elementary-number-theory/bezouts-lemma-integers.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma-integers.lagda.md
@@ -40,19 +40,15 @@ bezouts-lemma-eqn-to-int :
   nat-gcd-ℤ x y ＝
   dist-ℕ
     ( abs-ℤ
-      ( mul-ℤ
-        ( int-ℕ (minimal-positive-distance-x-coeff (abs-ℤ x) (abs-ℤ y) H)) x))
+      ( int-ℕ (minimal-positive-distance-x-coeff (abs-ℤ x) (abs-ℤ y) H) *ℤ x))
     ( abs-ℤ
-      ( mul-ℤ
-        ( int-ℕ (minimal-positive-distance-y-coeff (abs-ℤ x) (abs-ℤ y) H)) y))
+      ( int-ℕ (minimal-positive-distance-y-coeff (abs-ℤ x) (abs-ℤ y) H) *ℤ y))
 bezouts-lemma-eqn-to-int x y H =
   equational-reasoning
     nat-gcd-ℤ x y
     ＝ dist-ℕ
-      ( mul-ℕ
-        ( minimal-positive-distance-x-coeff (abs-ℤ x) (abs-ℤ y) H) (abs-ℤ x))
-      ( mul-ℕ
-        ( minimal-positive-distance-y-coeff (abs-ℤ x) (abs-ℤ y) H) (abs-ℤ y))
+      ( (minimal-positive-distance-x-coeff (abs-ℤ x) (abs-ℤ y) H) *ℕ (abs-ℤ x))
+      ( (minimal-positive-distance-y-coeff (abs-ℤ x) (abs-ℤ y) H) *ℕ (abs-ℤ y))
       by (inv (bezouts-lemma-eqn-ℕ (abs-ℤ x) (abs-ℤ y) H))
     ＝ dist-ℕ
         ( mul-ℕ

--- a/src/elementary-number-theory/bezouts-lemma-integers.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma-integers.lagda.md
@@ -280,7 +280,7 @@ bezouts-lemma-ℤ (inl x) (inl y) = pair (neg-ℤ s) (pair (neg-ℤ t) eqn)
       ( λ s →
         Σ ( ℤ)
           ( λ t →
-            ( add-ℤ (s *ℤ (inr (inr x))) (t *ℤ (inr (inr y)))) ＝
+            ( (s *ℤ (inr (inr x))) +ℤ (t *ℤ (inr (inr y)))) ＝
             ( gcd-ℤ (inr (inr x)) (inr (inr y)))))
   pos-bezout = bezouts-lemma-pos-ints (inr (inr x)) (inr (inr y)) star star
   s : ℤ
@@ -288,19 +288,19 @@ bezouts-lemma-ℤ (inl x) (inl y) = pair (neg-ℤ s) (pair (neg-ℤ t) eqn)
   t : ℤ
   t = pr1 (pr2 (pos-bezout))
   eqn :
-    add-ℤ ((neg-ℤ s) *ℤ (inl x)) ((neg-ℤ t) *ℤ (inl y)) ＝
+    ((neg-ℤ s) *ℤ (inl x)) +ℤ ((neg-ℤ t) *ℤ (inl y)) ＝
     gcd-ℤ (inl x) (inl y)
   eqn =
     equational-reasoning
       add-ℤ
         ( (neg-ℤ s) *ℤ (neg-ℤ (inr (inr x))))
         ( (neg-ℤ t) *ℤ (neg-ℤ (inr (inr y))))
-      ＝ add-ℤ (s *ℤ (inr (inr x))) ((neg-ℤ t) *ℤ (neg-ℤ (inr (inr y))))
+      ＝ (s *ℤ (inr (inr x))) +ℤ ((neg-ℤ t) *ℤ (neg-ℤ (inr (inr y))))
         by
           ( ap
             ( _+ℤ ((neg-ℤ t) *ℤ (neg-ℤ (inr (inr y)))))
             ( double-negative-law-mul-ℤ s (inr (inr x))))
-      ＝ add-ℤ (s *ℤ (inr (inr x))) (t *ℤ (inr (inr y)))
+      ＝ (s *ℤ (inr (inr x))) +ℤ (t *ℤ (inr (inr y)))
         by
           ( ap
             ( add-ℤ (s *ℤ (inr (inr x))))
@@ -337,7 +337,7 @@ bezouts-lemma-ℤ (inl x) (inr (inr y)) = pair (neg-ℤ s) (pair t eqn)
       ( λ s →
         Σ ( ℤ)
           ( λ t →
-            add-ℤ (s *ℤ (inr (inr x))) (t *ℤ (inr (inr y))) ＝
+            (s *ℤ (inr (inr x))) +ℤ (t *ℤ (inr (inr y))) ＝
             gcd-ℤ (inr (inr x)) (inr (inr y))))
   pos-bezout = bezouts-lemma-pos-ints (inr (inr x)) (inr (inr y)) star star
   s : ℤ
@@ -345,12 +345,12 @@ bezouts-lemma-ℤ (inl x) (inr (inr y)) = pair (neg-ℤ s) (pair t eqn)
   t : ℤ
   t = pr1 (pr2 (pos-bezout))
   eqn :
-    add-ℤ ((neg-ℤ s) *ℤ (inl x)) (t *ℤ (inr (inr y))) ＝
+    ((neg-ℤ s) *ℤ (inl x)) +ℤ (t *ℤ (inr (inr y))) ＝
     gcd-ℤ (inl x) (inr (inr y))
   eqn =
     equational-reasoning
       add-ℤ ((neg-ℤ s) *ℤ (neg-ℤ (inr (inr x)))) (t *ℤ (inr (inr y)))
-      ＝ add-ℤ (s *ℤ (inr (inr x))) (t *ℤ (inr (inr y)))
+      ＝ (s *ℤ (inr (inr x))) +ℤ (t *ℤ (inr (inr y)))
         by ap (_+ℤ (t *ℤ (inr (inr y))))
           (double-negative-law-mul-ℤ s (inr (inr x)))
       ＝ gcd-ℤ (inr (inr x)) (inr (inr y))
@@ -360,12 +360,12 @@ bezouts-lemma-ℤ (inl x) (inr (inr y)) = pair (neg-ℤ s) (pair t eqn)
 bezouts-lemma-ℤ (inr (inl star)) (inl y) = pair one-ℤ (pair neg-one-ℤ eqn)
   where
   eqn :
-    add-ℤ (one-ℤ *ℤ (inr (inl star))) (neg-one-ℤ *ℤ (inl y)) ＝
+    (one-ℤ *ℤ (inr (inl star))) +ℤ (neg-one-ℤ *ℤ (inl y)) ＝
     gcd-ℤ (inr (inl star)) (inl y)
   eqn =
     equational-reasoning
-      add-ℤ (one-ℤ *ℤ (inr (inl star))) (neg-one-ℤ *ℤ (inl y))
-      ＝ add-ℤ (one-ℤ *ℤ (inr (inl star))) (inr (inr y))
+      (one-ℤ *ℤ (inr (inl star))) +ℤ (neg-one-ℤ *ℤ (inl y))
+      ＝ (one-ℤ *ℤ (inr (inl star))) +ℤ (inr (inr y))
         by
           ap
             ( add-ℤ (one-ℤ *ℤ (inr (inl star))))
@@ -379,11 +379,11 @@ bezouts-lemma-ℤ (inr (inl star)) (inl y) = pair one-ℤ (pair neg-one-ℤ eqn)
 bezouts-lemma-ℤ (inr (inl star)) (inr (inl star)) = pair one-ℤ (pair one-ℤ eqn)
   where
   eqn :
-    add-ℤ (one-ℤ *ℤ (inr (inl star))) (one-ℤ *ℤ (inr (inl star))) ＝
+    (one-ℤ *ℤ (inr (inl star))) +ℤ (one-ℤ *ℤ (inr (inl star))) ＝
     gcd-ℤ zero-ℤ zero-ℤ
   eqn =
     equational-reasoning
-      add-ℤ (one-ℤ *ℤ (inr (inl star))) (one-ℤ *ℤ (inr (inl star)))
+      (one-ℤ *ℤ (inr (inl star))) +ℤ (one-ℤ *ℤ (inr (inl star)))
       ＝ zero-ℤ +ℤ (one-ℤ *ℤ (inr (inl star)))
         by
           ap
@@ -396,12 +396,12 @@ bezouts-lemma-ℤ (inr (inl star)) (inr (inl star)) = pair one-ℤ (pair one-ℤ
 bezouts-lemma-ℤ (inr (inl star)) (inr (inr y)) = pair one-ℤ (pair one-ℤ eqn)
   where
   eqn :
-    add-ℤ (one-ℤ *ℤ (inr (inl star))) (one-ℤ *ℤ (inr (inr y))) ＝
+    (one-ℤ *ℤ (inr (inl star))) +ℤ (one-ℤ *ℤ (inr (inr y))) ＝
     gcd-ℤ (inr (inl star)) (inr (inr y))
   eqn =
     equational-reasoning
-      add-ℤ (one-ℤ *ℤ (inr (inl star))) (one-ℤ *ℤ (inr (inr y)))
-      ＝ add-ℤ (one-ℤ *ℤ (inr (inl star))) (inr (inr y))
+      (one-ℤ *ℤ (inr (inl star))) +ℤ (one-ℤ *ℤ (inr (inr y)))
+      ＝ (one-ℤ *ℤ (inr (inl star))) +ℤ (inr (inr y))
         by ap
           ( add-ℤ (one-ℤ *ℤ (inr (inl star))))
           ( inv (left-unit-law-mul-ℤ (inr (inr y))))
@@ -423,7 +423,7 @@ bezouts-lemma-ℤ (inr (inr x)) (inl y) = pair s (pair (neg-ℤ t) eqn)
       ( λ s →
         Σ ( ℤ)
           ( λ t →
-            add-ℤ (s *ℤ (inr (inr x))) (t *ℤ (inr (inr y))) ＝
+            (s *ℤ (inr (inr x))) +ℤ (t *ℤ (inr (inr y))) ＝
             gcd-ℤ (inr (inr x)) (inr (inr y))))
   pos-bezout = bezouts-lemma-pos-ints (inr (inr x)) (inr (inr y)) star star
   s : ℤ
@@ -431,12 +431,12 @@ bezouts-lemma-ℤ (inr (inr x)) (inl y) = pair s (pair (neg-ℤ t) eqn)
   t : ℤ
   t = pr1 (pr2 (pos-bezout))
   eqn :
-    add-ℤ (s *ℤ (inr (inr x))) ((neg-ℤ t) *ℤ (inl y)) ＝
+    (s *ℤ (inr (inr x))) +ℤ ((neg-ℤ t) *ℤ (inl y)) ＝
     gcd-ℤ (inr (inr x)) (inl y)
   eqn =
     equational-reasoning
-      add-ℤ (s *ℤ (inr (inr x))) ((neg-ℤ t) *ℤ (neg-ℤ (inr (inr y))))
-      ＝ add-ℤ (s *ℤ (inr (inr x))) (t *ℤ (inr (inr y)))
+      (s *ℤ (inr (inr x))) +ℤ ((neg-ℤ t) *ℤ (neg-ℤ (inr (inr y))))
+      ＝ (s *ℤ (inr (inr x))) +ℤ (t *ℤ (inr (inr y)))
         by ap ((s *ℤ (inr (inr x))) +ℤ_)
           (double-negative-law-mul-ℤ t (inr (inr y)))
       ＝ gcd-ℤ (inr (inr x)) (inr (inr y))
@@ -446,11 +446,11 @@ bezouts-lemma-ℤ (inr (inr x)) (inl y) = pair s (pair (neg-ℤ t) eqn)
 bezouts-lemma-ℤ (inr (inr x)) (inr (inl star)) = pair one-ℤ (pair one-ℤ eqn)
   where
   eqn :
-    add-ℤ (one-ℤ *ℤ (inr (inr x))) (one-ℤ *ℤ (inr (inl star))) ＝
+    (one-ℤ *ℤ (inr (inr x))) +ℤ (one-ℤ *ℤ (inr (inl star))) ＝
     gcd-ℤ (inr (inr x)) (inr (inl star))
   eqn =
     equational-reasoning
-      add-ℤ (one-ℤ *ℤ (inr (inr x))) (one-ℤ *ℤ (inr (inl star)))
+      (one-ℤ *ℤ (inr (inr x))) +ℤ (one-ℤ *ℤ (inr (inl star)))
       ＝ (inr (inr x)) +ℤ (one-ℤ *ℤ (inr (inl star)))
         by
           ap
@@ -494,10 +494,10 @@ div-right-factor-coprime-ℤ x y z H K = pair ((s *ℤ z) +ℤ (t *ℤ k)) eqn
   k = pr1 H
   div-yz : k *ℤ x ＝ y *ℤ z
   div-yz = pr2 H
-  eqn : mul-ℤ ((s *ℤ z) +ℤ (t *ℤ k)) x ＝ z
+  eqn : ((s *ℤ z) +ℤ (t *ℤ k)) *ℤ x ＝ z
   eqn =
     equational-reasoning
-      mul-ℤ ((s *ℤ z) +ℤ (t *ℤ k)) x
+      ((s *ℤ z) +ℤ (t *ℤ k)) *ℤ x
       ＝ ((s *ℤ z) *ℤ x) +ℤ ((t *ℤ k) *ℤ x)
         by right-distributive-mul-add-ℤ (s *ℤ z) (t *ℤ k) x
       ＝ ((s *ℤ x) *ℤ z) +ℤ ((t *ℤ k) *ℤ x)
@@ -520,7 +520,7 @@ div-right-factor-coprime-ℤ x y z H K = pair ((s *ℤ z) +ℤ (t *ℤ k)) eqn
           by ap (t *ℤ_) div-yz
         ＝ (t *ℤ y) *ℤ z
           by inv (associative-mul-ℤ t y z))
-    ＝ mul-ℤ ((s *ℤ x) +ℤ (t *ℤ y)) z
+    ＝ ((s *ℤ x) +ℤ (t *ℤ y)) *ℤ z
       by inv (right-distributive-mul-add-ℤ (s *ℤ x) (t *ℤ y) z)
     ＝ one-ℤ *ℤ z
       by ap (_*ℤ z) (bezout-eqn ∙ K)
@@ -535,6 +535,6 @@ div-right-factor-coprime-ℕ x y z H K =
       ( int-ℕ x)
       ( int-ℕ y)
       ( int-ℕ z)
-        ( tr (λ p → div-ℤ (int-ℕ x) p) (inv (mul-int-ℕ y z)) (div-int-div-ℕ H))
+        ( tr (div-ℤ (int-ℕ x)) (inv (mul-int-ℕ y z)) (div-int-div-ℕ H))
       ( eq-gcd-gcd-int-ℕ x y ∙ ap int-ℕ K))
 ```

--- a/src/elementary-number-theory/bezouts-lemma-integers.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma-integers.lagda.md
@@ -263,13 +263,13 @@ bezouts-lemma-pos-ints x y H K =
               int-abs-is-nonnegative-ℤ
                 ( neg-ℤ (diff-ℤ (s *ℤ x) (t *ℤ y)))
                 ( neg)
-          ＝ add-ℤ (neg-ℤ (s *ℤ x)) (neg-ℤ (neg-ℤ (t *ℤ y)))
+          ＝ (neg-ℤ (s *ℤ x)) +ℤ (neg-ℤ (neg-ℤ (t *ℤ y)))
             by distributive-neg-add-ℤ (s *ℤ x) (neg-ℤ (t *ℤ y))
-          ＝ add-ℤ ((neg-ℤ s) *ℤ x) (neg-ℤ (neg-ℤ (t *ℤ y)))
+          ＝ ((neg-ℤ s) *ℤ x) +ℤ (neg-ℤ (neg-ℤ (t *ℤ y)))
             by ap (λ M → M +ℤ (neg-ℤ (neg-ℤ (t *ℤ y))))
               (inv (left-negative-law-mul-ℤ s x))
-          ＝ add-ℤ ((neg-ℤ s) *ℤ x) (t *ℤ y)
-            by ap (λ M → add-ℤ ((neg-ℤ s) *ℤ x) M) (neg-neg-ℤ (t *ℤ y)))
+          ＝ ((neg-ℤ s) *ℤ x) +ℤ (t *ℤ y)
+            by ap (λ M → ((neg-ℤ s) *ℤ x) +ℤ M) (neg-neg-ℤ (t *ℤ y)))
 
 bezouts-lemma-ℤ :
   (x y : ℤ) → Σ ℤ (λ s → Σ ℤ (λ t → (s *ℤ x) +ℤ (t *ℤ y) ＝ gcd-ℤ x y))
@@ -314,17 +314,17 @@ bezouts-lemma-ℤ (inl x) (inl y) = pair (neg-ℤ s) (pair (neg-ℤ t) eqn)
 bezouts-lemma-ℤ (inl x) (inr (inl star)) = pair neg-one-ℤ (pair one-ℤ eqn)
   where
   eqn :
-    add-ℤ (neg-one-ℤ *ℤ (inl x)) (one-ℤ *ℤ (inr (inl star))) ＝
+    (neg-one-ℤ *ℤ (inl x)) +ℤ (one-ℤ *ℤ (inr (inl star))) ＝
     gcd-ℤ (inl x) (inr (inl star))
   eqn =
     equational-reasoning
-      add-ℤ (neg-one-ℤ *ℤ (inl x)) (one-ℤ *ℤ (inr (inl star)))
-      ＝ add-ℤ (inr (inr x)) (one-ℤ *ℤ (inr (inl star)))
+      (neg-one-ℤ *ℤ (inl x)) +ℤ (one-ℤ *ℤ (inr (inl star)))
+      ＝ (inr (inr x)) +ℤ (one-ℤ *ℤ (inr (inl star)))
         by
           ap
             ( λ M → M +ℤ (one-ℤ *ℤ (inr (inl star))))
             ( inv (is-mul-neg-one-neg-ℤ (inl x)))
-      ＝ add-ℤ (inr (inr x)) zero-ℤ
+      ＝ (inr (inr x)) +ℤ zero-ℤ
         by ap (add-ℤ (inr (inr x))) (right-zero-law-mul-ℤ one-ℤ)
       ＝ int-ℕ (abs-ℤ (inl x))
         by right-unit-law-add-ℤ (inr (inr x))
@@ -451,13 +451,13 @@ bezouts-lemma-ℤ (inr (inr x)) (inr (inl star)) = pair one-ℤ (pair one-ℤ eq
   eqn =
     equational-reasoning
       add-ℤ (one-ℤ *ℤ (inr (inr x))) (one-ℤ *ℤ (inr (inl star)))
-      ＝ add-ℤ (inr (inr x)) (one-ℤ *ℤ (inr (inl star)))
+      ＝ (inr (inr x)) +ℤ (one-ℤ *ℤ (inr (inl star)))
         by
           ap
-            ( λ M → M +ℤ (one-ℤ *ℤ (inr (inl star))))
+            ( _+ℤ (one-ℤ *ℤ (inr (inl star))))
             ( left-unit-law-mul-ℤ (inr (inr x)))
-      ＝ add-ℤ (inr (inr x)) zero-ℤ
-        by ap (λ M → add-ℤ (inr (inr x)) M) (right-zero-law-mul-ℤ one-ℤ)
+      ＝ (inr (inr x)) +ℤ zero-ℤ
+        by ap ((inr (inr x)) +ℤ_) (right-zero-law-mul-ℤ one-ℤ)
       ＝ int-ℕ (abs-ℤ (inr (inr x)))
         by right-unit-law-add-ℤ (inr (inr x))
       ＝ gcd-ℤ (inr (inr x)) zero-ℤ
@@ -498,10 +498,10 @@ div-right-factor-coprime-ℤ x y z H K = pair ((s *ℤ z) +ℤ (t *ℤ k)) eqn
   eqn =
     equational-reasoning
       mul-ℤ ((s *ℤ z) +ℤ (t *ℤ k)) x
-      ＝ add-ℤ ((s *ℤ z) *ℤ x) ((t *ℤ k) *ℤ x)
+      ＝ ((s *ℤ z) *ℤ x) +ℤ ((t *ℤ k) *ℤ x)
         by right-distributive-mul-add-ℤ (s *ℤ z) (t *ℤ k) x
-      ＝ add-ℤ ((s *ℤ x) *ℤ z) ((t *ℤ k) *ℤ x)
-        by ap (λ M → M +ℤ ((t *ℤ k) *ℤ x))
+      ＝ ((s *ℤ x) *ℤ z) +ℤ ((t *ℤ k) *ℤ x)
+        by ap (_+ℤ ((t *ℤ k) *ℤ x))
         ( equational-reasoning
             (s *ℤ z) *ℤ x
             ＝ s *ℤ (z *ℤ x)
@@ -510,8 +510,8 @@ div-right-factor-coprime-ℤ x y z H K = pair ((s *ℤ z) +ℤ (t *ℤ k)) eqn
               by ap (λ P → s *ℤ P) (commutative-mul-ℤ z x)
             ＝ (s *ℤ x) *ℤ z
               by inv (associative-mul-ℤ s x z))
-      ＝ add-ℤ ((s *ℤ x) *ℤ z) ((t *ℤ y) *ℤ z)
-        by ap (λ M → add-ℤ ((s *ℤ x) *ℤ z) M)
+      ＝ ((s *ℤ x) *ℤ z) +ℤ ((t *ℤ y) *ℤ z)
+        by ap (λ M → ((s *ℤ x) *ℤ z) +ℤ M)
     ( equational-reasoning
         (t *ℤ k) *ℤ x
         ＝ t *ℤ (k *ℤ x)

--- a/src/elementary-number-theory/bezouts-lemma-integers.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma-integers.lagda.md
@@ -246,7 +246,7 @@ bezouts-lemma-pos-ints x y H K =
         ＝ diff-ℤ (s *ℤ x) (t *ℤ y)
           by int-abs-is-nonnegative-ℤ (diff-ℤ (s *ℤ x) (t *ℤ y)) pos
         ＝ (s *ℤ x) +ℤ ((neg-ℤ t) *ℤ y)
-          by ap (λ M → (s *ℤ x) +ℤ M) (inv (left-negative-law-mul-ℤ t y)))
+          by ap ((s *ℤ x) +ℤ_) (inv (left-negative-law-mul-ℤ t y)))
 
   pr1 (sx-ty-nonneg-case-split (inr neg)) = neg-ℤ s
   pr1 (pr2 (sx-ty-nonneg-case-split (inr neg))) = t
@@ -266,10 +266,10 @@ bezouts-lemma-pos-ints x y H K =
           ＝ (neg-ℤ (s *ℤ x)) +ℤ (neg-ℤ (neg-ℤ (t *ℤ y)))
             by distributive-neg-add-ℤ (s *ℤ x) (neg-ℤ (t *ℤ y))
           ＝ ((neg-ℤ s) *ℤ x) +ℤ (neg-ℤ (neg-ℤ (t *ℤ y)))
-            by ap (λ M → M +ℤ (neg-ℤ (neg-ℤ (t *ℤ y))))
+            by ap (_+ℤ (neg-ℤ (neg-ℤ (t *ℤ y))))
               (inv (left-negative-law-mul-ℤ s x))
           ＝ ((neg-ℤ s) *ℤ x) +ℤ (t *ℤ y)
-            by ap (λ M → ((neg-ℤ s) *ℤ x) +ℤ M) (neg-neg-ℤ (t *ℤ y)))
+            by ap (((neg-ℤ s) *ℤ x) +ℤ_) (neg-neg-ℤ (t *ℤ y)))
 
 bezouts-lemma-ℤ :
   (x y : ℤ) → Σ ℤ (λ s → Σ ℤ (λ t → (s *ℤ x) +ℤ (t *ℤ y) ＝ gcd-ℤ x y))
@@ -298,7 +298,7 @@ bezouts-lemma-ℤ (inl x) (inl y) = pair (neg-ℤ s) (pair (neg-ℤ t) eqn)
       ＝ add-ℤ (s *ℤ (inr (inr x))) ((neg-ℤ t) *ℤ (neg-ℤ (inr (inr y))))
         by
           ( ap
-            ( λ M → M +ℤ ((neg-ℤ t) *ℤ (neg-ℤ (inr (inr y)))))
+            ( _+ℤ ((neg-ℤ t) *ℤ (neg-ℤ (inr (inr y)))))
             ( double-negative-law-mul-ℤ s (inr (inr x))))
       ＝ add-ℤ (s *ℤ (inr (inr x))) (t *ℤ (inr (inr y)))
         by
@@ -322,7 +322,7 @@ bezouts-lemma-ℤ (inl x) (inr (inl star)) = pair neg-one-ℤ (pair one-ℤ eqn)
       ＝ (inr (inr x)) +ℤ (one-ℤ *ℤ (inr (inl star)))
         by
           ap
-            ( λ M → M +ℤ (one-ℤ *ℤ (inr (inl star))))
+            ( _+ℤ (one-ℤ *ℤ (inr (inl star))))
             ( inv (is-mul-neg-one-neg-ℤ (inl x)))
       ＝ (inr (inr x)) +ℤ zero-ℤ
         by ap (add-ℤ (inr (inr x))) (right-zero-law-mul-ℤ one-ℤ)
@@ -351,7 +351,7 @@ bezouts-lemma-ℤ (inl x) (inr (inr y)) = pair (neg-ℤ s) (pair t eqn)
     equational-reasoning
       add-ℤ ((neg-ℤ s) *ℤ (neg-ℤ (inr (inr x)))) (t *ℤ (inr (inr y)))
       ＝ add-ℤ (s *ℤ (inr (inr x))) (t *ℤ (inr (inr y)))
-        by ap (λ M → M +ℤ (t *ℤ (inr (inr y))))
+        by ap (_+ℤ (t *ℤ (inr (inr y))))
           (double-negative-law-mul-ℤ s (inr (inr x)))
       ＝ gcd-ℤ (inr (inr x)) (inr (inr y))
         by pr2 (pr2 (pos-bezout))
@@ -371,7 +371,7 @@ bezouts-lemma-ℤ (inr (inl star)) (inl y) = pair one-ℤ (pair neg-one-ℤ eqn)
             ( add-ℤ (one-ℤ *ℤ (inr (inl star))))
             ( inv (is-mul-neg-one-neg-ℤ (inl y)))
       ＝ zero-ℤ +ℤ (inr (inr y))
-        by ap (λ M → M +ℤ (inr (inr y))) (right-zero-law-mul-ℤ one-ℤ)
+        by ap (_+ℤ (inr (inr y))) (right-zero-law-mul-ℤ one-ℤ)
       ＝ int-ℕ (abs-ℤ (inl y))
         by left-unit-law-add-ℤ (inr (inr y))
       ＝ gcd-ℤ zero-ℤ (inl y)
@@ -387,10 +387,10 @@ bezouts-lemma-ℤ (inr (inl star)) (inr (inl star)) = pair one-ℤ (pair one-ℤ
       ＝ zero-ℤ +ℤ (one-ℤ *ℤ (inr (inl star)))
         by
           ap
-            ( λ M → M +ℤ (one-ℤ *ℤ (inr (inl star))))
+            ( _+ℤ (one-ℤ *ℤ (inr (inl star))))
             ( right-zero-law-mul-ℤ one-ℤ)
       ＝ zero-ℤ +ℤ zero-ℤ
-        by ap (λ M → zero-ℤ +ℤ M) (right-zero-law-mul-ℤ one-ℤ)
+        by ap (zero-ℤ +ℤ_) (right-zero-law-mul-ℤ one-ℤ)
       ＝ gcd-ℤ zero-ℤ zero-ℤ
         by inv (is-zero-gcd-ℤ zero-ℤ zero-ℤ refl refl)
 bezouts-lemma-ℤ (inr (inl star)) (inr (inr y)) = pair one-ℤ (pair one-ℤ eqn)
@@ -406,7 +406,7 @@ bezouts-lemma-ℤ (inr (inl star)) (inr (inr y)) = pair one-ℤ (pair one-ℤ eq
           ( add-ℤ (one-ℤ *ℤ (inr (inl star))))
           ( inv (left-unit-law-mul-ℤ (inr (inr y))))
       ＝ zero-ℤ +ℤ (inr (inr y))
-        by ap (λ M → M +ℤ (inr (inr y))) (right-zero-law-mul-ℤ one-ℤ)
+        by ap (_+ℤ (inr (inr y))) (right-zero-law-mul-ℤ one-ℤ)
       ＝ int-ℕ (abs-ℤ (inr (inr y)))
         by left-unit-law-add-ℤ (inr (inr y))
       ＝ gcd-ℤ zero-ℤ (inr (inr y))
@@ -437,7 +437,7 @@ bezouts-lemma-ℤ (inr (inr x)) (inl y) = pair s (pair (neg-ℤ t) eqn)
     equational-reasoning
       add-ℤ (s *ℤ (inr (inr x))) ((neg-ℤ t) *ℤ (neg-ℤ (inr (inr y))))
       ＝ add-ℤ (s *ℤ (inr (inr x))) (t *ℤ (inr (inr y)))
-        by ap (λ M → add-ℤ (s *ℤ (inr (inr x))) M)
+        by ap ((s *ℤ (inr (inr x))) +ℤ_)
           (double-negative-law-mul-ℤ t (inr (inr y)))
       ＝ gcd-ℤ (inr (inr x)) (inr (inr y))
         by pr2 (pr2 (pos-bezout))
@@ -507,23 +507,23 @@ div-right-factor-coprime-ℤ x y z H K = pair ((s *ℤ z) +ℤ (t *ℤ k)) eqn
             ＝ s *ℤ (z *ℤ x)
               by associative-mul-ℤ s z x
             ＝ s *ℤ (x *ℤ z)
-              by ap (λ P → s *ℤ P) (commutative-mul-ℤ z x)
+              by ap (s *ℤ_) (commutative-mul-ℤ z x)
             ＝ (s *ℤ x) *ℤ z
               by inv (associative-mul-ℤ s x z))
       ＝ ((s *ℤ x) *ℤ z) +ℤ ((t *ℤ y) *ℤ z)
-        by ap (λ M → ((s *ℤ x) *ℤ z) +ℤ M)
+        by ap (((s *ℤ x) *ℤ z) +ℤ_)
     ( equational-reasoning
         (t *ℤ k) *ℤ x
         ＝ t *ℤ (k *ℤ x)
           by associative-mul-ℤ t k x
         ＝ t *ℤ (y *ℤ z)
-          by ap (λ P → t *ℤ P) div-yz
+          by ap (t *ℤ_) div-yz
         ＝ (t *ℤ y) *ℤ z
           by inv (associative-mul-ℤ t y z))
     ＝ mul-ℤ ((s *ℤ x) +ℤ (t *ℤ y)) z
       by inv (right-distributive-mul-add-ℤ (s *ℤ x) (t *ℤ y) z)
     ＝ one-ℤ *ℤ z
-      by ap (λ M → M *ℤ z) (bezout-eqn ∙ K)
+      by ap (_*ℤ z) (bezout-eqn ∙ K)
     ＝ z
       by left-unit-law-mul-ℤ z
 

--- a/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
@@ -101,14 +101,9 @@ int-is-distance-between-multiples-ℕ :
     leq-ℕ
       ( (is-distance-between-multiples-fst-coeff-ℕ d) *ℕ x)
       ( (is-distance-between-multiples-snd-coeff-ℕ d) *ℕ y)) →
-  add-ℤ
-    ( int-ℕ z)
-    ( mul-ℤ
-      ( int-ℕ (is-distance-between-multiples-fst-coeff-ℕ d))
-      ( int-ℕ x)) ＝
-  mul-ℤ
-    ( int-ℕ (is-distance-between-multiples-snd-coeff-ℕ d))
-    ( int-ℕ y)
+  ( int-ℕ z) +ℤ
+  ( (int-ℕ (is-distance-between-multiples-fst-coeff-ℕ d)) *ℤ (int-ℕ x)) ＝
+  ( int-ℕ (is-distance-between-multiples-snd-coeff-ℕ d)) *ℤ (int-ℕ y)
 int-is-distance-between-multiples-ℕ x y z (k , l , p) H =
   equational-reasoning
     (int-ℕ z) +ℤ ((int-ℕ k) *ℤ (int-ℕ x))
@@ -117,8 +112,7 @@ int-is-distance-between-multiples-ℕ x y z (k , l , p) H =
     ＝ int-ℕ (z +ℕ (k *ℕ x))
       by add-int-ℕ z (k *ℕ x)
     ＝ int-ℕ (l *ℕ y)
-      by ap (int-ℕ)
-        (rewrite-left-dist-add-ℕ z (k *ℕ x) (l *ℕ y) H (inv p))
+      by ap (int-ℕ) (rewrite-left-dist-add-ℕ z (k *ℕ x) (l *ℕ y) H (inv p))
     ＝ (int-ℕ l) *ℤ (int-ℕ y)
       by inv (mul-int-ℕ l y)
 
@@ -239,9 +233,7 @@ div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
             ( add-ℤ-Mod x (mod-ℤ x ((neg-ℤ (int-ℕ l)) *ℤ (int-ℕ y))))
             ( inv (preserves-mul-mod-ℤ x (int-ℕ k) (int-ℕ x)))
         ＝ mod-ℤ x
-            ( add-ℤ
-              ( (neg-ℤ (int-ℕ l)) *ℤ (int-ℕ y))
-              ( (int-ℕ k) *ℤ (int-ℕ x)))
+            ( ((neg-ℤ (int-ℕ l)) *ℤ (int-ℕ y)) +ℤ ((int-ℕ k) *ℤ (int-ℕ x)))
           by
           inv
             ( preserves-add-mod-ℤ x
@@ -252,19 +244,13 @@ div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
           ap
             ( mod-ℤ x)
             ( equational-reasoning
-              add-ℤ
-                ( (neg-ℤ (int-ℕ l)) *ℤ (int-ℕ y))
-                ( (int-ℕ k) *ℤ (int-ℕ x))
-              ＝ add-ℤ
-                  ( neg-ℤ ((int-ℕ l) *ℤ (int-ℕ y)))
-                  ( (int-ℕ k) *ℤ (int-ℕ x))
+              ((neg-ℤ (int-ℕ l)) *ℤ (int-ℕ y)) +ℤ ((int-ℕ k) *ℤ (int-ℕ x))
+              ＝ (neg-ℤ ((int-ℕ l) *ℤ (int-ℕ y))) +ℤ ((int-ℕ k) *ℤ (int-ℕ x))
                 by
                 ap
                   ( _+ℤ ((int-ℕ k) *ℤ (int-ℕ x)))
                   ( left-negative-law-mul-ℤ (int-ℕ l) (int-ℕ y))
-              ＝ add-ℤ
-                  ( (int-ℕ k) *ℤ (int-ℕ x))
-                  ( neg-ℤ ((int-ℕ l) *ℤ (int-ℕ y)))
+              ＝ ((int-ℕ k) *ℤ (int-ℕ x)) +ℤ (neg-ℤ ((int-ℕ l) *ℤ (int-ℕ y)))
                 by
                 commutative-add-ℤ
                   ( neg-ℤ ((int-ℕ l) *ℤ (int-ℕ y)))
@@ -383,7 +369,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
           ( int-ℕ z))
       by
       ap
-        ( add-ℤ ((neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x))))
+        ( ((neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x))) +ℤ_)
         ( inv
           ( issec-add-neg-ℤ'
             ( int-ℕ z)
@@ -429,46 +415,32 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
       ( ((neg-ℤ a) +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x)))
       ( neg-ℤ
         ( mul-ℤ
-          ( add-ℤ
-            ( int-ℕ (succ-ℕ x))
-            ( neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
+          ( (int-ℕ (succ-ℕ x)) +ℤ (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
           ( int-ℕ y))) ＝
-    add-ℤ
-      ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
-      ( neg-ℤ (a *ℤ (int-ℕ (succ-ℕ x))))
+    ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ int-ℕ y) +ℤ (neg-ℤ (a *ℤ int-ℕ (succ-ℕ x)))
   a-extra-eqn-neg =
     equational-reasoning
     add-ℤ
       ( ((neg-ℤ a) +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x)))
       ( neg-ℤ
         ( mul-ℤ
-          ( add-ℤ
-            ( int-ℕ (succ-ℕ x))
-            ( neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
+          ( (int-ℕ (succ-ℕ x)) +ℤ (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
           ( int-ℕ y)))
     ＝ add-ℤ
         ( ((neg-ℤ a) +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x)))
         ( mul-ℤ
-          ( neg-ℤ
-            ( add-ℤ
-              ( int-ℕ (succ-ℕ x))
-              ( neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))))
+          ( neg-ℤ ((int-ℕ (succ-ℕ x)) +ℤ (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))))
           ( int-ℕ y))
       by
       ap
-        ( add-ℤ
-          ( mul-ℤ
-            ( (neg-ℤ a) +ℤ (int-ℕ y))
-            ( int-ℕ (succ-ℕ x))))
+        ( (((neg-ℤ a) +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x))) +ℤ_)
         ( inv
           ( left-negative-law-mul-ℤ
             ( (int-ℕ (succ-ℕ x)) +ℤ (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
             ( int-ℕ y)))
     ＝ add-ℤ
         ( ((neg-ℤ a) +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x)))
-        ( mul-ℤ
-          ( (int-ℤ-Mod (succ-ℕ x) u) +ℤ (neg-ℤ (int-ℕ (succ-ℕ x))))
-          ( int-ℕ y))
+        ( ((int-ℤ-Mod (succ-ℕ x) u) +ℤ (neg-ℤ (int-ℕ (succ-ℕ x)))) *ℤ (int-ℕ y))
       by
       ap
         ( λ p →
@@ -503,7 +475,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
           ( (neg-ℤ (int-ℕ (succ-ℕ x))) *ℤ (int-ℕ y)))
       by
       ap
-        ( add-ℤ (((neg-ℤ a) +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x))))
+        ( (((neg-ℤ a) +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x))) +ℤ_)
         ( right-distributive-mul-add-ℤ
           ( int-ℤ-Mod (succ-ℕ x) u)
           ( neg-ℤ (int-ℕ (succ-ℕ x)))
@@ -595,7 +567,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
         ( neg-ℤ (a *ℤ (int-ℕ (succ-ℕ x))))
       by
       ap
-        ( add-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)))
+        ( ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)) +ℤ_)
         ( left-negative-law-mul-ℤ a (int-ℕ (succ-ℕ x)))
 
   uy-z-case-split :
@@ -705,11 +677,10 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
           (int-abs-is-nonnegative-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
             (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) (int-ℤ-Mod-bounded x u))
         ＝ dist-ℤ
+            ( ((int-ℕ (abs-ℤ (neg-ℤ a))) +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x)))
             ( mul-ℤ
-              ( (int-ℕ (abs-ℤ (neg-ℤ a))) +ℤ (int-ℕ y))
-              ( int-ℕ (succ-ℕ x)))
-            ( mul-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
-            (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) (int-ℕ y))
+              ( (int-ℕ (succ-ℕ x)) +ℤ (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
+              ( int-ℕ y))
         by
           ap
             ( λ p →
@@ -720,8 +691,8 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
                   ( int-ℕ y)))
           (inv (abs-neg-ℤ a))
         ＝ dist-ℤ (((neg-ℤ a) +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x)))
-          (mul-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
-            (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) (int-ℕ y))
+          (mul-ℤ
+            ( (int-ℕ (succ-ℕ x)) +ℤ (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) (int-ℕ y))
         by ap (λ p → dist-ℤ ((p +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x)))
           (((int-ℕ (succ-ℕ x)) +ℤ (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) *ℤ
             (int-ℕ y)))
@@ -960,13 +931,11 @@ minimal-positive-distance-div-succ-x-eqn x y =
               ( succ-ℕ x)))
           by
             ( ap
-              ( λ H →
-                add-ℤ
-                  ( H)
-                  ( int-ℕ
-                    ( remainder-euclidean-division-ℕ
-                      ( minimal-positive-distance (succ-ℕ x) y)
-                      ( succ-ℕ x))))
+              ( _+ℤ
+                ( int-ℕ
+                  ( remainder-euclidean-division-ℕ
+                    ( minimal-positive-distance (succ-ℕ x) y)
+                    ( succ-ℕ x))))
               ( mul-int-ℕ
                 ( quotient-euclidean-division-ℕ
                   ( minimal-positive-distance (succ-ℕ x) y)
@@ -1057,9 +1026,7 @@ remainder-min-dist-succ-x-is-distance x y =
     where
     add-dist-eqn :
       int-ℕ d ＝
-      add-ℤ
-        ( (int-ℕ t) *ℤ (int-ℕ y))
-        ( (neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))
+      ((int-ℕ t) *ℤ (int-ℕ y)) +ℤ ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))
     add-dist-eqn =
       equational-reasoning
         int-ℕ d
@@ -1214,9 +1181,7 @@ remainder-min-dist-succ-x-is-distance x y =
             ap
               ( λ H →
               add-ℤ
-                ( add-ℤ
-                  ( neg-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)))
-                  ( H))
+                ( (neg-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))) +ℤ H)
                 ( int-ℕ (succ-ℕ x)))
               ( neg-neg-ℤ
                 ( ((int-ℕ q) *ℤ ((int-ℕ s))) *ℤ (int-ℕ (succ-ℕ x))))
@@ -1243,8 +1208,7 @@ remainder-min-dist-succ-x-is-distance x y =
             ap
               ( _+ℤ (neg-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))))
               ( ap
-                ( add-ℤ
-                  ( ((int-ℕ q) *ℤ ((int-ℕ s))) *ℤ (int-ℕ (succ-ℕ x))))
+                ( (((int-ℕ q) *ℤ ((int-ℕ s))) *ℤ (int-ℕ (succ-ℕ x))) +ℤ_)
                 ( left-unit-law-mul-ℤ (int-ℕ (succ-ℕ x))) ∙
                 ( inv
                   ( right-distributive-mul-add-ℤ
@@ -1374,40 +1338,30 @@ remainder-min-dist-succ-x-is-distance x y =
 
     add-dist-eqn :
       int-ℕ d ＝
-      add-ℤ
-        ( (neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y))
-        ( (int-ℕ s) *ℤ (int-ℕ (succ-ℕ x)))
+      ((neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y)) +ℤ ((int-ℕ s) *ℤ (int-ℕ (succ-ℕ x)))
     add-dist-eqn =
       equational-reasoning
         int-ℕ d
-        ＝ add-ℤ
-            ( neg-ℤ (int-ℕ (t *ℕ y)))
-            ( (int-ℕ (t *ℕ y)) +ℤ (int-ℕ d))
+        ＝ (neg-ℤ (int-ℕ (t *ℕ y))) +ℤ ((int-ℕ (t *ℕ y)) +ℤ (int-ℕ d))
           by inv (isretr-add-neg-ℤ (int-ℕ (t *ℕ y)) (int-ℕ d))
         ＝ (neg-ℤ (int-ℕ (t *ℕ y))) +ℤ (int-ℕ ((t *ℕ y) +ℕ d))
-          by ap (add-ℤ (neg-ℤ (int-ℕ (t *ℕ y)))) (add-int-ℕ (t *ℕ y) d)
+          by ap ((neg-ℤ (int-ℕ (t *ℕ y))) +ℤ_) (add-int-ℕ (t *ℕ y) d)
         ＝ (neg-ℤ (int-ℕ (t *ℕ y))) +ℤ (int-ℕ (s *ℕ (succ-ℕ x)))
           by ap (λ H → (neg-ℤ (int-ℕ (t *ℕ y))) +ℤ (int-ℕ H)) rewrite-dist
-        ＝ add-ℤ
-          ( neg-ℤ ((int-ℕ t) *ℤ (int-ℕ y)))
-          ( int-ℕ (s *ℕ (succ-ℕ x)))
+        ＝ (neg-ℤ ((int-ℕ t) *ℤ (int-ℕ y))) +ℤ (int-ℕ (s *ℕ (succ-ℕ x)))
           by
             ap
               ( λ H → (neg-ℤ H) +ℤ (int-ℕ (s *ℕ (succ-ℕ x))))
               ( inv (mul-int-ℕ t y))
-        ＝ add-ℤ
-            ( (neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y))
-            ( int-ℕ (s *ℕ (succ-ℕ x)))
+        ＝ ((neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y)) +ℤ (int-ℕ (s *ℕ (succ-ℕ x)))
           by
             ap
               ( _+ℤ (int-ℕ (s *ℕ (succ-ℕ x))))
               ( inv (left-negative-law-mul-ℤ (int-ℕ t) (int-ℕ y)))
-        ＝ add-ℤ
-            ( (neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y))
-            ( (int-ℕ s) *ℤ (int-ℕ (succ-ℕ x)))
+        ＝ ((neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y)) +ℤ ((int-ℕ s) *ℤ (int-ℕ (succ-ℕ x)))
           by
             ap
-              ( add-ℤ ((neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y)))
+              ( ((neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y)) +ℤ_)
               ( inv (mul-int-ℕ s (succ-ℕ x)))
 
     isolate-rem-eqn :
@@ -1511,9 +1465,7 @@ remainder-min-dist-succ-x-is-distance x y =
               ( λ H →
                 add-ℤ
                   ( neg-ℤ
-                    ( add-ℤ
-                      ( H)
-                      ( (int-ℕ q) *ℤ ((int-ℕ s) *ℤ (int-ℕ (succ-ℕ x))))))
+                    ( H +ℤ ((int-ℕ q) *ℤ ((int-ℕ s) *ℤ (int-ℕ (succ-ℕ x))))))
                   ( int-ℕ (succ-ℕ x)))
               ( inv (associative-mul-ℤ (int-ℕ q) (neg-ℤ (int-ℕ t)) (int-ℕ y)))
         ＝ add-ℤ
@@ -1627,7 +1579,7 @@ remainder-min-dist-succ-x-is-distance x y =
               ( int-ℕ (succ-ℕ x)))
           by
             ap
-              ( add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)))
+              ( (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)) +ℤ_)
               ( inv
                 ( right-distributive-mul-add-ℤ
                   ( neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s)))

--- a/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
@@ -529,7 +529,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
           ( neg-ℤ ((int-ℕ (succ-ℕ x)) *ℤ (int-ℕ y))))
       by
       ap
-        ( add-ℤ'
+        ( _+ℤ
           ( add-ℤ
             ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
             ( neg-ℤ ((int-ℕ (succ-ℕ x)) *ℤ (int-ℕ y)))))
@@ -1826,16 +1826,14 @@ minimal-positive-distance-div-fst (succ-ℕ x) y =
         by
           ( inv
             ( right-unit-law-add-ℕ
-              ( mul-ℕ
-                ( quotient-euclidean-division-ℕ
+              ( ( quotient-euclidean-division-ℕ
                   ( minimal-positive-distance (succ-ℕ x) y)
-                  ( succ-ℕ x))
+                  ( succ-ℕ x)) *ℕ
                 ( minimal-positive-distance (succ-ℕ x) y))))
       ＝ add-ℕ
-        ( mul-ℕ
-          ( quotient-euclidean-division-ℕ
+        ( ( quotient-euclidean-division-ℕ
             ( minimal-positive-distance (succ-ℕ x) y)
-            ( succ-ℕ x))
+            ( succ-ℕ x)) *ℕ
           ( minimal-positive-distance (succ-ℕ x) y))
         ( remainder-euclidean-division-ℕ
           ( minimal-positive-distance (succ-ℕ x) y)

--- a/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
@@ -195,7 +195,7 @@ div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
               ( mod-int-ℕ x y))
         ＝ mod-ℤ x ((neg-ℤ (int-ℕ l)) *ℤ (int-ℕ y))
           by inv (preserves-mul-mod-ℤ x (neg-ℤ (int-ℕ l)) (int-ℕ y))
-        ＝ mod-ℤ x (add-ℤ ((neg-ℤ (int-ℕ l)) *ℤ (int-ℕ y)) zero-ℤ)
+        ＝ mod-ℤ x (((neg-ℤ (int-ℕ l)) *ℤ (int-ℕ y)) +ℤ zero-ℤ)
           by
           ap
             ( mod-ℤ x)
@@ -347,7 +347,7 @@ is-distance-between-multiples-div-mod-ℕ zero-ℕ y z (u , p) =
 
 is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
   uy-z-case-split (decide-is-nonnegative-ℤ
-    { add-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)) (neg-ℤ (int-ℕ z))})
+    { ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)) +ℤ (neg-ℤ (int-ℕ z))})
   where
   a : ℤ
   a = pr1 (cong-div-mod-ℤ (succ-ℕ x) y z (u , p))
@@ -379,7 +379,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
     ＝ add-ℤ
         ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
         ( add-ℤ
-          ( add-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)) (neg-ℤ (int-ℕ z)))
+          ( ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)) +ℤ (neg-ℤ (int-ℕ z)))
           ( int-ℕ z))
       by
       ap
@@ -391,13 +391,13 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
     ＝ add-ℤ
         ( add-ℤ
           ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
-          ( add-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)) (neg-ℤ (int-ℕ z))))
+          ( ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)) +ℤ (neg-ℤ (int-ℕ z))))
         ( int-ℕ z)
       by
       inv
         ( associative-add-ℤ
           ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
-          ( add-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)) (neg-ℤ (int-ℕ z)))
+          ( ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)) +ℤ (neg-ℤ (int-ℕ z)))
           ( int-ℕ z))
     ＝ add-ℤ
         ( add-ℤ
@@ -518,7 +518,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
         ( λ p →
           add-ℤ
             ( ((neg-ℤ a) +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x)))
-            ( add-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)) p))
+            ( ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)) +ℤ p))
         ( left-negative-law-mul-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ y))
     ＝ add-ℤ
         ( add-ℤ
@@ -545,7 +545,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
       ap
         ( λ p →
           add-ℤ
-            ( add-ℤ ((neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x))) p)
+            ( ((neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x))) +ℤ p)
             ( add-ℤ
               ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
               ( neg-ℤ ((int-ℕ (succ-ℕ x)) *ℤ (int-ℕ y)))))
@@ -600,7 +600,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
 
   uy-z-case-split :
     ( ( is-nonnegative-ℤ
-        ( add-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)) (neg-ℤ (int-ℕ z)))) +
+        ( ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)) +ℤ (neg-ℤ (int-ℕ z)))) +
       ( is-nonnegative-ℤ
         ( neg-ℤ
           ( add-ℤ
@@ -683,24 +683,24 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
         by ap (λ p → dist-ℤ p (int-ℕ (mul-ℕ (abs-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
           (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))) y)))
           (inv (mul-int-ℕ ((abs-ℤ a) +ℕ y) (succ-ℕ x)))
-        ＝ dist-ℤ (mul-ℤ ((int-ℕ (abs-ℤ a)) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+        ＝ dist-ℤ (((int-ℕ (abs-ℤ a)) +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x)))
           (int-ℕ (mul-ℕ (abs-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
           (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))) y))
         by ap (λ p → dist-ℤ (p *ℤ (int-ℕ (succ-ℕ x)))
              (int-ℕ (mul-ℕ (abs-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
                (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))) y)))
           (inv (add-int-ℕ (abs-ℤ a) y))
-        ＝ dist-ℤ (mul-ℤ ((int-ℕ (abs-ℤ a)) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+        ＝ dist-ℤ (((int-ℕ (abs-ℤ a)) +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x)))
           (mul-ℤ (int-ℕ (abs-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
           (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))))) (int-ℕ y))
-        by ap (dist-ℤ (mul-ℤ ((int-ℕ (abs-ℤ a)) +ℤ (int-ℕ y))
+        by ap (dist-ℤ (((int-ℕ (abs-ℤ a)) +ℤ (int-ℕ y)) *ℤ
              (int-ℕ (succ-ℕ x))))
           (inv (mul-int-ℕ (abs-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
             (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))) y))
-        ＝ dist-ℤ (mul-ℤ ((int-ℕ (abs-ℤ a)) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+        ＝ dist-ℤ (((int-ℕ (abs-ℤ a)) +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x)))
           (mul-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
             (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) (int-ℕ y))
-        by ap (λ p → dist-ℤ (mul-ℤ ((int-ℕ (abs-ℤ a)) +ℤ (int-ℕ y))
+        by ap (λ p → dist-ℤ (((int-ℕ (abs-ℤ a)) +ℤ (int-ℕ y)) *ℤ
              (int-ℕ (succ-ℕ x))) (p *ℤ (int-ℕ y)))
           (int-abs-is-nonnegative-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
             (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) (int-ℤ-Mod-bounded x u))
@@ -723,7 +723,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
           (mul-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
             (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) (int-ℕ y))
         by ap (λ p → dist-ℤ ((p +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x)))
-          (mul-ℤ ((int-ℕ (succ-ℕ x)) +ℤ (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
+          (((int-ℕ (succ-ℕ x)) +ℤ (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) *ℤ
             (int-ℕ y)))
           (int-abs-is-nonnegative-ℤ (neg-ℤ a) neg-a-is-nonnegative-ℤ)
         ＝ abs-ℤ (int-ℕ z)
@@ -734,14 +734,14 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
     neg-a-is-nonnegative-ℤ = (is-nonnegative-left-factor-mul-ℤ
       (tr is-nonnegative-ℤ
       (equational-reasoning
-        neg-ℤ (add-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
+        neg-ℤ (((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)) +ℤ
           (neg-ℤ (int-ℕ z)))
-        ＝ add-ℤ (neg-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)))
+        ＝ (neg-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))) +ℤ
           (neg-ℤ (neg-ℤ (int-ℕ z)))
         by (distributive-neg-add-ℤ
           ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
           (neg-ℤ (int-ℕ z)))
-        ＝ add-ℤ (neg-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)))
+        ＝ (neg-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))) +ℤ
           (int-ℕ z)
         by ap ((neg-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))) +ℤ_)
           (neg-neg-ℤ (int-ℕ z))
@@ -1063,10 +1063,10 @@ remainder-min-dist-succ-x-is-distance x y =
     add-dist-eqn =
       equational-reasoning
         int-ℕ d
-        ＝ add-ℤ ((int-ℕ d) +ℤ (int-ℕ (s *ℕ (succ-ℕ x))))
+        ＝ ((int-ℕ d) +ℤ (int-ℕ (s *ℕ (succ-ℕ x)))) +ℤ
           (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x))))
           by inv (isretr-add-neg-ℤ' (int-ℕ (s *ℕ (succ-ℕ x))) (int-ℕ d))
-        ＝ add-ℤ (int-ℕ (d +ℕ (s *ℕ (succ-ℕ x))))
+        ＝ (int-ℕ (d +ℕ (s *ℕ (succ-ℕ x)))) +ℤ
           (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x))))
           by ap (_+ℤ (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x)))))
           (add-int-ℕ d (s *ℕ (succ-ℕ x)))
@@ -1153,19 +1153,19 @@ remainder-min-dist-succ-x-is-distance x y =
       equational-reasoning
         add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (((int-ℕ t) *ℤ (int-ℕ y)) +ℤ
           ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x))
-        ＝ add-ℤ (neg-ℤ (add-ℤ ((int-ℕ q) *ℤ ((int-ℕ t) *ℤ (int-ℕ y)))
+        ＝ add-ℤ (neg-ℤ (((int-ℕ q) *ℤ ((int-ℕ t) *ℤ (int-ℕ y))) +ℤ
           ((int-ℕ q) *ℤ ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))))))
             (int-ℕ (succ-ℕ x))
           by (ap (λ H → (neg-ℤ H) +ℤ (int-ℕ (succ-ℕ x)))
             (left-distributive-mul-add-ℤ (int-ℕ q) ((int-ℕ t) *ℤ (int-ℕ y))
               ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))
-        ＝ add-ℤ (neg-ℤ (add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
+        ＝ add-ℤ (neg-ℤ ((((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)) +ℤ
           ((int-ℕ q) *ℤ ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))))))
             (int-ℕ (succ-ℕ x))
           by (ap (λ H → add-ℤ (neg-ℤ (H +ℤ (mul-ℤ (int-ℕ q)
             ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x)))
               (inv (associative-mul-ℤ (int-ℕ q) (int-ℕ t) (int-ℕ y))))
-        ＝ add-ℤ (neg-ℤ (add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
+        ＝ add-ℤ (neg-ℤ ((((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)) +ℤ
           (neg-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))))))
             (int-ℕ (succ-ℕ x))
           by
@@ -1173,11 +1173,11 @@ remainder-min-dist-succ-x-is-distance x y =
               ( λ H →
                 add-ℤ
                   ( neg-ℤ
-                    ( add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)) H))
+                    ( (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)) +ℤ H))
                   ( int-ℕ (succ-ℕ x)))
             ( equational-reasoning
                 ((int-ℕ q) *ℤ ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))))
-                ＝ mul-ℤ ((int-ℕ q) *ℤ (neg-ℤ (int-ℕ s))) (int-ℕ (succ-ℕ x))
+                ＝ ((int-ℕ q) *ℤ (neg-ℤ (int-ℕ s))) *ℤ (int-ℕ (succ-ℕ x))
                   by
                     inv
                       ( associative-mul-ℤ
@@ -1219,8 +1219,8 @@ remainder-min-dist-succ-x-is-distance x y =
                   ( H))
                 ( int-ℕ (succ-ℕ x)))
               ( neg-neg-ℤ
-                ( mul-ℤ ((int-ℕ q) *ℤ ((int-ℕ s))) (int-ℕ (succ-ℕ x))))
-        ＝ add-ℤ (neg-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)))
+                ( ((int-ℕ q) *ℤ ((int-ℕ s))) *ℤ (int-ℕ (succ-ℕ x))))
+        ＝ (neg-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))) +ℤ
            ((((int-ℕ q) *ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))) +ℤ
              (int-ℕ (succ-ℕ x)))
           by associative-add-ℤ
@@ -1244,7 +1244,7 @@ remainder-min-dist-succ-x-is-distance x y =
               ( _+ℤ (neg-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))))
               ( ap
                 ( add-ℤ
-                  ( mul-ℤ ((int-ℕ q) *ℤ ((int-ℕ s))) (int-ℕ (succ-ℕ x))))
+                  ( ((int-ℕ q) *ℤ ((int-ℕ s))) *ℤ (int-ℕ (succ-ℕ x))))
                 ( left-unit-law-mul-ℤ (int-ℕ (succ-ℕ x))) ∙
                 ( inv
                   ( right-distributive-mul-add-ℤ
@@ -1264,7 +1264,7 @@ remainder-min-dist-succ-x-is-distance x y =
           (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
           by (ap (abs-ℤ) (isolate-rem-eqn ∙ rearrange-arith-eqn))
         ＝ dist-ℤ
-            ( mul-ℤ ((int-ℕ (q *ℕ s)) +ℤ (int-ℕ 1)) (int-ℕ (succ-ℕ x)))
+            ( ((int-ℕ (q *ℕ s)) +ℤ (int-ℕ 1)) *ℤ (int-ℕ (succ-ℕ x)))
             ( ((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
           by ap (λ H → dist-ℤ ((H +ℤ (int-ℕ 1)) *ℤ (int-ℕ (succ-ℕ x)))
             (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)))
@@ -1438,7 +1438,7 @@ remainder-min-dist-succ-x-is-distance x y =
                   ( (int-ℕ s) *ℤ (int-ℕ (succ-ℕ x)))))
               ( int-ℕ r))
           by inv (isretr-add-neg-ℤ (mul-ℤ (int-ℕ q)
-            (add-ℤ ((neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y))
+            (((neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y)) +ℤ
             ((int-ℕ s) *ℤ (int-ℕ (succ-ℕ x))))) (int-ℕ r))
         ＝ add-ℤ
             ( neg-ℤ
@@ -1478,14 +1478,14 @@ remainder-min-dist-succ-x-is-distance x y =
               ( minimal-positive-distance-div-succ-x-eqn x y)
 
     rearrange-arith :
-      add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (add-ℤ ((neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y))
+      add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (((neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y)) +ℤ
         ((int-ℕ s) *ℤ (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x))
-      ＝ add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
-        (neg-ℤ (mul-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ))
+      ＝ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)) +ℤ
+        (neg-ℤ ((((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ)) *ℤ
           (int-ℕ (succ-ℕ x))))
     rearrange-arith =
       equational-reasoning
-        add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (add-ℤ ((neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y))
+        add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (((neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y)) +ℤ
           ((int-ℕ s) *ℤ (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x))
         ＝ add-ℤ
             ( neg-ℤ
@@ -1503,7 +1503,7 @@ remainder-min-dist-succ-x-is-distance x y =
         ＝ add-ℤ
             ( neg-ℤ
               ( add-ℤ
-                ( mul-ℤ ((int-ℕ q) *ℤ (neg-ℤ (int-ℕ t))) (int-ℕ y))
+                ( ((int-ℕ q) *ℤ (neg-ℤ (int-ℕ t))) *ℤ (int-ℕ y))
                 ( (int-ℕ q) *ℤ ((int-ℕ s) *ℤ (int-ℕ (succ-ℕ x))))))
             ( int-ℕ (succ-ℕ x))
           by
@@ -1519,7 +1519,7 @@ remainder-min-dist-succ-x-is-distance x y =
         ＝ add-ℤ
             ( neg-ℤ
               ( add-ℤ
-                ( mul-ℤ ((int-ℕ q) *ℤ (neg-ℤ (int-ℕ t))) (int-ℕ y))
+                ( ((int-ℕ q) *ℤ (neg-ℤ (int-ℕ t))) *ℤ (int-ℕ y))
                 ( ((int-ℕ q) *ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))
             ( int-ℕ (succ-ℕ x))
           by
@@ -1528,7 +1528,7 @@ remainder-min-dist-succ-x-is-distance x y =
                 add-ℤ
                   ( neg-ℤ
                     ( add-ℤ
-                      ( mul-ℤ ((int-ℕ q) *ℤ (neg-ℤ (int-ℕ t))) (int-ℕ y))
+                      ( ((int-ℕ q) *ℤ (neg-ℤ (int-ℕ t))) *ℤ (int-ℕ y))
                       ( H)))
                   ( int-ℕ (succ-ℕ x)))
             ( inv (associative-mul-ℤ (int-ℕ q) (int-ℕ s) (int-ℕ (succ-ℕ x))))
@@ -1562,7 +1562,7 @@ remainder-min-dist-succ-x-is-distance x y =
               (int-ℕ (succ-ℕ x))))
         ＝ add-ℤ
             ( add-ℤ
-              ( mul-ℤ (neg-ℤ (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ t)))) (int-ℕ y))
+              ( (neg-ℤ (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ t)))) *ℤ (int-ℕ y))
               ( neg-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))
             ( int-ℕ (succ-ℕ x))
           by
@@ -1578,14 +1578,14 @@ remainder-min-dist-succ-x-is-distance x y =
               ( left-negative-law-mul-ℤ
                 ( neg-ℤ ((int-ℕ q) *ℤ (int-ℕ t)))
                 ( int-ℕ y)))
-        ＝ add-ℤ (add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
+        ＝ add-ℤ ((((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)) +ℤ
             (neg-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))
             (int-ℕ (succ-ℕ x))
           by ap (λ H → (add-ℤ ((H *ℤ (int-ℕ y)) +ℤ
             (neg-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))
               (int-ℕ (succ-ℕ x))))
             (neg-neg-ℤ ((int-ℕ q) *ℤ (int-ℕ t)))
-        ＝ add-ℤ (add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
+        ＝ add-ℤ ((((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)) +ℤ
             ((neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s))) *ℤ (int-ℕ (succ-ℕ x))))
           (int-ℕ (succ-ℕ x))
           by
@@ -1598,14 +1598,14 @@ remainder-min-dist-succ-x-is-distance x y =
                 ( left-negative-law-mul-ℤ
                   ( (int-ℕ q) *ℤ (int-ℕ s))
                   ( int-ℕ (succ-ℕ x))))
-        ＝ add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
-          (add-ℤ ((neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s))) *ℤ (int-ℕ (succ-ℕ x)))
+        ＝ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)) +ℤ
+          (((neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s))) *ℤ (int-ℕ (succ-ℕ x))) +ℤ
             (int-ℕ (succ-ℕ x)))
           by associative-add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
             ((neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s))) *ℤ (int-ℕ (succ-ℕ x)))
             (int-ℕ (succ-ℕ x))
-        ＝ add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
-          (add-ℤ ((neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s))) *ℤ (int-ℕ (succ-ℕ x)))
+        ＝ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)) +ℤ
+          (((neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s))) *ℤ (int-ℕ (succ-ℕ x))) +ℤ
             ((neg-ℤ (neg-ℤ one-ℤ)) *ℤ (int-ℕ (succ-ℕ x))))
           by
             ap
@@ -1637,11 +1637,11 @@ remainder-min-dist-succ-x-is-distance x y =
             ( ((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
             ( mul-ℤ (neg-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ
             (neg-ℤ one-ℤ))) (int-ℕ (succ-ℕ x)))
-          by ap (λ H → (add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
+          by ap (λ H → ((((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)) +ℤ
               (H *ℤ (int-ℕ (succ-ℕ x)))))
               (inv (distributive-neg-add-ℤ
                 ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ)))
-        ＝ add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
+        ＝ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)) +ℤ
           (neg-ℤ (mul-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ
             (neg-ℤ one-ℤ)) (int-ℕ (succ-ℕ x))))
           by ap ((((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)) +ℤ_)
@@ -1660,19 +1660,19 @@ remainder-min-dist-succ-x-is-distance x y =
       equational-reasoning
         r
         ＝ abs-ℤ (int-ℕ r) by (inv (abs-int-ℕ r))
-        ＝ abs-ℤ (add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
-            (neg-ℤ (mul-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ))
+        ＝ abs-ℤ ((((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)) +ℤ
+            (neg-ℤ ((((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ)) *ℤ
             (int-ℕ (succ-ℕ x)))))
           by (ap abs-ℤ (isolate-rem-eqn ∙ rearrange-arith))
         ＝ dist-ℤ ((int-ℕ (q *ℕ t)) *ℤ (int-ℕ y))
-          (mul-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ))
+          ((((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ)) *ℤ
             (int-ℕ (succ-ℕ x)))
           by ap (λ H → (dist-ℤ (H *ℤ (int-ℕ y))
-            (mul-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ))
+            ((((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ)) *ℤ
               (int-ℕ (succ-ℕ x)))))
               (mul-int-ℕ q t)
         ＝ dist-ℤ (int-ℕ ((q *ℕ t) *ℕ y))
-          (mul-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ))
+          ((((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ)) *ℤ
           (int-ℕ (succ-ℕ x)))
           by
             ap
@@ -1710,14 +1710,14 @@ remainder-min-dist-succ-x-is-distance x y =
                 ( abs-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ)))
                 ( succ-ℕ x))
         ＝ dist-ℕ ((q *ℕ t) *ℕ y)
-          (mul-ℕ (abs-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ)))
+          ((abs-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ))) *ℕ
             (succ-ℕ x))
           by dist-int-ℕ
             ((q *ℕ t) *ℕ y)
-            (mul-ℕ (abs-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ)))
+            ((abs-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ))) *ℕ
               (succ-ℕ x))
         ＝ dist-ℕ
-          (mul-ℕ (abs-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ)))
+          ((abs-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ))) *ℕ
             (succ-ℕ x))
             ((q *ℕ t) *ℕ y)
           by symmetric-dist-ℕ

--- a/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
@@ -62,7 +62,7 @@ such that `P z` holds is `gcd x y`.
 ```agda
 is-distance-between-multiples-ℕ : ℕ → ℕ → ℕ → UU lzero
 is-distance-between-multiples-ℕ x y z =
-  Σ ℕ (λ k → Σ ℕ (λ l → dist-ℕ (mul-ℕ k x) (mul-ℕ l y) ＝ z))
+  Σ ℕ (λ k → Σ ℕ (λ l → dist-ℕ (k *ℕ x) (l *ℕ y) ＝ z))
 
 is-distance-between-multiples-fst-coeff-ℕ :
   {x y z : ℕ} → is-distance-between-multiples-ℕ x y z → ℕ
@@ -75,15 +75,15 @@ is-distance-between-multiples-snd-coeff-ℕ dist = pr1 (pr2 dist)
 is-distance-between-multiples-eqn-ℕ :
   {x y z : ℕ} (d : is-distance-between-multiples-ℕ x y z) →
   dist-ℕ
-    ( mul-ℕ (is-distance-between-multiples-fst-coeff-ℕ d) x)
-    ( mul-ℕ (is-distance-between-multiples-snd-coeff-ℕ d) y) ＝ z
+    ( (is-distance-between-multiples-fst-coeff-ℕ d) *ℕ x)
+    ( (is-distance-between-multiples-snd-coeff-ℕ d) *ℕ y) ＝ z
 is-distance-between-multiples-eqn-ℕ dist = pr2 (pr2 dist)
 
 is-distance-between-multiples-sym-ℕ :
   (x y z : ℕ) → is-distance-between-multiples-ℕ x y z →
   is-distance-between-multiples-ℕ y x z
 is-distance-between-multiples-sym-ℕ x y z (pair k (pair l eqn)) =
-  pair l (pair k (symmetric-dist-ℕ (mul-ℕ l y) (mul-ℕ k x) ∙ eqn))
+  pair l (pair k (symmetric-dist-ℕ (l *ℕ y) (k *ℕ x) ∙ eqn))
 ```
 
 ## Lemmas
@@ -99,8 +99,8 @@ int-is-distance-between-multiples-ℕ :
   (x y z : ℕ) (d : is-distance-between-multiples-ℕ x y z) →
   ( H :
     leq-ℕ
-      ( mul-ℕ (is-distance-between-multiples-fst-coeff-ℕ d) x)
-      ( mul-ℕ (is-distance-between-multiples-snd-coeff-ℕ d) y)) →
+      ( (is-distance-between-multiples-fst-coeff-ℕ d) *ℕ x)
+      ( (is-distance-between-multiples-snd-coeff-ℕ d) *ℕ y)) →
   add-ℤ
     ( int-ℕ z)
     ( mul-ℤ
@@ -111,25 +111,25 @@ int-is-distance-between-multiples-ℕ :
     ( int-ℕ y)
 int-is-distance-between-multiples-ℕ x y z (k , l , p) H =
   equational-reasoning
-    (int-ℕ z) +ℤ (mul-ℤ (int-ℕ k) (int-ℕ x))
-    ＝ (int-ℕ z) +ℤ (int-ℕ (mul-ℕ k x))
+    (int-ℕ z) +ℤ ((int-ℕ k) *ℤ (int-ℕ x))
+    ＝ (int-ℕ z) +ℤ (int-ℕ (k *ℕ x))
       by ap (λ p → (int-ℕ z) +ℤ p) (mul-int-ℕ k x)
-    ＝ int-ℕ (z +ℕ (mul-ℕ k x))
-      by add-int-ℕ z (mul-ℕ k x)
-    ＝ int-ℕ (mul-ℕ l y)
+    ＝ int-ℕ (z +ℕ (k *ℕ x))
+      by add-int-ℕ z (k *ℕ x)
+    ＝ int-ℕ (l *ℕ y)
       by ap (int-ℕ)
-        (rewrite-left-dist-add-ℕ z (mul-ℕ k x) (mul-ℕ l y) H (inv p))
-    ＝ mul-ℤ (int-ℕ l) (int-ℕ y)
+        (rewrite-left-dist-add-ℕ z (k *ℕ x) (l *ℕ y) H (inv p))
+    ＝ (int-ℕ l) *ℤ (int-ℕ y)
       by inv (mul-int-ℕ l y)
 
 div-mod-is-distance-between-multiples-ℕ :
   (x y z : ℕ) →
   is-distance-between-multiples-ℕ x y z → div-ℤ-Mod x (mod-ℕ x y) (mod-ℕ x z)
 div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
-  kxly-case-split (linear-leq-ℕ (mul-ℕ k x) (mul-ℕ l y))
+  kxly-case-split (linear-leq-ℕ (k *ℕ x) (l *ℕ y))
   where
   kxly-case-split :
-    leq-ℕ (mul-ℕ k x) (mul-ℕ l y) + leq-ℕ (mul-ℕ l y) (mul-ℕ k x) →
+    leq-ℕ (k *ℕ x) (l *ℕ y) + leq-ℕ (l *ℕ y) (k *ℕ x) →
     div-ℤ-Mod x (mod-ℕ x y) (mod-ℕ x z)
   kxly-case-split (inl kxly) =
     ( mod-ℕ x l ,
@@ -139,16 +139,16 @@ div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
           by inv (ap (λ p → mul-ℤ-Mod x p (mod-ℕ x y)) (mod-int-ℕ x l))
         ＝ mul-ℤ-Mod x (mod-ℤ x (int-ℕ l)) (mod-ℤ x (int-ℕ y))
           by inv (ap (λ p → mul-ℤ-Mod x (mod-ℤ x (int-ℕ l)) p) (mod-int-ℕ x y))
-        ＝ mod-ℤ x (mul-ℤ (int-ℕ l) (int-ℕ y))
+        ＝ mod-ℤ x ((int-ℕ l) *ℤ (int-ℕ y))
           by inv (preserves-mul-mod-ℤ x (int-ℕ l) (int-ℕ y))
-        ＝ mod-ℤ x ((int-ℕ z) +ℤ (mul-ℤ (int-ℕ k) (int-ℕ x)))
+        ＝ mod-ℤ x ((int-ℕ z) +ℤ ((int-ℕ k) *ℤ (int-ℕ x)))
           by
           inv
             ( ap
               ( mod-ℤ x)
               ( int-is-distance-between-multiples-ℕ x y z (k , l , p) kxly))
-        ＝ add-ℤ-Mod x (mod-ℤ x (int-ℕ z)) (mod-ℤ x (mul-ℤ (int-ℕ k) (int-ℕ x)))
-          by preserves-add-mod-ℤ x (int-ℕ z) (mul-ℤ (int-ℕ k) (int-ℕ x))
+        ＝ add-ℤ-Mod x (mod-ℤ x (int-ℕ z)) (mod-ℤ x ((int-ℕ k) *ℤ (int-ℕ x)))
+          by preserves-add-mod-ℤ x (int-ℕ z) ((int-ℕ k) *ℤ (int-ℕ x))
         ＝ add-ℤ-Mod x
             ( mod-ℤ x (int-ℕ z))
             ( mul-ℤ-Mod x (mod-ℤ x (int-ℕ k)) (mod-ℤ x (int-ℕ x)))
@@ -168,7 +168,7 @@ div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
             ( mod-int-ℕ x x ∙ (mod-refl-ℕ x ∙ inv (mod-zero-ℤ x)))
         ＝ add-ℤ-Mod x
             ( mod-ℤ x (int-ℕ z))
-            ( mod-ℤ x (mul-ℤ (int-ℕ k) zero-ℤ))
+            ( mod-ℤ x ((int-ℕ k) *ℤ zero-ℤ))
           by
           ap
             ( λ p → add-ℤ-Mod x (mod-ℤ x (int-ℕ z)) p)
@@ -206,7 +206,7 @@ div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
           by preserves-add-mod-ℤ x (mul-ℤ (neg-ℤ (int-ℕ l)) (int-ℕ y)) (zero-ℤ)
         ＝ add-ℤ-Mod x
             ( mod-ℤ x (mul-ℤ (neg-ℤ (int-ℕ l)) (int-ℕ y)))
-            ( mod-ℤ x (mul-ℤ (int-ℕ k) zero-ℤ))
+            ( mod-ℤ x ((int-ℕ k) *ℤ zero-ℤ))
           by
           ap
             ( λ p →
@@ -233,7 +233,7 @@ div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
             ( mod-zero-ℤ x ∙ (inv (mod-refl-ℕ x) ∙ inv (mod-int-ℕ x x)))
         ＝ add-ℤ-Mod x
             ( mod-ℤ x (mul-ℤ (neg-ℤ (int-ℕ l)) (int-ℕ y)))
-            ( mod-ℤ x (mul-ℤ (int-ℕ k) (int-ℕ x)))
+            ( mod-ℤ x ((int-ℕ k) *ℤ (int-ℕ x)))
           by
           ap
             ( add-ℤ-Mod x (mod-ℤ x (mul-ℤ (neg-ℤ (int-ℕ l)) (int-ℕ y))))
@@ -241,12 +241,12 @@ div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
         ＝ mod-ℤ x
             ( add-ℤ
               ( mul-ℤ (neg-ℤ (int-ℕ l)) (int-ℕ y))
-              ( mul-ℤ (int-ℕ k) (int-ℕ x)))
+              ( (int-ℕ k) *ℤ (int-ℕ x)))
           by
           inv
             ( preserves-add-mod-ℤ x
               ( mul-ℤ (neg-ℤ (int-ℕ l)) (int-ℕ y))
-              ( mul-ℤ (int-ℕ k) (int-ℕ x)))
+              ( (int-ℕ k) *ℤ (int-ℕ x)))
         ＝ mod-ℤ x (int-ℕ z)
           by
           ap
@@ -254,33 +254,33 @@ div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
             ( equational-reasoning
               add-ℤ
                 ( mul-ℤ (neg-ℤ (int-ℕ l)) (int-ℕ y))
-                ( mul-ℤ (int-ℕ k) (int-ℕ x))
+                ( (int-ℕ k) *ℤ (int-ℕ x))
               ＝ add-ℤ
-                  ( neg-ℤ (mul-ℤ (int-ℕ l) (int-ℕ y)))
-                  ( mul-ℤ (int-ℕ k) (int-ℕ x))
+                  ( neg-ℤ ((int-ℕ l) *ℤ (int-ℕ y)))
+                  ( (int-ℕ k) *ℤ (int-ℕ x))
                 by
                 ap
-                  ( λ p → p +ℤ (mul-ℤ (int-ℕ k) (int-ℕ x)))
+                  ( λ p → p +ℤ ((int-ℕ k) *ℤ (int-ℕ x)))
                   ( left-negative-law-mul-ℤ (int-ℕ l) (int-ℕ y))
               ＝ add-ℤ
-                  ( mul-ℤ (int-ℕ k) (int-ℕ x))
-                  ( neg-ℤ (mul-ℤ (int-ℕ l) (int-ℕ y)))
+                  ( (int-ℕ k) *ℤ (int-ℕ x))
+                  ( neg-ℤ ((int-ℕ l) *ℤ (int-ℕ y)))
                 by
                 commutative-add-ℤ
-                  ( neg-ℤ (mul-ℤ (int-ℕ l) (int-ℕ y)))
-                  ( mul-ℤ (int-ℕ k) (int-ℕ x))
+                  ( neg-ℤ ((int-ℕ l) *ℤ (int-ℕ y)))
+                  ( (int-ℕ k) *ℤ (int-ℕ x))
               ＝ add-ℤ
-                  ( (int-ℕ z) +ℤ (mul-ℤ (int-ℕ l) (int-ℕ y)))
-                  ( neg-ℤ (mul-ℤ (int-ℕ l) (int-ℕ y)))
+                  ( (int-ℕ z) +ℤ ((int-ℕ l) *ℤ (int-ℕ y)))
+                  ( neg-ℤ ((int-ℕ l) *ℤ (int-ℕ y)))
                 by
                 ap
-                  ( λ p → p +ℤ (neg-ℤ (mul-ℤ (int-ℕ l) (int-ℕ y))))
+                  ( λ p → p +ℤ (neg-ℤ ((int-ℕ l) *ℤ (int-ℕ y))))
                   ( inv
                     ( int-is-distance-between-multiples-ℕ y x z
                       ( is-distance-between-multiples-sym-ℕ x y z (k , l , p))
                     ( lykx)))
               ＝ int-ℕ z
-                by isretr-add-neg-ℤ' (mul-ℤ (int-ℕ l) (int-ℕ y)) (int-ℕ z))
+                by isretr-add-neg-ℤ' ((int-ℕ l) *ℤ (int-ℕ y)) (int-ℕ z))
               ＝ mod-ℕ x z by mod-int-ℕ x z))
 ```
 
@@ -301,10 +301,10 @@ cong-div-mod-ℤ :
   cong-ℤ (int-ℕ x) (mul-ℤ (int-ℤ-Mod x (pr1 q)) (int-ℕ y)) (int-ℕ z)
 cong-div-mod-ℤ x y z (u , p) =
   cong-eq-mod-ℤ x
-    ( mul-ℤ (int-ℤ-Mod x u) (int-ℕ y))
+    ( (int-ℤ-Mod x u) *ℤ (int-ℕ y))
     ( int-ℕ z)
     ( equational-reasoning
-      mod-ℤ x (mul-ℤ (int-ℤ-Mod x u) (int-ℕ y))
+      mod-ℤ x ((int-ℤ-Mod x u) *ℤ (int-ℕ y))
       ＝ mul-ℤ-Mod x (mod-ℤ x (int-ℤ-Mod x u)) (mod-ℤ x (int-ℕ y))
         by preserves-mul-mod-ℤ x (int-ℤ-Mod x u) (int-ℕ y)
       ＝ mul-ℤ-Mod x u (mod-ℤ x (int-ℕ y))
@@ -329,7 +329,7 @@ is-distance-between-multiples-div-mod-ℕ zero-ℕ y z (u , p) =
       is-injective-int-ℕ
         ( inv (mul-int-ℕ (abs-ℤ u) y) ∙
           ( ( ap
-              ( λ H → mul-ℤ H (int-ℕ y))
+              ( λ H → H *ℤ (int-ℕ y))
               ( int-abs-is-nonnegative-ℤ u nonneg)) ∙
             ( p))))
   u-nonneg-case-split (inr neg) =
@@ -355,76 +355,76 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
   a-eqn-pos :
     add-ℤ
       ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
-      ( neg-ℤ (mul-ℤ a (int-ℕ (succ-ℕ x)))) ＝
+      ( neg-ℤ (a *ℤ (int-ℕ (succ-ℕ x)))) ＝
     int-ℕ z
   a-eqn-pos =
     equational-reasoning
     add-ℤ
       ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
-      ( neg-ℤ (mul-ℤ a (int-ℕ (succ-ℕ x))))
+      ( neg-ℤ (a *ℤ (int-ℕ (succ-ℕ x))))
     ＝ add-ℤ
-        ( neg-ℤ (mul-ℤ a (int-ℕ (succ-ℕ x))))
+        ( neg-ℤ (a *ℤ (int-ℕ (succ-ℕ x))))
         ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
       by
       commutative-add-ℤ
         ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
-        ( neg-ℤ (mul-ℤ a (int-ℕ (succ-ℕ x))))
+        ( neg-ℤ (a *ℤ (int-ℕ (succ-ℕ x))))
     ＝ add-ℤ
-        ( mul-ℤ (neg-ℤ a) (int-ℕ (succ-ℕ x)))
+        ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
         ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
       by
       ap
         ( λ p → p +ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)))
         ( inv (left-negative-law-mul-ℤ a (int-ℕ (succ-ℕ x))))
     ＝ add-ℤ
-        ( mul-ℤ (neg-ℤ a) (int-ℕ (succ-ℕ x)))
+        ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
         ( add-ℤ
           ( add-ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)) (neg-ℤ (int-ℕ z)))
           ( int-ℕ z))
       by
       ap
-        ( add-ℤ (mul-ℤ (neg-ℤ a) (int-ℕ (succ-ℕ x))))
+        ( add-ℤ ((neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x))))
         ( inv
           ( issec-add-neg-ℤ'
             ( int-ℕ z)
             ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))))
     ＝ add-ℤ
         ( add-ℤ
-          ( mul-ℤ (neg-ℤ a) (int-ℕ (succ-ℕ x)))
+          ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
           ( add-ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)) (neg-ℤ (int-ℕ z))))
         ( int-ℕ z)
       by
       inv
         ( associative-add-ℤ
-          ( mul-ℤ (neg-ℤ a) (int-ℕ (succ-ℕ x)))
+          ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
           ( add-ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)) (neg-ℤ (int-ℕ z)))
           ( int-ℕ z))
     ＝ add-ℤ
         ( add-ℤ
-          ( mul-ℤ (neg-ℤ a) (int-ℕ (succ-ℕ x)))
-          ( mul-ℤ a (int-ℕ (succ-ℕ x))))
+          ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
+          ( a *ℤ (int-ℕ (succ-ℕ x))))
         ( int-ℕ z)
       by
       ap
         ( λ p →
           add-ℤ
-            ( add-ℤ (mul-ℤ (neg-ℤ a) (int-ℕ (succ-ℕ x))) p)
+            ( add-ℤ ((neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x))) p)
             ( int-ℕ z))
         ( inv (pr2 (cong-div-mod-ℤ (succ-ℕ x) y z (u , p))))
     ＝ add-ℤ
         ( add-ℤ
-          ( neg-ℤ (mul-ℤ a (int-ℕ (succ-ℕ x))))
-          ( mul-ℤ a (int-ℕ (succ-ℕ x))))
+          ( neg-ℤ (a *ℤ (int-ℕ (succ-ℕ x))))
+          ( a *ℤ (int-ℕ (succ-ℕ x))))
         ( int-ℕ z)
       by
       ap
-        ( λ p → add-ℤ (p +ℤ (mul-ℤ a (int-ℕ (succ-ℕ x)))) (int-ℕ z))
+        ( λ p → add-ℤ (p +ℤ (a *ℤ (int-ℕ (succ-ℕ x)))) (int-ℕ z))
         ( left-negative-law-mul-ℤ a (int-ℕ (succ-ℕ x)))
     ＝ zero-ℤ +ℤ (int-ℕ z)
       by
       ap
         ( add-ℤ' (int-ℕ z))
-        ( left-inverse-law-add-ℤ (mul-ℤ a (int-ℕ (succ-ℕ x))))
+        ( left-inverse-law-add-ℤ (a *ℤ (int-ℕ (succ-ℕ x))))
     ＝ int-ℕ z by left-unit-law-add-ℤ (int-ℕ z)
 
   a-extra-eqn-neg :
@@ -438,7 +438,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
           ( int-ℕ y))) ＝
     add-ℤ
       ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
-      ( neg-ℤ (mul-ℤ a (int-ℕ (succ-ℕ x))))
+      ( neg-ℤ (a *ℤ (int-ℕ (succ-ℕ x))))
   a-extra-eqn-neg =
     equational-reasoning
     add-ℤ
@@ -477,7 +477,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
         ( λ p →
           add-ℤ
             ( mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
-            ( mul-ℤ p (int-ℕ y)))
+            ( p *ℤ (int-ℕ y)))
         ( equational-reasoning
           neg-ℤ (add-ℤ (int-ℕ (succ-ℕ x)) (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
           ＝ neg-ℤ (add-ℤ (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)) (int-ℕ (succ-ℕ x)))
@@ -525,8 +525,8 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
         ( left-negative-law-mul-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ y))
     ＝ add-ℤ
         ( add-ℤ
-          ( mul-ℤ (neg-ℤ a) (int-ℕ (succ-ℕ x)))
-          ( mul-ℤ (int-ℕ y) (int-ℕ (succ-ℕ x))))
+          ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
+          ( (int-ℕ y) *ℤ (int-ℕ (succ-ℕ x))))
         ( add-ℤ
           ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
           ( neg-ℤ (mul-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ y))))
@@ -539,7 +539,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
         ( right-distributive-mul-add-ℤ (neg-ℤ a) (int-ℕ y) (int-ℕ (succ-ℕ x)))
     ＝ add-ℤ
         ( add-ℤ
-          ( mul-ℤ (neg-ℤ a) (int-ℕ (succ-ℕ x)))
+          ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
           ( mul-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ y)))
         ( add-ℤ
           ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
@@ -548,54 +548,54 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
       ap
         ( λ p →
           add-ℤ
-            ( add-ℤ (mul-ℤ (neg-ℤ a) (int-ℕ (succ-ℕ x))) p)
+            ( add-ℤ ((neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x))) p)
             ( add-ℤ
               ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
               ( neg-ℤ (mul-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ y)))))
         ( commutative-mul-ℤ (int-ℕ y) (int-ℕ (succ-ℕ x)))
     ＝ add-ℤ
         ( add-ℤ
-          ( mul-ℤ (neg-ℤ a) (int-ℕ (succ-ℕ x)))
+          ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
           ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)))
         ( add-ℤ
           ( mul-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ y))
           ( neg-ℤ (mul-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ y))))
       by
       interchange-law-add-add-ℤ
-        ( mul-ℤ (neg-ℤ a) (int-ℕ (succ-ℕ x)))
+        ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
         ( mul-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ y))
         ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
         ( neg-ℤ (mul-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ y)))
     ＝ add-ℤ
         ( add-ℤ
-          ( mul-ℤ (neg-ℤ a) (int-ℕ (succ-ℕ x)))
+          ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
           ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)))
         ( zero-ℤ)
       by
       ap
         ( add-ℤ
           ( add-ℤ
-            ( mul-ℤ (neg-ℤ a) (int-ℕ (succ-ℕ x)))
+            ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
             ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))))
           ( right-inverse-law-add-ℤ (mul-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ y)))
     ＝ add-ℤ
-        ( mul-ℤ (neg-ℤ a) (int-ℕ (succ-ℕ x)))
+        ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
         ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
       by
       right-unit-law-add-ℤ
         ( add-ℤ
-          ( mul-ℤ (neg-ℤ a) (int-ℕ (succ-ℕ x)))
+          ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
           ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)))
     ＝ add-ℤ
         ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
-        ( mul-ℤ (neg-ℤ a) (int-ℕ (succ-ℕ x)))
+        ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
       by
       commutative-add-ℤ
-        ( mul-ℤ (neg-ℤ a) (int-ℕ (succ-ℕ x)))
+        ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
         ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
     ＝ add-ℤ
         ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
-        ( neg-ℤ (mul-ℤ a (int-ℕ (succ-ℕ x))))
+        ( neg-ℤ (a *ℤ (int-ℕ (succ-ℕ x))))
       by
       ap
         ( add-ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)))
@@ -614,20 +614,20 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
     ( abs-ℤ a ,
       nat-Fin (succ-ℕ x) u ,
       ( equational-reasoning
-        dist-ℕ (mul-ℕ (abs-ℤ a) (succ-ℕ x)) (mul-ℕ (nat-Fin (succ-ℕ x) u) y)
-        ＝ dist-ℕ (mul-ℕ (nat-Fin (succ-ℕ x) u) y) (mul-ℕ (abs-ℤ a) (succ-ℕ x))
+        dist-ℕ ((abs-ℤ a) *ℕ (succ-ℕ x)) (mul-ℕ (nat-Fin (succ-ℕ x) u) y)
+        ＝ dist-ℕ (mul-ℕ (nat-Fin (succ-ℕ x) u) y) ((abs-ℤ a) *ℕ (succ-ℕ x))
           by
           symmetric-dist-ℕ
-            ( mul-ℕ (abs-ℤ a) (succ-ℕ x))
+            ( (abs-ℤ a) *ℕ (succ-ℕ x))
             ( mul-ℕ (nat-Fin (succ-ℕ x) u) y)
         ＝ dist-ℤ
             ( int-ℕ (mul-ℕ (nat-Fin (succ-ℕ x) u) y))
-            ( int-ℕ (mul-ℕ (abs-ℤ a) (succ-ℕ x)))
+            ( int-ℕ ((abs-ℤ a) *ℕ (succ-ℕ x)))
           by
           inv
             ( dist-int-ℕ
               ( mul-ℕ (nat-Fin (succ-ℕ x) u) y)
-              ( mul-ℕ (abs-ℤ a) (succ-ℕ x)))
+              ( (abs-ℤ a) *ℕ (succ-ℕ x)))
         ＝ dist-ℤ
             ( int-ℕ (mul-ℕ (nat-Fin (succ-ℕ x) u) y))
             ( mul-ℤ (int-ℕ (abs-ℤ a)) (int-ℕ (succ-ℕ x)))
@@ -644,13 +644,13 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
             ( inv (mul-int-ℕ (nat-Fin (succ-ℕ x) u) y))
         ＝ dist-ℤ
             ( mul-ℤ (int-ℕ (nat-Fin (succ-ℕ x) u)) (int-ℕ y))
-            ( mul-ℤ a (int-ℕ (succ-ℕ x)))
+            ( a *ℤ (int-ℕ (succ-ℕ x)))
           by
           ap
             ( λ p →
               dist-ℤ
                 ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
-                ( mul-ℤ p (int-ℕ (succ-ℕ x))))
+                ( p *ℤ (int-ℕ (succ-ℕ x))))
             ( int-abs-is-nonnegative-ℤ a a-is-nonnegative-ℤ)
         ＝ abs-ℤ (int-ℕ z)
           by ap (abs-ℤ) a-eqn-pos
@@ -689,7 +689,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
         ＝ dist-ℤ (mul-ℤ (add-ℤ (int-ℕ (abs-ℤ a)) (int-ℕ y)) (int-ℕ (succ-ℕ x)))
           (int-ℕ (mul-ℕ (abs-ℤ (add-ℤ (int-ℕ (succ-ℕ x))
           (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))) y))
-        by ap (λ p → dist-ℤ (mul-ℤ p (int-ℕ (succ-ℕ x)))
+        by ap (λ p → dist-ℤ (p *ℤ (int-ℕ (succ-ℕ x)))
              (int-ℕ (mul-ℕ (abs-ℤ (add-ℤ (int-ℕ (succ-ℕ x))
                (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))) y)))
           (inv (add-int-ℕ (abs-ℤ a) y))
@@ -704,7 +704,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
           (mul-ℤ (add-ℤ (int-ℕ (succ-ℕ x))
             (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) (int-ℕ y))
         by ap (λ p → dist-ℤ (mul-ℤ (add-ℤ (int-ℕ (abs-ℤ a)) (int-ℕ y))
-             (int-ℕ (succ-ℕ x))) (mul-ℤ p (int-ℕ y)))
+             (int-ℕ (succ-ℕ x))) (p *ℤ (int-ℕ y)))
           (int-abs-is-nonnegative-ℤ (add-ℤ (int-ℕ (succ-ℕ x))
             (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) (int-ℤ-Mod-bounded x u))
         ＝ dist-ℤ
@@ -754,7 +754,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
         by commutative-add-ℤ
           (neg-ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)))
           (int-ℕ z)
-        ＝ mul-ℤ (neg-ℤ a) (int-ℕ (succ-ℕ x))
+        ＝ (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x))
         by inv (pr2
           (symmetric-cong-ℤ (int-ℕ (succ-ℕ x))
             (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)) (int-ℕ z)
@@ -903,8 +903,8 @@ minimal-positive-distance-succ-y-coeff x y =
 minimal-positive-distance-eqn :
   (x y : ℕ) (H : is-nonzero-ℕ (x +ℕ y)) →
   dist-ℕ
-    ( mul-ℕ (minimal-positive-distance-x-coeff x y H) x)
-    ( mul-ℕ (minimal-positive-distance-y-coeff x y H) y) ＝
+    ( (minimal-positive-distance-x-coeff x y H) *ℕ x)
+    ( (minimal-positive-distance-y-coeff x y H) *ℕ y) ＝
   minimal-positive-distance x y
 minimal-positive-distance-eqn x y H =
   pr2 (pr2 (minimal-positive-distance-is-distance x y H))
@@ -912,8 +912,8 @@ minimal-positive-distance-eqn x y H =
 minimal-positive-distance-succ-eqn :
   (x y : ℕ) →
   dist-ℕ
-    ( mul-ℕ (minimal-positive-distance-succ-x-coeff x y) (succ-ℕ x))
-    ( mul-ℕ (minimal-positive-distance-succ-y-coeff x y) y) ＝
+    ( (minimal-positive-distance-succ-x-coeff x y) *ℕ (succ-ℕ x))
+    ( (minimal-positive-distance-succ-y-coeff x y) *ℕ y) ＝
   minimal-positive-distance (succ-ℕ x) y
 minimal-positive-distance-succ-eqn x y =
   minimal-positive-distance-eqn
@@ -1032,7 +1032,7 @@ remainder-min-dist-succ-x-is-distance :
       ( minimal-positive-distance (succ-ℕ x) y)
       ( succ-ℕ x)))
 remainder-min-dist-succ-x-is-distance x y =
-  sx-ty-case-split (linear-leq-ℕ (mul-ℕ s (succ-ℕ x)) (mul-ℕ t y))
+  sx-ty-case-split (linear-leq-ℕ (s *ℕ (succ-ℕ x)) (t *ℕ y))
   where
   d : ℕ
   d = minimal-positive-distance (succ-ℕ x) y
@@ -1049,46 +1049,46 @@ remainder-min-dist-succ-x-is-distance x y =
   r : ℕ
   r = remainder-euclidean-division-ℕ d (succ-ℕ x)
 
-  dist-sx-ty-eq-d : dist-ℕ (mul-ℕ s (succ-ℕ x)) (mul-ℕ t y) ＝ d
+  dist-sx-ty-eq-d : dist-ℕ (s *ℕ (succ-ℕ x)) (t *ℕ y) ＝ d
   dist-sx-ty-eq-d = minimal-positive-distance-succ-eqn x y
 
   sx-ty-case-split :
-    ( leq-ℕ (mul-ℕ s (succ-ℕ x)) (mul-ℕ t y) +
-      leq-ℕ (mul-ℕ t y) (mul-ℕ s (succ-ℕ x))) →
+    ( leq-ℕ (s *ℕ (succ-ℕ x)) (t *ℕ y) +
+      leq-ℕ (t *ℕ y) (s *ℕ (succ-ℕ x))) →
     is-distance-between-multiples-ℕ (succ-ℕ x) y r
   sx-ty-case-split (inl sxty) =
-    ((mul-ℕ q s) +ℕ 1 , mul-ℕ q t , inv (dist-eqn))
+    ((q *ℕ s) +ℕ 1 , q *ℕ t , inv (dist-eqn))
     where
     add-dist-eqn :
       int-ℕ d ＝
       add-ℤ
-        ( mul-ℤ (int-ℕ t) (int-ℕ y))
+        ( (int-ℕ t) *ℤ (int-ℕ y))
         ( mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))
     add-dist-eqn =
       equational-reasoning
         int-ℕ d
-        ＝ add-ℤ ((int-ℕ d) +ℤ (int-ℕ (mul-ℕ s (succ-ℕ x))))
-          (neg-ℤ (int-ℕ (mul-ℕ s (succ-ℕ x))))
-          by inv (isretr-add-neg-ℤ' (int-ℕ (mul-ℕ s (succ-ℕ x))) (int-ℕ d))
-        ＝ add-ℤ (int-ℕ (d +ℕ (mul-ℕ s (succ-ℕ x))))
-          (neg-ℤ (int-ℕ (mul-ℕ s (succ-ℕ x))))
-          by ap (λ H → H +ℤ (neg-ℤ (int-ℕ (mul-ℕ s (succ-ℕ x)))))
-          (add-int-ℕ d (mul-ℕ s (succ-ℕ x)))
-        ＝ add-ℤ (int-ℕ (mul-ℕ t y)) (neg-ℤ (int-ℕ (mul-ℕ s (succ-ℕ x))))
-          by ap (λ H → (int-ℕ H) +ℤ (neg-ℤ (int-ℕ (mul-ℕ s (succ-ℕ x)))))
-            (rewrite-left-dist-add-ℕ d (mul-ℕ s (succ-ℕ x))
-              (mul-ℕ t y) sxty (inv (dist-sx-ty-eq-d)))
-        ＝ add-ℤ (mul-ℤ (int-ℕ t) (int-ℕ y))
-          (neg-ℤ (int-ℕ (mul-ℕ s (succ-ℕ x))))
-          by ap (λ H → H +ℤ (neg-ℤ (int-ℕ (mul-ℕ s (succ-ℕ x)))))
+        ＝ add-ℤ ((int-ℕ d) +ℤ (int-ℕ (s *ℕ (succ-ℕ x))))
+          (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x))))
+          by inv (isretr-add-neg-ℤ' (int-ℕ (s *ℕ (succ-ℕ x))) (int-ℕ d))
+        ＝ add-ℤ (int-ℕ (d +ℕ (s *ℕ (succ-ℕ x))))
+          (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x))))
+          by ap (λ H → H +ℤ (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x)))))
+          (add-int-ℕ d (s *ℕ (succ-ℕ x)))
+        ＝ add-ℤ (int-ℕ (t *ℕ y)) (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x))))
+          by ap (λ H → (int-ℕ H) +ℤ (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x)))))
+            (rewrite-left-dist-add-ℕ d (s *ℕ (succ-ℕ x))
+              (t *ℕ y) sxty (inv (dist-sx-ty-eq-d)))
+        ＝ add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
+          (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x))))
+          by ap (λ H → H +ℤ (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x)))))
             (inv (mul-int-ℕ t y))
-        ＝ add-ℤ (mul-ℤ (int-ℕ t) (int-ℕ y))
-          (neg-ℤ (mul-ℤ (int-ℕ s) (int-ℕ (succ-ℕ x))))
-          by ap (λ H → add-ℤ (mul-ℤ (int-ℕ t) (int-ℕ y)) (neg-ℤ H))
+        ＝ add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
+          (neg-ℤ ((int-ℕ s) *ℤ (int-ℕ (succ-ℕ x))))
+          by ap (λ H → add-ℤ ((int-ℕ t) *ℤ (int-ℕ y)) (neg-ℤ H))
             (inv (mul-int-ℕ s (succ-ℕ x)))
-        ＝ add-ℤ (mul-ℤ (int-ℕ t) (int-ℕ y))
+        ＝ add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
           (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))
-          by ap (λ H → add-ℤ (mul-ℤ (int-ℕ t) (int-ℕ y)) H)
+          by ap (λ H → add-ℤ ((int-ℕ t) *ℤ (int-ℕ y)) H)
             (inv (left-negative-law-mul-ℤ (int-ℕ s) (int-ℕ (succ-ℕ x))))
 
     isolate-rem-eqn :
@@ -1098,24 +1098,24 @@ remainder-min-dist-succ-x-is-distance x y =
           ( mul-ℤ
             ( int-ℕ q)
             ( add-ℤ
-              ( mul-ℤ (int-ℕ t) (int-ℕ y))
+              ( (int-ℕ t) *ℤ (int-ℕ y))
               ( mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
         ( int-ℕ (succ-ℕ x))
     isolate-rem-eqn =
       equational-reasoning
         int-ℕ r
-        ＝ add-ℤ (neg-ℤ (mul-ℤ (int-ℕ q) (add-ℤ (mul-ℤ (int-ℕ t) (int-ℕ y))
+        ＝ add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
              (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
-          (add-ℤ (mul-ℤ (int-ℕ q) (add-ℤ (mul-ℤ (int-ℕ t) (int-ℕ y))
+          (add-ℤ ((int-ℕ q) *ℤ (add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
               (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
           (int-ℕ r))
           by inv (isretr-add-neg-ℤ
-            (mul-ℤ (int-ℕ q) (add-ℤ (mul-ℤ (int-ℕ t) (int-ℕ y))
+            ((int-ℕ q) *ℤ (add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
             (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
             (int-ℕ r))
-        ＝ add-ℤ (neg-ℤ (mul-ℤ (int-ℕ q) (add-ℤ (mul-ℤ (int-ℕ t) (int-ℕ y))
+        ＝ add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
              (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
-          (add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ d)) (int-ℕ r))
+          (add-ℤ ((int-ℕ q) *ℤ (int-ℕ d)) (int-ℕ r))
           by
             ap
               ( λ H →
@@ -1124,16 +1124,16 @@ remainder-min-dist-succ-x-is-distance x y =
                     ( mul-ℤ
                       ( int-ℕ q)
                       ( add-ℤ
-                        ( mul-ℤ (int-ℕ t) (int-ℕ y))
+                        ( (int-ℕ t) *ℤ (int-ℕ y))
                         ( mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
-                  ( add-ℤ (mul-ℤ (int-ℕ q) H) (int-ℕ r)))
+                  ( add-ℤ ((int-ℕ q) *ℤ H) (int-ℕ r)))
               ( inv add-dist-eqn)
         ＝ add-ℤ
             ( neg-ℤ
               ( mul-ℤ
                 ( int-ℕ q)
                 ( add-ℤ
-                  ( mul-ℤ (int-ℕ t) (int-ℕ y))
+                  ( (int-ℕ t) *ℤ (int-ℕ y))
                   ( mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
             ( int-ℕ (succ-ℕ x))
           by
@@ -1143,173 +1143,173 @@ remainder-min-dist-succ-x-is-distance x y =
                   ( mul-ℤ
                     ( int-ℕ q)
                     ( add-ℤ
-                      ( mul-ℤ (int-ℕ t) (int-ℕ y))
+                      ( (int-ℕ t) *ℤ (int-ℕ y))
                       ( mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))))
               ( minimal-positive-distance-div-succ-x-eqn x y)
 
     rearrange-arith-eqn :
-      add-ℤ (neg-ℤ (mul-ℤ (int-ℕ q) (add-ℤ (mul-ℤ (int-ℕ t) (int-ℕ y))
+      add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
         (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x))
-      ＝ add-ℤ (mul-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) one-ℤ)
+      ＝ add-ℤ (mul-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) one-ℤ)
           (int-ℕ (succ-ℕ x)))
-        (neg-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y)))
+        (neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
     rearrange-arith-eqn =
       equational-reasoning
-        add-ℤ (neg-ℤ (mul-ℤ (int-ℕ q) (add-ℤ (mul-ℤ (int-ℕ t) (int-ℕ y))
+        add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
           (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x))
-        ＝ add-ℤ (neg-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (mul-ℤ (int-ℕ t) (int-ℕ y)))
-          (mul-ℤ (int-ℕ q) (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
+        ＝ add-ℤ (neg-ℤ (add-ℤ ((int-ℕ q) *ℤ ((int-ℕ t) *ℤ (int-ℕ y)))
+          ((int-ℕ q) *ℤ (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
             (int-ℕ (succ-ℕ x))
           by (ap (λ H → (neg-ℤ H) +ℤ (int-ℕ (succ-ℕ x)))
-            (left-distributive-mul-add-ℤ (int-ℕ q) (mul-ℤ (int-ℕ t) (int-ℕ y))
+            (left-distributive-mul-add-ℤ (int-ℕ q) ((int-ℕ t) *ℤ (int-ℕ y))
               (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
-        ＝ add-ℤ (neg-ℤ (add-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
-          (mul-ℤ (int-ℕ q) (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
+        ＝ add-ℤ (neg-ℤ (add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
+          ((int-ℕ q) *ℤ (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
             (int-ℕ (succ-ℕ x))
           by (ap (λ H → add-ℤ (neg-ℤ (H +ℤ (mul-ℤ (int-ℕ q)
             (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x)))
               (inv (associative-mul-ℤ (int-ℕ q) (int-ℕ t) (int-ℕ y))))
-        ＝ add-ℤ (neg-ℤ (add-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
-          (neg-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
+        ＝ add-ℤ (neg-ℤ (add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
+          (neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
             (int-ℕ (succ-ℕ x))
           by
             ap
               ( λ H →
                 add-ℤ
                   ( neg-ℤ
-                    ( add-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y)) H))
+                    ( add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)) H))
                   ( int-ℕ (succ-ℕ x)))
             ( equational-reasoning
-                (mul-ℤ (int-ℕ q) (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))
-                ＝ mul-ℤ (mul-ℤ (int-ℕ q) (neg-ℤ (int-ℕ s))) (int-ℕ (succ-ℕ x))
+                ((int-ℕ q) *ℤ (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))
+                ＝ mul-ℤ ((int-ℕ q) *ℤ (neg-ℤ (int-ℕ s))) (int-ℕ (succ-ℕ x))
                   by
                     inv
                       ( associative-mul-ℤ
                         ( int-ℕ q)
                         ( neg-ℤ (int-ℕ s))
                         ( int-ℕ (succ-ℕ x)))
-                ＝ mul-ℤ (neg-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s))) (int-ℕ (succ-ℕ x))
-                  by ap (λ H → mul-ℤ H (int-ℕ (succ-ℕ x)))
+                ＝ mul-ℤ (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s))) (int-ℕ (succ-ℕ x))
+                  by ap (λ H → H *ℤ (int-ℕ (succ-ℕ x)))
                   (right-negative-law-mul-ℤ (int-ℕ q) (int-ℕ s))
-                ＝ neg-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (int-ℕ (succ-ℕ x)))
+                ＝ neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))
                   by
                     left-negative-law-mul-ℤ
-                      ( mul-ℤ (int-ℕ q) (int-ℕ s))
+                      ( (int-ℕ q) *ℤ (int-ℕ s))
                       ( int-ℕ (succ-ℕ x)))
         ＝ add-ℤ
             ( add-ℤ
-              ( neg-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y)))
+              ( neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
               ( neg-ℤ
                 ( neg-ℤ
-                  ( mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
+                  ( mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
             (int-ℕ (succ-ℕ x))
           by
             ap
               ( λ H → H +ℤ (int-ℕ (succ-ℕ x)))
               ( distributive-neg-add-ℤ
-                ( mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
-                ( neg-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
+                ( mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
+                ( neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
         ＝ add-ℤ
             ( add-ℤ
-              ( neg-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y)))
-              ( mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (int-ℕ (succ-ℕ x))))
+              ( neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
+              ( mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))
             ( int-ℕ (succ-ℕ x))
           by
             ap
               ( λ H →
               add-ℤ
                 ( add-ℤ
-                  ( neg-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y)))
+                  ( neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
                   ( H))
                 ( int-ℕ (succ-ℕ x)))
               ( neg-neg-ℤ
-                ( mul-ℤ (mul-ℤ (int-ℕ q) ((int-ℕ s))) (int-ℕ (succ-ℕ x))))
-        ＝ add-ℤ (neg-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y)))
-           (add-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (int-ℕ (succ-ℕ x)))
+                ( mul-ℤ ((int-ℕ q) *ℤ ((int-ℕ s))) (int-ℕ (succ-ℕ x))))
+        ＝ add-ℤ (neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
+           (add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))
              (int-ℕ (succ-ℕ x)))
           by associative-add-ℤ
-            (neg-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y)))
-            (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (int-ℕ (succ-ℕ x)))
+            (neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
+            (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))
             (int-ℕ (succ-ℕ x))
-        ＝ add-ℤ (add-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (int-ℕ (succ-ℕ x)))
+        ＝ add-ℤ (add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))
           (int-ℕ (succ-ℕ x)))
-          (neg-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y)))
+          (neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
           by commutative-add-ℤ
-            (neg-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y)))
-            (add-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (int-ℕ (succ-ℕ x)))
+            (neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
+            (add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))
             (int-ℕ (succ-ℕ x)))
         ＝ add-ℤ
             ( mul-ℤ
-              ( add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) one-ℤ)
+              ( add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) one-ℤ)
               ( int-ℕ (succ-ℕ x)))
-            ( neg-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y)))
+            ( neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
           by
             ap
               ( λ H →
-                H +ℤ (neg-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))))
+                H +ℤ (neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))))
               ( ap
                 ( add-ℤ
-                  ( mul-ℤ (mul-ℤ (int-ℕ q) ((int-ℕ s))) (int-ℕ (succ-ℕ x))))
+                  ( mul-ℤ ((int-ℕ q) *ℤ ((int-ℕ s))) (int-ℕ (succ-ℕ x))))
                 ( left-unit-law-mul-ℤ (int-ℕ (succ-ℕ x))) ∙
                 ( inv
                   ( right-distributive-mul-add-ℤ
-                    ( mul-ℤ (int-ℕ q) (int-ℕ s))
+                    ( (int-ℕ q) *ℤ (int-ℕ s))
                     ( one-ℤ)
                     ( int-ℕ (succ-ℕ x)))))
 
     dist-eqn :
-      r ＝ dist-ℕ (mul-ℕ ((mul-ℕ q s) +ℕ 1) (succ-ℕ x)) (mul-ℕ (mul-ℕ q t) y)
+      r ＝ dist-ℕ (mul-ℕ ((q *ℕ s) +ℕ 1) (succ-ℕ x)) ((q *ℕ t) *ℕ y)
     dist-eqn =
       equational-reasoning
         r
         ＝ abs-ℤ (int-ℕ r)
           by (inv (abs-int-ℕ r))
-        ＝ dist-ℤ (mul-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) one-ℤ)
+        ＝ dist-ℤ (mul-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) one-ℤ)
             (int-ℕ (succ-ℕ x)))
-          (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
+          (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
           by (ap (abs-ℤ) (isolate-rem-eqn ∙ rearrange-arith-eqn))
         ＝ dist-ℤ
-            ( mul-ℤ (add-ℤ (int-ℕ (mul-ℕ q s)) (int-ℕ 1)) (int-ℕ (succ-ℕ x)))
-            ( mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
+            ( mul-ℤ (add-ℤ (int-ℕ (q *ℕ s)) (int-ℕ 1)) (int-ℕ (succ-ℕ x)))
+            ( mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
           by ap (λ H → dist-ℤ (mul-ℤ (H +ℤ (int-ℕ 1)) (int-ℕ (succ-ℕ x)))
-            (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y)))
+            (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
             (mul-int-ℕ q s)
-        ＝ dist-ℤ (mul-ℤ (int-ℕ ((mul-ℕ q s) +ℕ 1)) (int-ℕ (succ-ℕ x)))
-          (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
-          by ap (λ H → dist-ℤ (mul-ℤ H (int-ℕ (succ-ℕ x)))
-            (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y)))
-            (add-int-ℕ (mul-ℕ q s) 1)
-        ＝ dist-ℤ (int-ℕ (mul-ℕ ((mul-ℕ q s) +ℕ 1) (succ-ℕ x)))
-          (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
-          by ap (λ H → dist-ℤ H (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y)))
-            (mul-int-ℕ ((mul-ℕ q s) +ℕ 1) (succ-ℕ x))
-        ＝ dist-ℤ (int-ℕ (mul-ℕ ((mul-ℕ q s) +ℕ 1) (succ-ℕ x)))
-          (mul-ℤ (int-ℕ (mul-ℕ q t)) (int-ℕ y))
-          by ap (λ H → dist-ℤ (int-ℕ (mul-ℕ ((mul-ℕ q s) +ℕ 1) (succ-ℕ x)))
-            (mul-ℤ H (int-ℕ y)))
+        ＝ dist-ℤ (mul-ℤ (int-ℕ ((q *ℕ s) +ℕ 1)) (int-ℕ (succ-ℕ x)))
+          (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
+          by ap (λ H → dist-ℤ (H *ℤ (int-ℕ (succ-ℕ x)))
+            (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
+            (add-int-ℕ (q *ℕ s) 1)
+        ＝ dist-ℤ (int-ℕ (mul-ℕ ((q *ℕ s) +ℕ 1) (succ-ℕ x)))
+          (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
+          by ap (λ H → dist-ℤ H (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
+            (mul-int-ℕ ((q *ℕ s) +ℕ 1) (succ-ℕ x))
+        ＝ dist-ℤ (int-ℕ (mul-ℕ ((q *ℕ s) +ℕ 1) (succ-ℕ x)))
+          (mul-ℤ (int-ℕ (q *ℕ t)) (int-ℕ y))
+          by ap (λ H → dist-ℤ (int-ℕ (mul-ℕ ((q *ℕ s) +ℕ 1) (succ-ℕ x)))
+            (H *ℤ (int-ℕ y)))
             (mul-int-ℕ q t)
-        ＝ dist-ℤ (int-ℕ (mul-ℕ ((mul-ℕ q s) +ℕ 1) (succ-ℕ x)))
-          (int-ℕ (mul-ℕ (mul-ℕ q t) y))
-          by ap (dist-ℤ (int-ℕ (mul-ℕ ((mul-ℕ q s) +ℕ 1) (succ-ℕ x))))
-            (mul-int-ℕ (mul-ℕ q t) y)
-        ＝ dist-ℕ (mul-ℕ ((mul-ℕ q s) +ℕ 1) (succ-ℕ x))
-          (mul-ℕ (mul-ℕ q t) y)
-          by dist-int-ℕ (mul-ℕ ((mul-ℕ q s) +ℕ 1) (succ-ℕ x))
-            (mul-ℕ (mul-ℕ q t) y)
+        ＝ dist-ℤ (int-ℕ (mul-ℕ ((q *ℕ s) +ℕ 1) (succ-ℕ x)))
+          (int-ℕ ((q *ℕ t) *ℕ y))
+          by ap (dist-ℤ (int-ℕ (mul-ℕ ((q *ℕ s) +ℕ 1) (succ-ℕ x))))
+            (mul-int-ℕ (q *ℕ t) y)
+        ＝ dist-ℕ (mul-ℕ ((q *ℕ s) +ℕ 1) (succ-ℕ x))
+          ((q *ℕ t) *ℕ y)
+          by dist-int-ℕ (mul-ℕ ((q *ℕ s) +ℕ 1) (succ-ℕ x))
+            ((q *ℕ t) *ℕ y)
 
   sx-ty-case-split (inr tysx) =
-    (abs-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (neg-ℤ one-ℤ)) ,
-      (mul-ℕ q t) , inv (dist-eqn))
+    (abs-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ)) ,
+      (q *ℕ t) , inv (dist-eqn))
     where
-    rewrite-dist : (mul-ℕ t y) +ℕ d ＝ (mul-ℕ s (succ-ℕ x))
+    rewrite-dist : (t *ℕ y) +ℕ d ＝ (s *ℕ (succ-ℕ x))
     rewrite-dist =
       rewrite-right-dist-add-ℕ
-        ( mul-ℕ t y)
+        ( t *ℕ y)
         ( d)
-        ( mul-ℕ s (succ-ℕ x))
+        ( s *ℕ (succ-ℕ x))
         ( tysx)
         ( inv (dist-sx-ty-eq-d) ∙
-          symmetric-dist-ℕ (mul-ℕ s (succ-ℕ x)) (mul-ℕ t y))
+          symmetric-dist-ℕ (s *ℕ (succ-ℕ x)) (t *ℕ y))
 
     quotient-min-dist-succ-x-nonzero : is-nonzero-ℕ q
     quotient-min-dist-succ-x-nonzero iszero =
@@ -1319,10 +1319,10 @@ remainder-min-dist-succ-x-is-distance x y =
       x-r-equality =
         equational-reasoning
           succ-ℕ x
-          ＝ (mul-ℕ q d) +ℕ r
+          ＝ (q *ℕ d) +ℕ r
             by (inv (eq-euclidean-division-ℕ d (succ-ℕ x)))
-          ＝ (mul-ℕ 0 d) +ℕ r
-            by (ap (λ H → (mul-ℕ H d) +ℕ r) iszero)
+          ＝ (0 *ℕ d) +ℕ r
+            by (ap (λ H → (H *ℕ d) +ℕ r) iszero)
           ＝ 0 +ℕ r
             by (ap (λ H → H +ℕ r) (left-zero-law-mul-ℕ d))
           ＝ r
@@ -1356,24 +1356,24 @@ remainder-min-dist-succ-x-is-distance x y =
           ( is-nonzero-succ-ℕ (x +ℕ y)))
         ( d-is-zero)
       where
-      zero-addition : (mul-ℕ t y) +ℕ d ＝ 0
+      zero-addition : (t *ℕ y) +ℕ d ＝ 0
       zero-addition =
         equational-reasoning
-          (mul-ℕ t y) +ℕ d
-          ＝ (mul-ℕ s (succ-ℕ x))
+          (t *ℕ y) +ℕ d
+          ＝ (s *ℕ (succ-ℕ x))
             by rewrite-dist
-          ＝ (mul-ℕ zero-ℕ (succ-ℕ x))
-            by (ap (λ H → mul-ℕ H (succ-ℕ x)) iszero)
+          ＝ (zero-ℕ *ℕ (succ-ℕ x))
+            by (ap (λ H → H *ℕ (succ-ℕ x)) iszero)
           ＝ zero-ℕ
             by (left-zero-law-mul-ℕ (succ-ℕ x))
 
       d-is-zero : is-zero-ℕ d
-      d-is-zero = is-zero-right-is-zero-add-ℕ (mul-ℕ t y) d (zero-addition)
+      d-is-zero = is-zero-right-is-zero-add-ℕ (t *ℕ y) d (zero-addition)
 
-    coeff-nonnegative : leq-ℤ one-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s))
+    coeff-nonnegative : leq-ℤ one-ℤ ((int-ℕ q) *ℤ (int-ℕ s))
     coeff-nonnegative = tr (λ z → leq-ℤ one-ℤ z)
-      (inv (mul-int-ℕ q s)) (leq-int-ℕ 1 (mul-ℕ q s)
-        (leq-succ-le-ℕ 0 (mul-ℕ q s) (le-is-nonzero-ℕ (mul-ℕ q s)
+      (inv (mul-int-ℕ q s)) (leq-int-ℕ 1 (q *ℕ s)
+        (leq-succ-le-ℕ 0 (q *ℕ s) (le-is-nonzero-ℕ (q *ℕ s)
           (is-nonzero-mul-ℕ q s quotient-min-dist-succ-x-nonzero
             min-dist-succ-x-coeff-nonzero))))
 
@@ -1381,35 +1381,35 @@ remainder-min-dist-succ-x-is-distance x y =
       int-ℕ d ＝
       add-ℤ
         ( mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
-        ( mul-ℤ (int-ℕ s) (int-ℕ (succ-ℕ x)))
+        ( (int-ℕ s) *ℤ (int-ℕ (succ-ℕ x)))
     add-dist-eqn =
       equational-reasoning
         int-ℕ d
         ＝ add-ℤ
-            ( neg-ℤ (int-ℕ (mul-ℕ t y)))
-            ( add-ℤ (int-ℕ (mul-ℕ t y)) (int-ℕ d))
-          by inv (isretr-add-neg-ℤ (int-ℕ (mul-ℕ t y)) (int-ℕ d))
-        ＝ add-ℤ (neg-ℤ (int-ℕ (mul-ℕ t y))) (int-ℕ ((mul-ℕ t y) +ℕ d))
-          by ap (add-ℤ (neg-ℤ (int-ℕ (mul-ℕ t y)))) (add-int-ℕ (mul-ℕ t y) d)
-        ＝ add-ℤ (neg-ℤ (int-ℕ (mul-ℕ t y))) (int-ℕ (mul-ℕ s (succ-ℕ x)))
-          by ap (λ H → add-ℤ (neg-ℤ (int-ℕ (mul-ℕ t y))) (int-ℕ H)) rewrite-dist
+            ( neg-ℤ (int-ℕ (t *ℕ y)))
+            ( add-ℤ (int-ℕ (t *ℕ y)) (int-ℕ d))
+          by inv (isretr-add-neg-ℤ (int-ℕ (t *ℕ y)) (int-ℕ d))
+        ＝ add-ℤ (neg-ℤ (int-ℕ (t *ℕ y))) (int-ℕ ((t *ℕ y) +ℕ d))
+          by ap (add-ℤ (neg-ℤ (int-ℕ (t *ℕ y)))) (add-int-ℕ (t *ℕ y) d)
+        ＝ add-ℤ (neg-ℤ (int-ℕ (t *ℕ y))) (int-ℕ (s *ℕ (succ-ℕ x)))
+          by ap (λ H → add-ℤ (neg-ℤ (int-ℕ (t *ℕ y))) (int-ℕ H)) rewrite-dist
         ＝ add-ℤ
-          ( neg-ℤ (mul-ℤ (int-ℕ t) (int-ℕ y)))
-          ( int-ℕ (mul-ℕ s (succ-ℕ x)))
+          ( neg-ℤ ((int-ℕ t) *ℤ (int-ℕ y)))
+          ( int-ℕ (s *ℕ (succ-ℕ x)))
           by
             ap
-              ( λ H → (neg-ℤ H) +ℤ (int-ℕ (mul-ℕ s (succ-ℕ x))))
+              ( λ H → (neg-ℤ H) +ℤ (int-ℕ (s *ℕ (succ-ℕ x))))
               ( inv (mul-int-ℕ t y))
         ＝ add-ℤ
             ( mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
-            ( int-ℕ (mul-ℕ s (succ-ℕ x)))
+            ( int-ℕ (s *ℕ (succ-ℕ x)))
           by
             ap
-              ( λ H → H +ℤ (int-ℕ (mul-ℕ s (succ-ℕ x))))
+              ( λ H → H +ℤ (int-ℕ (s *ℕ (succ-ℕ x))))
               ( inv (left-negative-law-mul-ℤ (int-ℕ t) (int-ℕ y)))
         ＝ add-ℤ
             ( mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
-            ( mul-ℤ (int-ℕ s) (int-ℕ (succ-ℕ x)))
+            ( (int-ℕ s) *ℤ (int-ℕ (succ-ℕ x)))
           by
             ap
               ( add-ℤ (mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y)))
@@ -1423,7 +1423,7 @@ remainder-min-dist-succ-x-is-distance x y =
             ( int-ℕ q)
             ( add-ℤ
               ( mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
-              ( mul-ℤ (int-ℕ s) (int-ℕ (succ-ℕ x))))))
+              ( (int-ℕ s) *ℤ (int-ℕ (succ-ℕ x))))))
         ( int-ℕ (succ-ℕ x))
     isolate-rem-eqn =
       equational-reasoning
@@ -1440,19 +1440,19 @@ remainder-min-dist-succ-x-is-distance x y =
                 ( int-ℕ q)
                 ( add-ℤ
                   ( mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
-                  ( mul-ℤ (int-ℕ s) (int-ℕ (succ-ℕ x)))))
+                  ( (int-ℕ s) *ℤ (int-ℕ (succ-ℕ x)))))
               ( int-ℕ r))
           by inv (isretr-add-neg-ℤ (mul-ℤ (int-ℕ q)
             (add-ℤ (mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
-            (mul-ℤ (int-ℕ s) (int-ℕ (succ-ℕ x))))) (int-ℕ r))
+            ((int-ℕ s) *ℤ (int-ℕ (succ-ℕ x))))) (int-ℕ r))
         ＝ add-ℤ
             ( neg-ℤ
               ( mul-ℤ
                 ( int-ℕ q)
                 ( add-ℤ
                   ( mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
-                  ( mul-ℤ (int-ℕ s) (int-ℕ (succ-ℕ x))))))
-            ( add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ d)) (int-ℕ r))
+                  ( (int-ℕ s) *ℤ (int-ℕ (succ-ℕ x))))))
+            ( add-ℤ ((int-ℕ q) *ℤ (int-ℕ d)) (int-ℕ r))
           by
             ap
               ( λ H →
@@ -1462,16 +1462,14 @@ remainder-min-dist-succ-x-is-distance x y =
                       ( int-ℕ q)
                       ( add-ℤ
                         ( mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
-                        ( mul-ℤ (int-ℕ s) (int-ℕ (succ-ℕ x))))))
-                  ( add-ℤ (mul-ℤ (int-ℕ q) H) (int-ℕ r)))
+                        ( (int-ℕ s) *ℤ (int-ℕ (succ-ℕ x))))))
+                  ( ((int-ℕ q) *ℤ H) +ℤ (int-ℕ r)))
               ( inv add-dist-eqn)
         ＝ add-ℤ
             ( neg-ℤ
-              ( mul-ℤ
-                ( int-ℕ q)
-                ( add-ℤ
-                  ( mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
-                  ( mul-ℤ (int-ℕ s) (int-ℕ (succ-ℕ x))))))
+              ( ( int-ℕ q) *ℤ
+                ( ( (neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y)) +ℤ
+                  ( (int-ℕ s) *ℤ (int-ℕ (succ-ℕ x))))))
             ( int-ℕ (succ-ℕ x))
           by
             ap
@@ -1481,24 +1479,24 @@ remainder-min-dist-succ-x-is-distance x y =
                     ( int-ℕ q)
                     ( add-ℤ
                       ( mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
-                      ( mul-ℤ (int-ℕ s) (int-ℕ (succ-ℕ x)))))))
+                      ( (int-ℕ s) *ℤ (int-ℕ (succ-ℕ x)))))))
               ( minimal-positive-distance-div-succ-x-eqn x y)
 
     rearrange-arith :
-      add-ℤ (neg-ℤ (mul-ℤ (int-ℕ q) (add-ℤ (mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
-        (mul-ℤ (int-ℕ s) (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x))
-      ＝ add-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
-        (neg-ℤ (mul-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (neg-ℤ one-ℤ))
+      add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (add-ℤ (mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
+        ((int-ℕ s) *ℤ (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x))
+      ＝ add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
+        (neg-ℤ (mul-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ))
           (int-ℕ (succ-ℕ x))))
     rearrange-arith =
       equational-reasoning
-        add-ℤ (neg-ℤ (mul-ℤ (int-ℕ q) (add-ℤ (mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
-          (mul-ℤ (int-ℕ s) (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x))
+        add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (add-ℤ (mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
+          ((int-ℕ s) *ℤ (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x))
         ＝ add-ℤ
             ( neg-ℤ
               ( add-ℤ
-                ( mul-ℤ (int-ℕ q) (mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y)))
-                ( mul-ℤ (int-ℕ q) (mul-ℤ (int-ℕ s) (int-ℕ (succ-ℕ x))))))
+                ( (int-ℕ q) *ℤ (mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y)))
+                ( (int-ℕ q) *ℤ ((int-ℕ s) *ℤ (int-ℕ (succ-ℕ x))))))
             ( int-ℕ (succ-ℕ x))
           by
             ap
@@ -1506,12 +1504,12 @@ remainder-min-dist-succ-x-is-distance x y =
               ( left-distributive-mul-add-ℤ
                 ( int-ℕ q)
                 ( mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
-                ( mul-ℤ (int-ℕ s) (int-ℕ (succ-ℕ x))))
+                ( (int-ℕ s) *ℤ (int-ℕ (succ-ℕ x))))
         ＝ add-ℤ
             ( neg-ℤ
               ( add-ℤ
-                ( mul-ℤ (mul-ℤ (int-ℕ q) (neg-ℤ (int-ℕ t))) (int-ℕ y))
-                ( mul-ℤ (int-ℕ q) (mul-ℤ (int-ℕ s) (int-ℕ (succ-ℕ x))))))
+                ( mul-ℤ ((int-ℕ q) *ℤ (neg-ℤ (int-ℕ t))) (int-ℕ y))
+                ( (int-ℕ q) *ℤ ((int-ℕ s) *ℤ (int-ℕ (succ-ℕ x))))))
             ( int-ℕ (succ-ℕ x))
           by
             ap
@@ -1520,14 +1518,14 @@ remainder-min-dist-succ-x-is-distance x y =
                   ( neg-ℤ
                     ( add-ℤ
                       ( H)
-                      ( mul-ℤ (int-ℕ q) (mul-ℤ (int-ℕ s) (int-ℕ (succ-ℕ x))))))
+                      ( (int-ℕ q) *ℤ ((int-ℕ s) *ℤ (int-ℕ (succ-ℕ x))))))
                   ( int-ℕ (succ-ℕ x)))
               ( inv (associative-mul-ℤ (int-ℕ q) (neg-ℤ (int-ℕ t)) (int-ℕ y)))
         ＝ add-ℤ
             ( neg-ℤ
               ( add-ℤ
-                ( mul-ℤ (mul-ℤ (int-ℕ q) (neg-ℤ (int-ℕ t))) (int-ℕ y))
-                ( mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
+                ( mul-ℤ ((int-ℕ q) *ℤ (neg-ℤ (int-ℕ t))) (int-ℕ y))
+                ( mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
             ( int-ℕ (succ-ℕ x))
           by
             ap
@@ -1535,15 +1533,15 @@ remainder-min-dist-succ-x-is-distance x y =
                 add-ℤ
                   ( neg-ℤ
                     ( add-ℤ
-                      ( mul-ℤ (mul-ℤ (int-ℕ q) (neg-ℤ (int-ℕ t))) (int-ℕ y))
+                      ( mul-ℤ ((int-ℕ q) *ℤ (neg-ℤ (int-ℕ t))) (int-ℕ y))
                       ( H)))
                   ( int-ℕ (succ-ℕ x)))
             ( inv (associative-mul-ℤ (int-ℕ q) (int-ℕ s) (int-ℕ (succ-ℕ x))))
         ＝ add-ℤ
             ( neg-ℤ
               ( add-ℤ
-                ( mul-ℤ (neg-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t))) (int-ℕ y))
-                ( mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
+                ( mul-ℤ (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ t))) (int-ℕ y))
+                ( mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
             ( int-ℕ (succ-ℕ x))
           by
             ap
@@ -1551,26 +1549,26 @@ remainder-min-dist-succ-x-is-distance x y =
                 add-ℤ
                   ( neg-ℤ
                     ( add-ℤ
-                      ( mul-ℤ H (int-ℕ y))
+                      ( H *ℤ (int-ℕ y))
                       ( mul-ℤ
-                        ( mul-ℤ (int-ℕ q) (int-ℕ s))
+                        ( (int-ℕ q) *ℤ (int-ℕ s))
                         ( int-ℕ (succ-ℕ x)))))
                   ( int-ℕ (succ-ℕ x)))
               ( right-negative-law-mul-ℤ (int-ℕ q) (int-ℕ t))
         ＝ add-ℤ
             ( add-ℤ
-              ( neg-ℤ (mul-ℤ (neg-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t))) (int-ℕ y)))
-              ( neg-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
+              ( neg-ℤ (mul-ℤ (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ t))) (int-ℕ y)))
+              ( neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
             ( int-ℕ (succ-ℕ x))
           by ap (λ H → H +ℤ (int-ℕ (succ-ℕ x)))
             (distributive-neg-add-ℤ
-              (mul-ℤ (neg-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t))) (int-ℕ y))
-              (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s))
+              (mul-ℤ (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ t))) (int-ℕ y))
+              (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s))
               (int-ℕ (succ-ℕ x))))
         ＝ add-ℤ
             ( add-ℤ
-              ( mul-ℤ (neg-ℤ (neg-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)))) (int-ℕ y))
-              ( neg-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
+              ( mul-ℤ (neg-ℤ (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ t)))) (int-ℕ y))
+              ( neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
             ( int-ℕ (succ-ℕ x))
           by
             ap
@@ -1579,156 +1577,156 @@ remainder-min-dist-succ-x-is-distance x y =
                 ( add-ℤ
                   ( H)
                   ( neg-ℤ
-                    ( mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
+                    ( mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
                 ( int-ℕ (succ-ℕ x)))
             ( inv
               ( left-negative-law-mul-ℤ
-                ( neg-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)))
+                ( neg-ℤ ((int-ℕ q) *ℤ (int-ℕ t)))
                 ( int-ℕ y)))
-        ＝ add-ℤ (add-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
-            (neg-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
+        ＝ add-ℤ (add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
+            (neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
             (int-ℕ (succ-ℕ x))
-          by ap (λ H → (add-ℤ (add-ℤ (mul-ℤ H (int-ℕ y))
-            (neg-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
+          by ap (λ H → (add-ℤ (add-ℤ (H *ℤ (int-ℕ y))
+            (neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
               (int-ℕ (succ-ℕ x))))
-            (neg-neg-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)))
-        ＝ add-ℤ (add-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
-            (mul-ℤ (neg-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s))) (int-ℕ (succ-ℕ x))))
+            (neg-neg-ℤ ((int-ℕ q) *ℤ (int-ℕ t)))
+        ＝ add-ℤ (add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
+            (mul-ℤ (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s))) (int-ℕ (succ-ℕ x))))
           (int-ℕ (succ-ℕ x))
           by
             ap
               ( λ H →
                 add-ℤ
-                  ( add-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y)) H)
+                  ( add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)) H)
                   ( int-ℕ (succ-ℕ x)))
               ( inv
                 ( left-negative-law-mul-ℤ
-                  ( mul-ℤ (int-ℕ q) (int-ℕ s))
+                  ( (int-ℕ q) *ℤ (int-ℕ s))
                   ( int-ℕ (succ-ℕ x))))
-        ＝ add-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
-          (add-ℤ (mul-ℤ (neg-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s))) (int-ℕ (succ-ℕ x)))
+        ＝ add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
+          (add-ℤ (mul-ℤ (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s))) (int-ℕ (succ-ℕ x)))
             (int-ℕ (succ-ℕ x)))
-          by associative-add-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
-            (mul-ℤ (neg-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s))) (int-ℕ (succ-ℕ x)))
+          by associative-add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
+            (mul-ℤ (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s))) (int-ℕ (succ-ℕ x)))
             (int-ℕ (succ-ℕ x))
-        ＝ add-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
-          (add-ℤ (mul-ℤ (neg-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s))) (int-ℕ (succ-ℕ x)))
+        ＝ add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
+          (add-ℤ (mul-ℤ (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s))) (int-ℕ (succ-ℕ x)))
             (mul-ℤ (neg-ℤ (neg-ℤ one-ℤ)) (int-ℕ (succ-ℕ x))))
           by
             ap
               ( λ H →
                 add-ℤ
-                  ( mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
+                  ( mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
                   ( add-ℤ
                     ( mul-ℤ
-                      ( neg-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)))
+                      ( neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s)))
                       ( int-ℕ (succ-ℕ x)))
-                    ( mul-ℤ H (int-ℕ (succ-ℕ x)))))
+                    ( H *ℤ (int-ℕ (succ-ℕ x)))))
               ( inv (neg-neg-ℤ one-ℤ))
         ＝ add-ℤ
-            ( mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
+            ( mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
             ( mul-ℤ
               ( add-ℤ
-                ( neg-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)))
+                ( neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s)))
                 ( neg-ℤ (neg-ℤ one-ℤ)))
               ( int-ℕ (succ-ℕ x)))
           by
             ap
-              ( add-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y)))
+              ( add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
               ( inv
                 ( right-distributive-mul-add-ℤ
-                  ( neg-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)))
+                  ( neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s)))
                   ( neg-ℤ (neg-ℤ one-ℤ))
                   ( int-ℕ (succ-ℕ x))))
         ＝ add-ℤ
-            ( mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
-            ( mul-ℤ (neg-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s))
+            ( mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
+            ( mul-ℤ (neg-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s))
             (neg-ℤ one-ℤ))) (int-ℕ (succ-ℕ x)))
-          by ap (λ H → (add-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
-              (mul-ℤ H (int-ℕ (succ-ℕ x)))))
+          by ap (λ H → (add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
+              (H *ℤ (int-ℕ (succ-ℕ x)))))
               (inv (distributive-neg-add-ℤ
-                (mul-ℤ (int-ℕ q) (int-ℕ s)) (neg-ℤ one-ℤ)))
-        ＝ add-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
-          (neg-ℤ (mul-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s))
+                ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ)))
+        ＝ add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
+          (neg-ℤ (mul-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s))
             (neg-ℤ one-ℤ)) (int-ℕ (succ-ℕ x))))
-          by ap (λ H → (add-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y)) H))
+          by ap (λ H → (add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)) H))
             (left-negative-law-mul-ℤ
-              (add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (neg-ℤ one-ℤ))
+              (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ))
               (int-ℕ (succ-ℕ x)))
 
     dist-eqn :
       r ＝
       dist-ℕ
         ( mul-ℕ
-          ( abs-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (neg-ℤ one-ℤ)))
+          ( abs-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ)))
           ( succ-ℕ x))
-        ( mul-ℕ (mul-ℕ q t) y)
+        ( (q *ℕ t) *ℕ y)
     dist-eqn =
       equational-reasoning
         r
         ＝ abs-ℤ (int-ℕ r) by (inv (abs-int-ℕ r))
-        ＝ abs-ℤ (add-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
-            (neg-ℤ (mul-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (neg-ℤ one-ℤ))
+        ＝ abs-ℤ (add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
+            (neg-ℤ (mul-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ))
             (int-ℕ (succ-ℕ x)))))
           by (ap abs-ℤ (isolate-rem-eqn ∙ rearrange-arith))
-        ＝ dist-ℤ (mul-ℤ (int-ℕ (mul-ℕ q t)) (int-ℕ y))
-          (mul-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (neg-ℤ one-ℤ))
+        ＝ dist-ℤ (mul-ℤ (int-ℕ (q *ℕ t)) (int-ℕ y))
+          (mul-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ))
             (int-ℕ (succ-ℕ x)))
-          by ap (λ H → (dist-ℤ (mul-ℤ H (int-ℕ y))
-            (mul-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (neg-ℤ one-ℤ))
+          by ap (λ H → (dist-ℤ (H *ℤ (int-ℕ y))
+            (mul-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ))
               (int-ℕ (succ-ℕ x)))))
               (mul-int-ℕ q t)
-        ＝ dist-ℤ (int-ℕ (mul-ℕ (mul-ℕ q t) y))
-          (mul-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (neg-ℤ one-ℤ))
+        ＝ dist-ℤ (int-ℕ ((q *ℕ t) *ℕ y))
+          (mul-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ))
           (int-ℕ (succ-ℕ x)))
           by
             ap
               ( λ H →
                 dist-ℤ H
                   ( mul-ℤ
-                    ( add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (neg-ℤ one-ℤ))
+                    ( add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ))
                     ( int-ℕ (succ-ℕ x))))
-              ( mul-int-ℕ (mul-ℕ q t) y)
+              ( mul-int-ℕ (q *ℕ t) y)
         ＝ dist-ℤ
-            ( int-ℕ (mul-ℕ (mul-ℕ q t) y))
+            ( int-ℕ ((q *ℕ t) *ℕ y))
             ( mul-ℤ
-              ( int-ℕ (abs-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (neg-ℤ one-ℤ))))
+              ( int-ℕ (abs-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ))))
               ( int-ℕ (succ-ℕ x)))
           by
             ap
               ( λ H →
                 dist-ℤ
-                  ( int-ℕ (mul-ℕ (mul-ℕ q t) y))
-                  ( mul-ℤ H (int-ℕ (succ-ℕ x))))
+                  ( int-ℕ ((q *ℕ t) *ℕ y))
+                  ( H *ℤ (int-ℕ (succ-ℕ x))))
               ( inv
                 ( int-abs-is-nonnegative-ℤ
-                  ( add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (neg-ℤ one-ℤ))
+                  ( add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ))
                   ( coeff-nonnegative)))
         ＝ dist-ℤ
-            ( int-ℕ (mul-ℕ (mul-ℕ q t) y))
+            ( int-ℕ ((q *ℕ t) *ℕ y))
             ( int-ℕ
               ( mul-ℕ
-                ( abs-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (neg-ℤ one-ℤ)))
+                ( abs-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ)))
                 ( succ-ℕ x)))
           by
             ap
-              ( dist-ℤ (int-ℕ (mul-ℕ (mul-ℕ q t) y)))
+              ( dist-ℤ (int-ℕ ((q *ℕ t) *ℕ y)))
               ( mul-int-ℕ
-                ( abs-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (neg-ℤ one-ℤ)))
+                ( abs-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ)))
                 ( succ-ℕ x))
-        ＝ dist-ℕ (mul-ℕ (mul-ℕ q t) y)
-          (mul-ℕ (abs-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (neg-ℤ one-ℤ)))
+        ＝ dist-ℕ ((q *ℕ t) *ℕ y)
+          (mul-ℕ (abs-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ)))
             (succ-ℕ x))
           by dist-int-ℕ
-            (mul-ℕ (mul-ℕ q t) y)
-            (mul-ℕ (abs-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (neg-ℤ one-ℤ)))
+            ((q *ℕ t) *ℕ y)
+            (mul-ℕ (abs-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ)))
               (succ-ℕ x))
         ＝ dist-ℕ
-          (mul-ℕ (abs-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (neg-ℤ one-ℤ)))
+          (mul-ℕ (abs-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ)))
             (succ-ℕ x))
-            (mul-ℕ (mul-ℕ q t) y)
+            ((q *ℕ t) *ℕ y)
           by symmetric-dist-ℕ
-            (mul-ℕ (mul-ℕ q t) y)
+            ((q *ℕ t) *ℕ y)
             (mul-ℕ (abs-ℤ (add-ℤ (mul-ℤ (int-ℕ q)
               (int-ℕ s)) (neg-ℤ one-ℤ)))
             (succ-ℕ x))
@@ -1883,7 +1881,7 @@ minimal-positive-distance-div-gcd-ℕ x y =
 gcd-ℕ-div-x-mults :
   (x y z : ℕ)
   (d : is-distance-between-multiples-ℕ x y z) →
-  div-ℕ (gcd-ℕ x y) (mul-ℕ (is-distance-between-multiples-fst-coeff-ℕ d) x)
+  div-ℕ (gcd-ℕ x y) ((is-distance-between-multiples-fst-coeff-ℕ d) *ℕ x)
 gcd-ℕ-div-x-mults x y z d =
   div-mul-ℕ
     ( is-distance-between-multiples-fst-coeff-ℕ d)
@@ -1894,7 +1892,7 @@ gcd-ℕ-div-x-mults x y z d =
 gcd-ℕ-div-y-mults :
   (x y z : ℕ)
   (d : is-distance-between-multiples-ℕ x y z) →
-  div-ℕ (gcd-ℕ x y) (mul-ℕ (is-distance-between-multiples-snd-coeff-ℕ d) y)
+  div-ℕ (gcd-ℕ x y) ((is-distance-between-multiples-snd-coeff-ℕ d) *ℕ y)
 gcd-ℕ-div-y-mults x y z d =
   div-mul-ℕ
     ( is-distance-between-multiples-snd-coeff-ℕ d)
@@ -1905,7 +1903,7 @@ gcd-ℕ-div-y-mults x y z d =
 gcd-ℕ-div-dist-between-mult :
   (x y z : ℕ) → is-distance-between-multiples-ℕ x y z → div-ℕ (gcd-ℕ x y) z
 gcd-ℕ-div-dist-between-mult x y z dist =
-  sx-ty-case-split (linear-leq-ℕ (mul-ℕ s x) (mul-ℕ t y))
+  sx-ty-case-split (linear-leq-ℕ (s *ℕ x) (t *ℕ y))
   where
   s : ℕ
   s = is-distance-between-multiples-fst-coeff-ℕ dist
@@ -1913,31 +1911,31 @@ gcd-ℕ-div-dist-between-mult x y z dist =
   t = is-distance-between-multiples-snd-coeff-ℕ dist
 
   sx-ty-case-split :
-    (leq-ℕ (mul-ℕ s x) (mul-ℕ t y) + leq-ℕ (mul-ℕ t y) (mul-ℕ s x)) →
+    (leq-ℕ (s *ℕ x) (t *ℕ y) + leq-ℕ (t *ℕ y) (s *ℕ x)) →
     div-ℕ (gcd-ℕ x y) z
   sx-ty-case-split (inl sxty) =
-    div-right-summand-ℕ (gcd-ℕ x y) (mul-ℕ s x) z
+    div-right-summand-ℕ (gcd-ℕ x y) (s *ℕ x) z
       (gcd-ℕ-div-x-mults x y z dist)
       (concatenate-div-eq-ℕ (gcd-ℕ-div-y-mults x y z dist)
         (inv rewrite-dist))
     where
-    rewrite-dist : (mul-ℕ s x) +ℕ z ＝ mul-ℕ t y
+    rewrite-dist : (s *ℕ x) +ℕ z ＝ t *ℕ y
     rewrite-dist = rewrite-right-dist-add-ℕ
-      (mul-ℕ s x) z (mul-ℕ t y) sxty
+      (s *ℕ x) z (t *ℕ y) sxty
       (inv (is-distance-between-multiples-eqn-ℕ dist))
 
   sx-ty-case-split (inr tysx) =
-    div-right-summand-ℕ (gcd-ℕ x y) (mul-ℕ t y) z
+    div-right-summand-ℕ (gcd-ℕ x y) (t *ℕ y) z
       (gcd-ℕ-div-y-mults x y z dist)
       (concatenate-div-eq-ℕ (gcd-ℕ-div-x-mults x y z dist) (inv rewrite-dist))
     where
-    rewrite-dist : (mul-ℕ t y) +ℕ z ＝ mul-ℕ s x
+    rewrite-dist : (t *ℕ y) +ℕ z ＝ s *ℕ x
     rewrite-dist =
-      rewrite-right-dist-add-ℕ (mul-ℕ t y) z (mul-ℕ s x) tysx
+      rewrite-right-dist-add-ℕ (t *ℕ y) z (s *ℕ x) tysx
         ( inv (is-distance-between-multiples-eqn-ℕ dist) ∙
-          symmetric-dist-ℕ (mul-ℕ s x) (mul-ℕ t y))
+          symmetric-dist-ℕ (s *ℕ x) (t *ℕ y))
 
-    div-gcd-x : div-ℕ (gcd-ℕ x y) (mul-ℕ s x)
+    div-gcd-x : div-ℕ (gcd-ℕ x y) (s *ℕ x)
     div-gcd-x = div-mul-ℕ s (gcd-ℕ x y) x (pr1 (is-common-divisor-gcd-ℕ x y))
 
 gcd-ℕ-div-minimal-positive-distance :
@@ -1964,8 +1962,8 @@ bezouts-lemma-eqn-ℕ :
   (x y : ℕ)
   (H : is-nonzero-ℕ (x +ℕ y)) →
   dist-ℕ
-    ( mul-ℕ (minimal-positive-distance-x-coeff x y H) x)
-    ( mul-ℕ (minimal-positive-distance-y-coeff x y H) y) ＝
+    ( (minimal-positive-distance-x-coeff x y H) *ℕ x)
+    ( (minimal-positive-distance-y-coeff x y H) *ℕ y) ＝
   gcd-ℕ x y
 bezouts-lemma-eqn-ℕ x y H =
   minimal-positive-distance-eqn x y H ∙ bezouts-lemma-ℕ x y H

--- a/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
@@ -423,7 +423,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
     ＝ zero-ℤ +ℤ (int-ℕ z)
       by
       ap
-        ( add-ℤ' (int-ℕ z))
+        ( _+ℤ (int-ℕ z))
         ( left-inverse-law-add-ℤ (a *ℤ (int-ℕ (succ-ℕ x))))
     ＝ int-ℕ z by left-unit-law-add-ℤ (int-ℕ z)
 

--- a/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
@@ -111,8 +111,8 @@ int-is-distance-between-multiples-ℕ :
     ( int-ℕ y)
 int-is-distance-between-multiples-ℕ x y z (k , l , p) H =
   equational-reasoning
-    add-ℤ (int-ℕ z) (mul-ℤ (int-ℕ k) (int-ℕ x))
-    ＝ add-ℤ (int-ℕ z) (int-ℕ (mul-ℕ k x))
+    (int-ℕ z) +ℤ (mul-ℤ (int-ℕ k) (int-ℕ x))
+    ＝ (int-ℕ z) +ℤ (int-ℕ (mul-ℕ k x))
       by ap (λ p → (int-ℕ z) +ℤ p) (mul-int-ℕ k x)
     ＝ int-ℕ (z +ℕ (mul-ℕ k x))
       by add-int-ℕ z (mul-ℕ k x)
@@ -141,7 +141,7 @@ div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
           by inv (ap (λ p → mul-ℤ-Mod x (mod-ℤ x (int-ℕ l)) p) (mod-int-ℕ x y))
         ＝ mod-ℤ x (mul-ℤ (int-ℕ l) (int-ℕ y))
           by inv (preserves-mul-mod-ℤ x (int-ℕ l) (int-ℕ y))
-        ＝ mod-ℤ x (add-ℤ (int-ℕ z) (mul-ℤ (int-ℕ k) (int-ℕ x)))
+        ＝ mod-ℤ x ((int-ℕ z) +ℤ (mul-ℤ (int-ℕ k) (int-ℕ x)))
           by
           inv
             ( ap
@@ -260,7 +260,7 @@ div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
                   ( mul-ℤ (int-ℕ k) (int-ℕ x))
                 by
                 ap
-                  ( λ p → add-ℤ p (mul-ℤ (int-ℕ k) (int-ℕ x)))
+                  ( λ p → p +ℤ (mul-ℤ (int-ℕ k) (int-ℕ x)))
                   ( left-negative-law-mul-ℤ (int-ℕ l) (int-ℕ y))
               ＝ add-ℤ
                   ( mul-ℤ (int-ℕ k) (int-ℕ x))
@@ -270,11 +270,11 @@ div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
                   ( neg-ℤ (mul-ℤ (int-ℕ l) (int-ℕ y)))
                   ( mul-ℤ (int-ℕ k) (int-ℕ x))
               ＝ add-ℤ
-                  ( add-ℤ (int-ℕ z) (mul-ℤ (int-ℕ l) (int-ℕ y)))
+                  ( (int-ℕ z) +ℤ (mul-ℤ (int-ℕ l) (int-ℕ y)))
                   ( neg-ℤ (mul-ℤ (int-ℕ l) (int-ℕ y)))
                 by
                 ap
-                  ( λ p → add-ℤ p (neg-ℤ (mul-ℤ (int-ℕ l) (int-ℕ y))))
+                  ( λ p → p +ℤ (neg-ℤ (mul-ℤ (int-ℕ l) (int-ℕ y))))
                   ( inv
                     ( int-is-distance-between-multiples-ℕ y x z
                       ( is-distance-between-multiples-sym-ℕ x y z (k , l , p))
@@ -374,7 +374,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
         ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
       by
       ap
-        ( λ p → add-ℤ p (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)))
+        ( λ p → p +ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)))
         ( inv (left-negative-law-mul-ℤ a (int-ℕ (succ-ℕ x))))
     ＝ add-ℤ
         ( mul-ℤ (neg-ℤ a) (int-ℕ (succ-ℕ x)))
@@ -418,7 +418,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
         ( int-ℕ z)
       by
       ap
-        ( λ p → add-ℤ (add-ℤ p (mul-ℤ a (int-ℕ (succ-ℕ x)))) (int-ℕ z))
+        ( λ p → add-ℤ (p +ℤ (mul-ℤ a (int-ℕ (succ-ℕ x)))) (int-ℕ z))
         ( left-negative-law-mul-ℤ a (int-ℕ (succ-ℕ x)))
     ＝ zero-ℤ +ℤ (int-ℕ z)
       by
@@ -497,7 +497,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
           ＝ add-ℤ (int-ℤ-Mod (succ-ℕ x) u) (neg-ℤ (int-ℕ (succ-ℕ x)))
             by
             ap
-              ( λ p → (add-ℤ p (neg-ℤ (int-ℕ (succ-ℕ x)))))
+              ( λ p → (p +ℤ (neg-ℤ (int-ℕ (succ-ℕ x)))))
               ( neg-neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
     ＝ add-ℤ
         ( mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
@@ -1067,20 +1067,20 @@ remainder-min-dist-succ-x-is-distance x y =
     add-dist-eqn =
       equational-reasoning
         int-ℕ d
-        ＝ add-ℤ (add-ℤ (int-ℕ d) (int-ℕ (mul-ℕ s (succ-ℕ x))))
+        ＝ add-ℤ ((int-ℕ d) +ℤ (int-ℕ (mul-ℕ s (succ-ℕ x))))
           (neg-ℤ (int-ℕ (mul-ℕ s (succ-ℕ x))))
           by inv (isretr-add-neg-ℤ' (int-ℕ (mul-ℕ s (succ-ℕ x))) (int-ℕ d))
-        ＝ add-ℤ (int-ℕ (add-ℕ d (mul-ℕ s (succ-ℕ x))))
+        ＝ add-ℤ (int-ℕ (d +ℕ (mul-ℕ s (succ-ℕ x))))
           (neg-ℤ (int-ℕ (mul-ℕ s (succ-ℕ x))))
-          by ap (λ H → add-ℤ H (neg-ℤ (int-ℕ (mul-ℕ s (succ-ℕ x)))))
+          by ap (λ H → H +ℤ (neg-ℤ (int-ℕ (mul-ℕ s (succ-ℕ x)))))
           (add-int-ℕ d (mul-ℕ s (succ-ℕ x)))
         ＝ add-ℤ (int-ℕ (mul-ℕ t y)) (neg-ℤ (int-ℕ (mul-ℕ s (succ-ℕ x))))
-          by ap (λ H → add-ℤ (int-ℕ H) (neg-ℤ (int-ℕ (mul-ℕ s (succ-ℕ x)))))
+          by ap (λ H → (int-ℕ H) +ℤ (neg-ℤ (int-ℕ (mul-ℕ s (succ-ℕ x)))))
             (rewrite-left-dist-add-ℕ d (mul-ℕ s (succ-ℕ x))
               (mul-ℕ t y) sxty (inv (dist-sx-ty-eq-d)))
         ＝ add-ℤ (mul-ℤ (int-ℕ t) (int-ℕ y))
           (neg-ℤ (int-ℕ (mul-ℕ s (succ-ℕ x))))
-          by ap (λ H → add-ℤ H (neg-ℤ (int-ℕ (mul-ℕ s (succ-ℕ x)))))
+          by ap (λ H → H +ℤ (neg-ℤ (int-ℕ (mul-ℕ s (succ-ℕ x)))))
             (inv (mul-int-ℕ t y))
         ＝ add-ℤ (mul-ℤ (int-ℕ t) (int-ℕ y))
           (neg-ℤ (mul-ℤ (int-ℕ s) (int-ℕ (succ-ℕ x))))
@@ -1160,13 +1160,13 @@ remainder-min-dist-succ-x-is-distance x y =
         ＝ add-ℤ (neg-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (mul-ℤ (int-ℕ t) (int-ℕ y)))
           (mul-ℤ (int-ℕ q) (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
             (int-ℕ (succ-ℕ x))
-          by (ap (λ H → add-ℤ (neg-ℤ H) (int-ℕ (succ-ℕ x)))
+          by (ap (λ H → (neg-ℤ H) +ℤ (int-ℕ (succ-ℕ x)))
             (left-distributive-mul-add-ℤ (int-ℕ q) (mul-ℤ (int-ℕ t) (int-ℕ y))
               (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
         ＝ add-ℤ (neg-ℤ (add-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
           (mul-ℤ (int-ℕ q) (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
             (int-ℕ (succ-ℕ x))
-          by (ap (λ H → add-ℤ (neg-ℤ (add-ℤ H (mul-ℤ (int-ℕ q)
+          by (ap (λ H → add-ℤ (neg-ℤ (H +ℤ (mul-ℤ (int-ℕ q)
             (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x)))
               (inv (associative-mul-ℤ (int-ℕ q) (int-ℕ t) (int-ℕ y))))
         ＝ add-ℤ (neg-ℤ (add-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
@@ -1205,7 +1205,7 @@ remainder-min-dist-succ-x-is-distance x y =
             (int-ℕ (succ-ℕ x))
           by
             ap
-              ( λ H → add-ℤ H (int-ℕ (succ-ℕ x)))
+              ( λ H → H +ℤ (int-ℕ (succ-ℕ x)))
               ( distributive-neg-add-ℤ
                 ( mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
                 ( neg-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
@@ -1246,7 +1246,7 @@ remainder-min-dist-succ-x-is-distance x y =
           by
             ap
               ( λ H →
-                add-ℤ H (neg-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))))
+                H +ℤ (neg-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))))
               ( ap
                 ( add-ℤ
                   ( mul-ℤ (mul-ℤ (int-ℕ q) ((int-ℕ s))) (int-ℕ (succ-ℕ x))))
@@ -1398,14 +1398,14 @@ remainder-min-dist-succ-x-is-distance x y =
           ( int-ℕ (mul-ℕ s (succ-ℕ x)))
           by
             ap
-              ( λ H → add-ℤ (neg-ℤ H) (int-ℕ (mul-ℕ s (succ-ℕ x))))
+              ( λ H → (neg-ℤ H) +ℤ (int-ℕ (mul-ℕ s (succ-ℕ x))))
               ( inv (mul-int-ℕ t y))
         ＝ add-ℤ
             ( mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
             ( int-ℕ (mul-ℕ s (succ-ℕ x)))
           by
             ap
-              ( λ H → add-ℤ H (int-ℕ (mul-ℕ s (succ-ℕ x))))
+              ( λ H → H +ℤ (int-ℕ (mul-ℕ s (succ-ℕ x))))
               ( inv (left-negative-law-mul-ℤ (int-ℕ t) (int-ℕ y)))
         ＝ add-ℤ
             ( mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
@@ -1502,7 +1502,7 @@ remainder-min-dist-succ-x-is-distance x y =
             ( int-ℕ (succ-ℕ x))
           by
             ap
-              ( λ H → add-ℤ (neg-ℤ H) (int-ℕ (succ-ℕ x)))
+              ( λ H → (neg-ℤ H) +ℤ (int-ℕ (succ-ℕ x)))
               ( left-distributive-mul-add-ℤ
                 ( int-ℕ q)
                 ( mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
@@ -1562,7 +1562,7 @@ remainder-min-dist-succ-x-is-distance x y =
               ( neg-ℤ (mul-ℤ (neg-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t))) (int-ℕ y)))
               ( neg-ℤ (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
             ( int-ℕ (succ-ℕ x))
-          by ap (λ H → add-ℤ H (int-ℕ (succ-ℕ x)))
+          by ap (λ H → H +ℤ (int-ℕ (succ-ℕ x)))
             (distributive-neg-add-ℤ
               (mul-ℤ (neg-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t))) (int-ℕ y))
               (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s))

--- a/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
@@ -193,59 +193,59 @@ div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
             ( ap
               ( λ p → mul-ℤ-Mod x (mod-ℤ x (neg-ℤ (int-ℕ l))) p)
               ( mod-int-ℕ x y))
-        ＝ mod-ℤ x (mul-ℤ (neg-ℤ (int-ℕ l)) (int-ℕ y))
+        ＝ mod-ℤ x ((neg-ℤ (int-ℕ l)) *ℤ (int-ℕ y))
           by inv (preserves-mul-mod-ℤ x (neg-ℤ (int-ℕ l)) (int-ℕ y))
-        ＝ mod-ℤ x (add-ℤ (mul-ℤ (neg-ℤ (int-ℕ l)) (int-ℕ y)) zero-ℤ)
+        ＝ mod-ℤ x (add-ℤ ((neg-ℤ (int-ℕ l)) *ℤ (int-ℕ y)) zero-ℤ)
           by
           ap
             ( mod-ℤ x)
-            ( inv (right-unit-law-add-ℤ (mul-ℤ (neg-ℤ (int-ℕ l)) (int-ℕ y))))
+            ( inv (right-unit-law-add-ℤ ((neg-ℤ (int-ℕ l)) *ℤ (int-ℕ y))))
         ＝ add-ℤ-Mod x
-            ( mod-ℤ x (mul-ℤ (neg-ℤ (int-ℕ l)) (int-ℕ y)))
+            ( mod-ℤ x ((neg-ℤ (int-ℕ l)) *ℤ (int-ℕ y)))
             ( mod-ℤ x zero-ℤ)
-          by preserves-add-mod-ℤ x (mul-ℤ (neg-ℤ (int-ℕ l)) (int-ℕ y)) (zero-ℤ)
+          by preserves-add-mod-ℤ x ((neg-ℤ (int-ℕ l)) *ℤ (int-ℕ y)) (zero-ℤ)
         ＝ add-ℤ-Mod x
-            ( mod-ℤ x (mul-ℤ (neg-ℤ (int-ℕ l)) (int-ℕ y)))
+            ( mod-ℤ x ((neg-ℤ (int-ℕ l)) *ℤ (int-ℕ y)))
             ( mod-ℤ x ((int-ℕ k) *ℤ zero-ℤ))
           by
           ap
             ( λ p →
               add-ℤ-Mod x
-                ( mod-ℤ x (mul-ℤ (neg-ℤ (int-ℕ l)) (int-ℕ y)))
+                ( mod-ℤ x ((neg-ℤ (int-ℕ l)) *ℤ (int-ℕ y)))
                 ( mod-ℤ x p))
             ( inv (right-zero-law-mul-ℤ (int-ℕ k)))
         ＝ add-ℤ-Mod x
-            ( mod-ℤ x (mul-ℤ (neg-ℤ (int-ℕ l)) (int-ℕ y)))
+            ( mod-ℤ x ((neg-ℤ (int-ℕ l)) *ℤ (int-ℕ y)))
             ( mul-ℤ-Mod x (mod-ℤ x (int-ℕ k)) (mod-ℤ x zero-ℤ))
           by
           ap
-            ( add-ℤ-Mod x (mod-ℤ x (mul-ℤ (neg-ℤ (int-ℕ l)) (int-ℕ y))))
+            ( add-ℤ-Mod x (mod-ℤ x ((neg-ℤ (int-ℕ l)) *ℤ (int-ℕ y))))
             ( preserves-mul-mod-ℤ x (int-ℕ k) zero-ℤ)
         ＝ add-ℤ-Mod x
-            ( mod-ℤ x (mul-ℤ (neg-ℤ (int-ℕ l)) (int-ℕ y)))
+            ( mod-ℤ x ((neg-ℤ (int-ℕ l)) *ℤ (int-ℕ y)))
             ( mul-ℤ-Mod x (mod-ℤ x (int-ℕ k)) (mod-ℤ x (int-ℕ x)))
           by
           ap
             ( λ p →
               add-ℤ-Mod x
-                ( mod-ℤ x (mul-ℤ (neg-ℤ (int-ℕ l)) (int-ℕ y)))
+                ( mod-ℤ x ((neg-ℤ (int-ℕ l)) *ℤ (int-ℕ y)))
                 ( mul-ℤ-Mod x (mod-ℤ x (int-ℕ k)) p))
             ( mod-zero-ℤ x ∙ (inv (mod-refl-ℕ x) ∙ inv (mod-int-ℕ x x)))
         ＝ add-ℤ-Mod x
-            ( mod-ℤ x (mul-ℤ (neg-ℤ (int-ℕ l)) (int-ℕ y)))
+            ( mod-ℤ x ((neg-ℤ (int-ℕ l)) *ℤ (int-ℕ y)))
             ( mod-ℤ x ((int-ℕ k) *ℤ (int-ℕ x)))
           by
           ap
-            ( add-ℤ-Mod x (mod-ℤ x (mul-ℤ (neg-ℤ (int-ℕ l)) (int-ℕ y))))
+            ( add-ℤ-Mod x (mod-ℤ x ((neg-ℤ (int-ℕ l)) *ℤ (int-ℕ y))))
             ( inv (preserves-mul-mod-ℤ x (int-ℕ k) (int-ℕ x)))
         ＝ mod-ℤ x
             ( add-ℤ
-              ( mul-ℤ (neg-ℤ (int-ℕ l)) (int-ℕ y))
+              ( (neg-ℤ (int-ℕ l)) *ℤ (int-ℕ y))
               ( (int-ℕ k) *ℤ (int-ℕ x)))
           by
           inv
             ( preserves-add-mod-ℤ x
-              ( mul-ℤ (neg-ℤ (int-ℕ l)) (int-ℕ y))
+              ( (neg-ℤ (int-ℕ l)) *ℤ (int-ℕ y))
               ( (int-ℕ k) *ℤ (int-ℕ x)))
         ＝ mod-ℤ x (int-ℕ z)
           by
@@ -253,7 +253,7 @@ div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
             ( mod-ℤ x)
             ( equational-reasoning
               add-ℤ
-                ( mul-ℤ (neg-ℤ (int-ℕ l)) (int-ℕ y))
+                ( (neg-ℤ (int-ℕ l)) *ℤ (int-ℕ y))
                 ( (int-ℕ k) *ℤ (int-ℕ x))
               ＝ add-ℤ
                   ( neg-ℤ ((int-ℕ l) *ℤ (int-ℕ y)))
@@ -298,7 +298,7 @@ Then, in this case, we again can extract the distance condition we desire.
 ```agda
 cong-div-mod-ℤ :
   (x y z : ℕ) (q : div-ℤ-Mod x (mod-ℕ x y) (mod-ℕ x z)) →
-  cong-ℤ (int-ℕ x) (mul-ℤ (int-ℤ-Mod x (pr1 q)) (int-ℕ y)) (int-ℕ z)
+  cong-ℤ (int-ℕ x) ((int-ℤ-Mod x (pr1 q)) *ℤ (int-ℕ y)) (int-ℕ z)
 cong-div-mod-ℤ x y z (u , p) =
   cong-eq-mod-ℤ x
     ( (int-ℤ-Mod x u) *ℤ (int-ℕ y))
@@ -347,39 +347,39 @@ is-distance-between-multiples-div-mod-ℕ zero-ℕ y z (u , p) =
 
 is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
   uy-z-case-split (decide-is-nonnegative-ℤ
-    { add-ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)) (neg-ℤ (int-ℕ z))})
+    { add-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)) (neg-ℤ (int-ℕ z))})
   where
   a : ℤ
   a = pr1 (cong-div-mod-ℤ (succ-ℕ x) y z (u , p))
 
   a-eqn-pos :
     add-ℤ
-      ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
+      ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
       ( neg-ℤ (a *ℤ (int-ℕ (succ-ℕ x)))) ＝
     int-ℕ z
   a-eqn-pos =
     equational-reasoning
     add-ℤ
-      ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
+      ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
       ( neg-ℤ (a *ℤ (int-ℕ (succ-ℕ x))))
     ＝ add-ℤ
         ( neg-ℤ (a *ℤ (int-ℕ (succ-ℕ x))))
-        ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
+        ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
       by
       commutative-add-ℤ
-        ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
+        ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
         ( neg-ℤ (a *ℤ (int-ℕ (succ-ℕ x))))
     ＝ add-ℤ
         ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
-        ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
+        ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
       by
       ap
-        ( λ p → p +ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)))
+        ( λ p → p +ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)))
         ( inv (left-negative-law-mul-ℤ a (int-ℕ (succ-ℕ x))))
     ＝ add-ℤ
         ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
         ( add-ℤ
-          ( add-ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)) (neg-ℤ (int-ℕ z)))
+          ( add-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)) (neg-ℤ (int-ℕ z)))
           ( int-ℕ z))
       by
       ap
@@ -387,17 +387,17 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
         ( inv
           ( issec-add-neg-ℤ'
             ( int-ℕ z)
-            ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))))
+            ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))))
     ＝ add-ℤ
         ( add-ℤ
           ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
-          ( add-ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)) (neg-ℤ (int-ℕ z))))
+          ( add-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)) (neg-ℤ (int-ℕ z))))
         ( int-ℕ z)
       by
       inv
         ( associative-add-ℤ
           ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
-          ( add-ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)) (neg-ℤ (int-ℕ z)))
+          ( add-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)) (neg-ℤ (int-ℕ z)))
           ( int-ℕ z))
     ＝ add-ℤ
         ( add-ℤ
@@ -437,7 +437,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
             ( neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
           ( int-ℕ y))) ＝
     add-ℤ
-      ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
+      ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
       ( neg-ℤ (a *ℤ (int-ℕ (succ-ℕ x))))
   a-extra-eqn-neg =
     equational-reasoning
@@ -465,12 +465,12 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
             ( int-ℕ (succ-ℕ x))))
         ( inv
           ( left-negative-law-mul-ℤ
-            ( add-ℤ (int-ℕ (succ-ℕ x)) (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
+            ( (int-ℕ (succ-ℕ x)) +ℤ (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
             ( int-ℕ y)))
     ＝ add-ℤ
         ( mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
         ( mul-ℤ
-          ( add-ℤ (int-ℤ-Mod (succ-ℕ x) u) (neg-ℤ (int-ℕ (succ-ℕ x))))
+          ( (int-ℤ-Mod (succ-ℕ x) u) +ℤ (neg-ℤ (int-ℕ (succ-ℕ x))))
           ( int-ℕ y))
       by
       ap
@@ -479,7 +479,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
             ( mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
             ( p *ℤ (int-ℕ y)))
         ( equational-reasoning
-          neg-ℤ (add-ℤ (int-ℕ (succ-ℕ x)) (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
+          neg-ℤ ((int-ℕ (succ-ℕ x)) +ℤ (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
           ＝ neg-ℤ (add-ℤ (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)) (int-ℕ (succ-ℕ x)))
             by
             ap
@@ -494,7 +494,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
             distributive-neg-add-ℤ
               ( neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))
               ( int-ℕ (succ-ℕ x))
-          ＝ add-ℤ (int-ℤ-Mod (succ-ℕ x) u) (neg-ℤ (int-ℕ (succ-ℕ x)))
+          ＝ (int-ℤ-Mod (succ-ℕ x) u) +ℤ (neg-ℤ (int-ℕ (succ-ℕ x)))
             by
             ap
               ( λ p → (p +ℤ (neg-ℤ (int-ℕ (succ-ℕ x)))))
@@ -502,7 +502,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
     ＝ add-ℤ
         ( mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
         ( add-ℤ
-          ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
+          ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
           ( mul-ℤ (neg-ℤ (int-ℕ (succ-ℕ x))) (int-ℕ y)))
       by
       ap
@@ -514,133 +514,133 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
     ＝ add-ℤ
         ( mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
         ( add-ℤ
-          ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
-          ( neg-ℤ (mul-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ y))))
+          ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
+          ( neg-ℤ ((int-ℕ (succ-ℕ x)) *ℤ (int-ℕ y))))
       by
       ap
         ( λ p →
           add-ℤ
             ( mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
-            ( add-ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)) p))
+            ( add-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)) p))
         ( left-negative-law-mul-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ y))
     ＝ add-ℤ
         ( add-ℤ
           ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
           ( (int-ℕ y) *ℤ (int-ℕ (succ-ℕ x))))
         ( add-ℤ
-          ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
-          ( neg-ℤ (mul-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ y))))
+          ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
+          ( neg-ℤ ((int-ℕ (succ-ℕ x)) *ℤ (int-ℕ y))))
       by
       ap
         ( add-ℤ'
           ( add-ℤ
-            ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
-            ( neg-ℤ (mul-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ y)))))
+            ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
+            ( neg-ℤ ((int-ℕ (succ-ℕ x)) *ℤ (int-ℕ y)))))
         ( right-distributive-mul-add-ℤ (neg-ℤ a) (int-ℕ y) (int-ℕ (succ-ℕ x)))
     ＝ add-ℤ
         ( add-ℤ
           ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
-          ( mul-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ y)))
+          ( (int-ℕ (succ-ℕ x)) *ℤ (int-ℕ y)))
         ( add-ℤ
-          ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
-          ( neg-ℤ (mul-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ y))))
+          ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
+          ( neg-ℤ ((int-ℕ (succ-ℕ x)) *ℤ (int-ℕ y))))
       by
       ap
         ( λ p →
           add-ℤ
             ( add-ℤ ((neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x))) p)
             ( add-ℤ
-              ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
-              ( neg-ℤ (mul-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ y)))))
+              ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
+              ( neg-ℤ ((int-ℕ (succ-ℕ x)) *ℤ (int-ℕ y)))))
         ( commutative-mul-ℤ (int-ℕ y) (int-ℕ (succ-ℕ x)))
     ＝ add-ℤ
         ( add-ℤ
           ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
-          ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)))
+          ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)))
         ( add-ℤ
-          ( mul-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ y))
-          ( neg-ℤ (mul-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ y))))
+          ( (int-ℕ (succ-ℕ x)) *ℤ (int-ℕ y))
+          ( neg-ℤ ((int-ℕ (succ-ℕ x)) *ℤ (int-ℕ y))))
       by
       interchange-law-add-add-ℤ
         ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
-        ( mul-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ y))
-        ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
-        ( neg-ℤ (mul-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ y)))
+        ( (int-ℕ (succ-ℕ x)) *ℤ (int-ℕ y))
+        ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
+        ( neg-ℤ ((int-ℕ (succ-ℕ x)) *ℤ (int-ℕ y)))
     ＝ add-ℤ
         ( add-ℤ
           ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
-          ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)))
+          ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)))
         ( zero-ℤ)
       by
       ap
         ( add-ℤ
           ( add-ℤ
             ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
-            ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))))
-          ( right-inverse-law-add-ℤ (mul-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ y)))
+            ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))))
+          ( right-inverse-law-add-ℤ ((int-ℕ (succ-ℕ x)) *ℤ (int-ℕ y)))
     ＝ add-ℤ
         ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
-        ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
+        ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
       by
       right-unit-law-add-ℤ
         ( add-ℤ
           ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
-          ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)))
+          ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)))
     ＝ add-ℤ
-        ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
+        ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
         ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
       by
       commutative-add-ℤ
         ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
-        ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
+        ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
     ＝ add-ℤ
-        ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
+        ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
         ( neg-ℤ (a *ℤ (int-ℕ (succ-ℕ x))))
       by
       ap
-        ( add-ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)))
+        ( add-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)))
         ( left-negative-law-mul-ℤ a (int-ℕ (succ-ℕ x)))
 
   uy-z-case-split :
     ( ( is-nonnegative-ℤ
-        ( add-ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)) (neg-ℤ (int-ℕ z)))) +
+        ( add-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)) (neg-ℤ (int-ℕ z)))) +
       ( is-nonnegative-ℤ
         ( neg-ℤ
           ( add-ℤ
-            ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
+            ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
             ( neg-ℤ (int-ℕ z)))))) →
     is-distance-between-multiples-ℕ (succ-ℕ x) y z
   uy-z-case-split (inl uy-z) =
     ( abs-ℤ a ,
       nat-Fin (succ-ℕ x) u ,
       ( equational-reasoning
-        dist-ℕ ((abs-ℤ a) *ℕ (succ-ℕ x)) (mul-ℕ (nat-Fin (succ-ℕ x) u) y)
-        ＝ dist-ℕ (mul-ℕ (nat-Fin (succ-ℕ x) u) y) ((abs-ℤ a) *ℕ (succ-ℕ x))
+        dist-ℕ ((abs-ℤ a) *ℕ (succ-ℕ x)) ((nat-Fin (succ-ℕ x) u) *ℕ y)
+        ＝ dist-ℕ ((nat-Fin (succ-ℕ x) u) *ℕ y) ((abs-ℤ a) *ℕ (succ-ℕ x))
           by
           symmetric-dist-ℕ
             ( (abs-ℤ a) *ℕ (succ-ℕ x))
-            ( mul-ℕ (nat-Fin (succ-ℕ x) u) y)
+            ( (nat-Fin (succ-ℕ x) u) *ℕ y)
         ＝ dist-ℤ
-            ( int-ℕ (mul-ℕ (nat-Fin (succ-ℕ x) u) y))
+            ( int-ℕ ((nat-Fin (succ-ℕ x) u) *ℕ y))
             ( int-ℕ ((abs-ℤ a) *ℕ (succ-ℕ x)))
           by
           inv
             ( dist-int-ℕ
-              ( mul-ℕ (nat-Fin (succ-ℕ x) u) y)
+              ( (nat-Fin (succ-ℕ x) u) *ℕ y)
               ( (abs-ℤ a) *ℕ (succ-ℕ x)))
         ＝ dist-ℤ
-            ( int-ℕ (mul-ℕ (nat-Fin (succ-ℕ x) u) y))
-            ( mul-ℤ (int-ℕ (abs-ℤ a)) (int-ℕ (succ-ℕ x)))
+            ( int-ℕ ((nat-Fin (succ-ℕ x) u) *ℕ y))
+            ( (int-ℕ (abs-ℤ a)) *ℤ (int-ℕ (succ-ℕ x)))
           by
           ap
-            ( dist-ℤ (int-ℕ (mul-ℕ (nat-Fin (succ-ℕ x) u) y)))
+            ( dist-ℤ (int-ℕ ((nat-Fin (succ-ℕ x) u) *ℕ y)))
             ( inv (mul-int-ℕ (abs-ℤ a) (succ-ℕ x)))
         ＝ dist-ℤ
             ( mul-ℤ (int-ℕ (nat-Fin (succ-ℕ x) u)) (int-ℕ y))
-            ( mul-ℤ (int-ℕ (abs-ℤ a)) (int-ℕ (succ-ℕ x)))
+            ( (int-ℕ (abs-ℤ a)) *ℤ (int-ℕ (succ-ℕ x)))
           by
           ap
-            ( λ p → dist-ℤ p (mul-ℤ (int-ℕ (abs-ℤ a)) (int-ℕ (succ-ℕ x))))
+            ( λ p → dist-ℤ p ((int-ℕ (abs-ℤ a)) *ℤ (int-ℕ (succ-ℕ x))))
             ( inv (mul-int-ℕ (nat-Fin (succ-ℕ x) u) y))
         ＝ dist-ℤ
             ( mul-ℤ (int-ℕ (nat-Fin (succ-ℕ x) u)) (int-ℕ y))
@@ -649,7 +649,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
           ap
             ( λ p →
               dist-ℤ
-                ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
+                ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
                 ( p *ℤ (int-ℕ (succ-ℕ x))))
             ( int-abs-is-nonnegative-ℤ a a-is-nonnegative-ℤ)
         ＝ abs-ℤ (int-ℕ z)
@@ -669,49 +669,49 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
 
   uy-z-case-split (inr z-uy) =
     ( (abs-ℤ a) +ℕ y ,
-      abs-ℤ (add-ℤ (int-ℕ (succ-ℕ x)) (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) ,
+      abs-ℤ ((int-ℕ (succ-ℕ x)) +ℤ (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) ,
       ( equational-reasoning
-        dist-ℕ (mul-ℕ ((abs-ℤ a) +ℕ y) (succ-ℕ x))
-          (mul-ℕ (abs-ℤ (add-ℤ (int-ℕ (succ-ℕ x))
+        dist-ℕ (((abs-ℤ a) +ℕ y) *ℕ (succ-ℕ x))
+          (mul-ℕ (abs-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
           (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))) y)
-        ＝ dist-ℤ (int-ℕ (mul-ℕ ((abs-ℤ a) +ℕ y) (succ-ℕ x)))
-          (int-ℕ (mul-ℕ (abs-ℤ (add-ℤ (int-ℕ (succ-ℕ x))
+        ＝ dist-ℤ (int-ℕ (((abs-ℤ a) +ℕ y) *ℕ (succ-ℕ x)))
+          (int-ℕ (mul-ℕ (abs-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
           (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))) y))
-        by inv (dist-int-ℕ (mul-ℕ ((abs-ℤ a) +ℕ y) (succ-ℕ x))
-          (mul-ℕ (abs-ℤ (add-ℤ (int-ℕ (succ-ℕ x))
+        by inv (dist-int-ℕ (((abs-ℤ a) +ℕ y) *ℕ (succ-ℕ x))
+          (mul-ℕ (abs-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
           (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))) y))
         ＝ dist-ℤ (mul-ℤ (int-ℕ ((abs-ℤ a) +ℕ y)) (int-ℕ (succ-ℕ x)))
-          (int-ℕ (mul-ℕ (abs-ℤ (add-ℤ (int-ℕ (succ-ℕ x))
+          (int-ℕ (mul-ℕ (abs-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
           (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))) y))
-        by ap (λ p → dist-ℤ p (int-ℕ (mul-ℕ (abs-ℤ (add-ℤ (int-ℕ (succ-ℕ x))
+        by ap (λ p → dist-ℤ p (int-ℕ (mul-ℕ (abs-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
           (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))) y)))
           (inv (mul-int-ℕ ((abs-ℤ a) +ℕ y) (succ-ℕ x)))
-        ＝ dist-ℤ (mul-ℤ (add-ℤ (int-ℕ (abs-ℤ a)) (int-ℕ y)) (int-ℕ (succ-ℕ x)))
-          (int-ℕ (mul-ℕ (abs-ℤ (add-ℤ (int-ℕ (succ-ℕ x))
+        ＝ dist-ℤ (mul-ℤ ((int-ℕ (abs-ℤ a)) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+          (int-ℕ (mul-ℕ (abs-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
           (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))) y))
         by ap (λ p → dist-ℤ (p *ℤ (int-ℕ (succ-ℕ x)))
-             (int-ℕ (mul-ℕ (abs-ℤ (add-ℤ (int-ℕ (succ-ℕ x))
+             (int-ℕ (mul-ℕ (abs-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
                (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))) y)))
           (inv (add-int-ℕ (abs-ℤ a) y))
-        ＝ dist-ℤ (mul-ℤ (add-ℤ (int-ℕ (abs-ℤ a)) (int-ℕ y)) (int-ℕ (succ-ℕ x)))
-          (mul-ℤ (int-ℕ (abs-ℤ (add-ℤ (int-ℕ (succ-ℕ x))
+        ＝ dist-ℤ (mul-ℤ ((int-ℕ (abs-ℤ a)) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+          (mul-ℤ (int-ℕ (abs-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
           (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))))) (int-ℕ y))
-        by ap (λ p → dist-ℤ (mul-ℤ (add-ℤ (int-ℕ (abs-ℤ a)) (int-ℕ y))
+        by ap (λ p → dist-ℤ (mul-ℤ ((int-ℕ (abs-ℤ a)) +ℤ (int-ℕ y))
              (int-ℕ (succ-ℕ x))) p)
-          (inv (mul-int-ℕ (abs-ℤ (add-ℤ (int-ℕ (succ-ℕ x))
+          (inv (mul-int-ℕ (abs-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
             (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))) y))
-        ＝ dist-ℤ (mul-ℤ (add-ℤ (int-ℕ (abs-ℤ a)) (int-ℕ y)) (int-ℕ (succ-ℕ x)))
-          (mul-ℤ (add-ℤ (int-ℕ (succ-ℕ x))
+        ＝ dist-ℤ (mul-ℤ ((int-ℕ (abs-ℤ a)) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+          (mul-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
             (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) (int-ℕ y))
-        by ap (λ p → dist-ℤ (mul-ℤ (add-ℤ (int-ℕ (abs-ℤ a)) (int-ℕ y))
+        by ap (λ p → dist-ℤ (mul-ℤ ((int-ℕ (abs-ℤ a)) +ℤ (int-ℕ y))
              (int-ℕ (succ-ℕ x))) (p *ℤ (int-ℕ y)))
-          (int-abs-is-nonnegative-ℤ (add-ℤ (int-ℕ (succ-ℕ x))
+          (int-abs-is-nonnegative-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
             (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) (int-ℤ-Mod-bounded x u))
         ＝ dist-ℤ
             ( mul-ℤ
               ( add-ℤ (int-ℕ (abs-ℤ (neg-ℤ a))) (int-ℕ y))
               ( int-ℕ (succ-ℕ x)))
-            ( mul-ℤ (add-ℤ (int-ℕ (succ-ℕ x))
+            ( mul-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
             (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) (int-ℕ y))
         by
           ap
@@ -719,14 +719,14 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
               dist-ℤ
                 ( mul-ℤ ((int-ℕ p) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
                 ( mul-ℤ
-                  ( add-ℤ (int-ℕ (succ-ℕ x)) (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
+                  ( (int-ℕ (succ-ℕ x)) +ℤ (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
                   ( int-ℕ y)))
           (inv (abs-neg-ℤ a))
         ＝ dist-ℤ (mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
-          (mul-ℤ (add-ℤ (int-ℕ (succ-ℕ x))
+          (mul-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
             (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) (int-ℕ y))
-        by ap (λ p → dist-ℤ (mul-ℤ (p +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
-          (mul-ℤ (add-ℤ (int-ℕ (succ-ℕ x)) (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
+        by ap (λ p → dist-ℤ ((p +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x)))
+          (mul-ℤ ((int-ℕ (succ-ℕ x)) +ℤ (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
             (int-ℕ y)))
           (int-abs-is-nonnegative-ℤ (neg-ℤ a) neg-a-is-nonnegative-ℤ)
         ＝ abs-ℤ (int-ℕ z)
@@ -737,27 +737,27 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
     neg-a-is-nonnegative-ℤ = (is-nonnegative-left-factor-mul-ℤ
       (tr is-nonnegative-ℤ
       (equational-reasoning
-        neg-ℤ (add-ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
+        neg-ℤ (add-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
           (neg-ℤ (int-ℕ z)))
-        ＝ add-ℤ (neg-ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)))
+        ＝ add-ℤ (neg-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)))
           (neg-ℤ (neg-ℤ (int-ℕ z)))
         by (distributive-neg-add-ℤ
-          (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
+          ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
           (neg-ℤ (int-ℕ z)))
-        ＝ add-ℤ (neg-ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)))
+        ＝ add-ℤ (neg-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)))
           (int-ℕ z)
         by ap (λ p → add-ℤ
-          (neg-ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))) p)
+          (neg-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))) p)
           (neg-neg-ℤ (int-ℕ z))
         ＝ add-ℤ (int-ℕ z)
-          (neg-ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)))
+          (neg-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)))
         by commutative-add-ℤ
-          (neg-ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)))
+          (neg-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)))
           (int-ℕ z)
         ＝ (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x))
         by inv (pr2
           (symmetric-cong-ℤ (int-ℕ (succ-ℕ x))
-            (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)) (int-ℕ z)
+            ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)) (int-ℕ z)
             (cong-div-mod-ℤ (succ-ℕ x) y z (u , p)))))
         z-uy) (is-nonnegative-int-ℕ (succ-ℕ x)))
 ```
@@ -1063,7 +1063,7 @@ remainder-min-dist-succ-x-is-distance x y =
       int-ℕ d ＝
       add-ℤ
         ( (int-ℕ t) *ℤ (int-ℕ y))
-        ( mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))
+        ( (neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))
     add-dist-eqn =
       equational-reasoning
         int-ℕ d
@@ -1074,7 +1074,7 @@ remainder-min-dist-succ-x-is-distance x y =
           (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x))))
           by ap (λ H → H +ℤ (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x)))))
           (add-int-ℕ d (s *ℕ (succ-ℕ x)))
-        ＝ add-ℤ (int-ℕ (t *ℕ y)) (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x))))
+        ＝ (int-ℕ (t *ℕ y)) +ℤ (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x))))
           by ap (λ H → (int-ℕ H) +ℤ (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x)))))
             (rewrite-left-dist-add-ℕ d (s *ℕ (succ-ℕ x))
               (t *ℕ y) sxty (inv (dist-sx-ty-eq-d)))
@@ -1087,7 +1087,7 @@ remainder-min-dist-succ-x-is-distance x y =
           by ap (λ H → add-ℤ ((int-ℕ t) *ℤ (int-ℕ y)) (neg-ℤ H))
             (inv (mul-int-ℕ s (succ-ℕ x)))
         ＝ add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
-          (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))
+          ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))
           by ap (λ H → add-ℤ ((int-ℕ t) *ℤ (int-ℕ y)) H)
             (inv (left-negative-law-mul-ℤ (int-ℕ s) (int-ℕ (succ-ℕ x))))
 
@@ -1099,22 +1099,22 @@ remainder-min-dist-succ-x-is-distance x y =
             ( int-ℕ q)
             ( add-ℤ
               ( (int-ℕ t) *ℤ (int-ℕ y))
-              ( mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
+              ( (neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))))))
         ( int-ℕ (succ-ℕ x))
     isolate-rem-eqn =
       equational-reasoning
         int-ℕ r
         ＝ add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
-             (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
+             ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))))))
           (add-ℤ ((int-ℕ q) *ℤ (add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
-              (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
+              ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))
           (int-ℕ r))
           by inv (isretr-add-neg-ℤ
             ((int-ℕ q) *ℤ (add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
-            (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
+            ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))
             (int-ℕ r))
         ＝ add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
-             (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
+             ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))))))
           (add-ℤ ((int-ℕ q) *ℤ (int-ℕ d)) (int-ℕ r))
           by
             ap
@@ -1125,8 +1125,8 @@ remainder-min-dist-succ-x-is-distance x y =
                       ( int-ℕ q)
                       ( add-ℤ
                         ( (int-ℕ t) *ℤ (int-ℕ y))
-                        ( mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
-                  ( add-ℤ ((int-ℕ q) *ℤ H) (int-ℕ r)))
+                        ( (neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))))))
+                  ( ((int-ℕ q) *ℤ H) +ℤ (int-ℕ r)))
               ( inv add-dist-eqn)
         ＝ add-ℤ
             ( neg-ℤ
@@ -1134,7 +1134,7 @@ remainder-min-dist-succ-x-is-distance x y =
                 ( int-ℕ q)
                 ( add-ℤ
                   ( (int-ℕ t) *ℤ (int-ℕ y))
-                  ( mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
+                  ( (neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))))))
             ( int-ℕ (succ-ℕ x))
           by
             ap
@@ -1144,30 +1144,30 @@ remainder-min-dist-succ-x-is-distance x y =
                     ( int-ℕ q)
                     ( add-ℤ
                       ( (int-ℕ t) *ℤ (int-ℕ y))
-                      ( mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))))
+                      ( (neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))))
               ( minimal-positive-distance-div-succ-x-eqn x y)
 
     rearrange-arith-eqn :
       add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
-        (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x))
+        ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x))
       ＝ add-ℤ (mul-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) one-ℤ)
           (int-ℕ (succ-ℕ x)))
         (neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
     rearrange-arith-eqn =
       equational-reasoning
         add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
-          (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x))
+          ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x))
         ＝ add-ℤ (neg-ℤ (add-ℤ ((int-ℕ q) *ℤ ((int-ℕ t) *ℤ (int-ℕ y)))
-          ((int-ℕ q) *ℤ (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
+          ((int-ℕ q) *ℤ ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))))))
             (int-ℕ (succ-ℕ x))
           by (ap (λ H → (neg-ℤ H) +ℤ (int-ℕ (succ-ℕ x)))
             (left-distributive-mul-add-ℤ (int-ℕ q) ((int-ℕ t) *ℤ (int-ℕ y))
-              (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
+              ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))
         ＝ add-ℤ (neg-ℤ (add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
-          ((int-ℕ q) *ℤ (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
+          ((int-ℕ q) *ℤ ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))))))
             (int-ℕ (succ-ℕ x))
           by (ap (λ H → add-ℤ (neg-ℤ (H +ℤ (mul-ℤ (int-ℕ q)
-            (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x)))
+            ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x)))
               (inv (associative-mul-ℤ (int-ℕ q) (int-ℕ t) (int-ℕ y))))
         ＝ add-ℤ (neg-ℤ (add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
           (neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
@@ -1180,7 +1180,7 @@ remainder-min-dist-succ-x-is-distance x y =
                     ( add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)) H))
                   ( int-ℕ (succ-ℕ x)))
             ( equational-reasoning
-                ((int-ℕ q) *ℤ (mul-ℤ (neg-ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))
+                ((int-ℕ q) *ℤ ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))))
                 ＝ mul-ℤ ((int-ℕ q) *ℤ (neg-ℤ (int-ℕ s))) (int-ℕ (succ-ℕ x))
                   by
                     inv
@@ -1258,7 +1258,7 @@ remainder-min-dist-succ-x-is-distance x y =
                     ( int-ℕ (succ-ℕ x)))))
 
     dist-eqn :
-      r ＝ dist-ℕ (mul-ℕ ((q *ℕ s) +ℕ 1) (succ-ℕ x)) ((q *ℕ t) *ℕ y)
+      r ＝ dist-ℕ (((q *ℕ s) +ℕ 1) *ℕ (succ-ℕ x)) ((q *ℕ t) *ℕ y)
     dist-eqn =
       equational-reasoning
         r
@@ -1269,9 +1269,9 @@ remainder-min-dist-succ-x-is-distance x y =
           (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
           by (ap (abs-ℤ) (isolate-rem-eqn ∙ rearrange-arith-eqn))
         ＝ dist-ℤ
-            ( mul-ℤ (add-ℤ (int-ℕ (q *ℕ s)) (int-ℕ 1)) (int-ℕ (succ-ℕ x)))
+            ( mul-ℤ ((int-ℕ (q *ℕ s)) +ℤ (int-ℕ 1)) (int-ℕ (succ-ℕ x)))
             ( mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
-          by ap (λ H → dist-ℤ (mul-ℤ (H +ℤ (int-ℕ 1)) (int-ℕ (succ-ℕ x)))
+          by ap (λ H → dist-ℤ ((H +ℤ (int-ℕ 1)) *ℤ (int-ℕ (succ-ℕ x)))
             (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
             (mul-int-ℕ q s)
         ＝ dist-ℤ (mul-ℤ (int-ℕ ((q *ℕ s) +ℕ 1)) (int-ℕ (succ-ℕ x)))
@@ -1279,22 +1279,22 @@ remainder-min-dist-succ-x-is-distance x y =
           by ap (λ H → dist-ℤ (H *ℤ (int-ℕ (succ-ℕ x)))
             (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
             (add-int-ℕ (q *ℕ s) 1)
-        ＝ dist-ℤ (int-ℕ (mul-ℕ ((q *ℕ s) +ℕ 1) (succ-ℕ x)))
+        ＝ dist-ℤ (int-ℕ (((q *ℕ s) +ℕ 1) *ℕ (succ-ℕ x)))
           (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
           by ap (λ H → dist-ℤ H (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
             (mul-int-ℕ ((q *ℕ s) +ℕ 1) (succ-ℕ x))
-        ＝ dist-ℤ (int-ℕ (mul-ℕ ((q *ℕ s) +ℕ 1) (succ-ℕ x)))
-          (mul-ℤ (int-ℕ (q *ℕ t)) (int-ℕ y))
-          by ap (λ H → dist-ℤ (int-ℕ (mul-ℕ ((q *ℕ s) +ℕ 1) (succ-ℕ x)))
+        ＝ dist-ℤ (int-ℕ (((q *ℕ s) +ℕ 1) *ℕ (succ-ℕ x)))
+          ((int-ℕ (q *ℕ t)) *ℤ (int-ℕ y))
+          by ap (λ H → dist-ℤ (int-ℕ (((q *ℕ s) +ℕ 1) *ℕ (succ-ℕ x)))
             (H *ℤ (int-ℕ y)))
             (mul-int-ℕ q t)
-        ＝ dist-ℤ (int-ℕ (mul-ℕ ((q *ℕ s) +ℕ 1) (succ-ℕ x)))
+        ＝ dist-ℤ (int-ℕ (((q *ℕ s) +ℕ 1) *ℕ (succ-ℕ x)))
           (int-ℕ ((q *ℕ t) *ℕ y))
-          by ap (dist-ℤ (int-ℕ (mul-ℕ ((q *ℕ s) +ℕ 1) (succ-ℕ x))))
+          by ap (dist-ℤ (int-ℕ (((q *ℕ s) +ℕ 1) *ℕ (succ-ℕ x))))
             (mul-int-ℕ (q *ℕ t) y)
-        ＝ dist-ℕ (mul-ℕ ((q *ℕ s) +ℕ 1) (succ-ℕ x))
+        ＝ dist-ℕ (((q *ℕ s) +ℕ 1) *ℕ (succ-ℕ x))
           ((q *ℕ t) *ℕ y)
-          by dist-int-ℕ (mul-ℕ ((q *ℕ s) +ℕ 1) (succ-ℕ x))
+          by dist-int-ℕ (((q *ℕ s) +ℕ 1) *ℕ (succ-ℕ x))
             ((q *ℕ t) *ℕ y)
 
   sx-ty-case-split (inr tysx) =
@@ -1380,14 +1380,14 @@ remainder-min-dist-succ-x-is-distance x y =
     add-dist-eqn :
       int-ℕ d ＝
       add-ℤ
-        ( mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
+        ( (neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y))
         ( (int-ℕ s) *ℤ (int-ℕ (succ-ℕ x)))
     add-dist-eqn =
       equational-reasoning
         int-ℕ d
         ＝ add-ℤ
             ( neg-ℤ (int-ℕ (t *ℕ y)))
-            ( add-ℤ (int-ℕ (t *ℕ y)) (int-ℕ d))
+            ( (int-ℕ (t *ℕ y)) +ℤ (int-ℕ d))
           by inv (isretr-add-neg-ℤ (int-ℕ (t *ℕ y)) (int-ℕ d))
         ＝ add-ℤ (neg-ℤ (int-ℕ (t *ℕ y))) (int-ℕ ((t *ℕ y) +ℕ d))
           by ap (add-ℤ (neg-ℤ (int-ℕ (t *ℕ y)))) (add-int-ℕ (t *ℕ y) d)
@@ -1401,18 +1401,18 @@ remainder-min-dist-succ-x-is-distance x y =
               ( λ H → (neg-ℤ H) +ℤ (int-ℕ (s *ℕ (succ-ℕ x))))
               ( inv (mul-int-ℕ t y))
         ＝ add-ℤ
-            ( mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
+            ( (neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y))
             ( int-ℕ (s *ℕ (succ-ℕ x)))
           by
             ap
               ( λ H → H +ℤ (int-ℕ (s *ℕ (succ-ℕ x))))
               ( inv (left-negative-law-mul-ℤ (int-ℕ t) (int-ℕ y)))
         ＝ add-ℤ
-            ( mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
+            ( (neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y))
             ( (int-ℕ s) *ℤ (int-ℕ (succ-ℕ x)))
           by
             ap
-              ( add-ℤ (mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y)))
+              ( add-ℤ ((neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y)))
               ( inv (mul-int-ℕ s (succ-ℕ x)))
 
     isolate-rem-eqn :
@@ -1422,7 +1422,7 @@ remainder-min-dist-succ-x-is-distance x y =
           ( mul-ℤ
             ( int-ℕ q)
             ( add-ℤ
-              ( mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
+              ( (neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y))
               ( (int-ℕ s) *ℤ (int-ℕ (succ-ℕ x))))))
         ( int-ℕ (succ-ℕ x))
     isolate-rem-eqn =
@@ -1433,24 +1433,24 @@ remainder-min-dist-succ-x-is-distance x y =
               ( mul-ℤ
                 ( int-ℕ q)
                 ( add-ℤ
-                  ( mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
-                  ( mul-ℤ ((int-ℕ s)) (int-ℕ (succ-ℕ x))))))
+                  ( (neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y))
+                  ( ((int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))))))
             ( add-ℤ
               ( mul-ℤ
                 ( int-ℕ q)
                 ( add-ℤ
-                  ( mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
+                  ( (neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y))
                   ( (int-ℕ s) *ℤ (int-ℕ (succ-ℕ x)))))
               ( int-ℕ r))
           by inv (isretr-add-neg-ℤ (mul-ℤ (int-ℕ q)
-            (add-ℤ (mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
+            (add-ℤ ((neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y))
             ((int-ℕ s) *ℤ (int-ℕ (succ-ℕ x))))) (int-ℕ r))
         ＝ add-ℤ
             ( neg-ℤ
               ( mul-ℤ
                 ( int-ℕ q)
                 ( add-ℤ
-                  ( mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
+                  ( (neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y))
                   ( (int-ℕ s) *ℤ (int-ℕ (succ-ℕ x))))))
             ( add-ℤ ((int-ℕ q) *ℤ (int-ℕ d)) (int-ℕ r))
           by
@@ -1461,7 +1461,7 @@ remainder-min-dist-succ-x-is-distance x y =
                     ( mul-ℤ
                       ( int-ℕ q)
                       ( add-ℤ
-                        ( mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
+                        ( (neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y))
                         ( (int-ℕ s) *ℤ (int-ℕ (succ-ℕ x))))))
                   ( ((int-ℕ q) *ℤ H) +ℤ (int-ℕ r)))
               ( inv add-dist-eqn)
@@ -1478,24 +1478,24 @@ remainder-min-dist-succ-x-is-distance x y =
                   ( mul-ℤ
                     ( int-ℕ q)
                     ( add-ℤ
-                      ( mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
+                      ( (neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y))
                       ( (int-ℕ s) *ℤ (int-ℕ (succ-ℕ x)))))))
               ( minimal-positive-distance-div-succ-x-eqn x y)
 
     rearrange-arith :
-      add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (add-ℤ (mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
+      add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (add-ℤ ((neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y))
         ((int-ℕ s) *ℤ (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x))
       ＝ add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
         (neg-ℤ (mul-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ))
           (int-ℕ (succ-ℕ x))))
     rearrange-arith =
       equational-reasoning
-        add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (add-ℤ (mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
+        add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (add-ℤ ((neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y))
           ((int-ℕ s) *ℤ (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x))
         ＝ add-ℤ
             ( neg-ℤ
               ( add-ℤ
-                ( (int-ℕ q) *ℤ (mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y)))
+                ( (int-ℕ q) *ℤ ((neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y)))
                 ( (int-ℕ q) *ℤ ((int-ℕ s) *ℤ (int-ℕ (succ-ℕ x))))))
             ( int-ℕ (succ-ℕ x))
           by
@@ -1503,7 +1503,7 @@ remainder-min-dist-succ-x-is-distance x y =
               ( λ H → (neg-ℤ H) +ℤ (int-ℕ (succ-ℕ x)))
               ( left-distributive-mul-add-ℤ
                 ( int-ℕ q)
-                ( mul-ℤ (neg-ℤ (int-ℕ t)) (int-ℕ y))
+                ( (neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y))
                 ( (int-ℕ s) *ℤ (int-ℕ (succ-ℕ x))))
         ＝ add-ℤ
             ( neg-ℤ
@@ -1586,7 +1586,7 @@ remainder-min-dist-succ-x-is-distance x y =
         ＝ add-ℤ (add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
             (neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
             (int-ℕ (succ-ℕ x))
-          by ap (λ H → (add-ℤ (add-ℤ (H *ℤ (int-ℕ y))
+          by ap (λ H → (add-ℤ ((H *ℤ (int-ℕ y)) +ℤ
             (neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
               (int-ℕ (succ-ℕ x))))
             (neg-neg-ℤ ((int-ℕ q) *ℤ (int-ℕ t)))
@@ -1611,7 +1611,7 @@ remainder-min-dist-succ-x-is-distance x y =
             (int-ℕ (succ-ℕ x))
         ＝ add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
           (add-ℤ (mul-ℤ (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s))) (int-ℕ (succ-ℕ x)))
-            (mul-ℤ (neg-ℤ (neg-ℤ one-ℤ)) (int-ℕ (succ-ℕ x))))
+            ((neg-ℤ (neg-ℤ one-ℤ)) *ℤ (int-ℕ (succ-ℕ x))))
           by
             ap
               ( λ H →
@@ -1669,7 +1669,7 @@ remainder-min-dist-succ-x-is-distance x y =
             (neg-ℤ (mul-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ))
             (int-ℕ (succ-ℕ x)))))
           by (ap abs-ℤ (isolate-rem-eqn ∙ rearrange-arith))
-        ＝ dist-ℤ (mul-ℤ (int-ℕ (q *ℕ t)) (int-ℕ y))
+        ＝ dist-ℤ ((int-ℕ (q *ℕ t)) *ℤ (int-ℕ y))
           (mul-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ))
             (int-ℕ (succ-ℕ x)))
           by ap (λ H → (dist-ℤ (H *ℤ (int-ℕ y))

--- a/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
@@ -266,7 +266,7 @@ div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
                       ( is-distance-between-multiples-sym-ℕ x y z (k , l , p))
                     ( lykx)))
               ＝ int-ℕ z
-                by isretr-add-neg-ℤ' ((int-ℕ l) *ℤ (int-ℕ y)) (int-ℕ z))
+                by isretr-right-add-neg-ℤ ((int-ℕ l) *ℤ (int-ℕ y)) (int-ℕ z))
               ＝ mod-ℕ x z by mod-int-ℕ x z))
 ```
 
@@ -371,7 +371,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
       ap
         ( ((neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x))) +ℤ_)
         ( inv
-          ( issec-add-neg-ℤ'
+          ( issec-right-add-neg-ℤ
             ( int-ℕ z)
             ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))))
     ＝ add-ℤ
@@ -1032,7 +1032,7 @@ remainder-min-dist-succ-x-is-distance x y =
         int-ℕ d
         ＝ ((int-ℕ d) +ℤ (int-ℕ (s *ℕ (succ-ℕ x)))) +ℤ
           (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x))))
-          by inv (isretr-add-neg-ℤ' (int-ℕ (s *ℕ (succ-ℕ x))) (int-ℕ d))
+          by inv (isretr-right-add-neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x))) (int-ℕ d))
         ＝ (int-ℕ (d +ℕ (s *ℕ (succ-ℕ x)))) +ℤ
           (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x))))
           by ap (_+ℤ (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x)))))
@@ -1072,7 +1072,7 @@ remainder-min-dist-succ-x-is-distance x y =
           (add-ℤ ((int-ℕ q) *ℤ (((int-ℕ t) *ℤ (int-ℕ y)) +ℤ
               ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))
           (int-ℕ r))
-          by inv (isretr-add-neg-ℤ
+          by inv (isretr-left-add-neg-ℤ
             ((int-ℕ q) *ℤ (((int-ℕ t) *ℤ (int-ℕ y)) +ℤ
             ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))
             (int-ℕ r))
@@ -1343,7 +1343,7 @@ remainder-min-dist-succ-x-is-distance x y =
       equational-reasoning
         int-ℕ d
         ＝ (neg-ℤ (int-ℕ (t *ℕ y))) +ℤ ((int-ℕ (t *ℕ y)) +ℤ (int-ℕ d))
-          by inv (isretr-add-neg-ℤ (int-ℕ (t *ℕ y)) (int-ℕ d))
+          by inv (isretr-left-add-neg-ℤ (int-ℕ (t *ℕ y)) (int-ℕ d))
         ＝ (neg-ℤ (int-ℕ (t *ℕ y))) +ℤ (int-ℕ ((t *ℕ y) +ℕ d))
           by ap ((neg-ℤ (int-ℕ (t *ℕ y))) +ℤ_) (add-int-ℕ (t *ℕ y) d)
         ＝ (neg-ℤ (int-ℕ (t *ℕ y))) +ℤ (int-ℕ (s *ℕ (succ-ℕ x)))
@@ -1391,7 +1391,7 @@ remainder-min-dist-succ-x-is-distance x y =
                   ( (neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y))
                   ( (int-ℕ s) *ℤ (int-ℕ (succ-ℕ x)))))
               ( int-ℕ r))
-          by inv (isretr-add-neg-ℤ (mul-ℤ (int-ℕ q)
+          by inv (isretr-left-add-neg-ℤ (mul-ℤ (int-ℕ q)
             (((neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y)) +ℤ
             ((int-ℕ s) *ℤ (int-ℕ (succ-ℕ x))))) (int-ℕ r))
         ＝ add-ℤ

--- a/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
@@ -426,7 +426,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
 
   a-extra-eqn-neg :
     add-ℤ
-      ( mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+      ( ((neg-ℤ a) +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x)))
       ( neg-ℤ
         ( mul-ℤ
           ( add-ℤ
@@ -439,7 +439,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
   a-extra-eqn-neg =
     equational-reasoning
     add-ℤ
-      ( mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+      ( ((neg-ℤ a) +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x)))
       ( neg-ℤ
         ( mul-ℤ
           ( add-ℤ
@@ -447,7 +447,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
             ( neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
           ( int-ℕ y)))
     ＝ add-ℤ
-        ( mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+        ( ((neg-ℤ a) +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x)))
         ( mul-ℤ
           ( neg-ℤ
             ( add-ℤ
@@ -465,7 +465,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
             ( (int-ℕ (succ-ℕ x)) +ℤ (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
             ( int-ℕ y)))
     ＝ add-ℤ
-        ( mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+        ( ((neg-ℤ a) +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x)))
         ( mul-ℤ
           ( (int-ℤ-Mod (succ-ℕ x) u) +ℤ (neg-ℤ (int-ℕ (succ-ℕ x))))
           ( int-ℕ y))
@@ -473,11 +473,11 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
       ap
         ( λ p →
           add-ℤ
-            ( mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+            ( ((neg-ℤ a) +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x)))
             ( p *ℤ (int-ℕ y)))
         ( equational-reasoning
           neg-ℤ ((int-ℕ (succ-ℕ x)) +ℤ (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
-          ＝ neg-ℤ (add-ℤ (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)) (int-ℕ (succ-ℕ x)))
+          ＝ neg-ℤ ((neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)) +ℤ (int-ℕ (succ-ℕ x)))
             by
             ap
               ( neg-ℤ)
@@ -497,19 +497,19 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
               ( _+ℤ (neg-ℤ (int-ℕ (succ-ℕ x))))
               ( neg-neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
     ＝ add-ℤ
-        ( mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+        ( ((neg-ℤ a) +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x)))
         ( add-ℤ
           ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
-          ( mul-ℤ (neg-ℤ (int-ℕ (succ-ℕ x))) (int-ℕ y)))
+          ( (neg-ℤ (int-ℕ (succ-ℕ x))) *ℤ (int-ℕ y)))
       by
       ap
-        ( add-ℤ (mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x))))
+        ( add-ℤ (((neg-ℤ a) +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x))))
         ( right-distributive-mul-add-ℤ
           ( int-ℤ-Mod (succ-ℕ x) u)
           ( neg-ℤ (int-ℕ (succ-ℕ x)))
           ( int-ℕ y))
     ＝ add-ℤ
-        ( mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+        ( ((neg-ℤ a) +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x)))
         ( add-ℤ
           ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
           ( neg-ℤ ((int-ℕ (succ-ℕ x)) *ℤ (int-ℕ y))))
@@ -517,7 +517,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
       ap
         ( λ p →
           add-ℤ
-            ( mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+            ( ((neg-ℤ a) +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x)))
             ( add-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)) p))
         ( left-negative-law-mul-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ y))
     ＝ add-ℤ
@@ -633,14 +633,14 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
             ( dist-ℤ (int-ℕ ((nat-Fin (succ-ℕ x) u) *ℕ y)))
             ( inv (mul-int-ℕ (abs-ℤ a) (succ-ℕ x)))
         ＝ dist-ℤ
-            ( mul-ℤ (int-ℕ (nat-Fin (succ-ℕ x) u)) (int-ℕ y))
+            ( (int-ℕ (nat-Fin (succ-ℕ x) u)) *ℤ (int-ℕ y))
             ( (int-ℕ (abs-ℤ a)) *ℤ (int-ℕ (succ-ℕ x)))
           by
           ap
             ( λ p → dist-ℤ p ((int-ℕ (abs-ℤ a)) *ℤ (int-ℕ (succ-ℕ x))))
             ( inv (mul-int-ℕ (nat-Fin (succ-ℕ x) u) y))
         ＝ dist-ℤ
-            ( mul-ℤ (int-ℕ (nat-Fin (succ-ℕ x) u)) (int-ℕ y))
+            ( (int-ℕ (nat-Fin (succ-ℕ x) u)) *ℤ (int-ℕ y))
             ( a *ℤ (int-ℕ (succ-ℕ x)))
           by
           ap
@@ -677,7 +677,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
         by inv (dist-int-ℕ (((abs-ℤ a) +ℕ y) *ℕ (succ-ℕ x))
           (mul-ℕ (abs-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
           (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))) y))
-        ＝ dist-ℤ (mul-ℤ (int-ℕ ((abs-ℤ a) +ℕ y)) (int-ℕ (succ-ℕ x)))
+        ＝ dist-ℤ ((int-ℕ ((abs-ℤ a) +ℕ y)) *ℤ (int-ℕ (succ-ℕ x)))
           (int-ℕ (mul-ℕ (abs-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
           (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))) y))
         by ap (λ p → dist-ℤ p (int-ℕ (mul-ℕ (abs-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
@@ -706,7 +706,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
             (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) (int-ℤ-Mod-bounded x u))
         ＝ dist-ℤ
             ( mul-ℤ
-              ( add-ℤ (int-ℕ (abs-ℤ (neg-ℤ a))) (int-ℕ y))
+              ( (int-ℕ (abs-ℤ (neg-ℤ a))) +ℤ (int-ℕ y))
               ( int-ℕ (succ-ℕ x)))
             ( mul-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
             (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) (int-ℕ y))
@@ -714,12 +714,12 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
           ap
             ( λ p →
               dist-ℤ
-                ( mul-ℤ ((int-ℕ p) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+                ( ((int-ℕ p) +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x)))
                 ( mul-ℤ
                   ( (int-ℕ (succ-ℕ x)) +ℤ (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
                   ( int-ℕ y)))
           (inv (abs-neg-ℤ a))
-        ＝ dist-ℤ (mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+        ＝ dist-ℤ (((neg-ℤ a) +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x)))
           (mul-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
             (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) (int-ℕ y))
         by ap (λ p → dist-ℤ ((p +ℤ (int-ℕ y)) *ℤ (int-ℕ (succ-ℕ x)))
@@ -1074,15 +1074,15 @@ remainder-min-dist-succ-x-is-distance x y =
           by ap (λ H → (int-ℕ H) +ℤ (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x)))))
             (rewrite-left-dist-add-ℕ d (s *ℕ (succ-ℕ x))
               (t *ℕ y) sxty (inv (dist-sx-ty-eq-d)))
-        ＝ add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
+        ＝ ((int-ℕ t) *ℤ (int-ℕ y)) +ℤ
           (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x))))
           by ap (_+ℤ (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x)))))
             (inv (mul-int-ℕ t y))
-        ＝ add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
+        ＝ ((int-ℕ t) *ℤ (int-ℕ y)) +ℤ
           (neg-ℤ ((int-ℕ s) *ℤ (int-ℕ (succ-ℕ x))))
           by ap (λ H → ((int-ℕ t) *ℤ (int-ℕ y)) +ℤ (neg-ℤ H))
             (inv (mul-int-ℕ s (succ-ℕ x)))
-        ＝ add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
+        ＝ ((int-ℕ t) *ℤ (int-ℕ y)) +ℤ
           ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))
           by ap (((int-ℕ t) *ℤ (int-ℕ y)) +ℤ_)
             (inv (left-negative-law-mul-ℤ (int-ℕ s) (int-ℕ (succ-ℕ x))))
@@ -1100,18 +1100,18 @@ remainder-min-dist-succ-x-is-distance x y =
     isolate-rem-eqn =
       equational-reasoning
         int-ℕ r
-        ＝ add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
+        ＝ add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (((int-ℕ t) *ℤ (int-ℕ y)) +ℤ
              ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))))))
-          (add-ℤ ((int-ℕ q) *ℤ (add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
+          (add-ℤ ((int-ℕ q) *ℤ (((int-ℕ t) *ℤ (int-ℕ y)) +ℤ
               ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))
           (int-ℕ r))
           by inv (isretr-add-neg-ℤ
-            ((int-ℕ q) *ℤ (add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
+            ((int-ℕ q) *ℤ (((int-ℕ t) *ℤ (int-ℕ y)) +ℤ
             ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))
             (int-ℕ r))
-        ＝ add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
+        ＝ add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (((int-ℕ t) *ℤ (int-ℕ y)) +ℤ
              ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))))))
-          (add-ℤ ((int-ℕ q) *ℤ (int-ℕ d)) (int-ℕ r))
+          (((int-ℕ q) *ℤ (int-ℕ d)) +ℤ (int-ℕ r))
           by
             ap
               ( λ H →
@@ -1144,14 +1144,14 @@ remainder-min-dist-succ-x-is-distance x y =
               ( minimal-positive-distance-div-succ-x-eqn x y)
 
     rearrange-arith-eqn :
-      add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
+      add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (((int-ℕ t) *ℤ (int-ℕ y)) +ℤ
         ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x))
-      ＝ add-ℤ (mul-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) one-ℤ)
+      ＝ add-ℤ ((((int-ℕ q) *ℤ (int-ℕ s)) +ℤ one-ℤ) *ℤ
           (int-ℕ (succ-ℕ x)))
-        (neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
+        (neg-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)))
     rearrange-arith-eqn =
       equational-reasoning
-        add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
+        add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (((int-ℕ t) *ℤ (int-ℕ y)) +ℤ
           ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x))
         ＝ add-ℤ (neg-ℤ (add-ℤ ((int-ℕ q) *ℤ ((int-ℕ t) *ℤ (int-ℕ y)))
           ((int-ℕ q) *ℤ ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))))))
@@ -1159,21 +1159,21 @@ remainder-min-dist-succ-x-is-distance x y =
           by (ap (λ H → (neg-ℤ H) +ℤ (int-ℕ (succ-ℕ x)))
             (left-distributive-mul-add-ℤ (int-ℕ q) ((int-ℕ t) *ℤ (int-ℕ y))
               ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))
-        ＝ add-ℤ (neg-ℤ (add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
+        ＝ add-ℤ (neg-ℤ (add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
           ((int-ℕ q) *ℤ ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))))))
             (int-ℕ (succ-ℕ x))
           by (ap (λ H → add-ℤ (neg-ℤ (H +ℤ (mul-ℤ (int-ℕ q)
             ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x)))
               (inv (associative-mul-ℤ (int-ℕ q) (int-ℕ t) (int-ℕ y))))
-        ＝ add-ℤ (neg-ℤ (add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
-          (neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
+        ＝ add-ℤ (neg-ℤ (add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
+          (neg-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))))))
             (int-ℕ (succ-ℕ x))
           by
             ap
               ( λ H →
                 add-ℤ
                   ( neg-ℤ
-                    ( add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)) H))
+                    ( add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)) H))
                   ( int-ℕ (succ-ℕ x)))
             ( equational-reasoning
                 ((int-ℕ q) *ℤ ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))))
@@ -1184,64 +1184,64 @@ remainder-min-dist-succ-x-is-distance x y =
                         ( int-ℕ q)
                         ( neg-ℤ (int-ℕ s))
                         ( int-ℕ (succ-ℕ x)))
-                ＝ mul-ℤ (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s))) (int-ℕ (succ-ℕ x))
+                ＝ (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s))) *ℤ (int-ℕ (succ-ℕ x))
                   by ap (_*ℤ (int-ℕ (succ-ℕ x)))
                   (right-negative-law-mul-ℤ (int-ℕ q) (int-ℕ s))
-                ＝ neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))
+                ＝ neg-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))
                   by
                     left-negative-law-mul-ℤ
                       ( (int-ℕ q) *ℤ (int-ℕ s))
                       ( int-ℕ (succ-ℕ x)))
         ＝ add-ℤ
             ( add-ℤ
-              ( neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
+              ( neg-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)))
               ( neg-ℤ
                 ( neg-ℤ
-                  ( mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))))
+                  ( ((int-ℕ q) *ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))))))
             (int-ℕ (succ-ℕ x))
           by
             ap
               ( _+ℤ (int-ℕ (succ-ℕ x)))
               ( distributive-neg-add-ℤ
-                ( mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
-                ( neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
+                ( ((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
+                ( neg-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))
         ＝ add-ℤ
             ( add-ℤ
-              ( neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
-              ( mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x))))
+              ( neg-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)))
+              ( ((int-ℕ q) *ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))))
             ( int-ℕ (succ-ℕ x))
           by
             ap
               ( λ H →
               add-ℤ
                 ( add-ℤ
-                  ( neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
+                  ( neg-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)))
                   ( H))
                 ( int-ℕ (succ-ℕ x)))
               ( neg-neg-ℤ
                 ( mul-ℤ ((int-ℕ q) *ℤ ((int-ℕ s))) (int-ℕ (succ-ℕ x))))
-        ＝ add-ℤ (neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
-           (add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))
+        ＝ add-ℤ (neg-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)))
+           ((((int-ℕ q) *ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))) +ℤ
              (int-ℕ (succ-ℕ x)))
           by associative-add-ℤ
-            (neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
-            (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))
+            (neg-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)))
+            (((int-ℕ q) *ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))
             (int-ℕ (succ-ℕ x))
-        ＝ add-ℤ (add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))
+        ＝ add-ℤ ((((int-ℕ q) *ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))) +ℤ
           (int-ℕ (succ-ℕ x)))
-          (neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
+          (neg-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)))
           by commutative-add-ℤ
-            (neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
-            (add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))
+            (neg-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)))
+            ((((int-ℕ q) *ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))) +ℤ
             (int-ℕ (succ-ℕ x)))
         ＝ add-ℤ
             ( mul-ℤ
-              ( add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) one-ℤ)
+              ( ((int-ℕ q) *ℤ (int-ℕ s)) +ℤ one-ℤ)
               ( int-ℕ (succ-ℕ x)))
-            ( neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
+            ( neg-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)))
           by
             ap
-              ( _+ℤ (neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))))
+              ( _+ℤ (neg-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))))
               ( ap
                 ( add-ℤ
                   ( mul-ℤ ((int-ℕ q) *ℤ ((int-ℕ s))) (int-ℕ (succ-ℕ x))))
@@ -1259,24 +1259,24 @@ remainder-min-dist-succ-x-is-distance x y =
         r
         ＝ abs-ℤ (int-ℕ r)
           by (inv (abs-int-ℕ r))
-        ＝ dist-ℤ (mul-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) one-ℤ)
+        ＝ dist-ℤ ((((int-ℕ q) *ℤ (int-ℕ s)) +ℤ one-ℤ) *ℤ
             (int-ℕ (succ-ℕ x)))
-          (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
+          (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
           by (ap (abs-ℤ) (isolate-rem-eqn ∙ rearrange-arith-eqn))
         ＝ dist-ℤ
             ( mul-ℤ ((int-ℕ (q *ℕ s)) +ℤ (int-ℕ 1)) (int-ℕ (succ-ℕ x)))
-            ( mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
+            ( ((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
           by ap (λ H → dist-ℤ ((H +ℤ (int-ℕ 1)) *ℤ (int-ℕ (succ-ℕ x)))
-            (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
+            (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)))
             (mul-int-ℕ q s)
-        ＝ dist-ℤ (mul-ℤ (int-ℕ ((q *ℕ s) +ℕ 1)) (int-ℕ (succ-ℕ x)))
-          (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
+        ＝ dist-ℤ ((int-ℕ ((q *ℕ s) +ℕ 1)) *ℤ (int-ℕ (succ-ℕ x)))
+          (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
           by ap (λ H → dist-ℤ (H *ℤ (int-ℕ (succ-ℕ x)))
-            (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
+            (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)))
             (add-int-ℕ (q *ℕ s) 1)
         ＝ dist-ℤ (int-ℕ (((q *ℕ s) +ℕ 1) *ℕ (succ-ℕ x)))
-          (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
-          by ap (λ H → dist-ℤ H (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
+          (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
+          by ap (λ H → dist-ℤ H (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)))
             (mul-int-ℕ ((q *ℕ s) +ℕ 1) (succ-ℕ x))
         ＝ dist-ℤ (int-ℕ (((q *ℕ s) +ℕ 1) *ℕ (succ-ℕ x)))
           ((int-ℕ (q *ℕ t)) *ℤ (int-ℕ y))
@@ -1293,7 +1293,7 @@ remainder-min-dist-succ-x-is-distance x y =
             ((q *ℕ t) *ℕ y)
 
   sx-ty-case-split (inr tysx) =
-    (abs-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ)) ,
+    (abs-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ)) ,
       (q *ℕ t) , inv (dist-eqn))
     where
     rewrite-dist : (t *ℕ y) +ℕ d ＝ (s *ℕ (succ-ℕ x))
@@ -1384,10 +1384,10 @@ remainder-min-dist-succ-x-is-distance x y =
             ( neg-ℤ (int-ℕ (t *ℕ y)))
             ( (int-ℕ (t *ℕ y)) +ℤ (int-ℕ d))
           by inv (isretr-add-neg-ℤ (int-ℕ (t *ℕ y)) (int-ℕ d))
-        ＝ add-ℤ (neg-ℤ (int-ℕ (t *ℕ y))) (int-ℕ ((t *ℕ y) +ℕ d))
+        ＝ (neg-ℤ (int-ℕ (t *ℕ y))) +ℤ (int-ℕ ((t *ℕ y) +ℕ d))
           by ap (add-ℤ (neg-ℤ (int-ℕ (t *ℕ y)))) (add-int-ℕ (t *ℕ y) d)
-        ＝ add-ℤ (neg-ℤ (int-ℕ (t *ℕ y))) (int-ℕ (s *ℕ (succ-ℕ x)))
-          by ap (λ H → add-ℤ (neg-ℤ (int-ℕ (t *ℕ y))) (int-ℕ H)) rewrite-dist
+        ＝ (neg-ℤ (int-ℕ (t *ℕ y))) +ℤ (int-ℕ (s *ℕ (succ-ℕ x)))
+          by ap (λ H → (neg-ℤ (int-ℕ (t *ℕ y))) +ℤ (int-ℕ H)) rewrite-dist
         ＝ add-ℤ
           ( neg-ℤ ((int-ℕ t) *ℤ (int-ℕ y)))
           ( int-ℕ (s *ℕ (succ-ℕ x)))
@@ -1447,7 +1447,7 @@ remainder-min-dist-succ-x-is-distance x y =
                 ( add-ℤ
                   ( (neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y))
                   ( (int-ℕ s) *ℤ (int-ℕ (succ-ℕ x))))))
-            ( add-ℤ ((int-ℕ q) *ℤ (int-ℕ d)) (int-ℕ r))
+            ( ((int-ℕ q) *ℤ (int-ℕ d)) +ℤ (int-ℕ r))
           by
             ap
               ( λ H →
@@ -1480,8 +1480,8 @@ remainder-min-dist-succ-x-is-distance x y =
     rearrange-arith :
       add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (add-ℤ ((neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y))
         ((int-ℕ s) *ℤ (int-ℕ (succ-ℕ x)))))) (int-ℕ (succ-ℕ x))
-      ＝ add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
-        (neg-ℤ (mul-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ))
+      ＝ add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
+        (neg-ℤ (mul-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ))
           (int-ℕ (succ-ℕ x))))
     rearrange-arith =
       equational-reasoning
@@ -1520,7 +1520,7 @@ remainder-min-dist-succ-x-is-distance x y =
             ( neg-ℤ
               ( add-ℤ
                 ( mul-ℤ ((int-ℕ q) *ℤ (neg-ℤ (int-ℕ t))) (int-ℕ y))
-                ( mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
+                ( ((int-ℕ q) *ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))
             ( int-ℕ (succ-ℕ x))
           by
             ap
@@ -1535,8 +1535,8 @@ remainder-min-dist-succ-x-is-distance x y =
         ＝ add-ℤ
             ( neg-ℤ
               ( add-ℤ
-                ( mul-ℤ (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ t))) (int-ℕ y))
-                ( mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
+                ( (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ t))) *ℤ (int-ℕ y))
+                ( ((int-ℕ q) *ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))
             ( int-ℕ (succ-ℕ x))
           by
             ap
@@ -1552,18 +1552,18 @@ remainder-min-dist-succ-x-is-distance x y =
               ( right-negative-law-mul-ℤ (int-ℕ q) (int-ℕ t))
         ＝ add-ℤ
             ( add-ℤ
-              ( neg-ℤ (mul-ℤ (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ t))) (int-ℕ y)))
-              ( neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
+              ( neg-ℤ ((neg-ℤ ((int-ℕ q) *ℤ (int-ℕ t))) *ℤ (int-ℕ y)))
+              ( neg-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))
             ( int-ℕ (succ-ℕ x))
           by ap (_+ℤ (int-ℕ (succ-ℕ x)))
             (distributive-neg-add-ℤ
-              (mul-ℤ (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ t))) (int-ℕ y))
-              (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s))
+              ((neg-ℤ ((int-ℕ q) *ℤ (int-ℕ t))) *ℤ (int-ℕ y))
+              (((int-ℕ q) *ℤ (int-ℕ s)) *ℤ
               (int-ℕ (succ-ℕ x))))
         ＝ add-ℤ
             ( add-ℤ
               ( mul-ℤ (neg-ℤ (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ t)))) (int-ℕ y))
-              ( neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
+              ( neg-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))
             ( int-ℕ (succ-ℕ x))
           by
             ap
@@ -1572,21 +1572,21 @@ remainder-min-dist-succ-x-is-distance x y =
                 ( add-ℤ
                   ( H)
                   ( neg-ℤ
-                    ( mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
+                    ( ((int-ℕ q) *ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))
                 ( int-ℕ (succ-ℕ x)))
             ( inv
               ( left-negative-law-mul-ℤ
                 ( neg-ℤ ((int-ℕ q) *ℤ (int-ℕ t)))
                 ( int-ℕ y)))
-        ＝ add-ℤ (add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
-            (neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
+        ＝ add-ℤ (add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
+            (neg-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))
             (int-ℕ (succ-ℕ x))
           by ap (λ H → (add-ℤ ((H *ℤ (int-ℕ y)) +ℤ
-            (neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
+            (neg-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))
               (int-ℕ (succ-ℕ x))))
             (neg-neg-ℤ ((int-ℕ q) *ℤ (int-ℕ t)))
-        ＝ add-ℤ (add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
-            (mul-ℤ (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s))) (int-ℕ (succ-ℕ x))))
+        ＝ add-ℤ (add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
+            ((neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s))) *ℤ (int-ℕ (succ-ℕ x))))
           (int-ℕ (succ-ℕ x))
           by
             ap
@@ -1598,14 +1598,14 @@ remainder-min-dist-succ-x-is-distance x y =
                 ( left-negative-law-mul-ℤ
                   ( (int-ℕ q) *ℤ (int-ℕ s))
                   ( int-ℕ (succ-ℕ x))))
-        ＝ add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
-          (add-ℤ (mul-ℤ (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s))) (int-ℕ (succ-ℕ x)))
+        ＝ add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
+          (add-ℤ ((neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s))) *ℤ (int-ℕ (succ-ℕ x)))
             (int-ℕ (succ-ℕ x)))
-          by associative-add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
-            (mul-ℤ (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s))) (int-ℕ (succ-ℕ x)))
+          by associative-add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
+            ((neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s))) *ℤ (int-ℕ (succ-ℕ x)))
             (int-ℕ (succ-ℕ x))
-        ＝ add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
-          (add-ℤ (mul-ℤ (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s))) (int-ℕ (succ-ℕ x)))
+        ＝ add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
+          (add-ℤ ((neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s))) *ℤ (int-ℕ (succ-ℕ x)))
             ((neg-ℤ (neg-ℤ one-ℤ)) *ℤ (int-ℕ (succ-ℕ x))))
           by
             ap
@@ -1619,7 +1619,7 @@ remainder-min-dist-succ-x-is-distance x y =
                     ( H *ℤ (int-ℕ (succ-ℕ x)))))
               ( inv (neg-neg-ℤ one-ℤ))
         ＝ add-ℤ
-            ( mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
+            ( ((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
             ( mul-ℤ
               ( add-ℤ
                 ( neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s)))
@@ -1627,65 +1627,65 @@ remainder-min-dist-succ-x-is-distance x y =
               ( int-ℕ (succ-ℕ x)))
           by
             ap
-              ( add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
+              ( add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)))
               ( inv
                 ( right-distributive-mul-add-ℤ
                   ( neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s)))
                   ( neg-ℤ (neg-ℤ one-ℤ))
                   ( int-ℕ (succ-ℕ x))))
         ＝ add-ℤ
-            ( mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
-            ( mul-ℤ (neg-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s))
+            ( ((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
+            ( mul-ℤ (neg-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ
             (neg-ℤ one-ℤ))) (int-ℕ (succ-ℕ x)))
-          by ap (λ H → (add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
+          by ap (λ H → (add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
               (H *ℤ (int-ℕ (succ-ℕ x)))))
               (inv (distributive-neg-add-ℤ
                 ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ)))
-        ＝ add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
-          (neg-ℤ (mul-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s))
+        ＝ add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
+          (neg-ℤ (mul-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ
             (neg-ℤ one-ℤ)) (int-ℕ (succ-ℕ x))))
-          by ap ((mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)) +ℤ_)
+          by ap ((((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)) +ℤ_)
             (left-negative-law-mul-ℤ
-              (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ))
+              (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ))
               (int-ℕ (succ-ℕ x)))
 
     dist-eqn :
       r ＝
       dist-ℕ
         ( mul-ℕ
-          ( abs-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ)))
+          ( abs-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ)))
           ( succ-ℕ x))
         ( (q *ℕ t) *ℕ y)
     dist-eqn =
       equational-reasoning
         r
         ＝ abs-ℤ (int-ℕ r) by (inv (abs-int-ℕ r))
-        ＝ abs-ℤ (add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
-            (neg-ℤ (mul-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ))
+        ＝ abs-ℤ (add-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
+            (neg-ℤ (mul-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ))
             (int-ℕ (succ-ℕ x)))))
           by (ap abs-ℤ (isolate-rem-eqn ∙ rearrange-arith))
         ＝ dist-ℤ ((int-ℕ (q *ℕ t)) *ℤ (int-ℕ y))
-          (mul-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ))
+          (mul-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ))
             (int-ℕ (succ-ℕ x)))
           by ap (λ H → (dist-ℤ (H *ℤ (int-ℕ y))
-            (mul-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ))
+            (mul-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ))
               (int-ℕ (succ-ℕ x)))))
               (mul-int-ℕ q t)
         ＝ dist-ℤ (int-ℕ ((q *ℕ t) *ℕ y))
-          (mul-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ))
+          (mul-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ))
           (int-ℕ (succ-ℕ x)))
           by
             ap
               ( λ H →
                 dist-ℤ H
                   ( mul-ℤ
-                    ( add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ))
+                    ( ((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ))
                     ( int-ℕ (succ-ℕ x))))
               ( mul-int-ℕ (q *ℕ t) y)
         ＝ dist-ℤ
             ( int-ℕ ((q *ℕ t) *ℕ y))
             ( mul-ℤ
-              ( int-ℕ (abs-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ))))
+              ( int-ℕ (abs-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ))))
               ( int-ℕ (succ-ℕ x)))
           by
             ap
@@ -1695,29 +1695,29 @@ remainder-min-dist-succ-x-is-distance x y =
                   ( H *ℤ (int-ℕ (succ-ℕ x))))
               ( inv
                 ( int-abs-is-nonnegative-ℤ
-                  ( add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ))
+                  ( ((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ))
                   ( coeff-nonnegative)))
         ＝ dist-ℤ
             ( int-ℕ ((q *ℕ t) *ℕ y))
             ( int-ℕ
               ( mul-ℕ
-                ( abs-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ)))
+                ( abs-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ)))
                 ( succ-ℕ x)))
           by
             ap
               ( dist-ℤ (int-ℕ ((q *ℕ t) *ℕ y)))
               ( mul-int-ℕ
-                ( abs-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ)))
+                ( abs-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ)))
                 ( succ-ℕ x))
         ＝ dist-ℕ ((q *ℕ t) *ℕ y)
-          (mul-ℕ (abs-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ)))
+          (mul-ℕ (abs-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ)))
             (succ-ℕ x))
           by dist-int-ℕ
             ((q *ℕ t) *ℕ y)
-            (mul-ℕ (abs-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ)))
+            (mul-ℕ (abs-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ)))
               (succ-ℕ x))
         ＝ dist-ℕ
-          (mul-ℕ (abs-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ)))
+          (mul-ℕ (abs-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ)))
             (succ-ℕ x))
             ((q *ℕ t) *ℕ y)
           by symmetric-dist-ℕ

--- a/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
@@ -13,7 +13,6 @@ open import elementary-number-theory.addition-natural-numbers
 open import elementary-number-theory.congruence-integers
 open import elementary-number-theory.distance-integers
 open import elementary-number-theory.distance-natural-numbers
-open import elementary-number-theory.divisibility-integers
 open import elementary-number-theory.divisibility-modular-arithmetic
 open import elementary-number-theory.divisibility-natural-numbers
 open import elementary-number-theory.equality-natural-numbers

--- a/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
@@ -113,8 +113,8 @@ int-is-distance-between-multiples-ℕ x y z (k , l , p) H =
   equational-reasoning
     add-ℤ (int-ℕ z) (mul-ℤ (int-ℕ k) (int-ℕ x))
     ＝ add-ℤ (int-ℕ z) (int-ℕ (mul-ℕ k x))
-      by ap (λ p → add-ℤ (int-ℕ z) p) (mul-int-ℕ k x)
-    ＝ int-ℕ (add-ℕ z (mul-ℕ k x))
+      by ap (λ p → (int-ℕ z) +ℤ p) (mul-int-ℕ k x)
+    ＝ int-ℕ (z +ℕ (mul-ℕ k x))
       by add-int-ℕ z (mul-ℕ k x)
     ＝ int-ℕ (mul-ℕ l y)
       by ap (int-ℕ)
@@ -178,7 +178,7 @@ div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
           ap
             ( λ p → add-ℤ-Mod x (mod-ℤ x (int-ℕ z)) (mod-ℤ x p))
             ( right-zero-law-mul-ℤ (int-ℕ k))
-        ＝ mod-ℤ x (add-ℤ (int-ℕ z) zero-ℤ)
+        ＝ mod-ℤ x ((int-ℕ z) +ℤ zero-ℤ)
           by inv (preserves-add-mod-ℤ x (int-ℕ z) zero-ℤ)
         ＝ mod-ℤ x (int-ℕ z)
           by ap (mod-ℤ x) (right-unit-law-add-ℤ (int-ℕ z))
@@ -420,7 +420,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
       ap
         ( λ p → add-ℤ (add-ℤ p (mul-ℤ a (int-ℕ (succ-ℕ x)))) (int-ℕ z))
         ( left-negative-law-mul-ℤ a (int-ℕ (succ-ℕ x)))
-    ＝ add-ℤ zero-ℤ (int-ℕ z)
+    ＝ zero-ℤ +ℤ (int-ℕ z)
       by
       ap
         ( add-ℤ' (int-ℕ z))
@@ -429,7 +429,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
 
   a-extra-eqn-neg :
     add-ℤ
-      ( mul-ℤ (add-ℤ (neg-ℤ a) (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+      ( mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
       ( neg-ℤ
         ( mul-ℤ
           ( add-ℤ
@@ -442,7 +442,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
   a-extra-eqn-neg =
     equational-reasoning
     add-ℤ
-      ( mul-ℤ (add-ℤ (neg-ℤ a) (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+      ( mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
       ( neg-ℤ
         ( mul-ℤ
           ( add-ℤ
@@ -450,7 +450,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
             ( neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
           ( int-ℕ y)))
     ＝ add-ℤ
-        ( mul-ℤ (add-ℤ (neg-ℤ a) (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+        ( mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
         ( mul-ℤ
           ( neg-ℤ
             ( add-ℤ
@@ -461,14 +461,14 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
       ap
         ( add-ℤ
           ( mul-ℤ
-            ( add-ℤ (neg-ℤ a) (int-ℕ y))
+            ( (neg-ℤ a) +ℤ (int-ℕ y))
             ( int-ℕ (succ-ℕ x))))
         ( inv
           ( left-negative-law-mul-ℤ
             ( add-ℤ (int-ℕ (succ-ℕ x)) (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
             ( int-ℕ y)))
     ＝ add-ℤ
-        ( mul-ℤ (add-ℤ (neg-ℤ a) (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+        ( mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
         ( mul-ℤ
           ( add-ℤ (int-ℤ-Mod (succ-ℕ x) u) (neg-ℤ (int-ℕ (succ-ℕ x))))
           ( int-ℕ y))
@@ -476,7 +476,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
       ap
         ( λ p →
           add-ℤ
-            ( mul-ℤ (add-ℤ (neg-ℤ a) (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+            ( mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
             ( mul-ℤ p (int-ℕ y)))
         ( equational-reasoning
           neg-ℤ (add-ℤ (int-ℕ (succ-ℕ x)) (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
@@ -500,19 +500,19 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
               ( λ p → (add-ℤ p (neg-ℤ (int-ℕ (succ-ℕ x)))))
               ( neg-neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
     ＝ add-ℤ
-        ( mul-ℤ (add-ℤ (neg-ℤ a) (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+        ( mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
         ( add-ℤ
           ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
           ( mul-ℤ (neg-ℤ (int-ℕ (succ-ℕ x))) (int-ℕ y)))
       by
       ap
-        ( add-ℤ (mul-ℤ (add-ℤ (neg-ℤ a) (int-ℕ y)) (int-ℕ (succ-ℕ x))))
+        ( add-ℤ (mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x))))
         ( right-distributive-mul-add-ℤ
           ( int-ℤ-Mod (succ-ℕ x) u)
           ( neg-ℤ (int-ℕ (succ-ℕ x)))
           ( int-ℕ y))
     ＝ add-ℤ
-        ( mul-ℤ (add-ℤ (neg-ℤ a) (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+        ( mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
         ( add-ℤ
           ( mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y))
           ( neg-ℤ (mul-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ y))))
@@ -520,7 +520,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
       ap
         ( λ p →
           add-ℤ
-            ( mul-ℤ (add-ℤ (neg-ℤ a) (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+            ( mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
             ( add-ℤ (mul-ℤ (int-ℤ-Mod (succ-ℕ x) u) (int-ℕ y)) p))
         ( left-negative-law-mul-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ y))
     ＝ add-ℤ
@@ -668,24 +668,24 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
         ( is-nonnegative-int-ℕ (succ-ℕ x))
 
   uy-z-case-split (inr z-uy) =
-    ( add-ℕ (abs-ℤ a) y ,
+    ( (abs-ℤ a) +ℕ y ,
       abs-ℤ (add-ℤ (int-ℕ (succ-ℕ x)) (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) ,
       ( equational-reasoning
-        dist-ℕ (mul-ℕ (add-ℕ (abs-ℤ a) y) (succ-ℕ x))
+        dist-ℕ (mul-ℕ ((abs-ℤ a) +ℕ y) (succ-ℕ x))
           (mul-ℕ (abs-ℤ (add-ℤ (int-ℕ (succ-ℕ x))
           (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))) y)
-        ＝ dist-ℤ (int-ℕ (mul-ℕ (add-ℕ (abs-ℤ a) y) (succ-ℕ x)))
+        ＝ dist-ℤ (int-ℕ (mul-ℕ ((abs-ℤ a) +ℕ y) (succ-ℕ x)))
           (int-ℕ (mul-ℕ (abs-ℤ (add-ℤ (int-ℕ (succ-ℕ x))
           (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))) y))
-        by inv (dist-int-ℕ (mul-ℕ (add-ℕ (abs-ℤ a) y) (succ-ℕ x))
+        by inv (dist-int-ℕ (mul-ℕ ((abs-ℤ a) +ℕ y) (succ-ℕ x))
           (mul-ℕ (abs-ℤ (add-ℤ (int-ℕ (succ-ℕ x))
           (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))) y))
-        ＝ dist-ℤ (mul-ℤ (int-ℕ (add-ℕ (abs-ℤ a) y)) (int-ℕ (succ-ℕ x)))
+        ＝ dist-ℤ (mul-ℤ (int-ℕ ((abs-ℤ a) +ℕ y)) (int-ℕ (succ-ℕ x)))
           (int-ℕ (mul-ℕ (abs-ℤ (add-ℤ (int-ℕ (succ-ℕ x))
           (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))) y))
         by ap (λ p → dist-ℤ p (int-ℕ (mul-ℕ (abs-ℤ (add-ℤ (int-ℕ (succ-ℕ x))
           (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))) y)))
-          (inv (mul-int-ℕ (add-ℕ (abs-ℤ a) y) (succ-ℕ x)))
+          (inv (mul-int-ℕ ((abs-ℤ a) +ℕ y) (succ-ℕ x)))
         ＝ dist-ℤ (mul-ℤ (add-ℤ (int-ℕ (abs-ℤ a)) (int-ℕ y)) (int-ℕ (succ-ℕ x)))
           (int-ℕ (mul-ℕ (abs-ℤ (add-ℤ (int-ℕ (succ-ℕ x))
           (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))) y))
@@ -717,15 +717,15 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
           ap
             ( λ p →
               dist-ℤ
-                ( mul-ℤ (add-ℤ (int-ℕ p) (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+                ( mul-ℤ ((int-ℕ p) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
                 ( mul-ℤ
                   ( add-ℤ (int-ℕ (succ-ℕ x)) (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
                   ( int-ℕ y)))
           (inv (abs-neg-ℤ a))
-        ＝ dist-ℤ (mul-ℤ (add-ℤ (neg-ℤ a) (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+        ＝ dist-ℤ (mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
           (mul-ℤ (add-ℤ (int-ℕ (succ-ℕ x))
             (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) (int-ℕ y))
-        by ap (λ p → dist-ℤ (mul-ℤ (add-ℤ p (int-ℕ y)) (int-ℕ (succ-ℕ x)))
+        by ap (λ p → dist-ℤ (mul-ℤ (p +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
           (mul-ℤ (add-ℤ (int-ℕ (succ-ℕ x)) (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
             (int-ℕ y)))
           (int-abs-is-nonnegative-ℤ (neg-ℤ a) neg-a-is-nonnegative-ℤ)
@@ -790,7 +790,7 @@ distance `d` between multiples of `x` and `y`.
 
 ```agda
 pos-distance-between-multiples : (x y z : ℕ) → UU lzero
-pos-distance-between-multiples x y z = is-nonzero-ℕ (add-ℕ x y) →
+pos-distance-between-multiples x y z = is-nonzero-ℕ (x +ℕ y) →
   (is-nonzero-ℕ z) × (is-distance-between-multiples-ℕ x y z)
 
 is-inhabited-pos-distance-between-multiples :
@@ -809,7 +809,7 @@ minimal-pos-distance-between-multiples :
 minimal-pos-distance-between-multiples x y = well-ordering-principle-ℕ
   (pos-distance-between-multiples x y)
   (λ z → is-decidable-function-type
-    (is-decidable-neg (is-decidable-is-zero-ℕ (add-ℕ x y)))
+    (is-decidable-neg (is-decidable-is-zero-ℕ (x +ℕ y)))
     (is-decidable-prod (is-decidable-neg (is-decidable-is-zero-ℕ z))
       (is-decidable-is-distance-between-multiples-ℕ x y z)))
   (is-inhabited-pos-distance-between-multiples x y)
@@ -824,7 +824,7 @@ form `dist-ℕ (kx,ly)`, it follows that `gcd x y | d`, and hence that
 
 ```agda
 minimal-positive-distance-is-distance :
-  (x y : ℕ) → is-nonzero-ℕ (add-ℕ x y) →
+  (x y : ℕ) → is-nonzero-ℕ (x +ℕ y) →
   (is-distance-between-multiples-ℕ x y (minimal-positive-distance x y))
 minimal-positive-distance-is-distance x y nonzero =
   pr2 ((pr1 (pr2 (minimal-pos-distance-between-multiples x y))) nonzero)
@@ -839,7 +839,7 @@ minimal-positive-distance-is-minimal x y =
 
 minimal-positive-distance-nonzero :
   (x y : ℕ) →
-  (is-nonzero-ℕ (add-ℕ x y)) →
+  (is-nonzero-ℕ (x +ℕ y)) →
   (is-nonzero-ℕ (minimal-positive-distance x y))
 minimal-positive-distance-nonzero x y nonzero =
   pr1 ((pr1 (pr2 (minimal-pos-distance-between-multiples x y))) nonzero)
@@ -872,7 +872,7 @@ minimal-positive-distance-sym x y = antisymmetric-leq-ℕ
   (minimal-positive-distance-leq-sym x y)
   (minimal-positive-distance-leq-sym y x)
 
-minimal-positive-distance-x-coeff : (x y : ℕ) → (is-nonzero-ℕ (add-ℕ x y)) → ℕ
+minimal-positive-distance-x-coeff : (x y : ℕ) → (is-nonzero-ℕ (x +ℕ y)) → ℕ
 minimal-positive-distance-x-coeff x y H =
   pr1 (minimal-positive-distance-is-distance x y H)
 
@@ -884,9 +884,9 @@ minimal-positive-distance-succ-x-coeff x y =
     ( tr
       ( is-nonzero-ℕ)
       ( inv (left-successor-law-add-ℕ x y))
-      ( is-nonzero-succ-ℕ (add-ℕ x y)))
+      ( is-nonzero-succ-ℕ (x +ℕ y)))
 
-minimal-positive-distance-y-coeff : (x y : ℕ) → (is-nonzero-ℕ (add-ℕ x y)) → ℕ
+minimal-positive-distance-y-coeff : (x y : ℕ) → (is-nonzero-ℕ (x +ℕ y)) → ℕ
 minimal-positive-distance-y-coeff x y H =
   pr1 (pr2 (minimal-positive-distance-is-distance x y H))
 
@@ -898,10 +898,10 @@ minimal-positive-distance-succ-y-coeff x y =
     ( tr
       ( is-nonzero-ℕ)
       ( inv (left-successor-law-add-ℕ x y))
-      ( is-nonzero-succ-ℕ (add-ℕ x y)))
+      ( is-nonzero-succ-ℕ (x +ℕ y)))
 
 minimal-positive-distance-eqn :
-  (x y : ℕ) (H : is-nonzero-ℕ (add-ℕ x y)) →
+  (x y : ℕ) (H : is-nonzero-ℕ (x +ℕ y)) →
   dist-ℕ
     ( mul-ℕ (minimal-positive-distance-x-coeff x y H) x)
     ( mul-ℕ (minimal-positive-distance-y-coeff x y H) y) ＝
@@ -922,7 +922,7 @@ minimal-positive-distance-succ-eqn x y =
     ( tr
       ( is-nonzero-ℕ)
       ( inv (left-successor-law-add-ℕ x y))
-      ( is-nonzero-succ-ℕ (add-ℕ x y)))
+      ( is-nonzero-succ-ℕ (x +ℕ y)))
 
 minimal-positive-distance-div-succ-x-eqn :
   (x y : ℕ) →
@@ -1021,7 +1021,7 @@ remainder-min-dist-succ-x-le-min-dist x y =
       ( tr
         ( is-nonzero-ℕ)
         ( inv (left-successor-law-add-ℕ x y))
-        ( is-nonzero-succ-ℕ (add-ℕ x y))))
+        ( is-nonzero-succ-ℕ (x +ℕ y))))
 
 remainder-min-dist-succ-x-is-distance :
   (x y : ℕ) →
@@ -1057,7 +1057,7 @@ remainder-min-dist-succ-x-is-distance x y =
       leq-ℕ (mul-ℕ t y) (mul-ℕ s (succ-ℕ x))) →
     is-distance-between-multiples-ℕ (succ-ℕ x) y r
   sx-ty-case-split (inl sxty) =
-    (add-ℕ (mul-ℕ q s) 1 , mul-ℕ q t , inv (dist-eqn))
+    ((mul-ℕ q s) +ℕ 1 , mul-ℕ q t , inv (dist-eqn))
     where
     add-dist-eqn :
       int-ℕ d ＝
@@ -1258,7 +1258,7 @@ remainder-min-dist-succ-x-is-distance x y =
                     ( int-ℕ (succ-ℕ x)))))
 
     dist-eqn :
-      r ＝ dist-ℕ (mul-ℕ (add-ℕ (mul-ℕ q s) 1) (succ-ℕ x)) (mul-ℕ (mul-ℕ q t) y)
+      r ＝ dist-ℕ (mul-ℕ ((mul-ℕ q s) +ℕ 1) (succ-ℕ x)) (mul-ℕ (mul-ℕ q t) y)
     dist-eqn =
       equational-reasoning
         r
@@ -1271,37 +1271,37 @@ remainder-min-dist-succ-x-is-distance x y =
         ＝ dist-ℤ
             ( mul-ℤ (add-ℤ (int-ℕ (mul-ℕ q s)) (int-ℕ 1)) (int-ℕ (succ-ℕ x)))
             ( mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
-          by ap (λ H → dist-ℤ (mul-ℤ (add-ℤ H (int-ℕ 1)) (int-ℕ (succ-ℕ x)))
+          by ap (λ H → dist-ℤ (mul-ℤ (H +ℤ (int-ℕ 1)) (int-ℕ (succ-ℕ x)))
             (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y)))
             (mul-int-ℕ q s)
-        ＝ dist-ℤ (mul-ℤ (int-ℕ (add-ℕ (mul-ℕ q s) 1)) (int-ℕ (succ-ℕ x)))
+        ＝ dist-ℤ (mul-ℤ (int-ℕ ((mul-ℕ q s) +ℕ 1)) (int-ℕ (succ-ℕ x)))
           (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
           by ap (λ H → dist-ℤ (mul-ℤ H (int-ℕ (succ-ℕ x)))
             (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y)))
             (add-int-ℕ (mul-ℕ q s) 1)
-        ＝ dist-ℤ (int-ℕ (mul-ℕ (add-ℕ (mul-ℕ q s) 1) (succ-ℕ x)))
+        ＝ dist-ℤ (int-ℕ (mul-ℕ ((mul-ℕ q s) +ℕ 1) (succ-ℕ x)))
           (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y))
           by ap (λ H → dist-ℤ H (mul-ℤ (mul-ℤ (int-ℕ q) (int-ℕ t)) (int-ℕ y)))
-            (mul-int-ℕ (add-ℕ (mul-ℕ q s) 1) (succ-ℕ x))
-        ＝ dist-ℤ (int-ℕ (mul-ℕ (add-ℕ (mul-ℕ q s) 1) (succ-ℕ x)))
+            (mul-int-ℕ ((mul-ℕ q s) +ℕ 1) (succ-ℕ x))
+        ＝ dist-ℤ (int-ℕ (mul-ℕ ((mul-ℕ q s) +ℕ 1) (succ-ℕ x)))
           (mul-ℤ (int-ℕ (mul-ℕ q t)) (int-ℕ y))
-          by ap (λ H → dist-ℤ (int-ℕ (mul-ℕ (add-ℕ (mul-ℕ q s) 1) (succ-ℕ x)))
+          by ap (λ H → dist-ℤ (int-ℕ (mul-ℕ ((mul-ℕ q s) +ℕ 1) (succ-ℕ x)))
             (mul-ℤ H (int-ℕ y)))
             (mul-int-ℕ q t)
-        ＝ dist-ℤ (int-ℕ (mul-ℕ (add-ℕ (mul-ℕ q s) 1) (succ-ℕ x)))
+        ＝ dist-ℤ (int-ℕ (mul-ℕ ((mul-ℕ q s) +ℕ 1) (succ-ℕ x)))
           (int-ℕ (mul-ℕ (mul-ℕ q t) y))
-          by ap (dist-ℤ (int-ℕ (mul-ℕ (add-ℕ (mul-ℕ q s) 1) (succ-ℕ x))))
+          by ap (dist-ℤ (int-ℕ (mul-ℕ ((mul-ℕ q s) +ℕ 1) (succ-ℕ x))))
             (mul-int-ℕ (mul-ℕ q t) y)
-        ＝ dist-ℕ (mul-ℕ (add-ℕ (mul-ℕ q s) 1) (succ-ℕ x))
+        ＝ dist-ℕ (mul-ℕ ((mul-ℕ q s) +ℕ 1) (succ-ℕ x))
           (mul-ℕ (mul-ℕ q t) y)
-          by dist-int-ℕ (mul-ℕ (add-ℕ (mul-ℕ q s) 1) (succ-ℕ x))
+          by dist-int-ℕ (mul-ℕ ((mul-ℕ q s) +ℕ 1) (succ-ℕ x))
             (mul-ℕ (mul-ℕ q t) y)
 
   sx-ty-case-split (inr tysx) =
     (abs-ℤ (add-ℤ (mul-ℤ (int-ℕ q) (int-ℕ s)) (neg-ℤ one-ℤ)) ,
       (mul-ℕ q t) , inv (dist-eqn))
     where
-    rewrite-dist : add-ℕ (mul-ℕ t y) d ＝ (mul-ℕ s (succ-ℕ x))
+    rewrite-dist : (mul-ℕ t y) +ℕ d ＝ (mul-ℕ s (succ-ℕ x))
     rewrite-dist =
       rewrite-right-dist-add-ℕ
         ( mul-ℕ t y)
@@ -1319,12 +1319,12 @@ remainder-min-dist-succ-x-is-distance x y =
       x-r-equality =
         equational-reasoning
           succ-ℕ x
-          ＝ add-ℕ (mul-ℕ q d) r
+          ＝ (mul-ℕ q d) +ℕ r
             by (inv (eq-euclidean-division-ℕ d (succ-ℕ x)))
-          ＝ add-ℕ (mul-ℕ 0 d) r
-            by (ap (λ H → add-ℕ (mul-ℕ H d) r) iszero)
-          ＝ add-ℕ 0 r
-            by (ap (λ H → add-ℕ H r) (left-zero-law-mul-ℕ d))
+          ＝ (mul-ℕ 0 d) +ℕ r
+            by (ap (λ H → (mul-ℕ H d) +ℕ r) iszero)
+          ＝ 0 +ℕ r
+            by (ap (λ H → H +ℕ r) (left-zero-law-mul-ℕ d))
           ＝ r
             by (left-unit-law-add-ℕ r)
 
@@ -1353,13 +1353,13 @@ remainder-min-dist-succ-x-is-distance x y =
         ( tr
           ( is-nonzero-ℕ)
           ( inv (left-successor-law-add-ℕ x y))
-          ( is-nonzero-succ-ℕ (add-ℕ x y)))
+          ( is-nonzero-succ-ℕ (x +ℕ y)))
         ( d-is-zero)
       where
-      zero-addition : add-ℕ (mul-ℕ t y) d ＝ 0
+      zero-addition : (mul-ℕ t y) +ℕ d ＝ 0
       zero-addition =
         equational-reasoning
-          add-ℕ (mul-ℕ t y) d
+          (mul-ℕ t y) +ℕ d
           ＝ (mul-ℕ s (succ-ℕ x))
             by rewrite-dist
           ＝ (mul-ℕ zero-ℕ (succ-ℕ x))
@@ -1389,7 +1389,7 @@ remainder-min-dist-succ-x-is-distance x y =
             ( neg-ℤ (int-ℕ (mul-ℕ t y)))
             ( add-ℤ (int-ℕ (mul-ℕ t y)) (int-ℕ d))
           by inv (isretr-add-neg-ℤ (int-ℕ (mul-ℕ t y)) (int-ℕ d))
-        ＝ add-ℤ (neg-ℤ (int-ℕ (mul-ℕ t y))) (int-ℕ (add-ℕ (mul-ℕ t y) d))
+        ＝ add-ℤ (neg-ℤ (int-ℕ (mul-ℕ t y))) (int-ℕ ((mul-ℕ t y) +ℕ d))
           by ap (add-ℤ (neg-ℤ (int-ℕ (mul-ℕ t y)))) (add-int-ℕ (mul-ℕ t y) d)
         ＝ add-ℤ (neg-ℤ (int-ℕ (mul-ℕ t y))) (int-ℕ (mul-ℕ s (succ-ℕ x)))
           by ap (λ H → add-ℤ (neg-ℤ (int-ℕ (mul-ℕ t y))) (int-ℕ H)) rewrite-dist
@@ -1921,7 +1921,7 @@ gcd-ℕ-div-dist-between-mult x y z dist =
       (concatenate-div-eq-ℕ (gcd-ℕ-div-y-mults x y z dist)
         (inv rewrite-dist))
     where
-    rewrite-dist : add-ℕ (mul-ℕ s x) z ＝ mul-ℕ t y
+    rewrite-dist : (mul-ℕ s x) +ℕ z ＝ mul-ℕ t y
     rewrite-dist = rewrite-right-dist-add-ℕ
       (mul-ℕ s x) z (mul-ℕ t y) sxty
       (inv (is-distance-between-multiples-eqn-ℕ dist))
@@ -1931,7 +1931,7 @@ gcd-ℕ-div-dist-between-mult x y z dist =
       (gcd-ℕ-div-y-mults x y z dist)
       (concatenate-div-eq-ℕ (gcd-ℕ-div-x-mults x y z dist) (inv rewrite-dist))
     where
-    rewrite-dist : add-ℕ (mul-ℕ t y) z ＝ mul-ℕ s x
+    rewrite-dist : (mul-ℕ t y) +ℕ z ＝ mul-ℕ s x
     rewrite-dist =
       rewrite-right-dist-add-ℕ (mul-ℕ t y) z (mul-ℕ s x) tysx
         ( inv (is-distance-between-multiples-eqn-ℕ dist) ∙
@@ -1941,7 +1941,7 @@ gcd-ℕ-div-dist-between-mult x y z dist =
     div-gcd-x = div-mul-ℕ s (gcd-ℕ x y) x (pr1 (is-common-divisor-gcd-ℕ x y))
 
 gcd-ℕ-div-minimal-positive-distance :
-  (x y : ℕ) → is-nonzero-ℕ (add-ℕ x y) →
+  (x y : ℕ) → is-nonzero-ℕ (x +ℕ y) →
   div-ℕ (gcd-ℕ x y) (minimal-positive-distance x y)
 gcd-ℕ-div-minimal-positive-distance x y H =
   gcd-ℕ-div-dist-between-mult
@@ -1951,7 +1951,7 @@ gcd-ℕ-div-minimal-positive-distance x y H =
     ( minimal-positive-distance-is-distance x y H)
 
 bezouts-lemma-ℕ :
-  (x y : ℕ) → is-nonzero-ℕ (add-ℕ x y) →
+  (x y : ℕ) → is-nonzero-ℕ (x +ℕ y) →
   minimal-positive-distance x y ＝ gcd-ℕ x y
 bezouts-lemma-ℕ x y H =
   antisymmetric-div-ℕ
@@ -1962,7 +1962,7 @@ bezouts-lemma-ℕ x y H =
 
 bezouts-lemma-eqn-ℕ :
   (x y : ℕ)
-  (H : is-nonzero-ℕ (add-ℕ x y)) →
+  (H : is-nonzero-ℕ (x +ℕ y)) →
   dist-ℕ
     ( mul-ℕ (minimal-positive-distance-x-coeff x y H) x)
     ( mul-ℕ (minimal-positive-distance-y-coeff x y H) y) ＝

--- a/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
@@ -113,7 +113,7 @@ int-is-distance-between-multiples-ℕ x y z (k , l , p) H =
   equational-reasoning
     (int-ℕ z) +ℤ ((int-ℕ k) *ℤ (int-ℕ x))
     ＝ (int-ℕ z) +ℤ (int-ℕ (k *ℕ x))
-      by ap (λ p → (int-ℕ z) +ℤ p) (mul-int-ℕ k x)
+      by ap ((int-ℕ z) +ℤ_) (mul-int-ℕ k x)
     ＝ int-ℕ (z +ℕ (k *ℕ x))
       by add-int-ℕ z (k *ℕ x)
     ＝ int-ℕ (l *ℕ y)
@@ -154,7 +154,7 @@ div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
             ( mul-ℤ-Mod x (mod-ℤ x (int-ℕ k)) (mod-ℤ x (int-ℕ x)))
           by
           ap
-            ( λ p → add-ℤ-Mod x (mod-ℤ x (int-ℕ z)) p)
+            ( add-ℤ-Mod x (mod-ℤ x (int-ℕ z)))
             ( preserves-mul-mod-ℤ x (int-ℕ k) (int-ℕ x))
         ＝ add-ℤ-Mod x
             ( mod-ℤ x (int-ℕ z))
@@ -171,7 +171,7 @@ div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
             ( mod-ℤ x ((int-ℕ k) *ℤ zero-ℤ))
           by
           ap
-            ( λ p → add-ℤ-Mod x (mod-ℤ x (int-ℕ z)) p)
+            ( add-ℤ-Mod x (mod-ℤ x (int-ℕ z)))
             ( inv (preserves-mul-mod-ℤ x (int-ℕ k) zero-ℤ))
         ＝ add-ℤ-Mod x (mod-ℤ x (int-ℕ z)) (mod-ℤ x zero-ℤ)
           by
@@ -191,7 +191,7 @@ div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
           by
           inv
             ( ap
-              ( λ p → mul-ℤ-Mod x (mod-ℤ x (neg-ℤ (int-ℕ l))) p)
+              ( mul-ℤ-Mod x (mod-ℤ x (neg-ℤ (int-ℕ l))))
               ( mod-int-ℕ x y))
         ＝ mod-ℤ x ((neg-ℤ (int-ℕ l)) *ℤ (int-ℕ y))
           by inv (preserves-mul-mod-ℤ x (neg-ℤ (int-ℕ l)) (int-ℕ y))
@@ -260,7 +260,7 @@ div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
                   ( (int-ℕ k) *ℤ (int-ℕ x))
                 by
                 ap
-                  ( λ p → p +ℤ ((int-ℕ k) *ℤ (int-ℕ x)))
+                  ( _+ℤ ((int-ℕ k) *ℤ (int-ℕ x)))
                   ( left-negative-law-mul-ℤ (int-ℕ l) (int-ℕ y))
               ＝ add-ℤ
                   ( (int-ℕ k) *ℤ (int-ℕ x))
@@ -274,7 +274,7 @@ div-mod-is-distance-between-multiples-ℕ x y z (k , l , p) =
                   ( neg-ℤ ((int-ℕ l) *ℤ (int-ℕ y)))
                 by
                 ap
-                  ( λ p → p +ℤ (neg-ℤ ((int-ℕ l) *ℤ (int-ℕ y))))
+                  ( _+ℤ (neg-ℤ ((int-ℕ l) *ℤ (int-ℕ y))))
                   ( inv
                     ( int-is-distance-between-multiples-ℕ y x z
                       ( is-distance-between-multiples-sym-ℕ x y z (k , l , p))
@@ -310,7 +310,7 @@ cong-div-mod-ℤ x y z (u , p) =
       ＝ mul-ℤ-Mod x u (mod-ℤ x (int-ℕ y))
         by ap (λ p → mul-ℤ-Mod x p (mod-ℤ x (int-ℕ y))) (issec-int-ℤ-Mod x u)
       ＝ mul-ℤ-Mod x u (mod-ℕ x y)
-        by ap (λ p → mul-ℤ-Mod x u p) (mod-int-ℕ x y)
+        by ap (mul-ℤ-Mod x u) (mod-int-ℕ x y)
       ＝ mod-ℕ x z by p
       ＝ mod-ℤ x (int-ℕ z) by inv (mod-int-ℕ x z))
 
@@ -329,7 +329,7 @@ is-distance-between-multiples-div-mod-ℕ zero-ℕ y z (u , p) =
       is-injective-int-ℕ
         ( inv (mul-int-ℕ (abs-ℤ u) y) ∙
           ( ( ap
-              ( λ H → H *ℤ (int-ℕ y))
+              ( _*ℤ (int-ℕ y))
               ( int-abs-is-nonnegative-ℤ u nonneg)) ∙
             ( p))))
   u-nonneg-case-split (inr neg) =
@@ -374,7 +374,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
         ( (int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))
       by
       ap
-        ( λ p → p +ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)))
+        ( _+ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)))
         ( inv (left-negative-law-mul-ℤ a (int-ℕ (succ-ℕ x))))
     ＝ add-ℤ
         ( (neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x)))
@@ -406,10 +406,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
         ( int-ℕ z)
       by
       ap
-        ( λ p →
-          add-ℤ
-            ( add-ℤ ((neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x))) p)
-            ( int-ℕ z))
+        ( λ p → (((neg-ℤ a) *ℤ (int-ℕ (succ-ℕ x))) +ℤ p) +ℤ (int-ℕ z))
         ( inv (pr2 (cong-div-mod-ℤ (succ-ℕ x) y z (u , p))))
     ＝ add-ℤ
         ( add-ℤ
@@ -418,7 +415,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
         ( int-ℕ z)
       by
       ap
-        ( λ p → add-ℤ (p +ℤ (a *ℤ (int-ℕ (succ-ℕ x)))) (int-ℕ z))
+        ( λ p → (p +ℤ (a *ℤ (int-ℕ (succ-ℕ x)))) +ℤ (int-ℕ z))
         ( left-negative-law-mul-ℤ a (int-ℕ (succ-ℕ x)))
     ＝ zero-ℤ +ℤ (int-ℕ z)
       by
@@ -497,7 +494,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
           ＝ (int-ℤ-Mod (succ-ℕ x) u) +ℤ (neg-ℤ (int-ℕ (succ-ℕ x)))
             by
             ap
-              ( λ p → (p +ℤ (neg-ℤ (int-ℕ (succ-ℕ x)))))
+              ( _+ℤ (neg-ℤ (int-ℕ (succ-ℕ x))))
               ( neg-neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))
     ＝ add-ℤ
         ( mul-ℤ ((neg-ℤ a) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
@@ -696,8 +693,8 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
         ＝ dist-ℤ (mul-ℤ ((int-ℕ (abs-ℤ a)) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
           (mul-ℤ (int-ℕ (abs-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
           (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))))) (int-ℕ y))
-        by ap (λ p → dist-ℤ (mul-ℤ ((int-ℕ (abs-ℤ a)) +ℤ (int-ℕ y))
-             (int-ℕ (succ-ℕ x))) p)
+        by ap (dist-ℤ (mul-ℤ ((int-ℕ (abs-ℤ a)) +ℤ (int-ℕ y))
+             (int-ℕ (succ-ℕ x))))
           (inv (mul-int-ℕ (abs-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
             (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u)))) y))
         ＝ dist-ℤ (mul-ℤ ((int-ℕ (abs-ℤ a)) +ℤ (int-ℕ y)) (int-ℕ (succ-ℕ x)))
@@ -746,8 +743,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
           (neg-ℤ (int-ℕ z)))
         ＝ add-ℤ (neg-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)))
           (int-ℕ z)
-        by ap (λ p → add-ℤ
-          (neg-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))) p)
+        by ap ((neg-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y))) +ℤ_)
           (neg-neg-ℤ (int-ℕ z))
         ＝ add-ℤ (int-ℕ z)
           (neg-ℤ ((int-ℤ-Mod (succ-ℕ x) u) *ℤ (int-ℕ y)))
@@ -1072,7 +1068,7 @@ remainder-min-dist-succ-x-is-distance x y =
           by inv (isretr-add-neg-ℤ' (int-ℕ (s *ℕ (succ-ℕ x))) (int-ℕ d))
         ＝ add-ℤ (int-ℕ (d +ℕ (s *ℕ (succ-ℕ x))))
           (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x))))
-          by ap (λ H → H +ℤ (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x)))))
+          by ap (_+ℤ (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x)))))
           (add-int-ℕ d (s *ℕ (succ-ℕ x)))
         ＝ (int-ℕ (t *ℕ y)) +ℤ (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x))))
           by ap (λ H → (int-ℕ H) +ℤ (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x)))))
@@ -1080,15 +1076,15 @@ remainder-min-dist-succ-x-is-distance x y =
               (t *ℕ y) sxty (inv (dist-sx-ty-eq-d)))
         ＝ add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
           (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x))))
-          by ap (λ H → H +ℤ (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x)))))
+          by ap (_+ℤ (neg-ℤ (int-ℕ (s *ℕ (succ-ℕ x)))))
             (inv (mul-int-ℕ t y))
         ＝ add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
           (neg-ℤ ((int-ℕ s) *ℤ (int-ℕ (succ-ℕ x))))
-          by ap (λ H → add-ℤ ((int-ℕ t) *ℤ (int-ℕ y)) (neg-ℤ H))
+          by ap (λ H → ((int-ℕ t) *ℤ (int-ℕ y)) +ℤ (neg-ℤ H))
             (inv (mul-int-ℕ s (succ-ℕ x)))
         ＝ add-ℤ ((int-ℕ t) *ℤ (int-ℕ y))
           ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))
-          by ap (λ H → add-ℤ ((int-ℕ t) *ℤ (int-ℕ y)) H)
+          by ap (((int-ℕ t) *ℤ (int-ℕ y)) +ℤ_)
             (inv (left-negative-law-mul-ℤ (int-ℕ s) (int-ℕ (succ-ℕ x))))
 
     isolate-rem-eqn :
@@ -1189,7 +1185,7 @@ remainder-min-dist-succ-x-is-distance x y =
                         ( neg-ℤ (int-ℕ s))
                         ( int-ℕ (succ-ℕ x)))
                 ＝ mul-ℤ (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s))) (int-ℕ (succ-ℕ x))
-                  by ap (λ H → H *ℤ (int-ℕ (succ-ℕ x)))
+                  by ap (_*ℤ (int-ℕ (succ-ℕ x)))
                   (right-negative-law-mul-ℤ (int-ℕ q) (int-ℕ s))
                 ＝ neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))
                   by
@@ -1205,7 +1201,7 @@ remainder-min-dist-succ-x-is-distance x y =
             (int-ℕ (succ-ℕ x))
           by
             ap
-              ( λ H → H +ℤ (int-ℕ (succ-ℕ x)))
+              ( _+ℤ (int-ℕ (succ-ℕ x)))
               ( distributive-neg-add-ℤ
                 ( mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
                 ( neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
@@ -1245,8 +1241,7 @@ remainder-min-dist-succ-x-is-distance x y =
             ( neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)))
           by
             ap
-              ( λ H →
-                H +ℤ (neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))))
+              ( _+ℤ (neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))))
               ( ap
                 ( add-ℤ
                   ( mul-ℤ ((int-ℕ q) *ℤ ((int-ℕ s))) (int-ℕ (succ-ℕ x))))
@@ -1324,7 +1319,7 @@ remainder-min-dist-succ-x-is-distance x y =
           ＝ (0 *ℕ d) +ℕ r
             by (ap (λ H → (H *ℕ d) +ℕ r) iszero)
           ＝ 0 +ℕ r
-            by (ap (λ H → H +ℕ r) (left-zero-law-mul-ℕ d))
+            by (ap (_+ℕ r) (left-zero-law-mul-ℕ d))
           ＝ r
             by (left-unit-law-add-ℕ r)
 
@@ -1363,7 +1358,7 @@ remainder-min-dist-succ-x-is-distance x y =
           ＝ (s *ℕ (succ-ℕ x))
             by rewrite-dist
           ＝ (zero-ℕ *ℕ (succ-ℕ x))
-            by (ap (λ H → H *ℕ (succ-ℕ x)) iszero)
+            by (ap (_*ℕ (succ-ℕ x)) iszero)
           ＝ zero-ℕ
             by (left-zero-law-mul-ℕ (succ-ℕ x))
 
@@ -1371,7 +1366,7 @@ remainder-min-dist-succ-x-is-distance x y =
       d-is-zero = is-zero-right-is-zero-add-ℕ (t *ℕ y) d (zero-addition)
 
     coeff-nonnegative : leq-ℤ one-ℤ ((int-ℕ q) *ℤ (int-ℕ s))
-    coeff-nonnegative = tr (λ z → leq-ℤ one-ℤ z)
+    coeff-nonnegative = tr (leq-ℤ one-ℤ)
       (inv (mul-int-ℕ q s)) (leq-int-ℕ 1 (q *ℕ s)
         (leq-succ-le-ℕ 0 (q *ℕ s) (le-is-nonzero-ℕ (q *ℕ s)
           (is-nonzero-mul-ℕ q s quotient-min-dist-succ-x-nonzero
@@ -1405,7 +1400,7 @@ remainder-min-dist-succ-x-is-distance x y =
             ( int-ℕ (s *ℕ (succ-ℕ x)))
           by
             ap
-              ( λ H → H +ℤ (int-ℕ (s *ℕ (succ-ℕ x))))
+              ( _+ℤ (int-ℕ (s *ℕ (succ-ℕ x))))
               ( inv (left-negative-law-mul-ℤ (int-ℕ t) (int-ℕ y)))
         ＝ add-ℤ
             ( (neg-ℤ (int-ℕ t)) *ℤ (int-ℕ y))
@@ -1560,7 +1555,7 @@ remainder-min-dist-succ-x-is-distance x y =
               ( neg-ℤ (mul-ℤ (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ t))) (int-ℕ y)))
               ( neg-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (int-ℕ (succ-ℕ x)))))
             ( int-ℕ (succ-ℕ x))
-          by ap (λ H → H +ℤ (int-ℕ (succ-ℕ x)))
+          by ap (_+ℤ (int-ℕ (succ-ℕ x)))
             (distributive-neg-add-ℤ
               (mul-ℤ (neg-ℤ ((int-ℕ q) *ℤ (int-ℕ t))) (int-ℕ y))
               (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ s))
@@ -1597,7 +1592,7 @@ remainder-min-dist-succ-x-is-distance x y =
             ap
               ( λ H →
                 add-ℤ
-                  ( add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)) H)
+                  ( (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)) +ℤ H)
                   ( int-ℕ (succ-ℕ x)))
               ( inv
                 ( left-negative-law-mul-ℤ
@@ -1616,7 +1611,7 @@ remainder-min-dist-succ-x-is-distance x y =
             ap
               ( λ H →
                 add-ℤ
-                  ( mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
+                  ( ((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))
                   ( add-ℤ
                     ( mul-ℤ
                       ( neg-ℤ ((int-ℕ q) *ℤ (int-ℕ s)))
@@ -1649,7 +1644,7 @@ remainder-min-dist-succ-x-is-distance x y =
         ＝ add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y))
           (neg-ℤ (mul-ℤ (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s))
             (neg-ℤ one-ℤ)) (int-ℕ (succ-ℕ x))))
-          by ap (λ H → (add-ℤ (mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)) H))
+          by ap ((mul-ℤ ((int-ℕ q) *ℤ (int-ℕ t)) (int-ℕ y)) +ℤ_)
             (left-negative-law-mul-ℤ
               (add-ℤ ((int-ℕ q) *ℤ (int-ℕ s)) (neg-ℤ one-ℤ))
               (int-ℕ (succ-ℕ x)))

--- a/src/elementary-number-theory/binomial-coefficients.lagda.md
+++ b/src/elementary-number-theory/binomial-coefficients.lagda.md
@@ -33,7 +33,7 @@ binomial-coefficient-ℕ zero-ℕ zero-ℕ = 1
 binomial-coefficient-ℕ zero-ℕ (succ-ℕ k) = 0
 binomial-coefficient-ℕ (succ-ℕ n) zero-ℕ = 1
 binomial-coefficient-ℕ (succ-ℕ n) (succ-ℕ k) =
-  add-ℕ (binomial-coefficient-ℕ n k) (binomial-coefficient-ℕ n (succ-ℕ k))
+  (binomial-coefficient-ℕ n k) +ℕ (binomial-coefficient-ℕ n (succ-ℕ k))
 ```
 
 ### Binomial coefficients indexed by elements of standard finite types

--- a/src/elementary-number-theory/binomial-theorem-integers.lagda.md
+++ b/src/elementary-number-theory/binomial-theorem-integers.lagda.md
@@ -77,13 +77,13 @@ htpy-binomial-sum-ℤ =
 ```agda
 left-distributive-mul-binomial-sum-ℤ :
   (n : ℕ) (x : ℤ) (f : functional-vec ℤ (succ-ℕ n)) →
-  mul-ℤ x (binomial-sum-ℤ n f) ＝ binomial-sum-ℤ n (λ i → mul-ℤ x (f i))
+  x *ℤ (binomial-sum-ℤ n f) ＝ binomial-sum-ℤ n (λ i → x *ℤ (f i))
 left-distributive-mul-binomial-sum-ℤ =
   left-distributive-mul-binomial-sum-Commutative-Ring ℤ-Commutative-Ring
 
 right-distributive-mul-binomial-sum-ℤ :
   (n : ℕ) (f : functional-vec ℤ (succ-ℕ n)) (x : ℤ) →
-  mul-ℤ (binomial-sum-ℤ n f) x ＝ binomial-sum-ℤ n (λ i → mul-ℤ (f i) x)
+  (binomial-sum-ℤ n f) *ℤ x ＝ binomial-sum-ℤ n (λ i → (f i) *ℤ x)
 right-distributive-mul-binomial-sum-ℤ =
   right-distributive-mul-binomial-sum-Commutative-Ring
     ℤ-Commutative-Ring

--- a/src/elementary-number-theory/binomial-theorem-integers.lagda.md
+++ b/src/elementary-number-theory/binomial-theorem-integers.lagda.md
@@ -99,8 +99,7 @@ binomial-theorem-ℤ :
   power-ℤ n (x +ℤ y) ＝
   binomial-sum-ℤ n
     ( λ i →
-      mul-ℤ
-      ( power-ℤ (nat-Fin (succ-ℕ n) i) x)
-      ( power-ℤ (dist-ℕ (nat-Fin (succ-ℕ n) i) n) y))
+        ( power-ℤ (nat-Fin (succ-ℕ n) i) x) *ℤ
+        ( power-ℤ (dist-ℕ (nat-Fin (succ-ℕ n) i) n) y))
 binomial-theorem-ℤ = binomial-theorem-Commutative-Ring ℤ-Commutative-Ring
 ```

--- a/src/elementary-number-theory/binomial-theorem-integers.lagda.md
+++ b/src/elementary-number-theory/binomial-theorem-integers.lagda.md
@@ -57,7 +57,7 @@ binomial-sum-one-element-ℤ =
 
 binomial-sum-two-elements-ℤ :
   (f : functional-vec ℤ 2) →
-  binomial-sum-ℤ 1 f ＝ add-ℤ (f (zero-Fin 1)) (f (one-Fin 1))
+  binomial-sum-ℤ 1 f ＝ (f (zero-Fin 1)) +ℤ (f (one-Fin 1))
 binomial-sum-two-elements-ℤ =
   binomial-sum-two-elements-Commutative-Ring ℤ-Commutative-Ring
 ```

--- a/src/elementary-number-theory/binomial-theorem-integers.lagda.md
+++ b/src/elementary-number-theory/binomial-theorem-integers.lagda.md
@@ -96,7 +96,7 @@ right-distributive-mul-binomial-sum-ℤ =
 ```agda
 binomial-theorem-ℤ :
   (n : ℕ) (x y : ℤ) →
-  power-ℤ n (add-ℤ x y) ＝
+  power-ℤ n (x +ℤ y) ＝
   binomial-sum-ℤ n
     ( λ i →
       mul-ℤ

--- a/src/elementary-number-theory/binomial-theorem-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/binomial-theorem-natural-numbers.lagda.md
@@ -76,13 +76,13 @@ htpy-binomial-sum-ℕ =
 ```agda
 left-distributive-mul-binomial-sum-ℕ :
   (n : ℕ) (x : ℕ) (f : functional-vec ℕ (succ-ℕ n)) →
-  mul-ℕ x (binomial-sum-ℕ n f) ＝ binomial-sum-ℕ n (λ i → mul-ℕ x (f i))
+  x *ℕ (binomial-sum-ℕ n f) ＝ binomial-sum-ℕ n (λ i → x *ℕ (f i))
 left-distributive-mul-binomial-sum-ℕ =
   left-distributive-mul-binomial-sum-Commutative-Semiring ℕ-Commutative-Semiring
 
 right-distributive-mul-binomial-sum-ℕ :
   (n : ℕ) (f : functional-vec ℕ (succ-ℕ n)) (x : ℕ) →
-  mul-ℕ (binomial-sum-ℕ n f) x ＝ binomial-sum-ℕ n (λ i → mul-ℕ (f i) x)
+  (binomial-sum-ℕ n f) *ℕ x ＝ binomial-sum-ℕ n (λ i → (f i) *ℕ x)
 right-distributive-mul-binomial-sum-ℕ =
   right-distributive-mul-binomial-sum-Commutative-Semiring
     ℕ-Commutative-Semiring

--- a/src/elementary-number-theory/binomial-theorem-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/binomial-theorem-natural-numbers.lagda.md
@@ -95,7 +95,7 @@ right-distributive-mul-binomial-sum-ℕ =
 ```agda
 binomial-theorem-ℕ :
   (n : ℕ) (x y : ℕ) →
-  power-ℕ n (add-ℕ x y) ＝
+  power-ℕ n (x +ℕ y) ＝
   binomial-sum-ℕ n
     ( λ i →
       mul-ℕ

--- a/src/elementary-number-theory/binomial-theorem-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/binomial-theorem-natural-numbers.lagda.md
@@ -56,7 +56,7 @@ binomial-sum-one-element-ℕ =
 
 binomial-sum-two-elements-ℕ :
   (f : functional-vec ℕ 2) →
-  binomial-sum-ℕ 1 f ＝ add-ℕ (f (zero-Fin 1)) (f (one-Fin 1))
+  binomial-sum-ℕ 1 f ＝ (f (zero-Fin 1)) +ℕ (f (one-Fin 1))
 binomial-sum-two-elements-ℕ =
   binomial-sum-two-elements-Commutative-Semiring ℕ-Commutative-Semiring
 ```

--- a/src/elementary-number-theory/binomial-theorem-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/binomial-theorem-natural-numbers.lagda.md
@@ -98,8 +98,7 @@ binomial-theorem-ℕ :
   power-ℕ n (x +ℕ y) ＝
   binomial-sum-ℕ n
     ( λ i →
-      mul-ℕ
-      ( power-ℕ (nat-Fin (succ-ℕ n) i) x)
+      ( power-ℕ (nat-Fin (succ-ℕ n) i) x) *ℕ
       ( power-ℕ (dist-ℕ (nat-Fin (succ-ℕ n) i) n) y))
 binomial-theorem-ℕ =
   binomial-theorem-Commutative-Semiring ℕ-Commutative-Semiring

--- a/src/elementary-number-theory/catalan-numbers.lagda.md
+++ b/src/elementary-number-theory/catalan-numbers.lagda.md
@@ -49,6 +49,6 @@ catalan-numbers =
 catalan-numbers-binomial : ℕ → ℕ
 catalan-numbers-binomial n =
   dist-ℕ
-    ( binomial-coefficient-ℕ (mul-ℕ 2 n) n)
-    ( binomial-coefficient-ℕ (mul-ℕ 2 n) (succ-ℕ n))
+    ( binomial-coefficient-ℕ (2 *ℕ n) n)
+    ( binomial-coefficient-ℕ (2 *ℕ n) (succ-ℕ n))
 ```

--- a/src/elementary-number-theory/collatz-bijection.lagda.md
+++ b/src/elementary-number-theory/collatz-bijection.lagda.md
@@ -28,11 +28,11 @@ We define a bijection of Collatz
 ```agda
 cases-map-collatz-bijection : (n : ℕ) (x : ℤ-Mod 3) (p : mod-ℕ 3 n ＝ x) → ℕ
 cases-map-collatz-bijection n (inl (inl (inr star))) p =
-  quotient-euclidean-division-ℕ 3 (mul-ℕ 2 n)
+  quotient-euclidean-division-ℕ 3 (2 *ℕ n)
 cases-map-collatz-bijection n (inl (inr star)) p =
-  quotient-euclidean-division-ℕ 3 (dist-ℕ (mul-ℕ 4 n) 1)
+  quotient-euclidean-division-ℕ 3 (dist-ℕ (4 *ℕ n) 1)
 cases-map-collatz-bijection n (inr star) p =
-  quotient-euclidean-division-ℕ 3 (succ-ℕ (mul-ℕ 4 n))
+  quotient-euclidean-division-ℕ 3 (succ-ℕ (4 *ℕ n))
 
 map-collatz-bijection : ℕ → ℕ
 map-collatz-bijection n = cases-map-collatz-bijection n (mod-ℕ 3 n) refl

--- a/src/elementary-number-theory/collatz-conjecture.lagda.md
+++ b/src/elementary-number-theory/collatz-conjecture.lagda.md
@@ -24,7 +24,7 @@ open import foundation.universe-levels
 collatz : ℕ → ℕ
 collatz n with is-decidable-div-ℕ 2 n
 ... | inl (pair y p) = y
-... | inr f = succ-ℕ (mul-ℕ 3 n)
+... | inr f = succ-ℕ (3 *ℕ n)
 
 iterate-collatz : ℕ → ℕ → ℕ
 iterate-collatz zero-ℕ n = n

--- a/src/elementary-number-theory/congruence-integers.lagda.md
+++ b/src/elementary-number-theory/congruence-integers.lagda.md
@@ -55,7 +55,7 @@ pr2 (is-unit-cong-succ-ℤ k x (pair y p)) =
   ( is-injective-neg-ℤ
     ( ( neg-neg-ℤ (y *ℤ k)) ∙
       ( ( p) ∙
-        ( ( ap (add-ℤ x) (neg-succ-ℤ x)) ∙
+        ( ( ap (x +ℤ_) (neg-succ-ℤ x)) ∙
           ( ( right-predecessor-law-add-ℤ x (neg-ℤ x)) ∙
             ( ap pred-ℤ (right-inverse-law-add-ℤ x)))))))
 
@@ -63,7 +63,7 @@ is-unit-cong-pred-ℤ : (k x : ℤ) → cong-ℤ k x (pred-ℤ x) → is-unit-�
 pr1 (is-unit-cong-pred-ℤ k x (pair y p)) = y
 pr2 (is-unit-cong-pred-ℤ k x (pair y p)) =
   ( p) ∙
-  ( ( ap (add-ℤ x) (neg-pred-ℤ x)) ∙
+  ( ( ap (x +ℤ_) (neg-pred-ℤ x)) ∙
     ( ( right-successor-law-add-ℤ x (neg-ℤ x)) ∙
       ( ap succ-ℤ (right-inverse-law-add-ℤ x))))
 

--- a/src/elementary-number-theory/congruence-integers.lagda.md
+++ b/src/elementary-number-theory/congruence-integers.lagda.md
@@ -79,7 +79,7 @@ pr2 (symmetric-cong-ℤ k x y (pair d p)) =
     ( distributive-neg-diff-ℤ x y))
 
 transitive-cong-ℤ : (k x y z : ℤ) → cong-ℤ k x y → cong-ℤ k y z → cong-ℤ k x z
-pr1 (transitive-cong-ℤ k x y z (pair d p) (pair e q)) = add-ℤ d e
+pr1 (transitive-cong-ℤ k x y z (pair d p) (pair e q)) = d +ℤ e
 pr2 (transitive-cong-ℤ k x y z (pair d p) (pair e q)) =
   ( right-distributive-mul-add-ℤ d e k) ∙
   ( ( ap-add-ℤ p q) ∙

--- a/src/elementary-number-theory/congruence-integers.lagda.md
+++ b/src/elementary-number-theory/congruence-integers.lagda.md
@@ -53,7 +53,7 @@ pr1 (is-unit-cong-succ-ℤ k x (pair y p)) = neg-ℤ y
 pr2 (is-unit-cong-succ-ℤ k x (pair y p)) =
   ( left-negative-law-mul-ℤ y k) ∙
   ( is-injective-neg-ℤ
-    ( ( neg-neg-ℤ (mul-ℤ y k)) ∙
+    ( ( neg-neg-ℤ (y *ℤ k)) ∙
       ( ( p) ∙
         ( ( ap (add-ℤ x) (neg-succ-ℤ x)) ∙
           ( ( right-predecessor-law-add-ℤ x (neg-ℤ x)) ∙

--- a/src/elementary-number-theory/congruence-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/congruence-natural-numbers.lagda.md
@@ -164,7 +164,7 @@ scalar-invariant-cong-ℕ :
 pr1 (scalar-invariant-cong-ℕ k x y z (pair d p)) = z *ℕ d
 pr2 (scalar-invariant-cong-ℕ k x y z (pair d p)) =
   ( associative-mul-ℕ z d k) ∙
-    ( ( ap (mul-ℕ z) p) ∙
+    ( ( ap (z *ℕ_) p) ∙
       ( left-distributive-mul-dist-ℕ x y z))
 
 scalar-invariant-cong-ℕ' :

--- a/src/elementary-number-theory/congruence-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/congruence-natural-numbers.lagda.md
@@ -192,13 +192,13 @@ congruence-mul-ℕ k {x} {y} {x'} {y'} H K =
 
 ```agda
 translation-invariant-cong-ℕ :
-  (k x y z : ℕ) → cong-ℕ k x y → cong-ℕ k (add-ℕ z x) (add-ℕ z y)
+  (k x y z : ℕ) → cong-ℕ k x y → cong-ℕ k (z +ℕ x) (z +ℕ y)
 pr1 (translation-invariant-cong-ℕ k x y z (pair d p)) = d
 pr2 (translation-invariant-cong-ℕ k x y z (pair d p)) =
   p ∙ inv (translation-invariant-dist-ℕ z x y)
 
 translation-invariant-cong-ℕ' :
-  (k x y z : ℕ) → cong-ℕ k x y → cong-ℕ k (add-ℕ x z) (add-ℕ y z)
+  (k x y z : ℕ) → cong-ℕ k x y → cong-ℕ k (x +ℕ z) (y +ℕ z)
 translation-invariant-cong-ℕ' k x y z H =
   concatenate-eq-cong-eq-ℕ k
     ( commutative-add-ℕ x z)
@@ -210,7 +210,7 @@ step-invariant-cong-ℕ :
 step-invariant-cong-ℕ k x y = translation-invariant-cong-ℕ' k x y 1
 
 reflects-cong-add-ℕ :
-  {k : ℕ} (x : ℕ) {y z : ℕ} → cong-ℕ k (add-ℕ x y) (add-ℕ x z) → cong-ℕ k y z
+  {k : ℕ} (x : ℕ) {y z : ℕ} → cong-ℕ k (x +ℕ y) (x +ℕ z) → cong-ℕ k y z
 pr1 (reflects-cong-add-ℕ {k} x {y} {z} (pair d p)) = d
 pr2 (reflects-cong-add-ℕ {k} x {y} {z} (pair d p)) =
   p ∙ translation-invariant-dist-ℕ x y z

--- a/src/elementary-number-theory/congruence-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/congruence-natural-numbers.lagda.md
@@ -160,15 +160,15 @@ is-one-cong-succ-ℕ {k} x H =
 
 ```agda
 scalar-invariant-cong-ℕ :
-  (k x y z : ℕ) → cong-ℕ k x y → cong-ℕ k (mul-ℕ z x) (mul-ℕ z y)
-pr1 (scalar-invariant-cong-ℕ k x y z (pair d p)) = mul-ℕ z d
+  (k x y z : ℕ) → cong-ℕ k x y → cong-ℕ k (z *ℕ x) (z *ℕ y)
+pr1 (scalar-invariant-cong-ℕ k x y z (pair d p)) = z *ℕ d
 pr2 (scalar-invariant-cong-ℕ k x y z (pair d p)) =
   ( associative-mul-ℕ z d k) ∙
     ( ( ap (mul-ℕ z) p) ∙
       ( left-distributive-mul-dist-ℕ x y z))
 
 scalar-invariant-cong-ℕ' :
-  (k x y z : ℕ) → cong-ℕ k x y → cong-ℕ k (mul-ℕ x z) (mul-ℕ y z)
+  (k x y z : ℕ) → cong-ℕ k x y → cong-ℕ k (x *ℕ z) (y *ℕ z)
 scalar-invariant-cong-ℕ' k x y z H =
   concatenate-eq-cong-eq-ℕ k
     ( commutative-mul-ℕ x z)
@@ -181,9 +181,9 @@ scalar-invariant-cong-ℕ' k x y z H =
 ```agda
 congruence-mul-ℕ :
   (k : ℕ) {x y x' y' : ℕ} →
-  cong-ℕ k x x' → cong-ℕ k y y' → cong-ℕ k (mul-ℕ x y) (mul-ℕ x' y')
+  cong-ℕ k x x' → cong-ℕ k y y' → cong-ℕ k (x *ℕ y) (x' *ℕ y')
 congruence-mul-ℕ k {x} {y} {x'} {y'} H K =
-  trans-cong-ℕ k (mul-ℕ x y) (mul-ℕ x y') (mul-ℕ x' y')
+  trans-cong-ℕ k (x *ℕ y) (x *ℕ y') (x' *ℕ y')
     ( scalar-invariant-cong-ℕ k y y' x K)
     ( scalar-invariant-cong-ℕ' k x x' y' H)
 ```

--- a/src/elementary-number-theory/decidable-total-order-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/decidable-total-order-natural-numbers.lagda.md
@@ -8,7 +8,6 @@ module elementary-number-theory.decidable-total-order-natural-numbers where
 
 ```agda
 open import elementary-number-theory.inequality-natural-numbers
-open import elementary-number-theory.natural-numbers
 
 open import foundation.dependent-pair-types
 open import foundation.propositional-truncations

--- a/src/elementary-number-theory/difference-integers.lagda.md
+++ b/src/elementary-number-theory/difference-integers.lagda.md
@@ -35,7 +35,7 @@ eq-diff-ℤ {x} {y} H =
   ( inv (right-unit-law-add-ℤ x)) ∙
   ( ( ap (add-ℤ x) (inv (left-inverse-law-add-ℤ y))) ∙
     ( ( inv (associative-add-ℤ x (neg-ℤ y) y)) ∙
-      ( ( ap (add-ℤ' y) H) ∙
+      ( ( ap (_+ℤ y) H) ∙
         ( left-unit-law-add-ℤ y))))
 
 is-zero-diff-ℤ' : (x : ℤ) → is-zero-ℤ (diff-ℤ x x)
@@ -76,7 +76,7 @@ triangle-diff-ℤ x y z =
   ( ap
     ( add-ℤ x)
     ( ( inv (associative-add-ℤ (neg-ℤ y) y (neg-ℤ z))) ∙
-      ( ( ap (add-ℤ' (neg-ℤ z)) (left-inverse-law-add-ℤ y)) ∙
+      ( ( ap (_+ℤ (neg-ℤ z)) (left-inverse-law-add-ℤ y)) ∙
         ( left-unit-law-add-ℤ (neg-ℤ z)))))
 
 distributive-neg-diff-ℤ :
@@ -98,7 +98,7 @@ left-translation-diff-ℤ :
   (x y z : ℤ) → diff-ℤ (z +ℤ x) (z +ℤ y) ＝ diff-ℤ x y
 left-translation-diff-ℤ x y z =
   ( interchange-law-diff-add-ℤ z x z y) ∙
-  ( ( ap (add-ℤ' (diff-ℤ x y)) (right-inverse-law-add-ℤ z)) ∙
+  ( ( ap (_+ℤ (diff-ℤ x y)) (right-inverse-law-add-ℤ z)) ∙
     ( left-unit-law-add-ℤ (diff-ℤ x y)))
 
 right-translation-diff-ℤ :

--- a/src/elementary-number-theory/difference-integers.lagda.md
+++ b/src/elementary-number-theory/difference-integers.lagda.md
@@ -33,7 +33,7 @@ ap-diff-ℤ p q = ap-binary diff-ℤ p q
 eq-diff-ℤ : {x y : ℤ} → is-zero-ℤ (diff-ℤ x y) → x ＝ y
 eq-diff-ℤ {x} {y} H =
   ( inv (right-unit-law-add-ℤ x)) ∙
-  ( ( ap (add-ℤ x) (inv (left-inverse-law-add-ℤ y))) ∙
+  ( ( ap (x +ℤ_) (inv (left-inverse-law-add-ℤ y))) ∙
     ( ( inv (associative-add-ℤ x (neg-ℤ y) y)) ∙
       ( ( ap (_+ℤ y) H) ∙
         ( left-unit-law-add-ℤ y))))
@@ -58,7 +58,7 @@ left-successor-law-diff-ℤ x y = left-successor-law-add-ℤ x (neg-ℤ y)
 right-successor-law-diff-ℤ :
   (x y : ℤ) → diff-ℤ x (succ-ℤ y) ＝ pred-ℤ (diff-ℤ x y)
 right-successor-law-diff-ℤ x y =
-  ap (add-ℤ x) (neg-succ-ℤ y) ∙ right-predecessor-law-add-ℤ x (neg-ℤ y)
+  ap (x +ℤ_) (neg-succ-ℤ y) ∙ right-predecessor-law-add-ℤ x (neg-ℤ y)
 
 left-predecessor-law-diff-ℤ :
   (x y : ℤ) → diff-ℤ (pred-ℤ x) y ＝ pred-ℤ (diff-ℤ x y)
@@ -67,14 +67,14 @@ left-predecessor-law-diff-ℤ x y = left-predecessor-law-add-ℤ x (neg-ℤ y)
 right-predecessor-law-diff-ℤ :
   (x y : ℤ) → diff-ℤ x (pred-ℤ y) ＝ succ-ℤ (diff-ℤ x y)
 right-predecessor-law-diff-ℤ x y =
-  ap (add-ℤ x) (neg-pred-ℤ y) ∙ right-successor-law-add-ℤ x (neg-ℤ y)
+  ap (x +ℤ_) (neg-pred-ℤ y) ∙ right-successor-law-add-ℤ x (neg-ℤ y)
 
 triangle-diff-ℤ :
   (x y z : ℤ) → (diff-ℤ x y) +ℤ (diff-ℤ y z) ＝ diff-ℤ x z
 triangle-diff-ℤ x y z =
   ( associative-add-ℤ x (neg-ℤ y) (diff-ℤ y z)) ∙
   ( ap
-    ( add-ℤ x)
+    ( x +ℤ_)
     ( ( inv (associative-add-ℤ (neg-ℤ y) y (neg-ℤ z))) ∙
       ( ( ap (_+ℤ (neg-ℤ z)) (left-inverse-law-add-ℤ y)) ∙
         ( left-unit-law-add-ℤ (neg-ℤ z)))))
@@ -83,13 +83,13 @@ distributive-neg-diff-ℤ :
   (x y : ℤ) → neg-ℤ (diff-ℤ x y) ＝ diff-ℤ y x
 distributive-neg-diff-ℤ x y =
   ( distributive-neg-add-ℤ x (neg-ℤ y)) ∙
-  ( ( ap (add-ℤ (neg-ℤ x)) (neg-neg-ℤ y)) ∙
+  ( ( ap ((neg-ℤ x) +ℤ_) (neg-neg-ℤ y)) ∙
     ( commutative-add-ℤ (neg-ℤ x) y))
 
 interchange-law-add-diff-ℤ : interchange-law add-ℤ diff-ℤ
 interchange-law-add-diff-ℤ x y u v =
   ( interchange-law-add-add-ℤ x (neg-ℤ y) u (neg-ℤ v)) ∙
-  ( ap (add-ℤ (x +ℤ u)) (inv (distributive-neg-add-ℤ y v)))
+  ( ap ((x +ℤ u) +ℤ_) (inv (distributive-neg-add-ℤ y v)))
 
 interchange-law-diff-add-ℤ : interchange-law diff-ℤ add-ℤ
 interchange-law-diff-add-ℤ x y u v = inv (interchange-law-add-diff-ℤ x u y v)
@@ -111,7 +111,7 @@ right-translation-diff-ℤ x y z =
 ```agda
 diff-succ-ℤ : (x y : ℤ) → diff-ℤ (succ-ℤ x) (succ-ℤ y) ＝ diff-ℤ x y
 diff-succ-ℤ x y =
-  ( ap (add-ℤ (succ-ℤ x)) (neg-succ-ℤ y)) ∙
+  ( ap ((succ-ℤ x) +ℤ_) (neg-succ-ℤ y)) ∙
   ( ( left-successor-law-add-ℤ x (pred-ℤ (neg-ℤ y))) ∙
     ( ( ap succ-ℤ (right-predecessor-law-add-ℤ x (neg-ℤ y))) ∙
       ( issec-pred-ℤ (diff-ℤ x y))))

--- a/src/elementary-number-theory/difference-integers.lagda.md
+++ b/src/elementary-number-theory/difference-integers.lagda.md
@@ -25,7 +25,7 @@ are derived there.
 
 ```agda
 diff-ℤ : ℤ → ℤ → ℤ
-diff-ℤ x y = add-ℤ x (neg-ℤ y)
+diff-ℤ x y = x +ℤ (neg-ℤ y)
 
 ap-diff-ℤ : {x x' y y' : ℤ} → x ＝ x' → y ＝ y' → diff-ℤ x y ＝ diff-ℤ x' y'
 ap-diff-ℤ p q = ap-binary diff-ℤ p q
@@ -70,7 +70,7 @@ right-predecessor-law-diff-ℤ x y =
   ap (add-ℤ x) (neg-pred-ℤ y) ∙ right-successor-law-add-ℤ x (neg-ℤ y)
 
 triangle-diff-ℤ :
-  (x y z : ℤ) → add-ℤ (diff-ℤ x y) (diff-ℤ y z) ＝ diff-ℤ x z
+  (x y z : ℤ) → (diff-ℤ x y) +ℤ (diff-ℤ y z) ＝ diff-ℤ x z
 triangle-diff-ℤ x y z =
   ( associative-add-ℤ x (neg-ℤ y) (diff-ℤ y z)) ∙
   ( ap
@@ -89,20 +89,20 @@ distributive-neg-diff-ℤ x y =
 interchange-law-add-diff-ℤ : interchange-law add-ℤ diff-ℤ
 interchange-law-add-diff-ℤ x y u v =
   ( interchange-law-add-add-ℤ x (neg-ℤ y) u (neg-ℤ v)) ∙
-  ( ap (add-ℤ (add-ℤ x u)) (inv (distributive-neg-add-ℤ y v)))
+  ( ap (add-ℤ (x +ℤ u)) (inv (distributive-neg-add-ℤ y v)))
 
 interchange-law-diff-add-ℤ : interchange-law diff-ℤ add-ℤ
 interchange-law-diff-add-ℤ x y u v = inv (interchange-law-add-diff-ℤ x u y v)
 
 left-translation-diff-ℤ :
-  (x y z : ℤ) → diff-ℤ (add-ℤ z x) (add-ℤ z y) ＝ diff-ℤ x y
+  (x y z : ℤ) → diff-ℤ (z +ℤ x) (z +ℤ y) ＝ diff-ℤ x y
 left-translation-diff-ℤ x y z =
   ( interchange-law-diff-add-ℤ z x z y) ∙
   ( ( ap (add-ℤ' (diff-ℤ x y)) (right-inverse-law-add-ℤ z)) ∙
     ( left-unit-law-add-ℤ (diff-ℤ x y)))
 
 right-translation-diff-ℤ :
-  (x y z : ℤ) → diff-ℤ (add-ℤ x z) (add-ℤ y z) ＝ diff-ℤ x y
+  (x y z : ℤ) → diff-ℤ (x +ℤ z) (y +ℤ z) ＝ diff-ℤ x y
 right-translation-diff-ℤ x y z =
   ( ap-diff-ℤ (commutative-add-ℤ x z) (commutative-add-ℤ y z)) ∙
   ( left-translation-diff-ℤ x y z)

--- a/src/elementary-number-theory/distance-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/distance-natural-numbers.lagda.md
@@ -323,17 +323,17 @@ translation-invariant-dist-ℕ' k m n =
 
 ```agda
 left-distributive-mul-dist-ℕ :
-  (m n k : ℕ) → mul-ℕ k (dist-ℕ m n) ＝ dist-ℕ (mul-ℕ k m) (mul-ℕ k n)
+  (m n k : ℕ) → k *ℕ (dist-ℕ m n) ＝ dist-ℕ (k *ℕ m) (k *ℕ n)
 left-distributive-mul-dist-ℕ zero-ℕ zero-ℕ zero-ℕ = refl
 left-distributive-mul-dist-ℕ zero-ℕ zero-ℕ (succ-ℕ k) =
   left-distributive-mul-dist-ℕ zero-ℕ zero-ℕ k
 left-distributive-mul-dist-ℕ zero-ℕ (succ-ℕ n) zero-ℕ = refl
 left-distributive-mul-dist-ℕ zero-ℕ (succ-ℕ n) (succ-ℕ k) =
-  ap ( dist-ℕ' (mul-ℕ (succ-ℕ k) (succ-ℕ n)))
+  ap ( dist-ℕ' ((succ-ℕ k) *ℕ (succ-ℕ n)))
      ( inv (right-zero-law-mul-ℕ (succ-ℕ k)))
 left-distributive-mul-dist-ℕ (succ-ℕ m) zero-ℕ zero-ℕ = refl
 left-distributive-mul-dist-ℕ (succ-ℕ m) zero-ℕ (succ-ℕ k) =
-  ap ( dist-ℕ (mul-ℕ (succ-ℕ k) (succ-ℕ m)))
+  ap ( dist-ℕ ((succ-ℕ k) *ℕ (succ-ℕ m)))
      ( inv (right-zero-law-mul-ℕ (succ-ℕ k)))
 left-distributive-mul-dist-ℕ (succ-ℕ m) (succ-ℕ n) zero-ℕ = refl
 left-distributive-mul-dist-ℕ (succ-ℕ m) (succ-ℕ n) (succ-ℕ k) =
@@ -343,12 +343,12 @@ left-distributive-mul-dist-ℕ (succ-ℕ m) (succ-ℕ n) (succ-ℕ k) =
         ( right-successor-law-mul-ℕ (succ-ℕ k) n)) ∙
       ( ( translation-invariant-dist-ℕ
           ( succ-ℕ k)
-          ( mul-ℕ (succ-ℕ k) m)
-          ( mul-ℕ (succ-ℕ k) n)) ∙
+          ( (succ-ℕ k) *ℕ m)
+          ( (succ-ℕ k) *ℕ n)) ∙
         ( inv (left-distributive-mul-dist-ℕ m n (succ-ℕ k)))))
 
 right-distributive-mul-dist-ℕ :
-  (x y k : ℕ) → mul-ℕ (dist-ℕ x y) k ＝ dist-ℕ (mul-ℕ x k) (mul-ℕ y k)
+  (x y k : ℕ) → (dist-ℕ x y) *ℕ k ＝ dist-ℕ (x *ℕ k) (y *ℕ k)
 right-distributive-mul-dist-ℕ x y k =
   ( commutative-mul-ℕ (dist-ℕ x y) k) ∙
   ( ( left-distributive-mul-dist-ℕ x y k) ∙

--- a/src/elementary-number-theory/distance-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/distance-natural-numbers.lagda.md
@@ -110,7 +110,7 @@ triangle-inequality-dist-ℕ zero-ℕ (succ-ℕ n) (succ-ℕ k) =
   concatenate-eq-leq-eq-ℕ
     ( inv (ap succ-ℕ (left-unit-law-dist-ℕ n)))
     ( triangle-inequality-dist-ℕ zero-ℕ n k)
-    ( ( ap (succ-ℕ ∘ (add-ℕ' (dist-ℕ k n))) (left-unit-law-dist-ℕ k)) ∙
+    ( ( ap (succ-ℕ ∘ (_+ℕ (dist-ℕ k n))) (left-unit-law-dist-ℕ k)) ∙
       ( inv (left-successor-law-add-ℕ k (dist-ℕ k n))))
 triangle-inequality-dist-ℕ (succ-ℕ m) zero-ℕ zero-ℕ = refl-leq-ℕ (succ-ℕ m)
 triangle-inequality-dist-ℕ (succ-ℕ m) zero-ℕ (succ-ℕ k) =
@@ -250,7 +250,7 @@ is-total-dist-ℕ x y z | inr (inl (inr (pair H1 H2))) =
 is-total-dist-ℕ x y z | inr (inr (inl (pair H1 H2))) =
   inr
     ( inr
-      ( ( ap (add-ℕ' (dist-ℕ x y)) (symmetric-dist-ℕ x z)) ∙
+      ( ( ap (_+ℕ (dist-ℕ x y)) (symmetric-dist-ℕ x z)) ∙
         ( ( triangle-equality-dist-ℕ z x y H1 H2) ∙
           ( symmetric-dist-ℕ z y))))
 is-total-dist-ℕ x y z | inr (inr (inr (pair H1 H2))) =

--- a/src/elementary-number-theory/distance-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/distance-natural-numbers.lagda.md
@@ -117,7 +117,7 @@ triangle-inequality-dist-ℕ (succ-ℕ m) zero-ℕ (succ-ℕ k) =
   concatenate-eq-leq-eq-ℕ
     ( inv (ap succ-ℕ (right-unit-law-dist-ℕ m)))
     ( triangle-inequality-dist-ℕ m zero-ℕ k)
-    ( ap (succ-ℕ ∘ (add-ℕ (dist-ℕ m k))) (right-unit-law-dist-ℕ k))
+    ( ap (succ-ℕ ∘ ((dist-ℕ m k) +ℕ_)) (right-unit-law-dist-ℕ k))
 triangle-inequality-dist-ℕ (succ-ℕ m) (succ-ℕ n) zero-ℕ =
   concatenate-leq-eq-ℕ
     ( dist-ℕ m n)
@@ -233,18 +233,18 @@ is-total-dist-ℕ x y z | inl (inr (pair H1 H2)) =
   inr
     ( inl
       ( ( commutative-add-ℕ (dist-ℕ y z) (dist-ℕ x z)) ∙
-        ( ( ap (add-ℕ (dist-ℕ x z)) (symmetric-dist-ℕ y z)) ∙
+        ( ( ap ((dist-ℕ x z) +ℕ_) (symmetric-dist-ℕ y z)) ∙
           ( triangle-equality-dist-ℕ x z y H1 H2))))
 is-total-dist-ℕ x y z | inr (inl (inl (pair H1 H2))) =
   inr
     ( inl
-      ( ( ap (add-ℕ (dist-ℕ y z)) (symmetric-dist-ℕ x z)) ∙
+      ( ( ap ((dist-ℕ y z) +ℕ_) (symmetric-dist-ℕ x z)) ∙
         ( ( triangle-equality-dist-ℕ y z x H1 H2) ∙
           ( symmetric-dist-ℕ y x))))
 is-total-dist-ℕ x y z | inr (inl (inr (pair H1 H2))) =
   inr
     ( inr
-      ( ( ap (add-ℕ (dist-ℕ x z)) (symmetric-dist-ℕ x y)) ∙
+      ( ( ap ((dist-ℕ x z) +ℕ_) (symmetric-dist-ℕ x y)) ∙
         ( ( commutative-add-ℕ (dist-ℕ x z) (dist-ℕ y x)) ∙
           ( triangle-equality-dist-ℕ y x z H1 H2))))
 is-total-dist-ℕ x y z | inr (inr (inl (pair H1 H2))) =

--- a/src/elementary-number-theory/distance-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/distance-natural-numbers.lagda.md
@@ -99,7 +99,7 @@ right-unit-law-dist-ℕ (succ-ℕ n) = refl
 
 ```agda
 triangle-inequality-dist-ℕ :
-  (m n k : ℕ) → (dist-ℕ m n) ≤-ℕ (add-ℕ (dist-ℕ m k) (dist-ℕ k n))
+  (m n k : ℕ) → (dist-ℕ m n) ≤-ℕ ((dist-ℕ m k) +ℕ (dist-ℕ k n))
 triangle-inequality-dist-ℕ zero-ℕ zero-ℕ zero-ℕ = star
 triangle-inequality-dist-ℕ zero-ℕ zero-ℕ (succ-ℕ k) = star
 triangle-inequality-dist-ℕ zero-ℕ (succ-ℕ n) zero-ℕ =
@@ -123,14 +123,14 @@ triangle-inequality-dist-ℕ (succ-ℕ m) (succ-ℕ n) zero-ℕ =
     ( dist-ℕ m n)
     ( transitive-leq-ℕ
       ( dist-ℕ m n)
-      ( succ-ℕ (add-ℕ (dist-ℕ m zero-ℕ) (dist-ℕ zero-ℕ n)))
-      ( succ-ℕ (succ-ℕ (add-ℕ (dist-ℕ m zero-ℕ) (dist-ℕ zero-ℕ n))))
-      ( succ-leq-ℕ (succ-ℕ (add-ℕ (dist-ℕ m zero-ℕ) (dist-ℕ zero-ℕ n))))
+      ( succ-ℕ ((dist-ℕ m zero-ℕ) +ℕ (dist-ℕ zero-ℕ n)))
+      ( succ-ℕ (succ-ℕ ((dist-ℕ m zero-ℕ) +ℕ (dist-ℕ zero-ℕ n))))
+      ( succ-leq-ℕ (succ-ℕ ((dist-ℕ m zero-ℕ) +ℕ (dist-ℕ zero-ℕ n))))
       ( transitive-leq-ℕ
         ( dist-ℕ m n)
-        ( add-ℕ (dist-ℕ m zero-ℕ) (dist-ℕ zero-ℕ n))
-        ( succ-ℕ (add-ℕ (dist-ℕ m zero-ℕ) (dist-ℕ zero-ℕ n)))
-        ( succ-leq-ℕ (add-ℕ (dist-ℕ m zero-ℕ) (dist-ℕ zero-ℕ n)))
+        ( (dist-ℕ m zero-ℕ) +ℕ (dist-ℕ zero-ℕ n))
+        ( succ-ℕ ((dist-ℕ m zero-ℕ) +ℕ (dist-ℕ zero-ℕ n)))
+        ( succ-leq-ℕ ((dist-ℕ m zero-ℕ) +ℕ (dist-ℕ zero-ℕ n)))
         ( triangle-inequality-dist-ℕ m n zero-ℕ)))
     ( ( ap (succ-ℕ ∘ succ-ℕ)
            ( ap-add-ℕ (right-unit-law-dist-ℕ m) (left-unit-law-dist-ℕ n))) ∙
@@ -143,7 +143,7 @@ triangle-inequality-dist-ℕ (succ-ℕ m) (succ-ℕ n) (succ-ℕ k) =
 
 ```agda
 is-additive-right-inverse-dist-ℕ :
-  (x y : ℕ) → x ≤-ℕ y → add-ℕ x (dist-ℕ x y) ＝ y
+  (x y : ℕ) → x ≤-ℕ y → x +ℕ (dist-ℕ x y) ＝ y
 is-additive-right-inverse-dist-ℕ zero-ℕ zero-ℕ H = refl
 is-additive-right-inverse-dist-ℕ zero-ℕ (succ-ℕ y) star =
   left-unit-law-add-ℕ (succ-ℕ y)
@@ -152,33 +152,33 @@ is-additive-right-inverse-dist-ℕ (succ-ℕ x) (succ-ℕ y) H =
   ( ap succ-ℕ (is-additive-right-inverse-dist-ℕ x y H))
 
 rewrite-left-add-dist-ℕ :
-  (x y z : ℕ) → add-ℕ x y ＝ z → x ＝ dist-ℕ y z
+  (x y z : ℕ) → x +ℕ y ＝ z → x ＝ dist-ℕ y z
 rewrite-left-add-dist-ℕ zero-ℕ zero-ℕ .zero-ℕ refl = refl
-rewrite-left-add-dist-ℕ zero-ℕ (succ-ℕ y) .(succ-ℕ (add-ℕ zero-ℕ y)) refl =
+rewrite-left-add-dist-ℕ zero-ℕ (succ-ℕ y) .(succ-ℕ (zero-ℕ +ℕ y)) refl =
   ( inv (dist-eq-ℕ' y)) ∙
   ( inv (ap (dist-ℕ (succ-ℕ y)) (left-unit-law-add-ℕ (succ-ℕ y))))
 rewrite-left-add-dist-ℕ (succ-ℕ x) zero-ℕ .(succ-ℕ x) refl = refl
 rewrite-left-add-dist-ℕ (succ-ℕ x) (succ-ℕ y) ._ refl =
-  rewrite-left-add-dist-ℕ (succ-ℕ x) y (add-ℕ (succ-ℕ x) y) refl
+  rewrite-left-add-dist-ℕ (succ-ℕ x) y ((succ-ℕ x) +ℕ y) refl
 
 rewrite-left-dist-add-ℕ :
-  (x y z : ℕ) → y ≤-ℕ z → x ＝ dist-ℕ y z → add-ℕ x y ＝ z
+  (x y z : ℕ) → y ≤-ℕ z → x ＝ dist-ℕ y z → x +ℕ y ＝ z
 rewrite-left-dist-add-ℕ .(dist-ℕ y z) y z H refl =
   ( commutative-add-ℕ (dist-ℕ y z) y) ∙
   ( is-additive-right-inverse-dist-ℕ y z H)
 
 rewrite-right-add-dist-ℕ :
-  (x y z : ℕ) → add-ℕ x y ＝ z → y ＝ dist-ℕ x z
+  (x y z : ℕ) → x +ℕ y ＝ z → y ＝ dist-ℕ x z
 rewrite-right-add-dist-ℕ x y z p =
   rewrite-left-add-dist-ℕ y x z (commutative-add-ℕ y x ∙ p)
 
 rewrite-right-dist-add-ℕ :
-  (x y z : ℕ) → x ≤-ℕ z → y ＝ dist-ℕ x z → add-ℕ x y ＝ z
+  (x y z : ℕ) → x ≤-ℕ z → y ＝ dist-ℕ x z → x +ℕ y ＝ z
 rewrite-right-dist-add-ℕ x .(dist-ℕ x z) z H refl =
   is-additive-right-inverse-dist-ℕ x z H
 
 is-difference-dist-ℕ :
-  (x y : ℕ) → x ≤-ℕ y → add-ℕ x (dist-ℕ x y) ＝ y
+  (x y : ℕ) → x ≤-ℕ y → x +ℕ (dist-ℕ x y) ＝ y
 is-difference-dist-ℕ zero-ℕ zero-ℕ H = refl
 is-difference-dist-ℕ zero-ℕ (succ-ℕ y) H = left-unit-law-add-ℕ (succ-ℕ y)
 is-difference-dist-ℕ (succ-ℕ x) (succ-ℕ y) H =
@@ -186,7 +186,7 @@ is-difference-dist-ℕ (succ-ℕ x) (succ-ℕ y) H =
   ( ap succ-ℕ (is-difference-dist-ℕ x y H))
 
 is-difference-dist-ℕ' :
-  (x y : ℕ) → x ≤-ℕ y → add-ℕ (dist-ℕ x y) x ＝ y
+  (x y : ℕ) → x ≤-ℕ y → (dist-ℕ x y) +ℕ x ＝ y
 is-difference-dist-ℕ' x y H =
   ( commutative-add-ℕ (dist-ℕ x y) x) ∙
   ( is-difference-dist-ℕ x y H)
@@ -195,11 +195,11 @@ is-difference-dist-ℕ' x y H =
 ### The distance from `n` to `n + m` is `m`
 
 ```agda
-dist-add-ℕ : (x y : ℕ) → dist-ℕ x (add-ℕ x y) ＝ y
-dist-add-ℕ x y = inv (rewrite-right-add-dist-ℕ x y (add-ℕ x y) refl)
+dist-add-ℕ : (x y : ℕ) → dist-ℕ x (x +ℕ y) ＝ y
+dist-add-ℕ x y = inv (rewrite-right-add-dist-ℕ x y (x +ℕ y) refl)
 
-dist-add-ℕ' : (x y : ℕ) → dist-ℕ (add-ℕ x y) x ＝ y
-dist-add-ℕ' x y = symmetric-dist-ℕ (add-ℕ x y) x ∙ dist-add-ℕ x y
+dist-add-ℕ' : (x y : ℕ) → dist-ℕ (x +ℕ y) x ＝ y
+dist-add-ℕ' x y = symmetric-dist-ℕ (x +ℕ y) x ∙ dist-add-ℕ x y
 ```
 
 ### If three elements are ordered linearly, then their distances add up
@@ -207,7 +207,7 @@ dist-add-ℕ' x y = symmetric-dist-ℕ (add-ℕ x y) x ∙ dist-add-ℕ x y
 ```agda
 triangle-equality-dist-ℕ :
   (x y z : ℕ) → (x ≤-ℕ y) → (y ≤-ℕ z) →
-  add-ℕ (dist-ℕ x y) (dist-ℕ y z) ＝ dist-ℕ x z
+  (dist-ℕ x y) +ℕ (dist-ℕ y z) ＝ dist-ℕ x z
 triangle-equality-dist-ℕ zero-ℕ zero-ℕ zero-ℕ H1 H2 = refl
 triangle-equality-dist-ℕ zero-ℕ zero-ℕ (succ-ℕ z) star star =
   ap succ-ℕ (left-unit-law-add-ℕ z)
@@ -220,9 +220,9 @@ triangle-equality-dist-ℕ (succ-ℕ x) (succ-ℕ y) (succ-ℕ z) H1 H2 =
 cases-dist-ℕ :
   (x y z : ℕ) → UU lzero
 cases-dist-ℕ x y z =
-  ( add-ℕ (dist-ℕ x y) (dist-ℕ y z) ＝ dist-ℕ x z) +
-  ( ( add-ℕ (dist-ℕ y z) (dist-ℕ x z) ＝ dist-ℕ x y) +
-    ( add-ℕ (dist-ℕ x z) (dist-ℕ x y) ＝ dist-ℕ y z))
+  ( (dist-ℕ x y) +ℕ (dist-ℕ y z) ＝ dist-ℕ x z) +
+  ( ( (dist-ℕ y z) +ℕ (dist-ℕ x z) ＝ dist-ℕ x y) +
+    ( (dist-ℕ x z) +ℕ (dist-ℕ x y) ＝ dist-ℕ y z))
 
 is-total-dist-ℕ :
   (x y z : ℕ) → cases-dist-ℕ x y z
@@ -305,7 +305,7 @@ left-successor-law-dist-ℕ (succ-ℕ x) (succ-ℕ y) H =
 
 ```agda
 translation-invariant-dist-ℕ :
-  (k m n : ℕ) → dist-ℕ (add-ℕ k m) (add-ℕ k n) ＝ dist-ℕ m n
+  (k m n : ℕ) → dist-ℕ (k +ℕ m) (k +ℕ n) ＝ dist-ℕ m n
 translation-invariant-dist-ℕ zero-ℕ m n =
   ap-dist-ℕ (left-unit-law-add-ℕ m) (left-unit-law-add-ℕ n)
 translation-invariant-dist-ℕ (succ-ℕ k) m n =
@@ -313,7 +313,7 @@ translation-invariant-dist-ℕ (succ-ℕ k) m n =
   ( translation-invariant-dist-ℕ k m n)
 
 translation-invariant-dist-ℕ' :
-  (k m n : ℕ) → dist-ℕ (add-ℕ m k) (add-ℕ n k) ＝ dist-ℕ m n
+  (k m n : ℕ) → dist-ℕ (m +ℕ k) (n +ℕ k) ＝ dist-ℕ m n
 translation-invariant-dist-ℕ' k m n =
   ( ap-dist-ℕ (commutative-add-ℕ m k) (commutative-add-ℕ n k)) ∙
   ( translation-invariant-dist-ℕ k m n)

--- a/src/elementary-number-theory/divisibility-integers.lagda.md
+++ b/src/elementary-number-theory/divisibility-integers.lagda.md
@@ -105,7 +105,7 @@ div-is-unit-ℤ :
   (x y : ℤ) → is-unit-ℤ x → div-ℤ x y
 pr1 (div-is-unit-ℤ x y (pair d p)) = y *ℤ d
 pr2 (div-is-unit-ℤ x y (pair d p)) =
-  associative-mul-ℤ y d x ∙ (ap (mul-ℤ y) p ∙ right-unit-law-mul-ℤ y)
+  associative-mul-ℤ y d x ∙ (ap (y *ℤ_) p ∙ right-unit-law-mul-ℤ y)
 ```
 
 ### The equivalence relation `sim-unit-ℤ`
@@ -144,7 +144,7 @@ trans-div-ℤ :
 pr1 (trans-div-ℤ x y z (pair d p) (pair e q)) = e *ℤ d
 pr2 (trans-div-ℤ x y z (pair d p) (pair e q)) =
   ( associative-mul-ℤ e d x) ∙
-    ( ( ap (mul-ℤ e) p) ∙
+    ( ( ap (e *ℤ_) p) ∙
       ( q))
 ```
 
@@ -249,7 +249,7 @@ pr2 (preserves-div-mul-ℤ k x y (pair q p)) =
   ( inv (associative-mul-ℤ q k x)) ∙
     ( ( ap (_*ℤ x) (commutative-mul-ℤ q k)) ∙
       ( ( associative-mul-ℤ k q x) ∙
-        ( ap (mul-ℤ k) p)))
+        ( ap (k *ℤ_) p)))
 ```
 
 ### Multiplication by a nonzero number reflects divisibility
@@ -411,7 +411,7 @@ pr1 (is-unit-mul-ℤ x y (pair d p) (pair e q)) = e *ℤ d
 pr2 (is-unit-mul-ℤ x y (pair d p) (pair e q)) =
   ( associative-mul-ℤ e d (x *ℤ y)) ∙
     ( ( ap
-        ( mul-ℤ e)
+        ( e *ℤ_)
         ( ( inv (associative-mul-ℤ d x y)) ∙
           ( ap (_*ℤ y) p))) ∙
       ( q))
@@ -424,13 +424,13 @@ is-unit-left-factor-mul-ℤ :
   (x y : ℤ) → is-unit-ℤ (x *ℤ y) → is-unit-ℤ x
 pr1 (is-unit-left-factor-mul-ℤ x y (pair d p)) = d *ℤ y
 pr2 (is-unit-left-factor-mul-ℤ x y (pair d p)) =
-  associative-mul-ℤ d y x ∙ (ap (mul-ℤ d) (commutative-mul-ℤ y x) ∙ p)
+  associative-mul-ℤ d y x ∙ (ap (d *ℤ_) (commutative-mul-ℤ y x) ∙ p)
 
 is-unit-right-factor-ℤ :
   (x y : ℤ) → is-unit-ℤ (x *ℤ y) → is-unit-ℤ y
 is-unit-right-factor-ℤ x y (pair d p) =
   is-unit-left-factor-mul-ℤ y x
-    ( pair d (ap (mul-ℤ d) (commutative-mul-ℤ y x) ∙ p))
+    ( pair d (ap (d *ℤ_) (commutative-mul-ℤ y x) ∙ p))
 ```
 
 ### The relations `presim-unit-ℤ` and `sim-unit-ℤ` are logically equivalent
@@ -476,7 +476,7 @@ is-zero-sim-unit-ℤ :
 is-zero-sim-unit-ℤ {x} {y} H p =
   double-negation-elim-is-decidable
     ( has-decidable-equality-ℤ y zero-ℤ)
-    ( λ g → g (inv (β g) ∙ (ap (mul-ℤ (u g)) p ∙ right-zero-law-mul-ℤ (u g))))
+    ( λ g → g (inv (β g) ∙ (ap ((u g) *ℤ_) p ∙ right-zero-law-mul-ℤ (u g))))
   where
   K : is-nonzero-ℤ y → presim-unit-ℤ x y
   K g = H (λ {(pair u v) → g v})
@@ -512,7 +512,7 @@ symm-presim-unit-ℤ {x} {y} (pair (pair u H) p) =
   pr1 (f (inl refl)) = one-unit-ℤ
   pr2 (f (inl refl)) = inv p
   pr1 (f (inr refl)) = neg-one-unit-ℤ
-  pr2 (f (inr refl)) = inv (inv (neg-neg-ℤ x) ∙ ap (mul-ℤ neg-one-ℤ) p)
+  pr2 (f (inr refl)) = inv (inv (neg-neg-ℤ x) ∙ ap (neg-one-ℤ *ℤ_) p)
 
 symm-sim-unit-ℤ : {x y : ℤ} → sim-unit-ℤ x y → sim-unit-ℤ y x
 symm-sim-unit-ℤ {x} {y} H f =
@@ -565,7 +565,7 @@ antisymmetric-div-ℤ x y (pair d p) (pair e q) H =
     is-injective-mul-ℤ x g
       ( ( commutative-mul-ℤ x (e *ℤ d)) ∙
         ( ( associative-mul-ℤ e d x) ∙
-          ( ( ap (mul-ℤ e) p) ∙
+          ( ( ap (e *ℤ_) p) ∙
             ( q ∙ inv (right-unit-law-mul-ℤ x)))))
   pr2 (f (inr g)) = p
 ```
@@ -595,7 +595,7 @@ pr2 (div-presim-unit-ℤ {x} {y} {x'} {y'} (pair u q) (pair v r) (pair d p)) =
         ( ( inv (associative-mul-ℤ (int-unit-ℤ u) (int-unit-ℤ u) x)) ∙
           ( ap (_*ℤ x) (idempotent-is-unit-ℤ (is-unit-int-unit-ℤ u))))) ∙
       ( ( associative-mul-ℤ (int-unit-ℤ v) d x) ∙
-        ( ( ap (mul-ℤ (int-unit-ℤ v)) p) ∙
+        ( ( ap ((int-unit-ℤ v) *ℤ_) p) ∙
           ( r)))))
 
 div-sim-unit-ℤ :

--- a/src/elementary-number-theory/divisibility-integers.lagda.md
+++ b/src/elementary-number-theory/divisibility-integers.lagda.md
@@ -305,7 +305,7 @@ pr2 (div-div-int-ℕ {succ-ℕ x} {y} (pair d p)) =
   is-injective-int-ℕ
     ( ( inv (mul-int-ℕ (abs-ℤ d) (succ-ℕ x))) ∙
       ( ( ap
-          ( mul-ℤ' (inr (inr x)))
+          ( _*ℤ (inr (inr x)))
           { int-abs-ℤ d}
           { d}
           ( int-abs-is-nonnegative-ℤ d
@@ -585,13 +585,13 @@ div-presim-unit-ℤ :
 pr1 (div-presim-unit-ℤ {x} {y} {x'} {y'} (pair u q) (pair v r) (pair d p)) =
   ((int-unit-ℤ v) *ℤ d) *ℤ (int-unit-ℤ u)
 pr2 (div-presim-unit-ℤ {x} {y} {x'} {y'} (pair u q) (pair v r) (pair d p)) =
-  ( ap (mul-ℤ (((int-unit-ℤ v) *ℤ d) *ℤ (int-unit-ℤ u))) (inv q)) ∙
+  ( ap ((((int-unit-ℤ v) *ℤ d) *ℤ (int-unit-ℤ u)) *ℤ_) (inv q)) ∙
   ( ( associative-mul-ℤ
       ( (int-unit-ℤ v) *ℤ d)
       ( int-unit-ℤ u)
       ( (int-unit-ℤ u) *ℤ x)) ∙
     ( ( ap
-        ( mul-ℤ ((int-unit-ℤ v) *ℤ d))
+        ( ((int-unit-ℤ v) *ℤ d) *ℤ_)
         ( ( inv (associative-mul-ℤ (int-unit-ℤ u) (int-unit-ℤ u) x)) ∙
           ( ap (_*ℤ x) (idempotent-is-unit-ℤ (is-unit-int-unit-ℤ u))))) ∙
       ( ( associative-mul-ℤ (int-unit-ℤ v) d x) ∙

--- a/src/elementary-number-theory/divisibility-integers.lagda.md
+++ b/src/elementary-number-theory/divisibility-integers.lagda.md
@@ -247,7 +247,7 @@ preserves-div-mul-ℤ :
 pr1 (preserves-div-mul-ℤ k x y (pair q p)) = q
 pr2 (preserves-div-mul-ℤ k x y (pair q p)) =
   ( inv (associative-mul-ℤ q k x)) ∙
-    ( ( ap (mul-ℤ' x) (commutative-mul-ℤ q k)) ∙
+    ( ( ap (_*ℤ x) (commutative-mul-ℤ q k)) ∙
       ( ( associative-mul-ℤ k q x) ∙
         ( ap (mul-ℤ k) p)))
 ```
@@ -261,7 +261,7 @@ pr1 (reflects-div-mul-ℤ k x y H (pair q p)) = q
 pr2 (reflects-div-mul-ℤ k x y H (pair q p)) =
   is-injective-mul-ℤ k H
     ( ( inv (associative-mul-ℤ k q x)) ∙
-      ( ( ap (mul-ℤ' x) (commutative-mul-ℤ k q)) ∙
+      ( ( ap (_*ℤ x) (commutative-mul-ℤ k q)) ∙
         ( ( associative-mul-ℤ q k x) ∙
           ( p))))
 ```
@@ -413,7 +413,7 @@ pr2 (is-unit-mul-ℤ x y (pair d p) (pair e q)) =
     ( ( ap
         ( mul-ℤ e)
         ( ( inv (associative-mul-ℤ d x y)) ∙
-          ( ap (mul-ℤ' y) p))) ∙
+          ( ap (_*ℤ y) p))) ∙
       ( q))
 
 mul-unit-ℤ : unit-ℤ → unit-ℤ → unit-ℤ
@@ -461,7 +461,7 @@ presim-unit-sim-unit-ℤ {inr (inr x)} {inr (inr y)} H =
 is-nonzero-presim-unit-ℤ :
   {x y : ℤ} → presim-unit-ℤ x y → is-nonzero-ℤ x → is-nonzero-ℤ y
 is-nonzero-presim-unit-ℤ {x} {y} (pair (pair v (pair u α)) β) f p =
-  Eq-eq-ℤ (ap (mul-ℤ' u) (inv q) ∙ (commutative-mul-ℤ v u ∙ α))
+  Eq-eq-ℤ (ap (_*ℤ u) (inv q) ∙ (commutative-mul-ℤ v u ∙ α))
   where
   q : is-zero-ℤ v
   q = is-injective-mul-ℤ' x f {v} {zero-ℤ} (β ∙ p)
@@ -593,7 +593,7 @@ pr2 (div-presim-unit-ℤ {x} {y} {x'} {y'} (pair u q) (pair v r) (pair d p)) =
     ( ( ap
         ( mul-ℤ ((int-unit-ℤ v) *ℤ d))
         ( ( inv (associative-mul-ℤ (int-unit-ℤ u) (int-unit-ℤ u) x)) ∙
-          ( ap (mul-ℤ' x) (idempotent-is-unit-ℤ (is-unit-int-unit-ℤ u))))) ∙
+          ( ap (_*ℤ x) (idempotent-is-unit-ℤ (is-unit-int-unit-ℤ u))))) ∙
       ( ( associative-mul-ℤ (int-unit-ℤ v) d x) ∙
         ( ( ap (mul-ℤ (int-unit-ℤ v)) p) ∙
           ( r)))))
@@ -635,7 +635,7 @@ is-plus-or-minus-sim-unit-ℤ {x} {y} H | inr nz | inl pos =
       ＝ one-ℤ *ℤ x
         by (inv (left-unit-law-mul-ℤ x))
       ＝ mul-ℤ (int-unit-ℤ (pr1 (H (λ u → nz (pr1 u))))) x
-        by inv (ap (mul-ℤ' x) pos)
+        by inv (ap (_*ℤ x) pos)
       ＝ y
         by pr2 (H (λ u → nz (pr1 u))))
 is-plus-or-minus-sim-unit-ℤ {x} {y} H | inr nz | inr p =
@@ -643,7 +643,7 @@ is-plus-or-minus-sim-unit-ℤ {x} {y} H | inr nz | inr p =
     ( equational-reasoning
       neg-ℤ x
       ＝ mul-ℤ (int-unit-ℤ (pr1 (H (λ u → nz (pr1 u))))) x
-        by ap (mul-ℤ' x) (inv p)
+        by ap (_*ℤ x) (inv p)
       ＝ y
         by pr2 (H (λ u → nz (pr1 u))))
 ```

--- a/src/elementary-number-theory/divisibility-integers.lagda.md
+++ b/src/elementary-number-theory/divisibility-integers.lagda.md
@@ -127,7 +127,7 @@ sim-unit-ℤ x y = ¬ (is-zero-ℤ x × is-zero-ℤ y) → presim-unit-ℤ x y
 
 ```agda
 is-prop-div-ℤ : (d x : ℤ) → is-nonzero-ℤ d → is-prop (div-ℤ d x)
-is-prop-div-ℤ d x f = is-prop-map-is-emb (is-emb-mul-ℤ' d f) x
+is-prop-div-ℤ d x f = is-prop-map-is-emb (is-emb-right-mul-ℤ d f) x
 ```
 
 ### The divisibility relation is a preorder
@@ -259,7 +259,7 @@ reflects-div-mul-ℤ :
   (k x y : ℤ) → is-nonzero-ℤ k → div-ℤ (k *ℤ x) (k *ℤ y) → div-ℤ x y
 pr1 (reflects-div-mul-ℤ k x y H (pair q p)) = q
 pr2 (reflects-div-mul-ℤ k x y H (pair q p)) =
-  is-injective-mul-ℤ k H
+  is-injective-left-mul-ℤ k H
     ( ( inv (associative-mul-ℤ k q x)) ∙
       ( ( ap (_*ℤ x) (commutative-mul-ℤ k q)) ∙
         ( ( associative-mul-ℤ q k x) ∙
@@ -464,7 +464,7 @@ is-nonzero-presim-unit-ℤ {x} {y} (pair (pair v (pair u α)) β) f p =
   Eq-eq-ℤ (ap (_*ℤ u) (inv q) ∙ (commutative-mul-ℤ v u ∙ α))
   where
   q : is-zero-ℤ v
-  q = is-injective-mul-ℤ' x f {v} {zero-ℤ} (β ∙ p)
+  q = is-injective-right-mul-ℤ x f {v} {zero-ℤ} (β ∙ p)
 
 is-nonzero-sim-unit-ℤ :
   {x y : ℤ} → sim-unit-ℤ x y → is-nonzero-ℤ x → is-nonzero-ℤ y
@@ -562,7 +562,7 @@ antisymmetric-div-ℤ x y (pair d p) (pair e q) H =
   pr1 (pr1 (f (inr g))) = d
   pr1 (pr2 (pr1 (f (inr g)))) = e
   pr2 (pr2 (pr1 (f (inr g)))) =
-    is-injective-mul-ℤ x g
+    is-injective-left-mul-ℤ x g
       ( ( commutative-mul-ℤ x (e *ℤ d)) ∙
         ( ( associative-mul-ℤ e d x) ∙
           ( ( ap (e *ℤ_) p) ∙

--- a/src/elementary-number-theory/divisibility-integers.lagda.md
+++ b/src/elementary-number-theory/divisibility-integers.lagda.md
@@ -634,7 +634,7 @@ is-plus-or-minus-sim-unit-ℤ {x} {y} H | inr nz | inl pos =
       x
       ＝ one-ℤ *ℤ x
         by (inv (left-unit-law-mul-ℤ x))
-      ＝ mul-ℤ (int-unit-ℤ (pr1 (H (λ u → nz (pr1 u))))) x
+      ＝ (int-unit-ℤ (pr1 (H (λ u → nz (pr1 u))))) *ℤ x
         by inv (ap (_*ℤ x) pos)
       ＝ y
         by pr2 (H (λ u → nz (pr1 u))))
@@ -642,7 +642,7 @@ is-plus-or-minus-sim-unit-ℤ {x} {y} H | inr nz | inr p =
   inr
     ( equational-reasoning
       neg-ℤ x
-      ＝ mul-ℤ (int-unit-ℤ (pr1 (H (λ u → nz (pr1 u))))) x
+      ＝ (int-unit-ℤ (pr1 (H (λ u → nz (pr1 u))))) *ℤ x
         by ap (_*ℤ x) (inv p)
       ＝ y
         by pr2 (H (λ u → nz (pr1 u))))

--- a/src/elementary-number-theory/divisibility-integers.lagda.md
+++ b/src/elementary-number-theory/divisibility-integers.lagda.md
@@ -583,9 +583,9 @@ div-presim-unit-ℤ :
   {x y x' y' : ℤ} → presim-unit-ℤ x x' → presim-unit-ℤ y y' →
   div-ℤ x y → div-ℤ x' y'
 pr1 (div-presim-unit-ℤ {x} {y} {x'} {y'} (pair u q) (pair v r) (pair d p)) =
-  mul-ℤ ((int-unit-ℤ v) *ℤ d) (int-unit-ℤ u)
+  ((int-unit-ℤ v) *ℤ d) *ℤ (int-unit-ℤ u)
 pr2 (div-presim-unit-ℤ {x} {y} {x'} {y'} (pair u q) (pair v r) (pair d p)) =
-  ( ap (mul-ℤ (mul-ℤ ((int-unit-ℤ v) *ℤ d) (int-unit-ℤ u))) (inv q)) ∙
+  ( ap (mul-ℤ (((int-unit-ℤ v) *ℤ d) *ℤ (int-unit-ℤ u))) (inv q)) ∙
   ( ( associative-mul-ℤ
       ( (int-unit-ℤ v) *ℤ d)
       ( int-unit-ℤ u)

--- a/src/elementary-number-theory/divisibility-integers.lagda.md
+++ b/src/elementary-number-theory/divisibility-integers.lagda.md
@@ -197,8 +197,8 @@ is-zero-is-zero-div-ℤ x .zero-ℤ k-div-x refl = is-zero-div-zero-ℤ x k-div-
 ### If `x` divides both `y` and `z`, then it divides `y + z`
 
 ```agda
-div-add-ℤ : (x y z : ℤ) → div-ℤ x y → div-ℤ x z → div-ℤ x (add-ℤ y z)
-pr1 (div-add-ℤ x y z (pair d p) (pair e q)) = add-ℤ d e
+div-add-ℤ : (x y z : ℤ) → div-ℤ x y → div-ℤ x z → div-ℤ x (y +ℤ z)
+pr1 (div-add-ℤ x y z (pair d p) (pair e q)) = d +ℤ e
 pr2 (div-add-ℤ x y z (pair d p) (pair e q)) =
   ( right-distributive-mul-add-ℤ d e x) ∙
   ( ap-add-ℤ p q)

--- a/src/elementary-number-theory/divisibility-integers.lagda.md
+++ b/src/elementary-number-theory/divisibility-integers.lagda.md
@@ -38,7 +38,7 @@ An integer `m` is said to **divide** an integer `n` if there exists an integer
 interpretation of logic into type theory, we express divisibility as follows:
 
 ```md
-  div-ℤ m n := Σ (k : ℤ), mul-ℤ k m ＝ n.
+  div-ℤ m n := Σ (k : ℤ), k *ℤ m ＝ n.
 ```
 
 If `n` is a nonzero integer, then `div-ℤ m n` is always a proposition in the
@@ -54,17 +54,17 @@ divisibility relation on the integers.
 
 ```agda
 div-ℤ : ℤ → ℤ → UU lzero
-div-ℤ d x = Σ ℤ (λ k → mul-ℤ k d ＝ x)
+div-ℤ d x = Σ ℤ (λ k → k *ℤ d ＝ x)
 
 quotient-div-ℤ : (x y : ℤ) → div-ℤ x y → ℤ
 quotient-div-ℤ x y H = pr1 H
 
 eq-quotient-div-ℤ :
-  (x y : ℤ) (H : div-ℤ x y) → mul-ℤ (quotient-div-ℤ x y H) x ＝ y
+  (x y : ℤ) (H : div-ℤ x y) → (quotient-div-ℤ x y H) *ℤ x ＝ y
 eq-quotient-div-ℤ x y H = pr2 H
 
 eq-quotient-div-ℤ' :
-  (x y : ℤ) (H : div-ℤ x y) → mul-ℤ x (quotient-div-ℤ x y H) ＝ y
+  (x y : ℤ) (H : div-ℤ x y) → x *ℤ (quotient-div-ℤ x y H) ＝ y
 eq-quotient-div-ℤ' x y H =
   commutative-mul-ℤ x (quotient-div-ℤ x y H) ∙ eq-quotient-div-ℤ x y H
 
@@ -103,7 +103,7 @@ is-unit-int-unit-ℤ = pr2
 
 div-is-unit-ℤ :
   (x y : ℤ) → is-unit-ℤ x → div-ℤ x y
-pr1 (div-is-unit-ℤ x y (pair d p)) = mul-ℤ y d
+pr1 (div-is-unit-ℤ x y (pair d p)) = y *ℤ d
 pr2 (div-is-unit-ℤ x y (pair d p)) =
   associative-mul-ℤ y d x ∙ (ap (mul-ℤ y) p ∙ right-unit-law-mul-ℤ y)
 ```
@@ -115,7 +115,7 @@ We define the equivalence relation `sim-unit-ℤ` in such a way that
 
 ```agda
 presim-unit-ℤ : ℤ → ℤ → UU lzero
-presim-unit-ℤ x y = Σ unit-ℤ (λ u → mul-ℤ (pr1 u) x ＝ y)
+presim-unit-ℤ x y = Σ unit-ℤ (λ u → (pr1 u) *ℤ x ＝ y)
 
 sim-unit-ℤ : ℤ → ℤ → UU lzero
 sim-unit-ℤ x y = ¬ (is-zero-ℤ x × is-zero-ℤ y) → presim-unit-ℤ x y
@@ -141,7 +141,7 @@ pr2 (refl-div-ℤ x) = left-unit-law-mul-ℤ x
 
 trans-div-ℤ :
   (x y z : ℤ) → div-ℤ x y → div-ℤ y z → div-ℤ x z
-pr1 (trans-div-ℤ x y z (pair d p) (pair e q)) = mul-ℤ e d
+pr1 (trans-div-ℤ x y z (pair d p) (pair e q)) = e *ℤ d
 pr2 (trans-div-ℤ x y z (pair d p) (pair e q)) =
   ( associative-mul-ℤ e d x) ∙
     ( ( ap (mul-ℤ e) p) ∙
@@ -208,9 +208,9 @@ pr2 (div-add-ℤ x y z (pair d p) (pair e q)) =
 
 ```agda
 div-mul-ℤ :
-  (k x y : ℤ) → div-ℤ x y → div-ℤ x (mul-ℤ k y)
+  (k x y : ℤ) → div-ℤ x y → div-ℤ x (k *ℤ y)
 div-mul-ℤ k x y H =
-  trans-div-ℤ x y (mul-ℤ k y) H (pair k refl)
+  trans-div-ℤ x y (k *ℤ y) H (pair k refl)
 ```
 
 ### If `x` divides `y` then it divides `-y`
@@ -228,13 +228,13 @@ neg-div-ℤ : (x y : ℤ) → div-ℤ x y → div-ℤ (neg-ℤ x) y
 pr1 (neg-div-ℤ x y (pair d p)) = neg-ℤ d
 pr2 (neg-div-ℤ x y (pair d p)) =
   equational-reasoning
-    mul-ℤ (neg-ℤ d) (neg-ℤ x)
-    ＝ neg-ℤ (mul-ℤ d (neg-ℤ x))
+    (neg-ℤ d) *ℤ (neg-ℤ x)
+    ＝ neg-ℤ (d *ℤ (neg-ℤ x))
       by left-negative-law-mul-ℤ d (neg-ℤ x)
-    ＝ neg-ℤ (neg-ℤ (mul-ℤ d x))
+    ＝ neg-ℤ (neg-ℤ (d *ℤ x))
       by ap neg-ℤ (right-negative-law-mul-ℤ d x)
-    ＝ (mul-ℤ d x)
-      by neg-neg-ℤ (mul-ℤ d x)
+    ＝ (d *ℤ x)
+      by neg-neg-ℤ (d *ℤ x)
     ＝ y
       by p
 ```
@@ -243,7 +243,7 @@ pr2 (neg-div-ℤ x y (pair d p)) =
 
 ```agda
 preserves-div-mul-ℤ :
-  (k x y : ℤ) → div-ℤ x y → div-ℤ (mul-ℤ k x) (mul-ℤ k y)
+  (k x y : ℤ) → div-ℤ x y → div-ℤ (k *ℤ x) (k *ℤ y)
 pr1 (preserves-div-mul-ℤ k x y (pair q p)) = q
 pr2 (preserves-div-mul-ℤ k x y (pair q p)) =
   ( inv (associative-mul-ℤ q k x)) ∙
@@ -256,7 +256,7 @@ pr2 (preserves-div-mul-ℤ k x y (pair q p)) =
 
 ```agda
 reflects-div-mul-ℤ :
-  (k x y : ℤ) → is-nonzero-ℤ k → div-ℤ (mul-ℤ k x) (mul-ℤ k y) → div-ℤ x y
+  (k x y : ℤ) → is-nonzero-ℤ k → div-ℤ (k *ℤ x) (k *ℤ y) → div-ℤ x y
 pr1 (reflects-div-mul-ℤ k x y H (pair q p)) = q
 pr2 (reflects-div-mul-ℤ k x y H (pair q p)) =
   is-injective-mul-ℤ k H
@@ -271,18 +271,18 @@ pr2 (reflects-div-mul-ℤ k x y H (pair q p)) =
 ```agda
 div-quotient-div-div-ℤ :
   (x y d : ℤ) (H : div-ℤ d y) → is-nonzero-ℤ d →
-  div-ℤ (mul-ℤ d x) y → div-ℤ x (quotient-div-ℤ d y H)
+  div-ℤ (d *ℤ x) y → div-ℤ x (quotient-div-ℤ d y H)
 div-quotient-div-div-ℤ x y d H f K =
   reflects-div-mul-ℤ d x
     ( quotient-div-ℤ d y H)
     ( f)
-    ( tr (div-ℤ (mul-ℤ d x)) (inv (eq-quotient-div-ℤ' d y H)) K)
+    ( tr (div-ℤ (d *ℤ x)) (inv (eq-quotient-div-ℤ' d y H)) K)
 
 div-div-quotient-div-ℤ :
   (x y d : ℤ) (H : div-ℤ d y) →
-  div-ℤ x (quotient-div-ℤ d y H) → div-ℤ (mul-ℤ d x) y
+  div-ℤ x (quotient-div-ℤ d y H) → div-ℤ (d *ℤ x) y
 div-div-quotient-div-ℤ x y d H K =
-  tr ( div-ℤ (mul-ℤ d x))
+  tr ( div-ℤ (d *ℤ x))
      ( eq-quotient-div-ℤ' d y H)
      ( preserves-div-mul-ℤ d x (quotient-div-ℤ d y H) K)
 ```
@@ -387,11 +387,11 @@ is-one-or-neg-one-is-unit-ℤ
 ### Units are idempotent
 
 ```agda
-idempotent-is-unit-ℤ : {x : ℤ} → is-unit-ℤ x → mul-ℤ x x ＝ one-ℤ
+idempotent-is-unit-ℤ : {x : ℤ} → is-unit-ℤ x → x *ℤ x ＝ one-ℤ
 idempotent-is-unit-ℤ {x} H =
   f (is-one-or-neg-one-is-unit-ℤ x H)
   where
-  f : is-one-or-neg-one-ℤ x → mul-ℤ x x ＝ one-ℤ
+  f : is-one-or-neg-one-ℤ x → x *ℤ x ＝ one-ℤ
   f (inl refl) = refl
   f (inr refl) = refl
 
@@ -406,10 +406,10 @@ abstract
 
 ```agda
 is-unit-mul-ℤ :
-  (x y : ℤ) → is-unit-ℤ x → is-unit-ℤ y → is-unit-ℤ (mul-ℤ x y)
-pr1 (is-unit-mul-ℤ x y (pair d p) (pair e q)) = mul-ℤ e d
+  (x y : ℤ) → is-unit-ℤ x → is-unit-ℤ y → is-unit-ℤ (x *ℤ y)
+pr1 (is-unit-mul-ℤ x y (pair d p) (pair e q)) = e *ℤ d
 pr2 (is-unit-mul-ℤ x y (pair d p) (pair e q)) =
-  ( associative-mul-ℤ e d (mul-ℤ x y)) ∙
+  ( associative-mul-ℤ e d (x *ℤ y)) ∙
     ( ( ap
         ( mul-ℤ e)
         ( ( inv (associative-mul-ℤ d x y)) ∙
@@ -417,17 +417,17 @@ pr2 (is-unit-mul-ℤ x y (pair d p) (pair e q)) =
       ( q))
 
 mul-unit-ℤ : unit-ℤ → unit-ℤ → unit-ℤ
-pr1 (mul-unit-ℤ (pair x H) (pair y K)) = mul-ℤ x y
+pr1 (mul-unit-ℤ (pair x H) (pair y K)) = x *ℤ y
 pr2 (mul-unit-ℤ (pair x H) (pair y K)) = is-unit-mul-ℤ x y H K
 
 is-unit-left-factor-mul-ℤ :
-  (x y : ℤ) → is-unit-ℤ (mul-ℤ x y) → is-unit-ℤ x
-pr1 (is-unit-left-factor-mul-ℤ x y (pair d p)) = mul-ℤ d y
+  (x y : ℤ) → is-unit-ℤ (x *ℤ y) → is-unit-ℤ x
+pr1 (is-unit-left-factor-mul-ℤ x y (pair d p)) = d *ℤ y
 pr2 (is-unit-left-factor-mul-ℤ x y (pair d p)) =
   associative-mul-ℤ d y x ∙ (ap (mul-ℤ d) (commutative-mul-ℤ y x) ∙ p)
 
 is-unit-right-factor-ℤ :
-  (x y : ℤ) → is-unit-ℤ (mul-ℤ x y) → is-unit-ℤ y
+  (x y : ℤ) → is-unit-ℤ (x *ℤ y) → is-unit-ℤ y
 is-unit-right-factor-ℤ x y (pair d p) =
   is-unit-left-factor-mul-ℤ y x
     ( pair d (ap (mul-ℤ d) (commutative-mul-ℤ y x) ∙ p))
@@ -484,7 +484,7 @@ is-zero-sim-unit-ℤ {x} {y} H p =
   u g = pr1 (pr1 (K g))
   v : is-nonzero-ℤ y → ℤ
   v g = pr1 (pr2 (pr1 (K g)))
-  β : (g : is-nonzero-ℤ y) → mul-ℤ (u g) x ＝ y
+  β : (g : is-nonzero-ℤ y) → (u g) *ℤ x ＝ y
   β g = pr2 (K g)
 ```
 
@@ -563,7 +563,7 @@ antisymmetric-div-ℤ x y (pair d p) (pair e q) H =
   pr1 (pr2 (pr1 (f (inr g)))) = e
   pr2 (pr2 (pr1 (f (inr g)))) =
     is-injective-mul-ℤ x g
-      ( ( commutative-mul-ℤ x (mul-ℤ e d)) ∙
+      ( ( commutative-mul-ℤ x (e *ℤ d)) ∙
         ( ( associative-mul-ℤ e d x) ∙
           ( ( ap (mul-ℤ e) p) ∙
             ( q ∙ inv (right-unit-law-mul-ℤ x)))))
@@ -583,15 +583,15 @@ div-presim-unit-ℤ :
   {x y x' y' : ℤ} → presim-unit-ℤ x x' → presim-unit-ℤ y y' →
   div-ℤ x y → div-ℤ x' y'
 pr1 (div-presim-unit-ℤ {x} {y} {x'} {y'} (pair u q) (pair v r) (pair d p)) =
-  mul-ℤ (mul-ℤ (int-unit-ℤ v) d) (int-unit-ℤ u)
+  mul-ℤ ((int-unit-ℤ v) *ℤ d) (int-unit-ℤ u)
 pr2 (div-presim-unit-ℤ {x} {y} {x'} {y'} (pair u q) (pair v r) (pair d p)) =
-  ( ap (mul-ℤ (mul-ℤ (mul-ℤ (int-unit-ℤ v) d) (int-unit-ℤ u))) (inv q)) ∙
+  ( ap (mul-ℤ (mul-ℤ ((int-unit-ℤ v) *ℤ d) (int-unit-ℤ u))) (inv q)) ∙
   ( ( associative-mul-ℤ
-      ( mul-ℤ (int-unit-ℤ v) d)
+      ( (int-unit-ℤ v) *ℤ d)
       ( int-unit-ℤ u)
-      ( mul-ℤ (int-unit-ℤ u) x)) ∙
+      ( (int-unit-ℤ u) *ℤ x)) ∙
     ( ( ap
-        ( mul-ℤ (mul-ℤ (int-unit-ℤ v) d))
+        ( mul-ℤ ((int-unit-ℤ v) *ℤ d))
         ( ( inv (associative-mul-ℤ (int-unit-ℤ u) (int-unit-ℤ u) x)) ∙
           ( ap (mul-ℤ' x) (idempotent-is-unit-ℤ (is-unit-int-unit-ℤ u))))) ∙
       ( ( associative-mul-ℤ (int-unit-ℤ v) d x) ∙
@@ -632,7 +632,7 @@ is-plus-or-minus-sim-unit-ℤ {x} {y} H | inr nz | inl pos =
   inl
     ( equational-reasoning
       x
-      ＝ mul-ℤ one-ℤ x
+      ＝ one-ℤ *ℤ x
         by (inv (left-unit-law-mul-ℤ x))
       ＝ mul-ℤ (int-unit-ℤ (pr1 (H (λ u → nz (pr1 u))))) x
         by inv (ap (mul-ℤ' x) pos)

--- a/src/elementary-number-theory/divisibility-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/divisibility-natural-numbers.lagda.md
@@ -286,7 +286,7 @@ div-left-summand-ℕ :
 div-left-summand-ℕ zero-ℕ x y (pair m q) (pair n p) =
   pair zero-ℕ
     ( ( inv (right-zero-law-mul-ℕ n)) ∙
-      ( p ∙ (ap (add-ℕ x) ((inv q) ∙ (right-zero-law-mul-ℕ m)))))
+      ( p ∙ (ap (x +ℕ_) ((inv q) ∙ (right-zero-law-mul-ℕ m)))))
 pr1 (div-left-summand-ℕ (succ-ℕ d) x y (pair m q) (pair n p)) = dist-ℕ m n
 pr2 (div-left-summand-ℕ (succ-ℕ d) x y (pair m q) (pair n p)) =
   is-injective-add-ℕ' (m *ℕ (succ-ℕ d))
@@ -302,7 +302,7 @@ pr2 (div-left-summand-ℕ (succ-ℕ d) x y (pair m q) (pair n p)) =
               ( concatenate-eq-leq-eq-ℕ q
                 ( leq-add-ℕ' y x)
                 ( inv p))))) ∙
-        ( p ∙ (ap (add-ℕ x) (inv q)))))
+        ( p ∙ (ap (x +ℕ_) (inv q)))))
 
 div-right-summand-ℕ :
   (d x y : ℕ) → div-ℕ d x → div-ℕ d (x +ℕ y) → div-ℕ d y

--- a/src/elementary-number-theory/divisibility-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/divisibility-natural-numbers.lagda.md
@@ -137,14 +137,14 @@ antisymmetric-div-ℕ (succ-ℕ x) (succ-ℕ y) (pair k p) (pair l q) =
            ( is-one-right-is-one-mul-ℕ l k
              ( is-one-is-left-unit-mul-ℕ (l *ℕ k) x
                ( ( associative-mul-ℕ l k (succ-ℕ x)) ∙
-                 ( ap (mul-ℕ l) p ∙ q)))))) ∙
+                 ( ap (l *ℕ_) p ∙ q)))))) ∙
     ( p))
 
 transitive-div-ℕ :
   (x y z : ℕ) → div-ℕ x y → div-ℕ y z → div-ℕ x z
 pr1 (transitive-div-ℕ x y z (pair k p) (pair l q)) = l *ℕ k
 pr2 (transitive-div-ℕ x y z (pair k p) (pair l q)) =
-  associative-mul-ℕ l k x ∙ (ap (mul-ℕ l) p ∙ q)
+  associative-mul-ℕ l k x ∙ (ap (l *ℕ_) p ∙ q)
 ```
 
 ### If `x` is nonzero and `d | x`, then `d ≤ x`
@@ -327,7 +327,7 @@ pr2 (preserves-div-mul-ℕ k x y (pair q p)) =
   ( inv (associative-mul-ℕ q k x)) ∙
     ( ( ap (_*ℕ x) (commutative-mul-ℕ q k)) ∙
       ( ( associative-mul-ℕ k q x) ∙
-        ( ap (mul-ℕ k) p)))
+        ( ap (k *ℕ_) p)))
 ```
 
 ### Multiplication by a nonzero number reflects divisibility
@@ -413,7 +413,7 @@ simplify-mul-quotient-div-ℕ {a} {b} {c} nz H K L =
       ＝ a/b *ℕ (b/c *ℕ c)
         by associative-mul-ℕ a/b b/c c
       ＝ a/b *ℕ b
-        by ap (mul-ℕ a/b) (eq-quotient-div-ℕ c b K)
+        by ap (a/b *ℕ_) (eq-quotient-div-ℕ c b K)
       ＝ a
         by eq-quotient-div-ℕ b a H
       ＝ a/c *ℕ c

--- a/src/elementary-number-theory/divisibility-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/divisibility-natural-numbers.lagda.md
@@ -132,7 +132,7 @@ antisymmetric-div-ℕ (succ-ℕ x) zero-ℕ H (pair l q) =
   inv q ∙ right-zero-law-mul-ℕ l
 antisymmetric-div-ℕ (succ-ℕ x) (succ-ℕ y) (pair k p) (pair l q) =
   ( inv (left-unit-law-mul-ℕ (succ-ℕ x))) ∙
-  ( ( ap ( mul-ℕ' (succ-ℕ x))
+  ( ( ap ( _*ℕ (succ-ℕ x))
          ( inv
            ( is-one-right-is-one-mul-ℕ l k
              ( is-one-is-left-unit-mul-ℕ (l *ℕ k) x
@@ -296,7 +296,7 @@ pr2 (div-left-summand-ℕ (succ-ℕ d) x y (pair m q) (pair n p)) =
             ( m *ℕ (succ-ℕ d))
             ( (dist-ℕ m n) *ℕ (succ-ℕ d))))) ∙
       ( ( ap
-          ( mul-ℕ' (succ-ℕ d))
+          ( _*ℕ (succ-ℕ d))
           ( is-additive-right-inverse-dist-ℕ m n
             ( reflects-order-mul-ℕ d m n
               ( concatenate-eq-leq-eq-ℕ q
@@ -325,7 +325,7 @@ preserves-div-mul-ℕ :
 pr1 (preserves-div-mul-ℕ k x y (pair q p)) = q
 pr2 (preserves-div-mul-ℕ k x y (pair q p)) =
   ( inv (associative-mul-ℕ q k x)) ∙
-    ( ( ap (mul-ℕ' x) (commutative-mul-ℕ q k)) ∙
+    ( ( ap (_*ℕ x) (commutative-mul-ℕ q k)) ∙
       ( ( associative-mul-ℕ k q x) ∙
         ( ap (mul-ℕ k) p)))
 ```
@@ -339,7 +339,7 @@ pr1 (reflects-div-mul-ℕ k x y H (pair q p)) = q
 pr2 (reflects-div-mul-ℕ k x y H (pair q p)) =
   is-injective-mul-ℕ k H
     ( ( inv (associative-mul-ℕ k q x)) ∙
-      ( ( ap (mul-ℕ' x) (commutative-mul-ℕ k q)) ∙
+      ( ( ap (_*ℕ x) (commutative-mul-ℕ k q)) ∙
         ( ( associative-mul-ℕ q k x) ∙
           ( p))))
 ```
@@ -440,7 +440,7 @@ pr2 (pr1 (simplify-div-quotient-div-ℕ {a} {d} {x} nz H) (u , p)) =
     ＝ (u *ℕ x) *ℕ d
       by inv (associative-mul-ℕ u x d)
     ＝ (quotient-div-ℕ d a H) *ℕ d
-      by ap (mul-ℕ' d) p
+      by ap (_*ℕ d) p
     ＝ a
       by eq-quotient-div-ℕ d a H
 pr1 (pr2 (simplify-div-quotient-div-ℕ nz H) (u , p)) = u

--- a/src/elementary-number-theory/divisibility-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/divisibility-natural-numbers.lagda.md
@@ -275,14 +275,14 @@ div-mul-ℕ' k x y H =
 
 ```agda
 div-add-ℕ :
-  (d x y : ℕ) → div-ℕ d x → div-ℕ d y → div-ℕ d (add-ℕ x y)
-pr1 (div-add-ℕ d x y (pair n p) (pair m q)) = add-ℕ n m
+  (d x y : ℕ) → div-ℕ d x → div-ℕ d y → div-ℕ d (x +ℕ y)
+pr1 (div-add-ℕ d x y (pair n p) (pair m q)) = n +ℕ m
 pr2 (div-add-ℕ d x y (pair n p) (pair m q)) =
   ( right-distributive-mul-add-ℕ n m d) ∙
   ( ap-add-ℕ p q)
 
 div-left-summand-ℕ :
-  (d x y : ℕ) → div-ℕ d y → div-ℕ d (add-ℕ x y) → div-ℕ d x
+  (d x y : ℕ) → div-ℕ d y → div-ℕ d (x +ℕ y) → div-ℕ d x
 div-left-summand-ℕ zero-ℕ x y (pair m q) (pair n p) =
   pair zero-ℕ
     ( ( inv (right-zero-law-mul-ℕ n)) ∙
@@ -305,7 +305,7 @@ pr2 (div-left-summand-ℕ (succ-ℕ d) x y (pair m q) (pair n p)) =
         ( p ∙ (ap (add-ℕ x) (inv q)))))
 
 div-right-summand-ℕ :
-  (d x y : ℕ) → div-ℕ d x → div-ℕ d (add-ℕ x y) → div-ℕ d y
+  (d x y : ℕ) → div-ℕ d x → div-ℕ d (x +ℕ y) → div-ℕ d y
 div-right-summand-ℕ d x y H1 H2 =
   div-left-summand-ℕ d y x H1 (concatenate-div-eq-ℕ H2 (commutative-add-ℕ x y))
 ```

--- a/src/elementary-number-theory/divisibility-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/divisibility-natural-numbers.lagda.md
@@ -36,7 +36,7 @@ Curry-Howard interpretation of logic into type theory, we express divisibility
 as follows:
 
 ```md
-  div-ℕ m n := Σ (k : ℕ), mul-ℕ k m ＝ n.
+  div-ℕ m n := Σ (k : ℕ), k *ℕ m ＝ n.
 ```
 
 If `n` is a nonzero natural number, then `div-ℕ m n` is always a proposition in
@@ -46,17 +46,17 @@ the sense that the type `div-ℕ m n` contains at most one element.
 
 ```agda
 div-ℕ : ℕ → ℕ → UU lzero
-div-ℕ m n = Σ ℕ (λ k → mul-ℕ k m ＝ n)
+div-ℕ m n = Σ ℕ (λ k → k *ℕ m ＝ n)
 
 quotient-div-ℕ : (x y : ℕ) → div-ℕ x y → ℕ
 quotient-div-ℕ x y H = pr1 H
 
 eq-quotient-div-ℕ :
-  (x y : ℕ) (H : div-ℕ x y) → mul-ℕ (quotient-div-ℕ x y H) x ＝ y
+  (x y : ℕ) (H : div-ℕ x y) → (quotient-div-ℕ x y H) *ℕ x ＝ y
 eq-quotient-div-ℕ x y H = pr2 H
 
 eq-quotient-div-ℕ' :
-  (x y : ℕ) (H : div-ℕ x y) → mul-ℕ x (quotient-div-ℕ x y H) ＝ y
+  (x y : ℕ) (H : div-ℕ x y) → x *ℕ (quotient-div-ℕ x y H) ＝ y
 eq-quotient-div-ℕ' x y H =
   commutative-mul-ℕ x (quotient-div-ℕ x y H) ∙ eq-quotient-div-ℕ x y H
 
@@ -97,8 +97,8 @@ eq-quotient-div-eq-div-ℕ x y z n e H I =
     ( n)
   ( tr
     ( λ p →
-      mul-ℕ x (quotient-div-ℕ x z H) ＝
-      mul-ℕ p (quotient-div-ℕ y z I))
+      x *ℕ (quotient-div-ℕ x z H) ＝
+      p *ℕ (quotient-div-ℕ y z I))
     ( inv e)
     ( commutative-mul-ℕ x (quotient-div-ℕ x z H) ∙
       ( eq-quotient-div-ℕ x z H ∙
@@ -135,14 +135,14 @@ antisymmetric-div-ℕ (succ-ℕ x) (succ-ℕ y) (pair k p) (pair l q) =
   ( ( ap ( mul-ℕ' (succ-ℕ x))
          ( inv
            ( is-one-right-is-one-mul-ℕ l k
-             ( is-one-is-left-unit-mul-ℕ (mul-ℕ l k) x
+             ( is-one-is-left-unit-mul-ℕ (l *ℕ k) x
                ( ( associative-mul-ℕ l k (succ-ℕ x)) ∙
                  ( ap (mul-ℕ l) p ∙ q)))))) ∙
     ( p))
 
 transitive-div-ℕ :
   (x y z : ℕ) → div-ℕ x y → div-ℕ y z → div-ℕ x z
-pr1 (transitive-div-ℕ x y z (pair k p) (pair l q)) = mul-ℕ l k
+pr1 (transitive-div-ℕ x y z (pair k p) (pair l q)) = l *ℕ k
 pr2 (transitive-div-ℕ x y z (pair k p) (pair l q)) =
   associative-mul-ℕ l k x ∙ (ap (mul-ℕ l) p ∙ q)
 ```
@@ -254,19 +254,19 @@ is-zero-div-ℕ d (succ-ℕ x) H (pair (succ-ℕ k) p) =
     ( contradiction-le-ℕ
       ( succ-ℕ x) d H
       ( concatenate-leq-eq-ℕ d
-        ( leq-add-ℕ' d (mul-ℕ k d)) p))
+        ( leq-add-ℕ' d (k *ℕ d)) p))
 ```
 
 ### If `x` divides `y` then `x` divides any multiple of `y`
 
 ```agda
 div-mul-ℕ :
-  (k x y : ℕ) → div-ℕ x y → div-ℕ x (mul-ℕ k y)
+  (k x y : ℕ) → div-ℕ x y → div-ℕ x (k *ℕ y)
 div-mul-ℕ k x y H =
-  transitive-div-ℕ x y (mul-ℕ k y) H (pair k refl)
+  transitive-div-ℕ x y (k *ℕ y) H (pair k refl)
 
 div-mul-ℕ' :
-  (k x y : ℕ) → div-ℕ x y → div-ℕ x (mul-ℕ y k)
+  (k x y : ℕ) → div-ℕ x y → div-ℕ x (y *ℕ k)
 div-mul-ℕ' k x y H =
   tr (div-ℕ x) (commutative-mul-ℕ k y) (div-mul-ℕ k x y H)
 ```
@@ -289,12 +289,12 @@ div-left-summand-ℕ zero-ℕ x y (pair m q) (pair n p) =
       ( p ∙ (ap (add-ℕ x) ((inv q) ∙ (right-zero-law-mul-ℕ m)))))
 pr1 (div-left-summand-ℕ (succ-ℕ d) x y (pair m q) (pair n p)) = dist-ℕ m n
 pr2 (div-left-summand-ℕ (succ-ℕ d) x y (pair m q) (pair n p)) =
-  is-injective-add-ℕ' (mul-ℕ m (succ-ℕ d))
+  is-injective-add-ℕ' (m *ℕ (succ-ℕ d))
     ( ( inv
         ( ( right-distributive-mul-add-ℕ m (dist-ℕ m n) (succ-ℕ d)) ∙
           ( commutative-add-ℕ
-            ( mul-ℕ m (succ-ℕ d))
-            ( mul-ℕ (dist-ℕ m n) (succ-ℕ d))))) ∙
+            ( m *ℕ (succ-ℕ d))
+            ( (dist-ℕ m n) *ℕ (succ-ℕ d))))) ∙
       ( ( ap
           ( mul-ℕ' (succ-ℕ d))
           ( is-additive-right-inverse-dist-ℕ m n
@@ -321,7 +321,7 @@ is-one-div-ℕ x y H K = is-one-div-one-ℕ x (div-right-summand-ℕ x y 1 H K)
 
 ```agda
 preserves-div-mul-ℕ :
-  (k x y : ℕ) → div-ℕ x y → div-ℕ (mul-ℕ k x) (mul-ℕ k y)
+  (k x y : ℕ) → div-ℕ x y → div-ℕ (k *ℕ x) (k *ℕ y)
 pr1 (preserves-div-mul-ℕ k x y (pair q p)) = q
 pr2 (preserves-div-mul-ℕ k x y (pair q p)) =
   ( inv (associative-mul-ℕ q k x)) ∙
@@ -334,7 +334,7 @@ pr2 (preserves-div-mul-ℕ k x y (pair q p)) =
 
 ```agda
 reflects-div-mul-ℕ :
-  (k x y : ℕ) → is-nonzero-ℕ k → div-ℕ (mul-ℕ k x) (mul-ℕ k y) → div-ℕ x y
+  (k x y : ℕ) → is-nonzero-ℕ k → div-ℕ (k *ℕ x) (k *ℕ y) → div-ℕ x y
 pr1 (reflects-div-mul-ℕ k x y H (pair q p)) = q
 pr2 (reflects-div-mul-ℕ k x y H (pair q p)) =
   is-injective-mul-ℕ k H
@@ -349,18 +349,18 @@ pr2 (reflects-div-mul-ℕ k x y H (pair q p)) =
 ```agda
 div-quotient-div-div-ℕ :
   (x y d : ℕ) (H : div-ℕ d y) → is-nonzero-ℕ d →
-  div-ℕ (mul-ℕ d x) y → div-ℕ x (quotient-div-ℕ d y H)
+  div-ℕ (d *ℕ x) y → div-ℕ x (quotient-div-ℕ d y H)
 div-quotient-div-div-ℕ x y d H f K =
   reflects-div-mul-ℕ d x
     ( quotient-div-ℕ d y H)
     ( f)
-    ( tr (div-ℕ (mul-ℕ d x)) (inv (eq-quotient-div-ℕ' d y H)) K)
+    ( tr (div-ℕ (d *ℕ x)) (inv (eq-quotient-div-ℕ' d y H)) K)
 
 div-div-quotient-div-ℕ :
   (x y d : ℕ) (H : div-ℕ d y) →
-  div-ℕ x (quotient-div-ℕ d y H) → div-ℕ (mul-ℕ d x) y
+  div-ℕ x (quotient-div-ℕ d y H) → div-ℕ (d *ℕ x) y
 div-div-quotient-div-ℕ x y d H K =
-  tr ( div-ℕ (mul-ℕ d x))
+  tr ( div-ℕ (d *ℕ x))
      ( eq-quotient-div-ℕ' d y H)
      ( preserves-div-mul-ℕ d x (quotient-div-ℕ d y H) K)
 ```
@@ -371,7 +371,7 @@ div-div-quotient-div-ℕ x y d H K =
 is-nonzero-quotient-div-ℕ :
   {d x : ℕ} (H : div-ℕ d x) →
   is-nonzero-ℕ x → is-nonzero-ℕ (quotient-div-ℕ d x H)
-is-nonzero-quotient-div-ℕ {d} {.(mul-ℕ k d)} (pair k refl) =
+is-nonzero-quotient-div-ℕ {d} {.(k *ℕ d)} (pair k refl) =
   is-nonzero-left-factor-mul-ℕ k d
 ```
 
@@ -404,19 +404,19 @@ is-idempotent-quotient-div-ℕ (succ-ℕ a) nz (u , p) =
 simplify-mul-quotient-div-ℕ :
   {a b c : ℕ} → is-nonzero-ℕ c →
   (H : div-ℕ b a) (K : div-ℕ c b) (L : div-ℕ c a) →
-  ( mul-ℕ (quotient-div-ℕ b a H) (quotient-div-ℕ c b K)) ＝
+  ( (quotient-div-ℕ b a H) *ℕ (quotient-div-ℕ c b K)) ＝
   ( quotient-div-ℕ c a L)
 simplify-mul-quotient-div-ℕ {a} {b} {c} nz H K L =
   is-injective-mul-ℕ' c nz
     ( equational-reasoning
-      mul-ℕ (mul-ℕ a/b b/c) c
-      ＝ mul-ℕ a/b (mul-ℕ b/c c)
+      (a/b *ℕ b/c) *ℕ c
+      ＝ a/b *ℕ (b/c *ℕ c)
         by associative-mul-ℕ a/b b/c c
-      ＝ mul-ℕ a/b b
+      ＝ a/b *ℕ b
         by ap (mul-ℕ a/b) (eq-quotient-div-ℕ c b K)
       ＝ a
         by eq-quotient-div-ℕ b a H
-      ＝ mul-ℕ a/c c
+      ＝ a/c *ℕ c
         by inv (eq-quotient-div-ℕ c a L))
   where
   a/b : ℕ
@@ -432,14 +432,14 @@ simplify-mul-quotient-div-ℕ {a} {b} {c} nz H K L =
 ```agda
 simplify-div-quotient-div-ℕ :
   {a d x : ℕ} → is-nonzero-ℕ d → (H : div-ℕ d a) →
-  (div-ℕ x (quotient-div-ℕ d a H)) ↔ (div-ℕ (mul-ℕ x d) a)
+  (div-ℕ x (quotient-div-ℕ d a H)) ↔ (div-ℕ (x *ℕ d) a)
 pr1 (pr1 (simplify-div-quotient-div-ℕ nz H) (u , p)) = u
 pr2 (pr1 (simplify-div-quotient-div-ℕ {a} {d} {x} nz H) (u , p)) =
   equational-reasoning
-    mul-ℕ u (mul-ℕ x d)
-    ＝ mul-ℕ (mul-ℕ u x) d
+    u *ℕ (x *ℕ d)
+    ＝ (u *ℕ x) *ℕ d
       by inv (associative-mul-ℕ u x d)
-    ＝ mul-ℕ (quotient-div-ℕ d a H) d
+    ＝ (quotient-div-ℕ d a H) *ℕ d
       by ap (mul-ℕ' d) p
     ＝ a
       by eq-quotient-div-ℕ d a H
@@ -447,12 +447,12 @@ pr1 (pr2 (simplify-div-quotient-div-ℕ nz H) (u , p)) = u
 pr2 (pr2 (simplify-div-quotient-div-ℕ {a} {d} {x} nz H) (u , p)) =
   is-injective-mul-ℕ' d nz
     ( equational-reasoning
-        mul-ℕ (mul-ℕ u x) d
-        ＝ mul-ℕ u (mul-ℕ x d)
+        (u *ℕ x) *ℕ d
+        ＝ u *ℕ (x *ℕ d)
           by associative-mul-ℕ u x d
         ＝ a
           by p
-        ＝ mul-ℕ (quotient-div-ℕ d a H) d
+        ＝ (quotient-div-ℕ d a H) *ℕ d
           by inv (eq-quotient-div-ℕ d a H))
 ```
 

--- a/src/elementary-number-theory/divisibility-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/divisibility-natural-numbers.lagda.md
@@ -92,7 +92,7 @@ eq-quotient-div-eq-div-ℕ :
   (H : div-ℕ x z) → (I : div-ℕ y z) →
   quotient-div-ℕ x z H ＝ quotient-div-ℕ y z I
 eq-quotient-div-eq-div-ℕ x y z n e H I =
-  is-injective-mul-ℕ
+  is-injective-left-mul-ℕ
     ( x)
     ( n)
   ( tr
@@ -110,7 +110,7 @@ eq-quotient-div-eq-div-ℕ x y z n e H I =
 
 ```agda
 is-prop-div-ℕ : (k x : ℕ) → is-nonzero-ℕ k → is-prop (div-ℕ k x)
-is-prop-div-ℕ k x f = is-prop-map-is-emb (is-emb-mul-ℕ' k f) x
+is-prop-div-ℕ k x f = is-prop-map-is-emb (is-emb-right-mul-ℕ k f) x
 ```
 
 ### The divisibility relation is a partial order on the natural numbers
@@ -289,7 +289,7 @@ div-left-summand-ℕ zero-ℕ x y (pair m q) (pair n p) =
       ( p ∙ (ap (x +ℕ_) ((inv q) ∙ (right-zero-law-mul-ℕ m)))))
 pr1 (div-left-summand-ℕ (succ-ℕ d) x y (pair m q) (pair n p)) = dist-ℕ m n
 pr2 (div-left-summand-ℕ (succ-ℕ d) x y (pair m q) (pair n p)) =
-  is-injective-add-ℕ' (m *ℕ (succ-ℕ d))
+  is-injective-right-add-ℕ (m *ℕ (succ-ℕ d))
     ( ( inv
         ( ( right-distributive-mul-add-ℕ m (dist-ℕ m n) (succ-ℕ d)) ∙
           ( commutative-add-ℕ
@@ -337,7 +337,7 @@ reflects-div-mul-ℕ :
   (k x y : ℕ) → is-nonzero-ℕ k → div-ℕ (k *ℕ x) (k *ℕ y) → div-ℕ x y
 pr1 (reflects-div-mul-ℕ k x y H (pair q p)) = q
 pr2 (reflects-div-mul-ℕ k x y H (pair q p)) =
-  is-injective-mul-ℕ k H
+  is-injective-left-mul-ℕ k H
     ( ( inv (associative-mul-ℕ k q x)) ∙
       ( ( ap (_*ℕ x) (commutative-mul-ℕ k q)) ∙
         ( ( associative-mul-ℕ q k x) ∙
@@ -407,7 +407,7 @@ simplify-mul-quotient-div-ℕ :
   ( (quotient-div-ℕ b a H) *ℕ (quotient-div-ℕ c b K)) ＝
   ( quotient-div-ℕ c a L)
 simplify-mul-quotient-div-ℕ {a} {b} {c} nz H K L =
-  is-injective-mul-ℕ' c nz
+  is-injective-right-mul-ℕ c nz
     ( equational-reasoning
       (a/b *ℕ b/c) *ℕ c
       ＝ a/b *ℕ (b/c *ℕ c)
@@ -445,7 +445,7 @@ pr2 (pr1 (simplify-div-quotient-div-ℕ {a} {d} {x} nz H) (u , p)) =
       by eq-quotient-div-ℕ d a H
 pr1 (pr2 (simplify-div-quotient-div-ℕ nz H) (u , p)) = u
 pr2 (pr2 (simplify-div-quotient-div-ℕ {a} {d} {x} nz H) (u , p)) =
-  is-injective-mul-ℕ' d nz
+  is-injective-right-mul-ℕ d nz
     ( equational-reasoning
         (u *ℕ x) *ℕ d
         ＝ u *ℕ (x *ℕ d)
@@ -500,7 +500,7 @@ is-one-divisor-ℕ :
   (d x : ℕ) → is-nonzero-ℕ x → (H : div-ℕ d x) →
   quotient-div-ℕ d x H ＝ x → is-one-ℕ d
 is-one-divisor-ℕ d x f (.x , q) refl =
-  is-injective-mul-ℕ x f (q ∙ inv (right-unit-law-mul-ℕ x))
+  is-injective-left-mul-ℕ x f (q ∙ inv (right-unit-law-mul-ℕ x))
 ```
 
 ### If `x` is nonzero and `d | x` is a nontrivial divisor, then `x/d < x`

--- a/src/elementary-number-theory/euclidean-division-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/euclidean-division-natural-numbers.lagda.md
@@ -127,7 +127,7 @@ eq-euclidean-division-ℕ zero-ℕ x =
       ( right-zero-law-mul-ℕ (quotient-euclidean-division-ℕ zero-ℕ x)))) ∙
   ( left-unit-law-add-ℕ x)
 eq-euclidean-division-ℕ (succ-ℕ k) x =
-  ( ap ( add-ℕ' (remainder-euclidean-division-ℕ (succ-ℕ k) x))
+  ( ap ( _+ℕ (remainder-euclidean-division-ℕ (succ-ℕ k) x))
        ( ( pr2 (cong-euclidean-division-ℕ (succ-ℕ k) x)) ∙
          ( symmetric-dist-ℕ x
            ( remainder-euclidean-division-ℕ (succ-ℕ k) x)))) ∙

--- a/src/elementary-number-theory/euclidean-division-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/euclidean-division-natural-numbers.lagda.md
@@ -123,7 +123,7 @@ eq-euclidean-division-ℕ :
 eq-euclidean-division-ℕ zero-ℕ x =
   ( inv
     ( ap
-      ( add-ℕ' x)
+      ( _+ℕ x)
       ( right-zero-law-mul-ℕ (quotient-euclidean-division-ℕ zero-ℕ x)))) ∙
   ( left-unit-law-add-ℕ x)
 eq-euclidean-division-ℕ (succ-ℕ k) x =

--- a/src/elementary-number-theory/euclidean-division-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/euclidean-division-natural-numbers.lagda.md
@@ -109,7 +109,7 @@ quotient-euclidean-division-ℕ k x =
 
 eq-quotient-euclidean-division-ℕ :
   (k x : ℕ) →
-  ( mul-ℕ (quotient-euclidean-division-ℕ k x) k) ＝
+  ( (quotient-euclidean-division-ℕ k x) *ℕ k) ＝
   ( dist-ℕ x (remainder-euclidean-division-ℕ k x))
 eq-quotient-euclidean-division-ℕ k x =
   pr2 (cong-euclidean-division-ℕ k x)
@@ -117,7 +117,7 @@ eq-quotient-euclidean-division-ℕ k x =
 eq-euclidean-division-ℕ :
   (k x : ℕ) →
   ( add-ℕ
-    ( mul-ℕ (quotient-euclidean-division-ℕ k x) k)
+    ( (quotient-euclidean-division-ℕ k x) *ℕ k)
     ( remainder-euclidean-division-ℕ k x)) ＝
   ( x)
 eq-euclidean-division-ℕ zero-ℕ x =

--- a/src/elementary-number-theory/exponentiation-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/exponentiation-natural-numbers.lagda.md
@@ -29,7 +29,7 @@ times.
 ```agda
 exp-ℕ : ℕ → ℕ → ℕ
 exp-ℕ m 0 = 1
-exp-ℕ m (succ-ℕ n) = mul-ℕ (exp-ℕ m n) m
+exp-ℕ m (succ-ℕ n) = (exp-ℕ m n) *ℕ m
 
 infix 30 _^ℕ_
 _^ℕ_ = exp-ℕ

--- a/src/elementary-number-theory/factorials.lagda.md
+++ b/src/elementary-number-theory/factorials.lagda.md
@@ -25,7 +25,7 @@ open import foundation.identity-types
 ```agda
 factorial-ℕ : ℕ → ℕ
 factorial-ℕ 0 = 1
-factorial-ℕ (succ-ℕ m) = mul-ℕ (factorial-ℕ m) (succ-ℕ m)
+factorial-ℕ (succ-ℕ m) = (factorial-ℕ m) *ℕ (succ-ℕ m)
 ```
 
 ```agda

--- a/src/elementary-number-theory/falling-factorials.lagda.md
+++ b/src/elementary-number-theory/falling-factorials.lagda.md
@@ -25,7 +25,7 @@ falling-factorial-ℕ zero-ℕ zero-ℕ = 1
 falling-factorial-ℕ zero-ℕ (succ-ℕ m) = 0
 falling-factorial-ℕ (succ-ℕ n) zero-ℕ = 1
 falling-factorial-ℕ (succ-ℕ n) (succ-ℕ m) =
-  mul-ℕ (succ-ℕ n) (falling-factorial-ℕ n m)
+  (succ-ℕ n) *ℕ (falling-factorial-ℕ n m)
 
 {-
 Fin-falling-factorial-ℕ :

--- a/src/elementary-number-theory/fibonacci-sequence.lagda.md
+++ b/src/elementary-number-theory/fibonacci-sequence.lagda.md
@@ -83,9 +83,8 @@ Fibo k = Fibo-function k 0
 Fibonacci-add-ℕ :
   (m n : ℕ) →
   Fibonacci-ℕ (m +ℕ (succ-ℕ n)) ＝
-  add-ℕ
-    ( (Fibonacci-ℕ (succ-ℕ m)) *ℕ (Fibonacci-ℕ (succ-ℕ n)))
-    ( (Fibonacci-ℕ m) *ℕ (Fibonacci-ℕ n))
+  ( (Fibonacci-ℕ (succ-ℕ m)) *ℕ (Fibonacci-ℕ (succ-ℕ n))) +ℕ
+  ( (Fibonacci-ℕ m) *ℕ (Fibonacci-ℕ n))
 Fibonacci-add-ℕ m zero-ℕ =
   ap-add-ℕ
     ( inv (right-unit-law-mul-ℕ (Fibonacci-ℕ (succ-ℕ m))))
@@ -104,8 +103,7 @@ Fibonacci-add-ℕ m (succ-ℕ n) =
           ( (Fibonacci-ℕ m) *ℕ (Fibonacci-ℕ (succ-ℕ n)))
           ( (Fibonacci-ℕ (succ-ℕ m)) *ℕ (Fibonacci-ℕ n))) ∙
         ( ( ap
-            ( add-ℕ
-              ( (Fibonacci-ℕ (succ-ℕ m)) *ℕ (Fibonacci-ℕ (succ-ℕ n))))
+            ( ((Fibonacci-ℕ (succ-ℕ m)) *ℕ (Fibonacci-ℕ (succ-ℕ n))) +ℕ_)
             ( commutative-add-ℕ
               ( (Fibonacci-ℕ m) *ℕ (Fibonacci-ℕ (succ-ℕ n)))
               ( (Fibonacci-ℕ (succ-ℕ m)) *ℕ (Fibonacci-ℕ n)))) ∙

--- a/src/elementary-number-theory/fibonacci-sequence.lagda.md
+++ b/src/elementary-number-theory/fibonacci-sequence.lagda.md
@@ -85,7 +85,7 @@ Fibonacci-add-ℕ :
   Fibonacci-ℕ (m +ℕ (succ-ℕ n)) ＝
   add-ℕ
     ( mul-ℕ (Fibonacci-ℕ (succ-ℕ m)) (Fibonacci-ℕ (succ-ℕ n)))
-    ( mul-ℕ (Fibonacci-ℕ m) (Fibonacci-ℕ n))
+    ( (Fibonacci-ℕ m) *ℕ (Fibonacci-ℕ n))
 Fibonacci-add-ℕ m zero-ℕ =
   ap-add-ℕ
     ( inv (right-unit-law-mul-ℕ (Fibonacci-ℕ (succ-ℕ m))))
@@ -101,21 +101,21 @@ Fibonacci-add-ℕ m (succ-ℕ n) =
           ( Fibonacci-ℕ (succ-ℕ n)))) ∙
       ( ( associative-add-ℕ
           ( mul-ℕ (Fibonacci-ℕ (succ-ℕ m)) (Fibonacci-ℕ (succ-ℕ n)))
-          ( mul-ℕ (Fibonacci-ℕ m) (Fibonacci-ℕ (succ-ℕ n)))
+          ( (Fibonacci-ℕ m) *ℕ (Fibonacci-ℕ (succ-ℕ n)))
           ( mul-ℕ (Fibonacci-ℕ (succ-ℕ m)) (Fibonacci-ℕ n))) ∙
         ( ( ap
             ( add-ℕ
               ( mul-ℕ (Fibonacci-ℕ (succ-ℕ m)) (Fibonacci-ℕ (succ-ℕ n))))
             ( commutative-add-ℕ
-              ( mul-ℕ (Fibonacci-ℕ m) (Fibonacci-ℕ (succ-ℕ n)))
+              ( (Fibonacci-ℕ m) *ℕ (Fibonacci-ℕ (succ-ℕ n)))
               ( mul-ℕ (Fibonacci-ℕ (succ-ℕ m)) (Fibonacci-ℕ n)))) ∙
           ( ( inv
               ( associative-add-ℕ
                 ( mul-ℕ (Fibonacci-ℕ (succ-ℕ m)) (Fibonacci-ℕ (succ-ℕ n)))
                 ( mul-ℕ (Fibonacci-ℕ (succ-ℕ m)) (Fibonacci-ℕ n))
-                ( mul-ℕ (Fibonacci-ℕ m) (Fibonacci-ℕ (succ-ℕ n))))) ∙
+                ( (Fibonacci-ℕ m) *ℕ (Fibonacci-ℕ (succ-ℕ n))))) ∙
             ( ap
-              ( add-ℕ' (mul-ℕ (Fibonacci-ℕ m) (Fibonacci-ℕ (succ-ℕ n))))
+              ( add-ℕ' ((Fibonacci-ℕ m) *ℕ (Fibonacci-ℕ (succ-ℕ n))))
               ( inv
                 ( left-distributive-mul-add-ℕ
                   ( Fibonacci-ℕ (succ-ℕ m))
@@ -165,7 +165,7 @@ div-Fibonacci-add-ℕ d m (succ-ℕ n) H1 H2 =
     ( inv (Fibonacci-add-ℕ m n))
     ( div-add-ℕ d
       ( mul-ℕ (Fibonacci-ℕ (succ-ℕ m)) (Fibonacci-ℕ (succ-ℕ n)))
-      ( mul-ℕ (Fibonacci-ℕ m) (Fibonacci-ℕ n))
+      ( (Fibonacci-ℕ m) *ℕ (Fibonacci-ℕ n))
       ( div-mul-ℕ (Fibonacci-ℕ (succ-ℕ m)) d (Fibonacci-ℕ (succ-ℕ n)) H2)
       ( tr
         ( div-ℕ d)
@@ -179,18 +179,18 @@ div-Fibonacci-add-ℕ d m (succ-ℕ n) H1 H2 =
 div-Fibonacci-div-ℕ :
   (d m n : ℕ) → div-ℕ m n → div-ℕ d (Fibonacci-ℕ m) → div-ℕ d (Fibonacci-ℕ n)
 div-Fibonacci-div-ℕ d m .zero-ℕ (zero-ℕ , refl) H = div-zero-ℕ d
-div-Fibonacci-div-ℕ d zero-ℕ .(mul-ℕ k zero-ℕ) (succ-ℕ k , refl) H =
+div-Fibonacci-div-ℕ d zero-ℕ .(k *ℕ zero-ℕ) (succ-ℕ k , refl) H =
   tr
     ( div-ℕ d)
     ( ap Fibonacci-ℕ (inv (right-zero-law-mul-ℕ (succ-ℕ k))))
     ( div-zero-ℕ d)
 div-Fibonacci-div-ℕ d (succ-ℕ m) ._ (succ-ℕ k , refl) H =
    div-Fibonacci-add-ℕ d
-     ( mul-ℕ k (succ-ℕ m))
+     ( k *ℕ (succ-ℕ m))
      ( succ-ℕ m)
      ( div-Fibonacci-div-ℕ d
        ( succ-ℕ m)
-       ( mul-ℕ k (succ-ℕ m))
+       ( k *ℕ (succ-ℕ m))
        ( pair k refl)
        ( H))
      ( H)

--- a/src/elementary-number-theory/fibonacci-sequence.lagda.md
+++ b/src/elementary-number-theory/fibonacci-sequence.lagda.md
@@ -94,7 +94,7 @@ Fibonacci-add-ℕ m (succ-ℕ n) =
   ( ap Fibonacci-ℕ (inv (left-successor-law-add-ℕ m (succ-ℕ n)))) ∙
   ( ( Fibonacci-add-ℕ (succ-ℕ m) n) ∙
     ( ( ap
-        ( add-ℕ' ((Fibonacci-ℕ (succ-ℕ m)) *ℕ (Fibonacci-ℕ n)))
+        ( _+ℕ ((Fibonacci-ℕ (succ-ℕ m)) *ℕ (Fibonacci-ℕ n)))
         ( right-distributive-mul-add-ℕ
           ( Fibonacci-ℕ (succ-ℕ m))
           ( Fibonacci-ℕ m)
@@ -115,7 +115,7 @@ Fibonacci-add-ℕ m (succ-ℕ n) =
                 ( (Fibonacci-ℕ (succ-ℕ m)) *ℕ (Fibonacci-ℕ n))
                 ( (Fibonacci-ℕ m) *ℕ (Fibonacci-ℕ (succ-ℕ n))))) ∙
             ( ap
-              ( add-ℕ' ((Fibonacci-ℕ m) *ℕ (Fibonacci-ℕ (succ-ℕ n))))
+              ( _+ℕ ((Fibonacci-ℕ m) *ℕ (Fibonacci-ℕ (succ-ℕ n))))
               ( inv
                 ( left-distributive-mul-add-ℕ
                   ( Fibonacci-ℕ (succ-ℕ m))

--- a/src/elementary-number-theory/fibonacci-sequence.lagda.md
+++ b/src/elementary-number-theory/fibonacci-sequence.lagda.md
@@ -63,7 +63,7 @@ Fibo-zero-ℕ : ℕ → ℕ
 Fibo-zero-ℕ = shift-two 0 1 (λ x → 0)
 
 Fibo-succ-ℕ : (ℕ → ℕ) → (ℕ → ℕ)
-Fibo-succ-ℕ f = shift-two (f 1) (add-ℕ (f 1) (f 0)) (λ x → 0)
+Fibo-succ-ℕ f = shift-two (f 1) ((f 1) +ℕ (f 0)) (λ x → 0)
 
 Fibo-function : ℕ → ℕ → ℕ
 Fibo-function =
@@ -82,7 +82,7 @@ Fibo k = Fibo-function k 0
 ```agda
 Fibonacci-add-ℕ :
   (m n : ℕ) →
-  Fibonacci-ℕ (add-ℕ m (succ-ℕ n)) ＝
+  Fibonacci-ℕ (m +ℕ (succ-ℕ n)) ＝
   add-ℕ
     ( mul-ℕ (Fibonacci-ℕ (succ-ℕ m)) (Fibonacci-ℕ (succ-ℕ n)))
     ( mul-ℕ (Fibonacci-ℕ m) (Fibonacci-ℕ n))
@@ -152,12 +152,12 @@ third:
 
 1. `d | Fibonacci-ℕ m`
 2. `d | Fibonacci-ℕ n`
-3. `d | Fibonacci-ℕ (add-ℕ m n)`.
+3. `d | Fibonacci-ℕ (m +ℕ n)`.
 
 ```agda
 div-Fibonacci-add-ℕ :
   (d m n : ℕ) → div-ℕ d (Fibonacci-ℕ m) → div-ℕ d (Fibonacci-ℕ n) →
-  div-ℕ d (Fibonacci-ℕ (add-ℕ m n))
+  div-ℕ d (Fibonacci-ℕ (m +ℕ n))
 div-Fibonacci-add-ℕ d m zero-ℕ H1 H2 = H1
 div-Fibonacci-add-ℕ d m (succ-ℕ n) H1 H2 =
   tr

--- a/src/elementary-number-theory/fibonacci-sequence.lagda.md
+++ b/src/elementary-number-theory/fibonacci-sequence.lagda.md
@@ -28,7 +28,7 @@ open import foundation.identity-types
 Fibonacci-ℕ : ℕ → ℕ
 Fibonacci-ℕ 0 = 0
 Fibonacci-ℕ (succ-ℕ 0) = 1
-Fibonacci-ℕ (succ-ℕ (succ-ℕ n)) = add-ℕ (Fibonacci-ℕ (succ-ℕ n)) (Fibonacci-ℕ n)
+Fibonacci-ℕ (succ-ℕ (succ-ℕ n)) = (Fibonacci-ℕ (succ-ℕ n)) +ℕ (Fibonacci-ℕ n)
 ```
 
 ### A definition using the induction principle of `ℕ`
@@ -84,7 +84,7 @@ Fibonacci-add-ℕ :
   (m n : ℕ) →
   Fibonacci-ℕ (m +ℕ (succ-ℕ n)) ＝
   add-ℕ
-    ( mul-ℕ (Fibonacci-ℕ (succ-ℕ m)) (Fibonacci-ℕ (succ-ℕ n)))
+    ( (Fibonacci-ℕ (succ-ℕ m)) *ℕ (Fibonacci-ℕ (succ-ℕ n)))
     ( (Fibonacci-ℕ m) *ℕ (Fibonacci-ℕ n))
 Fibonacci-add-ℕ m zero-ℕ =
   ap-add-ℕ
@@ -94,25 +94,25 @@ Fibonacci-add-ℕ m (succ-ℕ n) =
   ( ap Fibonacci-ℕ (inv (left-successor-law-add-ℕ m (succ-ℕ n)))) ∙
   ( ( Fibonacci-add-ℕ (succ-ℕ m) n) ∙
     ( ( ap
-        ( add-ℕ' (mul-ℕ (Fibonacci-ℕ (succ-ℕ m)) (Fibonacci-ℕ n)))
+        ( add-ℕ' ((Fibonacci-ℕ (succ-ℕ m)) *ℕ (Fibonacci-ℕ n)))
         ( right-distributive-mul-add-ℕ
           ( Fibonacci-ℕ (succ-ℕ m))
           ( Fibonacci-ℕ m)
           ( Fibonacci-ℕ (succ-ℕ n)))) ∙
       ( ( associative-add-ℕ
-          ( mul-ℕ (Fibonacci-ℕ (succ-ℕ m)) (Fibonacci-ℕ (succ-ℕ n)))
+          ( (Fibonacci-ℕ (succ-ℕ m)) *ℕ (Fibonacci-ℕ (succ-ℕ n)))
           ( (Fibonacci-ℕ m) *ℕ (Fibonacci-ℕ (succ-ℕ n)))
-          ( mul-ℕ (Fibonacci-ℕ (succ-ℕ m)) (Fibonacci-ℕ n))) ∙
+          ( (Fibonacci-ℕ (succ-ℕ m)) *ℕ (Fibonacci-ℕ n))) ∙
         ( ( ap
             ( add-ℕ
-              ( mul-ℕ (Fibonacci-ℕ (succ-ℕ m)) (Fibonacci-ℕ (succ-ℕ n))))
+              ( (Fibonacci-ℕ (succ-ℕ m)) *ℕ (Fibonacci-ℕ (succ-ℕ n))))
             ( commutative-add-ℕ
               ( (Fibonacci-ℕ m) *ℕ (Fibonacci-ℕ (succ-ℕ n)))
-              ( mul-ℕ (Fibonacci-ℕ (succ-ℕ m)) (Fibonacci-ℕ n)))) ∙
+              ( (Fibonacci-ℕ (succ-ℕ m)) *ℕ (Fibonacci-ℕ n)))) ∙
           ( ( inv
               ( associative-add-ℕ
-                ( mul-ℕ (Fibonacci-ℕ (succ-ℕ m)) (Fibonacci-ℕ (succ-ℕ n)))
-                ( mul-ℕ (Fibonacci-ℕ (succ-ℕ m)) (Fibonacci-ℕ n))
+                ( (Fibonacci-ℕ (succ-ℕ m)) *ℕ (Fibonacci-ℕ (succ-ℕ n)))
+                ( (Fibonacci-ℕ (succ-ℕ m)) *ℕ (Fibonacci-ℕ n))
                 ( (Fibonacci-ℕ m) *ℕ (Fibonacci-ℕ (succ-ℕ n))))) ∙
             ( ap
               ( add-ℕ' ((Fibonacci-ℕ m) *ℕ (Fibonacci-ℕ (succ-ℕ n))))
@@ -164,7 +164,7 @@ div-Fibonacci-add-ℕ d m (succ-ℕ n) H1 H2 =
     ( div-ℕ d)
     ( inv (Fibonacci-add-ℕ m n))
     ( div-add-ℕ d
-      ( mul-ℕ (Fibonacci-ℕ (succ-ℕ m)) (Fibonacci-ℕ (succ-ℕ n)))
+      ( (Fibonacci-ℕ (succ-ℕ m)) *ℕ (Fibonacci-ℕ (succ-ℕ n)))
       ( (Fibonacci-ℕ m) *ℕ (Fibonacci-ℕ n))
       ( div-mul-ℕ (Fibonacci-ℕ (succ-ℕ m)) d (Fibonacci-ℕ (succ-ℕ n)) H2)
       ( tr

--- a/src/elementary-number-theory/finitary-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/finitary-natural-numbers.lagda.md
@@ -202,7 +202,7 @@ convert-based-succ-based-ℕ
            ( succ-ℕ k)
            ( succ-ℕ (convert-based-ℕ (succ-ℕ k) (succ-based-ℕ (succ-ℕ k) n)))))
        ( is-zero-nat-zero-Fin {k})) ∙
-  ( ( ap ( (mul-ℕ (succ-ℕ k)) ∘ succ-ℕ)
+  ( ( ap ( ((succ-ℕ k) *ℕ_) ∘ succ-ℕ)
          ( convert-based-succ-based-ℕ (succ-ℕ k) n)) ∙
     ( ( right-successor-law-mul-ℕ
         ( succ-ℕ k)

--- a/src/elementary-number-theory/finitary-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/finitary-natural-numbers.lagda.md
@@ -44,7 +44,7 @@ constant-ℕ : (k : ℕ) → Fin k → ℕ
 constant-ℕ k x = nat-Fin k x
 
 unary-op-ℕ : (k : ℕ) → Fin k → ℕ → ℕ
-unary-op-ℕ k x n = add-ℕ (k *ℕ (succ-ℕ n)) (nat-Fin k x)
+unary-op-ℕ k x n = (k *ℕ (succ-ℕ n)) +ℕ (nat-Fin k x)
 
 convert-based-ℕ : (k : ℕ) → based-ℕ k → ℕ
 convert-based-ℕ k (constant-based-ℕ .k x) =

--- a/src/elementary-number-theory/finitary-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/finitary-natural-numbers.lagda.md
@@ -193,13 +193,13 @@ convert-based-succ-based-ℕ
     ( is-zero-nat-zero-Fin {k})) ∙
   ( right-unit-law-mul-ℕ (succ-ℕ k))
 convert-based-succ-based-ℕ (succ-ℕ k) (unary-op-based-ℕ .(succ-ℕ k) (inl x) n) =
-  ap ( add-ℕ ((succ-ℕ k) *ℕ (succ-ℕ (convert-based-ℕ (succ-ℕ k) n))))
+  ap ( ((succ-ℕ k) *ℕ (succ-ℕ (convert-based-ℕ (succ-ℕ k) n))) +ℕ_)
      ( nat-succ-Fin k x)
 convert-based-succ-based-ℕ
   (succ-ℕ k) (unary-op-based-ℕ .(succ-ℕ k) (inr star) n) =
-  ( ap ( add-ℕ
-         ( ( succ-ℕ k) *ℕ
-           ( succ-ℕ (convert-based-ℕ (succ-ℕ k) (succ-based-ℕ (succ-ℕ k) n)))))
+  ( ap ( ( ( succ-ℕ k) *ℕ
+           ( succ-ℕ (convert-based-ℕ (succ-ℕ k) (succ-based-ℕ (succ-ℕ k) n))))
+          +ℕ_)
        ( is-zero-nat-zero-Fin {k})) ∙
   ( ( ap ( ((succ-ℕ k) *ℕ_) ∘ succ-ℕ)
          ( convert-based-succ-based-ℕ (succ-ℕ k) n)) ∙

--- a/src/elementary-number-theory/finitary-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/finitary-natural-numbers.lagda.md
@@ -189,7 +189,7 @@ convert-based-succ-based-ℕ (succ-ℕ k) (constant-based-ℕ .(succ-ℕ k) (inl
 convert-based-succ-based-ℕ
   ( succ-ℕ k) (constant-based-ℕ .(succ-ℕ k) (inr star)) =
   ( ap
-    ( λ t → add-ℕ ((succ-ℕ k) *ℕ (succ-ℕ t)) t)
+    ( λ t → ((succ-ℕ k) *ℕ (succ-ℕ t)) +ℕ t)
     ( is-zero-nat-zero-Fin {k})) ∙
   ( right-unit-law-mul-ℕ (succ-ℕ k))
 convert-based-succ-based-ℕ (succ-ℕ k) (unary-op-based-ℕ .(succ-ℕ k) (inl x) n) =

--- a/src/elementary-number-theory/finitary-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/finitary-natural-numbers.lagda.md
@@ -198,8 +198,7 @@ convert-based-succ-based-ℕ (succ-ℕ k) (unary-op-based-ℕ .(succ-ℕ k) (inl
 convert-based-succ-based-ℕ
   (succ-ℕ k) (unary-op-based-ℕ .(succ-ℕ k) (inr star) n) =
   ( ap ( add-ℕ
-         ( mul-ℕ
-           ( succ-ℕ k)
+         ( ( succ-ℕ k) *ℕ
            ( succ-ℕ (convert-based-ℕ (succ-ℕ k) (succ-based-ℕ (succ-ℕ k) n)))))
        ( is-zero-nat-zero-Fin {k})) ∙
   ( ( ap ( ((succ-ℕ k) *ℕ_) ∘ succ-ℕ)

--- a/src/elementary-number-theory/finitary-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/finitary-natural-numbers.lagda.md
@@ -146,8 +146,8 @@ is-injective-convert-based-ℕ
   ap ( unary-op-based-ℕ (succ-ℕ k) x)
      ( is-injective-convert-based-ℕ (succ-ℕ k)
        ( is-injective-succ-ℕ
-         ( is-injective-mul-succ-ℕ k
-           ( is-injective-add-ℕ' (nat-Fin (succ-ℕ k) x) p))))
+         ( is-injective-left-mul-succ-ℕ k
+           ( is-injective-right-add-ℕ (nat-Fin (succ-ℕ k) x) p))))
 ```
 
 ### The zero-element of the `k+1`-ary natural numbers

--- a/src/elementary-number-theory/finitary-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/finitary-natural-numbers.lagda.md
@@ -44,7 +44,7 @@ constant-ℕ : (k : ℕ) → Fin k → ℕ
 constant-ℕ k x = nat-Fin k x
 
 unary-op-ℕ : (k : ℕ) → Fin k → ℕ → ℕ
-unary-op-ℕ k x n = add-ℕ (mul-ℕ k (succ-ℕ n)) (nat-Fin k x)
+unary-op-ℕ k x n = add-ℕ (k *ℕ (succ-ℕ n)) (nat-Fin k x)
 
 convert-based-ℕ : (k : ℕ) → based-ℕ k → ℕ
 convert-based-ℕ k (constant-based-ℕ .k x) =
@@ -73,7 +73,7 @@ cong-unary-op-ℕ (succ-ℕ k) x n =
     { unary-op-ℕ (succ-ℕ k) x n}
     ( translation-invariant-cong-ℕ'
       ( succ-ℕ k)
-      ( mul-ℕ (succ-ℕ k) (succ-ℕ n))
+      ( (succ-ℕ k) *ℕ (succ-ℕ n))
       ( zero-ℕ)
       ( nat-Fin (succ-ℕ k) x)
       ( pair (succ-ℕ n) (commutative-mul-ℕ (succ-ℕ n) (succ-ℕ k))))
@@ -90,9 +90,9 @@ le-constant-unary-op-ℕ k x y m =
     ( strict-upper-bound-nat-Fin k x)
     ( transitive-leq-ℕ
       ( k)
-      ( mul-ℕ k (succ-ℕ m))
+      ( k *ℕ (succ-ℕ m))
       ( unary-op-ℕ k y m)
-      ( leq-add-ℕ (mul-ℕ k (succ-ℕ m)) (nat-Fin k y))
+      ( leq-add-ℕ (k *ℕ (succ-ℕ m)) (nat-Fin k y))
       ( leq-mul-ℕ m k))
 
 is-injective-convert-based-ℕ :
@@ -189,11 +189,11 @@ convert-based-succ-based-ℕ (succ-ℕ k) (constant-based-ℕ .(succ-ℕ k) (inl
 convert-based-succ-based-ℕ
   ( succ-ℕ k) (constant-based-ℕ .(succ-ℕ k) (inr star)) =
   ( ap
-    ( λ t → add-ℕ (mul-ℕ (succ-ℕ k) (succ-ℕ t)) t)
+    ( λ t → add-ℕ ((succ-ℕ k) *ℕ (succ-ℕ t)) t)
     ( is-zero-nat-zero-Fin {k})) ∙
   ( right-unit-law-mul-ℕ (succ-ℕ k))
 convert-based-succ-based-ℕ (succ-ℕ k) (unary-op-based-ℕ .(succ-ℕ k) (inl x) n) =
-  ap ( add-ℕ (mul-ℕ (succ-ℕ k) (succ-ℕ (convert-based-ℕ (succ-ℕ k) n))))
+  ap ( add-ℕ ((succ-ℕ k) *ℕ (succ-ℕ (convert-based-ℕ (succ-ℕ k) n))))
      ( nat-succ-Fin k x)
 convert-based-succ-based-ℕ
   (succ-ℕ k) (unary-op-based-ℕ .(succ-ℕ k) (inr star) n) =
@@ -209,7 +209,7 @@ convert-based-succ-based-ℕ
         ( succ-ℕ (convert-based-ℕ (succ-ℕ k) n))) ∙
       ( commutative-add-ℕ
         ( succ-ℕ k)
-        ( mul-ℕ (succ-ℕ k) (succ-ℕ (convert-based-ℕ (succ-ℕ k) n))))))
+        ( (succ-ℕ k) *ℕ (succ-ℕ (convert-based-ℕ (succ-ℕ k) n))))))
 
 issec-inv-convert-based-ℕ :
   (k n : ℕ) → convert-based-ℕ (succ-ℕ k) (inv-convert-based-ℕ k n) ＝ n

--- a/src/elementary-number-theory/fundamental-theorem-of-arithmetic.lagda.md
+++ b/src/elementary-number-theory/fundamental-theorem-of-arithmetic.lagda.md
@@ -29,7 +29,6 @@ open import foundation.coproduct-types
 open import foundation.decidable-types
 open import foundation.dependent-pair-types
 open import foundation.empty-types
-open import foundation.equality-dependent-pair-types
 open import foundation.identity-types
 open import foundation.propositions
 open import foundation.subtypes

--- a/src/elementary-number-theory/fundamental-theorem-of-arithmetic.lagda.md
+++ b/src/elementary-number-theory/fundamental-theorem-of-arithmetic.lagda.md
@@ -525,12 +525,9 @@ is-decomposition-list-fundamental-theorem-arithmetic-ℕ x H =
         ( λ p → is-decomposition-list-ℕ (succ-ℕ n) p)
         ( inv (compute-list-fundamental-theorem-arithmetic-succ-ℕ n N))
         ( ( ap
-            ( λ m →
-              mul-ℕ
-                ( nat-least-prime-divisor-ℕ
-                  ( succ-ℕ n)
-                  ( le-succ-leq-ℕ 1 n N))
-                ( m))
+            ( ( nat-least-prime-divisor-ℕ
+                ( succ-ℕ n)
+                ( le-succ-leq-ℕ 1 n N)) *ℕ_)
             ( f
               ( quotient-div-least-prime-divisor-ℕ
                 ( succ-ℕ n)

--- a/src/elementary-number-theory/goldbach-conjecture.lagda.md
+++ b/src/elementary-number-theory/goldbach-conjecture.lagda.md
@@ -27,5 +27,5 @@ open import foundation.universe-levels
 Goldbach-conjecture : UU lzero
 Goldbach-conjecture =
   ( n : ℕ) → (le-ℕ 2 n) → (is-even-ℕ n) →
-    Σ ℕ (λ p → (is-prime-ℕ p) × (Σ ℕ (λ q → (is-prime-ℕ q) × (add-ℕ p q ＝ n))))
+    Σ ℕ (λ p → (is-prime-ℕ p) × (Σ ℕ (λ q → (is-prime-ℕ q) × (p +ℕ q ＝ n))))
 ```

--- a/src/elementary-number-theory/greatest-common-divisor-integers.lagda.md
+++ b/src/elementary-number-theory/greatest-common-divisor-integers.lagda.md
@@ -238,7 +238,7 @@ is-positive-gcd-is-positive-left-ℤ x y H =
       ( abs-ℤ y)
       ( λ p → is-nonzero-abs-ℤ x H (f p)))
   where
-  f : is-zero-ℕ (add-ℕ (abs-ℤ x) (abs-ℤ y)) → is-zero-ℕ (abs-ℤ x)
+  f : is-zero-ℕ ((abs-ℤ x) +ℕ (abs-ℤ y)) → is-zero-ℕ (abs-ℤ x)
   f = is-zero-left-is-zero-add-ℕ (abs-ℤ x) (abs-ℤ y)
 
 is-positive-gcd-is-positive-right-ℤ :
@@ -251,7 +251,7 @@ is-positive-gcd-is-positive-right-ℤ x y H =
       ( abs-ℤ y)
       ( λ p → is-nonzero-abs-ℤ y H (f p)))
   where
-  f : is-zero-ℕ (add-ℕ (abs-ℤ x) (abs-ℤ y)) → is-zero-ℕ (abs-ℤ y)
+  f : is-zero-ℕ ((abs-ℤ x) +ℕ (abs-ℤ y)) → is-zero-ℕ (abs-ℤ y)
   f = is-zero-right-is-zero-add-ℕ (abs-ℤ x) (abs-ℤ y)
 
 is-positive-gcd-ℤ :

--- a/src/elementary-number-theory/greatest-common-divisor-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/greatest-common-divisor-natural-numbers.lagda.md
@@ -61,7 +61,7 @@ is-gcd-ℕ a b d = (x : ℕ) → (is-common-divisor-ℕ a b x) ↔ (div-ℕ x d)
 ```agda
 is-multiple-of-gcd-ℕ : (a b n : ℕ) → UU lzero
 is-multiple-of-gcd-ℕ a b n =
-  is-nonzero-ℕ (add-ℕ a b) →
+  is-nonzero-ℕ (a +ℕ b) →
   (is-nonzero-ℕ n) × ((x : ℕ) → is-common-divisor-ℕ a b x → div-ℕ x n)
 ```
 
@@ -111,17 +111,17 @@ uniqueness-is-gcd-ℕ a b d d' H H' =
 ```agda
 leq-sum-is-common-divisor-ℕ' :
   (a b d : ℕ) →
-  is-successor-ℕ (add-ℕ a b) → is-common-divisor-ℕ a b d → leq-ℕ d (add-ℕ a b)
+  is-successor-ℕ (a +ℕ b) → is-common-divisor-ℕ a b d → leq-ℕ d (a +ℕ b)
 leq-sum-is-common-divisor-ℕ' a zero-ℕ d (pair k p) H =
   concatenate-leq-eq-ℕ d
     ( leq-div-succ-ℕ d k (concatenate-div-eq-ℕ (pr1 H) p))
     ( inv p)
 leq-sum-is-common-divisor-ℕ' a (succ-ℕ b) d (pair k p) H =
-  leq-div-succ-ℕ d (add-ℕ a b) (div-add-ℕ d a (succ-ℕ b) (pr1 H) (pr2 H))
+  leq-div-succ-ℕ d (a +ℕ b) (div-add-ℕ d a (succ-ℕ b) (pr1 H) (pr2 H))
 
 leq-sum-is-common-divisor-ℕ :
   (a b d : ℕ) →
-  is-nonzero-ℕ (add-ℕ a b) → is-common-divisor-ℕ a b d → leq-ℕ d (add-ℕ a b)
+  is-nonzero-ℕ (a +ℕ b) → is-common-divisor-ℕ a b d → leq-ℕ d (a +ℕ b)
 leq-sum-is-common-divisor-ℕ a b d H =
   leq-sum-is-common-divisor-ℕ' a b d (is-successor-is-nonzero-ℕ H)
 ```
@@ -133,7 +133,7 @@ is-decidable-is-multiple-of-gcd-ℕ :
   (a b : ℕ) → is-decidable-fam (is-multiple-of-gcd-ℕ a b)
 is-decidable-is-multiple-of-gcd-ℕ a b n =
   is-decidable-function-type'
-    ( is-decidable-neg (is-decidable-is-zero-ℕ (add-ℕ a b)))
+    ( is-decidable-neg (is-decidable-is-zero-ℕ (a +ℕ b)))
     ( λ np →
       is-decidable-prod
         ( is-decidable-neg (is-decidable-is-zero-ℕ n))
@@ -142,14 +142,14 @@ is-decidable-is-multiple-of-gcd-ℕ a b n =
           ( λ x → div-ℕ x n)
           ( is-decidable-is-common-divisor-ℕ a b)
           ( λ x → is-decidable-div-ℕ x n)
-          ( add-ℕ a b)
+          ( a +ℕ b)
           ( λ x → leq-sum-is-common-divisor-ℕ a b x np)))
 ```
 
 ### The sum of `a` and `b` is a multiple of the greatest common divisor of `a` and `b`
 
 ```agda
-sum-is-multiple-of-gcd-ℕ : (a b : ℕ) → is-multiple-of-gcd-ℕ a b (add-ℕ a b)
+sum-is-multiple-of-gcd-ℕ : (a b : ℕ) → is-multiple-of-gcd-ℕ a b (a +ℕ b)
 pr1 (sum-is-multiple-of-gcd-ℕ a b np) = np
 pr2 (sum-is-multiple-of-gcd-ℕ a b np) x H = div-add-ℕ x a b (pr1 H) (pr2 H)
 ```
@@ -163,7 +163,7 @@ abstract
     well-ordering-principle-ℕ
       ( is-multiple-of-gcd-ℕ a b)
       ( is-decidable-is-multiple-of-gcd-ℕ a b)
-      ( pair (add-ℕ a b) (sum-is-multiple-of-gcd-ℕ a b))
+      ( pair (a +ℕ b) (sum-is-multiple-of-gcd-ℕ a b))
 
 gcd-ℕ : ℕ → ℕ → ℕ
 gcd-ℕ a b = pr1 (GCD-ℕ a b)
@@ -180,14 +180,14 @@ is-lower-bound-gcd-ℕ a b = pr2 (pr2 (GCD-ℕ a b))
 
 ```agda
 is-zero-gcd-ℕ :
-  (a b : ℕ) → is-zero-ℕ (add-ℕ a b) → is-zero-ℕ (gcd-ℕ a b)
+  (a b : ℕ) → is-zero-ℕ (a +ℕ b) → is-zero-ℕ (gcd-ℕ a b)
 is-zero-gcd-ℕ a b p =
   is-zero-leq-zero-ℕ
     ( gcd-ℕ a b)
     ( concatenate-leq-eq-ℕ
       ( gcd-ℕ a b)
       ( is-lower-bound-gcd-ℕ a b
-        ( add-ℕ a b)
+        ( a +ℕ b)
         ( sum-is-multiple-of-gcd-ℕ a b))
       ( p))
 
@@ -195,10 +195,10 @@ is-zero-gcd-zero-zero-ℕ : is-zero-ℕ (gcd-ℕ zero-ℕ zero-ℕ)
 is-zero-gcd-zero-zero-ℕ = is-zero-gcd-ℕ zero-ℕ zero-ℕ refl
 
 is-zero-add-is-zero-gcd-ℕ :
-  (a b : ℕ) → is-zero-ℕ (gcd-ℕ a b) → is-zero-ℕ (add-ℕ a b)
+  (a b : ℕ) → is-zero-ℕ (gcd-ℕ a b) → is-zero-ℕ (a +ℕ b)
 is-zero-add-is-zero-gcd-ℕ a b H =
   double-negation-elim-is-decidable
-    ( is-decidable-is-zero-ℕ (add-ℕ a b))
+    ( is-decidable-is-zero-ℕ (a +ℕ b))
     ( λ f → pr1 (is-multiple-of-gcd-gcd-ℕ a b f) H)
 ```
 
@@ -206,11 +206,11 @@ is-zero-add-is-zero-gcd-ℕ a b H =
 
 ```agda
 is-nonzero-gcd-ℕ :
-  (a b : ℕ) → is-nonzero-ℕ (add-ℕ a b) → is-nonzero-ℕ (gcd-ℕ a b)
+  (a b : ℕ) → is-nonzero-ℕ (a +ℕ b) → is-nonzero-ℕ (gcd-ℕ a b)
 is-nonzero-gcd-ℕ a b ne = pr1 (is-multiple-of-gcd-gcd-ℕ a b ne)
 
 is-successor-gcd-ℕ :
-  (a b : ℕ) → is-nonzero-ℕ (add-ℕ a b) → is-successor-ℕ (gcd-ℕ a b)
+  (a b : ℕ) → is-nonzero-ℕ (a +ℕ b) → is-successor-ℕ (gcd-ℕ a b)
 is-successor-gcd-ℕ a b ne =
   is-successor-is-nonzero-ℕ (is-nonzero-gcd-ℕ a b ne)
 ```
@@ -221,7 +221,7 @@ is-successor-gcd-ℕ a b ne =
 div-gcd-is-common-divisor-ℕ :
   (a b x : ℕ) → is-common-divisor-ℕ a b x → div-ℕ x (gcd-ℕ a b)
 div-gcd-is-common-divisor-ℕ a b x H with
-  is-decidable-is-zero-ℕ (add-ℕ a b)
+  is-decidable-is-zero-ℕ (a +ℕ b)
 ... | inl p = concatenate-div-eq-ℕ (div-zero-ℕ x) (inv (is-zero-gcd-ℕ a b p))
 ... | inr np = pr2 (is-multiple-of-gcd-gcd-ℕ a b np) x H
 ```
@@ -246,7 +246,7 @@ is-zero-is-common-divisor-le-gcd-ℕ a b r l d with is-decidable-is-zero-ℕ r
 div-left-factor-div-gcd-ℕ :
   (a b x : ℕ) → div-ℕ x (gcd-ℕ a b) → div-ℕ x a
 div-left-factor-div-gcd-ℕ a b x d with
-  is-decidable-is-zero-ℕ (add-ℕ a b)
+  is-decidable-is-zero-ℕ (a +ℕ b)
 ... | inl p =
   concatenate-div-eq-ℕ (div-zero-ℕ x) (inv (is-zero-left-is-zero-add-ℕ a b p))
 ... | inr np =
@@ -272,7 +272,7 @@ div-left-factor-div-gcd-ℕ a b x d with
 div-right-factor-div-gcd-ℕ :
   (a b x : ℕ) → div-ℕ x (gcd-ℕ a b) → div-ℕ x b
 div-right-factor-div-gcd-ℕ a b x d with
-  is-decidable-is-zero-ℕ (add-ℕ a b)
+  is-decidable-is-zero-ℕ (a +ℕ b)
 ... | inl p =
   concatenate-div-eq-ℕ (div-zero-ℕ x) (inv (is-zero-right-is-zero-add-ℕ a b p))
 ... | inr np =

--- a/src/elementary-number-theory/greatest-common-divisor-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/greatest-common-divisor-natural-numbers.lagda.md
@@ -256,7 +256,7 @@ div-left-factor-div-gcd-ℕ a b x d with
           ( ap ( dist-ℕ a)
                ( is-zero-is-common-divisor-le-gcd-ℕ a b r B
                  ( λ x H →
-                   div-right-summand-ℕ x (mul-ℕ q (gcd-ℕ a b)) r
+                   div-right-summand-ℕ x (q *ℕ (gcd-ℕ a b)) r
                      ( div-mul-ℕ q x (gcd-ℕ a b)
                        ( div-gcd-is-common-divisor-ℕ a b x H))
                      ( concatenate-div-eq-ℕ (pr1 H) (inv β)))))) ∙
@@ -281,7 +281,7 @@ div-right-factor-div-gcd-ℕ a b x d with
       ( ( α ∙ ( ap ( dist-ℕ b)
                ( is-zero-is-common-divisor-le-gcd-ℕ a b r B
                  ( λ x H →
-                   div-right-summand-ℕ x (mul-ℕ q (gcd-ℕ a b)) r
+                   div-right-summand-ℕ x (q *ℕ (gcd-ℕ a b)) r
                      ( div-mul-ℕ q x (gcd-ℕ a b)
                        ( div-gcd-is-common-divisor-ℕ a b x H))
                      ( concatenate-div-eq-ℕ (pr2 H) (inv β)))))) ∙
@@ -347,7 +347,7 @@ is-commutative-gcd-ℕ a b =
 ```agda
 preserves-is-common-divisor-mul-ℕ :
   (k a b d : ℕ) → is-common-divisor-ℕ a b d →
-  is-common-divisor-ℕ (mul-ℕ k a) (mul-ℕ k b) (mul-ℕ k d)
+  is-common-divisor-ℕ (k *ℕ a) (k *ℕ b) (k *ℕ d)
 preserves-is-common-divisor-mul-ℕ k a b d =
   map-prod
     ( preserves-div-mul-ℕ k d a)
@@ -355,7 +355,7 @@ preserves-is-common-divisor-mul-ℕ k a b d =
 
 reflects-is-common-divisor-mul-ℕ :
   (k a b d : ℕ) → is-nonzero-ℕ k →
-  is-common-divisor-ℕ (mul-ℕ k a) (mul-ℕ k b) (mul-ℕ k d) →
+  is-common-divisor-ℕ (k *ℕ a) (k *ℕ b) (k *ℕ d) →
   is-common-divisor-ℕ a b d
 reflects-is-common-divisor-mul-ℕ k a b d H =
   map-prod
@@ -427,7 +427,7 @@ simplify-is-common-divisor-quotient-div-ℕ :
     ( quotient-div-ℕ d a (pr1 H))
     ( quotient-div-ℕ d b (pr2 H))
     ( x) ↔
-  is-common-divisor-ℕ a b (mul-ℕ x d)
+  is-common-divisor-ℕ a b (x *ℕ d)
 pr1 (pr1 (simplify-is-common-divisor-quotient-div-ℕ nz H) K) =
   forward-implication (simplify-div-quotient-div-ℕ nz (pr1 H)) (pr1 K)
 pr2 (pr1 (simplify-is-common-divisor-quotient-div-ℕ nz H) K) =
@@ -455,10 +455,10 @@ is-gcd-quotient-div-gcd-ℕ {a} {b} {d} nz H x =
       ( quotient-div-ℕ d a (pr1 H))
       ( quotient-div-ℕ d b (pr2 H))
       ( x)
-    ↔ is-common-divisor-ℕ a b (mul-ℕ x d)
+    ↔ is-common-divisor-ℕ a b (x *ℕ d)
       by simplify-is-common-divisor-quotient-div-ℕ nz H
-    ↔ div-ℕ (mul-ℕ x d) (gcd-ℕ a b)
-      by is-gcd-gcd-ℕ a b (mul-ℕ x d)
+    ↔ div-ℕ (x *ℕ d) (gcd-ℕ a b)
+      by is-gcd-gcd-ℕ a b (x *ℕ d)
     ↔ div-ℕ x
         ( quotient-div-ℕ d
           ( gcd-ℕ a b)

--- a/src/elementary-number-theory/half-integers.lagda.md
+++ b/src/elementary-number-theory/half-integers.lagda.md
@@ -51,4 +51,7 @@ add-½ℤ (inl x) (inl y) = inr (succ-ℤ (x +ℤ y))
 add-½ℤ (inl x) (inr y) = inl (x +ℤ y)
 add-½ℤ (inr x) (inl y) = inl (x +ℤ y)
 add-½ℤ (inr x) (inr y) = inr (x +ℤ y)
+
+infix 30 _+½ℤ_
+_+½ℤ_ = add-½ℤ
 ```

--- a/src/elementary-number-theory/half-integers.lagda.md
+++ b/src/elementary-number-theory/half-integers.lagda.md
@@ -47,8 +47,8 @@ zero-½ℤ = inr zero-ℤ
 
 ```agda
 add-½ℤ : ½ℤ → ½ℤ → ½ℤ
-add-½ℤ (inl x) (inl y) = inr (succ-ℤ (add-ℤ x y))
-add-½ℤ (inl x) (inr y) = inl (add-ℤ x y)
-add-½ℤ (inr x) (inl y) = inl (add-ℤ x y)
-add-½ℤ (inr x) (inr y) = inr (add-ℤ x y)
+add-½ℤ (inl x) (inl y) = inr (succ-ℤ (x +ℤ y))
+add-½ℤ (inl x) (inr y) = inl (x +ℤ y)
+add-½ℤ (inr x) (inl y) = inl (x +ℤ y)
+add-½ℤ (inr x) (inr y) = inr (x +ℤ y)
 ```

--- a/src/elementary-number-theory/inequality-integer-fractions.lagda.md
+++ b/src/elementary-number-theory/inequality-integer-fractions.lagda.md
@@ -30,7 +30,7 @@ A fraction `m/n` is less (or equal) to a fraction `m'/n'` iff `m * n'` is less
 ```agda
 leq-fraction-ℤ-Prop : fraction-ℤ → fraction-ℤ → Prop lzero
 leq-fraction-ℤ-Prop (m , n , p) (m' , n' , p') =
-  leq-ℤ-Prop (mul-ℤ m n') (mul-ℤ m' n)
+  leq-ℤ-Prop (m *ℤ n') (m' *ℤ n)
 
 leq-fraction-ℤ : fraction-ℤ → fraction-ℤ → UU lzero
 leq-fraction-ℤ x y = type-Prop (leq-fraction-ℤ-Prop x y)
@@ -44,7 +44,7 @@ is-prop-leq-fraction-ℤ x y = is-prop-type-Prop (leq-fraction-ℤ-Prop x y)
 ```agda
 le-fraction-ℤ-Prop : fraction-ℤ → fraction-ℤ → Prop lzero
 le-fraction-ℤ-Prop (m , n , p) (m' , n' , p') =
-  le-ℤ-Prop (mul-ℤ m n') (mul-ℤ m' n)
+  le-ℤ-Prop (m *ℤ n') (m' *ℤ n)
 
 le-fraction-ℤ : fraction-ℤ → fraction-ℤ → UU lzero
 le-fraction-ℤ x y = type-Prop (le-fraction-ℤ-Prop x y)

--- a/src/elementary-number-theory/inequality-integers.lagda.md
+++ b/src/elementary-number-theory/inequality-integers.lagda.md
@@ -54,8 +54,8 @@ trans-leq-ℤ k l m p q =
   tr is-nonnegative-ℤ
     ( triangle-diff-ℤ m l k)
     ( is-nonnegative-add-ℤ
-      ( add-ℤ m (neg-ℤ l))
-      ( add-ℤ l (neg-ℤ k))
+      ( m +ℤ (neg-ℤ l))
+      ( l +ℤ (neg-ℤ k))
       ( q)
       ( p))
 
@@ -108,32 +108,32 @@ is-prop-le-ℤ x y = is-prop-type-Prop (le-ℤ-Prop x y)
 
 ```agda
 preserves-order-add-ℤ' :
-  {x y : ℤ} (z : ℤ) → leq-ℤ x y → leq-ℤ (add-ℤ x z) (add-ℤ y z)
+  {x y : ℤ} (z : ℤ) → leq-ℤ x y → leq-ℤ (x +ℤ z) (y +ℤ z)
 preserves-order-add-ℤ' {x} {y} z =
   is-nonnegative-eq-ℤ (inv (right-translation-diff-ℤ y x z))
 
 preserves-order-add-ℤ :
-  {x y : ℤ} (z : ℤ) → leq-ℤ x y → leq-ℤ (add-ℤ z x) (add-ℤ z y)
+  {x y : ℤ} (z : ℤ) → leq-ℤ x y → leq-ℤ (z +ℤ x) (z +ℤ y)
 preserves-order-add-ℤ {x} {y} z =
   is-nonnegative-eq-ℤ (inv (left-translation-diff-ℤ y x z))
 
 preserves-leq-add-ℤ :
-  {a b c d : ℤ} → leq-ℤ a b → leq-ℤ c d → leq-ℤ (add-ℤ a c) (add-ℤ b d)
+  {a b c d : ℤ} → leq-ℤ a b → leq-ℤ c d → leq-ℤ (a +ℤ c) (b +ℤ d)
 preserves-leq-add-ℤ {a} {b} {c} {d} H K =
   trans-leq-ℤ
-    ( add-ℤ a c)
-    ( add-ℤ b c)
-    ( add-ℤ b d)
+    ( a +ℤ c)
+    ( b +ℤ c)
+    ( b +ℤ d)
     ( preserves-order-add-ℤ' {a} {b} c H)
     ( preserves-order-add-ℤ b K)
 
 reflects-order-add-ℤ' :
-  {x y z : ℤ} → leq-ℤ (add-ℤ x z) (add-ℤ y z) → leq-ℤ x y
+  {x y z : ℤ} → leq-ℤ (x +ℤ z) (y +ℤ z) → leq-ℤ x y
 reflects-order-add-ℤ' {x} {y} {z} =
   is-nonnegative-eq-ℤ (right-translation-diff-ℤ y x z)
 
 reflects-order-add-ℤ :
-  {x y z : ℤ} → leq-ℤ (add-ℤ z x) (add-ℤ z y) → leq-ℤ x y
+  {x y z : ℤ} → leq-ℤ (z +ℤ x) (z +ℤ y) → leq-ℤ x y
 reflects-order-add-ℤ {x} {y} {z} =
   is-nonnegative-eq-ℤ (left-translation-diff-ℤ y x z)
 ```

--- a/src/elementary-number-theory/inequality-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/inequality-natural-numbers.lagda.md
@@ -364,16 +364,16 @@ leq-subtraction-ℕ (succ-ℕ n) (succ-ℕ m) l p =
 
 ```agda
 preserves-order-mul-ℕ :
-  (k m n : ℕ) → m ≤-ℕ n → (mul-ℕ m k) ≤-ℕ (mul-ℕ n k)
+  (k m n : ℕ) → m ≤-ℕ n → (m *ℕ k) ≤-ℕ (n *ℕ k)
 preserves-order-mul-ℕ k zero-ℕ n p = star
 preserves-order-mul-ℕ k (succ-ℕ m) (succ-ℕ n) p =
   left-law-leq-add-ℕ k
-    ( mul-ℕ m k)
-    ( mul-ℕ n k)
+    ( m *ℕ k)
+    ( n *ℕ k)
     ( preserves-order-mul-ℕ k m n p)
 
 preserves-order-mul-ℕ' :
-  (k m n : ℕ) → m ≤-ℕ n → (mul-ℕ k m) ≤-ℕ (mul-ℕ k n)
+  (k m n : ℕ) → m ≤-ℕ n → (k *ℕ m) ≤-ℕ (k *ℕ n)
 preserves-order-mul-ℕ' k m n H =
   concatenate-eq-leq-eq-ℕ
     ( commutative-mul-ℕ k m)
@@ -385,18 +385,18 @@ preserves-order-mul-ℕ' k m n H =
 
 ```agda
 reflects-order-mul-ℕ :
-  (k m n : ℕ) → (mul-ℕ m (succ-ℕ k)) ≤-ℕ (mul-ℕ n (succ-ℕ k)) → m ≤-ℕ n
+  (k m n : ℕ) → (m *ℕ (succ-ℕ k)) ≤-ℕ (n *ℕ (succ-ℕ k)) → m ≤-ℕ n
 reflects-order-mul-ℕ k zero-ℕ n p = star
 reflects-order-mul-ℕ k (succ-ℕ m) (succ-ℕ n) p =
   reflects-order-mul-ℕ k m n
     ( reflects-order-add-ℕ
       ( succ-ℕ k)
-      ( mul-ℕ m (succ-ℕ k))
-      ( mul-ℕ n (succ-ℕ k))
+      ( m *ℕ (succ-ℕ k))
+      ( n *ℕ (succ-ℕ k))
       ( p))
 
 reflects-order-mul-ℕ' :
-  (k m n : ℕ) → (mul-ℕ (succ-ℕ k) m) ≤-ℕ (mul-ℕ (succ-ℕ k) n) → m ≤-ℕ n
+  (k m n : ℕ) → ((succ-ℕ k) *ℕ m) ≤-ℕ ((succ-ℕ k) *ℕ n) → m ≤-ℕ n
 reflects-order-mul-ℕ' k m n H =
   reflects-order-mul-ℕ k m n
     ( concatenate-eq-leq-eq-ℕ
@@ -409,27 +409,27 @@ reflects-order-mul-ℕ' k m n H =
 
 ```agda
 leq-mul-ℕ :
-  (k x : ℕ) → x ≤-ℕ (mul-ℕ x (succ-ℕ k))
+  (k x : ℕ) → x ≤-ℕ (x *ℕ (succ-ℕ k))
 leq-mul-ℕ k x =
   concatenate-eq-leq-ℕ
-    ( mul-ℕ x (succ-ℕ k))
+    ( x *ℕ (succ-ℕ k))
     ( inv (right-unit-law-mul-ℕ x))
     ( preserves-order-mul-ℕ' x 1 (succ-ℕ k) (leq-zero-ℕ k))
 
 leq-mul-ℕ' :
-  (k x : ℕ) → x ≤-ℕ (mul-ℕ (succ-ℕ k) x)
+  (k x : ℕ) → x ≤-ℕ ((succ-ℕ k) *ℕ x)
 leq-mul-ℕ' k x =
   concatenate-leq-eq-ℕ x
     ( leq-mul-ℕ k x)
     ( commutative-mul-ℕ x (succ-ℕ k))
 
 leq-mul-is-nonzero-ℕ :
-  (k x : ℕ) → is-nonzero-ℕ k → x ≤-ℕ (mul-ℕ x k)
+  (k x : ℕ) → is-nonzero-ℕ k → x ≤-ℕ (x *ℕ k)
 leq-mul-is-nonzero-ℕ k x H with is-successor-is-nonzero-ℕ H
 ... | pair l refl = leq-mul-ℕ l x
 
 leq-mul-is-nonzero-ℕ' :
-  (k x : ℕ) → is-nonzero-ℕ k → x ≤-ℕ (mul-ℕ k x)
+  (k x : ℕ) → is-nonzero-ℕ k → x ≤-ℕ (k *ℕ x)
 leq-mul-is-nonzero-ℕ' k x H with is-successor-is-nonzero-ℕ H
 ... | pair l refl = leq-mul-ℕ' l x
 ```

--- a/src/elementary-number-theory/inequality-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/inequality-natural-numbers.lagda.md
@@ -289,11 +289,11 @@ contradiction-leq-ℕ' m n K H = contradiction-leq-ℕ m n H K
 
 ```agda
 left-law-leq-add-ℕ :
-  (k m n : ℕ) → m ≤-ℕ n → (add-ℕ m k) ≤-ℕ (add-ℕ n k)
+  (k m n : ℕ) → m ≤-ℕ n → (m +ℕ k) ≤-ℕ (n +ℕ k)
 left-law-leq-add-ℕ zero-ℕ m n = id
 left-law-leq-add-ℕ (succ-ℕ k) m n H = left-law-leq-add-ℕ k m n H
 
-right-law-leq-add-ℕ : (k m n : ℕ) → m ≤-ℕ n → (add-ℕ k m) ≤-ℕ (add-ℕ k n)
+right-law-leq-add-ℕ : (k m n : ℕ) → m ≤-ℕ n → (k +ℕ m) ≤-ℕ (k +ℕ n)
 right-law-leq-add-ℕ k m n H =
   concatenate-eq-leq-eq-ℕ
     ( commutative-add-ℕ k m)
@@ -301,12 +301,12 @@ right-law-leq-add-ℕ k m n H =
     ( commutative-add-ℕ n k)
 
 preserves-leq-add-ℕ :
-  {m m' n n' : ℕ} → m ≤-ℕ m' → n ≤-ℕ n' → (add-ℕ m n) ≤-ℕ (add-ℕ m' n')
+  {m m' n n' : ℕ} → m ≤-ℕ m' → n ≤-ℕ n' → (m +ℕ n) ≤-ℕ (m' +ℕ n')
 preserves-leq-add-ℕ {m} {m'} {n} {n'} H K =
   transitive-leq-ℕ
-    ( add-ℕ m n)
-    ( add-ℕ m' n)
-    ( add-ℕ m' n')
+    ( m +ℕ n)
+    ( m' +ℕ n)
+    ( m' +ℕ n')
     ( right-law-leq-add-ℕ m' n n' K)
     ( left-law-leq-add-ℕ n m m' H)
 ```
@@ -315,12 +315,12 @@ preserves-leq-add-ℕ {m} {m'} {n} {n'} H K =
 
 ```agda
 reflects-order-add-ℕ :
-  (k m n : ℕ) → (add-ℕ m k) ≤-ℕ (add-ℕ n k) → m ≤-ℕ n
+  (k m n : ℕ) → (m +ℕ k) ≤-ℕ (n +ℕ k) → m ≤-ℕ n
 reflects-order-add-ℕ zero-ℕ m n = id
 reflects-order-add-ℕ (succ-ℕ k) m n = reflects-order-add-ℕ k m n
 
 reflects-order-add-ℕ' :
-  (k m n : ℕ) → (add-ℕ k m) ≤-ℕ (add-ℕ k n) → m ≤-ℕ n
+  (k m n : ℕ) → (k +ℕ m) ≤-ℕ (k +ℕ n) → m ≤-ℕ n
 reflects-order-add-ℕ' k m n H =
   reflects-order-add-ℕ k m n
     ( concatenate-eq-leq-eq-ℕ
@@ -332,14 +332,14 @@ reflects-order-add-ℕ' k m n H =
 ### `m ≤ m + n` for any two natural numbers `m` and `n`
 
 ```agda
-leq-add-ℕ : (m n : ℕ) → m ≤-ℕ (add-ℕ m n)
+leq-add-ℕ : (m n : ℕ) → m ≤-ℕ (m +ℕ n)
 leq-add-ℕ m zero-ℕ = refl-leq-ℕ m
 leq-add-ℕ m (succ-ℕ n) =
-  transitive-leq-ℕ m (add-ℕ m n) (succ-ℕ (add-ℕ m n))
-    ( succ-leq-ℕ (add-ℕ m n))
+  transitive-leq-ℕ m (m +ℕ n) (succ-ℕ (m +ℕ n))
+    ( succ-leq-ℕ (m +ℕ n))
     ( leq-add-ℕ m n)
 
-leq-add-ℕ' : (m n : ℕ) → m ≤-ℕ (add-ℕ n m)
+leq-add-ℕ' : (m n : ℕ) → m ≤-ℕ (n +ℕ m)
 leq-add-ℕ' m n =
   concatenate-leq-eq-ℕ m (leq-add-ℕ m n) (commutative-add-ℕ m n)
 ```
@@ -347,14 +347,14 @@ leq-add-ℕ' m n =
 ### We have `n ≤ m` if and only if there is a number `l` such that `l+n=m`
 
 ```agda
-subtraction-leq-ℕ : (n m : ℕ) → n ≤-ℕ m → Σ ℕ (λ l → add-ℕ l n ＝ m)
+subtraction-leq-ℕ : (n m : ℕ) → n ≤-ℕ m → Σ ℕ (λ l → l +ℕ n ＝ m)
 subtraction-leq-ℕ zero-ℕ m p = pair m refl
 subtraction-leq-ℕ (succ-ℕ n) (succ-ℕ m) p = pair (pr1 P) (ap succ-ℕ (pr2 P))
   where
-  P : Σ ℕ (λ l' → add-ℕ l' n ＝ m)
+  P : Σ ℕ (λ l' → l' +ℕ n ＝ m)
   P = subtraction-leq-ℕ n m p
 
-leq-subtraction-ℕ : (n m l : ℕ) → add-ℕ l n ＝ m → n ≤-ℕ m
+leq-subtraction-ℕ : (n m l : ℕ) → l +ℕ n ＝ m → n ≤-ℕ m
 leq-subtraction-ℕ zero-ℕ m l p = leq-zero-ℕ m
 leq-subtraction-ℕ (succ-ℕ n) (succ-ℕ m) l p =
   leq-subtraction-ℕ n m l (is-injective-succ-ℕ p)

--- a/src/elementary-number-theory/integer-fractions.lagda.md
+++ b/src/elementary-number-theory/integer-fractions.lagda.md
@@ -116,8 +116,8 @@ is-set-fraction-ℤ = is-set-Σ is-set-ℤ λ _ → is-set-positive-ℤ
 sim-fraction-ℤ-Prop : fraction-ℤ → fraction-ℤ → Prop lzero
 sim-fraction-ℤ-Prop x y =
   Id-Prop ℤ-Set
-    (mul-ℤ (numerator-fraction-ℤ x) (denominator-fraction-ℤ y))
-    (mul-ℤ (numerator-fraction-ℤ y) (denominator-fraction-ℤ x))
+    ((numerator-fraction-ℤ x) *ℤ (denominator-fraction-ℤ y))
+    ((numerator-fraction-ℤ y) *ℤ (denominator-fraction-ℤ x))
 
 sim-fraction-ℤ : fraction-ℤ → fraction-ℤ → UU lzero
 sim-fraction-ℤ x y = type-Prop (sim-fraction-ℤ-Prop x y)

--- a/src/elementary-number-theory/integer-fractions.lagda.md
+++ b/src/elementary-number-theory/integer-fractions.lagda.md
@@ -144,7 +144,7 @@ trans-sim-fraction-ℤ x y z r s =
         ( denominator-fraction-ℤ z)
         ( denominator-fraction-ℤ y)) ∙
       ( ( ap
-          ( mul-ℤ (numerator-fraction-ℤ x))
+          ( (numerator-fraction-ℤ x) *ℤ_)
           ( commutative-mul-ℤ
             ( denominator-fraction-ℤ z)
             ( denominator-fraction-ℤ y))) ∙
@@ -159,7 +159,7 @@ trans-sim-fraction-ℤ x y z r s =
                 ( denominator-fraction-ℤ x)
                 ( denominator-fraction-ℤ z)) ∙
               ( ( ap
-                  ( mul-ℤ (numerator-fraction-ℤ y))
+                  ( (numerator-fraction-ℤ y) *ℤ_)
                   ( commutative-mul-ℤ
                     ( denominator-fraction-ℤ x)
                     ( denominator-fraction-ℤ z))) ∙
@@ -174,7 +174,7 @@ trans-sim-fraction-ℤ x y z r s =
                         ( denominator-fraction-ℤ y)
                         ( denominator-fraction-ℤ x)) ∙
                       ( ( ap
-                          ( mul-ℤ (numerator-fraction-ℤ z))
+                          ( (numerator-fraction-ℤ z) *ℤ_)
                           ( commutative-mul-ℤ
                             ( denominator-fraction-ℤ y)
                             ( denominator-fraction-ℤ x))) ∙

--- a/src/elementary-number-theory/integer-fractions.lagda.md
+++ b/src/elementary-number-theory/integer-fractions.lagda.md
@@ -153,7 +153,7 @@ trans-sim-fraction-ℤ x y z r s =
               ( numerator-fraction-ℤ x)
               ( denominator-fraction-ℤ y)
               ( denominator-fraction-ℤ z))) ∙
-          ( ( ap ( mul-ℤ' (denominator-fraction-ℤ z)) r) ∙
+          ( ( ap ( _*ℤ (denominator-fraction-ℤ z)) r) ∙
             ( ( associative-mul-ℤ
                 ( numerator-fraction-ℤ y)
                 ( denominator-fraction-ℤ x)
@@ -168,7 +168,7 @@ trans-sim-fraction-ℤ x y z r s =
                       ( numerator-fraction-ℤ y)
                       ( denominator-fraction-ℤ z)
                       ( denominator-fraction-ℤ x))) ∙
-                  ( ( ap (mul-ℤ' (denominator-fraction-ℤ x)) s) ∙
+                  ( ( ap (_*ℤ (denominator-fraction-ℤ x)) s) ∙
                     ( ( associative-mul-ℤ
                         ( numerator-fraction-ℤ z)
                         ( denominator-fraction-ℤ y)

--- a/src/elementary-number-theory/integer-fractions.lagda.md
+++ b/src/elementary-number-theory/integer-fractions.lagda.md
@@ -136,7 +136,7 @@ trans-sim-fraction-ℤ :
   (x y z : fraction-ℤ) →
   sim-fraction-ℤ x y → sim-fraction-ℤ y z → sim-fraction-ℤ x z
 trans-sim-fraction-ℤ x y z r s =
-  is-injective-mul-ℤ'
+  is-injective-right-mul-ℤ
     ( denominator-fraction-ℤ y)
     ( is-nonzero-denominator-fraction-ℤ y)
     ( ( associative-mul-ℤ

--- a/src/elementary-number-theory/maximum-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/maximum-natural-numbers.lagda.md
@@ -154,7 +154,7 @@ right-successor-diagonal-law-max-ℕ (succ-ℕ x) =
 
 ```agda
 left-distributive-add-max-ℕ :
-  (x y z : ℕ) → add-ℕ x (max-ℕ y z) ＝ max-ℕ (add-ℕ x y) (add-ℕ x z)
+  (x y z : ℕ) → x +ℕ (max-ℕ y z) ＝ max-ℕ (x +ℕ y) (x +ℕ z)
 left-distributive-add-max-ℕ zero-ℕ y z =
   ( left-unit-law-add-ℕ (max-ℕ y z)) ∙
   ( ap-max-ℕ (inv (left-unit-law-add-ℕ y)) (inv (left-unit-law-add-ℕ z)))
@@ -166,7 +166,7 @@ left-distributive-add-max-ℕ (succ-ℕ x) y z =
       ( inv (left-successor-law-add-ℕ x z))))
 
 right-distributive-add-max-ℕ :
-  (x y z : ℕ) → add-ℕ (max-ℕ x y) z ＝ max-ℕ (add-ℕ x z) (add-ℕ y z)
+  (x y z : ℕ) → (max-ℕ x y) +ℕ z ＝ max-ℕ (x +ℕ z) (y +ℕ z)
 right-distributive-add-max-ℕ x y z =
   ( commutative-add-ℕ (max-ℕ x y) z) ∙
   ( ( left-distributive-add-max-ℕ z x y) ∙

--- a/src/elementary-number-theory/minimum-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/minimum-natural-numbers.lagda.md
@@ -131,7 +131,7 @@ idempotent-min-ℕ (succ-ℕ x) = ap succ-ℕ (idempotent-min-ℕ x)
 
 ```agda
 left-distributive-add-min-ℕ :
-  (x y z : ℕ) → add-ℕ x (min-ℕ y z) ＝ min-ℕ (add-ℕ x y) (add-ℕ x z)
+  (x y z : ℕ) → x +ℕ (min-ℕ y z) ＝ min-ℕ (x +ℕ y) (x +ℕ z)
 left-distributive-add-min-ℕ zero-ℕ y z =
   ( left-unit-law-add-ℕ (min-ℕ y z)) ∙
   ( ap-min-ℕ (inv (left-unit-law-add-ℕ y)) (inv (left-unit-law-add-ℕ z)))
@@ -143,7 +143,7 @@ left-distributive-add-min-ℕ (succ-ℕ x) y z =
       ( inv (left-successor-law-add-ℕ x z))))
 
 right-distributive-add-min-ℕ :
-  (x y z : ℕ) → add-ℕ (min-ℕ x y) z ＝ min-ℕ (add-ℕ x z) (add-ℕ y z)
+  (x y z : ℕ) → (min-ℕ x y) +ℕ z ＝ min-ℕ (x +ℕ z) (y +ℕ z)
 right-distributive-add-min-ℕ x y z =
   ( commutative-add-ℕ (min-ℕ x y) z) ∙
   ( ( left-distributive-add-min-ℕ z x y) ∙

--- a/src/elementary-number-theory/modular-arithmetic-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/modular-arithmetic-standard-finite-types.lagda.md
@@ -182,7 +182,7 @@ leq-nat-mod-succ-ℕ k (succ-ℕ x) =
 ```agda
 add-Fin : (k : ℕ) → Fin k → Fin k → Fin k
 add-Fin (succ-ℕ k) x y =
-  mod-succ-ℕ k (add-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y))
+  mod-succ-ℕ k ((nat-Fin (succ-ℕ k) x) +ℕ (nat-Fin (succ-ℕ k) y))
 
 add-Fin' : (k : ℕ) → Fin k → Fin k → Fin k
 add-Fin' k x y = add-Fin k y x
@@ -196,7 +196,7 @@ cong-add-Fin :
   {k : ℕ} (x y : Fin k) →
   cong-ℕ k (nat-Fin k (add-Fin k x y)) ((nat-Fin k x) +ℕ (nat-Fin k y))
 cong-add-Fin {succ-ℕ k} x y =
-  cong-nat-mod-succ-ℕ k (add-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y))
+  cong-nat-mod-succ-ℕ k ((nat-Fin (succ-ℕ k) x) +ℕ (nat-Fin (succ-ℕ k) y))
 
 cong-add-ℕ :
   {k : ℕ} (x y : ℕ) →
@@ -299,7 +299,7 @@ cong-neg-Fin {succ-ℕ k} x =
 mul-Fin :
   (k : ℕ) → Fin k → Fin k → Fin k
 mul-Fin (succ-ℕ k) x y =
-  mod-succ-ℕ k (mul-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y))
+  mod-succ-ℕ k ((nat-Fin (succ-ℕ k) x) *ℕ (nat-Fin (succ-ℕ k) y))
 
 mul-Fin' :
   (k : ℕ) → Fin k → Fin k → Fin k
@@ -314,7 +314,7 @@ cong-mul-Fin :
   {k : ℕ} (x y : Fin k) →
   cong-ℕ k (nat-Fin k (mul-Fin k x y)) ((nat-Fin k x) *ℕ (nat-Fin k y))
 cong-mul-Fin {succ-ℕ k} x y =
-  cong-nat-mod-succ-ℕ k (mul-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y))
+  cong-nat-mod-succ-ℕ k ((nat-Fin (succ-ℕ k) x) *ℕ (nat-Fin (succ-ℕ k) y))
 ```
 
 ## Laws
@@ -346,12 +346,12 @@ associative-add-Fin (succ-ℕ k) x y z =
           ( nat-Fin (succ-ℕ k) z)}
       { x2 =
         add-ℕ
-          ( add-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y))
+          ( (nat-Fin (succ-ℕ k) x) +ℕ (nat-Fin (succ-ℕ k) y))
           ( nat-Fin (succ-ℕ k) z)}
       { x3 =
         add-ℕ
           ( nat-Fin (succ-ℕ k) x)
-          ( add-ℕ (nat-Fin (succ-ℕ k) y) (nat-Fin (succ-ℕ k) z))}
+          ( (nat-Fin (succ-ℕ k) y) +ℕ (nat-Fin (succ-ℕ k) z))}
       { x4 =
         add-ℕ
           ( nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k)
@@ -360,7 +360,7 @@ associative-add-Fin (succ-ℕ k) x y z =
         ( succ-ℕ k)
         { x = nat-Fin (succ-ℕ k) (add-Fin (succ-ℕ k) x y)}
         { y = nat-Fin (succ-ℕ k) z}
-        { x' = add-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y)}
+        { x' = (nat-Fin (succ-ℕ k) x) +ℕ (nat-Fin (succ-ℕ k) y)}
         { y' = nat-Fin (succ-ℕ k) z}
         ( cong-add-Fin x y)
         ( refl-cong-ℕ (succ-ℕ k) (nat-Fin (succ-ℕ k) z)))
@@ -371,22 +371,22 @@ associative-add-Fin (succ-ℕ k) x y z =
       ( congruence-add-ℕ
         ( succ-ℕ k)
         { x = nat-Fin (succ-ℕ k) x}
-        { y = add-ℕ (nat-Fin (succ-ℕ k) y) (nat-Fin (succ-ℕ k) z)}
+        { y = (nat-Fin (succ-ℕ k) y) +ℕ (nat-Fin (succ-ℕ k) z)}
         { x' = nat-Fin (succ-ℕ k) x}
         { y' = nat-Fin (succ-ℕ k) (add-Fin (succ-ℕ k) y z)}
         ( refl-cong-ℕ (succ-ℕ k) (nat-Fin (succ-ℕ k) x))
         ( symm-cong-ℕ
           ( succ-ℕ k)
           ( nat-Fin (succ-ℕ k) (add-Fin (succ-ℕ k) y z))
-          ( add-ℕ (nat-Fin (succ-ℕ k) y) (nat-Fin (succ-ℕ k) z))
+          ( (nat-Fin (succ-ℕ k) y) +ℕ (nat-Fin (succ-ℕ k) z))
           ( cong-add-Fin y z))))
 
 right-unit-law-add-Fin :
   (k : ℕ) (x : Fin (succ-ℕ k)) → add-Fin (succ-ℕ k) x (zero-Fin k) ＝ x
 right-unit-law-add-Fin k x =
   ( eq-mod-succ-cong-ℕ k
-    ( add-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) (zero-Fin k)))
-    ( add-ℕ (nat-Fin (succ-ℕ k) x) zero-ℕ)
+    ( (nat-Fin (succ-ℕ k) x) +ℕ (nat-Fin (succ-ℕ k) (zero-Fin k)))
+    ( (nat-Fin (succ-ℕ k) x) +ℕ zero-ℕ)
     ( congruence-add-ℕ
       ( succ-ℕ k)
       { x = nat-Fin (succ-ℕ k) x}
@@ -500,12 +500,12 @@ associative-mul-Fin (succ-ℕ k) x y z =
           ( nat-Fin (succ-ℕ k) z)}
       { x2 =
         mul-ℕ
-          ( mul-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y))
+          ( (nat-Fin (succ-ℕ k) x) *ℕ (nat-Fin (succ-ℕ k) y))
           ( nat-Fin (succ-ℕ k) z)}
       { x3 =
         mul-ℕ
           ( nat-Fin (succ-ℕ k) x)
-          ( mul-ℕ (nat-Fin (succ-ℕ k) y) (nat-Fin (succ-ℕ k) z))}
+          ( (nat-Fin (succ-ℕ k) y) *ℕ (nat-Fin (succ-ℕ k) z))}
       { x4 =
         mul-ℕ
           ( nat-Fin (succ-ℕ k) x)
@@ -527,7 +527,7 @@ associative-mul-Fin (succ-ℕ k) x y z =
           ( nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) y z)))
         ( mul-ℕ
           ( nat-Fin (succ-ℕ k) x)
-          ( mul-ℕ (nat-Fin (succ-ℕ k) y) (nat-Fin (succ-ℕ k) z)))
+          ( (nat-Fin (succ-ℕ k) y) *ℕ (nat-Fin (succ-ℕ k) z)))
         ( congruence-mul-ℕ
           ( succ-ℕ k)
           { x = nat-Fin (succ-ℕ k) x}
@@ -539,8 +539,8 @@ commutative-mul-Fin :
   (k : ℕ) (x y : Fin k) → mul-Fin k x y ＝ mul-Fin k y x
 commutative-mul-Fin (succ-ℕ k) x y =
   eq-mod-succ-cong-ℕ k
-    ( mul-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y))
-    ( mul-ℕ (nat-Fin (succ-ℕ k) y) (nat-Fin (succ-ℕ k) x))
+    ( (nat-Fin (succ-ℕ k) x) *ℕ (nat-Fin (succ-ℕ k) y))
+    ( (nat-Fin (succ-ℕ k) y) *ℕ (nat-Fin (succ-ℕ k) x))
     ( cong-identification-ℕ
       ( succ-ℕ k)
       ( commutative-mul-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y)))
@@ -607,11 +607,11 @@ left-distributive-mul-add-Fin (succ-ℕ k) x y z =
       { x2 =
         mul-ℕ
           ( nat-Fin (succ-ℕ k) x)
-          ( add-ℕ (nat-Fin (succ-ℕ k) y) (nat-Fin (succ-ℕ k) z))}
+          ( (nat-Fin (succ-ℕ k) y) +ℕ (nat-Fin (succ-ℕ k) z))}
       { x3 =
         add-ℕ
-          ( mul-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y))
-          ( mul-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) z))}
+          ( (nat-Fin (succ-ℕ k) x) *ℕ (nat-Fin (succ-ℕ k) y))
+          ( (nat-Fin (succ-ℕ k) x) *ℕ (nat-Fin (succ-ℕ k) z))}
       { x4 =
         add-ℕ
           ( nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) x y))
@@ -621,7 +621,7 @@ left-distributive-mul-add-Fin (succ-ℕ k) x y z =
         { x = nat-Fin (succ-ℕ k) x}
         { y = nat-Fin (succ-ℕ k) (add-Fin (succ-ℕ k) y z)}
         { x' = nat-Fin (succ-ℕ k) x}
-        { y' = add-ℕ (nat-Fin (succ-ℕ k) y) (nat-Fin (succ-ℕ k) z)}
+        { y' = (nat-Fin (succ-ℕ k) y) +ℕ (nat-Fin (succ-ℕ k) z)}
         ( refl-cong-ℕ (succ-ℕ k) (nat-Fin (succ-ℕ k) x))
         ( cong-add-Fin y z))
       ( left-distributive-mul-add-ℕ
@@ -633,14 +633,14 @@ left-distributive-mul-add-Fin (succ-ℕ k) x y z =
           ( nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) x y))
           ( nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) x z)))
         ( add-ℕ
-          ( mul-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y))
-          ( mul-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) z)))
+          ( (nat-Fin (succ-ℕ k) x) *ℕ (nat-Fin (succ-ℕ k) y))
+          ( (nat-Fin (succ-ℕ k) x) *ℕ (nat-Fin (succ-ℕ k) z)))
         ( congruence-add-ℕ
           ( succ-ℕ k)
           { x = nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) x y)}
           { y = nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) x z)}
-          { x' = mul-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y)}
-          { y' = mul-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) z)}
+          { x' = (nat-Fin (succ-ℕ k) x) *ℕ (nat-Fin (succ-ℕ k) y)}
+          { y' = (nat-Fin (succ-ℕ k) x) *ℕ (nat-Fin (succ-ℕ k) z)}
           ( cong-mul-Fin x y)
           ( cong-mul-Fin x z))))
 

--- a/src/elementary-number-theory/modular-arithmetic-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/modular-arithmetic-standard-finite-types.lagda.md
@@ -571,11 +571,11 @@ left-zero-law-mul-Fin :
   (k : ℕ) (x : Fin (succ-ℕ k)) → mul-Fin (succ-ℕ k) (zero-Fin k) x ＝ zero-Fin k
 left-zero-law-mul-Fin k x =
   ( eq-mod-succ-cong-ℕ k
-    ( mul-ℕ (nat-Fin (succ-ℕ k) (zero-Fin k)) (nat-Fin (succ-ℕ k) x))
+    ( (nat-Fin (succ-ℕ k) (zero-Fin k)) *ℕ (nat-Fin (succ-ℕ k) x))
     ( nat-Fin (succ-ℕ k) (zero-Fin k))
     ( cong-identification-ℕ
       ( succ-ℕ k)
-      { mul-ℕ (nat-Fin (succ-ℕ k) (zero-Fin k)) (nat-Fin (succ-ℕ k) x)}
+      { (nat-Fin (succ-ℕ k) (zero-Fin k)) *ℕ (nat-Fin (succ-ℕ k) x)}
       { nat-Fin (succ-ℕ k) (zero-Fin k)}
       ( ( ap (mul-ℕ' (nat-Fin (succ-ℕ k) x)) (is-zero-nat-zero-Fin {k})) ∙
         ( inv (is-zero-nat-zero-Fin {k}))))) ∙

--- a/src/elementary-number-theory/modular-arithmetic-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/modular-arithmetic-standard-finite-types.lagda.md
@@ -211,7 +211,7 @@ cong-add-ℕ {k} x y =
     ( add-ℕ
       ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k x))
       ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k y)))
-    ( add-ℕ x (nat-Fin (succ-ℕ k) (mod-succ-ℕ k y)))
+    ( x +ℕ (nat-Fin (succ-ℕ k) (mod-succ-ℕ k y)))
     ( x +ℕ y)
     ( translation-invariant-cong-ℕ'
       ( succ-ℕ k)

--- a/src/elementary-number-theory/modular-arithmetic-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/modular-arithmetic-standard-finite-types.lagda.md
@@ -408,7 +408,7 @@ left-inverse-law-add-Fin :
   is-zero-Fin (succ-ℕ k) (add-Fin (succ-ℕ k) (neg-Fin (succ-ℕ k) x) x)
 left-inverse-law-add-Fin k x =
   eq-mod-succ-cong-ℕ k
-    ( add-ℕ (nat-Fin (succ-ℕ k) (neg-Fin (succ-ℕ k) x)) (nat-Fin (succ-ℕ k) x))
+    ( (nat-Fin (succ-ℕ k) (neg-Fin (succ-ℕ k) x)) +ℕ (nat-Fin (succ-ℕ k) x))
     ( zero-ℕ)
     ( concatenate-cong-eq-cong-ℕ
       { succ-ℕ k}
@@ -417,7 +417,7 @@ left-inverse-law-add-Fin k x =
           ( nat-Fin (succ-ℕ k) (neg-Fin (succ-ℕ k) x))
           ( nat-Fin (succ-ℕ k) x)}
       { x2 =
-        add-ℕ (dist-ℕ (nat-Fin (succ-ℕ k) x) (succ-ℕ k)) (nat-Fin (succ-ℕ k) x)}
+        (dist-ℕ (nat-Fin (succ-ℕ k) x) (succ-ℕ k)) +ℕ (nat-Fin (succ-ℕ k) x)}
       { x3 = succ-ℕ k}
       { x4 = zero-ℕ}
       ( translation-invariant-cong-ℕ' (succ-ℕ k)

--- a/src/elementary-number-theory/modular-arithmetic-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/modular-arithmetic-standard-finite-types.lagda.md
@@ -194,7 +194,7 @@ ap-add-Fin k p q = ap-binary (add-Fin k) p q
 
 cong-add-Fin :
   {k : ℕ} (x y : Fin k) →
-  cong-ℕ k (nat-Fin k (add-Fin k x y)) (add-ℕ (nat-Fin k x) (nat-Fin k y))
+  cong-ℕ k (nat-Fin k (add-Fin k x y)) ((nat-Fin k x) +ℕ (nat-Fin k y))
 cong-add-Fin {succ-ℕ k} x y =
   cong-nat-mod-succ-ℕ k (add-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y))
 
@@ -205,14 +205,14 @@ cong-add-ℕ :
     ( add-ℕ
       ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k x))
       ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k y)))
-    ( add-ℕ x y)
+    ( x +ℕ y)
 cong-add-ℕ {k} x y =
   trans-cong-ℕ (succ-ℕ k)
     ( add-ℕ
       ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k x))
       ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k y)))
     ( add-ℕ x (nat-Fin (succ-ℕ k) (mod-succ-ℕ k y)))
-    ( add-ℕ x y)
+    ( x +ℕ y)
     ( translation-invariant-cong-ℕ'
       ( succ-ℕ k)
       ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k x))
@@ -228,19 +228,19 @@ cong-add-ℕ {k} x y =
 
 congruence-add-ℕ :
   (k : ℕ) {x y x' y' : ℕ} →
-  cong-ℕ k x x' → cong-ℕ k y y' → cong-ℕ k (add-ℕ x y) (add-ℕ x' y')
+  cong-ℕ k x x' → cong-ℕ k y y' → cong-ℕ k (x +ℕ y) (x' +ℕ y')
 congruence-add-ℕ k {x} {y} {x'} {y'} H K =
-  trans-cong-ℕ k (add-ℕ x y) (add-ℕ x y') (add-ℕ x' y')
+  trans-cong-ℕ k (x +ℕ y) (x +ℕ y') (x' +ℕ y')
     ( translation-invariant-cong-ℕ k y y' x K)
     ( translation-invariant-cong-ℕ' k x x' y' H)
 
 mod-succ-add-ℕ :
   (k x y : ℕ) →
-  mod-succ-ℕ k (add-ℕ x y) ＝
+  mod-succ-ℕ k (x +ℕ y) ＝
   add-Fin (succ-ℕ k) (mod-succ-ℕ k x) (mod-succ-ℕ k y)
 mod-succ-add-ℕ k x y =
   eq-mod-succ-cong-ℕ k
-    ( add-ℕ x y)
+    ( x +ℕ y)
     ( add-ℕ
       ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k x))
       ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k y)))

--- a/src/elementary-number-theory/modular-arithmetic-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/modular-arithmetic-standard-finite-types.lagda.md
@@ -487,28 +487,22 @@ associative-mul-Fin :
   mul-Fin k (mul-Fin k x y) z ＝ mul-Fin k x (mul-Fin k y z)
 associative-mul-Fin (succ-ℕ k) x y z =
   eq-mod-succ-cong-ℕ k
-    ( mul-ℕ
-      ( nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) x y))
+    ( ( nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) x y)) *ℕ
       ( nat-Fin (succ-ℕ k) z))
-    ( mul-ℕ
-      ( nat-Fin (succ-ℕ k) x)
+    ( ( nat-Fin (succ-ℕ k) x) *ℕ
       ( nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) y z)))
     ( concatenate-cong-eq-cong-ℕ
       { x1 =
-        mul-ℕ
-          ( nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) x y))
+          ( nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) x y)) *ℕ
           ( nat-Fin (succ-ℕ k) z)}
       { x2 =
-        mul-ℕ
-          ( (nat-Fin (succ-ℕ k) x) *ℕ (nat-Fin (succ-ℕ k) y))
+          ( (nat-Fin (succ-ℕ k) x) *ℕ (nat-Fin (succ-ℕ k) y)) *ℕ
           ( nat-Fin (succ-ℕ k) z)}
       { x3 =
-        mul-ℕ
-          ( nat-Fin (succ-ℕ k) x)
+          ( nat-Fin (succ-ℕ k) x) *ℕ
           ( (nat-Fin (succ-ℕ k) y) *ℕ (nat-Fin (succ-ℕ k) z))}
       { x4 =
-        mul-ℕ
-          ( nat-Fin (succ-ℕ k) x)
+          ( nat-Fin (succ-ℕ k) x) *ℕ
           ( nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) y z))}
       ( congruence-mul-ℕ
         ( succ-ℕ k)
@@ -522,11 +516,9 @@ associative-mul-Fin (succ-ℕ k) x y z =
         ( nat-Fin (succ-ℕ k) z))
       ( symm-cong-ℕ
         ( succ-ℕ k)
-        ( mul-ℕ
-          ( nat-Fin (succ-ℕ k) x)
+        ( ( nat-Fin (succ-ℕ k) x) *ℕ
           ( nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) y z)))
-        ( mul-ℕ
-          ( nat-Fin (succ-ℕ k) x)
+        ( ( nat-Fin (succ-ℕ k) x) *ℕ
           ( (nat-Fin (succ-ℕ k) y) *ℕ (nat-Fin (succ-ℕ k) z)))
         ( congruence-mul-ℕ
           ( succ-ℕ k)
@@ -550,13 +542,12 @@ left-unit-law-mul-Fin :
 left-unit-law-mul-Fin zero-ℕ (inr star) = refl
 left-unit-law-mul-Fin (succ-ℕ k) x =
   ( eq-mod-succ-cong-ℕ (succ-ℕ k)
-    ( mul-ℕ
-      ( nat-Fin (succ-ℕ (succ-ℕ k)) (one-Fin (succ-ℕ k)))
+    ( ( nat-Fin (succ-ℕ (succ-ℕ k)) (one-Fin (succ-ℕ k))) *ℕ
       ( nat-Fin (succ-ℕ (succ-ℕ k)) x))
     ( nat-Fin (succ-ℕ (succ-ℕ k)) x)
     ( cong-identification-ℕ
       ( succ-ℕ (succ-ℕ k))
-      ( ( ap ( mul-ℕ' (nat-Fin (succ-ℕ (succ-ℕ k)) x))
+      ( ( ap ( _*ℕ (nat-Fin (succ-ℕ (succ-ℕ k)) x))
              ( is-one-nat-one-Fin k)) ∙
         ( left-unit-law-mul-ℕ (nat-Fin (succ-ℕ (succ-ℕ k)) x))))) ∙
   ( issec-nat-Fin (succ-ℕ k) x)
@@ -577,7 +568,7 @@ left-zero-law-mul-Fin k x =
       ( succ-ℕ k)
       { (nat-Fin (succ-ℕ k) (zero-Fin k)) *ℕ (nat-Fin (succ-ℕ k) x)}
       { nat-Fin (succ-ℕ k) (zero-Fin k)}
-      ( ( ap (mul-ℕ' (nat-Fin (succ-ℕ k) x)) (is-zero-nat-zero-Fin {k})) ∙
+      ( ( ap (_*ℕ (nat-Fin (succ-ℕ k) x)) (is-zero-nat-zero-Fin {k})) ∙
         ( inv (is-zero-nat-zero-Fin {k}))))) ∙
   ( issec-nat-Fin k (zero-Fin k))
 
@@ -592,8 +583,7 @@ left-distributive-mul-add-Fin :
   mul-Fin k x (add-Fin k y z) ＝ add-Fin k (mul-Fin k x y) (mul-Fin k x z)
 left-distributive-mul-add-Fin (succ-ℕ k) x y z =
   eq-mod-succ-cong-ℕ k
-    ( mul-ℕ
-      ( nat-Fin (succ-ℕ k) x)
+    ( ( nat-Fin (succ-ℕ k) x) *ℕ
       ( nat-Fin (succ-ℕ k) (add-Fin (succ-ℕ k) y z)))
     ( add-ℕ
       ( nat-Fin (succ-ℕ k) (mul-Fin (succ-ℕ k) x y))
@@ -601,12 +591,10 @@ left-distributive-mul-add-Fin (succ-ℕ k) x y z =
     ( concatenate-cong-eq-cong-ℕ
       { k = succ-ℕ k}
       { x1 =
-        mul-ℕ
-          ( nat-Fin (succ-ℕ k) x)
+          ( nat-Fin (succ-ℕ k) x) *ℕ
           ( nat-Fin (succ-ℕ k) (add-Fin (succ-ℕ k) y z))}
       { x2 =
-        mul-ℕ
-          ( nat-Fin (succ-ℕ k) x)
+          ( nat-Fin (succ-ℕ k) x) *ℕ
           ( (nat-Fin (succ-ℕ k) y) +ℕ (nat-Fin (succ-ℕ k) z))}
       { x3 =
         add-ℕ

--- a/src/elementary-number-theory/modular-arithmetic-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/modular-arithmetic-standard-finite-types.lagda.md
@@ -448,7 +448,7 @@ is-add-one-succ-Fin' (succ-ℕ k) x =
   ( ap (succ-Fin (succ-ℕ (succ-ℕ k))) (inv (issec-nat-Fin (succ-ℕ k) x))) ∙
   ( ap ( mod-succ-ℕ (succ-ℕ k))
        ( ap
-         ( add-ℕ (nat-Fin (succ-ℕ (succ-ℕ k)) x))
+         ( (nat-Fin (succ-ℕ (succ-ℕ k)) x) +ℕ_)
          ( inv (is-one-nat-one-Fin (succ-ℕ k)))))
 
 is-add-one-succ-Fin :

--- a/src/elementary-number-theory/modular-arithmetic-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/modular-arithmetic-standard-finite-types.lagda.md
@@ -312,7 +312,7 @@ ap-mul-Fin k p q = ap-binary (mul-Fin k) p q
 
 cong-mul-Fin :
   {k : ℕ} (x y : Fin k) →
-  cong-ℕ k (nat-Fin k (mul-Fin k x y)) (mul-ℕ (nat-Fin k x) (nat-Fin k y))
+  cong-ℕ k (nat-Fin k (mul-Fin k x y)) ((nat-Fin k x) *ℕ (nat-Fin k y))
 cong-mul-Fin {succ-ℕ k} x y =
   cong-nat-mod-succ-ℕ k (mul-ℕ (nat-Fin (succ-ℕ k) x) (nat-Fin (succ-ℕ k) y))
 ```

--- a/src/elementary-number-theory/modular-arithmetic.lagda.md
+++ b/src/elementary-number-theory/modular-arithmetic.lagda.md
@@ -485,7 +485,7 @@ preserves-predecessor-mod-ℤ (succ-ℕ k) (inr (inr (succ-ℕ x))) =
 
 preserves-add-mod-ℤ :
   (k : ℕ) (x y : ℤ) →
-  mod-ℤ k (add-ℤ x y) ＝ add-ℤ-Mod k (mod-ℤ k x) (mod-ℤ k y)
+  mod-ℤ k (x +ℤ y) ＝ add-ℤ-Mod k (mod-ℤ k x) (mod-ℤ k y)
 preserves-add-mod-ℤ zero-ℕ x y = refl
 preserves-add-mod-ℤ (succ-ℕ k) (inl zero-ℕ) y =
   ( preserves-predecessor-mod-ℤ (succ-ℕ k) y) ∙
@@ -494,7 +494,7 @@ preserves-add-mod-ℤ (succ-ℕ k) (inl zero-ℕ) y =
       ( add-Fin' (succ-ℕ k) (mod-ℤ (succ-ℕ k) y))
       ( inv (mod-neg-one-ℤ (succ-ℕ k)))))
 preserves-add-mod-ℤ (succ-ℕ k) (inl (succ-ℕ x)) y =
-  ( preserves-predecessor-mod-ℤ (succ-ℕ k) (add-ℤ (inl x) y)) ∙
+  ( preserves-predecessor-mod-ℤ (succ-ℕ k) ((inl x) +ℤ y)) ∙
   ( ( ap (pred-Fin (succ-ℕ k)) (preserves-add-mod-ℤ (succ-ℕ k) (inl x) y)) ∙
     ( ( inv
         ( left-predecessor-law-add-Fin (succ-ℕ k)

--- a/src/elementary-number-theory/modular-arithmetic.lagda.md
+++ b/src/elementary-number-theory/modular-arithmetic.lagda.md
@@ -204,17 +204,17 @@ ap-add-ℤ-Mod :
 ap-add-ℤ-Mod k p q = ap-binary (add-ℤ-Mod k) p q
 
 abstract
-  is-equiv-add-ℤ-Mod : (k : ℕ) (x : ℤ-Mod k) → is-equiv (add-ℤ-Mod k x)
-  is-equiv-add-ℤ-Mod zero-ℕ = is-equiv-add-ℤ
-  is-equiv-add-ℤ-Mod (succ-ℕ k) = is-equiv-add-Fin (succ-ℕ k)
+  is-equiv-left-add-ℤ-Mod : (k : ℕ) (x : ℤ-Mod k) → is-equiv (add-ℤ-Mod k x)
+  is-equiv-left-add-ℤ-Mod zero-ℕ = is-equiv-left-add-ℤ
+  is-equiv-left-add-ℤ-Mod (succ-ℕ k) = is-equiv-add-Fin (succ-ℕ k)
 
-equiv-add-ℤ-Mod : (k : ℕ) (x : ℤ-Mod k) → ℤ-Mod k ≃ ℤ-Mod k
-pr1 (equiv-add-ℤ-Mod k x) = add-ℤ-Mod k x
-pr2 (equiv-add-ℤ-Mod k x) = is-equiv-add-ℤ-Mod k x
+equiv-left-add-ℤ-Mod : (k : ℕ) (x : ℤ-Mod k) → ℤ-Mod k ≃ ℤ-Mod k
+pr1 (equiv-left-add-ℤ-Mod k x) = add-ℤ-Mod k x
+pr2 (equiv-left-add-ℤ-Mod k x) = is-equiv-left-add-ℤ-Mod k x
 
 abstract
   is-equiv-add-ℤ-Mod' : (k : ℕ) (x : ℤ-Mod k) → is-equiv (add-ℤ-Mod' k x)
-  is-equiv-add-ℤ-Mod' zero-ℕ = is-equiv-add-ℤ'
+  is-equiv-add-ℤ-Mod' zero-ℕ = is-equiv-right-add-ℤ
   is-equiv-add-ℤ-Mod' (succ-ℕ k) = is-equiv-add-Fin' (succ-ℕ k)
 
 equiv-add-ℤ-Mod' : (k : ℕ) (x : ℤ-Mod k) → ℤ-Mod k ≃ ℤ-Mod k
@@ -226,7 +226,7 @@ is-injective-add-ℤ-Mod zero-ℕ = is-injective-add-ℤ
 is-injective-add-ℤ-Mod (succ-ℕ k) = is-injective-add-Fin (succ-ℕ k)
 
 is-injective-add-ℤ-Mod' : (k : ℕ) (x : ℤ-Mod k) → is-injective (add-ℤ-Mod' k x)
-is-injective-add-ℤ-Mod' zero-ℕ = is-injective-add-ℤ'
+is-injective-add-ℤ-Mod' zero-ℕ = is-injective-right-add-ℤ
 is-injective-add-ℤ-Mod' (succ-ℕ k) = is-injective-add-Fin' (succ-ℕ k)
 ```
 
@@ -308,25 +308,25 @@ right-predecessor-law-add-ℤ-Mod zero-ℕ = right-predecessor-law-add-ℤ
 right-predecessor-law-add-ℤ-Mod (succ-ℕ k) =
   right-predecessor-law-add-Fin (succ-ℕ k)
 
-is-add-one-succ-ℤ-Mod :
+is-left-add-one-succ-ℤ-Mod :
   (k : ℕ) (x : ℤ-Mod k) → succ-ℤ-Mod k x ＝ add-ℤ-Mod k (one-ℤ-Mod k) x
-is-add-one-succ-ℤ-Mod zero-ℕ = is-add-one-succ-ℤ
-is-add-one-succ-ℤ-Mod (succ-ℕ k) = is-add-one-succ-Fin k
+is-left-add-one-succ-ℤ-Mod zero-ℕ = is-left-add-one-succ-ℤ
+is-left-add-one-succ-ℤ-Mod (succ-ℕ k) = is-add-one-succ-Fin k
 
-is-add-one-succ-ℤ-Mod' :
+is-left-add-one-succ-ℤ-Mod' :
   (k : ℕ) (x : ℤ-Mod k) → succ-ℤ-Mod k x ＝ add-ℤ-Mod k x (one-ℤ-Mod k)
-is-add-one-succ-ℤ-Mod' zero-ℕ = is-add-one-succ-ℤ'
-is-add-one-succ-ℤ-Mod' (succ-ℕ k) = is-add-one-succ-Fin' k
+is-left-add-one-succ-ℤ-Mod' zero-ℕ = is-right-add-one-succ-ℤ
+is-left-add-one-succ-ℤ-Mod' (succ-ℕ k) = is-add-one-succ-Fin' k
 
-is-add-neg-one-pred-ℤ-Mod :
+is-left-add-neg-one-pred-ℤ-Mod :
   (k : ℕ) (x : ℤ-Mod k) → pred-ℤ-Mod k x ＝ add-ℤ-Mod k (neg-one-ℤ-Mod k) x
-is-add-neg-one-pred-ℤ-Mod zero-ℕ = is-add-neg-one-pred-ℤ
-is-add-neg-one-pred-ℤ-Mod (succ-ℕ k) = is-add-neg-one-pred-Fin k
+is-left-add-neg-one-pred-ℤ-Mod zero-ℕ = is-left-add-neg-one-pred-ℤ
+is-left-add-neg-one-pred-ℤ-Mod (succ-ℕ k) = is-add-neg-one-pred-Fin k
 
-is-add-neg-one-pred-ℤ-Mod' :
+is-left-add-neg-one-pred-ℤ-Mod' :
   (k : ℕ) (x : ℤ-Mod k) → pred-ℤ-Mod k x ＝ add-ℤ-Mod k x (neg-one-ℤ-Mod k)
-is-add-neg-one-pred-ℤ-Mod' zero-ℕ = is-add-neg-one-pred-ℤ'
-is-add-neg-one-pred-ℤ-Mod' (succ-ℕ k) = is-add-neg-one-pred-Fin' k
+is-left-add-neg-one-pred-ℤ-Mod' zero-ℕ = is-right-add-neg-one-pred-ℤ
+is-left-add-neg-one-pred-ℤ-Mod' (succ-ℕ k) = is-add-neg-one-pred-Fin' k
 ```
 
 ## Multiplication modulo k
@@ -385,15 +385,15 @@ right-distributive-mul-add-ℤ-Mod zero-ℕ = right-distributive-mul-add-ℤ
 right-distributive-mul-add-ℤ-Mod (succ-ℕ k) =
   right-distributive-mul-add-Fin (succ-ℕ k)
 
-is-mul-neg-one-neg-ℤ-Mod :
+is-left-mul-neg-one-neg-ℤ-Mod :
   (k : ℕ) (x : ℤ-Mod k) → neg-ℤ-Mod k x ＝ mul-ℤ-Mod k (neg-one-ℤ-Mod k) x
-is-mul-neg-one-neg-ℤ-Mod zero-ℕ = is-mul-neg-one-neg-ℤ
-is-mul-neg-one-neg-ℤ-Mod (succ-ℕ k) = is-mul-neg-one-neg-Fin k
+is-left-mul-neg-one-neg-ℤ-Mod zero-ℕ = is-left-mul-neg-one-neg-ℤ
+is-left-mul-neg-one-neg-ℤ-Mod (succ-ℕ k) = is-mul-neg-one-neg-Fin k
 
-is-mul-neg-one-neg-ℤ-Mod' :
+is-left-mul-neg-one-neg-ℤ-Mod' :
   (k : ℕ) (x : ℤ-Mod k) → neg-ℤ-Mod k x ＝ mul-ℤ-Mod k x (neg-one-ℤ-Mod k)
-is-mul-neg-one-neg-ℤ-Mod' zero-ℕ = is-mul-neg-one-neg-ℤ'
-is-mul-neg-one-neg-ℤ-Mod' (succ-ℕ k) = is-mul-neg-one-neg-Fin' k
+is-left-mul-neg-one-neg-ℤ-Mod' zero-ℕ = is-right-mul-neg-one-neg-ℤ
+is-left-mul-neg-one-neg-ℤ-Mod' (succ-ℕ k) = is-mul-neg-one-neg-Fin' k
 ```
 
 ## Congruence classes of integers modulo k

--- a/src/elementary-number-theory/modular-arithmetic.lagda.md
+++ b/src/elementary-number-theory/modular-arithmetic.lagda.md
@@ -537,7 +537,7 @@ preserves-neg-mod-ℤ (succ-ℕ k) x =
 
 preserves-mul-mod-ℤ :
   (k : ℕ) (x y : ℤ) →
-  mod-ℤ k (mul-ℤ x y) ＝ mul-ℤ-Mod k (mod-ℤ k x) (mod-ℤ k y)
+  mod-ℤ k (x *ℤ y) ＝ mul-ℤ-Mod k (mod-ℤ k x) (mod-ℤ k y)
 preserves-mul-mod-ℤ zero-ℕ x y = refl
 preserves-mul-mod-ℤ (succ-ℕ k) (inl zero-ℕ) y =
   ( preserves-neg-mod-ℤ (succ-ℕ k) y) ∙
@@ -546,7 +546,7 @@ preserves-mul-mod-ℤ (succ-ℕ k) (inl zero-ℕ) y =
       ( mul-ℤ-Mod' (succ-ℕ k) (mod-ℤ (succ-ℕ k) y))
       ( inv (mod-neg-one-ℤ (succ-ℕ k)))))
 preserves-mul-mod-ℤ (succ-ℕ k) (inl (succ-ℕ x)) y =
-  ( preserves-add-mod-ℤ (succ-ℕ k) (neg-ℤ y) (mul-ℤ (inl x) y)) ∙
+  ( preserves-add-mod-ℤ (succ-ℕ k) (neg-ℤ y) ((inl x) *ℤ y)) ∙
   ( ( ap-add-ℤ-Mod
       ( succ-ℕ k)
       ( preserves-neg-mod-ℤ (succ-ℕ k) y)
@@ -610,24 +610,24 @@ cong-int-mod-ℤ (succ-ℕ k) (inl x) =
         ( nat-Fin
           ( succ-ℕ k)
           ( mul-Fin (succ-ℕ k) (neg-one-Fin k) (mod-succ-ℕ k (succ-ℕ x)))))
-      ( int-ℕ (mul-ℕ k (nat-Fin (succ-ℕ k) (mod-succ-ℕ k (succ-ℕ x)))))
+      ( int-ℕ (k *ℕ (nat-Fin (succ-ℕ k) (mod-succ-ℕ k (succ-ℕ x)))))
       ( inl x)
       ( cong-int-cong-ℕ
         ( succ-ℕ k)
         ( nat-Fin
           ( succ-ℕ k)
           ( mul-Fin (succ-ℕ k) (neg-one-Fin k) (mod-succ-ℕ k (succ-ℕ x))))
-        ( mul-ℕ k (nat-Fin (succ-ℕ k) (mod-succ-ℕ k (succ-ℕ x))))
+        ( k *ℕ (nat-Fin (succ-ℕ k) (mod-succ-ℕ k (succ-ℕ x))))
         ( cong-mul-Fin (neg-one-Fin k) (mod-succ-ℕ k (succ-ℕ x))))
       ( transitive-cong-ℤ
         ( int-ℕ (succ-ℕ k))
-        ( int-ℕ (mul-ℕ k (nat-Fin (succ-ℕ k) (mod-succ-ℕ k (succ-ℕ x)))))
-        ( int-ℕ (mul-ℕ k (succ-ℕ x)))
+        ( int-ℕ (k *ℕ (nat-Fin (succ-ℕ k) (mod-succ-ℕ k (succ-ℕ x)))))
+        ( int-ℕ (k *ℕ (succ-ℕ x)))
         ( inl x)
         ( cong-int-cong-ℕ
           ( succ-ℕ k)
-          ( mul-ℕ k (nat-Fin (succ-ℕ k) (mod-succ-ℕ k (succ-ℕ x))))
-          ( mul-ℕ k (succ-ℕ x))
+          ( k *ℕ (nat-Fin (succ-ℕ k) (mod-succ-ℕ k (succ-ℕ x))))
+          ( k *ℕ (succ-ℕ x))
           ( congruence-mul-ℕ
             ( succ-ℕ k)
             {k} {nat-Fin (succ-ℕ k) (mod-succ-ℕ k (succ-ℕ x))} {k} {succ-ℕ x}

--- a/src/elementary-number-theory/modular-arithmetic.lagda.md
+++ b/src/elementary-number-theory/modular-arithmetic.lagda.md
@@ -139,10 +139,10 @@ int-ℤ-Mod-bounded :
   leq-ℤ (int-ℤ-Mod (succ-ℕ k) x) (int-ℕ (succ-ℕ k))
 int-ℤ-Mod-bounded zero-ℕ (inr x) = star
 int-ℤ-Mod-bounded (succ-ℕ k) (inl x) = is-nonnegative-succ-ℤ
-  (add-ℤ (inr (inr k))
+  ((inr (inr k)) +ℤ
   (neg-ℤ (int-ℕ (nat-Fin (succ-ℕ k) x)))) (int-ℤ-Mod-bounded k x)
 int-ℤ-Mod-bounded (succ-ℕ k) (inr x) = is-nonnegative-succ-ℤ
-  (add-ℤ (inr (inr k)) (inl k))
+  ((inr (inr k)) +ℤ (inl k))
   (is-nonnegative-eq-ℤ (inv (left-inverse-law-add-ℤ (inl k))) star)
 ```
 
@@ -516,7 +516,7 @@ preserves-add-mod-ℤ (succ-ℕ k) (inr (inr zero-ℕ)) y =
         ( zero-Fin k)
         ( mod-ℤ (succ-ℕ k) y))))
 preserves-add-mod-ℤ (succ-ℕ k) (inr (inr (succ-ℕ x))) y =
-  ( preserves-successor-mod-ℤ (succ-ℕ k) (add-ℤ (inr (inr x)) y)) ∙
+  ( preserves-successor-mod-ℤ (succ-ℕ k) ((inr (inr x)) +ℤ y)) ∙
   ( ( ap
       ( succ-Fin (succ-ℕ k))
       ( preserves-add-mod-ℤ (succ-ℕ k) (inr (inr x)) y)) ∙
@@ -563,7 +563,7 @@ preserves-mul-mod-ℤ (succ-ℕ k) (inr (inl star)) y =
 preserves-mul-mod-ℤ (succ-ℕ k) (inr (inr zero-ℕ)) y =
   inv (left-unit-law-mul-Fin k (mod-ℤ (succ-ℕ k) y))
 preserves-mul-mod-ℤ (succ-ℕ k) (inr (inr (succ-ℕ x))) y =
-  ( preserves-add-mod-ℤ (succ-ℕ k) y (mul-ℤ (inr (inr x)) y)) ∙
+  ( preserves-add-mod-ℤ (succ-ℕ k) y ((inr (inr x)) *ℤ y)) ∙
   ( ( ap
       ( add-ℤ-Mod (succ-ℕ k) (mod-ℤ (succ-ℕ k) y))
       ( preserves-mul-mod-ℤ (succ-ℕ k) (inr (inr x)) y)) ∙

--- a/src/elementary-number-theory/modular-arithmetic.lagda.md
+++ b/src/elementary-number-theory/modular-arithmetic.lagda.md
@@ -637,7 +637,7 @@ cong-int-mod-ℤ (succ-ℕ k) (inl x) =
           ( inr (inr x))
           ( ( commutative-mul-ℤ (inr (inr x)) (inr (inr k))) ∙
             ( ( ap
-                ( mul-ℤ' (inr (inr x)))
+                ( _*ℤ (inr (inr x)))
                 ( inv (succ-int-ℕ k) ∙ commutative-add-ℤ one-ℤ (int-ℕ k))) ∙
               ( ( right-distributive-mul-add-ℤ (int-ℕ k) one-ℤ (inr (inr x))) ∙
                 ( ap-add-ℤ

--- a/src/elementary-number-theory/multiplication-integers.lagda.md
+++ b/src/elementary-number-theory/multiplication-integers.lagda.md
@@ -308,12 +308,12 @@ interchange-law-mul-mul-ℤ =
     commutative-mul-ℤ
     associative-mul-ℤ
 
-is-mul-neg-one-neg-ℤ : (x : ℤ) → neg-ℤ x ＝ neg-one-ℤ *ℤ x
-is-mul-neg-one-neg-ℤ x = refl
+is-left-mul-neg-one-neg-ℤ : (x : ℤ) → neg-ℤ x ＝ neg-one-ℤ *ℤ x
+is-left-mul-neg-one-neg-ℤ x = refl
 
-is-mul-neg-one-neg-ℤ' : (x : ℤ) → neg-ℤ x ＝ x *ℤ neg-one-ℤ
-is-mul-neg-one-neg-ℤ' x =
-  is-mul-neg-one-neg-ℤ x ∙ commutative-mul-ℤ neg-one-ℤ x
+is-right-mul-neg-one-neg-ℤ : (x : ℤ) → neg-ℤ x ＝ x *ℤ neg-one-ℤ
+is-right-mul-neg-one-neg-ℤ x =
+  is-left-mul-neg-one-neg-ℤ x ∙ commutative-mul-ℤ neg-one-ℤ x
 
 double-negative-law-mul-ℤ : (k l : ℤ) → (neg-ℤ k) *ℤ (neg-ℤ l) ＝ k *ℤ l
 double-negative-law-mul-ℤ k l =
@@ -408,15 +408,15 @@ compute-mul-ℤ (inr (inr (succ-ℕ x))) (inr (inr y)) =
 ### Linearity of the difference
 
 ```agda
-linear-diff-ℤ :
+linear-diff-left-mul-ℤ :
   (z x y : ℤ) → diff-ℤ (z *ℤ x) (z *ℤ y) ＝ z *ℤ (diff-ℤ x y)
-linear-diff-ℤ z x y =
+linear-diff-left-mul-ℤ z x y =
   ( ap ((z *ℤ x) +ℤ_) (inv (right-negative-law-mul-ℤ z y))) ∙
   ( inv (left-distributive-mul-add-ℤ z x (neg-ℤ y)))
 
-linear-diff-ℤ' :
+linear-diff-right-mul-ℤ :
   (x y z : ℤ) → diff-ℤ (x *ℤ z) (y *ℤ z) ＝ (diff-ℤ x y) *ℤ z
-linear-diff-ℤ' x y z =
+linear-diff-right-mul-ℤ x y z =
   ( ap ((x *ℤ z) +ℤ_) (inv (left-negative-law-mul-ℤ y z))) ∙
   ( inv (right-distributive-mul-add-ℤ x (neg-ℤ y) z))
 ```
@@ -440,9 +440,9 @@ is-zero-is-zero-mul-ℤ (inr (inr x)) (inr (inr y)) H =
 ### Injectivity of multiplication
 
 ```agda
-is-injective-mul-ℤ :
+is-injective-left-mul-ℤ :
   (x : ℤ) → is-nonzero-ℤ x → is-injective (x *ℤ_)
-is-injective-mul-ℤ x f {y} {z} p =
+is-injective-left-mul-ℤ x f {y} {z} p =
   eq-diff-ℤ
     ( map-left-unit-law-coprod-is-empty
       ( is-zero-ℤ x)
@@ -450,22 +450,27 @@ is-injective-mul-ℤ x f {y} {z} p =
       ( f)
       ( is-zero-is-zero-mul-ℤ x
         ( diff-ℤ y z)
-        ( inv (linear-diff-ℤ x y z) ∙ is-zero-diff-ℤ p)))
+        ( inv (linear-diff-left-mul-ℤ x y z) ∙ is-zero-diff-ℤ p)))
 
-is-injective-mul-ℤ' :
+is-injective-right-mul-ℤ :
   (x : ℤ) → is-nonzero-ℤ x → is-injective (_*ℤ x)
-is-injective-mul-ℤ' x f {y} {z} p =
-  is-injective-mul-ℤ x f (commutative-mul-ℤ x y ∙ (p ∙ commutative-mul-ℤ z x))
+is-injective-right-mul-ℤ x f {y} {z} p =
+  is-injective-left-mul-ℤ
+    ( x)
+    ( f)
+    ( commutative-mul-ℤ x y ∙ (p ∙ commutative-mul-ℤ z x))
 ```
 
 ### Multiplication by a nonzero integer is an embedding
 
 ```agda
-is-emb-mul-ℤ : (x : ℤ) → is-nonzero-ℤ x → is-emb (x *ℤ_)
-is-emb-mul-ℤ x f = is-emb-is-injective is-set-ℤ (is-injective-mul-ℤ x f)
+is-emb-left-mul-ℤ : (x : ℤ) → is-nonzero-ℤ x → is-emb (x *ℤ_)
+is-emb-left-mul-ℤ x f =
+  is-emb-is-injective is-set-ℤ (is-injective-left-mul-ℤ x f)
 
-is-emb-mul-ℤ' : (x : ℤ) → is-nonzero-ℤ x → is-emb (_*ℤ x)
-is-emb-mul-ℤ' x f = is-emb-is-injective is-set-ℤ (is-injective-mul-ℤ' x f)
+is-emb-right-mul-ℤ : (x : ℤ) → is-nonzero-ℤ x → is-emb (_*ℤ x)
+is-emb-right-mul-ℤ x f =
+  is-emb-is-injective is-set-ℤ (is-injective-right-mul-ℤ x f)
 ```
 
 ```agda
@@ -511,22 +516,22 @@ is-nonnegative-right-factor-mul-ℤ {x} {y} H =
 ```
 
 ```agda
-preserves-leq-mul-ℤ :
+preserves-leq-left-mul-ℤ :
   (x y z : ℤ) → is-nonnegative-ℤ z → leq-ℤ x y → leq-ℤ (z *ℤ x) (z *ℤ y)
-preserves-leq-mul-ℤ x y (inr (inl star)) star K = star
-preserves-leq-mul-ℤ x y (inr (inr zero-ℕ)) star K = K
-preserves-leq-mul-ℤ x y (inr (inr (succ-ℕ n))) star K =
+preserves-leq-left-mul-ℤ x y (inr (inl star)) star K = star
+preserves-leq-left-mul-ℤ x y (inr (inr zero-ℕ)) star K = K
+preserves-leq-left-mul-ℤ x y (inr (inr (succ-ℕ n))) star K =
   preserves-leq-add-ℤ {x} {y}
     { (inr (inr n)) *ℤ x}
     { (inr (inr n)) *ℤ y}
     ( K)
-    ( preserves-leq-mul-ℤ x y (inr (inr n)) star K)
+    ( preserves-leq-left-mul-ℤ x y (inr (inr n)) star K)
 
-preserves-leq-mul-ℤ' :
+preserves-leq-right-mul-ℤ :
   (x y z : ℤ) → is-nonnegative-ℤ z → leq-ℤ x y → leq-ℤ (x *ℤ z) (y *ℤ z)
-preserves-leq-mul-ℤ' x y z H K =
+preserves-leq-right-mul-ℤ x y z H K =
   concatenate-eq-leq-eq-ℤ
     ( commutative-mul-ℤ x z)
-    ( preserves-leq-mul-ℤ x y z H K)
+    ( preserves-leq-left-mul-ℤ x y z H K)
     ( commutative-mul-ℤ z y)
 ```

--- a/src/elementary-number-theory/multiplication-integers.lagda.md
+++ b/src/elementary-number-theory/multiplication-integers.lagda.md
@@ -77,7 +77,7 @@ explicit-mul-ℤ' x y = explicit-mul-ℤ y x
 
 ```agda
 is-plus-or-minus-ℤ : ℤ → ℤ → UU lzero
-is-plus-or-minus-ℤ x y = (x ＝ y) + (mul-ℤ neg-one-ℤ x ＝ y)
+is-plus-or-minus-ℤ x y = (x ＝ y) + (neg-one-ℤ *ℤ x ＝ y)
 ```
 
 ## Properties

--- a/src/elementary-number-theory/multiplication-integers.lagda.md
+++ b/src/elementary-number-theory/multiplication-integers.lagda.md
@@ -453,7 +453,7 @@ is-injective-mul-ℤ x f {y} {z} p =
         ( inv (linear-diff-ℤ x y z) ∙ is-zero-diff-ℤ p)))
 
 is-injective-mul-ℤ' :
-  (x : ℤ) → is-nonzero-ℤ x → is-injective (mul-ℤ' x)
+  (x : ℤ) → is-nonzero-ℤ x → is-injective (_*ℤ x)
 is-injective-mul-ℤ' x f {y} {z} p =
   is-injective-mul-ℤ x f (commutative-mul-ℤ x y ∙ (p ∙ commutative-mul-ℤ z x))
 ```
@@ -464,7 +464,7 @@ is-injective-mul-ℤ' x f {y} {z} p =
 is-emb-mul-ℤ : (x : ℤ) → is-nonzero-ℤ x → is-emb (mul-ℤ x)
 is-emb-mul-ℤ x f = is-emb-is-injective is-set-ℤ (is-injective-mul-ℤ x f)
 
-is-emb-mul-ℤ' : (x : ℤ) → is-nonzero-ℤ x → is-emb (mul-ℤ' x)
+is-emb-mul-ℤ' : (x : ℤ) → is-nonzero-ℤ x → is-emb (_*ℤ x)
 is-emb-mul-ℤ' x f = is-emb-is-injective is-set-ℤ (is-injective-mul-ℤ' x f)
 ```
 

--- a/src/elementary-number-theory/multiplication-integers.lagda.md
+++ b/src/elementary-number-theory/multiplication-integers.lagda.md
@@ -39,10 +39,10 @@ open import foundation.universe-levels
 ```agda
 mul-ℤ : ℤ → ℤ → ℤ
 mul-ℤ (inl zero-ℕ) l = neg-ℤ l
-mul-ℤ (inl (succ-ℕ x)) l = add-ℤ (neg-ℤ l) (mul-ℤ (inl x) l)
+mul-ℤ (inl (succ-ℕ x)) l = (neg-ℤ l) +ℤ (mul-ℤ (inl x) l)
 mul-ℤ (inr (inl star)) l = zero-ℤ
 mul-ℤ (inr (inr zero-ℕ)) l = l
-mul-ℤ (inr (inr (succ-ℕ x))) l = add-ℤ l (mul-ℤ (inr (inr x)) l)
+mul-ℤ (inr (inr (succ-ℕ x))) l = l +ℤ (mul-ℤ (inr (inr x)) l)
 
 infix 30 _*ℤ_
 _*ℤ_ = mul-ℤ

--- a/src/elementary-number-theory/multiplication-integers.lagda.md
+++ b/src/elementary-number-theory/multiplication-integers.lagda.md
@@ -441,7 +441,7 @@ is-zero-is-zero-mul-ℤ (inr (inr x)) (inr (inr y)) H =
 
 ```agda
 is-injective-mul-ℤ :
-  (x : ℤ) → is-nonzero-ℤ x → is-injective (mul-ℤ x)
+  (x : ℤ) → is-nonzero-ℤ x → is-injective (x *ℤ_)
 is-injective-mul-ℤ x f {y} {z} p =
   eq-diff-ℤ
     ( map-left-unit-law-coprod-is-empty
@@ -461,7 +461,7 @@ is-injective-mul-ℤ' x f {y} {z} p =
 ### Multiplication by a nonzero integer is an embedding
 
 ```agda
-is-emb-mul-ℤ : (x : ℤ) → is-nonzero-ℤ x → is-emb (mul-ℤ x)
+is-emb-mul-ℤ : (x : ℤ) → is-nonzero-ℤ x → is-emb (x *ℤ_)
 is-emb-mul-ℤ x f = is-emb-is-injective is-set-ℤ (is-injective-mul-ℤ x f)
 
 is-emb-mul-ℤ' : (x : ℤ) → is-nonzero-ℤ x → is-emb (_*ℤ x)

--- a/src/elementary-number-theory/multiplication-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/multiplication-natural-numbers.lagda.md
@@ -161,46 +161,48 @@ interchange-law-mul-mul-ℕ =
     commutative-mul-ℕ
     associative-mul-ℕ
 
-is-injective-mul-succ-ℕ' :
+is-injective-right-mul-succ-ℕ :
   (k : ℕ) → is-injective (_*ℕ (succ-ℕ k))
-is-injective-mul-succ-ℕ' k {zero-ℕ} {zero-ℕ} p = refl
-is-injective-mul-succ-ℕ' k {succ-ℕ m} {succ-ℕ n} p =
+is-injective-right-mul-succ-ℕ k {zero-ℕ} {zero-ℕ} p = refl
+is-injective-right-mul-succ-ℕ k {succ-ℕ m} {succ-ℕ n} p =
   ap succ-ℕ
-    ( is-injective-mul-succ-ℕ' k {m} {n}
-      ( is-injective-add-ℕ'
+    ( is-injective-right-mul-succ-ℕ k {m} {n}
+      ( is-injective-right-add-ℕ
         ( succ-ℕ k)
         ( ( inv (left-successor-law-mul-ℕ m (succ-ℕ k))) ∙
           ( ( p) ∙
             ( left-successor-law-mul-ℕ n (succ-ℕ k))))))
 
-is-injective-mul-ℕ' : (k : ℕ) → is-nonzero-ℕ k → is-injective (_*ℕ k)
-is-injective-mul-ℕ' k H p with
+is-injective-right-mul-ℕ : (k : ℕ) → is-nonzero-ℕ k → is-injective (_*ℕ k)
+is-injective-right-mul-ℕ k H p with
   is-successor-is-nonzero-ℕ H
-... | pair l refl = is-injective-mul-succ-ℕ' l p
+... | pair l refl = is-injective-right-mul-succ-ℕ l p
 
-is-injective-mul-succ-ℕ :
+is-injective-left-mul-succ-ℕ :
   (k : ℕ) → is-injective ((succ-ℕ k) *ℕ_)
-is-injective-mul-succ-ℕ k {m} {n} p =
-  is-injective-mul-succ-ℕ' k
+is-injective-left-mul-succ-ℕ k {m} {n} p =
+  is-injective-right-mul-succ-ℕ k
     ( ( commutative-mul-ℕ m (succ-ℕ k)) ∙
       ( p ∙ commutative-mul-ℕ (succ-ℕ k) n))
 
-is-injective-mul-ℕ :
+is-injective-left-mul-ℕ :
   (k : ℕ) → is-nonzero-ℕ k → is-injective (k *ℕ_)
-is-injective-mul-ℕ k H p with
+is-injective-left-mul-ℕ k H p with
   is-successor-is-nonzero-ℕ H
-... | pair l refl = is-injective-mul-succ-ℕ l p
+... | pair l refl = is-injective-left-mul-succ-ℕ l p
 
-is-emb-mul-ℕ : (x : ℕ) → is-nonzero-ℕ x → is-emb (x *ℕ_)
-is-emb-mul-ℕ x H = is-emb-is-injective is-set-ℕ (is-injective-mul-ℕ x H)
+is-emb-left-mul-ℕ : (x : ℕ) → is-nonzero-ℕ x → is-emb (x *ℕ_)
+is-emb-left-mul-ℕ x H =
+  is-emb-is-injective is-set-ℕ (is-injective-left-mul-ℕ x H)
 
-is-emb-mul-ℕ' : (x : ℕ) → is-nonzero-ℕ x → is-emb (_*ℕ x)
-is-emb-mul-ℕ' x H = is-emb-is-injective is-set-ℕ (is-injective-mul-ℕ' x H)
+is-emb-right-mul-ℕ : (x : ℕ) → is-nonzero-ℕ x → is-emb (_*ℕ x)
+is-emb-right-mul-ℕ x H =
+  is-emb-is-injective is-set-ℕ (is-injective-right-mul-ℕ x H)
 
 is-nonzero-mul-ℕ :
   (x y : ℕ) → is-nonzero-ℕ x → is-nonzero-ℕ y → is-nonzero-ℕ (x *ℕ y)
 is-nonzero-mul-ℕ x y H K p =
-  K (is-injective-mul-ℕ x H (p ∙ (inv (right-zero-law-mul-ℕ x))))
+  K (is-injective-left-mul-ℕ x H (p ∙ (inv (right-zero-law-mul-ℕ x))))
 
 is-nonzero-left-factor-mul-ℕ :
   (x y : ℕ) → is-nonzero-ℕ (x *ℕ y) → is-nonzero-ℕ x
@@ -217,12 +219,12 @@ We conclude that $y = 1$ if $(x+1)y = x+1$.
 is-one-is-right-unit-mul-ℕ :
   (x y : ℕ) → (succ-ℕ x) *ℕ y ＝ succ-ℕ x → is-one-ℕ y
 is-one-is-right-unit-mul-ℕ x y p =
-  is-injective-mul-succ-ℕ x (p ∙ inv (right-unit-law-mul-ℕ (succ-ℕ x)))
+  is-injective-left-mul-succ-ℕ x (p ∙ inv (right-unit-law-mul-ℕ (succ-ℕ x)))
 
 is-one-is-left-unit-mul-ℕ :
   (x y : ℕ) → x *ℕ (succ-ℕ y) ＝ succ-ℕ y → is-one-ℕ x
 is-one-is-left-unit-mul-ℕ x y p =
-  is-injective-mul-succ-ℕ' y (p ∙ inv (left-unit-law-mul-ℕ (succ-ℕ y)))
+  is-injective-right-mul-succ-ℕ y (p ∙ inv (left-unit-law-mul-ℕ (succ-ℕ y)))
 
 is-one-right-is-one-mul-ℕ :
   (x y : ℕ) → is-one-ℕ (x *ℕ y) → is-one-ℕ y

--- a/src/elementary-number-theory/multiplication-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/multiplication-natural-numbers.lagda.md
@@ -31,7 +31,7 @@ open import group-theory.semigroups
 ```agda
 mul-ℕ : ℕ → ℕ → ℕ
 mul-ℕ 0 n = 0
-mul-ℕ (succ-ℕ m) n = add-ℕ (mul-ℕ m n) n
+mul-ℕ (succ-ℕ m) n = (mul-ℕ m n) +ℕ n
 
 infix 30 _*ℕ_
 _*ℕ_ = mul-ℕ

--- a/src/elementary-number-theory/multiplication-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/multiplication-natural-numbers.lagda.md
@@ -162,7 +162,7 @@ interchange-law-mul-mul-ℕ =
     associative-mul-ℕ
 
 is-injective-mul-succ-ℕ' :
-  (k : ℕ) → is-injective (mul-ℕ' (succ-ℕ k))
+  (k : ℕ) → is-injective (_*ℕ (succ-ℕ k))
 is-injective-mul-succ-ℕ' k {zero-ℕ} {zero-ℕ} p = refl
 is-injective-mul-succ-ℕ' k {succ-ℕ m} {succ-ℕ n} p =
   ap succ-ℕ
@@ -173,7 +173,7 @@ is-injective-mul-succ-ℕ' k {succ-ℕ m} {succ-ℕ n} p =
           ( ( p) ∙
             ( left-successor-law-mul-ℕ n (succ-ℕ k))))))
 
-is-injective-mul-ℕ' : (k : ℕ) → is-nonzero-ℕ k → is-injective (mul-ℕ' k)
+is-injective-mul-ℕ' : (k : ℕ) → is-nonzero-ℕ k → is-injective (_*ℕ k)
 is-injective-mul-ℕ' k H p with
   is-successor-is-nonzero-ℕ H
 ... | pair l refl = is-injective-mul-succ-ℕ' l p
@@ -194,7 +194,7 @@ is-injective-mul-ℕ k H p with
 is-emb-mul-ℕ : (x : ℕ) → is-nonzero-ℕ x → is-emb (mul-ℕ x)
 is-emb-mul-ℕ x H = is-emb-is-injective is-set-ℕ (is-injective-mul-ℕ x H)
 
-is-emb-mul-ℕ' : (x : ℕ) → is-nonzero-ℕ x → is-emb (mul-ℕ' x)
+is-emb-mul-ℕ' : (x : ℕ) → is-nonzero-ℕ x → is-emb (_*ℕ x)
 is-emb-mul-ℕ' x H = is-emb-is-injective is-set-ℕ (is-injective-mul-ℕ' x H)
 
 is-nonzero-mul-ℕ :

--- a/src/elementary-number-theory/multiplication-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/multiplication-natural-numbers.lagda.md
@@ -179,19 +179,19 @@ is-injective-mul-ℕ' k H p with
 ... | pair l refl = is-injective-mul-succ-ℕ' l p
 
 is-injective-mul-succ-ℕ :
-  (k : ℕ) → is-injective (mul-ℕ (succ-ℕ k))
+  (k : ℕ) → is-injective ((succ-ℕ k) *ℕ_)
 is-injective-mul-succ-ℕ k {m} {n} p =
   is-injective-mul-succ-ℕ' k
     ( ( commutative-mul-ℕ m (succ-ℕ k)) ∙
       ( p ∙ commutative-mul-ℕ (succ-ℕ k) n))
 
 is-injective-mul-ℕ :
-  (k : ℕ) → is-nonzero-ℕ k → is-injective (mul-ℕ k)
+  (k : ℕ) → is-nonzero-ℕ k → is-injective (k *ℕ_)
 is-injective-mul-ℕ k H p with
   is-successor-is-nonzero-ℕ H
 ... | pair l refl = is-injective-mul-succ-ℕ l p
 
-is-emb-mul-ℕ : (x : ℕ) → is-nonzero-ℕ x → is-emb (mul-ℕ x)
+is-emb-mul-ℕ : (x : ℕ) → is-nonzero-ℕ x → is-emb (x *ℕ_)
 is-emb-mul-ℕ x H = is-emb-is-injective is-set-ℕ (is-injective-mul-ℕ x H)
 
 is-emb-mul-ℕ' : (x : ℕ) → is-nonzero-ℕ x → is-emb (_*ℕ x)

--- a/src/elementary-number-theory/multiset-coefficients.lagda.md
+++ b/src/elementary-number-theory/multiset-coefficients.lagda.md
@@ -31,5 +31,5 @@ multiset-coefficient zero-ℕ zero-ℕ = 1
 multiset-coefficient zero-ℕ (succ-ℕ k) = 0
 multiset-coefficient (succ-ℕ n) zero-ℕ = 1
 multiset-coefficient (succ-ℕ n) (succ-ℕ k) =
-  add-ℕ (multiset-coefficient (succ-ℕ n) k) (multiset-coefficient n (succ-ℕ k))
+  (multiset-coefficient (succ-ℕ n) k) +ℕ (multiset-coefficient n (succ-ℕ k))
 ```

--- a/src/elementary-number-theory/parity-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/parity-natural-numbers.lagda.md
@@ -136,15 +136,15 @@ is-odd-is-even-succ-ℕ n p =
     ( is-odd-succ-is-even-ℕ (succ-ℕ n) p)
 ```
 
-### A natural number `x` is odd if and only if there is a natural number `y` such that `succ-ℕ (mul-ℕ y 2) ＝ x`
+### A natural number `x` is odd if and only if there is a natural number `y` such that `succ-ℕ (y *ℕ 2) ＝ x`
 
 ```agda
 has-odd-expansion : ℕ → UU lzero
-has-odd-expansion x = Σ ℕ (λ y → (succ-ℕ (mul-ℕ y 2)) ＝ x)
+has-odd-expansion x = Σ ℕ (λ y → (succ-ℕ (y *ℕ 2)) ＝ x)
 
 is-odd-has-odd-expansion : (n : ℕ) → has-odd-expansion n → is-odd-ℕ n
-is-odd-has-odd-expansion .(succ-ℕ (mul-ℕ m 2)) (m , refl) =
-  is-odd-succ-is-even-ℕ (mul-ℕ m 2) (m , refl)
+is-odd-has-odd-expansion .(succ-ℕ (m *ℕ 2)) (m , refl) =
+  is-odd-succ-is-even-ℕ (m *ℕ 2) (m , refl)
 
 has-odd-expansion-is-odd : (n : ℕ) → is-odd-ℕ n → has-odd-expansion n
 has-odd-expansion-is-odd zero-ℕ p = ex-falso (p is-even-zero-ℕ)

--- a/src/elementary-number-theory/powers-integers.lagda.md
+++ b/src/elementary-number-theory/powers-integers.lagda.md
@@ -36,6 +36,6 @@ power-ℤ = power-Commutative-Ring ℤ-Commutative-Ring
 ### `xⁿ⁺¹ = xⁿx`
 
 ```agda
-power-succ-ℤ : (n : ℕ) (x : ℤ) → power-ℤ (succ-ℕ n) x ＝ mul-ℤ (power-ℤ n x) x
+power-succ-ℤ : (n : ℕ) (x : ℤ) → power-ℤ (succ-ℕ n) x ＝ (power-ℤ n x) *ℤ x
 power-succ-ℤ = power-succ-Commutative-Ring ℤ-Commutative-Ring
 ```

--- a/src/elementary-number-theory/powers-of-two.lagda.md
+++ b/src/elementary-number-theory/powers-of-two.lagda.md
@@ -84,9 +84,9 @@ has-pair-expansion-is-even-or-odd n =
                ( succ-ℕ (mul-ℕ (pr2 (pr1 s)) 2))) ∙
              ( ( ap (λ a → mul-ℕ 2 a) (pr2 s)) ∙
              ( ( ap succ-ℕ
-               ( left-successor-law-add-ℕ (add-ℕ 0 (pr1 e)) (pr1 e))) ∙
+               ( left-successor-law-add-ℕ (0 +ℕ (pr1 e)) (pr1 e))) ∙
              ( ( ap (succ-ℕ ∘ succ-ℕ)
-               ( ap (λ a → add-ℕ a (pr1 e))
+               ( ap (λ a → a +ℕ (pr1 e))
                  ( left-unit-law-add-ℕ (pr1 e)))) ∙
              ( ( ap (succ-ℕ ∘ succ-ℕ)
                ( inv (right-two-law-mul-ℕ (pr1 e)))) ∙
@@ -112,19 +112,19 @@ is-pair-expansion-unique zero-ℕ zero-ℕ v v' p =
       ( is-injective-add-ℕ 0 (is-injective-succ-ℕ p))))
 is-pair-expansion-unique zero-ℕ (succ-ℕ u') v v' p = ex-falso (s t)
   where
-    s : is-odd-ℕ (succ-ℕ (add-ℕ 0 (mul-ℕ v 2)))
+    s : is-odd-ℕ (succ-ℕ (0 +ℕ (mul-ℕ v 2)))
     s = is-odd-has-odd-expansion _
       ( v , ap succ-ℕ (inv (left-unit-law-add-ℕ _)))
 
-    t : is-even-ℕ (succ-ℕ (add-ℕ 0 (mul-ℕ v 2)))
+    t : is-even-ℕ (succ-ℕ (0 +ℕ (mul-ℕ v 2)))
     t = tr is-even-ℕ (inv p) (div-mul-ℕ' _ 2 _ ((exp-ℕ 2 u') , refl))
 is-pair-expansion-unique (succ-ℕ u) zero-ℕ v v' p = ex-falso (s t)
   where
-    s : is-odd-ℕ (succ-ℕ (add-ℕ 0 (mul-ℕ v' 2)))
+    s : is-odd-ℕ (succ-ℕ (0 +ℕ (mul-ℕ v' 2)))
     s = is-odd-has-odd-expansion _
       ( v' , ap succ-ℕ (inv (left-unit-law-add-ℕ _)))
 
-    t : is-even-ℕ (succ-ℕ (add-ℕ 0 (mul-ℕ v' 2)))
+    t : is-even-ℕ (succ-ℕ (0 +ℕ (mul-ℕ v' 2)))
     t = tr is-even-ℕ p (div-mul-ℕ' _ 2 _ ((exp-ℕ 2 u) , refl))
 is-pair-expansion-unique (succ-ℕ u) (succ-ℕ u') v v' p = pu , pv
   where

--- a/src/elementary-number-theory/powers-of-two.lagda.md
+++ b/src/elementary-number-theory/powers-of-two.lagda.md
@@ -42,12 +42,12 @@ pair-expansion : ℕ → UU lzero
 pair-expansion n =
   Σ (ℕ × ℕ)
     ( λ p →
-      ( mul-ℕ (exp-ℕ 2 (pr1 p)) (succ-ℕ (mul-ℕ (pr2 p) 2))) ＝
+      ( mul-ℕ (exp-ℕ 2 (pr1 p)) (succ-ℕ ((pr2 p) *ℕ 2))) ＝
         succ-ℕ n)
 
 is-nonzero-pair-expansion :
   (u v : ℕ) →
-  is-nonzero-ℕ (mul-ℕ (exp-ℕ 2 u) (succ-ℕ (mul-ℕ v 2)))
+  is-nonzero-ℕ ((exp-ℕ 2 u) *ℕ (succ-ℕ (v *ℕ 2)))
 is-nonzero-pair-expansion u v =
   is-nonzero-mul-ℕ _ _
     ( is-nonzero-exp-ℕ 2 u is-nonzero-two-ℕ)
@@ -78,11 +78,11 @@ has-pair-expansion-is-even-or-odd n =
               s = f (pr1 e) t (is-decidable-is-even-ℕ (pr1 e))
            in pair
              ( (succ-ℕ (pr1 (pr1 s))) , pr2 (pr1 s))
-             ( ( ap (λ a → mul-ℕ a (succ-ℕ (mul-ℕ (pr2 (pr1 s)) 2)))
+             ( ( ap (λ a → a *ℕ (succ-ℕ (mul-ℕ (pr2 (pr1 s)) 2)))
                ( commutative-mul-ℕ (exp-ℕ 2 (pr1 (pr1 s))) 2)) ∙
              ( ( associative-mul-ℕ 2 (exp-ℕ 2 (pr1 (pr1 s)))
                ( succ-ℕ (mul-ℕ (pr2 (pr1 s)) 2))) ∙
-             ( ( ap (λ a → mul-ℕ 2 a) (pr2 s)) ∙
+             ( ( ap (λ a → 2 *ℕ a) (pr2 s)) ∙
              ( ( ap succ-ℕ
                ( left-successor-law-add-ℕ (0 +ℕ (pr1 e)) (pr1 e))) ∙
              ( ( ap (succ-ℕ ∘ succ-ℕ)
@@ -103,8 +103,8 @@ has-pair-expansion n =
 ```agda
 is-pair-expansion-unique :
   (u u' v v' : ℕ) →
-  (mul-ℕ (exp-ℕ 2 u) (succ-ℕ (mul-ℕ v 2))) ＝
-    (mul-ℕ (exp-ℕ 2 u') (succ-ℕ (mul-ℕ v' 2))) →
+  ((exp-ℕ 2 u) *ℕ (succ-ℕ (v *ℕ 2))) ＝
+    ((exp-ℕ 2 u') *ℕ (succ-ℕ (v' *ℕ 2))) →
   (u ＝ u') × (v ＝ v')
 is-pair-expansion-unique zero-ℕ zero-ℕ v v' p =
   ( pair refl
@@ -112,33 +112,33 @@ is-pair-expansion-unique zero-ℕ zero-ℕ v v' p =
       ( is-injective-add-ℕ 0 (is-injective-succ-ℕ p))))
 is-pair-expansion-unique zero-ℕ (succ-ℕ u') v v' p = ex-falso (s t)
   where
-    s : is-odd-ℕ (succ-ℕ (0 +ℕ (mul-ℕ v 2)))
+    s : is-odd-ℕ (succ-ℕ (0 +ℕ (v *ℕ 2)))
     s = is-odd-has-odd-expansion _
       ( v , ap succ-ℕ (inv (left-unit-law-add-ℕ _)))
 
-    t : is-even-ℕ (succ-ℕ (0 +ℕ (mul-ℕ v 2)))
+    t : is-even-ℕ (succ-ℕ (0 +ℕ (v *ℕ 2)))
     t = tr is-even-ℕ (inv p) (div-mul-ℕ' _ 2 _ ((exp-ℕ 2 u') , refl))
 is-pair-expansion-unique (succ-ℕ u) zero-ℕ v v' p = ex-falso (s t)
   where
-    s : is-odd-ℕ (succ-ℕ (0 +ℕ (mul-ℕ v' 2)))
+    s : is-odd-ℕ (succ-ℕ (0 +ℕ (v' *ℕ 2)))
     s = is-odd-has-odd-expansion _
       ( v' , ap succ-ℕ (inv (left-unit-law-add-ℕ _)))
 
-    t : is-even-ℕ (succ-ℕ (0 +ℕ (mul-ℕ v' 2)))
+    t : is-even-ℕ (succ-ℕ (0 +ℕ (v' *ℕ 2)))
     t = tr is-even-ℕ p (div-mul-ℕ' _ 2 _ ((exp-ℕ 2 u) , refl))
 is-pair-expansion-unique (succ-ℕ u) (succ-ℕ u') v v' p = pu , pv
   where
     q :
-      (mul-ℕ (exp-ℕ 2 u) (succ-ℕ (mul-ℕ v 2))) ＝
-        (mul-ℕ (exp-ℕ 2 u') (succ-ℕ (mul-ℕ v' 2)))
+      ((exp-ℕ 2 u) *ℕ (succ-ℕ (v *ℕ 2))) ＝
+        ((exp-ℕ 2 u') *ℕ (succ-ℕ (v' *ℕ 2)))
     q = is-injective-mul-ℕ 2 is-nonzero-two-ℕ
-      ( inv (associative-mul-ℕ 2 (exp-ℕ 2 u) (succ-ℕ (mul-ℕ v 2))) ∙
-      ( ( ap (mul-ℕ' (succ-ℕ (mul-ℕ v 2)))
+      ( inv (associative-mul-ℕ 2 (exp-ℕ 2 u) (succ-ℕ (v *ℕ 2))) ∙
+      ( ( ap (mul-ℕ' (succ-ℕ (v *ℕ 2)))
         ( commutative-mul-ℕ 2 (exp-ℕ 2 u))) ∙
       ( ( p) ∙
-      ( ( ap (mul-ℕ' (succ-ℕ (mul-ℕ v' 2)))
+      ( ( ap (mul-ℕ' (succ-ℕ (v' *ℕ 2)))
         ( commutative-mul-ℕ (exp-ℕ 2 u') 2)) ∙
-      ( associative-mul-ℕ 2 (exp-ℕ 2 u') (succ-ℕ (mul-ℕ v' 2)))))))
+      ( associative-mul-ℕ 2 (exp-ℕ 2 u') (succ-ℕ (v' *ℕ 2)))))))
 
     pu : (succ-ℕ u) ＝ (succ-ℕ u')
     pu = ap succ-ℕ (pr1 (is-pair-expansion-unique u u' v v' q))
@@ -173,7 +173,7 @@ is-split-surjective-pairing-map n = (u , v) , is-injective-succ-ℕ (q ∙ s)
 
    q :
      ( succ-ℕ (pairing-map (u , v))) ＝
-     ( mul-ℕ (exp-ℕ 2 u) (succ-ℕ (mul-ℕ v 2)))
+     ( (exp-ℕ 2 u) *ℕ (succ-ℕ (v *ℕ 2)))
    q = inv (pr2 r)
 ```
 
@@ -188,8 +188,8 @@ is-injecitve-pairing-map {u , v} {u' , v'} p =
     s = is-successor-is-nonzero-ℕ (is-nonzero-pair-expansion u' v')
 
     q :
-      ( mul-ℕ (exp-ℕ 2 u) (succ-ℕ (mul-ℕ v 2))) ＝
-        ( mul-ℕ (exp-ℕ 2 u') (succ-ℕ (mul-ℕ v' 2)))
+      ( (exp-ℕ 2 u) *ℕ (succ-ℕ (v *ℕ 2))) ＝
+        ( (exp-ℕ 2 u') *ℕ (succ-ℕ (v' *ℕ 2)))
     q = (pr2 r) ∙ (ap succ-ℕ p ∙ inv (pr2 s))
 ```
 

--- a/src/elementary-number-theory/powers-of-two.lagda.md
+++ b/src/elementary-number-theory/powers-of-two.lagda.md
@@ -133,10 +133,10 @@ is-pair-expansion-unique (succ-ℕ u) (succ-ℕ u') v v' p = pu , pv
         ((exp-ℕ 2 u') *ℕ (succ-ℕ (v' *ℕ 2)))
     q = is-injective-mul-ℕ 2 is-nonzero-two-ℕ
       ( inv (associative-mul-ℕ 2 (exp-ℕ 2 u) (succ-ℕ (v *ℕ 2))) ∙
-      ( ( ap (mul-ℕ' (succ-ℕ (v *ℕ 2)))
+      ( ( ap (_*ℕ (succ-ℕ (v *ℕ 2)))
         ( commutative-mul-ℕ 2 (exp-ℕ 2 u))) ∙
       ( ( p) ∙
-      ( ( ap (mul-ℕ' (succ-ℕ (v' *ℕ 2)))
+      ( ( ap (_*ℕ (succ-ℕ (v' *ℕ 2)))
         ( commutative-mul-ℕ (exp-ℕ 2 u') 2)) ∙
       ( associative-mul-ℕ 2 (exp-ℕ 2 u') (succ-ℕ (v' *ℕ 2)))))))
 

--- a/src/elementary-number-theory/powers-of-two.lagda.md
+++ b/src/elementary-number-theory/powers-of-two.lagda.md
@@ -108,8 +108,8 @@ is-pair-expansion-unique :
   (u ＝ u') × (v ＝ v')
 is-pair-expansion-unique zero-ℕ zero-ℕ v v' p =
   ( pair refl
-    ( is-injective-mul-ℕ' 2 is-nonzero-two-ℕ
-      ( is-injective-add-ℕ 0 (is-injective-succ-ℕ p))))
+    ( is-injective-right-mul-ℕ 2 is-nonzero-two-ℕ
+      ( is-injective-left-add-ℕ 0 (is-injective-succ-ℕ p))))
 is-pair-expansion-unique zero-ℕ (succ-ℕ u') v v' p = ex-falso (s t)
   where
     s : is-odd-ℕ (succ-ℕ (0 +ℕ (v *ℕ 2)))
@@ -131,7 +131,7 @@ is-pair-expansion-unique (succ-ℕ u) (succ-ℕ u') v v' p = pu , pv
     q :
       ((exp-ℕ 2 u) *ℕ (succ-ℕ (v *ℕ 2))) ＝
         ((exp-ℕ 2 u') *ℕ (succ-ℕ (v' *ℕ 2)))
-    q = is-injective-mul-ℕ 2 is-nonzero-two-ℕ
+    q = is-injective-left-mul-ℕ 2 is-nonzero-two-ℕ
       ( inv (associative-mul-ℕ 2 (exp-ℕ 2 u) (succ-ℕ (v *ℕ 2))) ∙
       ( ( ap (_*ℕ (succ-ℕ (v *ℕ 2)))
         ( commutative-mul-ℕ 2 (exp-ℕ 2 u))) ∙

--- a/src/elementary-number-theory/powers-of-two.lagda.md
+++ b/src/elementary-number-theory/powers-of-two.lagda.md
@@ -42,7 +42,7 @@ pair-expansion : ℕ → UU lzero
 pair-expansion n =
   Σ (ℕ × ℕ)
     ( λ p →
-      ( mul-ℕ (exp-ℕ 2 (pr1 p)) (succ-ℕ ((pr2 p) *ℕ 2))) ＝
+      ( (exp-ℕ 2 (pr1 p)) *ℕ (succ-ℕ ((pr2 p) *ℕ 2))) ＝
         succ-ℕ n)
 
 is-nonzero-pair-expansion :
@@ -78,10 +78,10 @@ has-pair-expansion-is-even-or-odd n =
               s = f (pr1 e) t (is-decidable-is-even-ℕ (pr1 e))
            in pair
              ( (succ-ℕ (pr1 (pr1 s))) , pr2 (pr1 s))
-             ( ( ap (λ a → a *ℕ (succ-ℕ (mul-ℕ (pr2 (pr1 s)) 2)))
+             ( ( ap (λ a → a *ℕ (succ-ℕ ((pr2 (pr1 s)) *ℕ 2)))
                ( commutative-mul-ℕ (exp-ℕ 2 (pr1 (pr1 s))) 2)) ∙
              ( ( associative-mul-ℕ 2 (exp-ℕ 2 (pr1 (pr1 s)))
-               ( succ-ℕ (mul-ℕ (pr2 (pr1 s)) 2))) ∙
+               ( succ-ℕ ((pr2 (pr1 s)) *ℕ 2))) ∙
              ( ( ap (λ a → 2 *ℕ a) (pr2 s)) ∙
              ( ( ap succ-ℕ
                ( left-successor-law-add-ℕ (0 +ℕ (pr1 e)) (pr1 e))) ∙

--- a/src/elementary-number-theory/products-of-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/products-of-natural-numbers.lagda.md
@@ -38,5 +38,5 @@ product-list-ℕ = fold-list 1 mul-ℕ
 ```agda
 Π-ℕ : (k : ℕ) → (Fin k → ℕ) → ℕ
 Π-ℕ zero-ℕ x = 1
-Π-ℕ (succ-ℕ k) x = mul-ℕ (Π-ℕ k (λ i → x (inl i))) (x (inr star))
+Π-ℕ (succ-ℕ k) x = (Π-ℕ k (λ i → x (inl i))) *ℕ (x (inr star))
 ```

--- a/src/elementary-number-theory/pythagorean-triples.lagda.md
+++ b/src/elementary-number-theory/pythagorean-triples.lagda.md
@@ -26,5 +26,5 @@ A Pythagorean triple is a triple `(a,b,c)` of natural numbers such that
 
 ```agda
 is-pythagorean-triple : ℕ → ℕ → ℕ → UU lzero
-is-pythagorean-triple a b c = (add-ℕ (square-ℕ a) (square-ℕ b) ＝ square-ℕ c)
+is-pythagorean-triple a b c = ((square-ℕ a) +ℕ (square-ℕ b) ＝ square-ℕ c)
 ```

--- a/src/elementary-number-theory/rational-numbers.lagda.md
+++ b/src/elementary-number-theory/rational-numbers.lagda.md
@@ -29,7 +29,7 @@ open import foundation.universe-levels
 ## Idea
 
 The type of rational numbers is the quotient of the type of fractions, by the
-equivalence relation given by `(n/m) ~ (n'/m') := Id (mul-ℤ n m') (mul-ℤ n' m)`.
+equivalence relation given by `(n/m) ~ (n'/m') := Id (n *ℤ m') (n' *ℤ m)`.
 
 ## Definitions
 

--- a/src/elementary-number-theory/reduced-integer-fractions.lagda.md
+++ b/src/elementary-number-theory/reduced-integer-fractions.lagda.md
@@ -148,10 +148,10 @@ is-reduced-reduce-fraction-ℤ x =
   is-zero-gcd-case-split (inr nz) =
     is-plus-or-minus-case-split
       ( is-plus-or-minus-sim-unit-ℤ
-      ( antisymmetric-div-ℤ (mul-ℤ alpha d) d
+      ( antisymmetric-div-ℤ (alpha *ℤ d) d
         ( div-gcd-is-common-divisor-ℤ
           ( numerator-fraction-ℤ x) ( denominator-fraction-ℤ x)
-            (mul-ℤ alpha d)
+            (alpha *ℤ d)
           ( pair
             -- alpha * d divides the numerator of x
             ( tr
@@ -184,7 +184,7 @@ is-reduced-reduce-fraction-ℤ x =
     d : ℤ
     d = gcd-ℤ (numerator-fraction-ℤ x) (denominator-fraction-ℤ x)
     is-plus-or-minus-case-split :
-      (is-plus-or-minus-ℤ (mul-ℤ alpha d) d) →
+      (is-plus-or-minus-ℤ (alpha *ℤ d) d) →
       is-reduced-fraction-ℤ (reduce-fraction-ℤ x)
     is-plus-or-minus-case-split (inl pos) =
       ( is-injective-mul-ℤ' d
@@ -225,7 +225,7 @@ sim-reduced-fraction-ℤ x =
     ＝ mul-ℤ (mul-ℤ (numerator-fraction-ℤ (reduce-fraction-ℤ x))
         (gcd-ℤ (numerator-fraction-ℤ x) (denominator-fraction-ℤ x)))
         (denominator-fraction-ℤ (reduce-fraction-ℤ x))
-      by ap (λ H → mul-ℤ H (denominator-fraction-ℤ (reduce-fraction-ℤ x)))
+      by ap (λ H → H *ℤ (denominator-fraction-ℤ (reduce-fraction-ℤ x)))
           (inv (eq-reduce-numerator-fraction-ℤ x))
     ＝ mul-ℤ (numerator-fraction-ℤ (reduce-fraction-ℤ x))
       (mul-ℤ (gcd-ℤ (numerator-fraction-ℤ x) (denominator-fraction-ℤ x))
@@ -387,7 +387,7 @@ unique-numerator-reduce-fraction-ℤ x y H =
           ( int-reduce-denominator-fraction-ℤ y) ＝
         mul-ℤ
           ( int-reduce-numerator-fraction-ℤ x)
-          ( mul-ℤ neg-one-ℤ (int-reduce-denominator-fraction-ℤ x))
+          ( neg-one-ℤ *ℤ (int-reduce-denominator-fraction-ℤ x))
       reduced-eqn =
         equational-reasoning
           mul-ℤ
@@ -398,18 +398,18 @@ unique-numerator-reduce-fraction-ℤ x y H =
               ( int-reduce-denominator-fraction-ℤ x)
             by reduce-preserves-sim-ℤ x y H
           ＝ mul-ℤ
-              ( mul-ℤ (int-reduce-numerator-fraction-ℤ x) neg-one-ℤ)
+              ( (int-reduce-numerator-fraction-ℤ x) *ℤ neg-one-ℤ)
               ( int-reduce-denominator-fraction-ℤ x)
             by
               ap
-                ( λ K → mul-ℤ K (int-reduce-denominator-fraction-ℤ x))
+                ( λ K → K *ℤ (int-reduce-denominator-fraction-ℤ x))
                 ( inv neg ∙
                   commutative-mul-ℤ
                     ( neg-one-ℤ)
                     ( int-reduce-numerator-fraction-ℤ x))
           ＝ mul-ℤ
               ( int-reduce-numerator-fraction-ℤ x)
-              ( mul-ℤ neg-one-ℤ (int-reduce-denominator-fraction-ℤ x))
+              ( neg-one-ℤ *ℤ (int-reduce-denominator-fraction-ℤ x))
             by
               associative-mul-ℤ
                 ( int-reduce-numerator-fraction-ℤ x)

--- a/src/elementary-number-theory/reduced-integer-fractions.lagda.md
+++ b/src/elementary-number-theory/reduced-integer-fractions.lagda.md
@@ -150,8 +150,9 @@ is-reduced-reduce-fraction-ℤ x =
       ( is-plus-or-minus-sim-unit-ℤ
       ( antisymmetric-div-ℤ (alpha *ℤ d) d
         ( div-gcd-is-common-divisor-ℤ
-          ( numerator-fraction-ℤ x) ( denominator-fraction-ℤ x)
-            (alpha *ℤ d)
+          ( numerator-fraction-ℤ x)
+          ( denominator-fraction-ℤ x)
+          ( alpha *ℤ d)
           ( pair
             -- alpha * d divides the numerator of x
             ( tr
@@ -179,8 +180,10 @@ is-reduced-reduce-fraction-ℤ x =
           ( denominator-fraction-ℤ (reduce-fraction-ℤ x))) refl)))
     where
     alpha : ℤ
-    alpha = gcd-ℤ (numerator-fraction-ℤ (reduce-fraction-ℤ x))
-      (denominator-fraction-ℤ (reduce-fraction-ℤ x))
+    alpha =
+      gcd-ℤ
+        ( numerator-fraction-ℤ (reduce-fraction-ℤ x))
+        ( denominator-fraction-ℤ (reduce-fraction-ℤ x))
     d : ℤ
     d = gcd-ℤ (numerator-fraction-ℤ x) (denominator-fraction-ℤ x)
     is-plus-or-minus-case-split :
@@ -219,13 +222,11 @@ sim-reduced-fraction-ℤ :
   (x : fraction-ℤ) → (sim-fraction-ℤ x (reduce-fraction-ℤ x))
 sim-reduced-fraction-ℤ x =
   equational-reasoning
-    mul-ℤ
-      ( numerator-fraction-ℤ x)
-      ( denominator-fraction-ℤ (reduce-fraction-ℤ x))
-    ＝ mul-ℤ ((numerator-fraction-ℤ (reduce-fraction-ℤ x)) *ℤ
-        (gcd-ℤ (numerator-fraction-ℤ x) (denominator-fraction-ℤ x)))
+    (numerator-fraction-ℤ x) *ℤ (denominator-fraction-ℤ (reduce-fraction-ℤ x))
+    ＝ ((numerator-fraction-ℤ (reduce-fraction-ℤ x)) *ℤ
+        (gcd-ℤ (numerator-fraction-ℤ x) (denominator-fraction-ℤ x))) *ℤ
         (denominator-fraction-ℤ (reduce-fraction-ℤ x))
-      by ap (λ H → H *ℤ (denominator-fraction-ℤ (reduce-fraction-ℤ x)))
+      by ap (_*ℤ (denominator-fraction-ℤ (reduce-fraction-ℤ x)))
           (inv (eq-reduce-numerator-fraction-ℤ x))
     ＝ (numerator-fraction-ℤ (reduce-fraction-ℤ x)) *ℤ
       ((gcd-ℤ (numerator-fraction-ℤ x) (denominator-fraction-ℤ x)) *ℤ
@@ -233,12 +234,10 @@ sim-reduced-fraction-ℤ x =
       by associative-mul-ℤ (numerator-fraction-ℤ (reduce-fraction-ℤ x))
         (gcd-ℤ (numerator-fraction-ℤ x) (denominator-fraction-ℤ x))
         (denominator-fraction-ℤ (reduce-fraction-ℤ x))
-    ＝ mul-ℤ
-      ( numerator-fraction-ℤ (reduce-fraction-ℤ x))
-      ( denominator-fraction-ℤ x)
+    ＝ (numerator-fraction-ℤ (reduce-fraction-ℤ x)) *ℤ (denominator-fraction-ℤ x)
       by
         ap
-        ( mul-ℤ (numerator-fraction-ℤ (reduce-fraction-ℤ x)))
+        ( (numerator-fraction-ℤ (reduce-fraction-ℤ x)) *ℤ_)
         ( ( commutative-mul-ℤ
             ( gcd-ℤ (numerator-fraction-ℤ x) (denominator-fraction-ℤ x))
             ( denominator-fraction-ℤ (reduce-fraction-ℤ x))) ∙
@@ -402,7 +401,7 @@ unique-numerator-reduce-fraction-ℤ x y H =
               ( int-reduce-denominator-fraction-ℤ x)
             by
               ap
-                ( λ K → K *ℤ (int-reduce-denominator-fraction-ℤ x))
+                ( _*ℤ (int-reduce-denominator-fraction-ℤ x))
                 ( inv neg ∙
                   commutative-mul-ℤ
                     ( neg-one-ℤ)
@@ -470,10 +469,10 @@ sim-unique-denominator-reduce-fraction-ℤ x y H = antisymmetric-div-ℤ
   reduced-eqn :
     mul-ℤ
       ( int-reduce-numerator-fraction-ℤ x)
-      ( int-reduce-denominator-fraction-ℤ y)
-    ＝ mul-ℤ
-        ( int-reduce-numerator-fraction-ℤ y)
-        ( int-reduce-denominator-fraction-ℤ x)
+      ( int-reduce-denominator-fraction-ℤ y) ＝
+    mul-ℤ
+      ( int-reduce-numerator-fraction-ℤ y)
+      ( int-reduce-denominator-fraction-ℤ x)
   reduced-eqn = reduce-preserves-sim-ℤ x y H
   div-red-x-num :
     div-ℤ

--- a/src/elementary-number-theory/reduced-integer-fractions.lagda.md
+++ b/src/elementary-number-theory/reduced-integer-fractions.lagda.md
@@ -190,7 +190,7 @@ is-reduced-reduce-fraction-ℤ x =
       (is-plus-or-minus-ℤ (alpha *ℤ d) d) →
       is-reduced-fraction-ℤ (reduce-fraction-ℤ x)
     is-plus-or-minus-case-split (inl pos) =
-      ( is-injective-mul-ℤ' d
+      ( is-injective-right-mul-ℤ d
         ( λ r → tr is-positive-ℤ r
           ( is-positive-gcd-is-positive-right-ℤ
             ( numerator-fraction-ℤ x) ( denominator-fraction-ℤ x)
@@ -201,7 +201,7 @@ is-reduced-reduce-fraction-ℤ x =
           (inv (neg-neg-ℤ ( gcd-ℤ ( numerator-fraction-ℤ (reduce-fraction-ℤ x))
             ( denominator-fraction-ℤ (reduce-fraction-ℤ x)))) ∙
              ap neg-ℤ
-               ( is-injective-mul-ℤ' d
+               ( is-injective-right-mul-ℤ d
                  ( λ r →
                    tr is-positive-ℤ r
                      ( is-positive-gcd-is-positive-right-ℤ
@@ -442,7 +442,7 @@ unique-numerator-reduce-fraction-ℤ x y H =
                     ( is-positive-int-reduce-denominator-fraction-ℤ y)))
           ＝ neg-ℤ (int-reduce-denominator-fraction-ℤ x)
             by
-              is-injective-mul-ℤ
+              is-injective-left-mul-ℤ
                 ( int-reduce-numerator-fraction-ℤ x)
                 ( nz)
                 ( reduced-eqn)

--- a/src/elementary-number-theory/reduced-integer-fractions.lagda.md
+++ b/src/elementary-number-theory/reduced-integer-fractions.lagda.md
@@ -228,7 +228,7 @@ sim-reduced-fraction-ℤ x =
       by ap (λ H → H *ℤ (denominator-fraction-ℤ (reduce-fraction-ℤ x)))
           (inv (eq-reduce-numerator-fraction-ℤ x))
     ＝ (numerator-fraction-ℤ (reduce-fraction-ℤ x)) *ℤ
-      (mul-ℤ (gcd-ℤ (numerator-fraction-ℤ x) (denominator-fraction-ℤ x))
+      ((gcd-ℤ (numerator-fraction-ℤ x) (denominator-fraction-ℤ x)) *ℤ
         (denominator-fraction-ℤ (reduce-fraction-ℤ x)))
       by associative-mul-ℤ (numerator-fraction-ℤ (reduce-fraction-ℤ x))
         (gcd-ℤ (numerator-fraction-ℤ x) (denominator-fraction-ℤ x))

--- a/src/elementary-number-theory/reduced-integer-fractions.lagda.md
+++ b/src/elementary-number-theory/reduced-integer-fractions.lagda.md
@@ -222,12 +222,12 @@ sim-reduced-fraction-ℤ x =
     mul-ℤ
       ( numerator-fraction-ℤ x)
       ( denominator-fraction-ℤ (reduce-fraction-ℤ x))
-    ＝ mul-ℤ (mul-ℤ (numerator-fraction-ℤ (reduce-fraction-ℤ x))
+    ＝ mul-ℤ ((numerator-fraction-ℤ (reduce-fraction-ℤ x)) *ℤ
         (gcd-ℤ (numerator-fraction-ℤ x) (denominator-fraction-ℤ x)))
         (denominator-fraction-ℤ (reduce-fraction-ℤ x))
       by ap (λ H → H *ℤ (denominator-fraction-ℤ (reduce-fraction-ℤ x)))
           (inv (eq-reduce-numerator-fraction-ℤ x))
-    ＝ mul-ℤ (numerator-fraction-ℤ (reduce-fraction-ℤ x))
+    ＝ (numerator-fraction-ℤ (reduce-fraction-ℤ x)) *ℤ
       (mul-ℤ (gcd-ℤ (numerator-fraction-ℤ x) (denominator-fraction-ℤ x))
         (denominator-fraction-ℤ (reduce-fraction-ℤ x)))
       by associative-mul-ℤ (numerator-fraction-ℤ (reduce-fraction-ℤ x))

--- a/src/elementary-number-theory/relatively-prime-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/relatively-prime-natural-numbers.lagda.md
@@ -104,7 +104,7 @@ is-relatively-prime-div-ℕ a b c d H K L =
 
 ```agda
 is-relatively-prime-quotient-div-gcd-ℕ :
-  (a b : ℕ) → is-nonzero-ℕ (add-ℕ a b) →
+  (a b : ℕ) → is-nonzero-ℕ (a +ℕ b) →
   is-relatively-prime-ℕ
     ( quotient-div-ℕ (gcd-ℕ a b) a (div-left-factor-gcd-ℕ a b))
     ( quotient-div-ℕ (gcd-ℕ a b) b (div-right-factor-gcd-ℕ a b))

--- a/src/elementary-number-theory/relatively-prime-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/relatively-prime-natural-numbers.lagda.md
@@ -14,7 +14,6 @@ open import elementary-number-theory.greatest-common-divisor-natural-numbers
 open import elementary-number-theory.natural-numbers
 open import elementary-number-theory.prime-numbers
 
-open import foundation.coproduct-types
 open import foundation.decidable-propositions
 open import foundation.decidable-types
 open import foundation.dependent-pair-types

--- a/src/elementary-number-theory/stirling-numbers-of-the-second-kind.lagda.md
+++ b/src/elementary-number-theory/stirling-numbers-of-the-second-kind.lagda.md
@@ -28,6 +28,6 @@ stirling-number-second-kind zero-ℕ (succ-ℕ n) = 0
 stirling-number-second-kind (succ-ℕ m) zero-ℕ = 0
 stirling-number-second-kind (succ-ℕ m) (succ-ℕ n) =
   add-ℕ
-    ( mul-ℕ (succ-ℕ n) (stirling-number-second-kind m (succ-ℕ n)))
+    ( (succ-ℕ n) *ℕ (stirling-number-second-kind m (succ-ℕ n)))
     ( stirling-number-second-kind m n)
 ```

--- a/src/elementary-number-theory/stirling-numbers-of-the-second-kind.lagda.md
+++ b/src/elementary-number-theory/stirling-numbers-of-the-second-kind.lagda.md
@@ -27,7 +27,6 @@ stirling-number-second-kind zero-ℕ zero-ℕ = 1
 stirling-number-second-kind zero-ℕ (succ-ℕ n) = 0
 stirling-number-second-kind (succ-ℕ m) zero-ℕ = 0
 stirling-number-second-kind (succ-ℕ m) (succ-ℕ n) =
-  add-ℕ
-    ( (succ-ℕ n) *ℕ (stirling-number-second-kind m (succ-ℕ n)))
-    ( stirling-number-second-kind m n)
+  ( (succ-ℕ n) *ℕ (stirling-number-second-kind m (succ-ℕ n))) +ℕ
+  ( stirling-number-second-kind m n)
 ```

--- a/src/elementary-number-theory/strict-inequality-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/strict-inequality-natural-numbers.lagda.md
@@ -172,15 +172,15 @@ linear-le-ℕ (succ-ℕ x) (succ-ℕ y) =
 
 ```agda
 subtraction-le-ℕ :
-  (n m : ℕ) → le-ℕ n m → Σ ℕ (λ l → (is-nonzero-ℕ l) × (add-ℕ l n ＝ m))
+  (n m : ℕ) → le-ℕ n m → Σ ℕ (λ l → (is-nonzero-ℕ l) × (l +ℕ n ＝ m))
 subtraction-le-ℕ zero-ℕ m p = pair m (pair (is-nonzero-le-ℕ zero-ℕ m p) refl)
 subtraction-le-ℕ (succ-ℕ n) (succ-ℕ m) p =
   pair (pr1 P) (pair (pr1 (pr2 P)) (ap succ-ℕ (pr2 (pr2 P))))
   where
-  P : Σ ℕ (λ l' → (is-nonzero-ℕ l') × (add-ℕ l' n ＝ m))
+  P : Σ ℕ (λ l' → (is-nonzero-ℕ l') × (l' +ℕ n ＝ m))
   P = subtraction-le-ℕ n m p
 
-le-subtraction-ℕ : (n m l : ℕ) → is-nonzero-ℕ l → add-ℕ l n ＝ m → le-ℕ n m
+le-subtraction-ℕ : (n m l : ℕ) → is-nonzero-ℕ l → l +ℕ n ＝ m → le-ℕ n m
 le-subtraction-ℕ zero-ℕ m l q p =
   tr (λ x → le-ℕ zero-ℕ x) p (le-is-nonzero-ℕ l q)
 le-subtraction-ℕ (succ-ℕ n) (succ-ℕ m) l q p =

--- a/src/elementary-number-theory/sums-of-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/sums-of-natural-numbers.lagda.md
@@ -97,7 +97,7 @@ abstract
   constant-sum-Fin-ℕ :
     (m n : ℕ) → sum-Fin-ℕ m (const (Fin m) ℕ n) ＝ m *ℕ n
   constant-sum-Fin-ℕ zero-ℕ n = refl
-  constant-sum-Fin-ℕ (succ-ℕ m) n = ap (add-ℕ' n) (constant-sum-Fin-ℕ m n)
+  constant-sum-Fin-ℕ (succ-ℕ m) n = ap (_+ℕ n) (constant-sum-Fin-ℕ m n)
 
 abstract
   constant-sum-count-ℕ :

--- a/src/elementary-number-theory/sums-of-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/sums-of-natural-numbers.lagda.md
@@ -95,14 +95,14 @@ abstract
 ```agda
 abstract
   constant-sum-Fin-ℕ :
-    (m n : ℕ) → sum-Fin-ℕ m (const (Fin m) ℕ n) ＝ mul-ℕ m n
+    (m n : ℕ) → sum-Fin-ℕ m (const (Fin m) ℕ n) ＝ m *ℕ n
   constant-sum-Fin-ℕ zero-ℕ n = refl
   constant-sum-Fin-ℕ (succ-ℕ m) n = ap (add-ℕ' n) (constant-sum-Fin-ℕ m n)
 
 abstract
   constant-sum-count-ℕ :
     {l : Level} {A : UU l} (e : count A) (n : ℕ) →
-    sum-count-ℕ e (const A ℕ n) ＝ mul-ℕ (number-of-elements-count e) n
+    sum-count-ℕ e (const A ℕ n) ＝ (number-of-elements-count e) *ℕ n
   constant-sum-count-ℕ (pair m e) n = constant-sum-Fin-ℕ m n
 ```
 

--- a/src/elementary-number-theory/sums-of-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/sums-of-natural-numbers.lagda.md
@@ -48,7 +48,7 @@ sum-list-ℕ = fold-list 0 add-ℕ
 ```agda
 sum-Fin-ℕ : (k : ℕ) → (Fin k → ℕ) → ℕ
 sum-Fin-ℕ zero-ℕ f = zero-ℕ
-sum-Fin-ℕ (succ-ℕ k) f = add-ℕ (sum-Fin-ℕ k (λ x → f (inl x))) (f (inr star))
+sum-Fin-ℕ (succ-ℕ k) f = (sum-Fin-ℕ k (λ x → f (inl x))) +ℕ (f (inr star))
 ```
 
 ### Sums of natural numbers indexed by a type equipped with a counting

--- a/src/elementary-number-theory/telephone-numbers.lagda.md
+++ b/src/elementary-number-theory/telephone-numbers.lagda.md
@@ -28,5 +28,5 @@ telephone-number : ℕ → ℕ
 telephone-number zero-ℕ = succ-ℕ zero-ℕ
 telephone-number (succ-ℕ zero-ℕ) = succ-ℕ zero-ℕ
 telephone-number (succ-ℕ (succ-ℕ n)) =
-  add-ℕ (telephone-number (succ-ℕ n)) ((succ-ℕ n) *ℕ (telephone-number n))
+  (telephone-number (succ-ℕ n)) +ℕ ((succ-ℕ n) *ℕ (telephone-number n))
 ```

--- a/src/elementary-number-theory/telephone-numbers.lagda.md
+++ b/src/elementary-number-theory/telephone-numbers.lagda.md
@@ -28,5 +28,5 @@ telephone-number : ℕ → ℕ
 telephone-number zero-ℕ = succ-ℕ zero-ℕ
 telephone-number (succ-ℕ zero-ℕ) = succ-ℕ zero-ℕ
 telephone-number (succ-ℕ (succ-ℕ n)) =
-  add-ℕ (telephone-number (succ-ℕ n)) (mul-ℕ (succ-ℕ n) (telephone-number n))
+  add-ℕ (telephone-number (succ-ℕ n)) ((succ-ℕ n) *ℕ (telephone-number n))
 ```

--- a/src/elementary-number-theory/triangular-numbers.lagda.md
+++ b/src/elementary-number-theory/triangular-numbers.lagda.md
@@ -18,5 +18,5 @@ open import elementary-number-theory.natural-numbers
 ```agda
 triangular-number-ℕ : ℕ → ℕ
 triangular-number-ℕ 0 = 0
-triangular-number-ℕ (succ-ℕ n) = add-ℕ (triangular-number-ℕ n) (succ-ℕ n)
+triangular-number-ℕ (succ-ℕ n) = (triangular-number-ℕ n) +ℕ (succ-ℕ n)
 ```

--- a/src/elementary-number-theory/type-arithmetic-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/type-arithmetic-natural-numbers.lagda.md
@@ -79,7 +79,7 @@ is-split-surjective-map-ℕ+ℕ-to-ℕ (succ-ℕ (succ-ℕ b)) =
 
 is-injective-map-ℕ+ℕ-to-ℕ : is-injective map-ℕ+ℕ-to-ℕ
 is-injective-map-ℕ+ℕ-to-ℕ {inl x} {inl y} p =
-  ( ap inl (is-injective-mul-succ-ℕ 1 p))
+  ( ap inl (is-injective-left-mul-succ-ℕ 1 p))
 is-injective-map-ℕ+ℕ-to-ℕ {inl x} {inr y} p = ex-falso (t s)
   where
     s : (div-ℕ 2 (succ-ℕ (2 *ℕ y)))
@@ -101,7 +101,7 @@ is-injective-map-ℕ+ℕ-to-ℕ {inr x} {inl y} p = ex-falso (t s)
         ( 2 *ℕ x)
         ( x , commutative-mul-ℕ x 2))
 is-injective-map-ℕ+ℕ-to-ℕ {inr x} {inr y} p =
-  ( ap inr (is-injective-mul-succ-ℕ 1 (is-injective-succ-ℕ p)))
+  ( ap inr (is-injective-left-mul-succ-ℕ 1 (is-injective-succ-ℕ p)))
 
 is-equiv-map-ℕ+ℕ-to-ℕ : is-equiv map-ℕ+ℕ-to-ℕ
 is-equiv-map-ℕ+ℕ-to-ℕ =

--- a/src/elementary-number-theory/type-arithmetic-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/type-arithmetic-natural-numbers.lagda.md
@@ -52,8 +52,8 @@ succ-ℕ+ℕ : ℕ + ℕ → ℕ + ℕ
 succ-ℕ+ℕ = map-coprod succ-ℕ succ-ℕ
 
 map-ℕ+ℕ-to-ℕ : ℕ + ℕ → ℕ
-map-ℕ+ℕ-to-ℕ (inl x) = mul-ℕ 2 x
-map-ℕ+ℕ-to-ℕ (inr x) = succ-ℕ (mul-ℕ 2 x)
+map-ℕ+ℕ-to-ℕ (inl x) = 2 *ℕ x
+map-ℕ+ℕ-to-ℕ (inr x) = succ-ℕ (2 *ℕ x)
 
 action-map-ℕ+ℕ-to-ℕ-on-succ-ℕ+ℕ :
   (x : ℕ + ℕ) →
@@ -82,23 +82,23 @@ is-injective-map-ℕ+ℕ-to-ℕ {inl x} {inl y} p =
   ( ap inl (is-injective-mul-succ-ℕ 1 p))
 is-injective-map-ℕ+ℕ-to-ℕ {inl x} {inr y} p = ex-falso (t s)
   where
-    s : (div-ℕ 2 (succ-ℕ (mul-ℕ 2 y)))
+    s : (div-ℕ 2 (succ-ℕ (2 *ℕ y)))
     s = concatenate-div-eq-ℕ (x , commutative-mul-ℕ x 2) p
 
-    t : ¬ (div-ℕ 2 (succ-ℕ (mul-ℕ 2 y)))
+    t : ¬ (div-ℕ 2 (succ-ℕ (2 *ℕ y)))
     t =
       ( is-odd-succ-is-even-ℕ
-        ( mul-ℕ 2 y)
+        ( 2 *ℕ y)
         ( y , commutative-mul-ℕ y 2))
 is-injective-map-ℕ+ℕ-to-ℕ {inr x} {inl y} p = ex-falso (t s)
   where
-    s : (div-ℕ 2 (succ-ℕ (mul-ℕ 2 x)))
+    s : (div-ℕ 2 (succ-ℕ (2 *ℕ x)))
     s = concatenate-div-eq-ℕ (y , commutative-mul-ℕ y 2) (inv p)
 
-    t : ¬ (div-ℕ 2 (succ-ℕ (mul-ℕ 2 x)))
+    t : ¬ (div-ℕ 2 (succ-ℕ (2 *ℕ x)))
     t =
       ( is-odd-succ-is-even-ℕ
-        ( mul-ℕ 2 x)
+        ( 2 *ℕ x)
         ( x , commutative-mul-ℕ x 2))
 is-injective-map-ℕ+ℕ-to-ℕ {inr x} {inr y} p =
   ( ap inr (is-injective-mul-succ-ℕ 1 (is-injective-succ-ℕ p)))

--- a/src/elementary-number-theory/unit-elements-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/unit-elements-standard-finite-types.lagda.md
@@ -61,7 +61,7 @@ pr1 (is-unit-neg-one-Fin {succ-ℕ k}) = neg-one-Fin (succ-ℕ k)
 pr2 (is-unit-neg-one-Fin {succ-ℕ k}) =
   eq-mod-succ-cong-ℕ
     ( succ-ℕ k)
-    ( mul-ℕ (succ-ℕ k) (succ-ℕ k))
+    ( (succ-ℕ k) *ℕ (succ-ℕ k))
     ( 1)
     ( concatenate-eq-cong-ℕ
       ( succ-ℕ (succ-ℕ k))

--- a/src/elementary-number-theory/unit-elements-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/unit-elements-standard-finite-types.lagda.md
@@ -69,7 +69,7 @@ pr2 (is-unit-neg-one-Fin {succ-ℕ k}) =
       ( square-succ-ℕ k)
       ( pair k
         ( ( commutative-mul-ℕ k (succ-ℕ (succ-ℕ k))) ∙
-          ( inv (right-unit-law-dist-ℕ (mul-ℕ (succ-ℕ (succ-ℕ k)) k))))))
+          ( inv (right-unit-law-dist-ℕ ((succ-ℕ (succ-ℕ k)) *ℕ k))))))
 
 neg-one-unit-Fin : (k : ℕ) → unit-Fin (succ-ℕ k)
 pr1 (neg-one-unit-Fin k) = neg-one-Fin k

--- a/src/elementary-number-theory/unit-similarity-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/unit-similarity-standard-finite-types.lagda.md
@@ -44,14 +44,14 @@ sim-unit-Fin k x y = Σ (unit-Fin k) (λ u → mul-Fin k (pr1 u) x ＝ y)
 sim-unit-ℕ :
   (k : ℕ) → ℕ → ℕ → UU lzero
 sim-unit-ℕ k x y =
-  Σ (Σ ℕ (λ l → cong-ℕ k l 1)) (λ l → cong-ℕ k (mul-ℕ (pr1 l) x) y)
+  Σ (Σ ℕ (λ l → cong-ℕ k l 1)) (λ l → cong-ℕ k ((pr1 l) *ℕ x) y)
 ```
 
 ### Congruence to `1`
 
 ```agda
 sim-unit-one-ℕ : (k x : ℕ) → UU lzero
-sim-unit-one-ℕ k x = Σ ℕ (λ l → cong-ℕ k (mul-ℕ l x) 1)
+sim-unit-one-ℕ k x = Σ ℕ (λ l → cong-ℕ k (l *ℕ x) 1)
 ```
 
 ## Properties

--- a/src/elementary-number-theory/unit-similarity-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/unit-similarity-standard-finite-types.lagda.md
@@ -98,9 +98,7 @@ pr2 (is-unit-similar-one-sim-unit-mod-succ-ℕ k x (pair u p)) =
     ( 1)
     ( ( eq-mod-succ-cong-ℕ k
         ( (nat-Fin (succ-ℕ k) (pr1 u)) *ℕ x)
-        ( mul-ℕ
-          ( nat-Fin (succ-ℕ k) (pr1 u))
-          ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k x)))
+        ( (nat-Fin (succ-ℕ k) (pr1 u)) *ℕ (nat-Fin (succ-ℕ k) (mod-succ-ℕ k x)))
         ( scalar-invariant-cong-ℕ
           ( succ-ℕ k)
           ( x)

--- a/src/elementary-number-theory/unit-similarity-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/unit-similarity-standard-finite-types.lagda.md
@@ -94,10 +94,10 @@ pr1 (is-unit-similar-one-sim-unit-mod-succ-ℕ k x (pair u p)) =
   nat-Fin (succ-ℕ k) (pr1 u)
 pr2 (is-unit-similar-one-sim-unit-mod-succ-ℕ k x (pair u p)) =
   cong-eq-mod-succ-ℕ k
-    ( mul-ℕ (nat-Fin (succ-ℕ k) (pr1 u)) x)
+    ( (nat-Fin (succ-ℕ k) (pr1 u)) *ℕ x)
     ( 1)
     ( ( eq-mod-succ-cong-ℕ k
-        ( mul-ℕ (nat-Fin (succ-ℕ k) (pr1 u)) x)
+        ( (nat-Fin (succ-ℕ k) (pr1 u)) *ℕ x)
         ( mul-ℕ
           ( nat-Fin (succ-ℕ k) (pr1 u))
           ( nat-Fin (succ-ℕ k) (mod-succ-ℕ k x)))

--- a/src/finite-group-theory/orbits-permutations.lagda.md
+++ b/src/finite-group-theory/orbits-permutations.lagda.md
@@ -387,16 +387,16 @@ module _
 
   mult-has-finite-orbits-permutation :
     (k : ℕ) →
-    Id (iterate (mul-ℕ k (pr1 has-finite-orbits-permutation)) (map-equiv f) a) a
+    Id (iterate (k *ℕ (pr1 has-finite-orbits-permutation)) (map-equiv f) a) a
   mult-has-finite-orbits-permutation zero-ℕ = refl
   mult-has-finite-orbits-permutation (succ-ℕ k) =
     ( iterate-add-ℕ
-      ( mul-ℕ k (pr1 has-finite-orbits-permutation))
+      ( k *ℕ (pr1 has-finite-orbits-permutation))
       ( pr1 has-finite-orbits-permutation)
       ( map-equiv f)
       ( a)) ∙
     ( ( ap
-        ( iterate (mul-ℕ k (pr1 has-finite-orbits-permutation)) (map-equiv f))
+        ( iterate (k *ℕ (pr1 has-finite-orbits-permutation)) (map-equiv f))
         ( pr2 (pr2 has-finite-orbits-permutation))) ∙
       ( mult-has-finite-orbits-permutation k))
 ```
@@ -445,11 +445,11 @@ module _
       (h : Fin n ≃ type-UU-Fin n X) (k : ℕ) →
       Σ ( ℕ)
         ( λ j →
-          Id (j +ℕ k) (mul-ℕ k (pr1 (has-finite-orbits-permutation-a h))))
+          Id (j +ℕ k) (k *ℕ (pr1 (has-finite-orbits-permutation-a h))))
     lemma h k =
       subtraction-leq-ℕ
         ( k)
-        ( mul-ℕ k (pr1 (has-finite-orbits-permutation-a h)))
+        ( k *ℕ (pr1 (has-finite-orbits-permutation-a h)))
         ( leq-mul-is-nonzero-ℕ
           ( pr1 (has-finite-orbits-permutation-a h))
           ( k)
@@ -985,19 +985,19 @@ module _
         ( pa : Σ ℕ (λ k → Id (iterate k (map-equiv g) a) b)) (k : ℕ) →
         Id
           ( iterate
-            ( mul-ℕ k (pr1 (minimal-element-iterate g a b pa)))
+            ( k *ℕ (pr1 (minimal-element-iterate g a b pa)))
             ( map-equiv (composition-transposition-a-b g))
             ( a))
           ( a)
       mult-lemma2 pa zero-ℕ = refl
       mult-lemma2 pa (succ-ℕ k) =
         ( iterate-add-ℕ
-          ( mul-ℕ k (pr1 (minimal-element-iterate g a b pa)))
+          ( k *ℕ (pr1 (minimal-element-iterate g a b pa)))
           ( pr1 (minimal-element-iterate g a b pa))
           ( map-equiv (composition-transposition-a-b g)) a) ∙
         ( ap
           ( iterate
-            ( mul-ℕ k (pr1 (minimal-element-iterate g a b pa)))
+            ( k *ℕ (pr1 (minimal-element-iterate g a b pa)))
             ( map-equiv (composition-transposition-a-b g)))
           ( lemma2
             ( pa)
@@ -1023,7 +1023,7 @@ module _
                 ( (inv
                     ( iterate-add-ℕ
                       ( r)
-                      ( mul-ℕ quo (pr1 (minimal-element-iterate g a b pa)))
+                      ( quo *ℕ (pr1 (minimal-element-iterate g a b pa)))
                       ( map-equiv (composition-transposition-a-b g)) a)) ∙
                   ( ( ap
                       ( λ n →
@@ -1033,7 +1033,7 @@ module _
                           ( a))
                       ( commutative-add-ℕ
                         ( r)
-                        ( mul-ℕ quo (pr1 (minimal-element-iterate g a b pa))) ∙
+                        ( quo *ℕ (pr1 (minimal-element-iterate g a b pa))) ∙
                         ( eq-euclidean-division-ℕ
                           ( pr1 (minimal-element-iterate g a b pa))
                           ( k)))) ∙

--- a/src/finite-group-theory/orbits-permutations.lagda.md
+++ b/src/finite-group-theory/orbits-permutations.lagda.md
@@ -99,7 +99,7 @@ module _
     iso-iterative-groupoid-automorphism-𝔽 x y →
     iso-iterative-groupoid-automorphism-𝔽 x z
   pr1 (comp-iso-iterative-groupoid-automorphism-𝔽 (pair n q) (pair m p)) =
-    add-ℕ n m
+    n +ℕ m
   pr2 (comp-iso-iterative-groupoid-automorphism-𝔽 (pair n q) (pair m p)) =
     iterate-add-ℕ n m (map-equiv e) _ ∙ (ap (iterate n (map-equiv e)) p ∙ q)
 ```
@@ -445,7 +445,7 @@ module _
       (h : Fin n ≃ type-UU-Fin n X) (k : ℕ) →
       Σ ( ℕ)
         ( λ j →
-          Id (add-ℕ j k) (mul-ℕ k (pr1 (has-finite-orbits-permutation-a h))))
+          Id (j +ℕ k) (mul-ℕ k (pr1 (has-finite-orbits-permutation-a h))))
     lemma h k =
       subtraction-leq-ℕ
         ( k)
@@ -465,7 +465,7 @@ module _
           ( λ { (pair k2 q) →
                 ( unit-trunc-Prop
                   ( pair
-                    ( add-ℕ k2 k1)
+                    ( k2 +ℕ k1)
                     ( (iterate-add-ℕ k2 k1 (map-equiv f) a) ∙
                       ( ap (iterate k2 (map-equiv f)) p ∙ q))))}))
 
@@ -633,7 +633,7 @@ module _
 
   sign-permutation-orbit : Fin 2
   sign-permutation-orbit =
-    iterate (add-ℕ n number-of-orbits-permutation) (succ-Fin 2) (zero-Fin 1)
+    iterate (n +ℕ number-of-orbits-permutation) (succ-Fin 2) (zero-Fin 1)
 ```
 
 ```agda
@@ -895,7 +895,7 @@ module _
           Σ ( ℕ)
             ( λ l →
               is-nonzero-ℕ l ×
-              Id (add-ℕ l k) (pr1 (minimal-element-iterate g a b pa)))
+              Id (l +ℕ k) (pr1 (minimal-element-iterate g a b pa)))
         pair-k2 =
           (subtraction-le-ℕ k (pr1 (minimal-element-iterate g a b pa)) ineq)
       pr2 (neq-iterate-nonzero-le-minimal-element pa k (pair nz ineq)) r =
@@ -2327,7 +2327,7 @@ module _
             succ-Fin
               ( 2)
               ( iterate
-                ( add-ℕ (number-of-elements-count eX) k)
+                ( (number-of-elements-count eX) +ℕ k)
                 ( succ-Fin 2)
                 ( zero-Fin 1)))
           ( number-orbits-composition-transposition g P)
@@ -2335,7 +2335,7 @@ module _
         ap
           ( λ k →
             iterate
-              ( add-ℕ (number-of-elements-count eX) k)
+              ( (number-of-elements-count eX) +ℕ k)
               ( succ-Fin 2)
               ( zero-Fin 1))
           ( number-orbits-composition-transposition' g NP)

--- a/src/finite-group-theory/orbits-permutations.lagda.md
+++ b/src/finite-group-theory/orbits-permutations.lagda.md
@@ -542,7 +542,7 @@ module _
                     ( ( inv
                         ( iterate-add-ℕ
                           ( remainder-euclidean-division-ℕ m (pr1 p))
-                          ( mul-ℕ (quotient-euclidean-division-ℕ m (pr1 p)) m)
+                          ( (quotient-euclidean-division-ℕ m (pr1 p)) *ℕ m)
                           ( map-equiv f)
                           ( a))) ∙
                       ( ( ap

--- a/src/finite-group-theory/orbits-permutations.lagda.md
+++ b/src/finite-group-theory/orbits-permutations.lagda.md
@@ -549,9 +549,7 @@ module _
                           ( λ x → iterate x (map-equiv f) a)
                           ( ( commutative-add-ℕ
                               ( remainder-euclidean-division-ℕ m (pr1 p))
-                              ( mul-ℕ
-                                ( quotient-euclidean-division-ℕ m (pr1 p))
-                                ( m))) ∙
+                              ( quotient-euclidean-division-ℕ m (pr1 p) *ℕ m)) ∙
                             ( eq-euclidean-division-ℕ m (pr1 p)))) ∙
                         ( pr2 p)))))))
         where

--- a/src/finite-group-theory/simpson-delooping-sign-homomorphism.lagda.md
+++ b/src/finite-group-theory/simpson-delooping-sign-homomorphism.lagda.md
@@ -121,10 +121,9 @@ module _
           ( inv P) ∙
           ( ap
             ( mod-two-ℕ ∘
-              add-ℕ
-                ( nat-Fin 2
-                  ( sign-homomorphism-Fin-two n
-                    (Fin-UU-Fin' n) (inv-equiv (inv-equiv f ∘e g)))))
+              ( nat-Fin 2
+                ( sign-homomorphism-Fin-two n
+                  (Fin-UU-Fin' n) (inv-equiv (inv-equiv f ∘e g)))) +ℕ_)
             ( is-zero-nat-zero-Fin {k = 1}) ∙
             ( issec-nat-Fin 1
               ( sign-homomorphism-Fin-two n

--- a/src/finite-group-theory/simpson-delooping-sign-homomorphism.lagda.md
+++ b/src/finite-group-theory/simpson-delooping-sign-homomorphism.lagda.md
@@ -139,7 +139,7 @@ module _
         ( zero-ℕ +ℕ_)
         ( inv (is-zero-nat-zero-Fin {k = 1}) ∙ ap (nat-Fin 2) Q) ∙
         ( ap
-          ( add-ℕ'
+          ( _+ℕ
             ( nat-Fin 2
               ( sign-homomorphism-Fin-two n
                 (Fin-UU-Fin' n) (inv-equiv g ∘e h))))

--- a/src/finite-group-theory/simpson-delooping-sign-homomorphism.lagda.md
+++ b/src/finite-group-theory/simpson-delooping-sign-homomorphism.lagda.md
@@ -136,7 +136,7 @@ module _
   pr2 (pr2 (pr2 sign-comp-Eq-Rel)) {f} {g} {h} P Q =
     ( ap mod-two-ℕ
       ( ap
-        ( add-ℕ zero-ℕ)
+        ( zero-ℕ +ℕ_)
         ( inv (is-zero-nat-zero-Fin {k = 1}) ∙ ap (nat-Fin 2) Q) ∙
         ( ap
           ( add-ℕ'

--- a/src/foundation/connected-maps.lagda.md
+++ b/src/foundation/connected-maps.lagda.md
@@ -205,7 +205,7 @@ module _
 
 ```agda
 is-trunc-map-precomp-Π-is-connected-map :
-  {l1 l2 l3 : Level} (k l n : 𝕋) → add-𝕋 k (succ-𝕋 (succ-𝕋 n)) ＝ l →
+  {l1 l2 l3 : Level} (k l n : 𝕋) → k +𝕋 (succ-𝕋 (succ-𝕋 n)) ＝ l →
   {A : UU l1} {B : UU l2} {f : A → B} → is-connected-map k f →
   (P : B → Truncated-Type l3 l) →
   is-trunc-map

--- a/src/foundation/iterated-cartesian-product-types.lagda.md
+++ b/src/foundation/iterated-cartesian-product-types.lagda.md
@@ -15,13 +15,11 @@ open import foundation.cartesian-product-types
 open import foundation.contractible-types
 open import foundation.coproduct-types
 open import foundation.dependent-pair-types
-open import foundation.equality-dependent-pair-types
 open import foundation.equivalences
 open import foundation.functions
 open import foundation.functoriality-cartesian-product-types
 open import foundation.functoriality-dependent-function-types
 open import foundation.identity-types
-open import foundation.propositions
 open import foundation.type-arithmetic-cartesian-product-types
 open import foundation.type-arithmetic-dependent-function-types
 open import foundation.unit-type

--- a/src/foundation/iterating-automorphisms.lagda.md
+++ b/src/foundation/iterating-automorphisms.lagda.md
@@ -272,11 +272,11 @@ module _
   iterate-automorphism-add-ℤ :
     (k l : ℤ) (e : Aut X) →
     htpy-equiv
-      ( iterate-automorphism-ℤ (add-ℤ k l) e)
+      ( iterate-automorphism-ℤ (k +ℤ l) e)
       ( iterate-automorphism-ℤ k e ∘e iterate-automorphism-ℤ l e)
   iterate-automorphism-add-ℤ (inl zero-ℕ) l e = iterate-automorphism-pred-ℤ' l e
   iterate-automorphism-add-ℤ (inl (succ-ℕ k)) l e =
-    ( iterate-automorphism-pred-ℤ' (add-ℤ (inl k) l) e) ∙h
+    ( iterate-automorphism-pred-ℤ' ((inl k) +ℤ l) e) ∙h
     ( map-inv-equiv e ·l iterate-automorphism-add-ℤ (inl k) l e)
   iterate-automorphism-add-ℤ (inr (inl star)) l e = refl-htpy
   iterate-automorphism-add-ℤ (inr (inr zero-ℕ)) l e =

--- a/src/foundation/iterating-automorphisms.lagda.md
+++ b/src/foundation/iterating-automorphisms.lagda.md
@@ -282,6 +282,6 @@ module _
   iterate-automorphism-add-ℤ (inr (inr zero-ℕ)) l e =
     iterate-automorphism-succ-ℤ' l e
   iterate-automorphism-add-ℤ (inr (inr (succ-ℕ x))) l e =
-    ( iterate-automorphism-succ-ℤ' (add-ℤ (inr (inr x)) l) e) ∙h
+    ( iterate-automorphism-succ-ℤ' ((inr (inr x)) +ℤ l) e) ∙h
     ( map-equiv e ·l iterate-automorphism-add-ℤ (inr (inr x)) l e)
 ```

--- a/src/foundation/iterating-functions.lagda.md
+++ b/src/foundation/iterating-functions.lagda.md
@@ -102,7 +102,7 @@ module _
 
   iterate-add-ℕ :
     (k l : ℕ) (f : X → X) (x : X) →
-    iterate (add-ℕ k l) f x ＝ iterate k f (iterate l f x)
+    iterate (k +ℕ l) f x ＝ iterate k f (iterate l f x)
   iterate-add-ℕ k zero-ℕ f x = refl
   iterate-add-ℕ k (succ-ℕ l) f x =
     ap f (iterate-add-ℕ k l f x) ∙ iterate-succ-ℕ k f (iterate l f x)

--- a/src/foundation/iterating-functions.lagda.md
+++ b/src/foundation/iterating-functions.lagda.md
@@ -132,10 +132,10 @@ module _
 
   iterate-mul-ℕ :
     (k l : ℕ) (f : X → X) (x : X) →
-    iterate (mul-ℕ k l) f x ＝ iterate k (iterate l f) x
+    iterate (k *ℕ l) f x ＝ iterate k (iterate l f) x
   iterate-mul-ℕ zero-ℕ l f x = refl
   iterate-mul-ℕ (succ-ℕ k) l f x =
-    ( iterate-add-ℕ (mul-ℕ k l) l f x) ∙
+    ( iterate-add-ℕ (k *ℕ l) l f x) ∙
     ( ( iterate-mul-ℕ k l f (iterate l f x)) ∙
       ( inv (iterate-succ-ℕ k (iterate l f) x)))
 

--- a/src/foundation/large-locale-of-propositions.lagda.md
+++ b/src/foundation/large-locale-of-propositions.lagda.md
@@ -15,7 +15,6 @@ open import foundation.propositions
 open import foundation.unit-type
 open import foundation.universe-levels
 
-open import order-theory.greatest-lower-bounds-large-posets
 open import order-theory.large-frames
 open import order-theory.large-locales
 open import order-theory.large-meet-semilattices

--- a/src/foundation/truncation-levels.lagda.md
+++ b/src/foundation/truncation-levels.lagda.md
@@ -80,8 +80,8 @@ left-successor-law-add-𝕋 n (succ-𝕋 k) = refl
 
 right-successor-law-add-𝕋 :
   (k n : 𝕋) →
-  add-𝕋 k (succ-𝕋 (succ-𝕋 (succ-𝕋 n))) ＝
-  succ-𝕋 (add-𝕋 k (succ-𝕋 (succ-𝕋 n)))
+  k +𝕋 (succ-𝕋 (succ-𝕋 (succ-𝕋 n))) ＝
+  succ-𝕋 (k +𝕋 (succ-𝕋 (succ-𝕋 n)))
 right-successor-law-add-𝕋 neg-two-𝕋 n = refl
 right-successor-law-add-𝕋 (succ-𝕋 neg-two-𝕋) n = refl
 right-successor-law-add-𝕋 (succ-𝕋 (succ-𝕋 k)) n =

--- a/src/foundation/truncation-levels.lagda.md
+++ b/src/foundation/truncation-levels.lagda.md
@@ -45,6 +45,9 @@ add-𝕋 (succ-𝕋 neg-two-𝕋) neg-two-𝕋 = neg-two-𝕋
 add-𝕋 (succ-𝕋 neg-two-𝕋) (succ-𝕋 l) = l
 add-𝕋 (succ-𝕋 (succ-𝕋 k)) neg-two-𝕋 = k
 add-𝕋 (succ-𝕋 (succ-𝕋 k)) (succ-𝕋 l) = succ-𝕋 (add-𝕋 (succ-𝕋 k) (succ-𝕋 l))
+
+infix 30 _+𝕋_
+_+𝕋_ = add-𝕋
 ```
 
 ## Properties
@@ -52,13 +55,13 @@ add-𝕋 (succ-𝕋 (succ-𝕋 k)) (succ-𝕋 l) = succ-𝕋 (add-𝕋 (succ-�
 ### Unit laws for addition of truncation levels
 
 ```agda
-left-unit-law-add-𝕋 : (k : 𝕋) → add-𝕋 zero-𝕋 k ＝ k
+left-unit-law-add-𝕋 : (k : 𝕋) → zero-𝕋 +𝕋 k ＝ k
 left-unit-law-add-𝕋 neg-two-𝕋 = refl
 left-unit-law-add-𝕋 (succ-𝕋 neg-two-𝕋) = refl
 left-unit-law-add-𝕋 (succ-𝕋 (succ-𝕋 neg-two-𝕋)) = refl
 left-unit-law-add-𝕋 (succ-𝕋 (succ-𝕋 (succ-𝕋 k))) = refl
 
-right-unit-law-add-𝕋 : (k : 𝕋) → add-𝕋 k zero-𝕋 ＝ k
+right-unit-law-add-𝕋 : (k : 𝕋) → k +𝕋 zero-𝕋 ＝ k
 right-unit-law-add-𝕋 neg-two-𝕋 = refl
 right-unit-law-add-𝕋 (succ-𝕋 neg-two-𝕋) = refl
 right-unit-law-add-𝕋 (succ-𝕋 (succ-𝕋 k)) =

--- a/src/foundation/truncation-levels.lagda.md
+++ b/src/foundation/truncation-levels.lagda.md
@@ -73,7 +73,7 @@ right-unit-law-add-𝕋 (succ-𝕋 (succ-𝕋 k)) =
 ```agda
 left-successor-law-add-𝕋 :
   (n k : 𝕋) →
-  add-𝕋 (succ-𝕋 (succ-𝕋 (succ-𝕋 n))) k ＝
+  (succ-𝕋 (succ-𝕋 (succ-𝕋 n))) +𝕋 k ＝
   succ-𝕋 (add-𝕋 (succ-𝕋 (succ-𝕋 n)) k)
 left-successor-law-add-𝕋 n neg-two-𝕋 = refl
 left-successor-law-add-𝕋 n (succ-𝕋 k) = refl

--- a/src/foundation/unions-subtypes.lagda.md
+++ b/src/foundation/unions-subtypes.lagda.md
@@ -9,7 +9,6 @@ module foundation.unions-subtypes where
 ```agda
 open import foundation.decidable-subtypes
 open import foundation.disjunction
-open import foundation.existential-quantification
 open import foundation.large-locale-of-subtypes
 
 open import foundation-core.subtypes

--- a/src/group-theory/free-groups-with-one-generator.lagda.md
+++ b/src/group-theory/free-groups-with-one-generator.lagda.md
@@ -151,7 +151,7 @@ module _
           ( λ x →
             ( ap
               ( map-hom-Group ℤ-Group G h)
-              ( is-add-one-succ-ℤ x)) ∙
+              ( is-left-add-one-succ-ℤ x)) ∙
             ( ( preserves-mul-hom-Group ℤ-Group G h one-ℤ x) ∙
               ( ap ( mul-Group' G (map-hom-Group ℤ-Group G h x)) p)))))
 

--- a/src/group-theory/free-groups-with-one-generator.lagda.md
+++ b/src/group-theory/free-groups-with-one-generator.lagda.md
@@ -118,7 +118,7 @@ module _
 
   preserves-mul-map-hom-free-group-with-one-generator-ℤ :
     (x y : ℤ) →
-    ( map-hom-free-group-with-one-generator-ℤ (add-ℤ x y)) ＝
+    ( map-hom-free-group-with-one-generator-ℤ (x +ℤ y)) ＝
     ( mul-Group G
       ( map-hom-free-group-with-one-generator-ℤ x)
       ( map-hom-free-group-with-one-generator-ℤ y))

--- a/src/group-theory/iterated-cartesian-products-concrete-groups.lagda.md
+++ b/src/group-theory/iterated-cartesian-products-concrete-groups.lagda.md
@@ -11,7 +11,6 @@ open import elementary-number-theory.natural-numbers
 
 open import foundation.0-connected-types
 open import foundation.1-types
-open import foundation.cartesian-product-types
 open import foundation.contractible-types
 open import foundation.coproduct-types
 open import foundation.dependent-pair-types
@@ -34,7 +33,6 @@ open import group-theory.concrete-groups
 open import group-theory.groups
 
 open import higher-group-theory.higher-groups
-open import higher-group-theory.iterated-cartesian-products-higher-groups
 
 open import structured-types.pointed-types
 

--- a/src/higher-group-theory/iterated-cartesian-products-higher-groups.lagda.md
+++ b/src/higher-group-theory/iterated-cartesian-products-higher-groups.lagda.md
@@ -10,11 +10,9 @@ module higher-group-theory.iterated-cartesian-products-higher-groups where
 open import elementary-number-theory.natural-numbers
 
 open import foundation.0-connected-types
-open import foundation.cartesian-product-types
 open import foundation.contractible-types
 open import foundation.coproduct-types
 open import foundation.dependent-pair-types
-open import foundation.equality-cartesian-product-types
 open import foundation.equivalences
 open import foundation.functions
 open import foundation.functoriality-cartesian-product-types
@@ -29,7 +27,6 @@ open import foundation.universe-levels
 open import higher-group-theory.cartesian-products-higher-groups
 open import higher-group-theory.higher-groups
 
-open import structured-types.iterated-pointed-cartesian-product-types
 open import structured-types.pointed-types
 
 open import synthetic-homotopy-theory.loop-spaces

--- a/src/lists/arrays.lagda.md
+++ b/src/lists/arrays.lagda.md
@@ -9,20 +9,16 @@ module lists.arrays where
 ```agda
 open import elementary-number-theory.natural-numbers
 
-open import foundation.contractible-types
 open import foundation.coproduct-types
 open import foundation.dependent-pair-types
 open import foundation.empty-types
 open import foundation.equality-dependent-pair-types
 open import foundation.equivalences
-open import foundation.function-extensionality
 open import foundation.functions
-open import foundation.functoriality-dependent-pair-types
 open import foundation.homotopies
 open import foundation.identity-types
 open import foundation.propositions
 open import foundation.unit-type
-open import foundation.universal-property-coproduct-types
 open import foundation.universe-levels
 
 open import linear-algebra.vectors

--- a/src/lists/concatenation-lists.lagda.md
+++ b/src/lists/concatenation-lists.lagda.md
@@ -83,7 +83,7 @@ snoc-concat-list (cons b x) y a = ap (cons b) (snoc-concat-list x y a)
 ```agda
 length-concat-list :
   {l1 : Level} {A : UU l1} (x y : list A) →
-  Id (length-list (concat-list x y)) (add-ℕ (length-list x) (length-list y))
+  Id (length-list (concat-list x y)) ((length-list x) +ℕ (length-list y))
 length-concat-list nil y = inv (left-unit-law-add-ℕ (length-list y))
 length-concat-list (cons a x) y =
   ( ap succ-ℕ (length-concat-list x y)) ∙

--- a/src/lists/flattening-lists.lagda.md
+++ b/src/lists/flattening-lists.lagda.md
@@ -49,7 +49,7 @@ length-flatten-list :
 length-flatten-list nil = refl
 length-flatten-list (cons a x) =
   ( length-concat-list a (flatten-list x)) ∙
-  ( ap (add-ℕ (length-list a)) (length-flatten-list x))
+  ( ap ((length-list a) +ℕ_) (length-flatten-list x))
 
 flatten-concat-list :
   {l1 : Level} {A : UU l1} (x y : list (list A)) →

--- a/src/lists/permutation-lists.lagda.md
+++ b/src/lists/permutation-lists.lagda.md
@@ -14,12 +14,8 @@ open import foundation.equivalences
 open import foundation.functions
 open import foundation.universe-levels
 
-open import linear-algebra.vectors
-
 open import lists.arrays
 open import lists.lists
-
-open import univalent-combinatorics.standard-finite-types
 ```
 
 </details>

--- a/src/lists/predicates-on-lists.lagda.md
+++ b/src/lists/predicates-on-lists.lagda.md
@@ -7,8 +7,6 @@ module lists.predicates-on-lists where
 <details><summary>Imports</summary>
 
 ```agda
-open import elementary-number-theory.natural-numbers
-
 open import foundation.propositions
 open import foundation.unit-type
 open import foundation.universe-levels

--- a/src/lists/sorted-lists.lagda.md
+++ b/src/lists/sorted-lists.lagda.md
@@ -7,8 +7,6 @@ module lists.sorted-lists where
 <details><summary>Imports</summary>
 
 ```agda
-open import elementary-number-theory.natural-numbers
-
 open import foundation.dependent-pair-types
 open import foundation.propositions
 open import foundation.unit-type

--- a/src/order-theory/dependent-products-large-locales.lagda.md
+++ b/src/order-theory/dependent-products-large-locales.lagda.md
@@ -7,18 +7,13 @@ module order-theory.dependent-products-large-locales where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.function-extensionality
 open import foundation.identity-types
 open import foundation.propositions
 open import foundation.sets
 open import foundation.universe-levels
 
 open import order-theory.dependent-products-large-frames
-open import order-theory.dependent-products-large-meet-semilattices
-open import order-theory.dependent-products-large-posets
-open import order-theory.dependent-products-large-suplattices
 open import order-theory.greatest-lower-bounds-large-posets
-open import order-theory.large-frames
 open import order-theory.large-locales
 open import order-theory.large-meet-semilattices
 open import order-theory.large-posets

--- a/src/order-theory/dependent-products-large-meet-semilattices.lagda.md
+++ b/src/order-theory/dependent-products-large-meet-semilattices.lagda.md
@@ -7,9 +7,7 @@ module order-theory.dependent-products-large-meet-semilattices where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.dependent-pair-types
 open import foundation.identity-types
-open import foundation.logical-equivalences
 open import foundation.sets
 open import foundation.universe-levels
 

--- a/src/order-theory/dependent-products-large-posets.lagda.md
+++ b/src/order-theory/dependent-products-large-posets.lagda.md
@@ -8,7 +8,6 @@ module order-theory.dependent-products-large-posets where
 
 ```agda
 open import foundation.function-extensionality
-open import foundation.functions
 open import foundation.identity-types
 open import foundation.propositions
 open import foundation.universe-levels

--- a/src/order-theory/homomorphisms-large-frames.lagda.md
+++ b/src/order-theory/homomorphisms-large-frames.lagda.md
@@ -7,14 +7,12 @@ module order-theory.homomorphisms-large-frames where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.functions
 open import foundation.identity-types
 open import foundation.universe-levels
 
 open import order-theory.homomorphisms-large-meet-semilattices
 open import order-theory.homomorphisms-large-suplattices
 open import order-theory.large-frames
-open import order-theory.order-preserving-maps-large-posets
 ```
 
 </details>

--- a/src/order-theory/large-meet-semilattices.lagda.md
+++ b/src/order-theory/large-meet-semilattices.lagda.md
@@ -7,15 +7,12 @@ module order-theory.large-meet-semilattices where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.cartesian-product-types
 open import foundation.identity-types
-open import foundation.logical-equivalences
 open import foundation.sets
 open import foundation.universe-levels
 
 open import order-theory.greatest-lower-bounds-large-posets
 open import order-theory.large-posets
-open import order-theory.lower-bounds-large-posets
 open import order-theory.top-elements-large-posets
 ```
 

--- a/src/order-theory/large-meet-subsemilattices.lagda.md
+++ b/src/order-theory/large-meet-subsemilattices.lagda.md
@@ -10,7 +10,6 @@ module order-theory.large-meet-subsemilattices where
 open import foundation.dependent-pair-types
 open import foundation.identity-types
 open import foundation.propositions
-open import foundation.sets
 open import foundation.universe-levels
 
 open import order-theory.greatest-lower-bounds-large-posets

--- a/src/order-theory/large-quotient-locales.lagda.md
+++ b/src/order-theory/large-quotient-locales.lagda.md
@@ -7,8 +7,6 @@ module order-theory.large-quotient-locales where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.dependent-pair-types
-open import foundation.functions
 open import foundation.identity-types
 open import foundation.propositions
 open import foundation.universe-levels

--- a/src/order-theory/large-subposets.lagda.md
+++ b/src/order-theory/large-subposets.lagda.md
@@ -10,7 +10,6 @@ module order-theory.large-subposets where
 open import foundation.dependent-pair-types
 open import foundation.identity-types
 open import foundation.propositions
-open import foundation.sets
 open import foundation.subtypes
 open import foundation.universe-levels
 

--- a/src/order-theory/large-subsuplattices.lagda.md
+++ b/src/order-theory/large-subsuplattices.lagda.md
@@ -7,14 +7,11 @@ module order-theory.large-subsuplattices where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.dependent-pair-types
 open import foundation.identity-types
 open import foundation.propositions
-open import foundation.subtypes
 open import foundation.universe-levels
 
 open import order-theory.large-posets
-open import order-theory.large-preorders
 open import order-theory.large-subposets
 open import order-theory.large-suplattices
 ```

--- a/src/order-theory/nuclei-large-locales.lagda.md
+++ b/src/order-theory/nuclei-large-locales.lagda.md
@@ -22,11 +22,8 @@ open import order-theory.large-locales
 open import order-theory.large-meet-semilattices
 open import order-theory.large-meet-subsemilattices
 open import order-theory.large-posets
-open import order-theory.large-quotient-locales
-open import order-theory.large-subframes
 open import order-theory.large-subposets
 open import order-theory.large-subpreorders
-open import order-theory.large-subsuplattices
 open import order-theory.large-suplattices
 open import order-theory.least-upper-bounds-large-posets
 ```

--- a/src/order-theory/upper-bounds-large-posets.lagda.md
+++ b/src/order-theory/upper-bounds-large-posets.lagda.md
@@ -7,7 +7,6 @@ module order-theory.upper-bounds-large-posets where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.cartesian-product-types
 open import foundation.dependent-pair-types
 open import foundation.logical-equivalences
 open import foundation.propositions

--- a/src/ring-theory/binomial-theorem-rings.lagda.md
+++ b/src/ring-theory/binomial-theorem-rings.lagda.md
@@ -150,7 +150,7 @@ is-linear-combination-power-add-Ring :
           mul-nat-scalar-Ring R
             ( binomial-coefficient-ℕ
               ( n +ℕ m)
-              ( add-ℕ n (nat-Fin (succ-ℕ m) i)))
+              ( n +ℕ (nat-Fin (succ-ℕ m) i)))
             ( mul-Ring R
               ( power-Ring R (nat-Fin (succ-ℕ m) i) x)
               ( power-Ring R (dist-ℕ (nat-Fin (succ-ℕ m) i) m) y)))))

--- a/src/ring-theory/binomial-theorem-rings.lagda.md
+++ b/src/ring-theory/binomial-theorem-rings.lagda.md
@@ -131,14 +131,14 @@ binomial-theorem-Ring R = binomial-theorem-Semiring (semiring-Ring R)
 is-linear-combination-power-add-Ring :
   {l : Level} (R : Ring l) (n m : ℕ) (x y : type-Ring R) →
   mul-Ring R x y ＝ mul-Ring R y x →
-  power-Ring R (add-ℕ n m) (add-Ring R x y) ＝
+  power-Ring R (n +ℕ m) (add-Ring R x y) ＝
   add-Ring R
     ( mul-Ring R
       ( power-Ring R m y)
       ( sum-Ring R n
         ( λ i →
           mul-nat-scalar-Ring R
-            ( binomial-coefficient-ℕ (add-ℕ n m) (nat-Fin n i))
+            ( binomial-coefficient-ℕ (n +ℕ m) (nat-Fin n i))
             ( mul-Ring R
               ( power-Ring R (nat-Fin n i) x)
               ( power-Ring R (dist-ℕ (nat-Fin n i) n) y)))))
@@ -149,7 +149,7 @@ is-linear-combination-power-add-Ring :
         ( λ i →
           mul-nat-scalar-Ring R
             ( binomial-coefficient-ℕ
-              ( add-ℕ n m)
+              ( n +ℕ m)
               ( add-ℕ n (nat-Fin (succ-ℕ m) i)))
             ( mul-Ring R
               ( power-Ring R (nat-Fin (succ-ℕ m) i) x)

--- a/src/ring-theory/binomial-theorem-semirings.lagda.md
+++ b/src/ring-theory/binomial-theorem-semirings.lagda.md
@@ -628,7 +628,7 @@ is-linear-combination-power-add-Semiring :
           mul-nat-scalar-Semiring R
             ( binomial-coefficient-ℕ
               ( n +ℕ m)
-              ( add-ℕ n (nat-Fin (succ-ℕ m) i)))
+              ( n +ℕ (nat-Fin (succ-ℕ m) i)))
             ( mul-Semiring R
               ( power-Semiring R (nat-Fin (succ-ℕ m) i) x)
               ( power-Semiring R (dist-ℕ (nat-Fin (succ-ℕ m) i) m) y)))))
@@ -742,7 +742,7 @@ is-linear-combination-power-add-Semiring R n m x y H =
                   ( mul-nat-scalar-Semiring R
                     ( binomial-coefficient-ℕ
                       ( n +ℕ m)
-                      ( add-ℕ n (nat-Fin (succ-ℕ m) i))))
+                      ( n +ℕ (nat-Fin (succ-ℕ m) i))))
                   ( ap-mul-Semiring R
                     ( power-add-Semiring R n (nat-Fin (succ-ℕ m) i))
                     ( ap
@@ -761,7 +761,7 @@ is-linear-combination-power-add-Semiring R n m x y H =
                   ( right-nat-scalar-law-mul-Semiring R
                     ( binomial-coefficient-ℕ
                       ( n +ℕ m)
-                      ( add-ℕ n (nat-Fin (succ-ℕ m) i)))
+                      ( n +ℕ (nat-Fin (succ-ℕ m) i)))
                     ( power-Semiring R n x)
                     ( mul-Semiring R
                       ( power-Semiring R (nat-Fin (succ-ℕ m) i) x)
@@ -776,7 +776,7 @@ is-linear-combination-power-add-Semiring R n m x y H =
                 mul-nat-scalar-Semiring R
                   ( binomial-coefficient-ℕ
                     ( n +ℕ m)
-                    ( add-ℕ n (nat-Fin (succ-ℕ m) i)))
+                    ( n +ℕ (nat-Fin (succ-ℕ m) i)))
                   ( mul-Semiring R
                     ( power-Semiring R (nat-Fin (succ-ℕ m) i) x)
                     ( power-Semiring R

--- a/src/ring-theory/binomial-theorem-semirings.lagda.md
+++ b/src/ring-theory/binomial-theorem-semirings.lagda.md
@@ -683,7 +683,7 @@ is-linear-combination-power-add-Semiring R n m x y H =
                                   ( upper-bound-nat-Fin' n i)
                                   ( leq-add-ℕ n m)) ∙
                                 ( ap
-                                  ( add-ℕ (dist-ℕ (nat-Fin n i) n))
+                                  ( (dist-ℕ (nat-Fin n i) n) +ℕ_)
                                   ( dist-add-ℕ n m))) ∙
                               ( commutative-add-ℕ
                                 ( dist-ℕ (nat-Fin n i) n)

--- a/src/ring-theory/binomial-theorem-semirings.lagda.md
+++ b/src/ring-theory/binomial-theorem-semirings.lagda.md
@@ -609,14 +609,14 @@ binomial-theorem-Semiring R (succ-ℕ (succ-ℕ n)) x y H =
 is-linear-combination-power-add-Semiring :
   {l : Level} (R : Semiring l) (n m : ℕ) (x y : type-Semiring R) →
   mul-Semiring R x y ＝ mul-Semiring R y x →
-  power-Semiring R (add-ℕ n m) (add-Semiring R x y) ＝
+  power-Semiring R (n +ℕ m) (add-Semiring R x y) ＝
   add-Semiring R
     ( mul-Semiring R
       ( power-Semiring R m y)
       ( sum-Semiring R n
         ( λ i →
           mul-nat-scalar-Semiring R
-            ( binomial-coefficient-ℕ (add-ℕ n m) (nat-Fin n i))
+            ( binomial-coefficient-ℕ (n +ℕ m) (nat-Fin n i))
             ( mul-Semiring R
               ( power-Semiring R (nat-Fin n i) x)
               ( power-Semiring R (dist-ℕ (nat-Fin n i) n) y)))))
@@ -627,28 +627,28 @@ is-linear-combination-power-add-Semiring :
         ( λ i →
           mul-nat-scalar-Semiring R
             ( binomial-coefficient-ℕ
-              ( add-ℕ n m)
+              ( n +ℕ m)
               ( add-ℕ n (nat-Fin (succ-ℕ m) i)))
             ( mul-Semiring R
               ( power-Semiring R (nat-Fin (succ-ℕ m) i) x)
               ( power-Semiring R (dist-ℕ (nat-Fin (succ-ℕ m) i) m) y)))))
 is-linear-combination-power-add-Semiring R n m x y H =
-  ( binomial-theorem-Semiring R (add-ℕ n m) x y H) ∙
+  ( binomial-theorem-Semiring R (n +ℕ m) x y H) ∙
   ( ( split-sum-Semiring R n
       ( succ-ℕ m)
       ( λ i →
         mul-nat-scalar-Semiring R
           ( binomial-coefficient-ℕ
-            ( add-ℕ n m)
-            ( nat-Fin (add-ℕ n (succ-ℕ m)) i))
+            ( n +ℕ m)
+            ( nat-Fin (n +ℕ (succ-ℕ m)) i))
           ( mul-Semiring R
             ( power-Semiring R
-              ( nat-Fin (add-ℕ n (succ-ℕ m)) i)
+              ( nat-Fin (n +ℕ (succ-ℕ m)) i)
               ( x))
             ( power-Semiring R
               ( dist-ℕ
-                ( nat-Fin (add-ℕ n (succ-ℕ m)) i)
-                ( add-ℕ n m))
+                ( nat-Fin (n +ℕ (succ-ℕ m)) i)
+                ( n +ℕ m))
               ( y))))) ∙
     ( ( ap-add-Semiring R
         ( ( htpy-sum-Semiring R n
@@ -656,17 +656,17 @@ is-linear-combination-power-add-Semiring R n m x y H =
               ( ap
                 ( λ u →
                   mul-nat-scalar-Semiring R
-                    ( binomial-coefficient-ℕ (add-ℕ n m) u)
+                    ( binomial-coefficient-ℕ (n +ℕ m) u)
                     ( mul-Semiring R
                       ( power-Semiring R u x)
                       ( power-Semiring R
-                        ( dist-ℕ u (add-ℕ n m))
+                        ( dist-ℕ u (n +ℕ m))
                         ( y))))
                 ( nat-inl-coprod-Fin n m i)) ∙
               ( ( ( ap
                     ( mul-nat-scalar-Semiring R
                       ( binomial-coefficient-ℕ
-                        ( add-ℕ n m)
+                        ( n +ℕ m)
                         ( nat-Fin n i)))
                     ( ( ap
                         ( mul-Semiring R
@@ -679,7 +679,7 @@ is-linear-combination-power-add-Semiring R n m x y H =
                                 ( triangle-equality-dist-ℕ
                                   ( nat-Fin n i)
                                   ( n)
-                                  ( add-ℕ n m)
+                                  ( n +ℕ m)
                                   ( upper-bound-nat-Fin' n i)
                                   ( leq-add-ℕ n m)) ∙
                                 ( ap
@@ -708,7 +708,7 @@ is-linear-combination-power-add-Semiring R n m x y H =
                   ( inv
                     ( right-nat-scalar-law-mul-Semiring R
                       ( binomial-coefficient-ℕ
-                        ( add-ℕ n m)
+                        ( n +ℕ m)
                         ( nat-Fin n i))
                       ( power-Semiring R m y)
                       ( mul-Semiring R
@@ -721,7 +721,7 @@ is-linear-combination-power-add-Semiring R n m x y H =
                 ( power-Semiring R m y)
                 ( λ i →
                   mul-nat-scalar-Semiring R
-                    ( binomial-coefficient-ℕ (add-ℕ n m) (nat-Fin n i))
+                    ( binomial-coefficient-ℕ (n +ℕ m) (nat-Fin n i))
                     ( mul-Semiring R
                       ( power-Semiring R (nat-Fin n i) x)
                       ( power-Semiring R (dist-ℕ (nat-Fin n i) n) y)))))))
@@ -731,17 +731,17 @@ is-linear-combination-power-add-Semiring R n m x y H =
               ( ap
                 ( λ u →
                   mul-nat-scalar-Semiring R
-                    ( binomial-coefficient-ℕ (add-ℕ n m) u)
+                    ( binomial-coefficient-ℕ (n +ℕ m) u)
                     ( mul-Semiring R
                       ( power-Semiring R u x)
                       ( power-Semiring R
-                        ( dist-ℕ u (add-ℕ n m))
+                        ( dist-ℕ u (n +ℕ m))
                         ( y))))
                 ( nat-inr-coprod-Fin n (succ-ℕ m) i)) ∙
               ( ( ap
                   ( mul-nat-scalar-Semiring R
                     ( binomial-coefficient-ℕ
-                      ( add-ℕ n m)
+                      ( n +ℕ m)
                       ( add-ℕ n (nat-Fin (succ-ℕ m) i))))
                   ( ap-mul-Semiring R
                     ( power-add-Semiring R n (nat-Fin (succ-ℕ m) i))
@@ -760,7 +760,7 @@ is-linear-combination-power-add-Semiring R n m x y H =
                 ( inv
                   ( right-nat-scalar-law-mul-Semiring R
                     ( binomial-coefficient-ℕ
-                      ( add-ℕ n m)
+                      ( n +ℕ m)
                       ( add-ℕ n (nat-Fin (succ-ℕ m) i)))
                     ( power-Semiring R n x)
                     ( mul-Semiring R
@@ -775,7 +775,7 @@ is-linear-combination-power-add-Semiring R n m x y H =
               ( λ i →
                 mul-nat-scalar-Semiring R
                   ( binomial-coefficient-ℕ
-                    ( add-ℕ n m)
+                    ( n +ℕ m)
                     ( add-ℕ n (nat-Fin (succ-ℕ m) i)))
                   ( mul-Semiring R
                     ( power-Semiring R (nat-Fin (succ-ℕ m) i) x)

--- a/src/ring-theory/nilpotent-elements-semirings.lagda.md
+++ b/src/ring-theory/nilpotent-elements-semirings.lagda.md
@@ -77,7 +77,7 @@ is-nilpotent-add-Semiring R x y H f h =
         ( is-nilpotent-element-semiring-Prop R (add-Semiring R x y))
         ( λ (m , q) →
           intro-∃
-            ( add-ℕ n m)
+            ( n +ℕ m)
             ( ( is-linear-combination-power-add-Semiring R n m x y H) ∙
               ( ( ap-add-Semiring R
                   ( ( ap (mul-Semiring' R _) q) ∙

--- a/src/ring-theory/powers-of-elements-rings.lagda.md
+++ b/src/ring-theory/powers-of-elements-rings.lagda.md
@@ -59,7 +59,7 @@ module _
 
   power-add-Ring :
     (m n : ℕ) {x : type-Ring R} →
-    power-Ring R (add-ℕ m n) x ＝
+    power-Ring R (m +ℕ n) x ＝
     mul-Ring R (power-Ring R m x) (power-Ring R n x)
   power-add-Ring = power-add-Semiring (semiring-Ring R)
 ```

--- a/src/ring-theory/powers-of-elements-semirings.lagda.md
+++ b/src/ring-theory/powers-of-elements-semirings.lagda.md
@@ -59,14 +59,14 @@ module _
 
   power-add-Semiring :
     (m n : ℕ) {x : type-Semiring R} →
-    power-Semiring R (add-ℕ m n) x ＝
+    power-Semiring R (m +ℕ n) x ＝
     mul-Semiring R (power-Semiring R m x) (power-Semiring R n x)
   power-add-Semiring m zero-ℕ {x} =
     inv
       ( right-unit-law-mul-Semiring R
         ( power-Semiring R m x))
   power-add-Semiring m (succ-ℕ n) {x} =
-    ( power-succ-Semiring R (add-ℕ m n) x) ∙
+    ( power-succ-Semiring R (m +ℕ n) x) ∙
     ( ( ap (mul-Semiring' R x) (power-add-Semiring m n)) ∙
       ( ( associative-mul-Semiring R
           ( power-Semiring R m x)

--- a/src/ring-theory/rings.lagda.md
+++ b/src/ring-theory/rings.lagda.md
@@ -491,7 +491,7 @@ module _
 
   right-distributive-mul-nat-scalar-add-Ring :
     (m n : ℕ) (x : type-Ring R) →
-    mul-nat-scalar-Ring (add-ℕ m n) x ＝
+    mul-nat-scalar-Ring (m +ℕ n) x ＝
     add-Ring R (mul-nat-scalar-Ring m x) (mul-nat-scalar-Ring n x)
   right-distributive-mul-nat-scalar-add-Ring =
     right-distributive-mul-nat-scalar-add-Semiring (semiring-Ring R)

--- a/src/ring-theory/semirings.lagda.md
+++ b/src/ring-theory/semirings.lagda.md
@@ -356,7 +356,7 @@ module _
 
   right-distributive-mul-nat-scalar-add-Semiring :
     (m n : ℕ) (x : type-Semiring R) →
-    mul-nat-scalar-Semiring (add-ℕ m n) x ＝
+    mul-nat-scalar-Semiring (m +ℕ n) x ＝
     add-Semiring R (mul-nat-scalar-Semiring m x) (mul-nat-scalar-Semiring n x)
   right-distributive-mul-nat-scalar-add-Semiring m zero-ℕ x =
     inv (right-unit-law-add-Semiring R (mul-nat-scalar-Semiring m x))

--- a/src/ring-theory/sums-rings.lagda.md
+++ b/src/ring-theory/sums-rings.lagda.md
@@ -187,8 +187,8 @@ module _
 ```agda
 split-sum-Ring :
   {l : Level} (R : Ring l)
-  (n m : ℕ) (f : functional-vec-Ring R (add-ℕ n m)) →
-  sum-Ring R (add-ℕ n m) f ＝
+  (n m : ℕ) (f : functional-vec-Ring R (n +ℕ m)) →
+  sum-Ring R (n +ℕ m) f ＝
   add-Ring R
     ( sum-Ring R n (f ∘ inl-coprod-Fin n m))
     ( sum-Ring R m (f ∘ inr-coprod-Fin n m))

--- a/src/ring-theory/sums-semirings.lagda.md
+++ b/src/ring-theory/sums-semirings.lagda.md
@@ -252,8 +252,8 @@ module _
 ```agda
 split-sum-Semiring :
   {l : Level} (R : Semiring l)
-  (n m : ℕ) (f : functional-vec-Semiring R (add-ℕ n m)) →
-  sum-Semiring R (add-ℕ n m) f ＝
+  (n m : ℕ) (f : functional-vec-Semiring R (n +ℕ m)) →
+  sum-Semiring R (n +ℕ m) f ＝
   add-Semiring R
     ( sum-Semiring R n (f ∘ inl-coprod-Fin n m))
     ( sum-Semiring R m (f ∘ inr-coprod-Fin n m))

--- a/src/structured-types/iterated-cartesian-products-types-equipped-with-endomorphisms.lagda.md
+++ b/src/structured-types/iterated-cartesian-products-types-equipped-with-endomorphisms.lagda.md
@@ -7,9 +7,6 @@ module structured-types.iterated-cartesian-products-types-equipped-with-endomorp
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.cartesian-product-types
-open import foundation.dependent-pair-types
-open import foundation.functoriality-cartesian-product-types
 open import foundation.universe-levels
 
 open import lists.lists

--- a/src/structured-types/iterated-pointed-cartesian-product-types.lagda.md
+++ b/src/structured-types/iterated-pointed-cartesian-product-types.lagda.md
@@ -7,13 +7,10 @@ module structured-types.iterated-pointed-cartesian-product-types where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.cartesian-product-types
 open import foundation.dependent-pair-types
-open import foundation.iterated-cartesian-product-types
 open import foundation.unit-type
 open import foundation.universe-levels
 
-open import lists.functoriality-lists
 open import lists.lists
 
 open import structured-types.pointed-cartesian-product-types

--- a/src/synthetic-homotopy-theory/infinite-cyclic-types.lagda.md
+++ b/src/synthetic-homotopy-theory/infinite-cyclic-types.lagda.md
@@ -163,7 +163,7 @@ module _
                           equiv-map-Π
                             ( λ k →
                               ( equiv-concat'
-                                ( add-ℤ (neg-ℤ x) (map-equiv e (succ-ℤ k)))
+                                ( (neg-ℤ x) +ℤ (map-equiv e (succ-ℤ k)))
                                 ( right-successor-law-add-ℤ
                                   ( neg-ℤ x)
                                   ( map-equiv e k))) ∘e
@@ -173,7 +173,7 @@ module _
                                 ( succ-ℤ (map-equiv e k))))))
                       ( λ e →
                         ( equiv-concat'
-                          ( add-ℤ (neg-ℤ x) (map-equiv (pr1 e) zero-ℤ))
+                          ( (neg-ℤ x) +ℤ (map-equiv (pr1 e) zero-ℤ))
                           ( left-inverse-law-add-ℤ x)) ∘e
                         ( equiv-ap
                           ( equiv-add-ℤ (neg-ℤ x))

--- a/src/synthetic-homotopy-theory/infinite-cyclic-types.lagda.md
+++ b/src/synthetic-homotopy-theory/infinite-cyclic-types.lagda.md
@@ -158,7 +158,7 @@ module _
                       ( λ e → Id (map-equiv (pr1 e) zero-ℤ) zero-ℤ)
                       ( equiv-Σ
                         ( λ e → (map-equiv e ∘ succ-ℤ) ~ (succ-ℤ ∘ map-equiv e))
-                        ( equiv-postcomp-equiv (equiv-add-ℤ (neg-ℤ x)) ℤ)
+                        ( equiv-postcomp-equiv (equiv-left-add-ℤ (neg-ℤ x)) ℤ)
                         ( λ e →
                           equiv-map-Π
                             ( λ k →
@@ -168,7 +168,7 @@ module _
                                   ( neg-ℤ x)
                                   ( map-equiv e k))) ∘e
                               ( equiv-ap
-                                ( equiv-add-ℤ (neg-ℤ x))
+                                ( equiv-left-add-ℤ (neg-ℤ x))
                                 ( map-equiv e (succ-ℤ k))
                                 ( succ-ℤ (map-equiv e k))))))
                       ( λ e →
@@ -176,7 +176,7 @@ module _
                           ( (neg-ℤ x) +ℤ (map-equiv (pr1 e) zero-ℤ))
                           ( left-inverse-law-add-ℤ x)) ∘e
                         ( equiv-ap
-                          ( equiv-add-ℤ (neg-ℤ x))
+                          ( equiv-left-add-ℤ (neg-ℤ x))
                           ( map-equiv (pr1 e) zero-ℤ)
                           ( x))))))))
             ( is-initial-ℤ-Pointed-Type-With-Aut ℤ-Pointed-Type-With-Aut))

--- a/src/synthetic-homotopy-theory/powers-of-loops.lagda.md
+++ b/src/synthetic-homotopy-theory/powers-of-loops.lagda.md
@@ -102,17 +102,17 @@ power-nat-add-Ω m (succ-ℕ n) A ω =
 ```agda
 power-nat-mul-Ω :
   {l : Level} (m n : ℕ) (A : Pointed-Type l) (ω : type-Ω A) →
-  power-nat-Ω (mul-ℕ m n) A ω ＝ power-nat-Ω m A (power-nat-Ω n A ω)
+  power-nat-Ω (m *ℕ n) A ω ＝ power-nat-Ω m A (power-nat-Ω n A ω)
 power-nat-mul-Ω zero-ℕ n A ω = refl
 power-nat-mul-Ω (succ-ℕ m) n A ω =
-  ( power-nat-add-Ω (mul-ℕ m n) n A ω) ∙
+  ( power-nat-add-Ω (m *ℕ n) n A ω) ∙
   ( ( ap
       ( concat' (point-Pointed-Type A) (power-nat-Ω n A ω))
       ( power-nat-mul-Ω m n A ω)))
 
 power-nat-mul-Ω' :
   {l : Level} (m n : ℕ) (A : Pointed-Type l) (ω : type-Ω A) →
-  power-nat-Ω (mul-ℕ m n) A ω ＝ power-nat-Ω n A (power-nat-Ω m A ω)
+  power-nat-Ω (m *ℕ n) A ω ＝ power-nat-Ω n A (power-nat-Ω m A ω)
 power-nat-mul-Ω' m n A ω =
   ( ap (λ u → power-nat-Ω u A ω) (commutative-mul-ℕ m n)) ∙
   ( power-nat-mul-Ω n m A ω)

--- a/src/synthetic-homotopy-theory/powers-of-loops.lagda.md
+++ b/src/synthetic-homotopy-theory/powers-of-loops.lagda.md
@@ -90,7 +90,7 @@ power-nat-succ-Ω' (succ-ℕ n) A ω =
 ```agda
 power-nat-add-Ω :
   {l : Level} (m n : ℕ) (A : Pointed-Type l) (ω : type-Ω A) →
-  power-nat-Ω (add-ℕ m n) A ω ＝ (power-nat-Ω m A ω ∙ power-nat-Ω n A ω)
+  power-nat-Ω (m +ℕ n) A ω ＝ (power-nat-Ω m A ω ∙ power-nat-Ω n A ω)
 power-nat-add-Ω m zero-ℕ A ω = inv right-unit
 power-nat-add-Ω m (succ-ℕ n) A ω =
   ( ap (concat' (point-Pointed-Type A) ω) (power-nat-add-Ω m n A ω)) ∙

--- a/src/type-theories/unityped-type-theories.lagda.md
+++ b/src/type-theories/unityped-type-theories.lagda.md
@@ -370,7 +370,7 @@ module unityped where
 
     iterated-weakening :
       {l : Level} {A : type-theory l} {m n : ℕ} →
-      El A n → El A (succ-ℕ (add-ℕ m n))
+      El A n → El A (succ-ℕ (m +ℕ n))
     iterated-weakening {l} {A} {zero-ℕ} {n} x =
       {!hom-system.element (weakening.element (type-theory.W A))!}
     iterated-weakening {l} {A} {succ-ℕ m} {n} x = {!!}
@@ -380,7 +380,7 @@ module unityped where
 
 ```agda
     hom : {l : Level} (A : type-theory l) → ℕ → ℕ → UU l
-    hom A m n = El A (succ-ℕ (add-ℕ m n))
+    hom A m n = El A (succ-ℕ (m +ℕ n))
 
     id-hom : {l : Level} (A : type-theory l) (n : ℕ) → hom A n n
     id-hom A zero-ℕ = generic-element.element (type-theory.δ A)

--- a/src/univalent-combinatorics/cartesian-product-types.lagda.md
+++ b/src/univalent-combinatorics/cartesian-product-types.lagda.md
@@ -50,21 +50,21 @@ operation on finite types.
 ### The standard finite types are closed under cartesian products
 
 ```agda
-prod-Fin : (k l : ℕ) → ((Fin k) × (Fin l)) ≃ Fin (mul-ℕ k l)
+prod-Fin : (k l : ℕ) → ((Fin k) × (Fin l)) ≃ Fin (k *ℕ l)
 prod-Fin zero-ℕ l = left-absorption-prod (Fin l)
 prod-Fin (succ-ℕ k) l =
-  ( ( coprod-Fin (mul-ℕ k l) l) ∘e
+  ( ( coprod-Fin (k *ℕ l) l) ∘e
     ( equiv-coprod (prod-Fin k l) left-unit-law-prod)) ∘e
   ( right-distributive-prod-coprod (Fin k) unit (Fin l))
 
-Fin-mul-ℕ : (k l : ℕ) → (Fin (mul-ℕ k l)) ≃ ((Fin k) × (Fin l))
+Fin-mul-ℕ : (k l : ℕ) → (Fin (k *ℕ l)) ≃ ((Fin k) × (Fin l))
 Fin-mul-ℕ k l = inv-equiv (prod-Fin k l)
 ```
 
 ```agda
 count-prod :
   {l1 l2 : Level} {X : UU l1} {Y : UU l2} → count X → count Y → count (X × Y)
-pr1 (count-prod (pair k e) (pair l f)) = mul-ℕ k l
+pr1 (count-prod (pair k e) (pair l f)) = k *ℕ l
 pr2 (count-prod (pair k e) (pair l f)) =
   (equiv-prod e f) ∘e (inv-equiv (prod-Fin k l))
 
@@ -161,14 +161,14 @@ abstract
 
 prod-UU-Fin :
   {l1 l2 : Level} (k l : ℕ) → UU-Fin l1 k → UU-Fin l2 l →
-  UU-Fin (l1 ⊔ l2) (mul-ℕ k l)
+  UU-Fin (l1 ⊔ l2) (k *ℕ l)
 pr1 (prod-UU-Fin k l (pair X H) (pair Y K)) = X × Y
 pr2 (prod-UU-Fin k l (pair X H) (pair Y K)) =
   apply-universal-property-trunc-Prop H
-    ( mere-equiv-Prop (Fin (mul-ℕ k l)) (X × Y))
+    ( mere-equiv-Prop (Fin (k *ℕ l)) (X × Y))
     ( λ e1 →
       apply-universal-property-trunc-Prop K
-        ( mere-equiv-Prop (Fin (mul-ℕ k l)) (X × Y))
+        ( mere-equiv-Prop (Fin (k *ℕ l)) (X × Y))
         ( λ e2 →
           unit-trunc-Prop (equiv-prod e1 e2 ∘e inv-equiv (prod-Fin k l))))
 ```

--- a/src/univalent-combinatorics/cartesian-product-types.lagda.md
+++ b/src/univalent-combinatorics/cartesian-product-types.lagda.md
@@ -113,7 +113,7 @@ abstract
   product-number-of-elements-prod :
     {l1 l2 : Level} {A : UU l1} {B : UU l2} (count-AB : count (A × B)) →
     (a : A) (b : B) →
-    Id ( mul-ℕ ( number-of-elements-count (count-left-factor count-AB b))
+    Id ( ( number-of-elements-count (count-left-factor count-AB b)) *ℕ
                ( number-of-elements-count (count-right-factor count-AB a)))
        ( number-of-elements-count count-AB)
   product-number-of-elements-prod count-AB a b =

--- a/src/univalent-combinatorics/cartesian-product-types.lagda.md
+++ b/src/univalent-combinatorics/cartesian-product-types.lagda.md
@@ -74,8 +74,7 @@ abstract
     (count-B : count B) →
     Id ( number-of-elements-count
          ( count-prod count-A count-B))
-       ( mul-ℕ
-         ( number-of-elements-count count-A)
+       ( ( number-of-elements-count count-A) *ℕ
          ( number-of-elements-count count-B))
   number-of-elements-count-prod (pair k e) (pair l f) = refl
 

--- a/src/univalent-combinatorics/coproduct-types.lagda.md
+++ b/src/univalent-combinatorics/coproduct-types.lagda.md
@@ -151,9 +151,7 @@ abstract
     { l1 l2 : Level} {A : UU l1} {B : UU l2}
     ( count-A : count A) (count-B : count B) (count-C : count (A + B)) →
     Id ( number-of-elements-count count-C)
-       ( add-ℕ
-         ( number-of-elements-count count-A)
-         ( number-of-elements-count count-B))
+       ( number-of-elements-count count-A +ℕ number-of-elements-count count-B)
   double-counting-coprod count-A count-B count-C =
     ( double-counting count-C (count-coprod count-A count-B)) ∙
     ( number-of-elements-count-coprod count-A count-B)
@@ -232,13 +230,9 @@ coprod-eq-is-finite {X = X} {Y = Y} P Q =
     ( number-of-elements-has-finite-cardinality)
     ( all-elements-equal-has-finite-cardinality
       ( pair
-        ( add-ℕ
-          ( number-of-elements-is-finite P)
-          ( number-of-elements-is-finite Q))
+        ( number-of-elements-is-finite P +ℕ number-of-elements-is-finite Q)
         ( has-cardinality-type-UU-Fin
-          ( add-ℕ
-            ( number-of-elements-is-finite P)
-            ( number-of-elements-is-finite Q))
+          ( number-of-elements-is-finite P +ℕ number-of-elements-is-finite Q)
           ( coprod-UU-Fin
             ( number-of-elements-is-finite P)
             ( number-of-elements-is-finite Q)

--- a/src/univalent-combinatorics/coproduct-types.lagda.md
+++ b/src/univalent-combinatorics/coproduct-types.lagda.md
@@ -44,25 +44,25 @@ Coproducts of finite types are finite, giving a coproduct operation on the type
 
 ```agda
 coprod-Fin :
-  (k l : ℕ) → (Fin k + Fin l) ≃ Fin (add-ℕ k l)
+  (k l : ℕ) → (Fin k + Fin l) ≃ Fin (k +ℕ l)
 coprod-Fin k zero-ℕ = right-unit-law-coprod (Fin k)
 coprod-Fin k (succ-ℕ l) =
   (equiv-coprod (coprod-Fin k l) id-equiv) ∘e inv-associative-coprod
 
 map-coprod-Fin :
-  (k l : ℕ) → (Fin k + Fin l) → Fin (add-ℕ k l)
+  (k l : ℕ) → (Fin k + Fin l) → Fin (k +ℕ l)
 map-coprod-Fin k l = map-equiv (coprod-Fin k l)
 
 Fin-add-ℕ :
-  (k l : ℕ) → Fin (add-ℕ k l) ≃ (Fin k + Fin l)
+  (k l : ℕ) → Fin (k +ℕ l) ≃ (Fin k + Fin l)
 Fin-add-ℕ k l = inv-equiv (coprod-Fin k l)
 
 inl-coprod-Fin :
-  (k l : ℕ) → Fin k → Fin (add-ℕ k l)
+  (k l : ℕ) → Fin k → Fin (k +ℕ l)
 inl-coprod-Fin k l = map-coprod-Fin k l ∘ inl
 
 inr-coprod-Fin :
-  (k l : ℕ) → Fin l → Fin (add-ℕ k l)
+  (k l : ℕ) → Fin l → Fin (k +ℕ l)
 inr-coprod-Fin k l = map-coprod-Fin k l ∘ inr
 
 compute-inl-coprod-Fin :
@@ -75,8 +75,8 @@ compute-inl-coprod-Fin k x = refl
 ```agda
 nat-coprod-Fin :
   (n m : ℕ) → (x : Fin n + Fin m) →
-  nat-Fin (add-ℕ n m) (map-coprod-Fin n m x) ＝
-  ind-coprod _ (nat-Fin n) (λ i → add-ℕ n (nat-Fin m i)) x
+  nat-Fin (n +ℕ m) (map-coprod-Fin n m x) ＝
+  ind-coprod _ (nat-Fin n) (λ i → n +ℕ (nat-Fin m i)) x
 nat-coprod-Fin n zero-ℕ (inl x) = refl
 nat-coprod-Fin n (succ-ℕ m) (inl x) = nat-coprod-Fin n m (inl x)
 nat-coprod-Fin n (succ-ℕ m) (inr (inl x)) = nat-coprod-Fin n m (inr x)
@@ -84,12 +84,12 @@ nat-coprod-Fin n (succ-ℕ m) (inr (inr star)) = refl
 
 nat-inl-coprod-Fin :
   (n m : ℕ) (i : Fin n) →
-  nat-Fin (add-ℕ n m) (inl-coprod-Fin n m i) ＝ nat-Fin n i
+  nat-Fin (n +ℕ m) (inl-coprod-Fin n m i) ＝ nat-Fin n i
 nat-inl-coprod-Fin n m i = nat-coprod-Fin n m (inl i)
 
 nat-inr-coprod-Fin :
   (n m : ℕ) (i : Fin m) →
-  nat-Fin (add-ℕ n m) (inr-coprod-Fin n m i) ＝ add-ℕ n (nat-Fin m i)
+  nat-Fin (n +ℕ m) (inr-coprod-Fin n m i) ＝ n +ℕ (nat-Fin m i)
 nat-inr-coprod-Fin n m i = nat-coprod-Fin n m (inr i)
 ```
 
@@ -99,7 +99,7 @@ nat-inr-coprod-Fin n m i = nat-coprod-Fin n m (inr i)
 count-coprod :
   {l1 l2 : Level} {X : UU l1} {Y : UU l2} →
   count X → count Y → count (X + Y)
-pr1 (count-coprod (pair k e) (pair l f)) = add-ℕ k l
+pr1 (count-coprod (pair k e) (pair l f)) = k +ℕ l
 pr2 (count-coprod (pair k e) (pair l f)) =
   (equiv-coprod e f) ∘e (inv-equiv (coprod-Fin k l))
 
@@ -107,7 +107,7 @@ abstract
   number-of-elements-count-coprod :
     {l1 l2 : Level} {X : UU l1} {Y : UU l2} (e : count X) (f : count Y) →
     Id ( number-of-elements-count (count-coprod e f))
-      ( add-ℕ (number-of-elements-count e) (number-of-elements-count f))
+      ( (number-of-elements-count e) +ℕ (number-of-elements-count f))
   number-of-elements-count-coprod (pair k e) (pair l f) = refl
 ```
 
@@ -210,14 +210,14 @@ abstract
 
 coprod-UU-Fin :
   {l1 l2 : Level} (k l : ℕ) → UU-Fin l1 k → UU-Fin l2 l →
-  UU-Fin (l1 ⊔ l2) (add-ℕ k l)
+  UU-Fin (l1 ⊔ l2) (k +ℕ l)
 pr1 (coprod-UU-Fin {l1} {l2} k l (pair X H) (pair Y K)) = X + Y
 pr2 (coprod-UU-Fin {l1} {l2} k l (pair X H) (pair Y K)) =
   apply-universal-property-trunc-Prop H
-    ( mere-equiv-Prop (Fin (add-ℕ k l)) (X + Y))
+    ( mere-equiv-Prop (Fin (k +ℕ l)) (X + Y))
     ( λ e1 →
       apply-universal-property-trunc-Prop K
-        ( mere-equiv-Prop (Fin (add-ℕ k l)) (X + Y))
+        ( mere-equiv-Prop (Fin (k +ℕ l)) (X + Y))
         ( λ e2 →
           unit-trunc-Prop
             ( equiv-coprod e1 e2 ∘e inv-equiv (coprod-Fin k l))))
@@ -225,7 +225,7 @@ pr2 (coprod-UU-Fin {l1} {l2} k l (pair X H) (pair Y K)) =
 coprod-eq-is-finite :
   {l1 l2 : Level} {X : UU l1} {Y : UU l2} (P : is-finite X) (Q : is-finite Y) →
     Id
-      ( add-ℕ (number-of-elements-is-finite P) (number-of-elements-is-finite Q))
+      ( (number-of-elements-is-finite P) +ℕ (number-of-elements-is-finite Q))
       ( number-of-elements-is-finite (is-finite-coprod P Q))
 coprod-eq-is-finite {X = X} {Y = Y} P Q =
   ap

--- a/src/univalent-combinatorics/coproduct-types.lagda.md
+++ b/src/univalent-combinatorics/coproduct-types.lagda.md
@@ -161,7 +161,7 @@ abstract
 abstract
   sum-number-of-elements-coprod :
     {l1 l2 : Level} {A : UU l1} {B : UU l2} (e : count (A + B)) →
-    Id ( add-ℕ ( number-of-elements-count (count-left-summand e))
+    Id ( ( number-of-elements-count (count-left-summand e)) +ℕ
                ( number-of-elements-count (count-right-summand e)))
        ( number-of-elements-count e)
   sum-number-of-elements-coprod e =

--- a/src/univalent-combinatorics/counting-dependent-pair-types.lagda.md
+++ b/src/univalent-combinatorics/counting-dependent-pair-types.lagda.md
@@ -106,7 +106,7 @@ abstract
       ( count-Σ' k id-equiv (λ x → f (map-equiv e (inl x))))
       ( f (map-equiv e (inr star)))) ∙
     ( ap
-      ( add-ℕ' (number-of-elements-count (f (map-equiv e (inr star)))))
+      ( _+ℕ (number-of-elements-count (f (map-equiv e (inr star)))))
       ( number-of-elements-count-Σ' k id-equiv (λ x → f (map-equiv e (inl x)))))
 
 abstract

--- a/src/univalent-combinatorics/cycle-prime-decomposition-natural-numbers.lagda.md
+++ b/src/univalent-combinatorics/cycle-prime-decomposition-natural-numbers.lagda.md
@@ -9,11 +9,8 @@ module univalent-combinatorics.cycle-prime-decomposition-natural-numbers where
 ```agda
 open import elementary-number-theory.fundamental-theorem-of-arithmetic
 open import elementary-number-theory.inequality-natural-numbers
-open import elementary-number-theory.modular-arithmetic
 open import elementary-number-theory.natural-numbers
 
-open import foundation.dependent-pair-types
-open import foundation.equivalences
 open import foundation.iterated-cartesian-product-types
 open import foundation.universe-levels
 
@@ -22,10 +19,8 @@ open import group-theory.iterated-cartesian-products-concrete-groups
 
 open import lists.arrays
 open import lists.functoriality-lists
-open import lists.lists
 
 open import univalent-combinatorics.cyclic-types
-open import univalent-combinatorics.finite-types
 ```
 
 </details>

--- a/src/univalent-combinatorics/cyclic-types.lagda.md
+++ b/src/univalent-combinatorics/cyclic-types.lagda.md
@@ -401,7 +401,7 @@ compute-map-preserves-succ-map-ℤ-Mod' :
   (x : ℤ) → Id (add-ℤ-Mod k (mod-ℤ k x) (f (zero-ℤ-Mod k))) (f (mod-ℤ k x))
 compute-map-preserves-succ-map-ℤ-Mod' k f H (inl zero-ℕ) =
   ( ap (add-ℤ-Mod' k (f (zero-ℤ-Mod k))) (mod-neg-one-ℤ k)) ∙
-  ( ( inv (is-add-neg-one-pred-ℤ-Mod k (f (zero-ℤ-Mod k)))) ∙
+  ( ( inv (is-left-add-neg-one-pred-ℤ-Mod k (f (zero-ℤ-Mod k)))) ∙
     ( ( ap (pred-ℤ-Mod k) (ap f (inv (mod-zero-ℤ k)))) ∙
       ( ( inv
           ( preserves-pred-preserves-succ-map-ℤ-Mod k f H (mod-ℤ k zero-ℤ))) ∙
@@ -423,7 +423,7 @@ compute-map-preserves-succ-map-ℤ-Mod' k f H (inr (inl star)) =
     ( ap f (inv (mod-zero-ℤ k))))
 compute-map-preserves-succ-map-ℤ-Mod' k f H (inr (inr zero-ℕ)) =
   ( ap-add-ℤ-Mod k (mod-one-ℤ k) (ap f (inv (mod-zero-ℤ k)))) ∙
-  ( ( inv (is-add-one-succ-ℤ-Mod k (f (mod-ℤ k zero-ℤ)))) ∙
+  ( ( inv (is-left-add-one-succ-ℤ-Mod k (f (mod-ℤ k zero-ℤ)))) ∙
     ( ( inv (H (mod-ℤ k zero-ℤ))) ∙
       ( ap f (inv (preserves-successor-mod-ℤ k zero-ℤ)))))
 compute-map-preserves-succ-map-ℤ-Mod' k f H (inr (inr (succ-ℕ x))) =

--- a/src/univalent-combinatorics/orientations-complete-undirected-graph.lagda.md
+++ b/src/univalent-combinatorics/orientations-complete-undirected-graph.lagda.md
@@ -301,12 +301,12 @@ module _
     inv
       ( is-zero-mod-succ-ℕ
         ( 1)
-        ( dist-ℕ (k1 +ℕ k2) (mul-ℕ 2 k'))
+        ( dist-ℕ (k1 +ℕ k2) (2 *ℕ k'))
         ( trans-cong-ℕ
           ( 2)
           ( k1 +ℕ k2)
           ( zero-ℕ)
-          ( mul-ℕ 2 k')
+          ( 2 *ℕ k')
           ( trans-cong-ℕ 2
             ( k1 +ℕ k2)
             ( add-ℕ
@@ -339,11 +339,11 @@ module _
           ( scalar-invariant-cong-ℕ' 2 0 2 k' (cong-zero-ℕ' 2)))) ∙
       ( ap
         ( mod-two-ℕ)
-        ( ( symmetric-dist-ℕ (k1 +ℕ k2) (mul-ℕ 2 k')) ∙
+        ( ( symmetric-dist-ℕ (k1 +ℕ k2) (2 *ℕ k')) ∙
           ( inv
             ( rewrite-left-add-dist-ℕ
               ( k)
-              ( mul-ℕ 2 k')
+              ( 2 *ℕ k')
               ( k1 +ℕ k2)
               ( inv
                 ( eq-symmetric-difference

--- a/src/univalent-combinatorics/orientations-complete-undirected-graph.lagda.md
+++ b/src/univalent-combinatorics/orientations-complete-undirected-graph.lagda.md
@@ -301,14 +301,14 @@ module _
     inv
       ( is-zero-mod-succ-ℕ
         ( 1)
-        ( dist-ℕ (add-ℕ k1 k2) (mul-ℕ 2 k'))
+        ( dist-ℕ (k1 +ℕ k2) (mul-ℕ 2 k'))
         ( trans-cong-ℕ
           ( 2)
-          ( add-ℕ k1 k2)
+          ( k1 +ℕ k2)
           ( zero-ℕ)
           ( mul-ℕ 2 k')
           ( trans-cong-ℕ 2
-            ( add-ℕ k1 k2)
+            ( k1 +ℕ k2)
             ( add-ℕ
               ( nat-Fin 2
                 ( mod-two-number-of-differences-orientation-Complete-Undirected-Graph
@@ -325,7 +325,7 @@ module _
                 ( nat-Fin 2
                   ( mod-two-number-of-differences-orientation-Complete-Undirected-Graph
                       d2 d3)))
-              ( add-ℕ k1 k2)
+              ( k1 +ℕ k2)
               ( cong-add-ℕ k1 k2))
             ( concatenate-eq-cong-ℕ 2
               ( ( ap-binary
@@ -333,18 +333,18 @@ module _
                 ( ap (nat-Fin 2) (inv p1))
                 ( ap (nat-Fin 2) (inv p2))) ∙
                 ( ap
-                  ( λ n → add-ℕ n (nat-Fin 2 m))
+                  ( λ n → n +ℕ (nat-Fin 2 m))
                   ( inv (left-unit-law-mul-ℕ (nat-Fin 2 m)))))
               ( scalar-invariant-cong-ℕ' 2 2 0 (nat-Fin 2 m) (cong-zero-ℕ' 2))))
           ( scalar-invariant-cong-ℕ' 2 0 2 k' (cong-zero-ℕ' 2)))) ∙
       ( ap
         ( mod-two-ℕ)
-        ( ( symmetric-dist-ℕ (add-ℕ k1 k2) (mul-ℕ 2 k')) ∙
+        ( ( symmetric-dist-ℕ (k1 +ℕ k2) (mul-ℕ 2 k')) ∙
           ( inv
             ( rewrite-left-add-dist-ℕ
               ( k)
               ( mul-ℕ 2 k')
-              ( add-ℕ k1 k2)
+              ( k1 +ℕ k2)
               ( inv
                 ( eq-symmetric-difference
                   ( 2-Element-Decidable-Subtype l (type-UU-Fin n X))

--- a/src/univalent-combinatorics/symmetric-difference.lagda.md
+++ b/src/univalent-combinatorics/symmetric-difference.lagda.md
@@ -47,7 +47,7 @@ module _
         ( number-of-elements-is-finite
           ( is-finite-type-decidable-subtype
             ( symmetric-difference-decidable-subtype P Q) F))
-        ( ( 2) *ℕ
+        ( 2 *ℕ
           ( number-of-elements-is-finite
             ( is-finite-type-decidable-subtype
               ( intersection-decidable-subtype P Q)
@@ -78,21 +78,16 @@ module _
               ( symmetric-difference-decidable-subtype P Q) F)
             ( is-finite-coprod is-finite-intersection is-finite-intersection)) ∙
           ( ap
-            ( λ n →
-              add-ℕ
-                ( number-of-elements-decidable-subtype-X
-                  ( symmetric-difference-decidable-subtype P Q))
-                ( n))
+            ( ( number-of-elements-decidable-subtype-X
+                ( symmetric-difference-decidable-subtype P Q)) +ℕ_)
             ( ( inv
                 ( coprod-eq-is-finite
                   ( is-finite-intersection)
                   ( is-finite-intersection))) ∙
               ( ap
-                ( λ n →
-                  add-ℕ
-                    ( n)
-                    ( number-of-elements-decidable-subtype-X
-                      ( intersection-decidable-subtype P Q)))
+                ( _+ℕ
+                  ( number-of-elements-decidable-subtype-X
+                    ( intersection-decidable-subtype P Q)))
                 ( inv
                   ( left-unit-law-mul-ℕ
                     ( number-of-elements-decidable-subtype-X

--- a/src/univalent-combinatorics/symmetric-difference.lagda.md
+++ b/src/univalent-combinatorics/symmetric-difference.lagda.md
@@ -47,8 +47,7 @@ module _
         ( number-of-elements-is-finite
           ( is-finite-type-decidable-subtype
             ( symmetric-difference-decidable-subtype P Q) F))
-        ( mul-ℕ
-          2
+        ( ( 2) *ℕ
           ( number-of-elements-is-finite
             ( is-finite-type-decidable-subtype
               ( intersection-decidable-subtype P Q)


### PR DESCRIPTION
- Refactor to use infix binary operators for arithmetic.
- Define infix binary operators for arithmetic operations on the Eisenstein integers, Gaussian integers,half integers,  and truncation levels.
- Swap to using left/right instead of a `'` for different laws for binary arithmetic operators.
- Some additional refactoring for Eisenstein integers and Gaussian integers

Note that the non-infix variants of the operators are still used some places, matching how `Id` and `pair` are used.