### PR TITLE
Remove unused imports and fix some unaddressed comments

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,8 +18,8 @@
       "problemMatcher": []
     },
     {
-      "label": "imports",
-      "detail": "Search for and remove unused imports. Warning: very slow!",
+      "label": "unused-imports",
+      "detail": "Search for and remove unused imports. Very slow!",
       "type": "shell",
       "command": "python scripts/remove_unused_imports.py && python scripts/demote_foundation_imports.py",
       "problemMatcher": []

--- a/src/category-theory/large-precategories.lagda.md
+++ b/src/category-theory/large-precategories.lagda.md
@@ -10,7 +10,6 @@ module category-theory.large-precategories where
 open import category-theory.precategories
 
 open import foundation.dependent-pair-types
-open import foundation.functions
 open import foundation.identity-types
 open import foundation.sets
 open import foundation.universe-levels

--- a/src/commutative-algebra/homomorphisms-commutative-rings.lagda.md
+++ b/src/commutative-algebra/homomorphisms-commutative-rings.lagda.md
@@ -13,14 +13,12 @@ open import commutative-algebra.homomorphisms-commutative-semirings
 open import foundation.contractible-types
 open import foundation.dependent-pair-types
 open import foundation.equivalences
-open import foundation.homotopies
 open import foundation.identity-types
 open import foundation.propositions
 open import foundation.sets
 open import foundation.universe-levels
 
 open import group-theory.homomorphisms-abelian-groups
-open import group-theory.homomorphisms-commutative-monoids
 open import group-theory.homomorphisms-monoids
 
 open import ring-theory.homomorphisms-rings

--- a/src/commutative-algebra/homomorphisms-commutative-semirings.lagda.md
+++ b/src/commutative-algebra/homomorphisms-commutative-semirings.lagda.md
@@ -12,13 +12,8 @@ open import commutative-algebra.commutative-semirings
 open import foundation.contractible-types
 open import foundation.dependent-pair-types
 open import foundation.equivalences
-open import foundation.fundamental-theorem-of-identity-types
-open import foundation.homotopies
 open import foundation.identity-types
-open import foundation.propositions
 open import foundation.sets
-open import foundation.subtype-identity-principle
-open import foundation.subtypes
 open import foundation.universe-levels
 
 open import group-theory.homomorphisms-commutative-monoids

--- a/src/commutative-algebra/ideals-generated-by-subsets-commutative-rings.lagda.md
+++ b/src/commutative-algebra/ideals-generated-by-subsets-commutative-rings.lagda.md
@@ -13,11 +13,9 @@ open import commutative-algebra.subsets-commutative-rings
 
 open import foundation.identity-types
 open import foundation.powersets
-open import foundation.propositions
 open import foundation.universe-levels
 
 open import lists.concatenation-lists
-open import lists.lists
 
 open import ring-theory.ideals-generated-by-subsets-rings
 ```

--- a/src/finite-group-theory/permutations-standard-finite-types.lagda.md
+++ b/src/finite-group-theory/permutations-standard-finite-types.lagda.md
@@ -11,15 +11,11 @@ module finite-group-theory.permutations-standard-finite-types where
 <details><summary>Imports</summary>
 
 ```agda
-open import elementary-number-theory.modular-arithmetic-standard-finite-types
 open import elementary-number-theory.natural-numbers
 
-open import finite-group-theory.orbits-permutations
 open import finite-group-theory.transpositions
 
 open import foundation.automorphisms
-open import foundation.cartesian-product-types
-open import foundation.contractible-types
 open import foundation.coproduct-types
 open import foundation.decidable-propositions
 open import foundation.dependent-pair-types
@@ -31,25 +27,15 @@ open import foundation.equivalences-maybe
 open import foundation.functions
 open import foundation.identity-types
 open import foundation.injective-maps
-open import foundation.iterating-functions
-open import foundation.iterating-involutions
-open import foundation.propositional-truncations
 open import foundation.propositions
 open import foundation.sets
-open import foundation.truncated-types
-open import foundation.truncation-levels
 open import foundation.unit-type
 open import foundation.universe-levels
-
-open import group-theory.subgroups-generated-by-subsets-groups
-open import group-theory.symmetric-groups
 
 open import lists.functoriality-lists
 open import lists.lists
 
 open import univalent-combinatorics.2-element-decidable-subtypes
-open import univalent-combinatorics.2-element-types
-open import univalent-combinatorics.counting
 open import univalent-combinatorics.equality-standard-finite-types
 open import univalent-combinatorics.finite-types
 open import univalent-combinatorics.standard-finite-types

--- a/src/finite-group-theory/permutations.lagda.md
+++ b/src/finite-group-theory/permutations.lagda.md
@@ -27,10 +27,8 @@ open import foundation.empty-types
 open import foundation.equality-dependent-pair-types
 open import foundation.equivalence-extensionality
 open import foundation.equivalences
-open import foundation.equivalences-maybe
 open import foundation.functions
 open import foundation.identity-types
-open import foundation.injective-maps
 open import foundation.iterating-functions
 open import foundation.iterating-involutions
 open import foundation.propositional-truncations
@@ -50,7 +48,6 @@ open import lists.lists
 open import univalent-combinatorics.2-element-decidable-subtypes
 open import univalent-combinatorics.2-element-types
 open import univalent-combinatorics.counting
-open import univalent-combinatorics.equality-standard-finite-types
 open import univalent-combinatorics.finite-types
 open import univalent-combinatorics.standard-finite-types
 ```

--- a/src/foundation/0-connected-types.lagda.md
+++ b/src/foundation/0-connected-types.lagda.md
@@ -7,7 +7,6 @@ module foundation.0-connected-types where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.cartesian-product-types
 open import foundation.contractible-types
 open import foundation.fiber-inclusions
 open import foundation.functoriality-set-truncation
@@ -20,6 +19,7 @@ open import foundation.surjective-maps
 open import foundation.unit-type
 open import foundation.universal-property-unit-type
 
+open import foundation-core.cartesian-product-types
 open import foundation-core.dependent-pair-types
 open import foundation-core.equivalences
 open import foundation-core.fibers-of-maps

--- a/src/foundation/category-of-sets.lagda.md
+++ b/src/foundation/category-of-sets.lagda.md
@@ -9,10 +9,11 @@ module foundation.category-of-sets where
 ```agda
 open import category-theory.large-precategories
 
-open import foundation.functions
-open import foundation.identity-types
 open import foundation.sets
-open import foundation.universe-levels
+
+open import foundation-core.functions
+open import foundation-core.identity-types
+open import foundation-core.universe-levels
 ```
 
 </details>

--- a/src/foundation/iterated-cartesian-product-types.lagda.md
+++ b/src/foundation/iterated-cartesian-product-types.lagda.md
@@ -11,22 +11,23 @@ open import elementary-number-theory.natural-numbers
 
 open import finite-group-theory.permutations-standard-finite-types
 
-open import foundation.cartesian-product-types
-open import foundation.contractible-types
-open import foundation.coproduct-types
-open import foundation.dependent-pair-types
-open import foundation.equivalences
-open import foundation.functions
 open import foundation.functoriality-cartesian-product-types
 open import foundation.functoriality-dependent-function-types
-open import foundation.identity-types
-open import foundation.type-arithmetic-cartesian-product-types
 open import foundation.type-arithmetic-dependent-function-types
 open import foundation.unit-type
 open import foundation.univalence
 open import foundation.universal-property-coproduct-types
 open import foundation.universal-property-empty-type
-open import foundation.universe-levels
+
+open import foundation-core.cartesian-product-types
+open import foundation-core.contractible-types
+open import foundation-core.coproduct-types
+open import foundation-core.dependent-pair-types
+open import foundation-core.equivalences
+open import foundation-core.functions
+open import foundation-core.identity-types
+open import foundation-core.type-arithmetic-cartesian-product-types
+open import foundation-core.universe-levels
 
 open import lists.arrays
 open import lists.lists

--- a/src/foundation/iterated-cartesian-product-types.lagda.md
+++ b/src/foundation/iterated-cartesian-product-types.lagda.md
@@ -47,7 +47,7 @@ In this file, we give three definitions of the iterated cartesian product
 
 We show that :
 
-- all these definitions are equivalent
+- all of these definitions are equivalent
 - iterated cartesian product of types is closed under permutations
 
 ## Definitions

--- a/src/foundation/large-locale-of-propositions.lagda.md
+++ b/src/foundation/large-locale-of-propositions.lagda.md
@@ -9,11 +9,12 @@ module foundation.large-locale-of-propositions where
 ```agda
 open import foundation.conjunction
 open import foundation.existential-quantification
-open import foundation.functions
 open import foundation.propositional-extensionality
-open import foundation.propositions
 open import foundation.unit-type
-open import foundation.universe-levels
+
+open import foundation-core.functions
+open import foundation-core.propositions
+open import foundation-core.universe-levels
 
 open import order-theory.large-frames
 open import order-theory.large-locales

--- a/src/foundation/large-locale-of-subtypes.lagda.md
+++ b/src/foundation/large-locale-of-subtypes.lagda.md
@@ -7,11 +7,12 @@ module foundation.large-locale-of-subtypes where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.identity-types
 open import foundation.large-locale-of-propositions
-open import foundation.propositions
-open import foundation.sets
-open import foundation.universe-levels
+
+open import foundation-core.identity-types
+open import foundation-core.propositions
+open import foundation-core.sets
+open import foundation-core.universe-levels
 
 open import order-theory.greatest-lower-bounds-large-posets
 open import order-theory.large-locales

--- a/src/foundation/type-duality.lagda.md
+++ b/src/foundation/type-duality.lagda.md
@@ -10,7 +10,6 @@ module foundation.type-duality where
 open import foundation.equivalences
 open import foundation.function-extensionality
 open import foundation.locally-small-types
-open import foundation.propositional-maps
 open import foundation.slice
 open import foundation.unit-type
 open import foundation.univalence

--- a/src/foundation/unit-type.lagda.md
+++ b/src/foundation/unit-type.lagda.md
@@ -19,8 +19,6 @@ open import foundation-core.sets
 open import foundation-core.truncated-types
 open import foundation-core.truncation-levels
 open import foundation-core.universe-levels
-
-open import structured-types.pointed-types
 ```
 
 </details>

--- a/src/graph-theory/acyclic-undirected-graphs.lagda.md
+++ b/src/graph-theory/acyclic-undirected-graphs.lagda.md
@@ -7,10 +7,6 @@ module graph-theory.acyclic-undirected-graphs where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.constant-maps
-open import foundation.contractible-types
-open import foundation.dependent-pair-types
-open import foundation.unit-type
 open import foundation.universe-levels
 
 open import graph-theory.geometric-realizations-undirected-graphs

--- a/src/graph-theory/equivalences-directed-graphs.lagda.md
+++ b/src/graph-theory/equivalences-directed-graphs.lagda.md
@@ -14,7 +14,6 @@ open import foundation.dependent-pair-types
 open import foundation.equality-dependent-function-types
 open import foundation.equivalence-extensionality
 open import foundation.equivalences
-open import foundation.function-extensionality
 open import foundation.functions
 open import foundation.functoriality-dependent-function-types
 open import foundation.functoriality-dependent-pair-types

--- a/src/group-theory/homomorphisms-abelian-groups.lagda.md
+++ b/src/group-theory/homomorphisms-abelian-groups.lagda.md
@@ -7,8 +7,6 @@ module group-theory.homomorphisms-abelian-groups where
 <details><summary>Imports</summary>
 
 ```agda
-open import category-theory.large-precategories
-
 open import foundation.contractible-types
 open import foundation.dependent-pair-types
 open import foundation.equivalences

--- a/src/linear-algebra/vectors.lagda.md
+++ b/src/linear-algebra/vectors.lagda.md
@@ -13,7 +13,6 @@ open import foundation.cartesian-product-types
 open import foundation.contractible-types
 open import foundation.coproduct-types
 open import foundation.dependent-pair-types
-open import foundation.empty-types
 open import foundation.equivalences
 open import foundation.function-extensionality
 open import foundation.functions

--- a/src/lists/lists.lagda.md
+++ b/src/lists/lists.lagda.md
@@ -14,9 +14,7 @@ open import foundation.contractible-types
 open import foundation.coproduct-types
 open import foundation.dependent-pair-types
 open import foundation.empty-types
-open import foundation.equality-dependent-pair-types
 open import foundation.equivalences
-open import foundation.function-extensionality
 open import foundation.functions
 open import foundation.functoriality-dependent-pair-types
 open import foundation.homotopies
@@ -29,8 +27,6 @@ open import foundation.truncated-types
 open import foundation.truncation-levels
 open import foundation.unit-type
 open import foundation.universe-levels
-
-open import linear-algebra.vectors
 ```
 
 </details>

--- a/src/lists/permutation-vectors.lagda.md
+++ b/src/lists/permutation-vectors.lagda.md
@@ -19,8 +19,6 @@ open import foundation.identity-types
 open import foundation.universe-levels
 
 open import linear-algebra.vectors
-
-open import univalent-combinatorics.standard-finite-types
 ```
 
 </details>

--- a/src/lists/predicates-on-lists.lagda.md
+++ b/src/lists/predicates-on-lists.lagda.md
@@ -16,10 +16,6 @@ open import lists.lists
 
 </details>
 
-## Idea
-
-In these file we define predicates on lists.
-
 ## Definitions
 
 ### For all

--- a/src/lists/quicksort-lists.lagda.md
+++ b/src/lists/quicksort-lists.lagda.md
@@ -11,27 +11,15 @@ open import elementary-number-theory.inequality-natural-numbers
 open import elementary-number-theory.natural-numbers
 open import elementary-number-theory.strong-induction-natural-numbers
 
-open import finite-group-theory.permutations-standard-finite-types
-
-open import foundation.cartesian-product-types
 open import foundation.coproduct-types
-open import foundation.dependent-pair-types
-open import foundation.empty-types
-open import foundation.equivalences
-open import foundation.functions
-open import foundation.functoriality-coproduct-types
 open import foundation.identity-types
-open import foundation.propositions
 open import foundation.unit-type
 open import foundation.universe-levels
 
 open import lists.concatenation-lists
 open import lists.lists
-open import lists.permutation-lists
 
 open import order-theory.decidable-total-orders
-
-open import univalent-combinatorics.standard-finite-types
 ```
 
 </details>

--- a/src/lists/sort-by-insertion-vectors.lagda.md
+++ b/src/lists/sort-by-insertion-vectors.lagda.md
@@ -15,7 +15,6 @@ open import finite-group-theory.transpositions-standard-finite-types
 open import foundation.coproduct-types
 open import foundation.dependent-pair-types
 open import foundation.equivalences
-open import foundation.functions
 open import foundation.functoriality-coproduct-types
 open import foundation.identity-types
 open import foundation.unit-type
@@ -28,8 +27,6 @@ open import lists.sorted-vectors
 open import lists.sorting-algorithms-vectors
 
 open import order-theory.decidable-total-orders
-
-open import univalent-combinatorics.standard-finite-types
 ```
 
 </details>

--- a/src/lists/sorted-lists.lagda.md
+++ b/src/lists/sorted-lists.lagda.md
@@ -21,7 +21,8 @@ open import order-theory.decidable-total-orders
 
 ## Idea
 
-In these file, we define sorted lists.
+We define a sorted list to be a list such that for every pair of consecutive
+entries `x` and `y`, the inequality `x ≤ y` holds.
 
 ## Definitions
 

--- a/src/lists/sorted-vectors.lagda.md
+++ b/src/lists/sorted-vectors.lagda.md
@@ -32,7 +32,8 @@ open import univalent-combinatorics.standard-finite-types
 
 ## Idea
 
-In these file, we define sorted vectors.
+We define a sorted vector to be a vector such that for every pair of consecutive
+elements `x` and `y`, the inequality `x ≤ y` holds.
 
 ## Definitions
 

--- a/src/lists/sorting-algorithms-vectors.lagda.md
+++ b/src/lists/sorting-algorithms-vectors.lagda.md
@@ -24,12 +24,10 @@ open import order-theory.decidable-total-orders
 
 ## Idea
 
-In these file we define the notion of sorting algorithms.
+A function `f` on vectors is a **sort** if `f` is a permutation and if for every
+vector `v`, `f v` is sorted.
 
 ## Definition
-
-A function `f` from `vec` to `vec` is a sort if `f` is a permutation and if for
-every vector `v`, `f v` is sorted
 
 ```agda
 module _

--- a/src/lists/sorting-algorithms-vectors.lagda.md
+++ b/src/lists/sorting-algorithms-vectors.lagda.md
@@ -9,8 +9,6 @@ module lists.sorting-algorithms-vectors where
 ```agda
 open import elementary-number-theory.natural-numbers
 
-open import finite-group-theory.permutations-standard-finite-types
-
 open import foundation.cartesian-product-types
 open import foundation.universe-levels
 
@@ -20,8 +18,6 @@ open import lists.permutation-vectors
 open import lists.sorted-vectors
 
 open import order-theory.decidable-total-orders
-
-open import univalent-combinatorics.standard-finite-types
 ```
 
 </details>

--- a/src/order-theory/decidable-posets.lagda.md
+++ b/src/order-theory/decidable-posets.lagda.md
@@ -7,7 +7,6 @@ module order-theory.decidable-posets where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.cartesian-product-types
 open import foundation.decidable-propositions
 open import foundation.dependent-pair-types
 open import foundation.identity-types

--- a/src/order-theory/decidable-subposets.lagda.md
+++ b/src/order-theory/decidable-subposets.lagda.md
@@ -7,7 +7,6 @@ module order-theory.decidable-subposets where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.decidable-propositions
 open import foundation.decidable-subtypes
 open import foundation.dependent-pair-types
 open import foundation.identity-types

--- a/src/order-theory/decidable-subpreorders.lagda.md
+++ b/src/order-theory/decidable-subpreorders.lagda.md
@@ -7,7 +7,6 @@ module order-theory.decidable-subpreorders where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.decidable-propositions
 open import foundation.decidable-subtypes
 open import foundation.dependent-pair-types
 open import foundation.identity-types

--- a/src/order-theory/decidable-total-orders.lagda.md
+++ b/src/order-theory/decidable-total-orders.lagda.md
@@ -10,10 +10,8 @@ module order-theory.decidable-total-orders where
 open import foundation.cartesian-product-types
 open import foundation.coproduct-types
 open import foundation.decidable-propositions
-open import foundation.decidable-types
 open import foundation.dependent-pair-types
 open import foundation.identity-types
-open import foundation.negation
 open import foundation.propositions
 open import foundation.sets
 open import foundation.universe-levels

--- a/src/order-theory/decidable-total-preorders.lagda.md
+++ b/src/order-theory/decidable-total-preorders.lagda.md
@@ -15,10 +15,8 @@ open import foundation.dependent-pair-types
 open import foundation.empty-types
 open import foundation.functions
 open import foundation.identity-types
-open import foundation.negation
 open import foundation.propositional-truncations
 open import foundation.propositions
-open import foundation.sets
 open import foundation.universe-levels
 
 open import order-theory.decidable-preorders

--- a/src/order-theory/directed-complete-posets.lagda.md
+++ b/src/order-theory/directed-complete-posets.lagda.md
@@ -7,7 +7,6 @@ module order-theory.directed-complete-posets where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.inhabited-types
 open import foundation.propositions
 open import foundation.subtypes
 open import foundation.universe-levels

--- a/src/order-theory/homomorphisms-meet-semilattices.lagda.md
+++ b/src/order-theory/homomorphisms-meet-semilattices.lagda.md
@@ -7,9 +7,7 @@ module order-theory.homomorphisms-meet-semilattices where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.cartesian-product-types
 open import foundation.dependent-pair-types
-open import foundation.functions
 open import foundation.identity-types
 open import foundation.propositions
 open import foundation.sets

--- a/src/order-theory/join-semilattices.lagda.md
+++ b/src/order-theory/join-semilattices.lagda.md
@@ -7,7 +7,6 @@ module order-theory.join-semilattices where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.cartesian-product-types
 open import foundation.dependent-pair-types
 open import foundation.identity-types
 open import foundation.logical-equivalences

--- a/src/order-theory/meet-semilattices.lagda.md
+++ b/src/order-theory/meet-semilattices.lagda.md
@@ -7,7 +7,6 @@ module order-theory.meet-semilattices where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.cartesian-product-types
 open import foundation.dependent-pair-types
 open import foundation.identity-types
 open import foundation.logical-equivalences

--- a/src/order-theory/total-orders.lagda.md
+++ b/src/order-theory/total-orders.lagda.md
@@ -7,7 +7,6 @@ module order-theory.total-orders where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.cartesian-product-types
 open import foundation.dependent-pair-types
 open import foundation.identity-types
 open import foundation.propositions

--- a/src/ring-theory/homomorphisms-rings.lagda.md
+++ b/src/ring-theory/homomorphisms-rings.lagda.md
@@ -7,9 +7,6 @@ module ring-theory.homomorphisms-rings where
 <details><summary>Imports</summary>
 
 ```agda
-open import category-theory.precategories
-
-open import foundation.cartesian-product-types
 open import foundation.contractible-types
 open import foundation.dependent-pair-types
 open import foundation.equivalences
@@ -20,7 +17,6 @@ open import foundation.propositions
 open import foundation.sets
 open import foundation.subtype-identity-principle
 open import foundation.subtypes
-open import foundation.truncation-levels
 open import foundation.universe-levels
 
 open import group-theory.homomorphisms-abelian-groups

--- a/src/ring-theory/precategory-of-rings.lagda.md
+++ b/src/ring-theory/precategory-of-rings.lagda.md
@@ -10,9 +10,6 @@ module ring-theory.precategory-of-rings where
 open import category-theory.large-precategories
 open import category-theory.precategories
 
-open import foundation.dependent-pair-types
-open import foundation.homotopies
-open import foundation.identity-types
 open import foundation.universe-levels
 
 open import ring-theory.homomorphisms-rings

--- a/src/synthetic-homotopy-theory/cocones-under-spans-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/cocones-under-spans-of-pointed-types.lagda.md
@@ -7,15 +7,12 @@ module synthetic-homotopy-theory.cocones-under-spans-of-pointed-types where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.constant-maps
 open import foundation.dependent-pair-types
-open import foundation.function-extensionality
 open import foundation.homotopies
 open import foundation.identity-types
 open import foundation.universe-levels
 
 open import structured-types.commuting-squares-of-pointed-maps
-open import structured-types.pointed-homotopies
 open import structured-types.pointed-maps
 open import structured-types.pointed-types
 

--- a/src/trees/algebras-polynomial-endofunctors.lagda.md
+++ b/src/trees/algebras-polynomial-endofunctors.lagda.md
@@ -7,15 +7,7 @@ module trees.algebras-polynomial-endofunctors where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.contractible-types
 open import foundation.dependent-pair-types
-open import foundation.equivalences
-open import foundation.functions
-open import foundation.functoriality-dependent-pair-types
-open import foundation.fundamental-theorem-of-identity-types
-open import foundation.homotopies
-open import foundation.identity-types
-open import foundation.structure-identity-principle
 open import foundation.universe-levels
 
 open import trees.polynomial-endofunctors

--- a/src/trees/coalgebra-of-directed-trees.lagda.md
+++ b/src/trees/coalgebra-of-directed-trees.lagda.md
@@ -8,15 +8,12 @@ module trees.coalgebra-of-directed-trees where
 
 ```agda
 open import foundation.dependent-pair-types
-open import foundation.functions
 open import foundation.universe-levels
 
 open import trees.bases-directed-trees
 open import trees.coalgebras-polynomial-endofunctors
 open import trees.directed-trees
 open import trees.fibers-directed-trees
-open import trees.morphisms-coalgebras-polynomial-endofunctors
-open import trees.underlying-trees-elements-coalgebras-polynomial-endofunctors
 ```
 
 </details>

--- a/src/trees/coalgebra-of-enriched-directed-trees.lagda.md
+++ b/src/trees/coalgebra-of-enriched-directed-trees.lagda.md
@@ -9,19 +9,13 @@ module trees.coalgebra-of-enriched-directed-trees where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.commuting-squares-of-maps
 open import foundation.dependent-pair-types
-open import foundation.identity-types
 open import foundation.universe-levels
 
 open import trees.coalgebras-polynomial-endofunctors
-open import trees.combinator-enriched-directed-trees
 open import trees.enriched-directed-trees
-open import trees.equivalences-enriched-directed-trees
 open import trees.fibers-enriched-directed-trees
-open import trees.morphisms-coalgebras-polynomial-endofunctors
 open import trees.polynomial-endofunctors
-open import trees.underlying-trees-elements-coalgebras-polynomial-endofunctors
 ```
 
 </details>

--- a/src/trees/combinator-directed-trees.lagda.md
+++ b/src/trees/combinator-directed-trees.lagda.md
@@ -7,7 +7,6 @@ module trees.combinator-directed-trees where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.contractible-maps
 open import foundation.contractible-types
 open import foundation.coproduct-types
 open import foundation.decidable-types
@@ -23,8 +22,6 @@ open import foundation.isolated-points
 open import foundation.maybe
 open import foundation.negation
 open import foundation.propositions
-open import foundation.singleton-induction
-open import foundation.unit-type
 open import foundation.universe-levels
 
 open import graph-theory.directed-graphs

--- a/src/trees/combinator-enriched-directed-trees.lagda.md
+++ b/src/trees/combinator-enriched-directed-trees.lagda.md
@@ -8,7 +8,6 @@ module trees.combinator-enriched-directed-trees where
 
 ```agda
 open import foundation.dependent-pair-types
-open import foundation.equality-dependent-pair-types
 open import foundation.equivalences
 open import foundation.functions
 open import foundation.homotopies
@@ -18,7 +17,6 @@ open import foundation.universe-levels
 
 open import graph-theory.directed-graphs
 
-open import trees.bases-enriched-directed-trees
 open import trees.combinator-directed-trees
 open import trees.directed-trees
 open import trees.enriched-directed-trees
@@ -26,7 +24,6 @@ open import trees.equivalences-directed-trees
 open import trees.equivalences-enriched-directed-trees
 open import trees.fibers-enriched-directed-trees
 open import trees.morphisms-directed-trees
-open import trees.morphisms-enriched-directed-trees
 ```
 
 </details>

--- a/src/trees/directed-trees.lagda.md
+++ b/src/trees/directed-trees.lagda.md
@@ -21,7 +21,6 @@ open import foundation.equality-dependent-pair-types
 open import foundation.equivalences
 open import foundation.functions
 open import foundation.functoriality-coproduct-types
-open import foundation.functoriality-dependent-pair-types
 open import foundation.identity-types
 open import foundation.isolated-points
 open import foundation.negation

--- a/src/trees/elementhood-relation-coalgebras-polynomial-endofunctors.lagda.md
+++ b/src/trees/elementhood-relation-coalgebras-polynomial-endofunctors.lagda.md
@@ -9,7 +9,6 @@ module trees.elementhood-relation-coalgebras-polynomial-endofunctors where
 ```agda
 open import foundation.dependent-pair-types
 open import foundation.fibers-of-maps
-open import foundation.identity-types
 open import foundation.universe-levels
 
 open import graph-theory.directed-graphs

--- a/src/trees/elementhood-relation-w-types.lagda.md
+++ b/src/trees/elementhood-relation-w-types.lagda.md
@@ -9,7 +9,6 @@ module trees.elementhood-relation-w-types where
 ```agda
 open import foundation.dependent-pair-types
 open import foundation.empty-types
-open import foundation.fibers-of-maps
 open import foundation.identity-types
 open import foundation.universe-levels
 

--- a/src/trees/equivalences-directed-trees.lagda.md
+++ b/src/trees/equivalences-directed-trees.lagda.md
@@ -8,7 +8,6 @@ module trees.equivalences-directed-trees where
 
 ```agda
 open import foundation.binary-transport
-open import foundation.cartesian-product-types
 open import foundation.contractible-types
 open import foundation.coproduct-types
 open import foundation.dependent-pair-types
@@ -18,12 +17,10 @@ open import foundation.functions
 open import foundation.functoriality-dependent-pair-types
 open import foundation.homotopies
 open import foundation.identity-types
-open import foundation.structure-identity-principle
 open import foundation.subtype-identity-principle
 open import foundation.universe-levels
 
 open import graph-theory.equivalences-directed-graphs
-open import graph-theory.morphisms-directed-graphs
 open import graph-theory.walks-directed-graphs
 
 open import trees.directed-trees

--- a/src/trees/functoriality-combinator-directed-trees.lagda.md
+++ b/src/trees/functoriality-combinator-directed-trees.lagda.md
@@ -10,7 +10,6 @@ module trees.functoriality-combinator-directed-trees where
 open import foundation.binary-transport
 open import foundation.contractible-types
 open import foundation.dependent-pair-types
-open import foundation.equivalences
 open import foundation.functions
 open import foundation.homotopies
 open import foundation.identity-types

--- a/src/trees/functoriality-fiber-directed-tree.lagda.md
+++ b/src/trees/functoriality-fiber-directed-tree.lagda.md
@@ -8,7 +8,6 @@ module trees.functoriality-fiber-directed-tree where
 
 ```agda
 open import foundation.dependent-pair-types
-open import foundation.embeddings
 open import foundation.equivalences
 open import foundation.functoriality-dependent-pair-types
 open import foundation.identity-types

--- a/src/trees/morphisms-coalgebras-polynomial-endofunctors.lagda.md
+++ b/src/trees/morphisms-coalgebras-polynomial-endofunctors.lagda.md
@@ -11,7 +11,6 @@ open import foundation.commuting-squares-of-maps
 open import foundation.contractible-types
 open import foundation.dependent-pair-types
 open import foundation.equivalences
-open import foundation.functions
 open import foundation.functoriality-dependent-pair-types
 open import foundation.fundamental-theorem-of-identity-types
 open import foundation.homotopies

--- a/src/trees/morphisms-enriched-directed-trees.lagda.md
+++ b/src/trees/morphisms-enriched-directed-trees.lagda.md
@@ -10,9 +10,6 @@ module trees.morphisms-enriched-directed-trees where
 open import foundation.commuting-squares-of-maps
 open import foundation.commuting-triangles-of-maps
 open import foundation.dependent-pair-types
-open import foundation.equivalence-extensionality
-open import foundation.equivalences
-open import foundation.functions
 open import foundation.functoriality-dependent-pair-types
 open import foundation.homotopies
 open import foundation.identity-types

--- a/src/trees/rooted-morphisms-directed-trees.lagda.md
+++ b/src/trees/rooted-morphisms-directed-trees.lagda.md
@@ -19,8 +19,6 @@ open import foundation.propositions
 open import foundation.subtype-identity-principle
 open import foundation.universe-levels
 
-open import structured-types.pointed-maps
-
 open import trees.bases-directed-trees
 open import trees.directed-trees
 open import trees.morphisms-directed-trees

--- a/src/trees/underlying-trees-elements-coalgebras-polynomial-endofunctors.lagda.md
+++ b/src/trees/underlying-trees-elements-coalgebras-polynomial-endofunctors.lagda.md
@@ -20,7 +20,6 @@ open import foundation.fundamental-theorem-of-identity-types
 open import foundation.homotopies
 open import foundation.identity-types
 open import foundation.isolated-points
-open import foundation.maybe
 open import foundation.negation
 open import foundation.propositions
 open import foundation.type-arithmetic-empty-type
@@ -30,7 +29,6 @@ open import graph-theory.directed-graphs
 open import graph-theory.morphisms-directed-graphs
 open import graph-theory.walks-directed-graphs
 
-open import trees.bases-enriched-directed-trees
 open import trees.coalgebras-polynomial-endofunctors
 open import trees.combinator-directed-trees
 open import trees.combinator-enriched-directed-trees
@@ -39,9 +37,6 @@ open import trees.elementhood-relation-coalgebras-polynomial-endofunctors
 open import trees.enriched-directed-trees
 open import trees.equivalences-directed-trees
 open import trees.equivalences-enriched-directed-trees
-open import trees.fibers-directed-trees
-open import trees.fibers-enriched-directed-trees
-open import trees.morphisms-directed-trees
 ```
 
 </details>

--- a/src/trees/underlying-trees-of-elements-of-w-types.lagda.md
+++ b/src/trees/underlying-trees-of-elements-of-w-types.lagda.md
@@ -7,25 +7,18 @@ module trees.underlying-trees-of-elements-of-w-types where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.binary-transport
 open import foundation.contractible-types
 open import foundation.coproduct-types
 open import foundation.dependent-pair-types
 open import foundation.empty-types
-open import foundation.equality-dependent-pair-types
 open import foundation.equivalence-extensionality
 open import foundation.equivalences
 open import foundation.functions
-open import foundation.functoriality-dependent-pair-types
-open import foundation.fundamental-theorem-of-identity-types
 open import foundation.homotopies
 open import foundation.identity-types
-open import foundation.injective-maps
 open import foundation.isolated-points
 open import foundation.negation
 open import foundation.propositions
-open import foundation.type-arithmetic-empty-type
-open import foundation.unit-type
 open import foundation.universe-levels
 
 open import graph-theory.directed-graphs
@@ -39,7 +32,6 @@ open import trees.elementhood-relation-w-types
 open import trees.enriched-directed-trees
 open import trees.equivalences-directed-trees
 open import trees.equivalences-enriched-directed-trees
-open import trees.inequality-w-types
 open import trees.underlying-trees-elements-coalgebras-polynomial-endofunctors
 open import trees.w-types
 ```

--- a/src/univalent-combinatorics/cycle-prime-decomposition-natural-numbers.lagda.md
+++ b/src/univalent-combinatorics/cycle-prime-decomposition-natural-numbers.lagda.md
@@ -1,4 +1,4 @@
-# Cycle decompositions of a natural numbers
+# Cycle prime decompositions of natural numbers
 
 ```agda
 module univalent-combinatorics.cycle-prime-decomposition-natural-numbers where
@@ -27,7 +27,7 @@ open import univalent-combinatorics.cyclic-types
 
 ## Idea
 
-Let `n` be a natural numbers. The `cycle-prime-decomposition-ℕ` of `n` is the
+Let `n` be a natural number. The `cycle-prime-decomposition-ℕ` of `n` is the
 iterated cartesian product of the cyclic types assocated to the prime
 decomposition of `n`.
 


### PR DESCRIPTION
Sorry, my script wasn't finished when I made the last commit in #620, and here are the remaining unused imports. This PR also fixes some comments I made earlier that went unaddressed.

I'm wondering, are the imports scripts interfering with people's merging process a lot? If so, we don't have to merge those changes now.