### PR TITLE
Enforce even indentation and automate some conventions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,14 +50,14 @@ repos:
         files: ^src\/.+\.lagda\.md$
         types_or: [markdown, text]
 
-      # - id: indentation-conventions
-      #   name: Agda indentation conventions
-      #   entry: scripts/indentation_conventions.py
-      #   language: python
-      #   always_run: true
-      #   files: ^src\/.+\.lagda\.md$
-      #   types_or: [markdown, text]
-      #   require_serial: true
+      - id: indentation-conventions
+        name: Agda indentation conventions
+        entry: scripts/indentation_conventions.py
+        language: python
+        always_run: true
+        files: ^src\/.+\.lagda\.md$
+        types_or: [markdown, text]
+        require_serial: true
 
       - id: simply-wrappable-long-lines
         name: Fix simply wrappable long lines of Agda code

--- a/scripts/indentation_conventions.py
+++ b/scripts/indentation_conventions.py
@@ -72,6 +72,6 @@ if __name__ == '__main__':
         print(*map(lambda kv: f'  {kv[0]}: {kv[1]} lines',
                    sorted(offender_files.items(), key=lambda kv: kv[1])), sep='\n')
         print(
-            f'\nTotal number of lines in library unevenly indented: {sum(offender_files.values())}.')
+            f'\nTotal number of lines in library unevenly indented: {sum(offender_files.values())}.\n\nUneven indentation means that there is code indented by a non-multiple of the base indentation (2 spaces). If you haven\'t already, we suggest you set up your environment to more easily spot uneven indentation. For instance using VSCode\'s indent-rainbow extension.')
 
     sys.exit(status)

--- a/scripts/indentation_conventions.py
+++ b/scripts/indentation_conventions.py
@@ -52,7 +52,7 @@ if __name__ == '__main__':
                         if (status == 0):
                             print('Error! Uneven indentation found')
 
-                        print(f'{fpath}:line {i}')
+                        print(f'{fpath}:line {i+1}')
 
                         offender_files[fpath] += 1
                         status |= STATUS_UNEVEN_INDENTATION

--- a/scripts/indentation_conventions.py
+++ b/scripts/indentation_conventions.py
@@ -10,7 +10,7 @@ import collections
 
 AGDA_INDENT = '  '
 
-even_indentation_pattern = re.compile(fr'({AGDA_INDENT})*(\S|$)')
+even_indentation_pattern = re.compile(fr'^({AGDA_INDENT})*(\S|$)')
 
 
 def is_even_indentation(line):

--- a/src/category-theory/coproducts-precategories.lagda.md
+++ b/src/category-theory/coproducts-precategories.lagda.md
@@ -37,10 +37,11 @@ module _
     (z : obj-Precategory C)
     (f : type-hom-Precategory C x z) →
     (g : type-hom-Precategory C y z) →
-    ∃! ( type-hom-Precategory C p z)
-       ( λ h →
-         ( comp-hom-Precategory C h l ＝ f) ×
-         ( comp-hom-Precategory C h r ＝ g))
+    ∃!
+      ( type-hom-Precategory C p z)
+      ( λ h →
+        ( comp-hom-Precategory C h l ＝ f) ×
+        ( comp-hom-Precategory C h r ＝ g))
 
   coproduct-Precategory : obj-Precategory C → obj-Precategory C → UU (l1 ⊔ l2)
   coproduct-Precategory x y =

--- a/src/category-theory/exponential-objects-precategories.lagda.md
+++ b/src/category-theory/exponential-objects-precategories.lagda.md
@@ -47,11 +47,12 @@ module _
   is-exponential-Precategory x y e ev =
     (z : obj-Precategory C)
     (f : type-hom-Precategory C (object-product-Precategory C p z x) y) →
-    ∃! ( type-hom-Precategory C z e)
-       ( λ g →
-         comp-hom-Precategory C ev
-           ( map-product-Precategory C p g (id-hom-Precategory C)) ＝
-           ( f))
+    ∃!
+      ( type-hom-Precategory C z e)
+      ( λ g →
+        comp-hom-Precategory C ev
+          ( map-product-Precategory C p g (id-hom-Precategory C)) ＝
+          ( f))
 
   exponential-Precategory :
     obj-Precategory C → obj-Precategory C → UU (l1 ⊔ l2)

--- a/src/category-theory/functors-large-precategories.lagda.md
+++ b/src/category-theory/functors-large-precategories.lagda.md
@@ -110,7 +110,8 @@ preserves-comp-functor-Large-Precategory
     ( hom-functor-Large-Precategory F g)
     ( hom-functor-Large-Precategory F f))
 preserves-id-functor-Large-Precategory (comp-functor-Large-Precategory G F) =
-  ( ap ( hom-functor-Large-Precategory G)
-       ( preserves-id-functor-Large-Precategory F)) ∙
+  ( ap
+    ( hom-functor-Large-Precategory G)
+    ( preserves-id-functor-Large-Precategory F)) ∙
   ( preserves-id-functor-Large-Precategory G)
 ```

--- a/src/category-theory/groupoids.lagda.md
+++ b/src/category-theory/groupoids.lagda.md
@@ -106,7 +106,7 @@ module _
 
 ## Property
 
-### The type of groupoids with respect to universe levels `l1` and `l2` is equivalent to the type of 1-types in `l1`.
+### The type of groupoids with respect to universe levels `l1` and `l2` is equivalent to the type of 1-types in `l1`
 
 #### The groupoid associated to a 1-type
 

--- a/src/category-theory/natural-numbers-object-precategories.lagda.md
+++ b/src/category-theory/natural-numbers-object-precategories.lagda.md
@@ -42,9 +42,11 @@ module _
     (x : obj-Precategory C)
     (q : type-hom-Precategory C t x)
     (f : type-hom-Precategory C x x) →
-    ∃! (type-hom-Precategory C n x) λ u →
-       (comp-hom-Precategory C u z ＝ q) ×
-       (comp-hom-Precategory C u s ＝ comp-hom-Precategory C f u)
+    ∃!
+      ( type-hom-Precategory C n x)
+      ( λ u →
+        ( comp-hom-Precategory C u z ＝ q) ×
+        ( comp-hom-Precategory C u s ＝ comp-hom-Precategory C f u))
 
   natural-numbers-object-Precategory : UU (l1 ⊔ l2)
   natural-numbers-object-Precategory =

--- a/src/category-theory/natural-transformations-precategories.lagda.md
+++ b/src/category-theory/natural-transformations-precategories.lagda.md
@@ -89,10 +89,10 @@ module _
     inv (left-unit-law-comp-hom-Precategory D _)
 
   comp-natural-transformation-Precategory :
-     (F G H : functor-Precategory C D) →
-     natural-transformation-Precategory C D G H →
-     natural-transformation-Precategory C D F G →
-     natural-transformation-Precategory C D F H
+    (F G H : functor-Precategory C D) →
+    natural-transformation-Precategory C D G H →
+    natural-transformation-Precategory C D F G →
+    natural-transformation-Precategory C D F H
   pr1 (comp-natural-transformation-Precategory F G H β α) x =
     comp-hom-Precategory D
       ( components-natural-transformation-Precategory C D G H β x)

--- a/src/category-theory/pullbacks-precategories.lagda.md
+++ b/src/category-theory/pullbacks-precategories.lagda.md
@@ -57,9 +57,11 @@ module _
     (p₁' : type-hom-Precategory C w' y) →
     (p₂' : type-hom-Precategory C w' z) →
     comp-hom-Precategory C f p₁' ＝ comp-hom-Precategory C g p₂' →
-    ∃! (type-hom-Precategory C w' w) λ h →
-       (comp-hom-Precategory C p₁ h ＝ p₁') ×
-       (comp-hom-Precategory C p₂ h ＝ p₂')
+    ∃!
+      ( type-hom-Precategory C w' w)
+      ( λ h →
+        ( comp-hom-Precategory C p₁ h ＝ p₁') ×
+        ( comp-hom-Precategory C p₂ h ＝ p₂'))
 
   pullback-Precategory :
     (x y z : obj-Precategory C) →

--- a/src/category-theory/slice-precategories.lagda.md
+++ b/src/category-theory/slice-precategories.lagda.md
@@ -333,15 +333,16 @@ module _
             ( comp-hom-Precategory C p₂ k' ＝ p₂')) →
             k ＝ k'
         σ k' (γ₁ , γ₂) =
-          ap ( pr1 ∘ pr1)
-             ( pr2
-               ( ψ (W' , comp-hom-Precategory C f p₁') (p₁' , refl) (p₂' , α'))
-               ( ( ( k') ,
-                   ( ( ap (comp-hom-Precategory C f) (inv γ₁)) ∙
-                     ( ( inv (associative-comp-hom-Precategory C f p₁ k')) ∙
-                       ( ap (λ l → comp-hom-Precategory C l k') (inv α₁))))) ,
-                 ( eq-hom-Slice-Precategory C A _ _ γ₁) ,
-                 ( eq-hom-Slice-Precategory C A _ _ γ₂)))
+          ap
+            ( pr1 ∘ pr1)
+            ( pr2
+              ( ψ (W' , comp-hom-Precategory C f p₁') (p₁' , refl) (p₂' , α'))
+              ( ( ( k') ,
+                  ( ( ap (comp-hom-Precategory C f) (inv γ₁)) ∙
+                    ( ( inv (associative-comp-hom-Precategory C f p₁ k')) ∙
+                      ( ap (λ l → comp-hom-Precategory C l k') (inv α₁))))) ,
+                ( eq-hom-Slice-Precategory C A _ _ γ₁) ,
+                ( eq-hom-Slice-Precategory C A _ _ γ₂)))
 
     equiv-is-pullback-is-product-Slice-Precategory :
       is-pullback-Precategory C A X Y f g W p₁ p₂ α ≃
@@ -393,21 +394,21 @@ module _
     ( map-pullback-product-Slice-Precategory ∘
       map-inv-pullback-product-Slice-Precategory) ~ id
   issec-map-inv-pullback-product-Slice-Precategory
-     ((Z , .(comp-hom-Precategory C f h₁)) , (h₁ , refl) , (h₂ , β₂) , q) =
+    ((Z , .(comp-hom-Precategory C f h₁)) , (h₁ , refl) , (h₂ , β₂) , q) =
     eq-pair-Σ
       ( refl)
       ( eq-pair-Σ
-         ( refl)
-         ( eq-type-subtype
-            ( λ _ →
-              is-product-Precategory-Prop
-                ( Slice-Precategory C A)
-                ( X , f)
-                ( Y , g)
-                ( _)
-                ( _)
-                ( _))
-            ( refl)))
+        ( refl)
+        ( eq-type-subtype
+          ( λ _ →
+            is-product-Precategory-Prop
+              ( Slice-Precategory C A)
+              ( X , f)
+              ( Y , g)
+              ( _)
+              ( _)
+              ( _))
+          ( refl)))
 
   isretr-map-inv-pullback-product-Slice-Precategory :
     ( map-inv-pullback-product-Slice-Precategory ∘

--- a/src/category-theory/yoneda-lemma-precategories.lagda.md
+++ b/src/category-theory/yoneda-lemma-precategories.lagda.md
@@ -80,7 +80,7 @@ module _
     sec yoneda-evid-Precategory
   pr1 sec-yoneda-evid-Precategory = yoneda-extension-Precategory
   pr2 sec-yoneda-evid-Precategory =
-    htpy-eq (preserves-id-functor-Precategory C (Set-Precategory _) F c)
+    htpy-eq (preserves-id-functor-Precategory C (Set-Precategory l1) F c)
 
   retr-yoneda-evid-Precategory :
     retr yoneda-evid-Precategory

--- a/src/commutative-algebra/commutative-rings.lagda.md
+++ b/src/commutative-algebra/commutative-rings.lagda.md
@@ -541,10 +541,11 @@ module _
 
   preserves-concat-add-list-Commutative-Ring :
     (l1 l2 : list type-Commutative-Ring) →
-    Id ( add-list-Commutative-Ring (concat-list l1 l2))
-       ( add-Commutative-Ring
-         ( add-list-Commutative-Ring l1)
-         ( add-list-Commutative-Ring l2))
+    Id
+      ( add-list-Commutative-Ring (concat-list l1 l2))
+      ( add-Commutative-Ring
+        ( add-list-Commutative-Ring l1)
+        ( add-list-Commutative-Ring l2))
   preserves-concat-add-list-Commutative-Ring =
     preserves-concat-add-list-Ring ring-Commutative-Ring
 ```

--- a/src/commutative-algebra/euclidean-domains.lagda.md
+++ b/src/commutative-algebra/euclidean-domains.lagda.md
@@ -631,10 +631,11 @@ module _
 
   preserves-concat-add-list-Euclidean-Domain :
     (l1 l2 : list type-Euclidean-Domain) →
-    Id ( add-list-Euclidean-Domain (concat-list l1 l2))
-       ( add-Euclidean-Domain
-         ( add-list-Euclidean-Domain l1)
-         ( add-list-Euclidean-Domain l2))
+    Id
+      ( add-list-Euclidean-Domain (concat-list l1 l2))
+      ( add-Euclidean-Domain
+        ( add-list-Euclidean-Domain l1)
+        ( add-list-Euclidean-Domain l2))
   preserves-concat-add-list-Euclidean-Domain =
     preserves-concat-add-list-Integral-Domain
       integral-domain-Euclidean-Domain
@@ -680,7 +681,7 @@ module _
           ( y))
         ( remainder-euclidean-division-Euclidean-Domain x y p)))
   equation-euclidean-division-Euclidean-Domain x y p =
-     pr1 (pr2 (pr2 is-euclidean-domain-Euclidean-Domain x y p))
+    pr1 (pr2 (pr2 is-euclidean-domain-Euclidean-Domain x y p))
 
   remainder-condition-euclidean-division-Euclidean-Domain :
     ( x y : type-Euclidean-Domain) →
@@ -691,5 +692,5 @@ module _
       ( remainder-euclidean-division-Euclidean-Domain x y p) <
     ( euclidean-valuation-Euclidean-Domain y))
   remainder-condition-euclidean-division-Euclidean-Domain x y p =
-     pr2 (pr2 (pr2 is-euclidean-domain-Euclidean-Domain x y p))
+    pr2 (pr2 (pr2 is-euclidean-domain-Euclidean-Domain x y p))
 ```

--- a/src/commutative-algebra/ideals-generated-by-subsets-commutative-rings.lagda.md
+++ b/src/commutative-algebra/ideals-generated-by-subsets-commutative-rings.lagda.md
@@ -62,10 +62,11 @@ module _
 
   preserves-concat-ev-formal-combination-subset-Commutative-Ring :
     (u v : formal-combination-subset-Commutative-Ring) →
-    Id ( ev-formal-combination-subset-Commutative-Ring (concat-list u v))
-       ( add-Commutative-Ring R
-         ( ev-formal-combination-subset-Commutative-Ring u)
-         ( ev-formal-combination-subset-Commutative-Ring v))
+    Id
+      ( ev-formal-combination-subset-Commutative-Ring (concat-list u v))
+      ( add-Commutative-Ring R
+        ( ev-formal-combination-subset-Commutative-Ring u)
+        ( ev-formal-combination-subset-Commutative-Ring v))
   preserves-concat-ev-formal-combination-subset-Commutative-Ring =
     preserves-concat-ev-formal-combination-subset-Ring
       ( ring-Commutative-Ring R)
@@ -81,10 +82,11 @@ module _
   preserves-mul-ev-formal-combination-subset-Commutative-Ring :
     (r : type-Commutative-Ring R)
     (u : formal-combination-subset-Commutative-Ring) →
-    Id ( ev-formal-combination-subset-Commutative-Ring
-         ( mul-formal-combination-subset-Commutative-Ring r u))
-       ( mul-Commutative-Ring R r
-         ( ev-formal-combination-subset-Commutative-Ring u))
+    Id
+      ( ev-formal-combination-subset-Commutative-Ring
+        ( mul-formal-combination-subset-Commutative-Ring r u))
+      ( mul-Commutative-Ring R r
+        ( ev-formal-combination-subset-Commutative-Ring u))
   preserves-mul-ev-formal-combination-subset-Commutative-Ring =
     preserves-mul-ev-formal-combination-subset-Ring
       ( ring-Commutative-Ring R)

--- a/src/commutative-algebra/integral-domains.lagda.md
+++ b/src/commutative-algebra/integral-domains.lagda.md
@@ -600,10 +600,11 @@ module _
 
   preserves-concat-add-list-Integral-Domain :
     (l1 l2 : list type-Integral-Domain) →
-    Id ( add-list-Integral-Domain (concat-list l1 l2))
-       ( add-Integral-Domain
-         ( add-list-Integral-Domain l1)
-         ( add-list-Integral-Domain l2))
+    Id
+      ( add-list-Integral-Domain (concat-list l1 l2))
+      ( add-Integral-Domain
+        ( add-list-Integral-Domain l1)
+        ( add-list-Integral-Domain l2))
   preserves-concat-add-list-Integral-Domain =
     preserves-concat-add-list-Commutative-Ring
       commutative-ring-Integral-Domain

--- a/src/commutative-algebra/maximal-ideals-commutative-rings.lagda.md
+++ b/src/commutative-algebra/maximal-ideals-commutative-rings.lagda.md
@@ -18,3 +18,5 @@ module commutative-algebra.maximal-ideals-commutative-rings where
 ideal `J` such that `I ⊆ J` satisfies `1 ∉ J ⇒ I ＝ J`.
 
 ## Definition
+
+This remains to be defined.

--- a/src/commutative-algebra/powers-of-elements-commutative-semirings.lagda.md
+++ b/src/commutative-algebra/powers-of-elements-commutative-semirings.lagda.md
@@ -68,7 +68,7 @@ module _
     power-add-Semiring (semiring-Commutative-Semiring A)
 ```
 
-### If `x` commutes with `y`, then powers distribute over the product of `x` and `y`.
+### If `x` commutes with `y`, then powers distribute over the product of `x` and `y`
 
 ```agda
 module _

--- a/src/commutative-algebra/products-commutative-rings.lagda.md
+++ b/src/commutative-algebra/products-commutative-rings.lagda.md
@@ -105,8 +105,9 @@ module _
 
   associative-add-prod-Commutative-Ring :
     (x y z : type-prod-Commutative-Ring) →
-    Id ( add-prod-Commutative-Ring (add-prod-Commutative-Ring x y) z)
-       ( add-prod-Commutative-Ring x (add-prod-Commutative-Ring y z))
+    Id
+      ( add-prod-Commutative-Ring (add-prod-Commutative-Ring x y) z)
+      ( add-prod-Commutative-Ring x (add-prod-Commutative-Ring y z))
   associative-add-prod-Commutative-Ring =
     associative-add-prod-Ring
       ( ring-Commutative-Ring R1)
@@ -137,8 +138,9 @@ module _
 
   associative-mul-prod-Commutative-Ring :
     (x y z : type-prod-Commutative-Ring) →
-    Id ( mul-prod-Commutative-Ring (mul-prod-Commutative-Ring x y) z)
-       ( mul-prod-Commutative-Ring x (mul-prod-Commutative-Ring y z))
+    Id
+      ( mul-prod-Commutative-Ring (mul-prod-Commutative-Ring x y) z)
+      ( mul-prod-Commutative-Ring x (mul-prod-Commutative-Ring y z))
   associative-mul-prod-Commutative-Ring =
     associative-mul-prod-Ring
       ( ring-Commutative-Ring R1)
@@ -162,10 +164,11 @@ module _
 
   left-distributive-mul-add-prod-Commutative-Ring :
     (x y z : type-prod-Commutative-Ring) →
-    Id ( mul-prod-Commutative-Ring x (add-prod-Commutative-Ring y z))
-       ( add-prod-Commutative-Ring
-         ( mul-prod-Commutative-Ring x y)
-         ( mul-prod-Commutative-Ring x z))
+    Id
+      ( mul-prod-Commutative-Ring x (add-prod-Commutative-Ring y z))
+      ( add-prod-Commutative-Ring
+        ( mul-prod-Commutative-Ring x y)
+        ( mul-prod-Commutative-Ring x z))
   left-distributive-mul-add-prod-Commutative-Ring =
     left-distributive-mul-add-prod-Ring
       ( ring-Commutative-Ring R1)
@@ -173,10 +176,11 @@ module _
 
   right-distributive-mul-add-prod-Commutative-Ring :
     (x y z : type-prod-Commutative-Ring) →
-    Id ( mul-prod-Commutative-Ring (add-prod-Commutative-Ring x y) z)
-       ( add-prod-Commutative-Ring
-         ( mul-prod-Commutative-Ring x z)
-         ( mul-prod-Commutative-Ring y z))
+    Id
+      ( mul-prod-Commutative-Ring (add-prod-Commutative-Ring x y) z)
+      ( add-prod-Commutative-Ring
+        ( mul-prod-Commutative-Ring x z)
+        ( mul-prod-Commutative-Ring y z))
   right-distributive-mul-add-prod-Commutative-Ring =
     right-distributive-mul-add-prod-Ring
       ( ring-Commutative-Ring R1)

--- a/src/elementary-number-theory/addition-integer-fractions.lagda.md
+++ b/src/elementary-number-theory/addition-integer-fractions.lagda.md
@@ -113,9 +113,9 @@ right-unit-law-add-fraction-ℤ :
   (k : fraction-ℤ) →
   sim-fraction-ℤ (k +fraction-ℤ zero-fraction-ℤ) k
 right-unit-law-add-fraction-ℤ (m , n , p) =
- ap-mul-ℤ
-   ( ap-add-ℤ (right-unit-law-mul-ℤ m) refl ∙ right-unit-law-add-ℤ m)
-   ( inv (right-unit-law-mul-ℤ n))
+  ap-mul-ℤ
+    ( ap-add-ℤ (right-unit-law-mul-ℤ m) refl ∙ right-unit-law-add-ℤ m)
+    ( inv (right-unit-law-mul-ℤ n))
 ```
 
 ### Addition is associative

--- a/src/elementary-number-theory/based-strong-induction-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/based-strong-induction-natural-numbers.lagda.md
@@ -130,8 +130,9 @@ cases-eq-succ-based-strong-ind-ℕ :
 cases-eq-succ-based-strong-ind-ℕ k P pS n N f M (inl H) =
   ex-falso (neg-succ-leq-ℕ n H)
 cases-eq-succ-based-strong-ind-ℕ k P pS n N f M (inr α) =
-  ap ( (cases-succ-based-strong-ind-ℕ k P pS n N f (succ-ℕ n) M) ∘ inr)
-     ( eq-is-prop' (is-set-ℕ (succ-ℕ n) (succ-ℕ n)) α refl)
+  ap
+    ( (cases-succ-based-strong-ind-ℕ k P pS n N f (succ-ℕ n) M) ∘ inr)
+    ( eq-is-prop' (is-set-ℕ (succ-ℕ n) (succ-ℕ n)) α refl)
 
 eq-succ-based-strong-ind-ℕ :
   {l : Level} (k : ℕ) (P : ℕ → UU l)
@@ -226,22 +227,22 @@ cases-eq-inductive-step-compute-succ-based-strong-ind-ℕ :
   ( c : (m ≤-ℕ n) + (m ＝ succ-ℕ n)) →
   ( α :
     (I : k ≤-ℕ n) (J : m ≤-ℕ n) →
-     inductive-step-based-strong-ind-ℕ k P
-       ( base-based-strong-ind-ℕ k P p0)
-       ( succ-based-strong-ind-ℕ k P pS)
-       ( n)
-       ( I)
-       ( m)
-       ( M)
-       ( J) ＝
-     inductive-step-based-strong-ind-ℕ k P
-       ( base-based-strong-ind-ℕ k P p0)
-       ( succ-based-strong-ind-ℕ k P pS)
-       ( m)
-       ( M)
-       ( m)
-       ( M)
-       ( refl-leq-ℕ m)) →
+    inductive-step-based-strong-ind-ℕ k P
+      ( base-based-strong-ind-ℕ k P p0)
+      ( succ-based-strong-ind-ℕ k P pS)
+      ( n)
+      ( I)
+      ( m)
+      ( M)
+      ( J) ＝
+    inductive-step-based-strong-ind-ℕ k P
+      ( base-based-strong-ind-ℕ k P p0)
+      ( succ-based-strong-ind-ℕ k P pS)
+      ( m)
+      ( M)
+      ( m)
+      ( M)
+      ( refl-leq-ℕ m)) →
   inductive-step-based-strong-ind-ℕ k P
     ( base-based-strong-ind-ℕ k P p0)
     ( succ-based-strong-ind-ℕ k P pS)

--- a/src/elementary-number-theory/bezouts-lemma-integers.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma-integers.lagda.md
@@ -461,7 +461,7 @@ bezouts-lemma-ℤ (inr (inr x)) (inr (inr y)) =
 Now that Bezout's Lemma has been established, we establish a few corollaries of
 Bezout.
 
-### If `x | y z` and `gcd-Z x y ＝ 1`, then `x | z`.
+### If `x | y z` and `gcd-Z x y ＝ 1`, then `x | z`
 
 ```agda
 div-right-factor-coprime-ℤ :

--- a/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
@@ -677,7 +677,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
           (mul-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
             (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) (int-ℕ y))
           by ap (λ p → dist-ℤ (((int-ℕ (abs-ℤ a)) +ℤ (int-ℕ y)) *ℤ
-             (int-ℕ (succ-ℕ x))) (p *ℤ (int-ℕ y)))
+              (int-ℕ (succ-ℕ x))) (p *ℤ (int-ℕ y)))
           (int-abs-is-nonnegative-ℤ ((int-ℕ (succ-ℕ x)) +ℤ
             (neg-ℤ (int-ℤ-Mod (succ-ℕ x) u))) (int-ℤ-Mod-bounded x u))
         ＝ dist-ℤ
@@ -747,7 +747,7 @@ is-decidable-is-distance-between-multiples-ℕ x y z =
       ¬ ( div-ℤ-Mod x (mod-ℕ x y) (mod-ℕ x z))) →
     is-decidable (is-distance-between-multiples-ℕ x y z)
   decidable-div-ℤ-case-split (inl div-Mod) =
-     inl (is-distance-between-multiples-div-mod-ℕ x y z div-Mod)
+    inl (is-distance-between-multiples-div-mod-ℕ x y z div-Mod)
   decidable-div-ℤ-case-split (inr neg-div-Mod) =
     inr (λ dist → neg-div-Mod
       (div-mod-is-distance-between-multiples-ℕ x y z dist))
@@ -1072,7 +1072,7 @@ remainder-min-dist-succ-x-is-distance x y =
       equational-reasoning
         int-ℕ r
         ＝ add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (((int-ℕ t) *ℤ (int-ℕ y)) +ℤ
-             ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))))))
+            ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))))))
           (add-ℤ ((int-ℕ q) *ℤ (((int-ℕ t) *ℤ (int-ℕ y)) +ℤ
               ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))
           (int-ℕ r))
@@ -1081,7 +1081,7 @@ remainder-min-dist-succ-x-is-distance x y =
             ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x)))))
             (int-ℕ r))
         ＝ add-ℤ (neg-ℤ ((int-ℕ q) *ℤ (((int-ℕ t) *ℤ (int-ℕ y)) +ℤ
-             ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))))))
+            ((neg-ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))))))
           (((int-ℕ q) *ℤ (int-ℕ d)) +ℤ (int-ℕ r))
           by
             ap
@@ -1190,7 +1190,7 @@ remainder-min-dist-succ-x-is-distance x y =
               ( neg-neg-ℤ
                 ( ((int-ℕ q) *ℤ ((int-ℕ s))) *ℤ (int-ℕ (succ-ℕ x))))
         ＝ (neg-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y))) +ℤ
-           ((((int-ℕ q) *ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))) +ℤ
+          ((((int-ℕ q) *ℤ (int-ℕ s)) *ℤ (int-ℕ (succ-ℕ x))) +ℤ
             (int-ℕ (succ-ℕ x)))
           by associative-add-ℤ
             (neg-ℤ (((int-ℕ q) *ℤ (int-ℕ t)) *ℤ (int-ℕ y)))

--- a/src/elementary-number-theory/decidable-types.lagda.md
+++ b/src/elementary-number-theory/decidable-types.lagda.md
@@ -33,7 +33,7 @@ decidable.
 
 ## Properties
 
-### Given a family of decidable types and a number `m` such that `Σ (m ≤ x), P x` is decidable, then `Σ ℕ P` is decidable.
+### Given a family of decidable types and a number `m` such that `Σ (m ≤ x), P x` is decidable, then `Σ ℕ P` is decidable
 
 ```agda
 is-decidable-Σ-ℕ :

--- a/src/elementary-number-theory/distance-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/distance-natural-numbers.lagda.md
@@ -103,9 +103,10 @@ triangle-inequality-dist-ℕ :
 triangle-inequality-dist-ℕ zero-ℕ zero-ℕ zero-ℕ = star
 triangle-inequality-dist-ℕ zero-ℕ zero-ℕ (succ-ℕ k) = star
 triangle-inequality-dist-ℕ zero-ℕ (succ-ℕ n) zero-ℕ =
-  tr ( leq-ℕ (succ-ℕ n))
-     ( inv (left-unit-law-add-ℕ (succ-ℕ n)))
-     ( refl-leq-ℕ (succ-ℕ n))
+  tr
+    ( leq-ℕ (succ-ℕ n))
+    ( inv (left-unit-law-add-ℕ (succ-ℕ n)))
+    ( refl-leq-ℕ (succ-ℕ n))
 triangle-inequality-dist-ℕ zero-ℕ (succ-ℕ n) (succ-ℕ k) =
   concatenate-eq-leq-eq-ℕ
     ( inv (ap succ-ℕ (left-unit-law-dist-ℕ n)))
@@ -132,8 +133,9 @@ triangle-inequality-dist-ℕ (succ-ℕ m) (succ-ℕ n) zero-ℕ =
         ( succ-ℕ ((dist-ℕ m zero-ℕ) +ℕ (dist-ℕ zero-ℕ n)))
         ( succ-leq-ℕ ((dist-ℕ m zero-ℕ) +ℕ (dist-ℕ zero-ℕ n)))
         ( triangle-inequality-dist-ℕ m n zero-ℕ)))
-    ( ( ap (succ-ℕ ∘ succ-ℕ)
-           ( ap-add-ℕ (right-unit-law-dist-ℕ m) (left-unit-law-dist-ℕ n))) ∙
+    ( ( ap
+        ( succ-ℕ ∘ succ-ℕ)
+        ( ap-add-ℕ (right-unit-law-dist-ℕ m) (left-unit-law-dist-ℕ n))) ∙
       ( inv (left-successor-law-add-ℕ m (succ-ℕ n))))
 triangle-inequality-dist-ℕ (succ-ℕ m) (succ-ℕ n) (succ-ℕ k) =
   triangle-inequality-dist-ℕ m n k
@@ -329,12 +331,14 @@ left-distributive-mul-dist-ℕ zero-ℕ zero-ℕ (succ-ℕ k) =
   left-distributive-mul-dist-ℕ zero-ℕ zero-ℕ k
 left-distributive-mul-dist-ℕ zero-ℕ (succ-ℕ n) zero-ℕ = refl
 left-distributive-mul-dist-ℕ zero-ℕ (succ-ℕ n) (succ-ℕ k) =
-  ap ( dist-ℕ' ((succ-ℕ k) *ℕ (succ-ℕ n)))
-     ( inv (right-zero-law-mul-ℕ (succ-ℕ k)))
+  ap
+    ( dist-ℕ' ((succ-ℕ k) *ℕ (succ-ℕ n)))
+    ( inv (right-zero-law-mul-ℕ (succ-ℕ k)))
 left-distributive-mul-dist-ℕ (succ-ℕ m) zero-ℕ zero-ℕ = refl
 left-distributive-mul-dist-ℕ (succ-ℕ m) zero-ℕ (succ-ℕ k) =
-  ap ( dist-ℕ ((succ-ℕ k) *ℕ (succ-ℕ m)))
-     ( inv (right-zero-law-mul-ℕ (succ-ℕ k)))
+  ap
+    ( dist-ℕ ((succ-ℕ k) *ℕ (succ-ℕ m)))
+    ( inv (right-zero-law-mul-ℕ (succ-ℕ k)))
 left-distributive-mul-dist-ℕ (succ-ℕ m) (succ-ℕ n) zero-ℕ = refl
 left-distributive-mul-dist-ℕ (succ-ℕ m) (succ-ℕ n) (succ-ℕ k) =
   inv

--- a/src/elementary-number-theory/divisibility-integers.lagda.md
+++ b/src/elementary-number-theory/divisibility-integers.lagda.md
@@ -176,7 +176,7 @@ is-zero-div-zero-ℤ x (pair d p) = inv p ∙ right-zero-law-mul-ℤ d
 
 ```agda
 eq-quotient-div-is-one-ℤ :
- (k x : ℤ) → is-one-ℤ k → (H : div-ℤ k x) → quotient-div-ℤ k x H ＝ x
+  (k x : ℤ) → is-one-ℤ k → (H : div-ℤ k x) → quotient-div-ℤ k x H ＝ x
 eq-quotient-div-is-one-ℤ .one-ℤ x refl H =
   ap
     ( quotient-div-ℤ one-ℤ x)
@@ -266,7 +266,7 @@ pr2 (reflects-div-mul-ℤ k x y H (pair q p)) =
           ( p))))
 ```
 
-### If a nonzero number `d` divides `y`, then `dx` divides `y` if and only if `x` divides the quotient `y/d`.
+### If a nonzero number `d` divides `y`, then `dx` divides `y` if and only if `x` divides the quotient `y/d`
 
 ```agda
 div-quotient-div-div-ℤ :
@@ -282,9 +282,10 @@ div-div-quotient-div-ℤ :
   (x y d : ℤ) (H : div-ℤ d y) →
   div-ℤ x (quotient-div-ℤ d y H) → div-ℤ (d *ℤ x) y
 div-div-quotient-div-ℤ x y d H K =
-  tr ( div-ℤ (d *ℤ x))
-     ( eq-quotient-div-ℤ' d y H)
-     ( preserves-div-mul-ℤ d x (quotient-div-ℤ d y H) K)
+  tr
+    ( div-ℤ (d *ℤ x))
+    ( eq-quotient-div-ℤ' d y H)
+    ( preserves-div-mul-ℤ d x (quotient-div-ℤ d y H) K)
 ```
 
 ### Comparison of divisibility on `ℕ` and on `ℤ`
@@ -317,7 +318,7 @@ pr2 (div-div-int-ℕ {succ-ℕ x} {y} (pair d p)) =
         ( p)))
 ```
 
-### An integer is a unit if and only if it is `1` or `-1`.
+### An integer is a unit if and only if it is `1` or `-1`
 
 ```agda
 is-one-or-neg-one-ℤ : ℤ → UU lzero
@@ -668,6 +669,8 @@ eq-sim-unit-is-nonnegative-ℤ {a} {b} H H' K | inr neg | inl z =
     ＝ b
       by neg
 eq-sim-unit-is-nonnegative-ℤ {a} {b} H H' K | inr neg | inr nz =
-  ex-falso ( nz ( is-zero-is-nonnegative-neg-is-nonnegative-ℤ
-   a H (tr is-nonnegative-ℤ (inv neg) H')))
+  ex-falso
+    ( nz
+      ( is-zero-is-nonnegative-neg-is-nonnegative-ℤ
+          a H (tr is-nonnegative-ℤ (inv neg) H')))
 ```

--- a/src/elementary-number-theory/divisibility-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/divisibility-natural-numbers.lagda.md
@@ -103,7 +103,7 @@ eq-quotient-div-eq-div-ℕ x y z n e H I =
     ( commutative-mul-ℕ x (quotient-div-ℕ x z H) ∙
       ( eq-quotient-div-ℕ x z H ∙
         ( inv (eq-quotient-div-ℕ y z I) ∙
-           commutative-mul-ℕ (quotient-div-ℕ y z I) y))))
+          commutative-mul-ℕ (quotient-div-ℕ y z I) y))))
 ```
 
 ### Divisibility by a nonzero natural number is a property
@@ -132,12 +132,13 @@ antisymmetric-div-ℕ (succ-ℕ x) zero-ℕ H (pair l q) =
   inv q ∙ right-zero-law-mul-ℕ l
 antisymmetric-div-ℕ (succ-ℕ x) (succ-ℕ y) (pair k p) (pair l q) =
   ( inv (left-unit-law-mul-ℕ (succ-ℕ x))) ∙
-  ( ( ap ( _*ℕ (succ-ℕ x))
-         ( inv
-           ( is-one-right-is-one-mul-ℕ l k
-             ( is-one-is-left-unit-mul-ℕ (l *ℕ k) x
-               ( ( associative-mul-ℕ l k (succ-ℕ x)) ∙
-                 ( ap (l *ℕ_) p ∙ q)))))) ∙
+  ( ( ap
+      ( _*ℕ (succ-ℕ x))
+      ( inv
+        ( is-one-right-is-one-mul-ℕ l k
+          ( is-one-is-left-unit-mul-ℕ (l *ℕ k) x
+            ( ( associative-mul-ℕ l k (succ-ℕ x)) ∙
+              ( ap (l *ℕ_) p ∙ q)))))) ∙
     ( p))
 
 transitive-div-ℕ :
@@ -360,9 +361,10 @@ div-div-quotient-div-ℕ :
   (x y d : ℕ) (H : div-ℕ d y) →
   div-ℕ x (quotient-div-ℕ d y H) → div-ℕ (d *ℕ x) y
 div-div-quotient-div-ℕ x y d H K =
-  tr ( div-ℕ (d *ℕ x))
-     ( eq-quotient-div-ℕ' d y H)
-     ( preserves-div-mul-ℕ d x (quotient-div-ℕ d y H) K)
+  tr
+    ( div-ℕ (d *ℕ x))
+    ( eq-quotient-div-ℕ' d y H)
+    ( preserves-div-mul-ℕ d x (quotient-div-ℕ d y H) K)
 ```
 
 ### If `d` divides a nonzero number `x`, then the quotient `x/d` is also nonzero
@@ -456,7 +458,7 @@ pr2 (pr2 (simplify-div-quotient-div-ℕ {a} {d} {x} nz H) (u , p)) =
           by inv (eq-quotient-div-ℕ d a H))
 ```
 
-### Suppose `H : b | a` and `K : c | b`, where `c` is nonzero. If `d` divides `b/c` then `d` divides `a/c`.
+### Suppose `H : b | a` and `K : c | b`, where `c` is nonzero. If `d` divides `b/c` then `d` divides `a/c`
 
 ```agda
 div-quotient-div-div-quotient-div-ℕ :

--- a/src/elementary-number-theory/euclidean-division-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/euclidean-division-natural-numbers.lagda.md
@@ -127,10 +127,11 @@ eq-euclidean-division-ℕ zero-ℕ x =
       ( right-zero-law-mul-ℕ (quotient-euclidean-division-ℕ zero-ℕ x)))) ∙
   ( left-unit-law-add-ℕ x)
 eq-euclidean-division-ℕ (succ-ℕ k) x =
-  ( ap ( _+ℕ (remainder-euclidean-division-ℕ (succ-ℕ k) x))
-       ( ( pr2 (cong-euclidean-division-ℕ (succ-ℕ k) x)) ∙
-         ( symmetric-dist-ℕ x
-           ( remainder-euclidean-division-ℕ (succ-ℕ k) x)))) ∙
+  ( ap
+    ( _+ℕ (remainder-euclidean-division-ℕ (succ-ℕ k) x))
+    ( ( pr2 (cong-euclidean-division-ℕ (succ-ℕ k) x)) ∙
+      ( symmetric-dist-ℕ x
+        ( remainder-euclidean-division-ℕ (succ-ℕ k) x)))) ∙
   ( is-difference-dist-ℕ' (remainder-euclidean-division-ℕ (succ-ℕ k) x) x
     ( leq-nat-mod-succ-ℕ k x))
 ```

--- a/src/elementary-number-theory/finitary-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/finitary-natural-numbers.lagda.md
@@ -143,11 +143,12 @@ is-injective-convert-based-ℕ
         ( p)
         ( cong-unary-op-ℕ (succ-ℕ k) y (convert-based-ℕ (succ-ℕ k) m))))
 ... | refl =
-  ap ( unary-op-based-ℕ (succ-ℕ k) x)
-     ( is-injective-convert-based-ℕ (succ-ℕ k)
-       ( is-injective-succ-ℕ
-         ( is-injective-left-mul-succ-ℕ k
-           ( is-injective-right-add-ℕ (nat-Fin (succ-ℕ k) x) p))))
+  ap
+    ( unary-op-based-ℕ (succ-ℕ k) x)
+    ( is-injective-convert-based-ℕ (succ-ℕ k)
+      ( is-injective-succ-ℕ
+        ( is-injective-left-mul-succ-ℕ k
+          ( is-injective-right-add-ℕ (nat-Fin (succ-ℕ k) x) p))))
 ```
 
 ### The zero-element of the `k+1`-ary natural numbers
@@ -193,16 +194,19 @@ convert-based-succ-based-ℕ
     ( is-zero-nat-zero-Fin {k})) ∙
   ( right-unit-law-mul-ℕ (succ-ℕ k))
 convert-based-succ-based-ℕ (succ-ℕ k) (unary-op-based-ℕ .(succ-ℕ k) (inl x) n) =
-  ap ( ((succ-ℕ k) *ℕ (succ-ℕ (convert-based-ℕ (succ-ℕ k) n))) +ℕ_)
-     ( nat-succ-Fin k x)
+  ap
+    ( ((succ-ℕ k) *ℕ (succ-ℕ (convert-based-ℕ (succ-ℕ k) n))) +ℕ_)
+    ( nat-succ-Fin k x)
 convert-based-succ-based-ℕ
   (succ-ℕ k) (unary-op-based-ℕ .(succ-ℕ k) (inr star) n) =
-  ( ap ( ( ( succ-ℕ k) *ℕ
-           ( succ-ℕ (convert-based-ℕ (succ-ℕ k) (succ-based-ℕ (succ-ℕ k) n))))
+  ( ap
+    ( ( ( succ-ℕ k) *ℕ
+        ( succ-ℕ (convert-based-ℕ (succ-ℕ k) (succ-based-ℕ (succ-ℕ k) n))))
           +ℕ_)
-       ( is-zero-nat-zero-Fin {k})) ∙
-  ( ( ap ( ((succ-ℕ k) *ℕ_) ∘ succ-ℕ)
-         ( convert-based-succ-based-ℕ (succ-ℕ k) n)) ∙
+    ( is-zero-nat-zero-Fin {k})) ∙
+  ( ( ap
+      ( ((succ-ℕ k) *ℕ_) ∘ succ-ℕ)
+      ( convert-based-succ-based-ℕ (succ-ℕ k) n)) ∙
     ( ( right-successor-law-mul-ℕ
         ( succ-ℕ k)
         ( succ-ℕ (convert-based-ℕ (succ-ℕ k) n))) ∙

--- a/src/elementary-number-theory/fundamental-theorem-of-arithmetic.lagda.md
+++ b/src/elementary-number-theory/fundamental-theorem-of-arithmetic.lagda.md
@@ -141,7 +141,7 @@ module _
         ( is-prop-is-decomposition-list-ℕ))
 
   is-prime-decomposition-list-ℕ-Prop :
-     Prop lzero
+    Prop lzero
   pr1 is-prime-decomposition-list-ℕ-Prop = is-prime-decomposition-list-ℕ
   pr2 is-prime-decomposition-list-ℕ-Prop = is-prop-is-prime-decomposition-list-ℕ
 ```
@@ -225,16 +225,16 @@ is-list-of-nontrivial-divisors-is-decomposition-is-prime-list-ℕ
   ( D)
   ( P) =
   ( is-nontrivial-divisor-head-is-decomposition-is-prime-list-ℕ x y l D P ,
-   is-nontrivial-divisors-div-list-ℕ
-    ( mul-list-ℕ l)
-    ( x)
-    ( y , D)
-    ( l)
-    ( is-list-of-nontrivial-divisors-is-decomposition-is-prime-list-ℕ
+    is-nontrivial-divisors-div-list-ℕ
       ( mul-list-ℕ l)
+      ( x)
+      ( y , D)
       ( l)
-      ( refl)
-      ( pr2 P)))
+      ( is-list-of-nontrivial-divisors-is-decomposition-is-prime-list-ℕ
+        ( mul-list-ℕ l)
+        ( l)
+        ( refl)
+        ( pr2 P)))
 
 is-divisor-head-prime-decomposition-list-ℕ :
   (x : ℕ) (y : ℕ) (l : list ℕ) →
@@ -930,15 +930,15 @@ fundamental-theorem-arithmetic-list-ℕ :
 pr1 (fundamental-theorem-arithmetic-list-ℕ x H) =
   prime-decomposition-fundamental-theorem-arithmetic-list-ℕ x H
 pr2 (fundamental-theorem-arithmetic-list-ℕ x H) d =
-   eq-type-subtype
-     ( is-prime-decomposition-list-ℕ-Prop x)
-     ( eq-prime-decomposition-list-ℕ
-       ( x)
-       ( H)
-       ( list-fundamental-theorem-arithmetic-ℕ x H)
-       ( pr1 d)
-       ( is-prime-decomposition-list-fundamental-theorem-arithmetic-ℕ x H)
-       ( pr2 d))
+  eq-type-subtype
+    ( is-prime-decomposition-list-ℕ-Prop x)
+    ( eq-prime-decomposition-list-ℕ
+      ( x)
+      ( H)
+      ( list-fundamental-theorem-arithmetic-ℕ x H)
+      ( pr1 d)
+      ( is-prime-decomposition-list-fundamental-theorem-arithmetic-ℕ x H)
+      ( pr2 d))
 ```
 
 ### The sorted list associated with the concatenation of the prime decomposition of `n` and the prime decomposition of `m` is the prime decomposition of `n *ℕ m`

--- a/src/elementary-number-theory/fundamental-theorem-of-arithmetic.lagda.md
+++ b/src/elementary-number-theory/fundamental-theorem-of-arithmetic.lagda.md
@@ -140,8 +140,7 @@ module _
         ( is-prop-is-prime-list-ℕ l)
         ( is-prop-is-decomposition-list-ℕ))
 
-  is-prime-decomposition-list-ℕ-Prop :
-    Prop lzero
+  is-prime-decomposition-list-ℕ-Prop : Prop lzero
   pr1 is-prime-decomposition-list-ℕ-Prop = is-prime-decomposition-list-ℕ
   pr2 is-prime-decomposition-list-ℕ-Prop = is-prop-is-prime-decomposition-list-ℕ
 ```

--- a/src/elementary-number-theory/greatest-common-divisor-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/greatest-common-divisor-natural-numbers.lagda.md
@@ -226,7 +226,7 @@ div-gcd-is-common-divisor-ℕ a b x H with
 ... | inr np = pr2 (is-multiple-of-gcd-gcd-ℕ a b np) x H
 ```
 
-### If every common divisor divides a number `r < gcd a b`, then `r = 0`.
+### If every common divisor divides a number `r < gcd a b`, then `r = 0`
 
 ```agda
 is-zero-is-common-divisor-le-gcd-ℕ :
@@ -253,20 +253,22 @@ div-left-factor-div-gcd-ℕ a b x d with
   transitive-div-ℕ x (gcd-ℕ a b) a d
     ( pair q
       ( ( ( α) ∙
-          ( ap ( dist-ℕ a)
-               ( is-zero-is-common-divisor-le-gcd-ℕ a b r B
-                 ( λ x H →
-                   div-right-summand-ℕ x (q *ℕ (gcd-ℕ a b)) r
-                     ( div-mul-ℕ q x (gcd-ℕ a b)
-                       ( div-gcd-is-common-divisor-ℕ a b x H))
-                     ( concatenate-div-eq-ℕ (pr1 H) (inv β)))))) ∙
+          ( ap
+            ( dist-ℕ a)
+            ( is-zero-is-common-divisor-le-gcd-ℕ a b r B
+              ( λ x H →
+                div-right-summand-ℕ x (q *ℕ (gcd-ℕ a b)) r
+                  ( div-mul-ℕ q x (gcd-ℕ a b)
+                    ( div-gcd-is-common-divisor-ℕ a b x H))
+                  ( concatenate-div-eq-ℕ (pr1 H) (inv β)))))) ∙
         ( right-unit-law-dist-ℕ a)))
   where
   r = remainder-euclidean-division-ℕ (gcd-ℕ a b) a
   q = quotient-euclidean-division-ℕ (gcd-ℕ a b) a
   α = eq-quotient-euclidean-division-ℕ (gcd-ℕ a b) a
-  B = strict-upper-bound-remainder-euclidean-division-ℕ (gcd-ℕ a b) a
-       ( is-nonzero-gcd-ℕ a b np)
+  B =
+    strict-upper-bound-remainder-euclidean-division-ℕ
+      (gcd-ℕ a b) a (is-nonzero-gcd-ℕ a b np)
   β = eq-euclidean-division-ℕ (gcd-ℕ a b) a
 
 div-right-factor-div-gcd-ℕ :
@@ -278,20 +280,23 @@ div-right-factor-div-gcd-ℕ a b x d with
 ... | inr np =
   transitive-div-ℕ x (gcd-ℕ a b) b d
     ( pair q
-      ( ( α ∙ ( ap ( dist-ℕ b)
-               ( is-zero-is-common-divisor-le-gcd-ℕ a b r B
-                 ( λ x H →
-                   div-right-summand-ℕ x (q *ℕ (gcd-ℕ a b)) r
-                     ( div-mul-ℕ q x (gcd-ℕ a b)
-                       ( div-gcd-is-common-divisor-ℕ a b x H))
-                     ( concatenate-div-eq-ℕ (pr2 H) (inv β)))))) ∙
+      ( ( α ∙
+          ( ap
+            ( dist-ℕ b)
+            ( is-zero-is-common-divisor-le-gcd-ℕ a b r B
+              ( λ x H →
+                div-right-summand-ℕ x (q *ℕ (gcd-ℕ a b)) r
+                  ( div-mul-ℕ q x (gcd-ℕ a b)
+                    ( div-gcd-is-common-divisor-ℕ a b x H))
+                  ( concatenate-div-eq-ℕ (pr2 H) (inv β)))))) ∙
         ( right-unit-law-dist-ℕ b)))
   where
   r = remainder-euclidean-division-ℕ (gcd-ℕ a b) b
   q = quotient-euclidean-division-ℕ (gcd-ℕ a b) b
   α = eq-quotient-euclidean-division-ℕ (gcd-ℕ a b) b
-  B = strict-upper-bound-remainder-euclidean-division-ℕ (gcd-ℕ a b) b
-       ( is-nonzero-gcd-ℕ a b np)
+  B =
+    strict-upper-bound-remainder-euclidean-division-ℕ
+      (gcd-ℕ a b) b (is-nonzero-gcd-ℕ a b np)
   β = eq-euclidean-division-ℕ (gcd-ℕ a b) b
 
 is-common-divisor-div-gcd-ℕ :
@@ -342,7 +347,7 @@ is-commutative-gcd-ℕ a b =
   pr2 (σ (pair x y)) = x
 ```
 
-### If `d` is a common divisor of `a` and `b`, then `kd` is a common divisor of `ka` and `kb`.
+### If `d` is a common divisor of `a` and `b`, then `kd` is a common divisor of `ka` and `kb`
 
 ```agda
 preserves-is-common-divisor-mul-ℕ :
@@ -405,7 +410,7 @@ is-id-is-gcd-zero-ℕ' {a} {x} H = is-id-is-gcd-zero-ℕ {a} {x}
   ((is-commutative-gcd-ℕ 0 a) ∙ H)
 ```
 
-### Consider a common divisor `d` of `a` and `b` and let `e` be a divisor of `d`. Then any divisor of `d/e` is a common divisor of `a/e` and `b/e`.
+### Consider a common divisor `d` of `a` and `b` and let `e` be a divisor of `d`. Then any divisor of `d/e` is a common divisor of `a/e` and `b/e`
 
 ```agda
 is-common-divisor-quotients-div-quotient-ℕ :

--- a/src/elementary-number-theory/modular-arithmetic-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/modular-arithmetic-standard-finite-types.lagda.md
@@ -446,10 +446,11 @@ is-add-one-succ-Fin' :
 is-add-one-succ-Fin' zero-ℕ (inr star) = refl
 is-add-one-succ-Fin' (succ-ℕ k) x =
   ( ap (succ-Fin (succ-ℕ (succ-ℕ k))) (inv (issec-nat-Fin (succ-ℕ k) x))) ∙
-  ( ap ( mod-succ-ℕ (succ-ℕ k))
-       ( ap
-         ( (nat-Fin (succ-ℕ (succ-ℕ k)) x) +ℕ_)
-         ( inv (is-one-nat-one-Fin (succ-ℕ k)))))
+  ( ap
+    ( mod-succ-ℕ (succ-ℕ k))
+    ( ap
+      ( (nat-Fin (succ-ℕ (succ-ℕ k)) x) +ℕ_)
+      ( inv (is-one-nat-one-Fin (succ-ℕ k)))))
 
 is-add-one-succ-Fin :
   (k : ℕ) (x : Fin (succ-ℕ k)) →
@@ -547,8 +548,9 @@ left-unit-law-mul-Fin (succ-ℕ k) x =
     ( nat-Fin (succ-ℕ (succ-ℕ k)) x)
     ( cong-identification-ℕ
       ( succ-ℕ (succ-ℕ k))
-      ( ( ap ( _*ℕ (nat-Fin (succ-ℕ (succ-ℕ k)) x))
-             ( is-one-nat-one-Fin k)) ∙
+      ( ( ap
+          ( _*ℕ (nat-Fin (succ-ℕ (succ-ℕ k)) x))
+          ( is-one-nat-one-Fin k)) ∙
         ( left-unit-law-mul-ℕ (nat-Fin (succ-ℕ (succ-ℕ k)) x))))) ∙
   ( issec-nat-Fin (succ-ℕ k) x)
 

--- a/src/elementary-number-theory/multiplication-integers.lagda.md
+++ b/src/elementary-number-theory/multiplication-integers.lagda.md
@@ -142,10 +142,10 @@ left-predecessor-law-mul-ℤ (inr (inl star)) l =
 left-predecessor-law-mul-ℤ (inr (inr zero-ℕ)) l =
   inv (left-inverse-law-add-ℤ l)
 left-predecessor-law-mul-ℤ (inr (inr (succ-ℕ x))) l =
-   ( ap
-     ( _+ℤ ((in-pos x) *ℤ l))
-     ( inv (left-inverse-law-add-ℤ l))) ∙
-   ( associative-add-ℤ (neg-ℤ l) l ((in-pos x) *ℤ l))
+  ( ap
+    ( _+ℤ ((in-pos x) *ℤ l))
+    ( inv (left-inverse-law-add-ℤ l))) ∙
+  ( associative-add-ℤ (neg-ℤ l) l ((in-pos x) *ℤ l))
 
 right-successor-law-mul-ℤ :
   (k l : ℤ) → k *ℤ (succ-ℤ l) ＝ k +ℤ (k *ℤ l)
@@ -393,10 +393,11 @@ compute-mul-ℤ (inr (inr zero-ℕ)) (inr (inl star)) = refl
 compute-mul-ℤ (inr (inr (succ-ℕ x))) (inr (inl star)) =
   right-zero-law-mul-ℤ (inr (inr (succ-ℕ x)))
 compute-mul-ℤ (inr (inr zero-ℕ)) (inr (inr y)) =
-  ap ( inr ∘ inr)
-     ( inv
-       ( ( ap (_+ℕ y) (left-zero-law-mul-ℕ (succ-ℕ y))) ∙
-         ( left-unit-law-add-ℕ y)))
+  ap
+    ( inr ∘ inr)
+    ( inv
+      ( ( ap (_+ℕ y) (left-zero-law-mul-ℕ (succ-ℕ y))) ∙
+        ( left-unit-law-add-ℕ y)))
 compute-mul-ℤ (inr (inr (succ-ℕ x))) (inr (inr y)) =
   ( ap ((inr (inr y)) +ℤ_) (compute-mul-ℤ (inr (inr x)) (inr (inr y)))) ∙
   ( ( add-int-ℕ (succ-ℕ y) ((succ-ℕ x) *ℕ (succ-ℕ y))) ∙

--- a/src/elementary-number-theory/multiplication-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/multiplication-natural-numbers.lagda.md
@@ -233,9 +233,10 @@ is-one-right-is-one-mul-ℕ zero-ℕ (succ-ℕ y) ()
 is-one-right-is-one-mul-ℕ (succ-ℕ x) zero-ℕ p =
   is-one-right-is-one-mul-ℕ x zero-ℕ p
 is-one-right-is-one-mul-ℕ (succ-ℕ x) (succ-ℕ y) p =
-  ap ( succ-ℕ)
-     ( is-zero-right-is-zero-add-ℕ (x *ℕ (succ-ℕ y)) y
-       ( is-injective-succ-ℕ p))
+  ap
+    ( succ-ℕ)
+    ( is-zero-right-is-zero-add-ℕ (x *ℕ (succ-ℕ y)) y
+      ( is-injective-succ-ℕ p))
 
 is-one-left-is-one-mul-ℕ :
   (x y : ℕ) → is-one-ℕ (x *ℕ y) → is-one-ℕ x

--- a/src/elementary-number-theory/pisano-periods.lagda.md
+++ b/src/elementary-number-theory/pisano-periods.lagda.md
@@ -56,9 +56,10 @@ inv-generating-map-fibonacci-pair-Fin k (pair x y) =
 
 issec-inv-generating-map-fibonacci-pair-Fin :
   (k : ℕ) (p : Fin (succ-ℕ k) × Fin (succ-ℕ k)) →
-  Id ( generating-map-fibonacci-pair-Fin k
-       ( inv-generating-map-fibonacci-pair-Fin k p))
-     ( p)
+  Id
+    ( generating-map-fibonacci-pair-Fin k
+      ( inv-generating-map-fibonacci-pair-Fin k p))
+    ( p)
 issec-inv-generating-map-fibonacci-pair-Fin k (pair x y) =
   ap-binary pair refl
     ( ( commutative-add-Fin
@@ -71,9 +72,10 @@ issec-inv-generating-map-fibonacci-pair-Fin k (pair x y) =
 
 isretr-inv-generating-map-fibonacci-pair-Fin :
   (k : ℕ) (p : Fin (succ-ℕ k) × Fin (succ-ℕ k)) →
-  Id ( inv-generating-map-fibonacci-pair-Fin k
-       ( generating-map-fibonacci-pair-Fin k p))
-     ( p)
+  Id
+    ( inv-generating-map-fibonacci-pair-Fin k
+      ( generating-map-fibonacci-pair-Fin k p))
+    ( p)
 isretr-inv-generating-map-fibonacci-pair-Fin k (pair x y) =
   ap-binary pair
     ( ( commutative-add-Fin
@@ -101,9 +103,9 @@ fibonacci-pair-Fin k (succ-ℕ n) =
 
 compute-fibonacci-pair-Fin :
   (k : ℕ) (n : ℕ) →
-  Id ( fibonacci-pair-Fin k n)
-     ( pair ( mod-succ-ℕ k (Fibonacci-ℕ n))
-            ( mod-succ-ℕ k (Fibonacci-ℕ (succ-ℕ n))))
+  Id
+    ( fibonacci-pair-Fin k n)
+    ( mod-succ-ℕ k (Fibonacci-ℕ n) , mod-succ-ℕ k (Fibonacci-ℕ (succ-ℕ n)))
 compute-fibonacci-pair-Fin k zero-ℕ = refl
 compute-fibonacci-pair-Fin k (succ-ℕ zero-ℕ) =
   ap-binary pair refl (right-unit-law-add-Fin k (one-Fin k))
@@ -166,11 +168,11 @@ cases-is-repetition-of-zero-pisano-period :
   Id (pisano-period k) y → is-zero-ℕ x
 cases-is-repetition-of-zero-pisano-period k zero-ℕ y p q = refl
 cases-is-repetition-of-zero-pisano-period k (succ-ℕ x) zero-ℕ p q =
-   ex-falso
-     ( concatenate-eq-le-eq-ℕ
-       ( inv p)
-       ( pr1 (pr2 (is-ordered-repetition-pisano-period k)))
-       ( q))
+  ex-falso
+    ( concatenate-eq-le-eq-ℕ
+      ( inv p)
+      ( pr1 (pr2 (is-ordered-repetition-pisano-period k)))
+      ( q))
 cases-is-repetition-of-zero-pisano-period k (succ-ℕ x) (succ-ℕ y) p q =
   ex-falso
     ( contradiction-leq-ℕ y y (refl-leq-ℕ y)
@@ -239,7 +241,8 @@ div-fibonacci-pisano-period k =
         ( ap pr1
           { x = fibonacci-pair-Fin k zero-ℕ}
           { y = fibonacci-pair-Fin k (pisano-period k)}
-          ( ( ap ( fibonacci-pair-Fin k)
-                 ( inv (is-repetition-of-zero-pisano-period k))) ∙
+          ( ( ap
+              ( fibonacci-pair-Fin k)
+              ( inv (is-repetition-of-zero-pisano-period k))) ∙
             ( pr2 (pr2 (is-ordered-repetition-pisano-period k)))))))
 ```

--- a/src/elementary-number-theory/relatively-prime-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/relatively-prime-natural-numbers.lagda.md
@@ -157,7 +157,7 @@ module _
         ( pr1 c))
 
   is-relatively-prime-is-prime-ℕ :
-     is-relatively-prime-ℕ a b
+    is-relatively-prime-ℕ a b
   is-relatively-prime-is-prime-ℕ =
     is-relatively-prime-is-one-is-common-divisor-ℕ
       ( a)

--- a/src/elementary-number-theory/repeating-element-standard-finite-type.lagda.md
+++ b/src/elementary-number-theory/repeating-element-standard-finite-type.lagda.md
@@ -34,11 +34,12 @@ abstract
     ¬ (inl x ＝ y) → ¬ (inl x ＝ z) →
     repeat-Fin k x y ＝ repeat-Fin k x z → y ＝ z
   is-almost-injective-repeat-Fin (succ-ℕ k) (inl x) {inl y} {inl z} f g p =
-    ap ( inl)
-       ( is-almost-injective-repeat-Fin k x
-         ( λ q → f (ap inl q))
-         ( λ q → g (ap inl q))
-         ( is-injective-inl p))
+    ap
+      ( inl)
+      ( is-almost-injective-repeat-Fin k x
+        ( λ q → f (ap inl q))
+        ( λ q → g (ap inl q))
+        ( is-injective-inl p))
   is-almost-injective-repeat-Fin (succ-ℕ k) (inl x) {inl y} {inr star} f g p =
     ex-falso (Eq-Fin-eq (succ-ℕ k) p)
   is-almost-injective-repeat-Fin (succ-ℕ k) (inl x) {inr star} {inl z} f g p =

--- a/src/elementary-number-theory/unit-similarity-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/unit-similarity-standard-finite-types.lagda.md
@@ -84,7 +84,7 @@ pr2 (trans-sim-unit-Fin {succ-ℕ k} x y z (pair u p) (pair v q)) =
   ( ap (mul-Fin (succ-ℕ k) (pr1 v)) p ∙ q)
 ```
 
-### A natural number `x` is congruent to `1` modulo `k+1` if and only if `[x]_{k+1}` is unit similar to `1`.
+### A natural number `x` is congruent to `1` modulo `k+1` if and only if `[x]_{k+1}` is unit similar to `1`
 
 ```agda
 is-unit-similar-one-sim-unit-mod-succ-ℕ :

--- a/src/finite-algebra/commutative-finite-rings.lagda.md
+++ b/src/finite-algebra/commutative-finite-rings.lagda.md
@@ -582,10 +582,11 @@ module _
 
   preserves-concat-add-list-Commutative-Ring-𝔽 :
     (l1 l2 : list type-Commutative-Ring-𝔽) →
-    Id ( add-list-Commutative-Ring-𝔽 (concat-list l1 l2))
-       ( add-Commutative-Ring-𝔽
-         ( add-list-Commutative-Ring-𝔽 l1)
-         ( add-list-Commutative-Ring-𝔽 l2))
+    Id
+      ( add-list-Commutative-Ring-𝔽 (concat-list l1 l2))
+      ( add-Commutative-Ring-𝔽
+        ( add-list-Commutative-Ring-𝔽 l1)
+        ( add-list-Commutative-Ring-𝔽 l2))
   preserves-concat-add-list-Commutative-Ring-𝔽 =
     preserves-concat-add-list-Ring-𝔽 finite-ring-Commutative-Ring-𝔽
 ```

--- a/src/finite-algebra/dependent-products-finite-rings.lagda.md
+++ b/src/finite-algebra/dependent-products-finite-rings.lagda.md
@@ -148,8 +148,9 @@ module _
 
   right-distributive-mul-add-Π-Ring-𝔽 :
     (f g h : type-Π-Ring-𝔽) →
-    Id ( mul-Π-Ring-𝔽 (add-Π-Ring-𝔽 f g) h)
-       ( add-Π-Ring-𝔽 (mul-Π-Ring-𝔽 f h) (mul-Π-Ring-𝔽 g h))
+    Id
+      ( mul-Π-Ring-𝔽 (add-Π-Ring-𝔽 f g) h)
+      ( add-Π-Ring-𝔽 (mul-Π-Ring-𝔽 f h) (mul-Π-Ring-𝔽 g h))
   right-distributive-mul-add-Π-Ring-𝔽 =
     right-distributive-mul-add-Π-Ring (type-𝔽 I) (ring-Ring-𝔽 ∘ A)
 

--- a/src/finite-algebra/finite-fields.lagda.md
+++ b/src/finite-algebra/finite-fields.lagda.md
@@ -532,10 +532,11 @@ module _
 
   preserves-concat-add-list-Field-𝔽 :
     (l1 l2 : list type-Field-𝔽) →
-    Id ( add-list-Field-𝔽 (concat-list l1 l2))
-       ( add-Field-𝔽
-         ( add-list-Field-𝔽 l1)
-         ( add-list-Field-𝔽 l2))
+    Id
+      ( add-list-Field-𝔽 (concat-list l1 l2))
+      ( add-Field-𝔽
+        ( add-list-Field-𝔽 l1)
+        ( add-list-Field-𝔽 l2))
   preserves-concat-add-list-Field-𝔽 =
     preserves-concat-add-list-Ring-𝔽 finite-ring-Field-𝔽
 ```

--- a/src/finite-algebra/finite-groups.lagda.md
+++ b/src/finite-algebra/finite-groups.lagda.md
@@ -229,5 +229,5 @@ module _
                     ( λ x → is-finite-eq-𝔽 X))
                   ( is-finite-Π
                     ( is-finite-type-𝔽 X)
-                     λ x → is-finite-eq-𝔽 X))))
+                    ( λ x → is-finite-eq-𝔽 X)))))
 ```

--- a/src/finite-algebra/finite-rings.lagda.md
+++ b/src/finite-algebra/finite-rings.lagda.md
@@ -493,8 +493,9 @@ module _
 
   preserves-concat-add-list-Ring-𝔽 :
     (l1 l2 : list (type-Ring-𝔽 R)) →
-    Id ( add-list-Ring-𝔽 (concat-list l1 l2))
-       ( add-Ring-𝔽 R (add-list-Ring-𝔽 l1) (add-list-Ring-𝔽 l2))
+    Id
+      ( add-list-Ring-𝔽 (concat-list l1 l2))
+      ( add-Ring-𝔽 R (add-list-Ring-𝔽 l1) (add-list-Ring-𝔽 l2))
   preserves-concat-add-list-Ring-𝔽 =
     preserves-concat-add-list-Ring (ring-Ring-𝔽 R)
 ```

--- a/src/finite-algebra/products-commutative-finite-rings.lagda.md
+++ b/src/finite-algebra/products-commutative-finite-rings.lagda.md
@@ -134,8 +134,9 @@ module _
 
   associative-add-prod-Commutative-Ring-𝔽 :
     (x y z : type-prod-Commutative-Ring-𝔽) →
-    Id ( add-prod-Commutative-Ring-𝔽 (add-prod-Commutative-Ring-𝔽 x y) z)
-       ( add-prod-Commutative-Ring-𝔽 x (add-prod-Commutative-Ring-𝔽 y z))
+    Id
+      ( add-prod-Commutative-Ring-𝔽 (add-prod-Commutative-Ring-𝔽 x y) z)
+      ( add-prod-Commutative-Ring-𝔽 x (add-prod-Commutative-Ring-𝔽 y z))
   associative-add-prod-Commutative-Ring-𝔽 =
     associative-add-prod-Commutative-Ring
       ( commutative-ring-Commutative-Ring-𝔽 R1)
@@ -166,8 +167,9 @@ module _
 
   associative-mul-prod-Commutative-Ring-𝔽 :
     (x y z : type-prod-Commutative-Ring-𝔽) →
-    Id ( mul-prod-Commutative-Ring-𝔽 (mul-prod-Commutative-Ring-𝔽 x y) z)
-       ( mul-prod-Commutative-Ring-𝔽 x (mul-prod-Commutative-Ring-𝔽 y z))
+    Id
+      ( mul-prod-Commutative-Ring-𝔽 (mul-prod-Commutative-Ring-𝔽 x y) z)
+      ( mul-prod-Commutative-Ring-𝔽 x (mul-prod-Commutative-Ring-𝔽 y z))
   associative-mul-prod-Commutative-Ring-𝔽 =
     associative-mul-prod-Commutative-Ring
       ( commutative-ring-Commutative-Ring-𝔽 R1)
@@ -191,10 +193,11 @@ module _
 
   left-distributive-mul-add-prod-Commutative-Ring-𝔽 :
     (x y z : type-prod-Commutative-Ring-𝔽) →
-    Id ( mul-prod-Commutative-Ring-𝔽 x (add-prod-Commutative-Ring-𝔽 y z))
-       ( add-prod-Commutative-Ring-𝔽
-         ( mul-prod-Commutative-Ring-𝔽 x y)
-         ( mul-prod-Commutative-Ring-𝔽 x z))
+    Id
+      ( mul-prod-Commutative-Ring-𝔽 x (add-prod-Commutative-Ring-𝔽 y z))
+      ( add-prod-Commutative-Ring-𝔽
+        ( mul-prod-Commutative-Ring-𝔽 x y)
+        ( mul-prod-Commutative-Ring-𝔽 x z))
   left-distributive-mul-add-prod-Commutative-Ring-𝔽 =
     left-distributive-mul-add-prod-Commutative-Ring
       ( commutative-ring-Commutative-Ring-𝔽 R1)
@@ -202,10 +205,11 @@ module _
 
   right-distributive-mul-add-prod-Commutative-Ring-𝔽 :
     (x y z : type-prod-Commutative-Ring-𝔽) →
-    Id ( mul-prod-Commutative-Ring-𝔽 (add-prod-Commutative-Ring-𝔽 x y) z)
-       ( add-prod-Commutative-Ring-𝔽
-         ( mul-prod-Commutative-Ring-𝔽 x z)
-         ( mul-prod-Commutative-Ring-𝔽 y z))
+    Id
+      ( mul-prod-Commutative-Ring-𝔽 (add-prod-Commutative-Ring-𝔽 x y) z)
+      ( add-prod-Commutative-Ring-𝔽
+        ( mul-prod-Commutative-Ring-𝔽 x z)
+        ( mul-prod-Commutative-Ring-𝔽 y z))
   right-distributive-mul-add-prod-Commutative-Ring-𝔽 =
     right-distributive-mul-add-prod-Commutative-Ring
       ( commutative-ring-Commutative-Ring-𝔽 R1)

--- a/src/finite-algebra/products-finite-rings.lagda.md
+++ b/src/finite-algebra/products-finite-rings.lagda.md
@@ -91,8 +91,9 @@ module _
 
   associative-add-prod-Ring-𝔽 :
     (x y z : type-prod-Ring-𝔽) →
-    Id ( add-prod-Ring-𝔽 (add-prod-Ring-𝔽 x y) z)
-       ( add-prod-Ring-𝔽 x (add-prod-Ring-𝔽 y z))
+    Id
+      ( add-prod-Ring-𝔽 (add-prod-Ring-𝔽 x y) z)
+      ( add-prod-Ring-𝔽 x (add-prod-Ring-𝔽 y z))
   associative-add-prod-Ring-𝔽 =
     associative-add-prod-Ring (ring-Ring-𝔽 R1) (ring-Ring-𝔽 R2)
 
@@ -109,8 +110,9 @@ module _
 
   associative-mul-prod-Ring-𝔽 :
     (x y z : type-prod-Ring-𝔽) →
-    Id ( mul-prod-Ring-𝔽 (mul-prod-Ring-𝔽 x y) z)
-       ( mul-prod-Ring-𝔽 x (mul-prod-Ring-𝔽 y z))
+    Id
+      ( mul-prod-Ring-𝔽 (mul-prod-Ring-𝔽 x y) z)
+      ( mul-prod-Ring-𝔽 x (mul-prod-Ring-𝔽 y z))
   associative-mul-prod-Ring-𝔽 =
     associative-mul-prod-Ring (ring-Ring-𝔽 R1) (ring-Ring-𝔽 R2)
 
@@ -126,15 +128,17 @@ module _
 
   left-distributive-mul-add-prod-Ring-𝔽 :
     (x y z : type-prod-Ring-𝔽) →
-    Id ( mul-prod-Ring-𝔽 x (add-prod-Ring-𝔽 y z))
-       ( add-prod-Ring-𝔽 (mul-prod-Ring-𝔽 x y) (mul-prod-Ring-𝔽 x z))
+    Id
+      ( mul-prod-Ring-𝔽 x (add-prod-Ring-𝔽 y z))
+      ( add-prod-Ring-𝔽 (mul-prod-Ring-𝔽 x y) (mul-prod-Ring-𝔽 x z))
   left-distributive-mul-add-prod-Ring-𝔽 =
     left-distributive-mul-add-prod-Ring (ring-Ring-𝔽 R1) (ring-Ring-𝔽 R2)
 
   right-distributive-mul-add-prod-Ring-𝔽 :
     (x y z : type-prod-Ring-𝔽) →
-    Id ( mul-prod-Ring-𝔽 (add-prod-Ring-𝔽 x y) z)
-       ( add-prod-Ring-𝔽 (mul-prod-Ring-𝔽 x z) (mul-prod-Ring-𝔽 y z))
+    Id
+      ( mul-prod-Ring-𝔽 (add-prod-Ring-𝔽 x y) z)
+      ( add-prod-Ring-𝔽 (mul-prod-Ring-𝔽 x z) (mul-prod-Ring-𝔽 y z))
   right-distributive-mul-add-prod-Ring-𝔽 =
     right-distributive-mul-add-prod-Ring (ring-Ring-𝔽 R1) (ring-Ring-𝔽 R2)
 

--- a/src/finite-group-theory/delooping-sign-homomorphism.lagda.md
+++ b/src/finite-group-theory/delooping-sign-homomorphism.lagda.md
@@ -475,7 +475,7 @@ module _
     type-Group (symmetric-Group (quotient-set-Fin (n +ℕ 2)))
   cases-map-quotient-aut-Fin n h (inl D) = id-equiv
   cases-map-quotient-aut-Fin n h (inr ND) =
-     that-thing n ∘e (equiv-succ-Fin 2 ∘e (inv-equiv (that-thing n)))
+    that-thing n ∘e (equiv-succ-Fin 2 ∘e (inv-equiv (that-thing n)))
 
   map-quotient-aut-Fin :
     (n : ℕ) →

--- a/src/finite-group-theory/orbits-permutations.lagda.md
+++ b/src/finite-group-theory/orbits-permutations.lagda.md
@@ -284,13 +284,15 @@ module _
                 ( f)
                 ( tr
                   ( λ x →
-                    Id ( iterate x (map-equiv f) a)
-                       ( iterate (succ-ℕ pred-second) (map-equiv f) a))
+                    Id
+                      ( iterate x (map-equiv f) a)
+                      ( iterate (succ-ℕ pred-second) (map-equiv f) a))
                   ( equality-pred-first)
                   ( tr
                     ( λ x →
-                      Id ( iterate first-point-min-repeating (map-equiv f) a)
-                         ( iterate x (map-equiv f) a))
+                      Id
+                        ( iterate first-point-min-repeating (map-equiv f) a)
+                        ( iterate x (map-equiv f) a))
                     ( equality-pred-second)
                     ( same-image-iterate-min-reporting)))))))
       where
@@ -326,8 +328,9 @@ module _
   pr2 (pr2 (has-finite-orbits-permutation' (inl p))) =
     tr
       ( λ x →
-        Id ( iterate first-point-min-repeating (map-equiv f) a)
-           ( iterate x (map-equiv f) a))
+        Id
+          ( iterate first-point-min-repeating (map-equiv f) a)
+          ( iterate x (map-equiv f) a))
       ( p)
       ( same-image-iterate-min-reporting)
   has-finite-orbits-permutation' (inr np) =
@@ -714,8 +717,9 @@ module _
       ( Ind :
         (n : ℕ) → C (succ-ℕ n) → is-nonzero-ℕ n → C n) →
       (k : ℕ) → (is-zero-ℕ k + C k) →
-      Id ( iterate k (map-equiv (composition-transposition-a-b g)) x)
-         ( iterate k (map-equiv g) x)
+      Id
+        ( iterate k (map-equiv (composition-transposition-a-b g)) x)
+        ( iterate k (map-equiv g) x)
     equal-iterate-transposition x g C F Ind zero-ℕ p = refl
     equal-iterate-transposition x g C F Ind (succ-ℕ k) (inl p) =
       ex-falso (is-nonzero-succ-ℕ k p)
@@ -730,8 +734,9 @@ module _
       where
       induction-cases-equal-iterate-transposition :
         is-decidable (Id k zero-ℕ) →
-        Id ( iterate k (map-equiv (composition-transposition-a-b g)) x)
-           ( iterate k (map-equiv g) x)
+        Id
+          ( iterate k (map-equiv (composition-transposition-a-b g)) x)
+          ( iterate k (map-equiv g) x)
       induction-cases-equal-iterate-transposition (inl s) =
         tr
           ( λ k →
@@ -1535,7 +1540,7 @@ module _
                     ( pr1 T))
                 { x =
                   composition-transposition-a-b
-                     (composition-transposition-a-b g)}
+                    (composition-transposition-a-b g)}
                 {y = g}
                 ( eq-htpy-equiv (composition-transposition-a-b-involution g))
                 ( pr2

--- a/src/finite-group-theory/permutations-standard-finite-types.lagda.md
+++ b/src/finite-group-theory/permutations-standard-finite-types.lagda.md
@@ -215,10 +215,11 @@ abstract
           neq-inr-inl
             ( is-injective-map-equiv f (p ∙ (r ∙ inv q))))
     lemma :
-      Id ( map-equiv
-           ( pr1 (map-equiv (extend-equiv-Maybe (Fin-Set (succ-ℕ n))) F'))
-           ( inl y))
-         ( inl z)
+      Id
+        ( map-equiv
+          ( pr1 (map-equiv (extend-equiv-Maybe (Fin-Set (succ-ℕ n))) F'))
+          ( inl y))
+        ( inl z)
     lemma =
       ( ap
         ( λ e → map-equiv (pr1 (map-equiv e P)) (inl y))

--- a/src/finite-group-theory/permutations-standard-finite-types.lagda.md
+++ b/src/finite-group-theory/permutations-standard-finite-types.lagda.md
@@ -491,7 +491,7 @@ private
               ( element-two-elements-transposition-Fin P ,
                 other-element-two-elements-transposition-Fin P) ,
               neq-elements-two-elements-transposition-Fin P)
-           ( l)))) ∙h
+            ( l)))) ∙h
     ( map-transposition P ·l
       htpy-permutation-list n l)
 

--- a/src/finite-group-theory/sign-homomorphism.lagda.md
+++ b/src/finite-group-theory/sign-homomorphism.lagda.md
@@ -65,8 +65,9 @@ module _
 
   preserves-add-sign-homomorphism-Fin-two :
     (f g : (type-UU-Fin n X) ≃ (type-UU-Fin n X)) →
-    Id ( sign-homomorphism-Fin-two (f ∘e g))
-       ( add-Fin 2 (sign-homomorphism-Fin-two f) (sign-homomorphism-Fin-two g))
+    Id
+      ( sign-homomorphism-Fin-two (f ∘e g))
+      ( add-Fin 2 (sign-homomorphism-Fin-two f) (sign-homomorphism-Fin-two g))
   preserves-add-sign-homomorphism-Fin-two f g =
     apply-universal-property-trunc-Prop
       ( has-cardinality-type-UU-Fin n X)
@@ -156,9 +157,10 @@ module _
     list-comp-f-g h = concat-list (list-trans f h) (list-trans g h)
     eq-list-comp-f-g :
       ( h : Fin n ≃ type-UU-Fin n X) →
-      Id ( f ∘e g)
-         ( permutation-list-transpositions
-           ( list-comp-f-g h))
+      Id
+        ( f ∘e g)
+        ( permutation-list-transpositions
+          ( list-comp-f-g h))
     eq-list-comp-f-g h =
       eq-htpy-equiv
         ( λ x →
@@ -209,8 +211,9 @@ module _
   preserves-conjugation-sign-homomorphism-Fin-two :
     (f : (type-UU-Fin n X) ≃ (type-UU-Fin n X)) →
     (g : (type-UU-Fin n X) ≃ (type-UU-Fin n Y)) →
-    Id ( sign-homomorphism-Fin-two n Y (g ∘e (f ∘e inv-equiv g)))
-       ( sign-homomorphism-Fin-two n X f)
+    Id
+      ( sign-homomorphism-Fin-two n Y (g ∘e (f ∘e inv-equiv g)))
+      ( sign-homomorphism-Fin-two n X f)
   preserves-conjugation-sign-homomorphism-Fin-two f g =
     apply-universal-property-trunc-Prop
       ( has-cardinality-type-UU-Fin n X)

--- a/src/finite-group-theory/simpson-delooping-sign-homomorphism.lagda.md
+++ b/src/finite-group-theory/simpson-delooping-sign-homomorphism.lagda.md
@@ -631,7 +631,7 @@ module _
           ( inv-equiv ( map-simpson-comp-equiv X X' e f) ∘e
             map-simpson-comp-equiv X X' e f'))
     lemma-sign-comp X X' e f f' =
-       ap
+      ap
         ( sign-homomorphism-Fin-two n (Fin-UU-Fin' n))
         ( ap
           ( inv-equiv f ∘e_)

--- a/src/finite-group-theory/transpositions-standard-finite-types.lagda.md
+++ b/src/finite-group-theory/transpositions-standard-finite-types.lagda.md
@@ -151,7 +151,7 @@ We show that this definiton is an instance of the previous one.
     ( inl (inl x))
     ( inr p)
     ( inr q) =
-     inv
+    inv
       ( is-fixed-point-transposition-Fin
         ( succ-ℕ (succ-ℕ n))
         ( neg-two-Fin (succ-ℕ n))
@@ -246,11 +246,11 @@ cases-htpy-map-coprod-map-transposition-id-Fin
       ( inl-Fin n)
       ( right-computation-transposition-Fin n k l neq)) ∙
     ( inv
-       ( right-computation-transposition-Fin
-         ( succ-ℕ n)
-         ( inl-Fin n k)
-         ( inl-Fin n l)
-         ( neq ∘ is-injective-inl-Fin n))))
+      ( right-computation-transposition-Fin
+        ( succ-ℕ n)
+        ( inl-Fin n k)
+        ( inl-Fin n l)
+        ( neq ∘ is-injective-inl-Fin n))))
 cases-htpy-map-coprod-map-transposition-id-Fin
   ( n)
   ( k)
@@ -439,10 +439,10 @@ htpy-conjugate-transposition-Fin :
     ( transposition-Fin n x z neqxz)
 htpy-conjugate-transposition-Fin n x y z neqxy neqyz neqxz =
   htpy-conjugate-transposition
-   ( has-decidable-equality-Fin n)
-   ( neqxy)
-   ( neqyz)
-   ( neqxz)
+    ( has-decidable-equality-Fin n)
+    ( neqxy)
+    ( neqyz)
+    ( neqxz)
 
 private
   htpy-whisk-conjugate :
@@ -594,14 +594,14 @@ htpy-permutation-inl-list-adjacent-transpositions :
 htpy-permutation-inl-list-adjacent-transpositions n nil =
   inv-htpy (id-map-coprod (Fin (succ-ℕ n)) unit)
 htpy-permutation-inl-list-adjacent-transpositions n (cons x l) =
-   ( ( map-coprod (map-adjacent-transposition-Fin n x) id ·l
-       htpy-permutation-inl-list-adjacent-transpositions n l) ∙h
-     ( ( inv-htpy
-         ( preserves-comp-map-coprod
-           ( map-permutation-list-adjacent-transpositions n l)
-           ( map-adjacent-transposition-Fin n x)
-           ( id)
-           ( id)))))
+  ( map-coprod (map-adjacent-transposition-Fin n x) id ·l
+    htpy-permutation-inl-list-adjacent-transpositions n l) ∙h
+  ( inv-htpy
+      ( preserves-comp-map-coprod
+        ( map-permutation-list-adjacent-transpositions n l)
+        ( map-adjacent-transposition-Fin n x)
+        ( id)
+        ( id)))
 
 htpy-permutation-snoc-list-adjacent-transpositions :
   (n : ℕ) (l : list (Fin n)) (x : Fin n) →

--- a/src/finite-group-theory/transpositions.lagda.md
+++ b/src/finite-group-theory/transpositions.lagda.md
@@ -232,15 +232,17 @@ module _
   -- !! Why not a homotopy?
   eq-concat-permutation-list-transpositions :
     (l l' : list (2-Element-Decidable-Subtype l2 X)) →
-    Id ( ( permutation-list-transpositions l) ∘e
-         ( permutation-list-transpositions l'))
-       ( permutation-list-transpositions (concat-list l l'))
+    Id
+      ( ( permutation-list-transpositions l) ∘e
+        ( permutation-list-transpositions l'))
+      ( permutation-list-transpositions (concat-list l l'))
   eq-concat-permutation-list-transpositions nil l' = eq-htpy-equiv refl-htpy
   eq-concat-permutation-list-transpositions (cons P l) l' =
     eq-htpy-equiv
       ( λ x →
-        ap ( map-equiv (transposition P))
-           ( htpy-eq-equiv (eq-concat-permutation-list-transpositions l l') x))
+        ap
+          ( map-equiv (transposition P))
+          ( htpy-eq-equiv (eq-concat-permutation-list-transpositions l l') x))
 ```
 
 ## Properties
@@ -297,10 +299,11 @@ module _
           ( λ y →
             Σ ( ¬ (Id x y))
               ( λ np →
-                Id ( standard-2-Element-Decidable-Subtype
-                     ( has-decidable-equality-count eX)
-                     ( np))
-                   ( Y))))
+                Id
+                  ( standard-2-Element-Decidable-Subtype
+                    ( has-decidable-equality-count eX)
+                    ( np))
+                  ( Y))))
   pr1 two-elements-transposition =
     pr1 element-is-not-identity-map-transposition
   pr1 (pr2 two-elements-transposition) =
@@ -381,16 +384,18 @@ module _
       (h : Fin 2 ≃ type-2-Element-Decidable-Subtype Y) →
       (k1 k2 k3 : Fin 2) →
       Id ( map-inv-equiv h (pair x p)) k1 →
-      Id ( map-inv-equiv h
-           ( pair
-             ( pr1 two-elements-transposition)
-             ( type-decidable-prop-pr1-two-elements-transposition)))
-         ( k2) →
-      Id ( map-inv-equiv h
-           ( pair
-             ( pr1 (pr2 two-elements-transposition))
-             ( type-decidable-prop-pr1-pr2-two-elements-transposition)))
-         ( k3) →
+      Id
+        ( map-inv-equiv h
+          ( pair
+            ( pr1 two-elements-transposition)
+            ( type-decidable-prop-pr1-two-elements-transposition)))
+        ( k2) →
+      Id
+        ( map-inv-equiv h
+          ( pair
+            ( pr1 (pr2 two-elements-transposition))
+            ( type-decidable-prop-pr1-pr2-two-elements-transposition)))
+        ( k3) →
       ( Id (pr1 two-elements-transposition) x) +
       ( Id (pr1 (pr2 two-elements-transposition)) x)
     cases-coprod-id-type-t x p h (inl (inr star)) (inl (inr star)) k3 K1 K2 K3 =
@@ -676,53 +681,53 @@ module _
       ( H)
       ( has-cardinality-Prop 2
         ( Σ Y (λ x → raise l4 (type-Decidable-Prop (P (map-inv-equiv e x))))))
-       λ h →
-        unit-trunc-Prop
-          ( pair
-            ( λ x →
-              pair
-                ( map-equiv e (pr1 (map-equiv h x)))
-                ( tr
-                  ( λ g →
-                    raise l4
-                      ( type-Decidable-Prop
-                        ( P (map-equiv g (pr1 (map-equiv h x))))))
-                  ( inv (left-inverse-law-equiv e))
-                  ( map-raise (pr2 (map-equiv h x)))))
-            ( is-equiv-has-inverse
-              ( λ (pair x p) →
-                map-inv-equiv h ( pair (map-inv-equiv e x) (map-inv-raise p)))
-              ( λ (pair x p) →
-                eq-pair-Σ
-                  ( ( ap
-                      ( λ g →
-                        map-equiv
-                          ( e)
-                          ( pr1
-                            ( map-equiv
-                              ( g)
-                              ( pair (map-inv-equiv e x) (map-inv-raise p)))))
-                      ( right-inverse-law-equiv h)) ∙
-                    ( ap (λ g → map-equiv g x) (right-inverse-law-equiv e)))
-                  ( eq-is-prop
-                    ( pr1
-                      ( pr2
+      λ h →
+      unit-trunc-Prop
+        ( pair
+          ( λ x →
+            pair
+              ( map-equiv e (pr1 (map-equiv h x)))
+              ( tr
+                ( λ g →
+                  raise l4
+                    ( type-Decidable-Prop
+                      ( P (map-equiv g (pr1 (map-equiv h x))))))
+                ( inv (left-inverse-law-equiv e))
+                ( map-raise (pr2 (map-equiv h x)))))
+          ( is-equiv-has-inverse
+            ( λ (pair x p) →
+              map-inv-equiv h ( pair (map-inv-equiv e x) (map-inv-raise p)))
+            ( λ (pair x p) →
+              eq-pair-Σ
+                ( ( ap
+                    ( λ g →
+                      map-equiv
+                        ( e)
                         ( pr1
-                          ( transposition-conjugation-equiv (pair P H))
-                          ( x))))))
-              ( λ b →
-                ( ap
-                  ( λ w →
-                    map-inv-equiv
-                      ( h)
-                      ( pair (map-equiv (pr1 w) (pr1 (map-equiv h b))) (pr2 w)))
-                  { y = pair id-equiv (pr2 (map-equiv h b))}
-                  ( eq-pair-Σ
-                    ( left-inverse-law-equiv e)
-                    ( eq-is-prop
-                      ( is-prop-type-Decidable-Prop
-                        ( P (pr1 (map-equiv h b)))))) ∙
-                  ( ap (λ g → map-equiv g b) (left-inverse-law-equiv h))))))
+                          ( map-equiv
+                            ( g)
+                            ( pair (map-inv-equiv e x) (map-inv-raise p)))))
+                    ( right-inverse-law-equiv h)) ∙
+                  ( ap (λ g → map-equiv g x) (right-inverse-law-equiv e)))
+                ( eq-is-prop
+                  ( pr1
+                    ( pr2
+                      ( pr1
+                        ( transposition-conjugation-equiv (pair P H))
+                        ( x))))))
+            ( λ b →
+              ( ap
+                ( λ w →
+                  map-inv-equiv
+                    ( h)
+                    ( pair (map-equiv (pr1 w) (pr1 (map-equiv h b))) (pr2 w)))
+                { y = pair id-equiv (pr2 (map-equiv h b))}
+                ( eq-pair-Σ
+                  ( left-inverse-law-equiv e)
+                  ( eq-is-prop
+                    ( is-prop-type-Decidable-Prop
+                      ( P (pr1 (map-equiv h b)))))) ∙
+                ( ap (λ g → map-equiv g b) (left-inverse-law-equiv h))))))
 
   abstract
     correct-transposition-conjugation-equiv :
@@ -857,10 +862,10 @@ pr2 (Fin-succ-Fin-transposition n (pair P H)) =
   where
   f :
     ( Σ (Fin n) (type-Decidable-Prop ∘ P)) + (Σ unit (λ _ → empty)) →
-    Σ (Fin (succ-ℕ n))
-    (λ x →
-       type-Decidable-Prop
-       (pr1 (Fin-succ-Fin-transposition n (pair P H)) x))
+    Σ ( Fin (succ-ℕ n))
+      ( λ x →
+        type-Decidable-Prop
+        (pr1 (Fin-succ-Fin-transposition n (pair P H)) x))
   f (inl (pair x p)) = pair (inl x) p
   inv-f :
     Σ ( Fin (succ-ℕ n))

--- a/src/finite-group-theory/transpositions.lagda.md
+++ b/src/finite-group-theory/transpositions.lagda.md
@@ -588,10 +588,11 @@ module _
           ( λ y →
             Σ ( ¬ (Id x y))
               ( λ np →
-                Id ( standard-2-Element-Decidable-Subtype
-                     ( has-decidable-equality-Fin n)
-                     ( np))
-                   ( Y))))
+                Id
+                  ( standard-2-Element-Decidable-Subtype
+                    ( has-decidable-equality-Fin n)
+                    ( np))
+                  ( Y))))
   two-elements-transposition-Fin =
     tr
       ( λ p →
@@ -605,7 +606,7 @@ module _
                       ( standard-2-Element-Decidable-Subtype
                         ( p)
                         ( np))
-                     ( Y)))))
+                      ( Y)))))
       ( eq-is-prop (is-prop-has-decidable-equality))
       ( two-elements-transposition (count-Fin n) Y)
 

--- a/src/foundation-core/contractible-maps.lagda.md
+++ b/src/foundation-core/contractible-maps.lagda.md
@@ -59,14 +59,15 @@ module _
   isretr-map-inv-is-contr-map :
     (H : is-contr-map f) → ((map-inv-is-contr-map H) ∘ f) ~ id
   isretr-map-inv-is-contr-map H x =
-    ap ( pr1 {B = λ z → (f z) ＝ (f x)})
-       ( ( inv
-           ( contraction
-             ( H (f x))
-             ( pair
-               ( map-inv-is-contr-map H (f x))
-               ( issec-map-inv-is-contr-map H (f x))))) ∙
-         ( contraction (H (f x)) (pair x refl)))
+    ap
+      ( pr1 {B = λ z → (f z) ＝ (f x)})
+      ( ( inv
+          ( contraction
+            ( H (f x))
+            ( pair
+              ( map-inv-is-contr-map H (f x))
+              ( issec-map-inv-is-contr-map H (f x))))) ∙
+        ( contraction (H (f x)) (pair x refl)))
 
   abstract
     is-equiv-is-contr-map : is-contr-map f → is-equiv f

--- a/src/foundation-core/decidable-propositions.lagda.md
+++ b/src/foundation-core/decidable-propositions.lagda.md
@@ -149,9 +149,9 @@ is-merely-decidable-is-decidable-trunc-Prop :
   {l : Level} (A : UU l) →
   is-decidable (type-trunc-Prop A) → is-merely-decidable A
 is-merely-decidable-is-decidable-trunc-Prop A (inl x) =
-   apply-universal-property-trunc-Prop x
-     ( is-merely-Decidable-Prop A)
-     ( unit-trunc-Prop ∘ inl)
+  apply-universal-property-trunc-Prop x
+    ( is-merely-Decidable-Prop A)
+    ( unit-trunc-Prop ∘ inl)
 is-merely-decidable-is-decidable-trunc-Prop A (inr f) =
   unit-trunc-Prop (inr (f ∘ unit-trunc-Prop))
 ```

--- a/src/foundation-core/functoriality-function-types.lagda.md
+++ b/src/foundation-core/functoriality-function-types.lagda.md
@@ -78,11 +78,12 @@ is-equiv-is-equiv-postcomp'
     ( pr1 sec-f)
     ( htpy-eq (pr2 sec-f))
     ( htpy-eq
-      ( ap ( pr1)
-           ( eq-is-contr'
-             ( is-contr-map-is-equiv (is-equiv-postcomp-f X) f)
-             ( pair ((pr1 sec-f) ∘ f) (ap (λ t → t ∘ f) (pr2 sec-f)))
-             ( pair id refl))))
+      ( ap
+        ( pr1)
+        ( eq-is-contr'
+          ( is-contr-map-is-equiv (is-equiv-postcomp-f X) f)
+          ( pair ((pr1 sec-f) ∘ f) (ap (λ t → t ∘ f) (pr2 sec-f)))
+          ( pair id refl))))
 
 abstract
   is-equiv-postcomp-is-equiv :

--- a/src/foundation-core/identity-systems.lagda.md
+++ b/src/foundation-core/identity-systems.lagda.md
@@ -50,15 +50,17 @@ module _
       (is-contr-AB : is-contr (Σ A B)) →
       {l : Level} → IND-identity-system l B a b
     pr1 (Ind-identity-system is-contr-AB P) p x y =
-      tr ( fam-Σ P)
-         ( eq-is-contr is-contr-AB)
-         ( p)
+      tr
+        ( fam-Σ P)
+        ( eq-is-contr is-contr-AB)
+        ( p)
     pr2 (Ind-identity-system is-contr-AB P) p =
-      ap ( λ t → tr (fam-Σ P) t p)
-         ( eq-is-contr'
-           ( is-prop-is-contr is-contr-AB (pair a b) (pair a b))
-           ( eq-is-contr is-contr-AB)
-           ( refl))
+      ap
+        ( λ t → tr (fam-Σ P) t p)
+        ( eq-is-contr'
+          ( is-prop-is-contr is-contr-AB (pair a b) (pair a b))
+          ( eq-is-contr is-contr-AB)
+          ( refl))
 
   abstract
     is-contr-total-space-IND-identity-system :

--- a/src/foundation-core/type-arithmetic-dependent-pair-types.lagda.md
+++ b/src/foundation-core/type-arithmetic-dependent-pair-types.lagda.md
@@ -50,8 +50,9 @@ module _
   issec-map-inv-left-unit-law-Σ-is-contr :
     ( map-left-unit-law-Σ-is-contr ∘ map-inv-left-unit-law-Σ-is-contr) ~ id
   issec-map-inv-left-unit-law-Σ-is-contr b =
-    ap ( λ (f : B a → B a) → f b)
-       ( compute-ind-singleton-is-contr a C (λ x → B x → B a) id)
+    ap
+      ( λ (f : B a → B a) → f b)
+      ( compute-ind-singleton-is-contr a C (λ x → B x → B a) id)
 
   isretr-map-inv-left-unit-law-Σ-is-contr :
     ( map-inv-left-unit-law-Σ-is-contr ∘ map-left-unit-law-Σ-is-contr) ~ id
@@ -60,14 +61,16 @@ module _
       ( ind-singleton-is-contr a C
         ( λ x →
           ( y : B x) →
-            Id ( ( map-inv-left-unit-law-Σ-is-contr ∘
-                   map-left-unit-law-Σ-is-contr)
-                 ( pair x y))
-               ( pair x y))
+            Id
+              ( ( map-inv-left-unit-law-Σ-is-contr ∘
+                  map-left-unit-law-Σ-is-contr)
+                ( pair x y))
+              ( pair x y))
         ( λ y → ap
           ( map-inv-left-unit-law-Σ-is-contr)
-          ( ap ( λ f → f y)
-               ( compute-ind-singleton-is-contr a C (λ x → B x → B a) id))))
+          ( ap
+            ( λ f → f y)
+            ( compute-ind-singleton-is-contr a C (λ x → B x → B a) id))))
 
   is-equiv-map-left-unit-law-Σ-is-contr :
     is-equiv map-left-unit-law-Σ-is-contr

--- a/src/foundation/apartness-relations.lagda.md
+++ b/src/foundation/apartness-relations.lagda.md
@@ -195,20 +195,20 @@ module _
         ( rel-apart-function-into-Type-With-Apartness X Y g h))
       ( λ (x , a) →
         apply-universal-property-trunc-Prop
-         ( cotransitive-apart-Type-With-Apartness Y (f x) (g x) (h x) a)
-         ( disj-Prop
-           ( rel-apart-function-into-Type-With-Apartness X Y f h)
-           ( rel-apart-function-into-Type-With-Apartness X Y g h))
-         ( λ { (inl b) →
-               inl-disj-Prop
-                 ( rel-apart-function-into-Type-With-Apartness X Y f h)
-                 ( rel-apart-function-into-Type-With-Apartness X Y g h)
-                 ( unit-trunc-Prop (x , b)) ;
-               (inr b) →
-               inr-disj-Prop
-                 ( rel-apart-function-into-Type-With-Apartness X Y f h)
-                 ( rel-apart-function-into-Type-With-Apartness X Y g h)
-                 ( unit-trunc-Prop (x , b))}))
+          ( cotransitive-apart-Type-With-Apartness Y (f x) (g x) (h x) a)
+          ( disj-Prop
+            ( rel-apart-function-into-Type-With-Apartness X Y f h)
+            ( rel-apart-function-into-Type-With-Apartness X Y g h))
+          ( λ { (inl b) →
+                inl-disj-Prop
+                  ( rel-apart-function-into-Type-With-Apartness X Y f h)
+                  ( rel-apart-function-into-Type-With-Apartness X Y g h)
+                  ( unit-trunc-Prop (x , b)) ;
+                (inr b) →
+                inr-disj-Prop
+                  ( rel-apart-function-into-Type-With-Apartness X Y f h)
+                  ( rel-apart-function-into-Type-With-Apartness X Y g h)
+                  ( unit-trunc-Prop (x , b))}))
 
   exp-Type-With-Apartness : Type-With-Apartness (l1 ⊔ l2) (l1 ⊔ l3)
   pr1 exp-Type-With-Apartness = X → type-Type-With-Apartness Y

--- a/src/foundation/arithmetic-law-coproduct-and-sigma-decompositions.lagda.md
+++ b/src/foundation/arithmetic-law-coproduct-and-sigma-decompositions.lagda.md
@@ -45,7 +45,7 @@ We also show a computational rule to simplify the use of this equivalence.
 
 ## Propositions
 
-### Coproduct decomposition of the indexing type of a relaxed Σ-decomposition are equivalent to relaxed Σ-decomposition of the left and right summand of a coproduct decomposition.
+### Coproduct decomposition of the indexing type of a relaxed Σ-decomposition are equivalent to relaxed Σ-decomposition of the left and right summand of a coproduct decomposition
 
 ```agda
 module _

--- a/src/foundation/arithmetic-law-product-and-pi-decompositions.lagda.md
+++ b/src/foundation/arithmetic-law-product-and-pi-decompositions.lagda.md
@@ -62,10 +62,10 @@ module _
           ( indexing-type-Π-Decomposition d)) ≃
         Σ ( UU l)
           ( λ A →
-             Σ ( UU l)
-               ( λ B →
-                 Σ ( Σ ( UU l) λ U → ( U ≃ (A + B)))
-                   ( λ U → Σ (pr1 U → UU l) (λ Y → X ≃ Π (pr1 U) Y))))
+            Σ ( UU l)
+              ( λ B →
+                Σ ( Σ ( UU l) λ U → ( U ≃ (A + B)))
+                  ( λ U → Σ (pr1 U → UU l) (λ Y → X ≃ Π (pr1 U) Y))))
     pr1 reassociate ((U , V , f) , A , B , e) = (A , B , (U , e) , V , f)
     pr2 reassociate =
       is-equiv-has-inverse
@@ -103,7 +103,7 @@ module _
     Σ ( Π-Decomposition l l X)
       ( λ d →
         binary-coproduct-Decomposition l l
-         ( indexing-type-Π-Decomposition d)) ≃
+          ( indexing-type-Π-Decomposition d)) ≃
     Σ ( binary-product-Decomposition l l X)
       ( λ d →
         Π-Decomposition l l

--- a/src/foundation/arithmetic-law-product-and-pi-decompositions.lagda.md
+++ b/src/foundation/arithmetic-law-product-and-pi-decompositions.lagda.md
@@ -37,18 +37,18 @@ open import foundation-core.universe-levels
 Let `X` be a type, we have the following equivalence :
 
 ```text
- Σ ( (U , V , e) : Π-Decomposition X)
-   ( binary-product-Decomposition U) ≃
- Σ ( (A , B , e) : binary-product-Decomposition X)
-   ( Π-Decomposition A ×
-     Π-Decomposition B )
+  Σ ( (U , V , e) : Π-Decomposition X)
+    ( binary-product-Decomposition U) ≃
+  Σ ( (A , B , e) : binary-product-Decomposition X)
+    ( Π-Decomposition A ×
+      Π-Decomposition B )
 ```
 
 We also show a computational rule to simplify the use of this equivalence.
 
 ## Propositions
 
-### Product decompositions of the indexing type of a Π-decomposition are equivalent to Π-decomposition of the left and right summand of a product decomposition.
+### Product decompositions of the indexing type of a Π-decomposition are equivalent to Π-decomposition of the left and right summand of a product decomposition
 
 ```agda
 module _

--- a/src/foundation/choice-of-representatives-equivalence-relation.lagda.md
+++ b/src/foundation/choice-of-representatives-equivalence-relation.lagda.md
@@ -101,7 +101,7 @@ module _
   equiv-equivalence-class-representatives :
     {P : A → UU l3} (H : is-choice-of-representatives P) →
     representatives H ≃ equivalence-class R
-  equiv-equivalence-class-representatives H =
-    pair ( class-representatives H)
-         ( is-equiv-class-representatives H)
+  pr1 (equiv-equivalence-class-representatives H) = class-representatives H
+  pr2 (equiv-equivalence-class-representatives H) =
+    is-equiv-class-representatives H
 ```

--- a/src/foundation/commuting-cubes-of-maps.lagda.md
+++ b/src/foundation/commuting-cubes-of-maps.lagda.md
@@ -36,8 +36,9 @@ coherence-htpy-parallel-cone-coherence-cube-maps :
   (front-left : (h ∘ hB) ~ (hD ∘ h'))
   (front-right : (k ∘ hC) ~ (hD ∘ k'))
   (bottom : (h ∘ f) ~ (k ∘ g)) →
-  (c : coherence-cube-maps f g h k f' g' h' k' hA hB hC hD
-       top back-left back-right front-left front-right bottom) →
+  (c :
+    coherence-cube-maps f g h k f' g' h' k' hA hB hC hD
+    top back-left back-right front-left front-right bottom) →
   coherence-htpy-parallel-cone
     ( front-left)
     ( refl-htpy' k)

--- a/src/foundation/coproduct-decompositions-subuniverse.lagda.md
+++ b/src/foundation/coproduct-decompositions-subuniverse.lagda.md
@@ -105,9 +105,9 @@ module _
   right-iterated-binary-coproduct-Decomposition-subuniverse : UU (lsuc l1 ⊔ l2)
   right-iterated-binary-coproduct-Decomposition-subuniverse =
     Σ ( binary-coproduct-Decomposition-subuniverse P X)
-       ( λ d →
-         binary-coproduct-Decomposition-subuniverse P
-           ( right-summand-binary-coproduct-Decomposition-subuniverse P X d))
+      ( λ d →
+        binary-coproduct-Decomposition-subuniverse P
+          ( right-summand-binary-coproduct-Decomposition-subuniverse P X d))
 ```
 
 ### Ternary coproduct Decomposition-subuniverses
@@ -120,11 +120,11 @@ module _
   ternary-coproduct-Decomposition-subuniverse : UU (lsuc l1 ⊔ l2)
   ternary-coproduct-Decomposition-subuniverse =
     Σ ( type-subuniverse P × (type-subuniverse P × type-subuniverse P))
-       ( λ x →
-         inclusion-subuniverse P X ≃
-         ( inclusion-subuniverse P (pr1 x) +
-           ( inclusion-subuniverse P (pr1 (pr2 x)) +
-             inclusion-subuniverse P (pr2 (pr2 x)))))
+      ( λ x →
+        inclusion-subuniverse P X ≃
+        ( inclusion-subuniverse P (pr1 x) +
+          ( inclusion-subuniverse P (pr1 (pr2 x)) +
+            inclusion-subuniverse P (pr2 (pr2 x)))))
 
   module _
     (d : ternary-coproduct-Decomposition-subuniverse)

--- a/src/foundation/coproduct-decompositions.lagda.md
+++ b/src/foundation/coproduct-decompositions.lagda.md
@@ -90,14 +90,14 @@ pr2 (equiv-coproduct-Decomposition-full-subuniverse X) =
         ( λ _ → unit-Prop)
         ( X , star)
         ( d) ,
-     type-right-summand-binary-coproduct-Decomposition-subuniverse
-       ( λ _ → unit-Prop)
-       ( X , star)
-       ( d) ,
-     matching-correspondence-binary-coproduct-Decomposition-subuniverse
-       ( λ _ → unit-Prop)
-       ( X , star)
-       ( d))
+      type-right-summand-binary-coproduct-Decomposition-subuniverse
+        ( λ _ → unit-Prop)
+        ( X , star)
+        ( d) ,
+      matching-correspondence-binary-coproduct-Decomposition-subuniverse
+        ( λ _ → unit-Prop)
+        ( X , star)
+        ( d))
     ( λ d →
       eq-equiv-binary-coproduct-Decomposition-subuniverse
         ( λ _ → unit-Prop)
@@ -271,11 +271,11 @@ module _
                     ( is-contr-Fin-one-ℕ)
                     ( inr star))
                   ( map-left-unit-law-Σ-is-contr is-contr-unit star))
-                  ( map-right-distributive-Σ-coprod
-                    ( Fin 1)
-                    ( unit)
-                    ( λ x → fib f x)
-                    ( pr1 a , x , pr2 a))))
+                ( map-right-distributive-Σ-coprod
+                  ( Fin 1)
+                  ( unit)
+                  ( λ x → fib f x)
+                  ( pr1 a , x , pr2 a))))
             ( λ z → pr1 (pr1 z) ＝ x))
         ( eq-pair-Σ p ( tr-Id p (inv p) ∙ left-inv p))
         ( ( ( x , (inv p)) ,
@@ -284,7 +284,7 @@ module _
               ( inv
                 ( inv-map-eq-transpose-equiv
                   ( left-unit-law-Σ-is-contr is-contr-Fin-one-ℕ (inr star))
-                  ( refl))))),
+                  ( refl))))) ,
           refl)
 
     compute-left-inv-matching-correspondence-binary-coporducd-Decomposition-map-into-Fin-Two-ℕ :
@@ -334,11 +334,11 @@ module _
                       ( is-contr-Fin-one-ℕ)
                       ( inr star))
                     ( map-left-unit-law-Σ-is-contr is-contr-unit star))
-                    ( map-right-distributive-Σ-coprod
-                      ( Fin 1)
-                      ( unit)
-                      ( λ x → fib f x)
-                      ( pr1 a , x , pr2 a))))
+                  ( map-right-distributive-Σ-coprod
+                    ( Fin 1)
+                    ( unit)
+                    ( λ x → fib f x)
+                    ( pr1 a , x , pr2 a))))
             ( λ z → pr1 (pr1 z) ＝ x))
         ( eq-pair-Σ p ( tr-Id p (inv p) ∙ left-inv p))
         ( ( ( x , (inv p)) ,
@@ -479,10 +479,8 @@ module _
     f x (inl y) =
     ( inv
       ( ap
-          ( λ p →
-            map-inv-equiv-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ-helper
-              ( map-equiv-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ f)
-              ( p))
+          ( map-inv-equiv-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ-helper
+              ( map-equiv-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ f))
           ( pr2
             ( pr1
               ( compute-left-matching-correspondence-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ
@@ -563,7 +561,7 @@ module _
     right-summand-binary-coproduct-Decomposition d
   equiv-right-summand-issec-map-inv-equiv-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ
     d =
-   ( ( left-unit-law-coprod
+    ( ( left-unit-law-coprod
         ( right-summand-binary-coproduct-Decomposition d)) ∘e
       ( ( equiv-coprod
           ( right-absorption-Σ
@@ -673,29 +671,29 @@ module _
                     ( λ y →
                       map-inv-equiv-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ-helper
                         d y ＝ inr star)))))
-           ( x)))
+            ( x)))
       ( eq-pair-Σ
-        {t =
+        { t =
           ( inr
-             ( pr1
-               ( compute-right-map-inv-equiv-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ
-                 ( d)
-                 ( x)
-                 ( inv p))),
-            refl)}
-          ( inv
-            ( pr2
+            ( pr1
               ( compute-right-map-inv-equiv-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ
                 ( d)
                 ( x)
-                ( inv p))))
-          ( eq-is-prop
-            ( is-set-Fin 2 _ _))) ∙
+                ( inv p))),
+            refl)}
+        ( inv
+          ( pr2
+            ( compute-right-map-inv-equiv-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ
+              ( d)
+              ( x)
+              ( inv p))))
+        ( eq-is-prop
+          ( is-set-Fin 2 _ _))) ∙
     ( pr2
-        ( compute-right-map-inv-equiv-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ
-          ( d)
-          ( x)
-          ( inv p)))
+      ( compute-right-map-inv-equiv-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ
+        ( d)
+        ( x)
+        ( inv p)))
 
   matching-correspondence-htpy-issec-map-inv-equiv-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ-helper :
     ( d : binary-coproduct-Decomposition l1 l1 X) →
@@ -717,7 +715,7 @@ module _
             ( d))) ∘
       map-equiv
         ( matching-correspondence-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ
-          (map-inv-equiv-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ d)))
+          ( map-inv-equiv-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ d)))
       ( x) ＝
     map-equiv (matching-correspondence-binary-coproduct-Decomposition d) x
   matching-correspondence-htpy-issec-map-inv-equiv-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ-helper
@@ -741,30 +739,30 @@ module _
     ( compute-equiv-left-summand-issec-map-inv-equiv-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ
       ( d)
       ( pr1
-         ( pr1
-           ( pr1
-             ( compute-left-matching-correspondence-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ
-               ( map-inv-equiv-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ
-                  ( d))
-               ( x)
-               ( p)))) ,
-        pr2
+        ( pr1
+          ( pr1
+            ( compute-left-matching-correspondence-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ
+              ( map-inv-equiv-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ
+                ( d))
+              ( x)
+              ( p)))) ,
+        ( pr2
           ( pr1
             ( pr1
               ( compute-left-matching-correspondence-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ
                 ( map-inv-equiv-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ
                   ( d))
                 ( x)
-                ( p))))) ∙
+                ( p)))))) ∙
       ap
         ( map-equiv
           ( matching-correspondence-binary-coproduct-Decomposition d))
         ( pr2
-            ( compute-left-matching-correspondence-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ
-              ( map-inv-equiv-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ
-                ( d))
-              ( x)
-              ( p))))
+          ( compute-left-matching-correspondence-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ
+            ( map-inv-equiv-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ
+              ( d))
+            ( x)
+            ( p))))
   matching-correspondence-htpy-issec-map-inv-equiv-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ-helper
     d x (inr p) =
     ap

--- a/src/foundation/epimorphisms-with-respect-to-sets.lagda.md
+++ b/src/foundation/epimorphisms-with-respect-to-sets.lagda.md
@@ -76,18 +76,19 @@ abstract
   is-surjective-is-epimorphism-Set {l1} {l2} {A} {B} {f} H b =
     map-equiv
       ( equiv-eq
-        ( ap ( pr1)
-             ( htpy-eq
-               ( is-injective-is-emb
-                 ( H (Prop-Set (l1 ⊔ l2)))
-                 { g}
-                 { h}
-                 ( eq-htpy
-                   ( λ a →
-                     eq-iff
-                       ( λ _ → unit-trunc-Prop (pair a refl))
-                       ( λ _ → raise-star))))
-               ( b))))
+        ( ap
+          ( pr1)
+          ( htpy-eq
+            ( is-injective-is-emb
+              ( H (Prop-Set (l1 ⊔ l2)))
+              { g}
+              { h}
+              ( eq-htpy
+                ( λ a →
+                  eq-iff
+                    ( λ _ → unit-trunc-Prop (pair a refl))
+                    ( λ _ → raise-star))))
+            ( b))))
       ( raise-star)
     where
     g : B → Prop (l1 ⊔ l2)

--- a/src/foundation/equivalences-maybe.lagda.md
+++ b/src/foundation/equivalences-maybe.lagda.md
@@ -337,8 +337,9 @@ abstract
     is-injective-unit-Maybe
       ( ( compute-map-inv-equiv-equiv-is-exception-Maybe e
           ( map-equiv-equiv-Maybe e x)
-          ( ( ap ( map-inv-equiv e)
-                 ( compute-map-equiv-equiv-is-exception-Maybe e x p)) ∙
+          ( ( ap
+              ( map-inv-equiv e)
+              ( compute-map-equiv-equiv-is-exception-Maybe e x p)) ∙
             ( isretr-map-inv-equiv e exception-Maybe))) ∙
         ( ( ap (map-inv-equiv e) (inv p)) ∙
           ( isretr-map-inv-equiv e (inl x))))
@@ -350,12 +351,14 @@ abstract
             ( map-inv-equiv e (inl (map-equiv-equiv-Maybe e x)))
             ( pair x
               ( inv
-                ( ( ap (map-inv-equiv e)
-                       ( compute-map-equiv-equiv-is-not-exception-Maybe
-                          e x f)) ∙
+                ( ( ap
+                    ( map-inv-equiv e)
+                    ( compute-map-equiv-equiv-is-not-exception-Maybe
+                        e x f)) ∙
                   ( isretr-map-inv-equiv e (inl x))))))) ∙
-        ( ( ap ( map-inv-equiv e)
-               ( compute-map-equiv-equiv-is-not-exception-Maybe e x f)) ∙
+        ( ( ap
+            ( map-inv-equiv e)
+            ( compute-map-equiv-equiv-is-not-exception-Maybe e x f)) ∙
           ( isretr-map-inv-equiv e (inl x))))
 ```
 

--- a/src/foundation/equivalences.lagda.md
+++ b/src/foundation/equivalences.lagda.md
@@ -90,10 +90,11 @@ module _
       ( issec-map-inv-equiv e y)) ＝
     ( p)
   triangle-eq-transpose-equiv {x} {y} p =
-    ( ap ( concat' (map-equiv e x) (issec-map-inv-equiv e y))
-         ( issec-map-inv-equiv
-           ( equiv-ap e x (map-inv-equiv e y))
-           ( p ∙ inv (issec-map-inv-equiv e y)))) ∙
+    ( ap
+      ( concat' (map-equiv e x) (issec-map-inv-equiv e y))
+      ( issec-map-inv-equiv
+        ( equiv-ap e x (map-inv-equiv e y))
+        ( p ∙ inv (issec-map-inv-equiv e y)))) ∙
     ( ( assoc
         ( p)
         ( inv (issec-map-inv-equiv e y))
@@ -125,13 +126,15 @@ module _
               ( ap (map-equiv e) (inv (map-eq-transpose-equiv' p)))
               ( issec-map-inv-equiv e y)
               ( inv p)
-              ( ( ap ( concat' (map-equiv e x) (issec-map-inv-equiv e y))
-                     ( ap ( ap (map-equiv e))
-                          ( inv-inv
-                            ( map-inv-equiv
-                              ( equiv-ap e x (map-inv-equiv e y))
-                              ( ( inv p) ∙
-                                ( inv (issec-map-inv-equiv e y))))))) ∙
+              ( ( ap
+                  ( concat' (map-equiv e x) (issec-map-inv-equiv e y))
+                  ( ap
+                    ( ap (map-equiv e))
+                    ( inv-inv
+                      ( map-inv-equiv
+                        ( equiv-ap e x (map-inv-equiv e y))
+                        ( ( inv p) ∙
+                          ( inv (issec-map-inv-equiv e y))))))) ∙
                 ( triangle-eq-transpose-equiv (inv p))))) ∙
           ( ap-inv (map-equiv e) (map-eq-transpose-equiv' p))))
 ```
@@ -186,13 +189,14 @@ abstract
     is-equiv-has-inverse
       ( pr1 retr-f)
       ( htpy-eq
-        ( ap ( pr1)
-             ( eq-is-contr'
-               ( is-contr-map-is-equiv (is-equiv-precomp-f _ B) f)
-                 ( pair
-                   ( f ∘ (pr1 retr-f))
-                   ( ap (λ (g : pr1 A → pr1 A) → f ∘ g) (pr2 retr-f)))
-                 ( pair id refl))))
+        ( ap
+          ( pr1)
+          ( eq-is-contr'
+            ( is-contr-map-is-equiv (is-equiv-precomp-f _ B) f)
+            ( pair
+              ( f ∘ (pr1 retr-f))
+              ( ap (λ (g : pr1 A → pr1 A) → f ∘ g) (pr2 retr-f)))
+            ( pair id refl))))
       ( htpy-eq (pr2 retr-f))
 ```
 

--- a/src/foundation/exclusive-disjunction.lagda.md
+++ b/src/foundation/exclusive-disjunction.lagda.md
@@ -178,16 +178,16 @@ module _
     ( equiv-coprod
       ( equiv-tot
         ( λ p →
-           ( ( equiv-map-Π
-               ( λ q → compute-eq-coprod-inl-inr p q)) ∘e
-             ( left-unit-law-prod-is-contr
-               ( is-contr-Π
-                 ( λ p' →
-                   is-contr-equiv'
-                     ( p ＝ p')
-                     ( equiv-ap-emb (emb-inl (type-Prop P) (type-Prop Q)))
-                     ( is-prop-type-Prop P p p'))))) ∘e
-           ( equiv-dependent-universal-property-coprod (λ x → inl p ＝ x))))
+          ( ( equiv-map-Π
+              ( λ q → compute-eq-coprod-inl-inr p q)) ∘e
+            ( left-unit-law-prod-is-contr
+              ( is-contr-Π
+                ( λ p' →
+                  is-contr-equiv'
+                    ( p ＝ p')
+                    ( equiv-ap-emb (emb-inl (type-Prop P) (type-Prop Q)))
+                    ( is-prop-type-Prop P p p'))))) ∘e
+          ( equiv-dependent-universal-property-coprod (λ x → inl p ＝ x))))
       ( equiv-tot
         ( λ q →
           ( ( equiv-map-Π

--- a/src/foundation/functoriality-coproduct-types.lagda.md
+++ b/src/foundation/functoriality-coproduct-types.lagda.md
@@ -243,7 +243,7 @@ module _
         ( λ {(a , p) → unit-trunc-Prop (inr a , ap inr p)})
 ```
 
-### For any two maps `f : A → B` and `g : C → D`, there is at most one pair of maps `f' : A → B` and `g' : C → D` such that `f' + g' = f + g`.
+### For any two maps `f : A → B` and `g : C → D`, there is at most one pair of maps `f' : A → B` and `g' : C → D` such that `f' + g' = f + g`
 
 ```agda
 is-contr-fib-map-coprod :
@@ -466,10 +466,10 @@ module _
   pr1 (equiv-left-to-left e u) = left-to-left ¬PQ' e u
   pr2 (equiv-left-to-left e u) =
     is-equiv-has-inverse
-      (tr is-left (isretr-map-inv-equiv e u) ∘
-       left-to-left ¬P'Q (inv-equiv e) (map-equiv e u))
-      (λ _ → eq-is-prop (is-prop-is-left (map-equiv e u)))
-      (λ _ → eq-is-prop (is-prop-is-left u))
+      ( tr is-left (isretr-map-inv-equiv e u) ∘
+        left-to-left ¬P'Q (inv-equiv e) (map-equiv e u))
+      ( λ _ → eq-is-prop (is-prop-is-left (map-equiv e u)))
+      ( λ _ → eq-is-prop (is-prop-is-left u))
 
   equiv-right-to-right :
     (e : (P + Q) ≃ (P' + Q')) (u : P + Q) →
@@ -477,8 +477,8 @@ module _
   pr1 (equiv-right-to-right e u) = right-to-right ¬P'Q e u
   pr2 (equiv-right-to-right e u) =
     is-equiv-has-inverse
-      (tr is-right (isretr-map-inv-equiv e u) ∘
-       right-to-right ¬PQ' (inv-equiv e) (map-equiv e u))
+      ( tr is-right (isretr-map-inv-equiv e u) ∘
+        right-to-right ¬PQ' (inv-equiv e) (map-equiv e u))
       (λ _ → eq-is-prop (is-prop-is-right (map-equiv e u)))
       (λ _ → eq-is-prop (is-prop-is-right u))
 

--- a/src/foundation/functoriality-dependent-function-types.lagda.md
+++ b/src/foundation/functoriality-dependent-function-types.lagda.md
@@ -64,9 +64,10 @@ module _
   compute-map-equiv-Π h a' =
     ( ap
       ( λ t →
-        tr B t ( map-equiv
-                 ( f (map-inv-equiv e (map-equiv e a')))
-                 ( h (map-inv-equiv e (map-equiv e a')))))
+        tr B t
+          ( map-equiv
+            ( f (map-inv-equiv e (map-equiv e a')))
+            ( h (map-inv-equiv e (map-equiv e a')))))
       ( coherence-map-inv-equiv e a')) ∙
     ( ( tr-ap
         ( map-equiv e)

--- a/src/foundation/induction-principle-propositional-truncation.lagda.md
+++ b/src/foundation/induction-principle-propositional-truncation.lagda.md
@@ -43,7 +43,7 @@ induction-principle-propositional-truncation l {l1} {l2} {A} P α f =
 
 ## Properties
 
-### A type family over the propositional truncation comes equipped with the structure to satisfy the path clause of the induction principle if and only if it is a family of propositions.
+### A type family over the propositional truncation comes equipped with the structure to satisfy the path clause of the induction principle if and only if it is a family of propositions
 
 ```agda
 abstract

--- a/src/foundation/isolated-points.lagda.md
+++ b/src/foundation/isolated-points.lagda.md
@@ -249,7 +249,7 @@ decidable-emb-isolated-point {l1} {A} a =
         ( is-emb-inclusion-isolated-point A)
         ( is-emb-is-injective
           ( is-set-isolated-point A)
-           λ { {star} {star} p → refl}))
+          ( λ { {star} {star} p → refl})))
       ( λ x → is-decidable-prod is-decidable-unit (pr2 a x)))
 ```
 
@@ -299,13 +299,15 @@ isretr-map-inv-maybe-structure-isolated-point :
   ( map-inv-maybe-structure-isolated-point X x ∘
     map-maybe-structure-isolated-point X x) ~ id
 isretr-map-inv-maybe-structure-isolated-point X (pair x dx) (inl (pair y f)) =
-  ap ( cases-map-inv-maybe-structure-isolated-point X (pair x dx) y)
-     ( eq-is-prop (is-prop-is-decidable (is-prop-eq-isolated-point x dx y)))
+  ap
+    ( cases-map-inv-maybe-structure-isolated-point X (pair x dx) y)
+    ( eq-is-prop (is-prop-is-decidable (is-prop-eq-isolated-point x dx y)))
 isretr-map-inv-maybe-structure-isolated-point X (pair x dx) (inr star) =
-  ap ( cases-map-inv-maybe-structure-isolated-point X (pair x dx) x)
-     { x = dx (map-maybe-structure-isolated-point X (pair x dx) (inr star))}
-     { y = inl refl}
-     ( eq-is-prop (is-prop-is-decidable (is-prop-eq-isolated-point x dx x)))
+  ap
+    ( cases-map-inv-maybe-structure-isolated-point X (pair x dx) x)
+    { x = dx (map-maybe-structure-isolated-point X (pair x dx) (inr star))}
+    { y = inl refl}
+    ( eq-is-prop (is-prop-is-decidable (is-prop-eq-isolated-point x dx x)))
 
 is-equiv-map-maybe-structure-isolated-point :
   {l1 : Level} (X : UU l1) (x : isolated-point X) →
@@ -319,15 +321,17 @@ is-equiv-map-maybe-structure-isolated-point X x =
 equiv-maybe-structure-isolated-point :
   {l1 : Level} (X : UU l1) (x : isolated-point X) →
   Maybe (complement-isolated-point X x) ≃ X
-equiv-maybe-structure-isolated-point X x =
-  pair ( map-maybe-structure-isolated-point X x)
-       ( is-equiv-map-maybe-structure-isolated-point X x)
+pr1 (equiv-maybe-structure-isolated-point X x) =
+  map-maybe-structure-isolated-point X x
+pr2 (equiv-maybe-structure-isolated-point X x) =
+  is-equiv-map-maybe-structure-isolated-point X x
 
 maybe-structure-isolated-point :
   {l1 : Level} {X : UU l1} → isolated-point X → maybe-structure X
-maybe-structure-isolated-point {l1} {X} x =
-  pair ( complement-isolated-point X x)
-       ( equiv-maybe-structure-isolated-point X x)
+pr1 (maybe-structure-isolated-point {l1} {X} x) =
+  complement-isolated-point X x
+pr2 (maybe-structure-isolated-point {l1} {X} x) =
+  equiv-maybe-structure-isolated-point X x
 ```
 
 ```agda

--- a/src/foundation/mere-embeddings.lagda.md
+++ b/src/foundation/mere-embeddings.lagda.md
@@ -62,7 +62,7 @@ transitive-leq-Large-Preorder mere-emb-Large-Preorder X Y Z =
   transitive-mere-emb
 ```
 
-### Assuming excluded middle, if there are mere embeddings between `A` and `B` in both directions, then there is a mere equivalence between them.
+### Assuming excluded middle, if there are mere embeddings between `A` and `B` in both directions, then there is a mere equivalence between them
 
 ```agda
 antisymmetric-mere-emb :
@@ -70,9 +70,9 @@ antisymmetric-mere-emb :
   (LEM (l1 ⊔ l2)) → mere-emb X Y → mere-emb Y X → mere-equiv X Y
 antisymmetric-mere-emb lem f g =
   apply-universal-property-trunc-Prop f
-   (mere-equiv-Prop _ _)
-   λ f' →
-     apply-universal-property-trunc-Prop g
-     (mere-equiv-Prop _ _)
-     λ g' → unit-trunc-Prop (Cantor-Schröder-Bernstein-Escardó lem f' g')
+    (mere-equiv-Prop _ _)
+    λ f' →
+      apply-universal-property-trunc-Prop g
+      (mere-equiv-Prop _ _)
+      λ g' → unit-trunc-Prop (Cantor-Schröder-Bernstein-Escardó lem f' g')
 ```

--- a/src/foundation/mere-equivalences.lagda.md
+++ b/src/foundation/mere-equivalences.lagda.md
@@ -94,10 +94,10 @@ module _
 
   is-trunc-mere-equiv : (k : 𝕋) → mere-equiv X Y → is-trunc k Y → is-trunc k X
   is-trunc-mere-equiv k e H =
-     apply-universal-property-trunc-Prop
-       ( e)
-       ( is-trunc-Prop k X)
-       ( λ f → is-trunc-equiv k Y f H)
+    apply-universal-property-trunc-Prop
+      ( e)
+      ( is-trunc-Prop k X)
+      ( λ f → is-trunc-equiv k Y f H)
 
   is-trunc-mere-equiv' : (k : 𝕋) → mere-equiv X Y → is-trunc k X → is-trunc k Y
   is-trunc-mere-equiv' k e H =

--- a/src/foundation/multivariable-functoriality-set-quotients.lagda.md
+++ b/src/foundation/multivariable-functoriality-set-quotients.lagda.md
@@ -67,7 +67,7 @@ module _
     ( quotient-map S ∘
       map-hom-Eq-Rel (all-sim-Eq-Rel n A R) S h)
   compute-multivariable-map-set-quotient =
-     coherence-square-map-is-set-quotient
+    coherence-square-map-is-set-quotient
       ( all-sim-Eq-Rel n A R)
       ( set-quotient-vector-Set n A R)
       ( reflecting-map-quotient-vector-map n A R)

--- a/src/foundation/partial-elements.lagda.md
+++ b/src/foundation/partial-elements.lagda.md
@@ -42,3 +42,5 @@ pr2 (unit-partial-element x) y = x
 ## Properties
 
 ### The type of partial elements is a directed complete poset
+
+This remains to be shown.

--- a/src/foundation/path-algebra.lagda.md
+++ b/src/foundation/path-algebra.lagda.md
@@ -576,16 +576,17 @@ module _
   cube
     p000̂ p00̂0 p0̂00 p00̂1 p0̂01 p010̂ p0̂10 p100̂ p10̂0 p0̂11 p10̂1 p110̂
     p00̂0̂ p0̂00̂ p0̂0̂0 p0̂0̂1 p0̂10̂ p10̂0̂ =
-    Id ( ( ap (concat' x000 p0̂11) p00̂0̂) ∙
-         ( ( assoc p00̂0 p010̂ p0̂11) ∙
-           ( ( ap (concat p00̂0 x111) p0̂10̂) ∙
-             ( ( inv (assoc p00̂0 p0̂10 p110̂)) ∙
-               ( ( ap (concat' x000 p110̂) p0̂0̂0) ∙
-                 ( assoc p0̂00 p10̂0 p110̂))))))
-       ( ( assoc p000̂ p00̂1 p0̂11) ∙
-         ( ( ap (concat p000̂ x111) p0̂0̂1) ∙
-           ( ( inv (assoc p000̂ p0̂01 p10̂1)) ∙
-             ( ( ap (concat' x000 p10̂1) p0̂00̂) ∙
-               ( ( assoc p0̂00 p100̂ p10̂1) ∙
-                 ( ( ap (concat p0̂00 x111) p10̂0̂)))))))
+    Id
+      ( ( ap (concat' x000 p0̂11) p00̂0̂) ∙
+        ( ( assoc p00̂0 p010̂ p0̂11) ∙
+          ( ( ap (concat p00̂0 x111) p0̂10̂) ∙
+            ( ( inv (assoc p00̂0 p0̂10 p110̂)) ∙
+              ( ( ap (concat' x000 p110̂) p0̂0̂0) ∙
+                ( assoc p0̂00 p10̂0 p110̂))))))
+      ( ( assoc p000̂ p00̂1 p0̂11) ∙
+        ( ( ap (concat p000̂ x111) p0̂0̂1) ∙
+          ( ( inv (assoc p000̂ p0̂01 p10̂1)) ∙
+            ( ( ap (concat' x000 p10̂1) p0̂00̂) ∙
+              ( ( assoc p0̂00 p100̂ p10̂1) ∙
+                ( ( ap (concat p0̂00 x111) p10̂0̂)))))))
 ```

--- a/src/foundation/perfect-images.lagda.md
+++ b/src/foundation/perfect-images.lagda.md
@@ -68,8 +68,8 @@ module _
   is-prop-is-perfect-image-is-emb :
     (a : A) → is-prop (is-perfect-image f g a)
   is-prop-is-perfect-image-is-emb a =
-     is-prop-Π (λ a₀ → (is-prop-Π λ n →
-        is-prop-Π (λ p → (is-prop-map-is-emb is-emb-g a₀))))
+    is-prop-Π (λ a₀ → (is-prop-Π λ n →
+      is-prop-Π (λ p → (is-prop-map-is-emb is-emb-g a₀))))
 
   is-perfect-image-Prop : A → Prop (l1 ⊔ l2)
   pr1 (is-perfect-image-Prop a) = is-perfect-image f g a
@@ -126,9 +126,9 @@ module _
     (b : B) (ρ : is-perfect-image f g (g b)) →
     inverse-of-perfect-image (g b) ρ ＝ b
   is-retr-inverse-of-perfect-image b ρ =
-     is-injective-is-emb
-       is-emb-g
-       (is-sec-inverse-of-perfect-image (g b) ρ)
+    is-injective-is-emb
+      is-emb-g
+      (is-sec-inverse-of-perfect-image (g b) ρ)
 ```
 
 If `g (f (a))` is a perfect image for `g`, so is `a`.

--- a/src/foundation/pi-decompositions.lagda.md
+++ b/src/foundation/pi-decompositions.lagda.md
@@ -383,8 +383,7 @@ module _
     equiv-tot
       ( λ X →
         equiv-tot
-          ( λ Y →
-             equiv-precomp-equiv (inv-equiv e) (Π X Y)))
+          ( λ Y → equiv-precomp-equiv (inv-equiv e) (Π X Y)))
 
   map-equiv-tr-Π-Decomposition :
     {l3 l4 : Level} →
@@ -464,10 +463,10 @@ module _
         ( λ U Vs e →
           ( Σ ( ( u : indexing-type-Π-Decomposition Y) →
                 cotype-Π-Decomposition Y u ≃ pr1 Vs (map-equiv e u))
-             ( λ f →
-               ( ( ( map-equiv-Π (λ u → pr1 Vs u) e f) ∘
-                   ( map-matching-correspondence-Π-Decomposition Y)) ~
-                 ( map-equiv (pr2 Vs))))))
+              ( λ f →
+                ( ( ( map-equiv-Π (λ u → pr1 Vs u) e f) ∘
+                    ( map-matching-correspondence-Π-Decomposition Y)) ~
+                  ( map-equiv (pr2 Vs))))))
         ( is-contr-total-equiv (indexing-type-Π-Decomposition Y))
         ( pair (indexing-type-Π-Decomposition Y) id-equiv)
         ( is-contr-total-Eq-structure

--- a/src/foundation/product-decompositions-subuniverse.lagda.md
+++ b/src/foundation/product-decompositions-subuniverse.lagda.md
@@ -92,11 +92,11 @@ module _
 
   right-iterated-binary-product-Decomposition-Subuniverse : UU (lsuc l1 ⊔ l2)
   right-iterated-binary-product-Decomposition-Subuniverse =
-    Σ ( binary-product-Decomposition-Subuniverse P X)
-       ( λ d →
-         binary-product-Decomposition-Subuniverse
-           ( P)
-           ( right-summand-binary-product-Decomposition-Subuniverse P X d))
+    Σ ( binary-product-Decomposition-Subuniverse P X)
+      ( λ d →
+        binary-product-Decomposition-Subuniverse
+          ( P)
+          ( right-summand-binary-product-Decomposition-Subuniverse P X d))
 ```
 
 ### Ternary product Decomposition-subuniverses
@@ -109,11 +109,11 @@ module _
   ternary-product-Decomposition-Subuniverse : UU (lsuc l1 ⊔ l2)
   ternary-product-Decomposition-Subuniverse =
     Σ ( type-subuniverse P × (type-subuniverse P × type-subuniverse P))
-       ( λ x →
-         inclusion-subuniverse P X ≃
-         ( inclusion-subuniverse P (pr1 x) ×
-           ( inclusion-subuniverse P (pr1 (pr2 x)) ×
-             inclusion-subuniverse P (pr2 (pr2 x)))))
+      ( λ x →
+        inclusion-subuniverse P X ≃
+        ( inclusion-subuniverse P (pr1 x) ×
+          ( inclusion-subuniverse P (pr1 (pr2 x)) ×
+            inclusion-subuniverse P (pr2 (pr2 x)))))
 
   module _
     (d : ternary-product-Decomposition-Subuniverse)
@@ -368,22 +368,22 @@ module _
                 ( right-unit-law-prod-is-contr is-contr-raise-unit)
                 ( inclusion-subuniverse P X)) ∘e
               ( ( left-unit-law-Σ-is-contr
-                     ( ( ( ( raise-unit l1) ,
-                           C1) ,
-                         is-contr-raise-unit) ,
-                       ( λ x →
-                         eq-pair-Σ
-                           ( eq-pair-Σ
-                             ( eq-equiv
-                               ( raise-unit l1)
-                               ( inclusion-subuniverse P (pr1 x))
-                               ( equiv-is-contr
-                                 is-contr-raise-unit
-                                 ( ( pr2 x))))
-                             ( eq-is-prop (is-prop-type-Prop (P _))))
-                           ( eq-is-prop is-property-is-contr)))
-                     ( ( raise-unit l1 , C1) ,
-                       is-contr-raise-unit)) ∘e
+                  ( ( ( ( raise-unit l1) ,
+                        C1) ,
+                      is-contr-raise-unit) ,
+                    ( λ x →
+                      eq-pair-Σ
+                        ( eq-pair-Σ
+                          ( eq-equiv
+                            ( raise-unit l1)
+                            ( inclusion-subuniverse P (pr1 x))
+                            ( equiv-is-contr
+                              is-contr-raise-unit
+                              ( ( pr2 x))))
+                          ( eq-is-prop (is-prop-type-Prop (P (pr1 (pr1 x))))))
+                        ( eq-is-prop is-property-is-contr)))
+                  ( ( raise-unit l1 , C1) ,
+                    is-contr-raise-unit)) ∘e
                 ( ( inv-associative-Σ _ _ _) ∘e
                   ( ( equiv-tot (λ _ → commutative-prod)) ∘e
                     ( ( associative-Σ _ _ _)))))))) ∘e

--- a/src/foundation/products-of-tuples-of-types.lagda.md
+++ b/src/foundation/products-of-tuples-of-types.lagda.md
@@ -49,5 +49,3 @@ equiv-universal-property-product-tuple-types A i =
   {!!}
   -}
 ```
-
-## Properties

--- a/src/foundation/propositional-truncations.lagda.md
+++ b/src/foundation/propositional-truncations.lagda.md
@@ -70,8 +70,9 @@ abstract
   is-prop-condition-ind-trunc-Prop' {P = P} H x =
     is-prop-all-elements-equal
       ( λ u v →
-        ( ap ( λ γ → tr P γ u)
-             ( eq-is-contr (is-prop-type-trunc-Prop x x))) ∙
+        ( ap
+          ( λ γ → tr P γ u)
+          ( eq-is-contr (is-prop-type-trunc-Prop x x))) ∙
         ( H x x u v))
 ```
 
@@ -81,8 +82,9 @@ abstract
 ind-trunc-Prop' :
   {l l1 : Level} {A : UU l1} (P : type-trunc-Prop A → UU l)
   (f : (x : A) → P (unit-trunc-Prop x))
-  (H : (x y : type-trunc-Prop A) (u : P x) (v : P y) →
-       tr P (all-elements-equal-type-trunc-Prop x y) u ＝ v) →
+  (H :
+    (x y : type-trunc-Prop A) (u : P x) (v : P y) →
+    tr P (all-elements-equal-type-trunc-Prop x y) u ＝ v) →
   (x : type-trunc-Prop A) → P x
 ind-trunc-Prop' P f H =
   function-dependent-universal-property-trunc

--- a/src/foundation/pullbacks.lagda.md
+++ b/src/foundation/pullbacks.lagda.md
@@ -469,11 +469,12 @@ abstract
     ind-htpy g
       ( λ g'' Hg' →
         ( c : cone f g C) (c' : cone f g'' C) →
-        Id ( tr
-             ( λ g'' → cone f g'' C)
-             ( eq-htpy Hg')
-             ( tr (λ f''' → cone f''' g C) (eq-htpy (refl-htpy' f)) c))
-           ( c') →
+        Id
+          ( tr
+            ( λ g'' → cone f g'' C)
+            ( eq-htpy Hg')
+            ( tr (λ f''' → cone f''' g C) (eq-htpy (refl-htpy' f)) c))
+          ( c') →
         htpy-parallel-cone refl-htpy Hg' c c')
       ( htpy-eq-square-refl-htpy f g)
 
@@ -525,8 +526,11 @@ abstract
       ( htpy-eq (htpy-eq (htpy-eq (htpy-eq (htpy-eq (htpy-eq (compute-ind-htpy f
         ( λ f'' Hf' →
           ( g g' : B → X) (Hg : g ~ g') (c : cone f g C) (c' : cone f'' g' C) →
-            ( Id ( tr (λ g'' → cone f'' g'' C) (eq-htpy Hg)
-                 ( tr (λ f''' → cone f''' g C) (eq-htpy Hf') c)) c') →
+            ( Id
+              ( tr
+                ( λ g'' → cone f'' g'' C)
+                ( eq-htpy Hg)
+                ( tr (λ f''' → cone f''' g C) (eq-htpy Hf') c)) c') →
             htpy-parallel-cone Hf' Hg c c')
         ( λ g g' → htpy-parallel-cone-eq' f {g = g} {g' = g'})) g) g)
         refl-htpy) c) c'))
@@ -815,8 +819,9 @@ is-pullback-bottom-is-pullback-top-cube-is-equiv :
   (front-left : (h ∘ hB) ~ (hD ∘ h'))
   (front-right : (k ∘ hC) ~ (hD ∘ k'))
   (bottom : (h ∘ f) ~ (k ∘ g)) →
-  (c : coherence-cube-maps f g h k f' g' h' k' hA hB hC hD
-       top back-left back-right front-left front-right bottom) →
+  (c :
+    coherence-cube-maps f g h k f' g' h' k' hA hB hC hD
+      top back-left back-right front-left front-right bottom) →
   is-equiv hA → is-equiv hB → is-equiv hC → is-equiv hD →
   is-pullback h' k' (pair f' (pair g' top)) →
   is-pullback h k (pair f (pair g bottom))
@@ -842,7 +847,7 @@ is-pullback-bottom-is-pullback-top-cube-is-equiv
           ( rectangle-back-left-bottom-cube
             f g h k f' g' h' k' hA hB hC hD
             top back-left back-right front-left front-right bottom))}
-       ( pair
+      ( pair
         ( f')
         ( pair
           ( hC ∘ g')
@@ -881,8 +886,9 @@ is-pullback-top-is-pullback-bottom-cube-is-equiv :
   (front-left : (h ∘ hB) ~ (hD ∘ h'))
   (front-right : (k ∘ hC) ~ (hD ∘ k'))
   (bottom : (h ∘ f) ~ (k ∘ g)) →
-  (c : coherence-cube-maps f g h k f' g' h' k' hA hB hC hD
-       top back-left back-right front-left front-right bottom) →
+  (c :
+    coherence-cube-maps f g h k f' g' h' k' hA hB hC hD
+      top back-left back-right front-left front-right bottom) →
   is-equiv hA → is-equiv hB → is-equiv hC → is-equiv hD →
   is-pullback h k (pair f (pair g bottom)) →
   is-pullback h' k' (pair f' (pair g' top))
@@ -941,8 +947,9 @@ is-pullback-front-left-is-pullback-back-right-cube-is-equiv :
   (front-left : (h ∘ hB) ~ (hD ∘ h'))
   (front-right : (k ∘ hC) ~ (hD ∘ k'))
   (bottom : (h ∘ f) ~ (k ∘ g)) →
-  (c : coherence-cube-maps f g h k f' g' h' k' hA hB hC hD
-       top back-left back-right front-left front-right bottom) →
+  (c :
+    coherence-cube-maps f g h k f' g' h' k' hA hB hC hD
+      top back-left back-right front-left front-right bottom) →
   is-equiv f' → is-equiv f → is-equiv k' → is-equiv k →
   is-pullback g hC (pair hA (pair g' back-right)) →
   is-pullback h hD (pair hB (pair h' front-left))
@@ -970,8 +977,9 @@ is-pullback-front-right-is-pullback-back-left-cube-is-equiv :
   (front-left : (h ∘ hB) ~ (hD ∘ h'))
   (front-right : (k ∘ hC) ~ (hD ∘ k'))
   (bottom : (h ∘ f) ~ (k ∘ g)) →
-  (c : coherence-cube-maps f g h k f' g' h' k' hA hB hC hD
-       top back-left back-right front-left front-right bottom) →
+  (c :
+    coherence-cube-maps f g h k f' g' h' k' hA hB hC hD
+      top back-left back-right front-left front-right bottom) →
   is-equiv g' → is-equiv h' → is-equiv g → is-equiv h →
   is-pullback f hB (pair hA (pair f' back-left)) →
   is-pullback k hD (pair hC (pair k' front-right))

--- a/src/foundation/sigma-decompositions.lagda.md
+++ b/src/foundation/sigma-decompositions.lagda.md
@@ -634,10 +634,10 @@ module _
           ( Σ ( ( u : indexing-type-Σ-Decomposition Y) →
                 cotype-Σ-Decomposition Y u ≃
                 type-Inhabited-Type (pr1 Vs (map-equiv e u)))
-             ( λ f →
-               ( ( ( map-equiv-Σ (λ u → type-Inhabited-Type (pr1 Vs u)) e f) ∘
-                   ( map-matching-correspondence-Σ-Decomposition Y)) ~
-                 ( map-equiv (pr2 Vs))))))
+              ( λ f →
+                ( ( ( map-equiv-Σ (λ u → type-Inhabited-Type (pr1 Vs u)) e f) ∘
+                    ( map-matching-correspondence-Σ-Decomposition Y)) ~
+                  ( map-equiv (pr2 Vs))))))
         ( is-contr-total-equiv (indexing-type-Σ-Decomposition Y))
         ( pair (indexing-type-Σ-Decomposition Y) id-equiv)
         ( is-contr-total-Eq-structure
@@ -827,7 +827,7 @@ module _
       ( snd-fibered-Σ-Decomposition fib-D)
 
   matching-correspondence-displayed-fibered-Σ-Decomposition :
-     A ≃ Σ U (λ u → Σ (V u) (λ v → Y (map-inv-equiv f (u , v))))
+    A ≃ Σ U (λ u → Σ (V u) (λ v → Y (map-inv-equiv f (u , v))))
   matching-correspondence-displayed-fibered-Σ-Decomposition =
     equivalence-reasoning
     A ≃ Σ X Y by e
@@ -931,7 +931,7 @@ module _
         ( map-equiv e a)
 
   isretr-map-inv-displayed-fibered-Σ-Decomposition :
-     map-inv-displayed-fibered-Σ-Decomposition
+    map-inv-displayed-fibered-Σ-Decomposition
       ( map-displayed-fibered-Σ-Decomposition fib-D) ＝ fib-D
   isretr-map-inv-displayed-fibered-Σ-Decomposition =
     eq-equiv-fibered-Σ-Decomposition
@@ -1002,7 +1002,7 @@ module _
       {l1} {l} {l} {l} {l} {A} fib-D) ＝
     disp-D
   issec-map-inv-displayed-fibered-Σ-Decomposition =
-     eq-equiv-displayed-Σ-Decomposition
+    eq-equiv-displayed-Σ-Decomposition
       ( map-displayed-fibered-Σ-Decomposition fib-D)
       ( disp-D)
       ( ( ( id-equiv) ,

--- a/src/foundation/slice.lagda.md
+++ b/src/foundation/slice.lagda.md
@@ -265,7 +265,7 @@ module _
 
   abstract
     is-prop-hom-slice :
-     (f : A → X) (i : B ↪ X) → is-prop (hom-slice f (map-emb i))
+      (f : A → X) (i : B ↪ X) → is-prop (hom-slice f (map-emb i))
     is-prop-hom-slice f i =
       is-prop-is-equiv
         ( is-equiv-fiberwise-hom-hom-slice f (map-emb i))

--- a/src/foundation/surjective-maps.lagda.md
+++ b/src/foundation/surjective-maps.lagda.md
@@ -720,3 +720,5 @@ module _
 ```
 
 ### The type of surjections `A ↠ B` is equivalent to the type of families `P` of inhabited types over `B` equipped with an equivalence `A ≃ Σ B P`
+
+This remains to be shown.

--- a/src/foundation/trivial-sigma-decompositions.lagda.md
+++ b/src/foundation/trivial-sigma-decompositions.lagda.md
@@ -124,13 +124,12 @@ is-contr-type-trivial-Σ-Decomposition :
 pr1 ( is-contr-type-trivial-Σ-Decomposition {l1} {l2} {A} p) =
   ( trivial-inhabited-Σ-Decomposition l2 A p ,
     is-trivial-trivial-inhabited-Σ-Decomposition p)
-pr2 ( is-contr-type-trivial-Σ-Decomposition {l1} {l2} {A} p) =
-   ( λ x →
-     eq-type-subtype
-       ( is-trivial-Prop-Σ-Decomposition)
-       ( inv
-         ( eq-equiv-Σ-Decomposition
-           ( pr1 x)
-           ( trivial-inhabited-Σ-Decomposition l2 A p)
-           ( equiv-trivial-is-trivial-Σ-Decomposition (pr1 x) (pr2 x)))))
+pr2 ( is-contr-type-trivial-Σ-Decomposition {l1} {l2} {A} p) x =
+  eq-type-subtype
+    ( is-trivial-Prop-Σ-Decomposition)
+    ( inv
+      ( eq-equiv-Σ-Decomposition
+        ( pr1 x)
+        ( trivial-inhabited-Σ-Decomposition l2 A p)
+        ( equiv-trivial-is-trivial-Σ-Decomposition (pr1 x) (pr2 x))))
 ```

--- a/src/foundation/truncated-equality.lagda.md
+++ b/src/foundation/truncated-equality.lagda.md
@@ -23,5 +23,3 @@ open import foundation-core.universe-levels
 trunc-eq : {l : Level} (k : 𝕋) {A : UU l} → A → A → Truncated-Type l k
 trunc-eq k x y = trunc k (x ＝ y)
 ```
-
-## Properties

--- a/src/foundation/truncations.lagda.md
+++ b/src/foundation/truncations.lagda.md
@@ -66,7 +66,7 @@ pr2 (equiv-universal-property-trunc A B) = is-truncation-trunc B
 
 ## Properties
 
-### The n-truncations satisfy the universal property
+### The `n`-truncations satisfy the universal property
 
 ```agda
 universal-property-trunc :
@@ -108,7 +108,7 @@ module _
     pr2 (apply-universal-property-trunc B f)
 ```
 
-### The n-truncations satisfy the dependent universal property
+### The `n`-truncations satisfy the dependent universal property
 
 ```agda
 module _
@@ -233,22 +233,24 @@ module _
 
   dependent-universal-property-total-truncated-fam-trunc :
     is-contr
-     ( Σ ( (t : total-truncated-fam-trunc B) → type-Truncated-Type (C t))
-         ( λ h →
-           (x : A) (y : type-Truncated-Type (B x)) →
-           Id ( h (pair (unit-trunc x) (map-compute-truncated-fam-trunc B x y)))
+      ( Σ ( (t : total-truncated-fam-trunc B) → type-Truncated-Type (C t))
+          ( λ h →
+            (x : A) (y : type-Truncated-Type (B x)) →
+            Id
+              ( h (pair (unit-trunc x) (map-compute-truncated-fam-trunc B x y)))
               ( f x y)))
   dependent-universal-property-total-truncated-fam-trunc =
     is-contr-equiv _
       ( equiv-Σ
         ( λ g →
           (x : A) →
-          Id ( g (unit-trunc x))
-             ( map-equiv-Π
-               ( λ u → type-Truncated-Type (C (pair (unit-trunc x) u)))
-               ( compute-truncated-fam-trunc B x)
-               ( λ u → id-equiv)
-               ( f x)))
+          Id
+            ( g (unit-trunc x))
+            ( map-equiv-Π
+              ( λ u → type-Truncated-Type (C (pair (unit-trunc x) u)))
+              ( compute-truncated-fam-trunc B x)
+              ( λ u → id-equiv)
+              ( f x)))
         ( equiv-ev-pair)
         ( λ g →
           equiv-map-Π
@@ -256,14 +258,15 @@ module _
                 ( inv-equiv equiv-funext) ∘e
                 ( equiv-Π
                   ( λ y →
-                    Id ( g (pair (unit-trunc x) y))
-                       ( map-equiv-Π
-                         ( λ u →
-                           type-Truncated-Type (C (pair (unit-trunc x) u)))
-                         ( compute-truncated-fam-trunc B x)
-                         ( λ u → id-equiv)
-                         ( f x)
-                         ( y)))
+                    Id
+                      ( g (pair (unit-trunc x) y))
+                      ( map-equiv-Π
+                        ( λ u →
+                          type-Truncated-Type (C (pair (unit-trunc x) u)))
+                        ( compute-truncated-fam-trunc B x)
+                        ( λ u → id-equiv)
+                        ( f x)
+                        ( y)))
                   ( compute-truncated-fam-trunc B x)
                   ( λ y →
                     equiv-concat'
@@ -298,14 +301,15 @@ module _
 
   htpy-dependent-universal-property-total-truncated-fam-trunc :
     (x : A) (y : type-Truncated-Type (B x)) →
-    Id ( function-dependent-universal-property-total-truncated-fam-trunc
-         ( pair (unit-trunc x) (map-compute-truncated-fam-trunc B x y)))
-       ( f x y)
+    Id
+      ( function-dependent-universal-property-total-truncated-fam-trunc
+        ( pair (unit-trunc x) (map-compute-truncated-fam-trunc B x y)))
+      ( f x y)
   htpy-dependent-universal-property-total-truncated-fam-trunc =
     pr2 (center dependent-universal-property-total-truncated-fam-trunc)
 ```
 
-### An n-truncated type is equivalent to its n-truncation
+### An n-truncated type is equivalent to its `n`-truncation
 
 ```agda
 module _
@@ -494,11 +498,12 @@ module _
           ( map-inv-trunc-Σ (map-trunc-Σ |ab|))
           ( |ab|))
       ( λ (pair a b) →
-        ap map-inv-trunc-Σ
-           ( triangle-universal-property-trunc _
-             ( λ (pair a' b') → unit-trunc (pair a' (unit-trunc b')))
-             ( pair a b)) ∙
-        (triangle-universal-property-trunc _
+        ( ap
+          ( map-inv-trunc-Σ)
+          ( triangle-universal-property-trunc _
+            ( λ (pair a' b') → unit-trunc (pair a' (unit-trunc b')))
+            ( pair a b))) ∙
+        ( triangle-universal-property-trunc _
           ( λ (pair a' |b'|) →
             map-universal-property-trunc
               ( trunc k (Σ A B))

--- a/src/foundation/type-arithmetic-dependent-function-types.lagda.md
+++ b/src/foundation/type-arithmetic-dependent-function-types.lagda.md
@@ -38,8 +38,7 @@ module _
         ( λ _ → B a)
         ( terminal-map , is-equiv-terminal-map-is-contr C)
         ( λ a →
-          equiv-eq
-           ( ap B ( eq-is-contr C)))))
+          equiv-eq (ap B ( eq-is-contr C)))))
 ```
 
 ### The swap function `((x : A) (y : B) → C x y) → ((y : B) (x : A) → C x y)` is an equivalence

--- a/src/foundation/uniqueness-image.lagda.md
+++ b/src/foundation/uniqueness-image.lagda.md
@@ -64,8 +64,9 @@ module _
                 ( map-emb i')
                 ( map-hom-slice (map-emb i) (map-emb i') h)
                 ( triangle-hom-slice (map-emb i) (map-emb i') h)
-                ( pair ( map-inv-is-equiv is-equiv-h)
-                       ( issec-map-inv-is-equiv is-equiv-h)))))
+                ( pair
+                  ( map-inv-is-equiv is-equiv-h)
+                  ( issec-map-inv-is-equiv is-equiv-h)))))
 
   abstract
     is-image-is-equiv-is-image :

--- a/src/foundation/uniqueness-truncation.lagda.md
+++ b/src/foundation/uniqueness-truncation.lagda.md
@@ -18,7 +18,7 @@ open import foundation-core.universe-levels
 
 ## Idea
 
-The universal property of n-truncations implies that n-truncations are
+The universal property of `n`-truncations implies that `n`-truncations are
 determined uniquely up to a unique equivalence.
 
 ```agda

--- a/src/foundation/universal-property-image.lagda.md
+++ b/src/foundation/universal-property-image.lagda.md
@@ -202,9 +202,10 @@ abstract
       { A = (fib f x)}
       ( fib-emb-Prop m x)
       ( λ t →
-        pair ( map-hom-slice f (map-emb m) h (pr1 t))
-             ( ( inv (triangle-hom-slice f (map-emb m) h (pr1 t))) ∙
-               ( pr2 t)))
+        pair
+          ( map-hom-slice f (map-emb m) h (pr1 t))
+          ( ( inv (triangle-hom-slice f (map-emb m) h (pr1 t))) ∙
+            ( pr2 t)))
 
   map-is-image-im :
     {l1 l2 l3 : Level} {X : UU l1} {A : UU l2} {B : UU l3} (f : A → X) →
@@ -226,8 +227,9 @@ abstract
     is-image-is-image'
       l f (emb-im f) (unit-im f)
       ( λ B m h →
-        pair ( map-is-image-im f m h)
-             ( triangle-is-image-im f m h))
+        pair
+          ( map-is-image-im f m h)
+          ( triangle-is-image-im f m h))
 ```
 
 ### A factorization of a map through an embedding is the image factorization if and only if the right factor is surjective
@@ -281,8 +283,9 @@ abstract
               ( pr1 q)
               ( H)
               ( λ b →
-                pair ( fib (map-emb m) (pr1 i b))
-                     ( is-prop-map-emb m (pr1 i b)))) ∘e
+                pair
+                  ( fib (map-emb m) (pr1 i b))
+                  ( is-prop-map-emb m (pr1 i b)))) ∘e
             ( ( equiv-map-Π (λ a → equiv-tr (fib (map-emb m)) (pr2 q a))) ∘e
               ( ( reduce-Π-fib f (fib (map-emb m))) ∘e
                 ( equiv-fiberwise-hom-hom-slice f (map-emb m)))))))

--- a/src/foundation/universal-property-propositional-truncation-into-sets.lagda.md
+++ b/src/foundation/universal-property-propositional-truncation-into-sets.lagda.md
@@ -41,8 +41,9 @@ is-weakly-constant-map-precomp-unit-trunc-Prop :
   {l1 l2 : Level} {A : UU l1} {B : UU l2} (g : type-trunc-Prop A → B) →
   is-weakly-constant-map (g ∘ unit-trunc-Prop)
 is-weakly-constant-map-precomp-unit-trunc-Prop g x y =
-  ap ( g)
-     ( eq-is-prop (is-prop-type-trunc-Prop))
+  ap
+    ( g)
+    ( eq-is-prop (is-prop-type-trunc-Prop))
 
 precomp-universal-property-set-quotient-trunc-Prop :
   {l1 l2 : Level} {A : UU l1} (B : Set l2) →

--- a/src/foundation/universal-property-set-quotients.lagda.md
+++ b/src/foundation/universal-property-set-quotients.lagda.md
@@ -292,9 +292,10 @@ module _
   emb-is-surjective-and-effective :
     (H : is-surjective-and-effective R q) →
     type-Set B ↪ (A → Prop l2)
-  emb-is-surjective-and-effective H =
-    pair ( map-emb-is-surjective-and-effective H)
-         ( is-emb-map-emb-is-surjective-and-effective H)
+  pr1 (emb-is-surjective-and-effective H) =
+    map-emb-is-surjective-and-effective H
+  pr2 (emb-is-surjective-and-effective H) =
+    is-emb-map-emb-is-surjective-and-effective H
 
   is-emb-large-map-emb-is-surjective-and-effective :
     (e : is-surjective-and-effective R q) →
@@ -319,12 +320,13 @@ module _
 
   large-emb-is-surjective-and-effective :
     is-surjective-and-effective R q → type-Set B ↪ (A → Prop l3)
-  large-emb-is-surjective-and-effective e =
-    pair ( large-map-emb-is-surjective-and-effective e)
-         ( is-emb-large-map-emb-is-surjective-and-effective e)
+  pr1 (large-emb-is-surjective-and-effective e) =
+    large-map-emb-is-surjective-and-effective e
+  pr2 (large-emb-is-surjective-and-effective e) =
+    is-emb-large-map-emb-is-surjective-and-effective e
 
   is-image-is-surjective-and-effective :
-    (H : is-surjective-and-effective R q) →
+    ( H : is-surjective-and-effective R q) →
     ( {l : Level} →
       is-image l
         ( prop-Eq-Rel R)
@@ -350,15 +352,16 @@ module _
     ({l : Level} → is-set-quotient l R B q) →
     is-surjective (map-reflecting-map-Eq-Rel R q)
   is-surjective-is-set-quotient q Q b =
-    tr ( λ y → type-trunc-Prop (fib (map-reflecting-map-Eq-Rel R q) y))
-       ( htpy-eq
-         ( ap pr1
-           ( eq-is-contr
-             ( universal-property-set-quotient-is-set-quotient R B q Q B q)
-             { pair (inclusion-im (map-reflecting-map-Eq-Rel R q) ∘ β) δ}
-             { pair id refl-htpy}))
-         ( b))
-       ( pr2 (β b))
+    tr
+      ( λ y → type-trunc-Prop (fib (map-reflecting-map-Eq-Rel R q) y))
+      ( htpy-eq
+        ( ap pr1
+          ( eq-is-contr
+            ( universal-property-set-quotient-is-set-quotient R B q Q B q)
+            { pair (inclusion-im (map-reflecting-map-Eq-Rel R q) ∘ β) δ}
+            { pair id refl-htpy}))
+        ( b))
+      ( pr2 (β b))
     where
     α : reflects-Eq-Rel R (map-unit-im (map-reflecting-map-Eq-Rel R q))
     α {x} {y} r =
@@ -381,15 +384,17 @@ module _
     γ :
       ( β ∘ (map-reflecting-map-Eq-Rel R q)) ~
       ( map-unit-im (map-reflecting-map-Eq-Rel R q))
-    γ = htpy-eq
-        ( ap pr1
-             ( issec-map-inv-is-equiv
-               ( Q ( pair
-                     ( im (map-reflecting-map-Eq-Rel R q))
-                     ( is-set-im
-                       ( map-reflecting-map-Eq-Rel R q)
-                       ( is-set-type-Set B))))
-               ( pair (map-unit-im (map-reflecting-map-Eq-Rel R q)) α)))
+    γ =
+      htpy-eq
+        ( ap
+            ( pr1)
+            ( issec-map-inv-is-equiv
+              ( Q ( pair
+                    ( im (map-reflecting-map-Eq-Rel R q))
+                    ( is-set-im
+                      ( map-reflecting-map-Eq-Rel R q)
+                      ( is-set-type-Set B))))
+              ( pair (map-unit-im (map-reflecting-map-Eq-Rel R q)) α)))
     δ :
       ( ( inclusion-im (map-reflecting-map-Eq-Rel R q) ∘ β) ∘
         ( map-reflecting-map-Eq-Rel R q)) ~
@@ -662,9 +667,10 @@ module _
 
   is-injective-map-universal-property-set-quotient-is-set-quotient :
     {l4 : Level} (B : Set l4) (f : reflecting-map-Eq-Rel R (type-Set B))
-    ( H : (x y : A) →
-          map-reflecting-map-Eq-Rel R f x ＝ map-reflecting-map-Eq-Rel R f y →
-          sim-Eq-Rel R x y) →
+    ( H :
+      (x y : A) →
+      map-reflecting-map-Eq-Rel R f x ＝ map-reflecting-map-Eq-Rel R f y →
+      sim-Eq-Rel R x y) →
     is-injective
       ( map-universal-property-set-quotient-is-set-quotient R Q q U B f)
   is-injective-map-universal-property-set-quotient-is-set-quotient

--- a/src/foundation/vectors-set-quotients.lagda.md
+++ b/src/foundation/vectors-set-quotients.lagda.md
@@ -178,9 +178,9 @@ equiv-set-quotient-vector (succ-ℕ n) A R =
           (all-sim-Eq-Rel n
           ( tail-functional-vec n A)
           ( λ x → R (inl x))))
-       by lemma
+      by lemma
     ≃ set-quotient (all-sim-Eq-Rel (succ-ℕ n) A R)
-       by (equiv-quotient-prod-prod-set-quotient _ _)
+      by (equiv-quotient-prod-prod-set-quotient _ _)
   where
   lemma :
     ( set-quotient (R (inr star)) ×
@@ -290,7 +290,7 @@ pr2 (issec-inv-precomp-vector-set-quotient (succ-ℕ n) A R X) f =
               ( all-sim-Eq-Rel n
               ( tail-functional-vec n A)
               ( λ x → R (inl x))) X f))
-           ( a0 , a)))))
+          ( a0 , a)))))
     ( eq-is-prop
       ( is-prop-reflects-Eq-Rel
         ( all-sim-Eq-Rel (succ-ℕ n) A R)
@@ -423,7 +423,7 @@ is-set-quotient-vector-set-quotient :
     ( set-quotient-vector-Set n A R)
     ( reflecting-map-quotient-vector-map n A R))
 pr1 (is-set-quotient-vector-set-quotient n A R X) =
-   issec-inv-precomp-vector-set-quotient n A R X
+  issec-inv-precomp-vector-set-quotient n A R X
 pr2 (is-set-quotient-vector-set-quotient n A R X) =
-   isretr-inv-precomp-vector-set-quotient n A R X
+  isretr-inv-precomp-vector-set-quotient n A R X
 ```

--- a/src/foundation/weak-function-extensionality.lagda.md
+++ b/src/foundation/weak-function-extensionality.lagda.md
@@ -108,8 +108,9 @@ cases-eq-function-converse-weak-funext :
   (H : is-contr ((i : I) → A i)) (i : I) (x : A i) (e : is-decidable (i ＝ i)) →
   cases-function-converse-weak-funext d H i x i e ＝ x
 cases-eq-function-converse-weak-funext d H i x (inl p) =
-  ap ( λ t → cases-function-converse-weak-funext d H i x i (inl t))
-     ( eq-is-prop (is-set-has-decidable-equality d i i) {p} {refl})
+  ap
+    ( λ t → cases-function-converse-weak-funext d H i x i (inl t))
+    ( eq-is-prop (is-set-has-decidable-equality d i i) {p} {refl})
 cases-eq-function-converse-weak-funext d H i x (inr f) = ex-falso (f refl)
 
 eq-function-converse-weak-funext :

--- a/src/graph-theory/connected-undirected-graphs.lagda.md
+++ b/src/graph-theory/connected-undirected-graphs.lagda.md
@@ -43,5 +43,5 @@ module _
   is-prop-is-connected-Undirected-Graph
     : is-prop is-connected-Undirected-Graph
   is-prop-is-connected-Undirected-Graph =
-     is-prop-Π (λ _ → is-prop-Π (λ _ → is-prop-type-trunc-Prop))
+    is-prop-Π (λ _ → is-prop-Π (λ _ → is-prop-type-trunc-Prop))
 ```

--- a/src/graph-theory/edge-coloured-undirected-graphs.lagda.md
+++ b/src/graph-theory/edge-coloured-undirected-graphs.lagda.md
@@ -99,5 +99,3 @@ module _
   is-emb-colouring-Edge-Coloured-Undirected-Graph =
     pr2 (pr2 G)
 ```
-
-## Properties

--- a/src/graph-theory/equivalences-undirected-graphs.lagda.md
+++ b/src/graph-theory/equivalences-undirected-graphs.lagda.md
@@ -193,11 +193,12 @@ module _
       ( λ gV gE α →
         ( p : unordered-pair-vertices-Undirected-Graph G) →
           ( e : edge-Undirected-Graph G p) →
-          Id ( tr
-               ( edge-Undirected-Graph H)
-               ( htpy-unordered-pair α p)
-               ( edge-equiv-Undirected-Graph G H f p e))
-             ( map-equiv (gE p) e))
+          Id
+            ( tr
+              ( edge-Undirected-Graph H)
+              ( htpy-unordered-pair α p)
+              ( edge-equiv-Undirected-Graph G H f p e))
+            ( map-equiv (gE p) e))
       ( is-contr-total-htpy-equiv (equiv-vertex-equiv-Undirected-Graph G H f))
       ( pair (equiv-vertex-equiv-Undirected-Graph G H f) refl-htpy)
       ( is-contr-equiv'

--- a/src/graph-theory/morphisms-undirected-graphs.lagda.md
+++ b/src/graph-theory/morphisms-undirected-graphs.lagda.md
@@ -110,20 +110,22 @@ module _
       ( λ α →
         ( p : unordered-pair-vertices-Undirected-Graph G) →
         ( e : edge-Undirected-Graph G p) →
-        Id ( tr
-             ( edge-Undirected-Graph H)
-             ( htpy-unordered-pair α p)
-             ( edge-hom-Undirected-Graph G H f p e))
-           ( edge-hom-Undirected-Graph G H g p e))
+        Id
+          ( tr
+            ( edge-Undirected-Graph H)
+            ( htpy-unordered-pair α p)
+            ( edge-hom-Undirected-Graph G H f p e))
+          ( edge-hom-Undirected-Graph G H g p e))
 
   refl-htpy-hom-Undirected-Graph :
     (f : hom-Undirected-Graph G H) → htpy-hom-Undirected-Graph f f
   pr1 (refl-htpy-hom-Undirected-Graph f) = refl-htpy
   pr2 (refl-htpy-hom-Undirected-Graph f) p e =
-    ap ( λ t →
-         tr (edge-Undirected-Graph H) t (edge-hom-Undirected-Graph G H f p e))
-       ( preserves-refl-htpy-unordered-pair
-         ( vertex-hom-Undirected-Graph G H f) p)
+    ap
+      ( λ t →
+        tr (edge-Undirected-Graph H) t (edge-hom-Undirected-Graph G H f p e))
+      ( preserves-refl-htpy-unordered-pair
+        ( vertex-hom-Undirected-Graph G H f) p)
 
   htpy-eq-hom-Undirected-Graph :
     (f g : hom-Undirected-Graph G H) → Id f g → htpy-hom-Undirected-Graph f g
@@ -138,11 +140,12 @@ module _
         ( λ gV gE α →
           ( p : unordered-pair-vertices-Undirected-Graph G) →
           ( e : edge-Undirected-Graph G p) →
-          Id ( tr
-               ( edge-Undirected-Graph H)
-               ( htpy-unordered-pair α p)
-               ( edge-hom-Undirected-Graph G H f p e))
-             ( gE p e))
+          Id
+            ( tr
+              ( edge-Undirected-Graph H)
+              ( htpy-unordered-pair α p)
+              ( edge-hom-Undirected-Graph G H f p e))
+            ( gE p e))
         ( is-contr-total-htpy (vertex-hom-Undirected-Graph G H f))
         ( pair (vertex-hom-Undirected-Graph G H f) refl-htpy)
         ( is-contr-equiv'

--- a/src/group-theory/abelian-groups.lagda.md
+++ b/src/group-theory/abelian-groups.lagda.md
@@ -588,8 +588,9 @@ module _
 
   preserves-concat-add-list-Ab :
     (l1 l2 : list (type-Ab A)) →
-    Id ( add-list-Ab (concat-list l1 l2))
-       ( add-Ab A (add-list-Ab l1) (add-list-Ab l2))
+    Id
+      ( add-list-Ab (concat-list l1 l2))
+      ( add-Ab A (add-list-Ab l1) (add-list-Ab l2))
   preserves-concat-add-list-Ab =
     preserves-concat-mul-list-Group (group-Ab A)
 ```

--- a/src/group-theory/addition-homomorphisms-abelian-groups.lagda.md
+++ b/src/group-theory/addition-homomorphisms-abelian-groups.lagda.md
@@ -65,8 +65,9 @@ module _
 
   associative-add-hom-Ab :
     (f g h : type-hom-Ab A B) →
-    Id ( add-hom-Ab A B (add-hom-Ab A B f g) h)
-       ( add-hom-Ab A B f (add-hom-Ab A B g h))
+    Id
+      ( add-hom-Ab A B (add-hom-Ab A B f g) h)
+      ( add-hom-Ab A B f (add-hom-Ab A B g h))
   associative-add-hom-Ab f g h =
     eq-htpy-hom-Ab A B
       ( λ x →
@@ -137,8 +138,9 @@ module _
 
   left-distributive-comp-add-hom-Ab :
     (h : type-hom-Ab B C) (f g : type-hom-Ab A B) →
-    Id ( comp-hom-Ab A B C h (add-hom-Ab A B f g))
-       ( add-hom-Ab A C (comp-hom-Ab A B C h f) (comp-hom-Ab A B C h g))
+    Id
+      ( comp-hom-Ab A B C h (add-hom-Ab A B f g))
+      ( add-hom-Ab A C (comp-hom-Ab A B C h f) (comp-hom-Ab A B C h g))
   left-distributive-comp-add-hom-Ab h f g =
     eq-htpy-hom-Ab A C
       ( λ x →
@@ -146,8 +148,9 @@ module _
 
   right-distributive-comp-add-hom-Ab :
     (g h : type-hom-Ab B C) (f : type-hom-Ab A B) →
-    Id ( comp-hom-Ab A B C (add-hom-Ab B C g h) f)
-       ( add-hom-Ab A C (comp-hom-Ab A B C g f) (comp-hom-Ab A B C h f))
+    Id
+      ( comp-hom-Ab A B C (add-hom-Ab B C g h) f)
+      ( add-hom-Ab A C (comp-hom-Ab A B C g f) (comp-hom-Ab A B C h f))
   right-distributive-comp-add-hom-Ab g h f =
     eq-htpy-hom-Ab A C (λ x → refl)
 ```

--- a/src/group-theory/cartesian-products-groups.lagda.md
+++ b/src/group-theory/cartesian-products-groups.lagda.md
@@ -54,8 +54,9 @@ module _
 
   associative-mul-prod-Group :
     (x y z : type-prod-Group) →
-    Id ( mul-prod-Group (mul-prod-Group x y) z)
-       ( mul-prod-Group x (mul-prod-Group y z))
+    Id
+      ( mul-prod-Group (mul-prod-Group x y) z)
+      ( mul-prod-Group x (mul-prod-Group y z))
   associative-mul-prod-Group = associative-mul-Semigroup semigroup-prod-Group
 
   unit-prod-Group : type-prod-Group

--- a/src/group-theory/cartesian-products-monoids.lagda.md
+++ b/src/group-theory/cartesian-products-monoids.lagda.md
@@ -50,8 +50,9 @@ module _
 
   associative-mul-prod-Monoid :
     (x y z : type-prod-Monoid) →
-    Id ( mul-prod-Monoid (mul-prod-Monoid x y) z)
-       ( mul-prod-Monoid x (mul-prod-Monoid y z))
+    Id
+      ( mul-prod-Monoid (mul-prod-Monoid x y) z)
+      ( mul-prod-Monoid x (mul-prod-Monoid y z))
   associative-mul-prod-Monoid =
     associative-mul-Semigroup semigroup-prod-Monoid
 

--- a/src/group-theory/cartesian-products-semigroups.lagda.md
+++ b/src/group-theory/cartesian-products-semigroups.lagda.md
@@ -46,8 +46,9 @@ module _
 
   associative-mul-prod-Semigroup :
     (x y z : type-prod-Semigroup) →
-    Id ( mul-prod-Semigroup (mul-prod-Semigroup x y) z)
-       ( mul-prod-Semigroup x (mul-prod-Semigroup y z))
+    Id
+      ( mul-prod-Semigroup (mul-prod-Semigroup x y) z)
+      ( mul-prod-Semigroup x (mul-prod-Semigroup y z))
   associative-mul-prod-Semigroup (pair x1 y1) (pair x2 y2) (pair x3 y3) =
     eq-pair
       ( associative-mul-Semigroup A x1 x2 x3)

--- a/src/group-theory/decidable-subgroups.lagda.md
+++ b/src/group-theory/decidable-subgroups.lagda.md
@@ -237,8 +237,9 @@ module _
 
   associative-mul-Decidable-Subgroup :
     (x y z : type-group-Decidable-Subgroup) →
-    Id (mul-Decidable-Subgroup (mul-Decidable-Subgroup x y) z)
-       (mul-Decidable-Subgroup x (mul-Decidable-Subgroup y z))
+    Id
+      ( mul-Decidable-Subgroup (mul-Decidable-Subgroup x y) z)
+      ( mul-Decidable-Subgroup x (mul-Decidable-Subgroup y z))
   associative-mul-Decidable-Subgroup =
     associative-mul-Subgroup G (subgroup-Decidable-Subgroup G H)
 
@@ -263,15 +264,17 @@ module _
 
   left-inverse-law-mul-Decidable-Subgroup :
     ( x : type-group-Decidable-Subgroup) →
-    Id ( mul-Decidable-Subgroup (inv-Decidable-Subgroup x) x)
-       ( unit-Decidable-Subgroup)
+    Id
+      ( mul-Decidable-Subgroup (inv-Decidable-Subgroup x) x)
+      ( unit-Decidable-Subgroup)
   left-inverse-law-mul-Decidable-Subgroup =
     left-inverse-law-mul-Subgroup G (subgroup-Decidable-Subgroup G H)
 
   right-inverse-law-mul-Decidable-Subgroup :
     (x : type-group-Decidable-Subgroup) →
-    Id ( mul-Decidable-Subgroup x (inv-Decidable-Subgroup x))
-       ( unit-Decidable-Subgroup)
+    Id
+      ( mul-Decidable-Subgroup x (inv-Decidable-Subgroup x))
+      ( unit-Decidable-Subgroup)
   right-inverse-law-mul-Decidable-Subgroup =
     right-inverse-law-mul-Subgroup G (subgroup-Decidable-Subgroup G H)
 

--- a/src/group-theory/equivalences-group-actions.lagda.md
+++ b/src/group-theory/equivalences-group-actions.lagda.md
@@ -288,11 +288,12 @@ module _
     (h : equiv-Abstract-Group-Action G X3 X4)
     (g : equiv-Abstract-Group-Action G X2 X3)
     (f : equiv-Abstract-Group-Action G X1 X2) →
-    Id ( comp-equiv-Abstract-Group-Action G X1 X2 X4
-         ( comp-equiv-Abstract-Group-Action G X2 X3 X4 h g)
-         ( f))
-       ( comp-equiv-Abstract-Group-Action G X1 X3 X4 h
-         ( comp-equiv-Abstract-Group-Action G X1 X2 X3 g f))
+    Id
+      ( comp-equiv-Abstract-Group-Action G X1 X2 X4
+        ( comp-equiv-Abstract-Group-Action G X2 X3 X4 h g)
+        ( f))
+      ( comp-equiv-Abstract-Group-Action G X1 X3 X4 h
+        ( comp-equiv-Abstract-Group-Action G X1 X2 X3 g f))
   associative-comp-equiv-Abstract-Group-Action h g f =
     eq-htpy-equiv-Abstract-Group-Action G X1 X4
       ( comp-equiv-Abstract-Group-Action G X1 X2 X4
@@ -309,10 +310,11 @@ module _
 
   left-unit-law-comp-equiv-Abstract-Group-Action :
     (f : equiv-Abstract-Group-Action G X Y) →
-    Id ( comp-equiv-Abstract-Group-Action G X Y Y
-         ( id-equiv-Abstract-Group-Action G Y)
-         ( f))
-       ( f)
+    Id
+      ( comp-equiv-Abstract-Group-Action G X Y Y
+        ( id-equiv-Abstract-Group-Action G Y)
+        ( f))
+      ( f)
   left-unit-law-comp-equiv-Abstract-Group-Action f =
     eq-htpy-equiv-Abstract-Group-Action G X Y
       ( comp-equiv-Abstract-Group-Action G X Y Y
@@ -323,9 +325,10 @@ module _
 
   right-unit-law-comp-equiv-Abstract-Group-Action :
     (f : equiv-Abstract-Group-Action G X Y) →
-    Id ( comp-equiv-Abstract-Group-Action G X X Y f
-         ( id-equiv-Abstract-Group-Action G X))
-       ( f)
+    Id
+      ( comp-equiv-Abstract-Group-Action G X X Y f
+        ( id-equiv-Abstract-Group-Action G X))
+      ( f)
   right-unit-law-comp-equiv-Abstract-Group-Action f =
     eq-htpy-equiv-Abstract-Group-Action G X Y
       ( comp-equiv-Abstract-Group-Action G X X Y f
@@ -335,10 +338,11 @@ module _
 
   left-inverse-law-comp-equiv-Abstract-Group-Action :
     (f : equiv-Abstract-Group-Action G X Y) →
-    Id ( comp-equiv-Abstract-Group-Action G X Y X
-         ( inv-equiv-Abstract-Group-Action G X Y f)
-         ( f))
-       ( id-equiv-Abstract-Group-Action G X)
+    Id
+      ( comp-equiv-Abstract-Group-Action G X Y X
+        ( inv-equiv-Abstract-Group-Action G X Y f)
+        ( f))
+      ( id-equiv-Abstract-Group-Action G X)
   left-inverse-law-comp-equiv-Abstract-Group-Action f =
     eq-htpy-equiv-Abstract-Group-Action G X X
       ( comp-equiv-Abstract-Group-Action G X Y X
@@ -349,9 +353,10 @@ module _
 
   right-inverse-law-comp-equiv-Abstract-Group-Action :
     (f : equiv-Abstract-Group-Action G X Y) →
-    Id ( comp-equiv-Abstract-Group-Action G Y X Y f
-         ( inv-equiv-Abstract-Group-Action G X Y f))
-       ( id-equiv-Abstract-Group-Action G Y)
+    Id
+      ( comp-equiv-Abstract-Group-Action G Y X Y f
+        ( inv-equiv-Abstract-Group-Action G X Y f))
+      ( id-equiv-Abstract-Group-Action G Y)
   right-inverse-law-comp-equiv-Abstract-Group-Action f =
     eq-htpy-equiv-Abstract-Group-Action G Y Y
       ( comp-equiv-Abstract-Group-Action G Y X Y f

--- a/src/group-theory/group-actions.lagda.md
+++ b/src/group-theory/group-actions.lagda.md
@@ -78,8 +78,9 @@ module _
 
   preserves-mul-Abstract-Group-Action :
     (g : type-Group G) (h : type-Group G) (x : type-Abstract-Group-Action) →
-    Id ( mul-Abstract-Group-Action (mul-Group G g h) x)
-       ( mul-Abstract-Group-Action g (mul-Abstract-Group-Action h x))
+    Id
+      ( mul-Abstract-Group-Action (mul-Group G g h) x)
+      ( mul-Abstract-Group-Action g (mul-Abstract-Group-Action h x))
   preserves-mul-Abstract-Group-Action g h =
     htpy-eq
       ( ap pr1

--- a/src/group-theory/homomorphisms-abelian-groups.lagda.md
+++ b/src/group-theory/homomorphisms-abelian-groups.lagda.md
@@ -140,8 +140,9 @@ comp-hom-Ab A B C =
 associative-comp-hom-Ab :
   { l1 l2 l3 l4 : Level} (A : Ab l1) (B : Ab l2) (C : Ab l3) (D : Ab l4) →
   ( h : type-hom-Ab C D) (g : type-hom-Ab B C) (f : type-hom-Ab A B) →
-  Id (comp-hom-Ab A B D (comp-hom-Ab B C D h g) f)
-     (comp-hom-Ab A C D h (comp-hom-Ab A B C g f))
+  Id
+    ( comp-hom-Ab A B D (comp-hom-Ab B C D h g) f)
+    ( comp-hom-Ab A C D h (comp-hom-Ab A B C g f))
 associative-comp-hom-Ab A B C D =
   associative-comp-hom-Semigroup
     ( semigroup-Ab A)

--- a/src/group-theory/homomorphisms-concrete-groups.lagda.md
+++ b/src/group-theory/homomorphisms-concrete-groups.lagda.md
@@ -58,8 +58,9 @@ module _
 
   preserves-point-classifying-map-hom-Concrete-Group :
     (f : hom-Concrete-Group) →
-    Id ( classifying-map-hom-Concrete-Group f (shape-Concrete-Group G))
-       ( shape-Concrete-Group H)
+    Id
+      ( classifying-map-hom-Concrete-Group f (shape-Concrete-Group G))
+      ( shape-Concrete-Group H)
   preserves-point-classifying-map-hom-Concrete-Group =
     preserves-point-classifying-map-hom-∞-Group
       ( ∞-group-Concrete-Group G)
@@ -74,8 +75,9 @@ module _
 
   preserves-unit-map-hom-Concrete-Group :
     (f : hom-Concrete-Group) →
-    Id ( map-hom-Concrete-Group f (unit-Concrete-Group G))
-       ( unit-Concrete-Group H)
+    Id
+      ( map-hom-Concrete-Group f (unit-Concrete-Group G))
+      ( unit-Concrete-Group H)
   preserves-unit-map-hom-Concrete-Group =
     preserves-unit-map-hom-∞-Group
       ( ∞-group-Concrete-Group G)
@@ -83,10 +85,11 @@ module _
 
   preserves-mul-map-hom-Concrete-Group :
     (f : hom-Concrete-Group) (x y : type-Concrete-Group G) →
-    Id ( map-hom-Concrete-Group f (mul-Concrete-Group G x y))
-       ( mul-Concrete-Group H
-         ( map-hom-Concrete-Group f x)
-         ( map-hom-Concrete-Group f y))
+    Id
+      ( map-hom-Concrete-Group f (mul-Concrete-Group G x y))
+      ( mul-Concrete-Group H
+        ( map-hom-Concrete-Group f x)
+        ( map-hom-Concrete-Group f y))
   preserves-mul-map-hom-Concrete-Group =
     preserves-mul-map-hom-∞-Group
       ( ∞-group-Concrete-Group G)
@@ -94,8 +97,9 @@ module _
 
   preserves-inv-map-hom-Concrete-Group :
     (f : hom-Concrete-Group) (x : type-Concrete-Group G) →
-    Id ( map-hom-Concrete-Group f (inv-Concrete-Group G x))
-       ( inv-Concrete-Group H (map-hom-Concrete-Group f x))
+    Id
+      ( map-hom-Concrete-Group f (inv-Concrete-Group G x))
+      ( inv-Concrete-Group H (map-hom-Concrete-Group f x))
   preserves-inv-map-hom-Concrete-Group =
     preserves-inv-map-hom-∞-Group
       ( ∞-group-Concrete-Group G)

--- a/src/group-theory/homomorphisms-group-actions.lagda.md
+++ b/src/group-theory/homomorphisms-group-actions.lagda.md
@@ -208,11 +208,12 @@ module _
     (h : type-hom-Abstract-Group-Action G X3 X4)
     (g : type-hom-Abstract-Group-Action G X2 X3)
     (f : type-hom-Abstract-Group-Action G X1 X2) →
-    Id ( comp-hom-Abstract-Group-Action G X1 X2 X4
-         ( comp-hom-Abstract-Group-Action G X2 X3 X4 h g)
-         ( f))
-       ( comp-hom-Abstract-Group-Action G X1 X3 X4 h
-         ( comp-hom-Abstract-Group-Action G X1 X2 X3 g f))
+    Id
+      ( comp-hom-Abstract-Group-Action G X1 X2 X4
+        ( comp-hom-Abstract-Group-Action G X2 X3 X4 h g)
+        ( f))
+      ( comp-hom-Abstract-Group-Action G X1 X3 X4 h
+        ( comp-hom-Abstract-Group-Action G X1 X2 X3 g f))
   associative-comp-hom-Abstract-Group-Action h g f =
     eq-htpy-hom-Abstract-Group-Action G X1 X4
       ( comp-hom-Abstract-Group-Action G X1 X2 X4
@@ -233,10 +234,11 @@ module _
 
   left-unit-law-comp-hom-Abstract-Group-Action :
     (f : type-hom-Abstract-Group-Action G X Y) →
-    Id ( comp-hom-Abstract-Group-Action G X Y Y
-         ( id-hom-Abstract-Group-Action G Y)
-         ( f))
-       ( f)
+    Id
+      ( comp-hom-Abstract-Group-Action G X Y Y
+        ( id-hom-Abstract-Group-Action G Y)
+        ( f))
+      ( f)
   left-unit-law-comp-hom-Abstract-Group-Action f =
     eq-htpy-hom-Abstract-Group-Action G X Y
       ( comp-hom-Abstract-Group-Action G X Y Y
@@ -247,9 +249,10 @@ module _
 
   right-unit-law-comp-hom-Abstract-Group-Action :
     (f : type-hom-Abstract-Group-Action G X Y) →
-    Id ( comp-hom-Abstract-Group-Action G X X Y f
-         ( id-hom-Abstract-Group-Action G X))
-       ( f)
+    Id
+      ( comp-hom-Abstract-Group-Action G X X Y f
+        ( id-hom-Abstract-Group-Action G X))
+      ( f)
   right-unit-law-comp-hom-Abstract-Group-Action f =
     eq-htpy-hom-Abstract-Group-Action G X Y
       ( comp-hom-Abstract-Group-Action G X X Y f

--- a/src/group-theory/homomorphisms-groups.lagda.md
+++ b/src/group-theory/homomorphisms-groups.lagda.md
@@ -145,8 +145,9 @@ associative-comp-hom-Group :
   {l1 l2 l3 l4 : Level}
   (G : Group l1) (H : Group l2) (K : Group l3) (L : Group l4)
   (h : type-hom-Group K L) (g : type-hom-Group H K) (f : type-hom-Group G H) →
-  Id ( comp-hom-Group G H L (comp-hom-Group H K L h g) f)
-     ( comp-hom-Group G K L h (comp-hom-Group G H K g f))
+  Id
+    ( comp-hom-Group G H L (comp-hom-Group H K L h g) f)
+    ( comp-hom-Group G K L h (comp-hom-Group G H K g f))
 associative-comp-hom-Group G H K L =
   associative-comp-hom-Semigroup
     ( semigroup-Group G)
@@ -190,10 +191,11 @@ module _
       ( f : type-hom-Group G H) → preserves-unit-Group (map-hom-Group G H f)
     preserves-unit-hom-Group f =
       ( inv (left-unit-law-mul-Group H (map-hom-Group G H f (unit-Group G)))) ∙
-      ( ( ap ( λ x → mul-Group H x (map-hom-Group G H f (unit-Group G)))
-             ( inv
-               ( left-inverse-law-mul-Group H
-                 ( map-hom-Group G H f (unit-Group G))))) ∙
+      ( ( ap
+          ( λ x → mul-Group H x (map-hom-Group G H f (unit-Group G)))
+          ( inv
+            ( left-inverse-law-mul-Group H
+              ( map-hom-Group G H f (unit-Group G))))) ∙
         ( ( associative-mul-Group H
             ( inv-Group H (map-hom-Group G H f (unit-Group G)))
             ( map-hom-Group G H f (unit-Group G))

--- a/src/group-theory/homomorphisms-semigroups.lagda.md
+++ b/src/group-theory/homomorphisms-semigroups.lagda.md
@@ -183,8 +183,9 @@ comp-hom-Semigroup :
 pr1 (comp-hom-Semigroup G H K g f) =
   (map-hom-Semigroup H K g) ∘ (map-hom-Semigroup G H f)
 pr2 (comp-hom-Semigroup G H K g f) x y =
-  ( ap ( map-hom-Semigroup H K g)
-       ( preserves-mul-hom-Semigroup G H f x y)) ∙
+  ( ap
+    ( map-hom-Semigroup H K g)
+    ( preserves-mul-hom-Semigroup G H f x y)) ∙
   ( preserves-mul-hom-Semigroup H K g
     ( map-hom-Semigroup G H f x)
     ( map-hom-Semigroup G H f y))
@@ -197,10 +198,11 @@ associative-comp-hom-Semigroup :
   { l1 l2 l3 l4 : Level} (G : Semigroup l1) (H : Semigroup l2)
   ( K : Semigroup l3) (L : Semigroup l4) (h : type-hom-Semigroup K L) →
   ( g : type-hom-Semigroup H K) (f : type-hom-Semigroup G H) →
-  Id ( comp-hom-Semigroup G H L
-       ( comp-hom-Semigroup H K L h g) f)
-     ( comp-hom-Semigroup G K L h
-       ( comp-hom-Semigroup G H K g f))
+  Id
+    ( comp-hom-Semigroup G H L
+      ( comp-hom-Semigroup H K L h g) f)
+    ( comp-hom-Semigroup G K L h
+      ( comp-hom-Semigroup G H K g f))
 associative-comp-hom-Semigroup
   G H K L (pair h μ-h) (pair g μ-g) (pair f μ-f) =
   eq-htpy-hom-Semigroup G L refl-htpy

--- a/src/group-theory/inverse-semigroups.lagda.md
+++ b/src/group-theory/inverse-semigroups.lagda.md
@@ -68,8 +68,9 @@ module _
 
   associative-mul-Inverse-Semigroup :
     (x y z : type-Inverse-Semigroup) →
-    Id ( mul-Inverse-Semigroup (mul-Inverse-Semigroup x y) z)
-       ( mul-Inverse-Semigroup x (mul-Inverse-Semigroup y z))
+    Id
+      ( mul-Inverse-Semigroup (mul-Inverse-Semigroup x y) z)
+      ( mul-Inverse-Semigroup x (mul-Inverse-Semigroup y z))
   associative-mul-Inverse-Semigroup =
     associative-mul-Semigroup semigroup-Inverse-Semigroup
 
@@ -83,19 +84,21 @@ module _
 
   inner-inverse-law-mul-Inverse-Semigroup :
     (x : type-Inverse-Semigroup) →
-    Id ( mul-Inverse-Semigroup
-         ( mul-Inverse-Semigroup x (inv-Inverse-Semigroup x))
-         ( x))
-       ( x)
+    Id
+      ( mul-Inverse-Semigroup
+        ( mul-Inverse-Semigroup x (inv-Inverse-Semigroup x))
+        ( x))
+      ( x)
   inner-inverse-law-mul-Inverse-Semigroup x =
     pr1 (pr2 (center (is-inverse-semigroup-Inverse-Semigroup x)))
 
   outer-inverse-law-mul-Inverse-Semigroup :
     (x : type-Inverse-Semigroup) →
-    Id ( mul-Inverse-Semigroup
-         ( mul-Inverse-Semigroup (inv-Inverse-Semigroup x) x)
-         ( inv-Inverse-Semigroup x))
-       ( inv-Inverse-Semigroup x)
+    Id
+      ( mul-Inverse-Semigroup
+        ( mul-Inverse-Semigroup (inv-Inverse-Semigroup x) x)
+        ( inv-Inverse-Semigroup x))
+      ( inv-Inverse-Semigroup x)
   outer-inverse-law-mul-Inverse-Semigroup x =
     pr2 (pr2 (center (is-inverse-semigroup-Inverse-Semigroup x)))
 ```

--- a/src/group-theory/isomorphisms-concrete-groups.lagda.md
+++ b/src/group-theory/isomorphisms-concrete-groups.lagda.md
@@ -34,6 +34,4 @@ iso-Concrete-Group = iso-Large-Precategory Concrete-Group-Large-Precategory
 
 ### Equivalences of concrete groups are isomorphisms of concrete groups
 
-```agda
-
-```
+This remains to be shown.

--- a/src/group-theory/isomorphisms-group-actions.lagda.md
+++ b/src/group-theory/isomorphisms-group-actions.lagda.md
@@ -76,19 +76,21 @@ module _
 
   issec-hom-inv-iso-Abstract-Group-Action :
     (f : type-iso-Abstract-Group-Action) →
-    Id ( comp-hom-Abstract-Group-Action G Y X Y
-         ( hom-iso-Abstract-Group-Action f)
-         ( hom-inv-iso-Abstract-Group-Action f))
-       ( id-hom-Abstract-Group-Action G Y)
+    Id
+      ( comp-hom-Abstract-Group-Action G Y X Y
+        ( hom-iso-Abstract-Group-Action f)
+        ( hom-inv-iso-Abstract-Group-Action f))
+      ( id-hom-Abstract-Group-Action G Y)
   issec-hom-inv-iso-Abstract-Group-Action =
     is-sec-hom-inv-iso-Large-Precategory C X Y
 
   isretr-hom-inv-iso-Abstract-Group-Action :
     (f : type-iso-Abstract-Group-Action) →
-    Id ( comp-hom-Abstract-Group-Action G X Y X
-         ( hom-inv-iso-Abstract-Group-Action f)
-         ( hom-iso-Abstract-Group-Action f))
-       ( id-hom-Abstract-Group-Action G X)
+    Id
+      ( comp-hom-Abstract-Group-Action G X Y X
+        ( hom-inv-iso-Abstract-Group-Action f)
+        ( hom-iso-Abstract-Group-Action f))
+      ( id-hom-Abstract-Group-Action G X)
   isretr-hom-inv-iso-Abstract-Group-Action =
     is-retr-hom-inv-iso-Large-Precategory C X Y
 

--- a/src/group-theory/isomorphisms-semigroups.lagda.md
+++ b/src/group-theory/isomorphisms-semigroups.lagda.md
@@ -66,19 +66,21 @@ module _
 
   issec-hom-inv-iso-Semigroup :
     (f : type-iso-Semigroup) →
-    Id ( comp-hom-Semigroup H G H
-         ( hom-iso-Semigroup f)
-         ( hom-inv-iso-Semigroup f))
-       ( id-hom-Semigroup H)
+    Id
+      ( comp-hom-Semigroup H G H
+        ( hom-iso-Semigroup f)
+        ( hom-inv-iso-Semigroup f))
+      ( id-hom-Semigroup H)
   issec-hom-inv-iso-Semigroup =
     is-sec-hom-inv-iso-Large-Precategory Semigroup-Large-Precategory G H
 
   isretr-hom-inv-iso-Semigroup :
     (f : type-iso-Semigroup) →
-    Id ( comp-hom-Semigroup G H G
-         ( hom-inv-iso-Semigroup f)
-         ( hom-iso-Semigroup f))
-       ( id-hom-Semigroup G)
+    Id
+      ( comp-hom-Semigroup G H G
+        ( hom-inv-iso-Semigroup f)
+        ( hom-iso-Semigroup f))
+      ( id-hom-Semigroup G)
   isretr-hom-inv-iso-Semigroup =
     is-retr-hom-inv-iso-Large-Precategory Semigroup-Large-Precategory G H
 ```
@@ -119,8 +121,9 @@ module _
             ( map-inv-is-equiv is-equiv-f x)
             ( map-inv-is-equiv is-equiv-f y)))
         ( ( ( issec-map-inv-is-equiv is-equiv-f (mul-Semigroup H x y)) ∙
-            ( ( ap ( λ t → mul-Semigroup H t y)
-                   ( inv (issec-map-inv-is-equiv is-equiv-f x))) ∙
+            ( ( ap
+                ( λ t → mul-Semigroup H t y)
+                ( inv (issec-map-inv-is-equiv is-equiv-f x))) ∙
               ( ap
                 ( mul-Semigroup H (f (map-inv-is-equiv is-equiv-f x)))
                 ( inv (issec-map-inv-is-equiv is-equiv-f y))))) ∙

--- a/src/group-theory/iterated-cartesian-products-concrete-groups.lagda.md
+++ b/src/group-theory/iterated-cartesian-products-concrete-groups.lagda.md
@@ -157,38 +157,42 @@ module _
 
   associative-mul-iterated-product-Concrete-Group :
     (x y z : type-iterated-product-Concrete-Group) →
-    Id (mul-iterated-product-Concrete-Group
-          ( mul-iterated-product-Concrete-Group x y)
-          ( z))
-       (mul-iterated-product-Concrete-Group
-          ( x)
-          ( mul-iterated-product-Concrete-Group y z))
+    Id
+      ( mul-iterated-product-Concrete-Group
+        ( mul-iterated-product-Concrete-Group x y)
+        ( z))
+      ( mul-iterated-product-Concrete-Group
+        ( x)
+        ( mul-iterated-product-Concrete-Group y z))
   associative-mul-iterated-product-Concrete-Group =
     associative-mul-∞-Group ∞-group-iterated-product-Concrete-Group
 
   left-unit-law-mul-iterated-product-Concrete-Group :
     (x : type-iterated-product-Concrete-Group) →
-    Id (mul-iterated-product-Concrete-Group
-          unit-iterated-product-Concrete-Group
-          x)
-       x
+    Id
+      ( mul-iterated-product-Concrete-Group
+        ( unit-iterated-product-Concrete-Group)
+        ( x))
+      ( x)
   left-unit-law-mul-iterated-product-Concrete-Group =
     left-unit-law-mul-∞-Group ∞-group-iterated-product-Concrete-Group
 
   right-unit-law-mul-iterated-product-Concrete-Group :
     (y : type-iterated-product-Concrete-Group) →
-    Id (mul-iterated-product-Concrete-Group
-          y
-          unit-iterated-product-Concrete-Group)
-       y
+    Id
+      ( mul-iterated-product-Concrete-Group
+        ( y)
+        ( unit-iterated-product-Concrete-Group))
+      ( y)
   right-unit-law-mul-iterated-product-Concrete-Group =
     right-unit-law-mul-∞-Group ∞-group-iterated-product-Concrete-Group
 
   coherence-unit-laws-mul-iterated-product-Concrete-Group :
-    Id ( left-unit-law-mul-iterated-product-Concrete-Group
-           unit-iterated-product-Concrete-Group)
-       ( right-unit-law-mul-iterated-product-Concrete-Group
-           unit-iterated-product-Concrete-Group)
+    Id
+      ( left-unit-law-mul-iterated-product-Concrete-Group
+          unit-iterated-product-Concrete-Group)
+      ( right-unit-law-mul-iterated-product-Concrete-Group
+          unit-iterated-product-Concrete-Group)
   coherence-unit-laws-mul-iterated-product-Concrete-Group =
     coherence-unit-laws-mul-∞-Group ∞-group-iterated-product-Concrete-Group
 
@@ -199,19 +203,21 @@ module _
 
   left-inverse-law-mul-iterated-product-Concrete-Group :
     (x : type-iterated-product-Concrete-Group) →
-    Id (mul-iterated-product-Concrete-Group
-          (inv-iterated-product-Concrete-Group x)
-          x)
-       unit-iterated-product-Concrete-Group
+    Id
+      ( mul-iterated-product-Concrete-Group
+        ( inv-iterated-product-Concrete-Group x)
+        ( x))
+      ( unit-iterated-product-Concrete-Group)
   left-inverse-law-mul-iterated-product-Concrete-Group =
     left-inverse-law-mul-∞-Group ∞-group-iterated-product-Concrete-Group
 
   right-inverse-law-mul-iterated-product-Concrete-Group :
     (x : type-iterated-product-Concrete-Group) →
-    Id (mul-iterated-product-Concrete-Group
-          x
-          (inv-iterated-product-Concrete-Group x))
-       unit-iterated-product-Concrete-Group
+    Id
+      ( mul-iterated-product-Concrete-Group
+        ( x)
+        ( inv-iterated-product-Concrete-Group x))
+      ( unit-iterated-product-Concrete-Group)z
   right-inverse-law-mul-iterated-product-Concrete-Group =
     right-inverse-law-mul-∞-Group ∞-group-iterated-product-Concrete-Group
 

--- a/src/group-theory/iterated-cartesian-products-concrete-groups.lagda.md
+++ b/src/group-theory/iterated-cartesian-products-concrete-groups.lagda.md
@@ -217,7 +217,7 @@ module _
       ( mul-iterated-product-Concrete-Group
         ( x)
         ( inv-iterated-product-Concrete-Group x))
-      ( unit-iterated-product-Concrete-Group)z
+      ( unit-iterated-product-Concrete-Group)
   right-inverse-law-mul-iterated-product-Concrete-Group =
     right-inverse-law-mul-∞-Group ∞-group-iterated-product-Concrete-Group
 

--- a/src/group-theory/orbits-monoid-actions.lagda.md
+++ b/src/group-theory/orbits-monoid-actions.lagda.md
@@ -57,8 +57,9 @@ module _
     {x y : type-Monoid-Action M X} (f g : hom-orbit-Monoid-Action x y) →
     UU l1
   htpy-hom-orbit-Monoid-Action {x} {y} f g =
-    Id ( element-hom-orbit-Monoid-Action f)
-       ( element-hom-orbit-Monoid-Action g)
+    Id
+      ( element-hom-orbit-Monoid-Action f)
+      ( element-hom-orbit-Monoid-Action g)
 
   refl-htpy-hom-orbit-Monoid-Action :
     {x y : type-Monoid-Action M X} (f : hom-orbit-Monoid-Action x y) →

--- a/src/group-theory/products-of-elements-monoids.lagda.md
+++ b/src/group-theory/products-of-elements-monoids.lagda.md
@@ -46,8 +46,9 @@ module _
 
   distributive-mul-concat-list-Monoid :
     (l1 l2 : list (type-Monoid M)) →
-    Id ( mul-list-Monoid M (concat-list l1 l2))
-       ( mul-Monoid M (mul-list-Monoid M l1) (mul-list-Monoid M l2))
+    Id
+      ( mul-list-Monoid M (concat-list l1 l2))
+      ( mul-Monoid M (mul-list-Monoid M l1) (mul-list-Monoid M l2))
   distributive-mul-concat-list-Monoid nil l2 =
     inv (left-unit-law-mul-Monoid M (mul-list-Monoid M l2))
   distributive-mul-concat-list-Monoid (cons x l1) l2 =

--- a/src/group-theory/subgroups-abelian-groups.lagda.md
+++ b/src/group-theory/subgroups-abelian-groups.lagda.md
@@ -213,8 +213,9 @@ module _
 
   associative-add-Subgroup-Ab :
     ( x y z : type-ab-Subgroup-Ab) →
-    Id (add-ab-Subgroup-Ab (add-ab-Subgroup-Ab x y) z)
-       (add-ab-Subgroup-Ab x (add-ab-Subgroup-Ab y z))
+    Id
+      ( add-ab-Subgroup-Ab (add-ab-Subgroup-Ab x y) z)
+      ( add-ab-Subgroup-Ab x (add-ab-Subgroup-Ab y z))
   associative-add-Subgroup-Ab =
     associative-mul-Subgroup (group-Ab A) B
 
@@ -232,15 +233,17 @@ module _
 
   left-inverse-law-add-Subgroup-Ab :
     (x : type-ab-Subgroup-Ab) →
-    Id ( add-ab-Subgroup-Ab (neg-ab-Subgroup-Ab x) x)
-       ( zero-ab-Subgroup-Ab)
+    Id
+      ( add-ab-Subgroup-Ab (neg-ab-Subgroup-Ab x) x)
+      ( zero-ab-Subgroup-Ab)
   left-inverse-law-add-Subgroup-Ab =
     left-inverse-law-mul-Subgroup (group-Ab A) B
 
   right-inverse-law-add-Subgroup-Ab :
     (x : type-ab-Subgroup-Ab) →
-    Id ( add-ab-Subgroup-Ab x (neg-ab-Subgroup-Ab x))
-       ( zero-ab-Subgroup-Ab)
+    Id
+      ( add-ab-Subgroup-Ab x (neg-ab-Subgroup-Ab x))
+      ( zero-ab-Subgroup-Ab)
   right-inverse-law-add-Subgroup-Ab =
     right-inverse-law-mul-Subgroup (group-Ab A) B
 

--- a/src/group-theory/subgroups-generated-by-subsets-groups.lagda.md
+++ b/src/group-theory/subgroups-generated-by-subsets-groups.lagda.md
@@ -79,10 +79,11 @@ module _
 
   preserves-concat-ev-formal-combination-subset-Group :
     (u v : formal-combination-subset-Group) →
-    Id ( ev-formal-combination-subset-Group (concat-list u v))
-       ( mul-Group G
-         ( ev-formal-combination-subset-Group u)
-         ( ev-formal-combination-subset-Group v))
+    Id
+      ( ev-formal-combination-subset-Group (concat-list u v))
+      ( mul-Group G
+        ( ev-formal-combination-subset-Group u)
+        ( ev-formal-combination-subset-Group v))
   preserves-concat-ev-formal-combination-subset-Group nil v =
     inv (left-unit-law-mul-Group G (ev-formal-combination-subset-Group v))
   preserves-concat-ev-formal-combination-subset-Group
@@ -118,9 +119,10 @@ module _
 
   preserves-inv-ev-formal-combination-subset-Group :
     (u : formal-combination-subset-Group) →
-    Id ( ev-formal-combination-subset-Group
-         ( inv-formal-combination-subset-Group u))
-       ( inv-Group G (ev-formal-combination-subset-Group u))
+    Id
+      ( ev-formal-combination-subset-Group
+        ( inv-formal-combination-subset-Group u))
+      ( inv-Group G (ev-formal-combination-subset-Group u))
   preserves-inv-ev-formal-combination-subset-Group nil =
     inv (inv-unit-Group G)
   preserves-inv-ev-formal-combination-subset-Group

--- a/src/group-theory/symmetric-concrete-groups.lagda.md
+++ b/src/group-theory/symmetric-concrete-groups.lagda.md
@@ -99,3 +99,5 @@ module _
 ```
 
 ### Equivalent sets have isomorphic symmetric concrete groups
+
+This remains to be shown.

--- a/src/group-theory/torsors.lagda.md
+++ b/src/group-theory/torsors.lagda.md
@@ -213,8 +213,9 @@ module _
     refl-htpy-equiv-Torsor-Abstract-Group
 
   is-contr-total-htpy-equiv-Torsor-Abstract-Group :
-    is-contr ( Σ ( equiv-Torsor-Abstract-Group G X Y)
-                 ( htpy-equiv-Torsor-Abstract-Group))
+    is-contr
+      ( Σ ( equiv-Torsor-Abstract-Group G X Y)
+          ( htpy-equiv-Torsor-Abstract-Group))
   is-contr-total-htpy-equiv-Torsor-Abstract-Group =
     is-contr-total-htpy-equiv-Abstract-Group-Action G
       ( action-Torsor-Abstract-Group G X)
@@ -306,11 +307,12 @@ module _
     (h : equiv-Torsor-Abstract-Group G X3 X4)
     (g : equiv-Torsor-Abstract-Group G X2 X3)
     (f : equiv-Torsor-Abstract-Group G X1 X2) →
-    Id ( comp-equiv-Torsor-Abstract-Group G X1 X2 X4
-         ( comp-equiv-Torsor-Abstract-Group G X2 X3 X4 h g)
-         ( f))
-       ( comp-equiv-Torsor-Abstract-Group G X1 X3 X4 h
-         ( comp-equiv-Torsor-Abstract-Group G X1 X2 X3 g f))
+    Id
+      ( comp-equiv-Torsor-Abstract-Group G X1 X2 X4
+        ( comp-equiv-Torsor-Abstract-Group G X2 X3 X4 h g)
+        ( f))
+      ( comp-equiv-Torsor-Abstract-Group G X1 X3 X4 h
+        ( comp-equiv-Torsor-Abstract-Group G X1 X2 X3 g f))
   associative-comp-equiv-Torsor-Abstract-Group h g f =
     eq-htpy-equiv-Torsor-Abstract-Group G X1 X4
       ( comp-equiv-Torsor-Abstract-Group G X1 X2 X4
@@ -327,10 +329,11 @@ module _
 
   left-unit-law-comp-equiv-Torsor-Abstract-Group :
     (f : equiv-Torsor-Abstract-Group G X Y) →
-    Id ( comp-equiv-Torsor-Abstract-Group G X Y Y
-         ( id-equiv-Torsor-Abstract-Group G Y)
-         ( f))
-       ( f)
+    Id
+      ( comp-equiv-Torsor-Abstract-Group G X Y Y
+        ( id-equiv-Torsor-Abstract-Group G Y)
+        ( f))
+      ( f)
   left-unit-law-comp-equiv-Torsor-Abstract-Group f =
     eq-htpy-equiv-Torsor-Abstract-Group G X Y
       ( comp-equiv-Torsor-Abstract-Group G X Y Y
@@ -341,9 +344,10 @@ module _
 
   right-unit-law-comp-equiv-Torsor-Abstract-Group :
     (f : equiv-Torsor-Abstract-Group G X Y) →
-    Id ( comp-equiv-Torsor-Abstract-Group G X X Y f
-         ( id-equiv-Torsor-Abstract-Group G X))
-       ( f)
+    Id
+      ( comp-equiv-Torsor-Abstract-Group G X X Y f
+        ( id-equiv-Torsor-Abstract-Group G X))
+      ( f)
   right-unit-law-comp-equiv-Torsor-Abstract-Group f =
     eq-htpy-equiv-Torsor-Abstract-Group G X Y
       ( comp-equiv-Torsor-Abstract-Group G X X Y f
@@ -353,10 +357,11 @@ module _
 
   left-inverse-law-comp-equiv-Torsor-Abstract-Group :
     (f : equiv-Torsor-Abstract-Group G X Y) →
-    Id ( comp-equiv-Torsor-Abstract-Group G X Y X
-         ( inv-equiv-Torsor-Abstract-Group G X Y f)
-         ( f))
-       ( id-equiv-Torsor-Abstract-Group G X)
+    Id
+      ( comp-equiv-Torsor-Abstract-Group G X Y X
+        ( inv-equiv-Torsor-Abstract-Group G X Y f)
+        ( f))
+      ( id-equiv-Torsor-Abstract-Group G X)
   left-inverse-law-comp-equiv-Torsor-Abstract-Group f =
     eq-htpy-equiv-Torsor-Abstract-Group G X X
       ( comp-equiv-Torsor-Abstract-Group G X Y X
@@ -367,9 +372,10 @@ module _
 
   right-inverse-law-comp-equiv-Torsor-Abstract-Group :
     (f : equiv-Torsor-Abstract-Group G X Y) →
-    Id ( comp-equiv-Torsor-Abstract-Group G Y X Y f
-         ( inv-equiv-Torsor-Abstract-Group G X Y f))
-       ( id-equiv-Torsor-Abstract-Group G Y)
+    Id
+      ( comp-equiv-Torsor-Abstract-Group G Y X Y f
+        ( inv-equiv-Torsor-Abstract-Group G X Y f))
+      ( id-equiv-Torsor-Abstract-Group G Y)
   right-inverse-law-comp-equiv-Torsor-Abstract-Group f =
     eq-htpy-equiv-Torsor-Abstract-Group G Y Y
       ( comp-equiv-Torsor-Abstract-Group G Y X Y f
@@ -384,10 +390,11 @@ module _
   preserves-mul-equiv-eq-Torsor-Abstract-Group :
     {l2 : Level} (X Y Z : Torsor-Abstract-Group G l2)
     (p : Id X Y) (q : Id Y Z) →
-    Id ( equiv-eq-Torsor-Abstract-Group G X Z (p ∙ q))
-       ( comp-equiv-Torsor-Abstract-Group G X Y Z
-         ( equiv-eq-Torsor-Abstract-Group G Y Z q)
-         ( equiv-eq-Torsor-Abstract-Group G X Y p))
+    Id
+      ( equiv-eq-Torsor-Abstract-Group G X Z (p ∙ q))
+      ( comp-equiv-Torsor-Abstract-Group G X Y Z
+        ( equiv-eq-Torsor-Abstract-Group G Y Z q)
+        ( equiv-eq-Torsor-Abstract-Group G X Y p))
   preserves-mul-equiv-eq-Torsor-Abstract-Group X .X Z refl q =
     inv ( right-unit-law-comp-equiv-Torsor-Abstract-Group G X Z
           ( equiv-eq-Torsor-Abstract-Group G X Z q))
@@ -504,27 +511,30 @@ module _
   Eq-equiv-Torsor-Abstract-Group X (pair e H) = map-equiv e (unit-Group G)
 
   preserves-mul-Eq-equiv-Torsor-Abstract-Group :
-    (e f : equiv-Torsor-Abstract-Group G
-           ( principal-Torsor-Abstract-Group G)
-           ( principal-Torsor-Abstract-Group G)) →
-    Id ( Eq-equiv-Torsor-Abstract-Group
-         ( principal-Torsor-Abstract-Group G)
-         ( comp-equiv-Torsor-Abstract-Group G
-           ( principal-Torsor-Abstract-Group G)
-           ( principal-Torsor-Abstract-Group G)
-           ( principal-Torsor-Abstract-Group G)
-           ( f)
-           ( e)))
-       ( mul-Group G
-         ( Eq-equiv-Torsor-Abstract-Group
-           ( principal-Torsor-Abstract-Group G)
-           ( e))
-         ( Eq-equiv-Torsor-Abstract-Group
-           ( principal-Torsor-Abstract-Group G)
-           ( f)))
+    (e f :
+      equiv-Torsor-Abstract-Group G
+        ( principal-Torsor-Abstract-Group G)
+        ( principal-Torsor-Abstract-Group G)) →
+    Id
+      ( Eq-equiv-Torsor-Abstract-Group
+        ( principal-Torsor-Abstract-Group G)
+        ( comp-equiv-Torsor-Abstract-Group G
+          ( principal-Torsor-Abstract-Group G)
+          ( principal-Torsor-Abstract-Group G)
+          ( principal-Torsor-Abstract-Group G)
+          ( f)
+          ( e)))
+      ( mul-Group G
+        ( Eq-equiv-Torsor-Abstract-Group
+          ( principal-Torsor-Abstract-Group G)
+          ( e))
+        ( Eq-equiv-Torsor-Abstract-Group
+          ( principal-Torsor-Abstract-Group G)
+          ( f)))
   preserves-mul-Eq-equiv-Torsor-Abstract-Group (pair e H) (pair f K) =
-    ( ap ( map-equiv f)
-         ( inv (right-unit-law-mul-Group G (map-equiv e (unit-Group G))))) ∙
+    ( ap
+      ( map-equiv f)
+      ( inv (right-unit-law-mul-Group G (map-equiv e (unit-Group G))))) ∙
     ( K (map-equiv e (unit-Group G)) (unit-Group G))
 
   equiv-Eq-Torsor-Abstract-Group :
@@ -565,15 +575,16 @@ module _
         ( is-torsor-action-Torsor-Abstract-Group G X)
         ( is-equiv-Prop (Eq-equiv-Torsor-Abstract-Group X))
         ( λ e →
-          tr ( λ Y → is-equiv (Eq-equiv-Torsor-Abstract-Group Y))
-             ( eq-equiv-Torsor-Abstract-Group G
-               ( principal-Torsor-Abstract-Group G)
-               ( X)
-               ( e))
-             ( is-equiv-has-inverse
-                 equiv-Eq-Torsor-Abstract-Group
-                 issec-equiv-Eq-Torsor-Abstract-Group
-                 isretr-equiv-Eq-Torsor-Abstract-Group))
+          tr
+            ( λ Y → is-equiv (Eq-equiv-Torsor-Abstract-Group Y))
+            ( eq-equiv-Torsor-Abstract-Group G
+              ( principal-Torsor-Abstract-Group G)
+              ( X)
+              ( e))
+            ( is-equiv-has-inverse
+                equiv-Eq-Torsor-Abstract-Group
+                issec-equiv-Eq-Torsor-Abstract-Group
+                isretr-equiv-Eq-Torsor-Abstract-Group))
 
   equiv-Eq-equiv-Torsor-Abstract-Group :
     (X : Torsor-Abstract-Group G l1) →
@@ -587,29 +598,33 @@ module _
       ( X))
 
   preserves-mul-equiv-Eq-equiv-Torsor-Abstract-Group :
-    ( p q : Id ( principal-Torsor-Abstract-Group G)
-               ( principal-Torsor-Abstract-Group G)) →
-    Id ( map-equiv
-         ( equiv-Eq-equiv-Torsor-Abstract-Group
-           ( principal-Torsor-Abstract-Group G))
-         ( p ∙ q))
-       ( mul-Group G
-         ( map-equiv
-           ( equiv-Eq-equiv-Torsor-Abstract-Group
-             ( principal-Torsor-Abstract-Group G))
-           ( p))
-         ( map-equiv
-           ( equiv-Eq-equiv-Torsor-Abstract-Group
-             ( principal-Torsor-Abstract-Group G))
-           ( q)))
+    ( p q :
+      Id
+        ( principal-Torsor-Abstract-Group G)
+        ( principal-Torsor-Abstract-Group G)) →
+    Id
+      ( map-equiv
+        ( equiv-Eq-equiv-Torsor-Abstract-Group
+          ( principal-Torsor-Abstract-Group G))
+        ( p ∙ q))
+      ( mul-Group G
+        ( map-equiv
+          ( equiv-Eq-equiv-Torsor-Abstract-Group
+            ( principal-Torsor-Abstract-Group G))
+          ( p))
+        ( map-equiv
+          ( equiv-Eq-equiv-Torsor-Abstract-Group
+            ( principal-Torsor-Abstract-Group G))
+          ( q)))
   preserves-mul-equiv-Eq-equiv-Torsor-Abstract-Group p q =
-    ( ap ( Eq-equiv-Torsor-Abstract-Group (principal-Torsor-Abstract-Group G))
-         ( preserves-mul-equiv-eq-Torsor-Abstract-Group G
-           ( principal-Torsor-Abstract-Group G)
-           ( principal-Torsor-Abstract-Group G)
-           ( principal-Torsor-Abstract-Group G)
-           ( p)
-           ( q))) ∙
+    ( ap
+      ( Eq-equiv-Torsor-Abstract-Group (principal-Torsor-Abstract-Group G))
+      ( preserves-mul-equiv-eq-Torsor-Abstract-Group G
+        ( principal-Torsor-Abstract-Group G)
+        ( principal-Torsor-Abstract-Group G)
+        ( principal-Torsor-Abstract-Group G)
+        ( p)
+        ( q))) ∙
     ( preserves-mul-Eq-equiv-Torsor-Abstract-Group
       ( equiv-eq-Torsor-Abstract-Group G
         ( principal-Torsor-Abstract-Group G)

--- a/src/higher-group-theory/homomorphisms-higher-groups.lagda.md
+++ b/src/higher-group-theory/homomorphisms-higher-groups.lagda.md
@@ -66,8 +66,9 @@ module _
 
   preserves-mul-map-hom-∞-Group :
     (f : hom-∞-Group) (x y : type-∞-Group G) →
-    Id ( map-hom-∞-Group f (mul-∞-Group G x y))
-       ( mul-∞-Group H (map-hom-∞-Group f x) (map-hom-∞-Group f y))
+    Id
+      ( map-hom-∞-Group f (mul-∞-Group G x y))
+      ( mul-∞-Group H (map-hom-∞-Group f x) (map-hom-∞-Group f y))
   preserves-mul-map-hom-∞-Group =
     preserves-mul-map-Ω
       ( classifying-pointed-type-∞-Group G)
@@ -75,8 +76,9 @@ module _
 
   preserves-inv-map-hom-∞-Group :
     (f : hom-∞-Group) (x : type-∞-Group G) →
-    Id ( map-hom-∞-Group f (inv-∞-Group G x))
-       ( inv-∞-Group H (map-hom-∞-Group f x))
+    Id
+      ( map-hom-∞-Group f (inv-∞-Group G x))
+      ( inv-∞-Group H (map-hom-∞-Group f x))
   preserves-inv-map-hom-∞-Group =
     preserves-inv-map-Ω
       ( classifying-pointed-type-∞-Group G)

--- a/src/higher-group-theory/iterated-cartesian-products-higher-groups.lagda.md
+++ b/src/higher-group-theory/iterated-cartesian-products-higher-groups.lagda.md
@@ -112,41 +112,45 @@ module _
 
   assoc-mul-iterated-product-∞-Group :
     (x y z : type-iterated-product-∞-Group) →
-    Id (mul-iterated-product-∞-Group
-          ( mul-iterated-product-∞-Group x y)
-          ( z))
-       (mul-iterated-product-∞-Group
-          ( x)
-          ( mul-iterated-product-∞-Group y z))
+    Id
+      ( mul-iterated-product-∞-Group
+        ( mul-iterated-product-∞-Group x y)
+        ( z))
+      ( mul-iterated-product-∞-Group
+        ( x)
+        ( mul-iterated-product-∞-Group y z))
   assoc-mul-iterated-product-∞-Group =
     associative-mul-Ω
       classifying-pointed-type-iterated-product-∞-Group
 
   left-unit-law-mul-iterated-product-∞-Group :
     (x : type-iterated-product-∞-Group) →
-    Id (mul-iterated-product-∞-Group
-          unit-iterated-product-∞-Group
-          x)
-       x
+    Id
+      ( mul-iterated-product-∞-Group
+        ( unit-iterated-product-∞-Group)
+        ( x))
+      ( x)
   left-unit-law-mul-iterated-product-∞-Group =
     left-unit-law-mul-Ω
       classifying-pointed-type-iterated-product-∞-Group
 
   right-unit-law-mul-iterated-product-∞-Group :
     (y : type-iterated-product-∞-Group) →
-    Id (mul-iterated-product-∞-Group
-          y
-          unit-iterated-product-∞-Group)
-       y
+    Id
+      ( mul-iterated-product-∞-Group
+        ( y)
+        ( unit-iterated-product-∞-Group))
+      ( y)
   right-unit-law-mul-iterated-product-∞-Group =
     right-unit-law-mul-Ω
       classifying-pointed-type-iterated-product-∞-Group
 
   coherence-unit-laws-mul-iterated-product-∞-Group :
-    Id ( left-unit-law-mul-iterated-product-∞-Group
-           unit-iterated-product-∞-Group)
-       ( right-unit-law-mul-iterated-product-∞-Group
-           unit-iterated-product-∞-Group)
+    Id
+      ( left-unit-law-mul-iterated-product-∞-Group
+          unit-iterated-product-∞-Group)
+      ( right-unit-law-mul-iterated-product-∞-Group
+          unit-iterated-product-∞-Group)
   coherence-unit-laws-mul-iterated-product-∞-Group = refl
 
   inv-iterated-product-∞-Group :
@@ -156,20 +160,22 @@ module _
 
   left-inverse-law-mul-iterated-product-∞-Group :
     (x : type-iterated-product-∞-Group) →
-    Id (mul-iterated-product-∞-Group
-          ( inv-iterated-product-∞-Group x)
-          ( x))
-       unit-iterated-product-∞-Group
+    Id
+      ( mul-iterated-product-∞-Group
+        ( inv-iterated-product-∞-Group x)
+        ( x))
+      ( unit-iterated-product-∞-Group)
   left-inverse-law-mul-iterated-product-∞-Group =
     left-inverse-law-mul-Ω
       classifying-pointed-type-iterated-product-∞-Group
 
   right-inverse-law-mul-iterated-product-∞-Group :
     (x : type-iterated-product-∞-Group) →
-    Id (mul-iterated-product-∞-Group
-          ( x)
-          ( inv-iterated-product-∞-Group x))
-       unit-iterated-product-∞-Group
+    Id
+      ( mul-iterated-product-∞-Group
+        ( x)
+        ( inv-iterated-product-∞-Group x))
+      ( unit-iterated-product-∞-Group)
   right-inverse-law-mul-iterated-product-∞-Group =
     right-inverse-law-mul-Ω
       classifying-pointed-type-iterated-product-∞-Group

--- a/src/linear-algebra/functoriality-vectors.lagda.md
+++ b/src/linear-algebra/functoriality-vectors.lagda.md
@@ -81,10 +81,10 @@ module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
   where
 
- binary-map-functional-vec :
-   (n : ℕ) → (A → B → C) →
-   functional-vec A n → functional-vec B n → functional-vec C n
- binary-map-functional-vec n f v w i = f (v i) (w i)
+  binary-map-functional-vec :
+    (n : ℕ) → (A → B → C) →
+    functional-vec A n → functional-vec B n → functional-vec C n
+  binary-map-functional-vec n f v w i = f (v i) (w i)
 ```
 
 ### Link between functoriality of the type of vectors and of the type of functional vectors

--- a/src/linear-algebra/matrices-on-rings.lagda.md
+++ b/src/linear-algebra/matrices-on-rings.lagda.md
@@ -69,8 +69,9 @@ module _
 
   associative-add-matrix-Ring :
     {m n : ℕ} (A B C : matrix-Ring R m n) →
-    Id ( add-matrix-Ring R (add-matrix-Ring R A B) C)
-       ( add-matrix-Ring R A (add-matrix-Ring R B C))
+    Id
+      ( add-matrix-Ring R (add-matrix-Ring R A B) C)
+      ( add-matrix-Ring R A (add-matrix-Ring R B C))
   associative-add-matrix-Ring empty-vec empty-vec empty-vec = refl
   associative-add-matrix-Ring (v ∷ A) (w ∷ B) (z ∷ C) =
     ap-binary _∷_

--- a/src/linear-algebra/transposition-matrices.lagda.md
+++ b/src/linear-algebra/transposition-matrices.lagda.md
@@ -58,6 +58,7 @@ is-involution-transpose-matrix {m = succ-ℕ m} (r ∷ rs) =
     Id (transpose-matrix xs) (map-vec tail-vec (transpose-matrix (x ∷ xs)))
   lemma-rest {n = zero-ℕ} empty-vec xs = refl
   lemma-rest {n = succ-ℕ n} (k ∷ ks) xs =
-    ap (_∷_ (map-vec head-vec xs))
-       (lemma-rest (tail-vec (k ∷ ks)) (map-vec tail-vec xs))
+    ap
+      ( _∷_ (map-vec head-vec xs))
+      ( lemma-rest (tail-vec (k ∷ ks)) (map-vec tail-vec xs))
 ```

--- a/src/lists/concatenation-lists.lagda.md
+++ b/src/lists/concatenation-lists.lagda.md
@@ -112,24 +112,27 @@ eta-list' (cons a (cons b x)) = ap (cons a) (eta-list' (cons b x))
 ```agda
 head-concat-list :
   {l1 : Level} {A : UU l1} (x y : list A) →
-  Id ( head-list (concat-list x y))
-     ( head-list (concat-list (head-list x) (head-list y)))
+  Id
+    ( head-list (concat-list x y))
+    ( head-list (concat-list (head-list x) (head-list y)))
 head-concat-list nil nil = refl
 head-concat-list nil (cons x y) = refl
 head-concat-list (cons a x) y = refl
 
 tail-concat-list :
   {l1 : Level} {A : UU l1} (x y : list A) →
-  Id ( tail-list (concat-list x y))
-     ( concat-list (tail-list x) (tail-list (concat-list (head-list x) y)))
+  Id
+    ( tail-list (concat-list x y))
+    ( concat-list (tail-list x) (tail-list (concat-list (head-list x) y)))
 tail-concat-list nil y = refl
 tail-concat-list (cons a x) y = refl
 
 last-element-concat-list :
   {l1 : Level} {A : UU l1} (x y : list A) →
-  Id ( last-element-list (concat-list x y))
-     ( last-element-list
-       ( concat-list (last-element-list x) (last-element-list y)))
+  Id
+    ( last-element-list (concat-list x y))
+    ( last-element-list
+      ( concat-list (last-element-list x) (last-element-list y)))
 last-element-concat-list nil nil = refl
 last-element-concat-list nil (cons b nil) = refl
 last-element-concat-list nil (cons b (cons c y)) =
@@ -143,10 +146,11 @@ last-element-concat-list (cons a (cons b x)) y =
 
 remove-last-element-concat-list :
   {l1 : Level} {A : UU l1} (x y : list A) →
-  Id ( remove-last-element-list (concat-list x y))
-     ( concat-list
-       ( remove-last-element-list (concat-list x (head-list y)))
-       ( remove-last-element-list y))
+  Id
+    ( remove-last-element-list (concat-list x y))
+    ( concat-list
+      ( remove-last-element-list (concat-list x (head-list y)))
+      ( remove-last-element-list y))
 remove-last-element-concat-list nil nil = refl
 remove-last-element-concat-list nil (cons a nil) = refl
 remove-last-element-concat-list nil (cons a (cons b y)) = refl
@@ -157,10 +161,11 @@ remove-last-element-concat-list (cons a (cons b x)) y =
 
 tail-concat-list' :
   {l1 : Level} {A : UU l1} (x y : list A) →
-  Id ( tail-list (concat-list x y))
-     ( concat-list
-       ( tail-list x)
-       ( tail-list (concat-list (last-element-list x) y)))
+  Id
+    ( tail-list (concat-list x y))
+    ( concat-list
+      ( tail-list x)
+      ( tail-list (concat-list (last-element-list x) y)))
 tail-concat-list' nil y = refl
 tail-concat-list' (cons a nil) y = refl
 tail-concat-list' (cons a (cons b x)) y =

--- a/src/lists/flattening-lists.lagda.md
+++ b/src/lists/flattening-lists.lagda.md
@@ -44,8 +44,9 @@ flatten-unit-list x = right-unit-law-concat-list x
 
 length-flatten-list :
   {l1 : Level} {A : UU l1} (x : list (list A)) →
-  Id ( length-list (flatten-list x))
-     ( sum-list-ℕ (map-list length-list x))
+  Id
+    ( length-list (flatten-list x))
+    ( sum-list-ℕ (map-list length-list x))
 length-flatten-list nil = refl
 length-flatten-list (cons a x) =
   ( length-concat-list a (flatten-list x)) ∙
@@ -53,8 +54,9 @@ length-flatten-list (cons a x) =
 
 flatten-concat-list :
   {l1 : Level} {A : UU l1} (x y : list (list A)) →
-  Id ( flatten-list (concat-list x y))
-     ( concat-list (flatten-list x) (flatten-list y))
+  Id
+    ( flatten-list (concat-list x y))
+    ( concat-list (flatten-list x) (flatten-list y))
 flatten-concat-list nil y = refl
 flatten-concat-list (cons a x) y =
   ( ap (concat-list a) (flatten-concat-list x y)) ∙
@@ -62,8 +64,9 @@ flatten-concat-list (cons a x) y =
 
 flatten-flatten-list :
   {l1 : Level} {A : UU l1} (x : list (list (list A))) →
-  Id ( flatten-list (flatten-list x))
-     ( flatten-list (map-list flatten-list x))
+  Id
+    ( flatten-list (flatten-list x))
+    ( flatten-list (map-list flatten-list x))
 flatten-flatten-list nil = refl
 flatten-flatten-list (cons a x) =
   ( flatten-concat-list a (flatten-list x)) ∙

--- a/src/lists/functoriality-lists.lagda.md
+++ b/src/lists/functoriality-lists.lagda.md
@@ -215,8 +215,9 @@ module _
 
   preserves-concat-map-list :
     (l k : list A) →
-    Id ( map-list f (concat-list l k))
-       ( concat-list (map-list f l) (map-list f k))
+    Id
+      ( map-list f (concat-list l k))
+      ( concat-list (map-list f l) (map-list f k))
   preserves-concat-map-list nil k = refl
   preserves-concat-map-list (cons x l) k =
     ap (cons (f x)) (preserves-concat-map-list l k)

--- a/src/lists/functoriality-lists.lagda.md
+++ b/src/lists/functoriality-lists.lagda.md
@@ -118,7 +118,7 @@ module _
                 ( vec B)
                 ( p)
                 ( vec-list (map-list f (list-vec n v))) ＝
-               map-vec f v)
+              map-vec f v)
             ( eq-is-prop
               ( is-set-ℕ
                 ( length-list (map-list f (list-vec n v)))

--- a/src/lists/lists.lagda.md
+++ b/src/lists/lists.lagda.md
@@ -168,8 +168,9 @@ eq-Eq-list (cons x l) (cons .x l') (pair refl e) =
 
 square-eq-Eq-list :
   {l1 : Level} {A : UU l1} {x : A} {l l' : list A} (p : Id l l') →
-  Id (Eq-eq-list (cons x l) (cons x l') (ap (cons x) p))
-     (pair refl (Eq-eq-list l l' p))
+  Id
+    ( Eq-eq-list (cons x l) (cons x l') (ap (cons x) p))
+    ( pair refl (Eq-eq-list l l' p))
 square-eq-Eq-list refl = refl
 
 issec-eq-Eq-list :

--- a/src/lists/permutation-lists.lagda.md
+++ b/src/lists/permutation-lists.lagda.md
@@ -229,26 +229,26 @@ helper-compute-list-vec-map-vec-permute-vec-vec-list :
     ( vec B)
     ( inv (length-permute-list p t))
     ( map-vec f (permute-vec (length-list p) (vec-list p) t)) ＝
-   map-vec f (vec-list (permute-list p t))
+  map-vec f (vec-list (permute-list p t))
 helper-compute-list-vec-map-vec-permute-vec-vec-list f p t =
-   ( ( compute-tr-map-vec
-       ( f)
-       ( inv (length-permute-list p t))
-       ( permute-vec (length-list p) (vec-list p) t)) ∙
-     ( ( ap
-         ( λ P →
-           map-vec
-             ( f)
-             ( tr (vec _) P (permute-vec (length-list p) (vec-list p) t)))
-         ( eq-is-prop (is-set-ℕ _ _))) ∙
-       ( ap
-         ( map-vec f)
-         ( pr2
-           ( pair-eq-Σ
-             ( inv
-               ( isretr-vec-list
-                 ( length-list p ,
-                   permute-vec (length-list p) (vec-list p) t))))))))
+  ( ( compute-tr-map-vec
+      ( f)
+      ( inv (length-permute-list p t))
+      ( permute-vec (length-list p) (vec-list p) t)) ∙
+    ( ( ap
+        ( λ P →
+          map-vec
+            ( f)
+            ( tr (vec _) P (permute-vec (length-list p) (vec-list p) t)))
+        ( eq-is-prop (is-set-ℕ _ _))) ∙
+      ( ap
+        ( map-vec f)
+        ( pr2
+          ( pair-eq-Σ
+            ( inv
+              ( isretr-vec-list
+                ( length-list p ,
+                  permute-vec (length-list p) (vec-list p) t))))))))
 
 compute-list-vec-map-vec-permute-vec-vec-list :
   {l1 l2 : Level} {A : UU l1} {B : UU l2}

--- a/src/lists/permutation-vectors.lagda.md
+++ b/src/lists/permutation-vectors.lagda.md
@@ -57,7 +57,7 @@ module _
     listed-vec-functional-vec n (functional-vec-vec n v ∘ (map-equiv s))
 ```
 
-### The predicate that a function from `vec` to `vec` is just permuting vectors.
+### The predicate that a function from `vec` to `vec` is just permuting vectors
 
 ```agda
   is-permutation-vec : (n : ℕ) → (vec A n → vec A n) → UU l

--- a/src/lists/permutation-vectors.lagda.md
+++ b/src/lists/permutation-vectors.lagda.md
@@ -249,17 +249,17 @@ module _
     fold-vec b μ v ＝
     fold-vec b μ (permute-vec (succ-ℕ n) v (adjacent-transposition-Fin n k))
   invariant-adjacent-transposition-fold-vec {succ-ℕ n} (x ∷ v) (inl k) =
-     ap
-       ( μ x)
-       ( invariant-adjacent-transposition-fold-vec v k) ∙
-     inv
-       ( ap
-         ( fold-vec b μ)
-         ( compute-equiv-coprod-permutation-id-equiv-permute-vec
-           ( succ-ℕ n)
-           ( v)
-           ( x)
-           ( adjacent-transposition-Fin n k)))
+    ap
+      ( μ x)
+      ( invariant-adjacent-transposition-fold-vec v k) ∙
+    inv
+      ( ap
+        ( fold-vec b μ)
+        ( compute-equiv-coprod-permutation-id-equiv-permute-vec
+          ( succ-ℕ n)
+          ( v)
+          ( x)
+          ( adjacent-transposition-Fin n k)))
   invariant-adjacent-transposition-fold-vec {succ-ℕ n} (x ∷ v) (inr _) =
     invariant-swap-two-last-elements-transposition-fold-vec (x ∷ v)
 
@@ -303,10 +303,11 @@ module _
       ( ap
         ( λ t → fold-vec b μ (permute-vec (succ-ℕ n) v t))
         ( eq-htpy-equiv
-          {e = permutation-list-adjacent-transpositions
-                 ( n)
-                 ( list-adjacent-transpositions-transposition-Fin n i j)}
-          {e' = transposition-Fin (succ-ℕ n) i j neq}
+          { e =
+            permutation-list-adjacent-transpositions
+              ( n)
+              ( list-adjacent-transpositions-transposition-Fin n i j)}
+          { e' = transposition-Fin (succ-ℕ n) i j neq}
           ( htpy-permutation-list-adjacent-transpositions-transposition-Fin
             ( n)
             ( i)
@@ -316,8 +317,7 @@ module _
   invariant-list-transpositions-fold-vec :
     {n : ℕ}
     (v : vec A n)
-    (l : list (Σ (Fin n × Fin n)
-                 ( λ (i , j) → ¬ (i ＝ j)))) →
+    (l : list (Σ (Fin n × Fin n) (λ (i , j) → ¬ (i ＝ j)))) →
     fold-vec b μ v ＝
     fold-vec
       ( b)

--- a/src/lists/reversing-lists.lagda.md
+++ b/src/lists/reversing-lists.lagda.md
@@ -58,8 +58,9 @@ length-reverse-list (cons a x) =
 
 reverse-concat-list :
   {l1 : Level} {A : UU l1} (x y : list A) →
-  Id ( reverse-list (concat-list x y))
-     ( concat-list (reverse-list y) (reverse-list x))
+  Id
+    ( reverse-list (concat-list x y))
+    ( concat-list (reverse-list y) (reverse-list x))
 reverse-concat-list nil y =
   inv (right-unit-law-concat-list (reverse-list y))
 reverse-concat-list (cons a x) y =
@@ -74,8 +75,9 @@ reverse-snoc-list (cons b x) a = ap (λ t → snoc t b) (reverse-snoc-list x a)
 
 reverse-flatten-list :
   {l1 : Level} {A : UU l1} (x : list (list A)) →
-  Id ( reverse-list (flatten-list x))
-     ( flatten-list (reverse-list (map-list reverse-list x)))
+  Id
+    ( reverse-list (flatten-list x))
+    ( flatten-list (reverse-list (map-list reverse-list x)))
 reverse-flatten-list nil = refl
 reverse-flatten-list (cons a x) =
   ( reverse-concat-list a (flatten-list x)) ∙

--- a/src/lists/sort-by-insertion-vectors.lagda.md
+++ b/src/lists/sort-by-insertion-vectors.lagda.md
@@ -261,7 +261,7 @@ module _
       ( X)
       ( helper-insertion-sort-vec x y (z ∷ v) (inr p))
       ( tr
-        ( λ l → is-least-element-vec X y l)
+        ( is-least-element-vec X y)
         ( inv
           ( helper-eq-permute-vec-permutation-insertion-sort-vec
             ( x)
@@ -269,6 +269,21 @@ module _
             ( v)
             ( is-leq-or-strict-greater-Decidable-Total-Order X x z)))
         ( is-least-element-permute-vec
+          ( X)
+          ( y)
+          ( x ∷ z ∷ v)
+          ( helper-permutation-insertion-sort-vec
+            ( x)
+            ( z)
+            ( v)
+            ( is-leq-or-strict-greater-Decidable-Total-Order X x z))
+          ( pr2 p ,
+            pr1
+              ( is-sorted-least-element-vec-is-sorted-vec
+                ( X)
+                ( y ∷ z ∷ v)
+                ( s)))) ,
+        ( is-sorted-least-element-vec-is-sorted-vec
           ( X)
           ( helper-insertion-sort-vec
             ( x)

--- a/src/lists/sort-by-insertion-vectors.lagda.md
+++ b/src/lists/sort-by-insertion-vectors.lagda.md
@@ -270,32 +270,17 @@ module _
             ( is-leq-or-strict-greater-Decidable-Total-Order X x z)))
         ( is-least-element-permute-vec
           ( X)
-          ( y)
-          ( x ∷ z ∷ v)
-          ( helper-permutation-insertion-sort-vec
+          ( helper-insertion-sort-vec
             ( x)
             ( z)
             ( v)
             ( is-leq-or-strict-greater-Decidable-Total-Order X x z))
-          ( pr2 p ,
-            pr1
-              ( is-sorted-least-element-vec-is-sorted-vec
-                ( X)
-                ( y ∷ z ∷ v)
-                ( s)))) ,
-         is-sorted-least-element-vec-is-sorted-vec
-           ( X)
-           ( helper-insertion-sort-vec
-             ( x)
-             ( z)
-             ( v)
-             ( is-leq-or-strict-greater-Decidable-Total-Order X x z))
-           ( helper-is-sorting-insertion-sort-vec
-             ( x)
-             ( z)
-             ( v)
-             ( is-leq-or-strict-greater-Decidable-Total-Order X x z)
-             ( is-sorted-tail-is-sorted-vec X (y ∷ z ∷ v) s)))
+          ( helper-is-sorting-insertion-sort-vec
+            ( x)
+            ( z)
+            ( v)
+            ( is-leq-or-strict-greater-Decidable-Total-Order X x z)
+            ( is-sorted-tail-is-sorted-vec X (y ∷ z ∷ v) s))))
 
   is-sorting-insertion-sort-vec :
     {n : ℕ}

--- a/src/lists/sorted-lists.lagda.md
+++ b/src/lists/sorted-lists.lagda.md
@@ -75,7 +75,7 @@ module _
 
 ## Properties
 
-### If a list is sorted, then its tail is also sorted.
+### If a list is sorted, then its tail is also sorted
 
 ```agda
   is-sorted-tail-is-sorted-list :

--- a/src/lists/sorted-vectors.lagda.md
+++ b/src/lists/sorted-vectors.lagda.md
@@ -78,7 +78,7 @@ module _
 
 ## Properties
 
-### If a vector is sorted, then its tail is also sorted.
+### If a vector is sorted, then its tail is also sorted
 
 ```agda
   is-sorted-tail-is-sorted-vec :

--- a/src/lists/universal-property-lists-wild-monoids.lagda.md
+++ b/src/lists/universal-property-lists-wild-monoids.lagda.md
@@ -51,9 +51,10 @@ list-Coherent-H-Space X =
 ```agda
 unit-law-011-associative-concat-list :
   {l1 : Level} {X : UU l1} (y z : list X) →
-  Id ( ( associative-concat-list nil y z) ∙
-       ( left-unit-law-concat-list (concat-list y z)))
-     ( ap (λ t → concat-list t z) (left-unit-law-concat-list y))
+  Id
+    ( ( associative-concat-list nil y z) ∙
+      ( left-unit-law-concat-list (concat-list y z)))
+    ( ap (λ t → concat-list t z) (left-unit-law-concat-list y))
 unit-law-011-associative-concat-list y z = refl
 
 concat-list' : {l : Level} {A : UU l} → list A → list A → list A
@@ -61,9 +62,10 @@ concat-list' x y = concat-list y x
 
 unit-law-101-associative-concat-list :
   {l1 : Level} {X : UU l1} (x z : list X) →
-  Id ( ( associative-concat-list x nil z) ∙
-       ( ap (concat-list x) (left-unit-law-concat-list z)))
-     ( ap (λ t → concat-list t z) (right-unit-law-concat-list x))
+  Id
+    ( ( associative-concat-list x nil z) ∙
+      ( ap (concat-list x) (left-unit-law-concat-list z)))
+    ( ap (λ t → concat-list t z) (right-unit-law-concat-list x))
 unit-law-101-associative-concat-list nil z = refl
 unit-law-101-associative-concat-list (cons x l) z =
   ( ( ( inv
@@ -78,9 +80,10 @@ unit-law-101-associative-concat-list (cons x l) z =
 
 unit-law-110-associative-concat-list :
   {l1 : Level} {X : UU l1} (x y : list X) →
-  Id ( ( associative-concat-list x y nil) ∙
-       ( ap (concat-list x) (right-unit-law-concat-list y)))
-     ( right-unit-law-concat-list (concat-list x y))
+  Id
+    ( ( associative-concat-list x y nil) ∙
+      ( ap (concat-list x) (right-unit-law-concat-list y)))
+    ( right-unit-law-concat-list (concat-list x y))
 unit-law-110-associative-concat-list nil y =
   ap-id (right-unit-law-concat-list y)
 unit-law-110-associative-concat-list (cons a x) y =

--- a/src/order-theory/finitely-graded-posets.lagda.md
+++ b/src/order-theory/finitely-graded-posets.lagda.md
@@ -185,13 +185,13 @@ If chains with jumps are never used, we'd like to call the following chains.
     refl-path-faces-Finitely-Graded-Poset = refl-leq-Fin (succ-ℕ k) i1
   leq-type-path-faces-Finitely-Graded-Poset {i1} x y
     ( cons-path-faces-Finitely-Graded-Poset {i3} {z} H K) =
-     transitive-leq-Fin
-       ( succ-ℕ k)
-       ( i1)
-       ( inl-Fin k i3)
-       ( succ-Fin (succ-ℕ k) (inl-Fin k i3))
-       ( leq-succ-Fin k i3)
-       ( leq-type-path-faces-Finitely-Graded-Poset x z K)
+    transitive-leq-Fin
+      ( succ-ℕ k)
+      ( i1)
+      ( inl-Fin k i3)
+      ( succ-Fin (succ-ℕ k) (inl-Fin k i3))
+      ( leq-succ-Fin k i3)
+      ( leq-type-path-faces-Finitely-Graded-Poset x z K)
 ```
 
 ### Antisymmetry of path-elements-Finitely-Graded-Poset

--- a/src/order-theory/order-preserving-maps-posets.lagda.md
+++ b/src/order-theory/order-preserving-maps-posets.lagda.md
@@ -190,8 +190,9 @@ module _
 
   associative-comp-hom-Poset :
     (h : type-hom-Poset R S) (g : type-hom-Poset Q R) (f : type-hom-Poset P Q) →
-    Id ( comp-hom-Poset P Q S (comp-hom-Poset Q R S h g) f)
-       ( comp-hom-Poset P R S h (comp-hom-Poset P Q R g f))
+    Id
+      ( comp-hom-Poset P Q S (comp-hom-Poset Q R S h g) f)
+      ( comp-hom-Poset P R S h (comp-hom-Poset P Q R g f))
   associative-comp-hom-Poset =
     associative-comp-hom-Preorder
       ( preorder-Poset P)

--- a/src/order-theory/order-preserving-maps-preorders.lagda.md
+++ b/src/order-theory/order-preserving-maps-preorders.lagda.md
@@ -157,7 +157,7 @@ module _
     (g : type-hom-Preorder Q R) (f : type-hom-Preorder P Q) →
     type-hom-Preorder P R
   pr1 (comp-hom-Preorder g f) =
-     map-hom-Preorder Q R g ∘ map-hom-Preorder P Q f
+    map-hom-Preorder Q R g ∘ map-hom-Preorder P Q f
   pr2 (comp-hom-Preorder g f) =
     preserves-order-comp-Preorder g f
 ```
@@ -200,8 +200,9 @@ module _
   where
 
   associative-comp-hom-Preorder :
-    Id ( comp-hom-Preorder P Q S (comp-hom-Preorder Q R S h g) f)
-       ( comp-hom-Preorder P R S h (comp-hom-Preorder P Q R g f))
+    Id
+      ( comp-hom-Preorder P Q S (comp-hom-Preorder Q R S h g) f)
+      ( comp-hom-Preorder P R S h (comp-hom-Preorder P Q R g f))
   associative-comp-hom-Preorder =
     eq-htpy-hom-Preorder P S
       ( comp-hom-Preorder P Q S (comp-hom-Preorder Q R S h g) f)

--- a/src/organic-chemistry/ethane.lagda.md
+++ b/src/organic-chemistry/ethane.lagda.md
@@ -207,21 +207,21 @@ module _
       ( is-decidable-standard-edge-ethane c c')
 
   abstract
-   number-of-elements-count-standard-edge-ethane-leq-3 :
-     (c c' : vertex-ethane) →
-     number-of-elements-count (count-standard-edge-ethane c c') ≤-ℕ 3
-   number-of-elements-count-standard-edge-ethane-leq-3
-     (inl (inr star)) (inl (inr star)) =
-     star
-   number-of-elements-count-standard-edge-ethane-leq-3
-     (inl (inr star)) (inr star) =
-     star
-   number-of-elements-count-standard-edge-ethane-leq-3
-     (inr star) (inl (inr star)) =
-     star
-   number-of-elements-count-standard-edge-ethane-leq-3
-     (inr star) (inr star) =
-     star
+    number-of-elements-count-standard-edge-ethane-leq-3 :
+      (c c' : vertex-ethane) →
+      number-of-elements-count (count-standard-edge-ethane c c') ≤-ℕ 3
+    number-of-elements-count-standard-edge-ethane-leq-3
+      (inl (inr star)) (inl (inr star)) =
+      star
+    number-of-elements-count-standard-edge-ethane-leq-3
+      (inl (inr star)) (inr star) =
+      star
+    number-of-elements-count-standard-edge-ethane-leq-3
+      (inr star) (inl (inr star)) =
+      star
+    number-of-elements-count-standard-edge-ethane-leq-3
+      (inr star) (inr star) =
+      star
 
   ethane : hydrocarbon lzero lzero
   pr1 ethane = finite-graph-ethane

--- a/src/orthogonal-factorization-systems/lifts-of-maps.lagda.md
+++ b/src/orthogonal-factorization-systems/lifts-of-maps.lagda.md
@@ -58,7 +58,7 @@ module _
 
 module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} (i : A → B)
-   {X : UU l3} {f : X → B}
+  {X : UU l3} {f : X → B}
   where
 
   map-lift : lift i f → X → A

--- a/src/reflection/precategory-solver.lagda.md
+++ b/src/reflection/precategory-solver.lagda.md
@@ -206,17 +206,17 @@ build-Precategory-Expr
           nil)) =
   con (quote id-hom-Precategory-Expr) nil
 build-Precategory-Expr
-   ( apply-pr1
-     ( visible-Arg
-       ( apply-pr1
-         ( visible-Arg
-           ( apply-pr2
-             ( visible-Arg
-               ( apply-pr2
-                 (visible-Arg C ∷ nil)) ∷ nil))
-              ∷ nil)) ∷
-       hidden-Arg x ∷ hidden-Arg y ∷ hidden-Arg z ∷
-       visible-Arg g ∷ visible-Arg f ∷ nil)) =
+  ( apply-pr1
+    ( visible-Arg
+      ( apply-pr1
+        ( visible-Arg
+          ( apply-pr2
+            ( visible-Arg
+              ( apply-pr2
+                (visible-Arg C ∷ nil)) ∷ nil))
+            ∷ nil)) ∷
+      hidden-Arg x ∷ hidden-Arg y ∷ hidden-Arg z ∷
+      visible-Arg g ∷ visible-Arg f ∷ nil)) =
   con
     ( quote comp-hom-Precategory-Expr)
     ( visible-Arg (build-Precategory-Expr g) ∷

--- a/src/ring-theory/algebras-rings.lagda.md
+++ b/src/ring-theory/algebras-rings.lagda.md
@@ -31,7 +31,7 @@ operation `x y ↦ xy : M → M → M` such that
   x(y+z) = xy+xz
 ```
 
-## Definition
+## Definitions
 
 ### Non-unital algebras over a ring
 
@@ -200,3 +200,5 @@ module _
 ```
 
 ### Unital algebras over a ring
+
+This remains to be defined.

--- a/src/ring-theory/dependent-products-rings.lagda.md
+++ b/src/ring-theory/dependent-products-rings.lagda.md
@@ -127,8 +127,9 @@ module _
 
   right-distributive-mul-add-Π-Ring :
     (f g h : type-Π-Ring) →
-    Id ( mul-Π-Ring (add-Π-Ring f g) h)
-       ( add-Π-Ring (mul-Π-Ring f h) (mul-Π-Ring g h))
+    Id
+      ( mul-Π-Ring (add-Π-Ring f g) h)
+      ( add-Π-Ring (mul-Π-Ring f h) (mul-Π-Ring g h))
   right-distributive-mul-add-Π-Ring =
     right-distributive-mul-add-Semiring semiring-Π-Ring
 

--- a/src/ring-theory/ideals-generated-by-subsets-rings.lagda.md
+++ b/src/ring-theory/ideals-generated-by-subsets-rings.lagda.md
@@ -74,10 +74,11 @@ module _
 
   preserves-concat-ev-formal-combination-subset-Ring :
     (u v : formal-combination-subset-Ring) →
-    Id ( ev-formal-combination-subset-Ring (concat-list u v))
-       ( add-Ring R
-         ( ev-formal-combination-subset-Ring u)
-         ( ev-formal-combination-subset-Ring v))
+    Id
+      ( ev-formal-combination-subset-Ring (concat-list u v))
+      ( add-Ring R
+        ( ev-formal-combination-subset-Ring u)
+        ( ev-formal-combination-subset-Ring v))
   preserves-concat-ev-formal-combination-subset-Ring nil v =
     inv (left-unit-law-add-Ring R (ev-formal-combination-subset-Ring v))
   preserves-concat-ev-formal-combination-subset-Ring (cons (pair r s) u) v =
@@ -98,9 +99,10 @@ module _
 
   preserves-mul-ev-formal-combination-subset-Ring :
     (r : type-Ring R) (u : formal-combination-subset-Ring) →
-    Id ( ev-formal-combination-subset-Ring
-         ( mul-formal-combination-subset-Ring r u))
-       ( mul-Ring R r (ev-formal-combination-subset-Ring u))
+    Id
+      ( ev-formal-combination-subset-Ring
+        ( mul-formal-combination-subset-Ring r u))
+      ( mul-Ring R r (ev-formal-combination-subset-Ring u))
   preserves-mul-ev-formal-combination-subset-Ring r nil =
     inv (right-zero-law-mul-Ring R r)
   preserves-mul-ev-formal-combination-subset-Ring r (cons x u) =
@@ -171,12 +173,13 @@ module _
   is-closed-under-negatives-left-ideal-subset-Ring :
     is-closed-under-negatives-subset-Ring R subset-left-ideal-subset-Ring
   is-closed-under-negatives-left-ideal-subset-Ring x H =
-    tr ( type-Prop ∘ subset-left-ideal-subset-Ring)
-       ( mul-neg-one-Ring R x)
-       ( is-closed-under-left-multiplication-ideal-subset-Ring
-         ( neg-one-Ring R)
-         ( x)
-         ( H))
+    tr
+      ( type-Prop ∘ subset-left-ideal-subset-Ring)
+      ( mul-neg-one-Ring R x)
+      ( is-closed-under-left-multiplication-ideal-subset-Ring
+        ( neg-one-Ring R)
+        ( x)
+        ( H))
 
   left-ideal-subset-Ring : left-ideal-Ring (l1 ⊔ l2) R
   pr1 left-ideal-subset-Ring = subset-left-ideal-subset-Ring

--- a/src/ring-theory/isomorphisms-rings.lagda.md
+++ b/src/ring-theory/isomorphisms-rings.lagda.md
@@ -160,16 +160,16 @@ inv-hom-iso-Ring R1 R2 f =
 
 is-iso-id-hom-Ring :
   { l1 : Level} (R1 : Ring l1) → is-iso-hom-Ring R1 R1 (id-hom-Ring R1)
-is-iso-id-hom-Ring R1 =
-  pair
-    ( id-hom-Ring R1)
-    ( pair
-      ( left-unit-law-comp-hom-Ring R1 R1 (id-hom-Ring R1))
-      ( left-unit-law-comp-hom-Ring R1 R1 (id-hom-Ring R1)))
+pr1 (is-iso-id-hom-Ring R1) = id-hom-Ring R1
+pr1 (pr2 (is-iso-id-hom-Ring R1)) =
+  left-unit-law-comp-hom-Ring R1 R1 (id-hom-Ring R1)
+pr2 (pr2 (is-iso-id-hom-Ring R1)) =
+  left-unit-law-comp-hom-Ring R1 R1 (id-hom-Ring R1)
 
 id-iso-Ring :
   { l1 : Level} (R1 : Ring l1) → iso-Ring R1 R1
-id-iso-Ring R1 = pair (id-hom-Ring R1) (is-iso-id-hom-Ring R1)
+pr1 (id-iso-Ring R1) = id-hom-Ring R1
+pr2 (id-iso-Ring R1) = is-iso-id-hom-Ring R1
 
 iso-eq-Ring :
   { l : Level} (R1 R2 : Ring l) → Id R1 R2 → iso-Ring R1 R2
@@ -190,16 +190,16 @@ is-iso-hom-Ab-is-iso-hom-Ring :
   { l1 l2 : Level} (R1 : Ring l1) (R2 : Ring l2) (f : type-hom-Ring R1 R2) →
   is-iso-hom-Ring R1 R2 f →
   is-iso-hom-Ab-hom-Ring R1 R2 f
-is-iso-hom-Ab-is-iso-hom-Ring R1 R2 f is-iso-f =
-  pair
-    ( hom-ab-hom-Ring R2 R1 (inv-is-iso-hom-Ring R1 R2 f is-iso-f))
-    ( pair
-      ( ap
-          ( hom-ab-hom-Ring R2 R2)
-          ( is-sec-inv-is-iso-hom-Ring R1 R2 f is-iso-f))
-      ( ap
-          ( hom-ab-hom-Ring R1 R1)
-          ( is-retr-inv-is-iso-hom-Ring R1 R2 f is-iso-f)))
+pr1 (is-iso-hom-Ab-is-iso-hom-Ring R1 R2 f is-iso-f) =
+  hom-ab-hom-Ring R2 R1 (inv-is-iso-hom-Ring R1 R2 f is-iso-f)
+pr1 (pr2 (is-iso-hom-Ab-is-iso-hom-Ring R1 R2 f is-iso-f)) =
+  ap
+    ( hom-ab-hom-Ring R2 R2)
+    ( is-sec-inv-is-iso-hom-Ring R1 R2 f is-iso-f)
+pr2 (pr2 (is-iso-hom-Ab-is-iso-hom-Ring R1 R2 f is-iso-f)) =
+  ap
+    ( hom-ab-hom-Ring R1 R1)
+    ( is-retr-inv-is-iso-hom-Ring R1 R2 f is-iso-f)
 
 abstract
   preserves-mul-inv-is-iso-hom-Ab :
@@ -266,31 +266,34 @@ is-ring-homomorphism-inv-is-iso-hom-Ab :
   ( is-ring-hom-f : is-ring-homomorphism-hom-Ab R1 R2 f) →
   is-ring-homomorphism-hom-Ab R2 R1
     ( inv-is-iso-hom-Ab (ab-Ring R1) (ab-Ring R2) f is-iso-f)
-is-ring-homomorphism-inv-is-iso-hom-Ab
-  R1 R2 f is-iso-f (pair pres-mul-f pres-unit-f) =
-  pair
-    ( preserves-mul-inv-is-iso-hom-Ab R1 R2 f is-iso-f pres-mul-f)
-    ( preserves-unit-inv-is-iso-hom-Ab R1 R2 f is-iso-f pres-unit-f)
+pr1
+  ( is-ring-homomorphism-inv-is-iso-hom-Ab
+      R1 R2 f is-iso-f (pres-mul-f , pres-unit-f)) =
+    preserves-mul-inv-is-iso-hom-Ab R1 R2 f is-iso-f pres-mul-f
+pr2
+  ( is-ring-homomorphism-inv-is-iso-hom-Ab
+      R1 R2 f is-iso-f (pres-mul-f , pres-unit-f)) =
+    preserves-unit-inv-is-iso-hom-Ab R1 R2 f is-iso-f pres-unit-f
 
 inv-hom-Ring-is-iso-hom-Ab :
   { l1 l2 : Level} (R1 : Ring l1) (R2 : Ring l2) (f : type-hom-Ring R1 R2) →
   ( is-iso-f :
-      is-iso-hom-Ab
-        ( ab-Ring R1)
-        ( ab-Ring R2)
-        ( hom-ab-hom-Ring R1 R2 f)) →
-  type-hom-Ring R2 R1
-inv-hom-Ring-is-iso-hom-Ab R1 R2 f is-iso-f =
-  pair
-    ( inv-is-iso-hom-Ab
+    is-iso-hom-Ab
       ( ab-Ring R1)
       ( ab-Ring R2)
-      ( hom-ab-hom-Ring R1 R2 f)
-      ( is-iso-f))
-    ( is-ring-homomorphism-inv-is-iso-hom-Ab R1 R2
-      ( hom-ab-hom-Ring R1 R2 f)
-      ( is-iso-f)
-      ( is-ring-homomorphism-hom-Ring R1 R2 f))
+      ( hom-ab-hom-Ring R1 R2 f)) →
+  type-hom-Ring R2 R1
+pr1 (inv-hom-Ring-is-iso-hom-Ab R1 R2 f is-iso-f) =
+  inv-is-iso-hom-Ab
+    ( ab-Ring R1)
+    ( ab-Ring R2)
+    ( hom-ab-hom-Ring R1 R2 f)
+    ( is-iso-f)
+pr2 (inv-hom-Ring-is-iso-hom-Ab R1 R2 f is-iso-f) =
+  is-ring-homomorphism-inv-is-iso-hom-Ab R1 R2
+    ( hom-ab-hom-Ring R1 R2 f)
+    ( is-iso-f)
+    ( is-ring-homomorphism-hom-Ring R1 R2 f)
 
 abstract
   is-iso-hom-Ring-is-iso-hom-Ab :
@@ -298,40 +301,40 @@ abstract
     ( f : type-hom-Ring R1 R2) →
     is-iso-hom-Ab (ab-Ring R1) (ab-Ring R2) (hom-ab-hom-Ring R1 R2 f) →
     is-iso-hom-Ring R1 R2 f
-  is-iso-hom-Ring-is-iso-hom-Ab R1 R2 f is-iso-f =
-    pair
-      ( inv-hom-Ring-is-iso-hom-Ab R1 R2 f is-iso-f)
-      ( pair
-        ( eq-htpy-hom-Ring R2 R2
+  pr1 (is-iso-hom-Ring-is-iso-hom-Ab R1 R2 f is-iso-f) =
+    inv-hom-Ring-is-iso-hom-Ab R1 R2 f is-iso-f
+  pr1 (pr2 (is-iso-hom-Ring-is-iso-hom-Ab R1 R2 f is-iso-f)) =
+    eq-htpy-hom-Ring R2 R2
+      ( comp-hom-Ring R2 R1 R2 f
+        ( inv-hom-Ring-is-iso-hom-Ab R1 R2 f is-iso-f))
+      ( id-hom-Ring R2)
+      ( htpy-eq-hom-Ab (ab-Ring R2) (ab-Ring R2)
+        ( hom-ab-hom-Ring R2 R2
           ( comp-hom-Ring R2 R1 R2 f
-            ( inv-hom-Ring-is-iso-hom-Ab R1 R2 f is-iso-f))
-          ( id-hom-Ring R2)
-          ( htpy-eq-hom-Ab (ab-Ring R2) (ab-Ring R2)
-            ( hom-ab-hom-Ring R2 R2
-              ( comp-hom-Ring R2 R1 R2 f
-                ( inv-hom-Ring-is-iso-hom-Ab R1 R2 f is-iso-f)))
-            ( id-hom-Ab (ab-Ring R2))
-            ( is-sec-inv-is-iso-hom-Ab
-              ( ab-Ring R1)
-              ( ab-Ring R2)
-              ( hom-ab-hom-Ring R1 R2 f)
-              ( is-iso-f))))
-        ( eq-htpy-hom-Ring R1 R1
+            ( inv-hom-Ring-is-iso-hom-Ab R1 R2 f is-iso-f)))
+        ( id-hom-Ab (ab-Ring R2))
+        ( is-sec-inv-is-iso-hom-Ab
+          ( ab-Ring R1)
+          ( ab-Ring R2)
+          ( hom-ab-hom-Ring R1 R2 f)
+          ( is-iso-f)))
+  pr2 (pr2 (is-iso-hom-Ring-is-iso-hom-Ab R1 R2 f is-iso-f)) =
+    eq-htpy-hom-Ring R1 R1
+      ( comp-hom-Ring R1 R2 R1
+        ( inv-hom-Ring-is-iso-hom-Ab R1 R2 f is-iso-f)
+        ( f))
+      ( id-hom-Ring R1)
+      ( htpy-eq-hom-Ab (ab-Ring R1) (ab-Ring R1)
+        ( hom-ab-hom-Ring R1 R1
           ( comp-hom-Ring R1 R2 R1
             ( inv-hom-Ring-is-iso-hom-Ab R1 R2 f is-iso-f)
-            ( f))
-          ( id-hom-Ring R1)
-          ( htpy-eq-hom-Ab (ab-Ring R1) (ab-Ring R1)
-            ( hom-ab-hom-Ring R1 R1
-              ( comp-hom-Ring R1 R2 R1
-                ( inv-hom-Ring-is-iso-hom-Ab R1 R2 f is-iso-f)
-                ( f)))
-            ( id-hom-Ab (ab-Ring R1))
-            ( is-retr-inv-is-iso-hom-Ab
-              ( ab-Ring R1)
-              ( ab-Ring R2)
-              ( hom-ab-hom-Ring R1 R2 f)
-              ( is-iso-f)))))
+            ( f)))
+        ( id-hom-Ab (ab-Ring R1))
+        ( is-retr-inv-is-iso-hom-Ab
+          ( ab-Ring R1)
+          ( ab-Ring R2)
+          ( hom-ab-hom-Ring R1 R2 f)
+          ( is-iso-f)))
 
 iso-Ab-Ring :
   { l1 l2 : Level} (R1 : Ring l1) (R2 : Ring l2) → UU (l1 ⊔ l2)
@@ -349,12 +352,11 @@ iso-Ab-iso-Ab-Ring R1 R2 = pr1
 iso-Ab-iso-Ring :
   { l1 l2 : Level} (R1 : Ring l1) (R2 : Ring l2) →
   iso-Ring R1 R2 → iso-Ab (ab-Ring R1) (ab-Ring R2)
-iso-Ab-iso-Ring R1 R2 f =
-  pair
-    ( hom-ab-hom-Ring R1 R2 (hom-iso-Ring R1 R2 f))
-    ( is-iso-hom-Ab-is-iso-hom-Ring R1 R2
-      ( hom-iso-Ring R1 R2 f)
-      ( is-iso-hom-iso-Ring R1 R2 f))
+pr1 (iso-Ab-iso-Ring R1 R2 f) = hom-ab-hom-Ring R1 R2 (hom-iso-Ring R1 R2 f)
+pr2 (iso-Ab-iso-Ring R1 R2 f) =
+  is-iso-hom-Ab-is-iso-hom-Ring R1 R2
+    ( hom-iso-Ring R1 R2 f)
+    ( is-iso-hom-iso-Ring R1 R2 f)
 
 equiv-iso-Ab-iso-Ring :
   { l1 : Level} (R1 : Ring l1) (R2 : Ring l1) →

--- a/src/ring-theory/isomorphisms-rings.lagda.md
+++ b/src/ring-theory/isomorphisms-rings.lagda.md
@@ -59,15 +59,17 @@ inv-is-iso-hom-Ring R1 R2 f = pr1
 is-sec-inv-is-iso-hom-Ring :
   { l1 l2 : Level} (R1 : Ring l1) (R2 : Ring l2) (f : type-hom-Ring R1 R2) →
   ( is-iso-f : is-iso-hom-Ring R1 R2 f) →
-  Id (comp-hom-Ring R2 R1 R2 f (inv-is-iso-hom-Ring R1 R2 f is-iso-f))
-     (id-hom-Ring R2)
+  Id
+    ( comp-hom-Ring R2 R1 R2 f (inv-is-iso-hom-Ring R1 R2 f is-iso-f))
+    ( id-hom-Ring R2)
 is-sec-inv-is-iso-hom-Ring R1 R2 f is-iso-f = pr1 (pr2 is-iso-f)
 
 is-retr-inv-is-iso-hom-Ring :
   { l1 l2 : Level} (R1 : Ring l1) (R2 : Ring l2) (f : type-hom-Ring R1 R2) →
   ( is-iso-f : is-iso-hom-Ring R1 R2 f) →
-  Id (comp-hom-Ring R1 R2 R1 (inv-is-iso-hom-Ring R1 R2 f is-iso-f) f)
-     (id-hom-Ring R1)
+  Id
+    ( comp-hom-Ring R1 R2 R1 (inv-is-iso-hom-Ring R1 R2 f is-iso-f) f)
+    ( id-hom-Ring R1)
 is-retr-inv-is-iso-hom-Ring R1 R2 f is-iso-f = pr2 (pr2 is-iso-f)
 
 inv-map-is-iso-hom-Ring :
@@ -122,8 +124,9 @@ all-elements-equal-is-iso-hom-Ring R1 R2 f inv-f inv-f' =
       ( inv-is-iso-hom-Ring R1 R2 f inv-f')
       ( λ x →
         ( inv
-          ( ap ( map-hom-Ring R2 R1 (pr1 inv-f))
-               ( is-sec-inv-map-is-iso-hom-Ring R1 R2 f inv-f' x))) ∙
+          ( ap
+            ( map-hom-Ring R2 R1 (pr1 inv-f))
+            ( is-sec-inv-map-is-iso-hom-Ring R1 R2 f inv-f' x))) ∙
         ( is-retr-inv-map-is-iso-hom-Ring R1 R2 f inv-f
           ( map-hom-Ring R2 R1 (pr1 inv-f') x))))
 
@@ -158,10 +161,11 @@ inv-hom-iso-Ring R1 R2 f =
 is-iso-id-hom-Ring :
   { l1 : Level} (R1 : Ring l1) → is-iso-hom-Ring R1 R1 (id-hom-Ring R1)
 is-iso-id-hom-Ring R1 =
-  pair ( id-hom-Ring R1)
-       ( pair
-         ( left-unit-law-comp-hom-Ring R1 R1 (id-hom-Ring R1))
-         ( left-unit-law-comp-hom-Ring R1 R1 (id-hom-Ring R1)))
+  pair
+    ( id-hom-Ring R1)
+    ( pair
+      ( left-unit-law-comp-hom-Ring R1 R1 (id-hom-Ring R1))
+      ( left-unit-law-comp-hom-Ring R1 R1 (id-hom-Ring R1)))
 
 id-iso-Ring :
   { l1 : Level} (R1 : Ring l1) → iso-Ring R1 R1
@@ -187,12 +191,15 @@ is-iso-hom-Ab-is-iso-hom-Ring :
   is-iso-hom-Ring R1 R2 f →
   is-iso-hom-Ab-hom-Ring R1 R2 f
 is-iso-hom-Ab-is-iso-hom-Ring R1 R2 f is-iso-f =
-  pair ( hom-ab-hom-Ring R2 R1 (inv-is-iso-hom-Ring R1 R2 f is-iso-f))
-       ( pair
-         ( ap ( hom-ab-hom-Ring R2 R2)
-              ( is-sec-inv-is-iso-hom-Ring R1 R2 f is-iso-f))
-         ( ap ( hom-ab-hom-Ring R1 R1)
-              ( is-retr-inv-is-iso-hom-Ring R1 R2 f is-iso-f)))
+  pair
+    ( hom-ab-hom-Ring R2 R1 (inv-is-iso-hom-Ring R1 R2 f is-iso-f))
+    ( pair
+      ( ap
+          ( hom-ab-hom-Ring R2 R2)
+          ( is-sec-inv-is-iso-hom-Ring R1 R2 f is-iso-f))
+      ( ap
+          ( hom-ab-hom-Ring R1 R1)
+          ( is-retr-inv-is-iso-hom-Ring R1 R2 f is-iso-f)))
 
 abstract
   preserves-mul-inv-is-iso-hom-Ab :
@@ -209,25 +216,29 @@ abstract
         ( ( pres-mul-f
             ( map-inv-is-iso-hom-Ab (ab-Ring R1) (ab-Ring R2) f is-iso-f x)
             ( map-inv-is-iso-hom-Ab (ab-Ring R1) (ab-Ring R2) f is-iso-f y)) ∙
-          ( ( ap ( mul-Ring R2
-                   ( map-hom-Ab (ab-Ring R1) (ab-Ring R2) f
-                     ( map-inv-is-iso-hom-Ab
-                       ( ab-Ring R1)
-                       ( ab-Ring R2)
-                       f is-iso-f x)))
-                 ( is-sec-map-inv-is-iso-hom-Ab
-                   ( ab-Ring R1)
-                   ( ab-Ring R2)
-                   ( f)
-                   ( is-iso-f)
-                   ( y))) ∙
-            ( ap ( λ z → mul-Ring R2 z y)
-                 ( is-sec-map-inv-is-iso-hom-Ab
-                   ( ab-Ring R1)
-                   ( ab-Ring R2)
-                   ( f)
-                   ( is-iso-f)
-                   ( x))))))) ∙
+          ( ( ap
+              ( mul-Ring R2
+                ( map-hom-Ab (ab-Ring R1) (ab-Ring R2) f
+                  ( map-inv-is-iso-hom-Ab
+                    ( ab-Ring R1)
+                    ( ab-Ring R2)
+                    ( f)
+                    ( is-iso-f)
+                    ( x))))
+              ( is-sec-map-inv-is-iso-hom-Ab
+                ( ab-Ring R1)
+                ( ab-Ring R2)
+                ( f)
+                ( is-iso-f)
+                ( y))) ∙
+            ( ap
+              ( λ z → mul-Ring R2 z y)
+              ( is-sec-map-inv-is-iso-hom-Ab
+                ( ab-Ring R1)
+                ( ab-Ring R2)
+                ( f)
+                ( is-iso-f)
+                ( x))))))) ∙
     ( is-retr-map-inv-is-iso-hom-Ab (ab-Ring R1) (ab-Ring R2) f is-iso-f
       ( mul-Ring R1
         ( map-inv-is-iso-hom-Ab (ab-Ring R1) (ab-Ring R2) f is-iso-f x)
@@ -263,10 +274,11 @@ is-ring-homomorphism-inv-is-iso-hom-Ab
 
 inv-hom-Ring-is-iso-hom-Ab :
   { l1 l2 : Level} (R1 : Ring l1) (R2 : Ring l2) (f : type-hom-Ring R1 R2) →
-  ( is-iso-f : is-iso-hom-Ab
-                 ( ab-Ring R1)
-                 ( ab-Ring R2)
-                 ( hom-ab-hom-Ring R1 R2 f)) →
+  ( is-iso-f :
+      is-iso-hom-Ab
+        ( ab-Ring R1)
+        ( ab-Ring R2)
+        ( hom-ab-hom-Ring R1 R2 f)) →
   type-hom-Ring R2 R1
 inv-hom-Ring-is-iso-hom-Ab R1 R2 f is-iso-f =
   pair
@@ -338,10 +350,11 @@ iso-Ab-iso-Ring :
   { l1 l2 : Level} (R1 : Ring l1) (R2 : Ring l2) →
   iso-Ring R1 R2 → iso-Ab (ab-Ring R1) (ab-Ring R2)
 iso-Ab-iso-Ring R1 R2 f =
-  pair ( hom-ab-hom-Ring R1 R2 (hom-iso-Ring R1 R2 f))
-       ( is-iso-hom-Ab-is-iso-hom-Ring R1 R2
-         ( hom-iso-Ring R1 R2 f)
-         ( is-iso-hom-iso-Ring R1 R2 f))
+  pair
+    ( hom-ab-hom-Ring R1 R2 (hom-iso-Ring R1 R2 f))
+    ( is-iso-hom-Ab-is-iso-hom-Ring R1 R2
+      ( hom-iso-Ring R1 R2 f)
+      ( is-iso-hom-iso-Ring R1 R2 f))
 
 equiv-iso-Ab-iso-Ring :
   { l1 : Level} (R1 : Ring l1) (R2 : Ring l1) →

--- a/src/ring-theory/localizations-rings.lagda.md
+++ b/src/ring-theory/localizations-rings.lagda.md
@@ -56,19 +56,21 @@ inv-inverts-element-hom-Ring R S x f H = pr1 H
 is-left-inverse-inv-inverts-element-hom-Ring :
   {l1 l2 : Level} (R : Ring l1) (S : Ring l2) (x : type-Ring R)
   (f : type-hom-Ring R S) (H : inverts-element-hom-Ring R S x f) →
-  Id ( mul-Ring S
-       ( inv-inverts-element-hom-Ring R S x f H)
-       ( map-hom-Ring R S f x))
-     ( one-Ring S)
+  Id
+    ( mul-Ring S
+      ( inv-inverts-element-hom-Ring R S x f H)
+      ( map-hom-Ring R S f x))
+    ( one-Ring S)
 is-left-inverse-inv-inverts-element-hom-Ring R S x f H = pr1 (pr2 H)
 
 is-right-inverse-inv-inverts-element-hom-Ring :
   {l1 l2 : Level} (R : Ring l1) (S : Ring l2) (x : type-Ring R)
   (f : type-hom-Ring R S) (H : inverts-element-hom-Ring R S x f) →
-  Id ( mul-Ring S
-       ( map-hom-Ring R S f x)
-       ( inv-inverts-element-hom-Ring R S x f H))
-     ( one-Ring S)
+  Id
+    ( mul-Ring S
+      ( map-hom-Ring R S f x)
+      ( inv-inverts-element-hom-Ring R S x f H))
+    ( one-Ring S)
 is-right-inverse-inv-inverts-element-hom-Ring R S x f H = pr2 (pr2 H)
 ```
 
@@ -126,8 +128,8 @@ unique-extension-universal-property-localization-Ring :
   universal-property-localization-Ring l3 R S x f H →
   (h : type-hom-Ring R T) (K : inverts-element-hom-Ring R T x h) →
   is-contr
-    (Σ ( type-hom-Ring S T)
-       ( λ g → htpy-hom-Ring R T (comp-hom-Ring R S T g f) h))
+    ( Σ ( type-hom-Ring S T)
+        ( λ g → htpy-hom-Ring R T (comp-hom-Ring R S T g f) h))
 unique-extension-universal-property-localization-Ring R S T x f H up-f h K =
   is-contr-equiv'
     ( fib (precomp-universal-property-localization-Ring R S T x f H) (pair h K))

--- a/src/ring-theory/maximal-ideals-rings.lagda.md
+++ b/src/ring-theory/maximal-ideals-rings.lagda.md
@@ -18,3 +18,5 @@ A maximal ideal in a ring `R` is a proper ideal `I` of `R` such that for any
 ideal `J` containing `I` is either `I` or the entire ring `R`.
 
 ## Definition
+
+This remains to be defined.

--- a/src/ring-theory/modules-rings.lagda.md
+++ b/src/ring-theory/modules-rings.lagda.md
@@ -80,8 +80,9 @@ module _
 
   associative-add-left-module-Ring :
     (x y z : type-left-module-Ring) →
-    Id ( add-left-module-Ring (add-left-module-Ring x y) z)
-       ( add-left-module-Ring x (add-left-module-Ring y z))
+    Id
+      ( add-left-module-Ring (add-left-module-Ring x y) z)
+      ( add-left-module-Ring x (add-left-module-Ring y z))
   associative-add-left-module-Ring =
     associative-add-Ab ab-left-module-Ring
 
@@ -99,15 +100,17 @@ module _
 
   left-inverse-law-add-left-module-Ring :
     (x : type-left-module-Ring) →
-    Id ( add-left-module-Ring (neg-left-module-Ring x) x)
-       ( zero-left-module-Ring)
+    Id
+      ( add-left-module-Ring (neg-left-module-Ring x) x)
+      ( zero-left-module-Ring)
   left-inverse-law-add-left-module-Ring =
     left-inverse-law-add-Ab ab-left-module-Ring
 
   right-inverse-law-add-left-module-Ring :
     (x : type-left-module-Ring) →
-    Id ( add-left-module-Ring x (neg-left-module-Ring x))
-       ( zero-left-module-Ring)
+    Id
+      ( add-left-module-Ring x (neg-left-module-Ring x))
+      ( zero-left-module-Ring)
   right-inverse-law-add-left-module-Ring =
     right-inverse-law-add-Ab ab-left-module-Ring
 
@@ -148,10 +151,11 @@ module _
 
   left-distributive-mul-add-left-module-Ring :
     (r : type-Ring R) (x y : type-left-module-Ring) →
-    Id ( mul-left-module-Ring r (add-left-module-Ring x y))
-       ( add-left-module-Ring
-         ( mul-left-module-Ring r x)
-         ( mul-left-module-Ring r y))
+    Id
+      ( mul-left-module-Ring r (add-left-module-Ring x y))
+      ( add-left-module-Ring
+        ( mul-left-module-Ring r x)
+        ( mul-left-module-Ring r y))
   left-distributive-mul-add-left-module-Ring r =
     preserves-add-hom-Ab
       ( ab-left-module-Ring)
@@ -163,10 +167,11 @@ module _
 
   right-distributive-mul-add-left-module-Ring :
     (r s : type-Ring R) (x : type-left-module-Ring) →
-    Id ( mul-left-module-Ring (add-Ring R r s) x)
-       ( add-left-module-Ring
-         ( mul-left-module-Ring r x)
-         ( mul-left-module-Ring s x))
+    Id
+      ( mul-left-module-Ring (add-Ring R r s) x)
+      ( add-left-module-Ring
+        ( mul-left-module-Ring r x)
+        ( mul-left-module-Ring s x))
   right-distributive-mul-add-left-module-Ring r s =
     htpy-eq-hom-Ab
       ( ab-left-module-Ring)
@@ -194,8 +199,9 @@ module _
 
   associative-mul-left-module-Ring :
     (r s : type-Ring R) (x : type-left-module-Ring) →
-    Id ( mul-left-module-Ring (mul-Ring R r s) x)
-       ( mul-left-module-Ring r (mul-left-module-Ring s x))
+    Id
+      ( mul-left-module-Ring (mul-Ring R r s) x)
+      ( mul-left-module-Ring r (mul-left-module-Ring s x))
   associative-mul-left-module-Ring r s =
     htpy-eq-hom-Ab
       ( ab-left-module-Ring)
@@ -252,8 +258,9 @@ module _
 
   left-negative-law-mul-left-module-Ring :
     (r : type-Ring R) (x : type-left-module-Ring) →
-    Id ( mul-left-module-Ring (neg-Ring R r) x)
-       ( neg-left-module-Ring (mul-left-module-Ring r x))
+    Id
+      ( mul-left-module-Ring (neg-Ring R r) x)
+      ( neg-left-module-Ring (mul-left-module-Ring r x))
   left-negative-law-mul-left-module-Ring r =
     htpy-eq-hom-Ab
       ( ab-left-module-Ring)
@@ -276,8 +283,9 @@ module _
 
   right-negative-law-mul-left-module-Ring :
     (r : type-Ring R) (x : type-left-module-Ring) →
-    Id ( mul-left-module-Ring r (neg-left-module-Ring x))
-       ( neg-left-module-Ring (mul-left-module-Ring r x))
+    Id
+      ( mul-left-module-Ring r (neg-left-module-Ring x))
+      ( neg-left-module-Ring (mul-left-module-Ring r x))
   right-negative-law-mul-left-module-Ring r =
     preserves-negatives-hom-Ab
       ( ab-left-module-Ring)
@@ -321,8 +329,9 @@ module _
 
   associative-add-right-module-Ring :
     (x y z : type-right-module-Ring) →
-    Id ( add-right-module-Ring (add-right-module-Ring x y) z)
-       ( add-right-module-Ring x (add-right-module-Ring y z))
+    Id
+      ( add-right-module-Ring (add-right-module-Ring x y) z)
+      ( add-right-module-Ring x (add-right-module-Ring y z))
   associative-add-right-module-Ring =
     associative-add-Ab ab-right-module-Ring
 
@@ -340,15 +349,17 @@ module _
 
   left-inverse-law-add-right-module-Ring :
     (x : type-right-module-Ring) →
-    Id ( add-right-module-Ring (neg-right-module-Ring x) x)
-       ( zero-right-module-Ring)
+    Id
+      ( add-right-module-Ring (neg-right-module-Ring x) x)
+      ( zero-right-module-Ring)
   left-inverse-law-add-right-module-Ring =
     left-inverse-law-add-Ab ab-right-module-Ring
 
   right-inverse-law-add-right-module-Ring :
     (x : type-right-module-Ring) →
-    Id ( add-right-module-Ring x (neg-right-module-Ring x))
-       ( zero-right-module-Ring)
+    Id
+      ( add-right-module-Ring x (neg-right-module-Ring x))
+      ( zero-right-module-Ring)
   right-inverse-law-add-right-module-Ring =
     right-inverse-law-add-Ab ab-right-module-Ring
 
@@ -389,10 +400,11 @@ module _
 
   left-distributive-mul-add-right-module-Ring :
     (r : type-Ring R) (x y : type-right-module-Ring) →
-    Id ( mul-right-module-Ring r (add-right-module-Ring x y))
-       ( add-right-module-Ring
-         ( mul-right-module-Ring r x)
-         ( mul-right-module-Ring r y))
+    Id
+      ( mul-right-module-Ring r (add-right-module-Ring x y))
+      ( add-right-module-Ring
+        ( mul-right-module-Ring r x)
+        ( mul-right-module-Ring r y))
   left-distributive-mul-add-right-module-Ring r =
     preserves-add-hom-Ab
       ( ab-right-module-Ring)
@@ -404,10 +416,11 @@ module _
 
   right-distributive-mul-add-right-module-Ring :
     (r s : type-Ring R) (x : type-right-module-Ring) →
-    Id ( mul-right-module-Ring (add-Ring R r s) x)
-       ( add-right-module-Ring
-         ( mul-right-module-Ring r x)
-         ( mul-right-module-Ring s x))
+    Id
+      ( mul-right-module-Ring (add-Ring R r s) x)
+      ( add-right-module-Ring
+        ( mul-right-module-Ring r x)
+        ( mul-right-module-Ring s x))
   right-distributive-mul-add-right-module-Ring r s =
     htpy-eq-hom-Ab
       ( ab-right-module-Ring)
@@ -435,8 +448,9 @@ module _
 
   associative-mul-right-module-Ring :
     (r s : type-Ring R) (x : type-right-module-Ring) →
-    Id ( mul-right-module-Ring (mul-Ring R r s) x)
-       ( mul-right-module-Ring s (mul-right-module-Ring r x))
+    Id
+      ( mul-right-module-Ring (mul-Ring R r s) x)
+      ( mul-right-module-Ring s (mul-right-module-Ring r x))
   associative-mul-right-module-Ring r s =
     htpy-eq-hom-Ab
       ( ab-right-module-Ring)
@@ -493,8 +507,9 @@ module _
 
   left-negative-law-mul-right-module-Ring :
     (r : type-Ring R) (x : type-right-module-Ring) →
-    Id ( mul-right-module-Ring (neg-Ring R r) x)
-       ( neg-right-module-Ring (mul-right-module-Ring r x))
+    Id
+      ( mul-right-module-Ring (neg-Ring R r) x)
+      ( neg-right-module-Ring (mul-right-module-Ring r x))
   left-negative-law-mul-right-module-Ring r =
     htpy-eq-hom-Ab
       ( ab-right-module-Ring)
@@ -517,8 +532,9 @@ module _
 
   right-negative-law-mul-right-module-Ring :
     (r : type-Ring R) (x : type-right-module-Ring) →
-    Id ( mul-right-module-Ring r (neg-right-module-Ring x))
-       ( neg-right-module-Ring (mul-right-module-Ring r x))
+    Id
+      ( mul-right-module-Ring r (neg-right-module-Ring x))
+      ( neg-right-module-Ring (mul-right-module-Ring r x))
   right-negative-law-mul-right-module-Ring r =
     preserves-negatives-hom-Ab
       ( ab-right-module-Ring)

--- a/src/ring-theory/products-rings.lagda.md
+++ b/src/ring-theory/products-rings.lagda.md
@@ -77,8 +77,9 @@ module _
 
   associative-add-prod-Ring :
     (x y z : type-prod-Ring) →
-    Id ( add-prod-Ring (add-prod-Ring x y) z)
-       ( add-prod-Ring x (add-prod-Ring y z))
+    Id
+      ( add-prod-Ring (add-prod-Ring x y) z)
+      ( add-prod-Ring x (add-prod-Ring y z))
   associative-add-prod-Ring (pair x1 y1) (pair x2 y2) (pair x3 y3) =
     eq-pair
       ( associative-add-Ring R1 x1 x2 x3)
@@ -101,8 +102,9 @@ module _
 
   associative-mul-prod-Ring :
     (x y z : type-prod-Ring) →
-    Id ( mul-prod-Ring (mul-prod-Ring x y) z)
-       ( mul-prod-Ring x (mul-prod-Ring y z))
+    Id
+      ( mul-prod-Ring (mul-prod-Ring x y) z)
+      ( mul-prod-Ring x (mul-prod-Ring y z))
   associative-mul-prod-Ring (pair x1 y1) (pair x2 y2) (pair x3 y3) =
     eq-pair
       ( associative-mul-Ring R1 x1 x2 x3)
@@ -120,8 +122,9 @@ module _
 
   left-distributive-mul-add-prod-Ring :
     (x y z : type-prod-Ring) →
-    Id ( mul-prod-Ring x (add-prod-Ring y z))
-       ( add-prod-Ring (mul-prod-Ring x y) (mul-prod-Ring x z))
+    Id
+      ( mul-prod-Ring x (add-prod-Ring y z))
+      ( add-prod-Ring (mul-prod-Ring x y) (mul-prod-Ring x z))
   left-distributive-mul-add-prod-Ring (pair x1 y1) (pair x2 y2) (pair x3 y3) =
     eq-pair
       ( left-distributive-mul-add-Ring R1 x1 x2 x3)
@@ -129,8 +132,9 @@ module _
 
   right-distributive-mul-add-prod-Ring :
     (x y z : type-prod-Ring) →
-    Id ( mul-prod-Ring (add-prod-Ring x y) z)
-       ( add-prod-Ring (mul-prod-Ring x z) (mul-prod-Ring y z))
+    Id
+      ( mul-prod-Ring (add-prod-Ring x y) z)
+      ( add-prod-Ring (mul-prod-Ring x z) (mul-prod-Ring y z))
   right-distributive-mul-add-prod-Ring (pair x1 y1) (pair x2 y2) (pair x3 y3) =
     eq-pair
       ( right-distributive-mul-add-Ring R1 x1 x2 x3)

--- a/src/ring-theory/quotient-rings.lagda.md
+++ b/src/ring-theory/quotient-rings.lagda.md
@@ -68,3 +68,5 @@ sim-congruence-ideal-Ring R I x y =
 ### The quotient ring
 
 #### The universal property of the quotient ring
+
+This remains to be defined.

--- a/src/ring-theory/rings.lagda.md
+++ b/src/ring-theory/rings.lagda.md
@@ -509,8 +509,9 @@ module _
 
   preserves-concat-add-list-Ring :
     (l1 l2 : list (type-Ring R)) →
-    Id ( add-list-Ring (concat-list l1 l2))
-       ( add-Ring R (add-list-Ring l1) (add-list-Ring l2))
+    Id
+      ( add-list-Ring (concat-list l1 l2))
+      ( add-Ring R (add-list-Ring l1) (add-list-Ring l2))
   preserves-concat-add-list-Ring = preserves-concat-add-list-Ab (ab-Ring R)
 ```
 

--- a/src/set-theory/countable-sets.lagda.md
+++ b/src/set-theory/countable-sets.lagda.md
@@ -135,12 +135,12 @@ module _
             ( f ∘ (pr1 P))
             ( is-surjective-comp is-surjective-f (pr2 P))))
     where
-     f : Maybe (type-Set X) → type-Set X
-     f (inl x) = x
-     f (inr star) = a
+      f : Maybe (type-Set X) → type-Set X
+      f (inl x) = x
+      f (inr star) = a
 
-     is-surjective-f : is-surjective f
-     is-surjective-f x = unit-trunc-Prop (pair (inl x) refl)
+      is-surjective-f : is-surjective f
+      is-surjective-f x = unit-trunc-Prop (pair (inl x) refl)
 
   is-countable-is-directly-countable :
     is-directly-countable X → is-countable X

--- a/src/set-theory/cumulative-hierarchy.lagda.md
+++ b/src/set-theory/cumulative-hierarchy.lagda.md
@@ -692,10 +692,10 @@ needed.
       ( λ f IH →
         h (set-pseudo-cumulative-hierarchy V f)
           ( λ y m →
-             map-universal-property-trunc-Prop
-               ( P y , P-prop y)
-               ( λ (a , p) → tr P p (IH a))
-               ( ∈-cumulative-hierarchy-mere-preimage m)))
+            map-universal-property-trunc-Prop
+              ( P y , P-prop y)
+              ( λ (a , p) → tr P p (IH a))
+              ( ∈-cumulative-hierarchy-mere-preimage m)))
 ```
 
 ### Cumulative hierarchies satisfy the replacement axiom

--- a/src/species/cauchy-composition-species-of-types-in-subuniverses.lagda.md
+++ b/src/species/cauchy-composition-species-of-types-in-subuniverses.lagda.md
@@ -144,8 +144,8 @@ module _
           ( Relaxed-Σ-Decomposition l1 l1 X)
           ( λ D →
               is-in-subuniverse P (indexing-type-Relaxed-Σ-Decomposition D) ×
-              ((x : indexing-type-Relaxed-Σ-Decomposition D) →
-               is-in-subuniverse P (cotype-Relaxed-Σ-Decomposition D x)))
+              ( (x : indexing-type-Relaxed-Σ-Decomposition D) →
+                is-in-subuniverse P (cotype-Relaxed-Σ-Decomposition D x)))
           ( _)) ∘e
         ( ( equiv-Σ-equiv-base
             ( _)

--- a/src/species/cauchy-exponentials-species-of-types-in-subuniverses.lagda.md
+++ b/src/species/cauchy-exponentials-species-of-types-in-subuniverses.lagda.md
@@ -170,13 +170,13 @@ module _
     reassociate' :
       Σ ( Relaxed-Σ-Decomposition l1 l1 (inclusion-subuniverse P X))
         ( λ d →
-           Σ ( ( u : (indexing-type-Relaxed-Σ-Decomposition d)) →
-               is-in-subuniverse P (cotype-Relaxed-Σ-Decomposition d u))
-             ( λ p →
-               ( ( u : indexing-type-Relaxed-Σ-Decomposition d) →
-                 inclusion-subuniverse
-                   ( subuniverse-global-subuniverse Q l3)
-                   ( S (cotype-Relaxed-Σ-Decomposition d u , p u)))))
+          Σ ( ( u : (indexing-type-Relaxed-Σ-Decomposition d)) →
+              is-in-subuniverse P (cotype-Relaxed-Σ-Decomposition d u))
+            ( λ p →
+              ( ( u : indexing-type-Relaxed-Σ-Decomposition d) →
+                inclusion-subuniverse
+                  ( subuniverse-global-subuniverse Q l3)
+                  ( S (cotype-Relaxed-Σ-Decomposition d u , p u)))))
         ≃
         cauchy-exponential-species-types
           ( Σ-extension-species-subuniverse

--- a/src/species/cauchy-products-species-of-types-in-subuniverses.lagda.md
+++ b/src/species/cauchy-products-species-of-types-in-subuniverses.lagda.md
@@ -408,14 +408,14 @@ module _
     reassociate' :
       Σ ( binary-coproduct-Decomposition l1 l1 X)
         ( λ d →
-           Σ ( Σ (pr1 (P (pr1 d))) (λ v → pr1 (P (pr1 (pr2 d)))))
-           (λ p → pr1 (S (pr1 d , pr1 p)) × pr1 (T (pr1 (pr2 d) , pr2 p))))
+          Σ ( Σ (pr1 (P (pr1 d))) (λ v → pr1 (P (pr1 (pr2 d)))))
+            ( λ p → pr1 (S (pr1 d , pr1 p)) × pr1 (T (pr1 (pr2 d) , pr2 p))))
       ≃
       cauchy-product-species-types
-      (Σ-extension-species-subuniverse P
-       (subuniverse-global-subuniverse Q l3) S)
-      (Σ-extension-species-subuniverse P
-       (subuniverse-global-subuniverse Q l4) T)
+      ( Σ-extension-species-subuniverse P
+        ( subuniverse-global-subuniverse Q l3) S)
+      ( Σ-extension-species-subuniverse P
+        ( subuniverse-global-subuniverse Q l4) T)
       X
     pr1 reassociate' (d , (pA , pB) , s , t) =
       d , (pA , s) , (pB , t)

--- a/src/species/composition-cauchy-series-species-of-types-in-subuniverses.lagda.md
+++ b/src/species/composition-cauchy-series-species-of-types-in-subuniverses.lagda.md
@@ -137,43 +137,43 @@ module _
       ( X) ≃
     composition-cauchy-series-species-subuniverse P Q S T X
   equiv-cauchy-series-composition-species-subuniverse =
-   ( equiv-composition-cauchy-series-Σ-extension-species-subuniverse P Q S T
-     ( X)) ∘e
-   ( ( equiv-cauchy-series-composition-species-types
-       ( Σ-extension-species-subuniverse
-         ( P)
-         ( subuniverse-global-subuniverse Q l3)
-         ( S))
-       ( Σ-extension-species-subuniverse
-         ( P)
-         ( subuniverse-global-subuniverse Q l4)
-         ( T))
-       ( X)) ∘e
-     ( ( equiv-cauchy-series-equiv-species-types
-         ( Σ-extension-species-subuniverse
-           ( P)
-           ( subuniverse-global-subuniverse Q (lsuc l1 ⊔ l2 ⊔ l3 ⊔ l4))
-           ( cauchy-composition-species-subuniverse P Q C1 C2 S T))
-         ( cauchy-composition-species-types
-           ( Σ-extension-species-subuniverse
-             ( P)
-             ( subuniverse-global-subuniverse Q l3)
-             ( S))
-           ( Σ-extension-species-subuniverse
-             ( P)
-             ( subuniverse-global-subuniverse Q l4)
-             ( T)))
-         ( preserves-cauchy-composition-Σ-extension-species-subuniverse
-           ( P)
-           ( Q)
-           ( C1)
-           ( C2)
-           ( S)
-           ( T))
-         ( X)) ∘e
-       ( equiv-cauchy-series-Σ-extension-species-subuniverse
-         ( P)
-         ( subuniverse-global-subuniverse Q (lsuc l1 ⊔ l2 ⊔ l3 ⊔ l4))
-         ( cauchy-composition-species-subuniverse P Q C1 C2 S T)
-         ( X))))
+    ( equiv-composition-cauchy-series-Σ-extension-species-subuniverse P Q S T
+      ( X)) ∘e
+    ( ( equiv-cauchy-series-composition-species-types
+        ( Σ-extension-species-subuniverse
+          ( P)
+          ( subuniverse-global-subuniverse Q l3)
+          ( S))
+        ( Σ-extension-species-subuniverse
+          ( P)
+          ( subuniverse-global-subuniverse Q l4)
+          ( T))
+        ( X)) ∘e
+      ( ( equiv-cauchy-series-equiv-species-types
+          ( Σ-extension-species-subuniverse
+            ( P)
+            ( subuniverse-global-subuniverse Q (lsuc l1 ⊔ l2 ⊔ l3 ⊔ l4))
+            ( cauchy-composition-species-subuniverse P Q C1 C2 S T))
+          ( cauchy-composition-species-types
+            ( Σ-extension-species-subuniverse
+              ( P)
+              ( subuniverse-global-subuniverse Q l3)
+              ( S))
+            ( Σ-extension-species-subuniverse
+              ( P)
+              ( subuniverse-global-subuniverse Q l4)
+              ( T)))
+          ( preserves-cauchy-composition-Σ-extension-species-subuniverse
+            ( P)
+            ( Q)
+            ( C1)
+            ( C2)
+            ( S)
+            ( T))
+          ( X)) ∘e
+        ( equiv-cauchy-series-Σ-extension-species-subuniverse
+          ( P)
+          ( subuniverse-global-subuniverse Q (lsuc l1 ⊔ l2 ⊔ l3 ⊔ l4))
+          ( cauchy-composition-species-subuniverse P Q C1 C2 S T)
+          ( X))))
 ```

--- a/src/species/composition-cauchy-series-species-of-types.lagda.md
+++ b/src/species/composition-cauchy-series-species-of-types.lagda.md
@@ -59,10 +59,10 @@ module _
       cauchy-series-species-types (cauchy-composition-species-types S T) X ≃
       Σ ( UU l1)
         ( λ U →
-           Σ ( U → UU l1)
-             ( λ V →
-               Σ ( Σ ( UU l1) (λ F → F ≃ Σ U V))
-                 ( λ F → (S U) × (((y : U) → T (V y)) × (pr1 F → X)))))
+          Σ ( U → UU l1)
+            ( λ V →
+              Σ ( Σ ( UU l1) (λ F → F ≃ Σ U V))
+                ( λ F → (S U) × (((y : U) → T (V y)) × (pr1 F → X)))))
     pr1 reassociate (F , ((U , V , e) , s , fs) , ft) =
       (U , V , (F , e) , s , fs , ft)
     pr2 reassociate =

--- a/src/species/coproducts-species-of-types.lagda.md
+++ b/src/species/coproducts-species-of-types.lagda.md
@@ -43,10 +43,12 @@ F H) × (hom-species-types G H)).
 
 ```agda
 equiv-universal-property-coproduct-species-types :
- {l1 l2 l3 l4 : Level}
- (F : species-types l1 l2) (G : species-types l1 l3) (H : species-types l1 l4) →
- hom-species-types (coproduct-species-types F G) H ≃
- ((hom-species-types F H) × (hom-species-types G H))
+  {l1 l2 l3 l4 : Level}
+  (F : species-types l1 l2)
+  (G : species-types l1 l3)
+  (H : species-types l1 l4) →
+  hom-species-types (coproduct-species-types F G) H ≃
+  ((hom-species-types F H) × (hom-species-types G H))
 equiv-universal-property-coproduct-species-types F G H =
   ( distributive-Π-Σ) ∘e
   ( equiv-map-Π (λ X → equiv-universal-property-coprod (H X)))

--- a/src/species/dirichlet-exponentials-species-of-types-in-subuniverses.lagda.md
+++ b/src/species/dirichlet-exponentials-species-of-types-in-subuniverses.lagda.md
@@ -144,13 +144,13 @@ module _
     reassociate' :
       Σ ( Π-Decomposition l1 l1 (inclusion-subuniverse P X))
         ( λ d →
-           Σ ( ( u : (indexing-type-Π-Decomposition d)) →
-               is-in-subuniverse P (cotype-Π-Decomposition d u))
-             ( λ p →
-               ( ( u : indexing-type-Π-Decomposition d) →
-                 inclusion-subuniverse
-                   ( subuniverse-global-subuniverse Q l3)
-                   ( S (cotype-Π-Decomposition d u , p u)))))
+          Σ ( ( u : (indexing-type-Π-Decomposition d)) →
+              is-in-subuniverse P (cotype-Π-Decomposition d u))
+            ( λ p →
+              ( ( u : indexing-type-Π-Decomposition d) →
+                inclusion-subuniverse
+                  ( subuniverse-global-subuniverse Q l3)
+                  ( S (cotype-Π-Decomposition d u , p u)))))
         ≃
         dirichlet-exponential-species-types
           ( Σ-extension-species-subuniverse

--- a/src/species/dirichlet-products-species-of-types-in-subuniverses.lagda.md
+++ b/src/species/dirichlet-products-species-of-types-in-subuniverses.lagda.md
@@ -439,15 +439,15 @@ module _
     reassociate' :
       Σ ( binary-product-Decomposition l1 l1 X)
         ( λ d →
-           Σ ( Σ (pr1 (P (pr1 d))) (λ v → pr1 (P (pr1 (pr2 d)))))
-           (λ p → pr1 (S (pr1 d , pr1 p)) × pr1 (T (pr1 (pr2 d) , pr2 p))))
+          Σ ( Σ (pr1 (P (pr1 d))) (λ v → pr1 (P (pr1 (pr2 d)))))
+          (λ p → pr1 (S (pr1 d , pr1 p)) × pr1 (T (pr1 (pr2 d) , pr2 p))))
       ≃
       dirichlet-product-species-types
-      (Σ-extension-species-subuniverse P
-       (subuniverse-global-subuniverse Q l3) S)
-      (Σ-extension-species-subuniverse P
-       (subuniverse-global-subuniverse Q l4) T)
-      X
+        ( Σ-extension-species-subuniverse P
+          ( subuniverse-global-subuniverse Q l3) S)
+        ( Σ-extension-species-subuniverse P
+          ( subuniverse-global-subuniverse Q l4) T)
+        ( X)
     pr1 reassociate' (d , (pA , pB) , s , t) =
       d , (pA , s) , (pB , t)
     pr2 reassociate' =

--- a/src/species/morphisms-finite-species.lagda.md
+++ b/src/species/morphisms-finite-species.lagda.md
@@ -84,8 +84,9 @@ associative-comp-hom-species-𝔽 :
   (G : species-𝔽 l1 l3) (H : species-𝔽 l1 l4) (K : species-𝔽 l1 l5)
   (h : type-hom-species-𝔽 H K)
   (g : type-hom-species-𝔽 G H) (f : type-hom-species-𝔽 F G) →
-  Id ( comp-hom-species-𝔽 F G K (comp-hom-species-𝔽 G H K h g) f)
-     ( comp-hom-species-𝔽 F H K h (comp-hom-species-𝔽 F G H g f))
+  Id
+    ( comp-hom-species-𝔽 F G K (comp-hom-species-𝔽 G H K h g) f)
+    ( comp-hom-species-𝔽 F H K h (comp-hom-species-𝔽 F G H g f))
 associative-comp-hom-species-𝔽 F G H K h g f = refl
 ```
 
@@ -124,7 +125,7 @@ is-contr-htpy-hom-species-𝔽 F G f =
 is-equiv-htpy-eq-hom-species-𝔽 :
   {l1 l2 l3 : Level} (F : species-𝔽 l1 l2) (G : species-𝔽 l1 l3)
   (f g : type-hom-species-𝔽 F G) →
-   is-equiv (htpy-eq-hom-species-𝔽 F G f g)
+    is-equiv (htpy-eq-hom-species-𝔽 F G f g)
 is-equiv-htpy-eq-hom-species-𝔽 F G f =
   fundamental-theorem-id
     ( is-contr-htpy-hom-species-𝔽 F G f)

--- a/src/species/morphisms-species-of-types.lagda.md
+++ b/src/species/morphisms-species-of-types.lagda.md
@@ -106,8 +106,9 @@ associative-comp-hom-species-types :
   {H : species-types l1 l4} {K : species-types l1 l5}
   (h : hom-species-types H K) (g : hom-species-types G H)
   (f : hom-species-types F G) →
-  Id ( comp-hom-species-types (comp-hom-species-types h g) f)
-     ( comp-hom-species-types h (comp-hom-species-types g f))
+  Id
+    ( comp-hom-species-types (comp-hom-species-types h g) f)
+    ( comp-hom-species-types h (comp-hom-species-types g f))
 associative-comp-hom-species-types h g f = refl
 ```
 

--- a/src/species/products-cauchy-series-species-of-types-in-subuniverses.lagda.md
+++ b/src/species/products-cauchy-series-species-of-types-in-subuniverses.lagda.md
@@ -66,15 +66,15 @@ module _
 
   equiv-product-cauchy-series-Σ-extension-species-subuniverse :
     ( product-cauchy-series-species-types
-       ( Σ-extension-species-subuniverse
-           ( P)
-           ( subuniverse-global-subuniverse Q l3)
-           ( S))
-       ( Σ-extension-species-subuniverse
-           ( P)
-           ( subuniverse-global-subuniverse Q l4)
-           ( T))
-       X)
+      ( Σ-extension-species-subuniverse
+          ( P)
+          ( subuniverse-global-subuniverse Q l3)
+          ( S))
+      ( Σ-extension-species-subuniverse
+          ( P)
+          ( subuniverse-global-subuniverse Q l4)
+          ( T))
+      X)
       ≃
     product-cauchy-series-species-subuniverse P Q S T X
   equiv-product-cauchy-series-Σ-extension-species-subuniverse =

--- a/src/species/products-cauchy-series-species-of-types.lagda.md
+++ b/src/species/products-cauchy-series-species-of-types.lagda.md
@@ -85,16 +85,16 @@ module _
     cauchy-series-species-types (cauchy-product-species-types S T) X ≃
     product-cauchy-series-species-types S T X
   equiv-cauchy-series-cauchy-product-species-types =
-     ( reassociate') ∘e
-     ( ( equiv-tot
-         ( λ A →
-           equiv-tot
-             ( λ B →
-               ( equiv-prod
-                 ( id-equiv)
-                 ( equiv-universal-property-coprod X)) ∘e
-               ( left-unit-law-Σ-is-contr
-                 ( is-contr-total-equiv' (A + B))
-                 ( A + B , id-equiv))))) ∘e
-       ( reassociate))
+    ( reassociate') ∘e
+    ( ( equiv-tot
+        ( λ A →
+          equiv-tot
+            ( λ B →
+              ( equiv-prod
+                ( id-equiv)
+                ( equiv-universal-property-coprod X)) ∘e
+              ( left-unit-law-Σ-is-contr
+                ( is-contr-total-equiv' (A + B))
+                ( A + B , id-equiv))))) ∘e
+      ( reassociate))
 ```

--- a/src/species/small-cauchy-composition-species-of-finite-inhabited-types.lagda.md
+++ b/src/species/small-cauchy-composition-species-of-finite-inhabited-types.lagda.md
@@ -115,7 +115,7 @@ module _
                   ( is-finite-and-inhabited-Prop)
                   ( map-compute-Inhabited-𝔽' X)
                   ( D)
-                   ( x)))))
+                  ( x)))))
 
   private
     C1 :

--- a/src/species/small-cauchy-composition-species-of-types-in-subuniverses.lagda.md
+++ b/src/species/small-cauchy-composition-species-of-types-in-subuniverses.lagda.md
@@ -121,8 +121,8 @@ module _
           ( Relaxed-Σ-Decomposition l1 l1 X)
           ( λ D →
               is-in-subuniverse P (indexing-type-Relaxed-Σ-Decomposition D) ×
-              ((x : indexing-type-Relaxed-Σ-Decomposition D) →
-               is-in-subuniverse P (cotype-Relaxed-Σ-Decomposition D x)))
+              ( (x : indexing-type-Relaxed-Σ-Decomposition D) →
+                is-in-subuniverse P (cotype-Relaxed-Σ-Decomposition D x)))
           ( _)) ∘e
         ( ( equiv-Σ-equiv-base
             ( _)
@@ -338,14 +338,14 @@ module _
             ( U)
             ( inclusion-subuniverse P X))) ∘e
         ( ( equiv-tot
-            λ D →
+            ( λ D →
               equiv-prod
-               ( inv-equiv
-                 ( equiv-small-cauchy-composition-Σ-extension-species-subuniverse
-                   ( S)
-                   ( T)
-                   ( indexing-type-Relaxed-Σ-Decomposition D)))
-               ( id-equiv)) ∘e
+                ( inv-equiv
+                  ( equiv-small-cauchy-composition-Σ-extension-species-subuniverse
+                    ( S)
+                    ( T)
+                    ( indexing-type-Relaxed-Σ-Decomposition D)))
+                ( id-equiv))) ∘e
           ( ( equiv-associative-cauchy-composition-species-types
               ( Σ-extension-species-subuniverse P Q S)
               ( Σ-extension-species-subuniverse P Q T)

--- a/src/species/unlabeled-structures-species.lagda.md
+++ b/src/species/unlabeled-structures-species.lagda.md
@@ -67,4 +67,6 @@ module _
   structure-unlabeled-structure-species-types = pr2 X
 ```
 
-### Equivalences of unlabeled structures of a speces
+### Equivalences of unlabeled structures of a species
+
+This remains to be defined.

--- a/src/structured-types/coherent-h-spaces.lagda.md
+++ b/src/structured-types/coherent-h-spaces.lagda.md
@@ -110,8 +110,9 @@ module _
     pr1 (pr2 coherent-unit-laws-mul-Coherent-H-Space)
 
   coh-unit-laws-mul-Coherent-H-Space :
-    Id ( left-unit-law-mul-Coherent-H-Space unit-Coherent-H-Space)
-       ( right-unit-law-mul-Coherent-H-Space unit-Coherent-H-Space)
+    Id
+      ( left-unit-law-mul-Coherent-H-Space unit-Coherent-H-Space)
+      ( right-unit-law-mul-Coherent-H-Space unit-Coherent-H-Space)
   coh-unit-laws-mul-Coherent-H-Space =
     pr2 (pr2 coherent-unit-laws-mul-Coherent-H-Space)
 ```

--- a/src/structured-types/equivalences-types-equipped-with-endomorphisms.lagda.md
+++ b/src/structured-types/equivalences-types-equipped-with-endomorphisms.lagda.md
@@ -230,8 +230,9 @@ module _
 
   preserves-concat-equiv-eq-Endo :
     (p : Id X Y) (q : Id Y Z) →
-    Id ( equiv-eq-Endo X Z (p ∙ q))
-       ( comp-equiv-Endo X Y Z (equiv-eq-Endo Y Z q) (equiv-eq-Endo X Y p))
+    Id
+      ( equiv-eq-Endo X Z (p ∙ q))
+      ( comp-equiv-Endo X Y Z (equiv-eq-Endo Y Z q) (equiv-eq-Endo X Y p))
   preserves-concat-equiv-eq-Endo refl q =
     inv (right-unit-law-comp-equiv-Endo X Z (equiv-eq-Endo X Z q))
 ```

--- a/src/structured-types/h-spaces.lagda.md
+++ b/src/structured-types/h-spaces.lagda.md
@@ -81,5 +81,3 @@ module _
     (x : type-H-Space) → Id (mul-H-Space x point-H-Space) x
   right-unit-law-mul-H-Space = pr2 unit-laws-mul-H-Space
 ```
-
-## Properties

--- a/src/structured-types/pointed-cartesian-product-types.lagda.md
+++ b/src/structured-types/pointed-cartesian-product-types.lagda.md
@@ -114,7 +114,7 @@ module _
   pr1 (gap-prod-Pointed-Type S f g) =
     map-gap-prod-Pointed-Type S f g
   pr2 (gap-prod-Pointed-Type S f g) =
-     eq-pair
+    eq-pair
       ( preserves-point-pointed-map S A f)
       ( preserves-point-pointed-map S B g)
 ```

--- a/src/structured-types/pointed-equivalences.lagda.md
+++ b/src/structured-types/pointed-equivalences.lagda.md
@@ -181,13 +181,16 @@ module _
   is-contr-sec-is-equiv-pointed-map H =
     is-contr-total-Eq-structure
       ( λ g p (G : (map-pointed-map A B f ∘ g) ~ id) →
-          Id { A = Id { A = type-Pointed-Type B}
-                      ( map-pointed-map A B f (g (point-Pointed-Type B)))
-                      ( point-Pointed-Type B)}
-             ( G (point-Pointed-Type B))
-             ( ( ( ap (map-pointed-map A B f) p) ∙
-                 ( preserves-point-pointed-map A B f)) ∙
-               ( refl)))
+          Id
+            { A =
+              Id
+                { A = type-Pointed-Type B}
+                ( map-pointed-map A B f (g (point-Pointed-Type B)))
+                ( point-Pointed-Type B)}
+            ( G (point-Pointed-Type B))
+            ( ( ( ap (map-pointed-map A B f) p) ∙
+                ( preserves-point-pointed-map A B f)) ∙
+              ( refl)))
       ( is-contr-sec-is-equiv H)
       ( pair (map-inv-is-equiv H) (issec-map-inv-is-equiv H))
       ( is-contr-equiv
@@ -220,13 +223,16 @@ module _
   is-contr-retr-is-equiv-pointed-map H =
     is-contr-total-Eq-structure
       ( λ g p (G : (g ∘ map-pointed-map A B f) ~ id) →
-        Id {A = Id { A = type-Pointed-Type A}
-                   ( g (map-pointed-map A B f (point-Pointed-Type A)))
-                   ( point-Pointed-Type A)}
-           ( G (point-Pointed-Type A))
-           ( ( ( ap g (preserves-point-pointed-map A B f)) ∙
-               ( p)) ∙
-             ( refl)))
+        Id
+          { A =
+            Id
+              { A = type-Pointed-Type A}
+              ( g (map-pointed-map A B f (point-Pointed-Type A)))
+              ( point-Pointed-Type A)}
+          ( G (point-Pointed-Type A))
+          ( ( ( ap g (preserves-point-pointed-map A B f)) ∙
+              ( p)) ∙
+            ( refl)))
       ( is-contr-retr-is-equiv H)
       ( pair (map-inv-is-equiv H) (isretr-map-inv-is-equiv H))
       ( is-contr-equiv

--- a/src/structured-types/pointed-homotopies.lagda.md
+++ b/src/structured-types/pointed-homotopies.lagda.md
@@ -43,8 +43,9 @@ module _
     pointed-Π A
       ( pair
         ( λ x →
-          Id ( function-pointed-Π A B f x)
-             ( function-pointed-Π A B g x))
+          Id
+            ( function-pointed-Π A B f x)
+            ( function-pointed-Π A B g x))
         ( ( preserves-point-function-pointed-Π A B f) ∙
           ( inv (preserves-point-function-pointed-Π A B g))))
 

--- a/src/structured-types/pointed-types-equipped-with-automorphisms.lagda.md
+++ b/src/structured-types/pointed-types-equipped-with-automorphisms.lagda.md
@@ -156,11 +156,12 @@ is-contr-total-htpy-hom-Pointed-Type-With-Aut :
 is-contr-total-htpy-hom-Pointed-Type-With-Aut X Y h1 =
   is-contr-total-Eq-structure
     ( λ ( map-h2 : type-Pointed-Type-With-Aut X → type-Pointed-Type-With-Aut Y)
-        ( str-h2 : ( ( map-h2 (point-Pointed-Type-With-Aut X)) ＝
-                     ( point-Pointed-Type-With-Aut Y)) ×
-                   ( ( x : type-Pointed-Type-With-Aut X) →
-                     ( map-h2 (map-aut-Pointed-Type-With-Aut X x)) ＝
-                     ( map-aut-Pointed-Type-With-Aut Y (map-h2 x))))
+        ( str-h2 :
+          ( ( map-h2 (point-Pointed-Type-With-Aut X)) ＝
+            ( point-Pointed-Type-With-Aut Y)) ×
+          ( ( x : type-Pointed-Type-With-Aut X) →
+            ( map-h2 (map-aut-Pointed-Type-With-Aut X x)) ＝
+            ( map-aut-Pointed-Type-With-Aut Y (map-h2 x))))
         ( H : map-hom-Pointed-Type-With-Aut X Y h1 ~ map-h2) →
         ( ( preserves-point-map-hom-Pointed-Type-With-Aut X Y h1) ＝
           ( ( H (point-Pointed-Type-With-Aut X)) ∙

--- a/src/structured-types/types-equipped-with-automorphisms.lagda.md
+++ b/src/structured-types/types-equipped-with-automorphisms.lagda.md
@@ -2,6 +2,11 @@
 
 ```agda
 module structured-types.types-equipped-with-automorphisms where
+
+open import foundation.universe-levels
+open import foundation.dependent-pair-types
+open import foundation.equivalences
+open import foundation.automorphisms
 ```
 
 <details><summary>Imports</summary>
@@ -18,3 +23,24 @@ A type equipped with an automorphism is a pair consisting of a type `A` and an
 automorphism on `A`.
 
 ## Definition
+
+```agda
+Type-Aut : (l : Level) → UU (lsuc l)
+Type-Aut l = Σ (UU l) (Aut)
+
+type-Type-Aut : {l : Level} → Type-Aut l → UU l
+type-Type-Aut (X , e) = X
+
+aut-Type-Aut : {l : Level} (A : Type-Aut l) → Aut (type-Type-Aut A)
+aut-Type-Aut (X , e) = e
+```
+
+## Properties
+
+### Every type can be equipped with the identity automorpism
+
+```agda
+id-Type-Aut : {l : Level} → UU l → Type-Aut l
+pr1 (id-Type-Aut X) = X
+pr2 (id-Type-Aut X) = id-equiv
+```

--- a/src/structured-types/wild-loops.lagda.md
+++ b/src/structured-types/wild-loops.lagda.md
@@ -79,8 +79,9 @@ module _
     right-unit-law-mul-Coherent-H-Space wild-unital-magma-Wild-Loop
 
   coh-unit-laws-mul-Wild-Loop :
-    Id ( left-unit-law-mul-Wild-Loop unit-Wild-Loop)
-       ( right-unit-law-mul-Wild-Loop unit-Wild-Loop)
+    Id
+      ( left-unit-law-mul-Wild-Loop unit-Wild-Loop)
+      ( right-unit-law-mul-Wild-Loop unit-Wild-Loop)
   coh-unit-laws-mul-Wild-Loop =
     coh-unit-laws-mul-Coherent-H-Space wild-unital-magma-Wild-Loop
 

--- a/src/structured-types/wild-semigroups.lagda.md
+++ b/src/structured-types/wild-semigroups.lagda.md
@@ -48,7 +48,8 @@ module _
 
   associative-mul-Wild-Semigroup :
     (x y z : type-Wild-Semigroup) →
-    Id ( mul-Wild-Semigroup (mul-Wild-Semigroup x y) z)
-       ( mul-Wild-Semigroup x (mul-Wild-Semigroup y z))
+    Id
+      ( mul-Wild-Semigroup (mul-Wild-Semigroup x y) z)
+      ( mul-Wild-Semigroup x (mul-Wild-Semigroup y z))
   associative-mul-Wild-Semigroup = pr2 G
 ```

--- a/src/synthetic-homotopy-theory/26-descent.lagda.md
+++ b/src/synthetic-homotopy-theory/26-descent.lagda.md
@@ -99,8 +99,9 @@ coherence-htpy-dep-cocone :
 coherence-htpy-dep-cocone {S = S} f g c P
   h h' K L =
   (s : S) →
-  Id ( ((pr2 (pr2 h)) s) ∙ (L (g s)))
-     ( (ap (tr P (pr2 (pr2 c) s)) (K (f s))) ∙ ((pr2 (pr2 h')) s))
+  Id
+    ( ((pr2 (pr2 h)) s) ∙ (L (g s)))
+    ( (ap (tr P (pr2 (pr2 c) s)) (K (f s))) ∙ ((pr2 (pr2 h')) s))
 
 htpy-dep-cocone :
   {l1 l2 l3 l4 l5 : Level} {S : UU l1} {A : UU l2} {B : UU l3}

--- a/src/synthetic-homotopy-theory/26-id-pushout.lagda.md
+++ b/src/synthetic-homotopy-theory/26-id-pushout.lagda.md
@@ -214,14 +214,16 @@ coherence-naturality-fam-maps :
   { l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2}
   (P : B → UU l3) (Q : B → UU l4) →
   { f f' : A → B} (H : f ~ f') (h : (b : B) → P b → Q b) (a : A) →
-  Id ( square-path-over-fam-maps (H a) (h (f a)) (h (f' a)) (apd h (H a)))
-     ( naturality-fam-maps h (H a))
+  Id
+    ( square-path-over-fam-maps (H a) (h (f a)) (h (f' a)) (apd h (H a)))
+    ( naturality-fam-maps h (H a))
 coherence-naturality-fam-maps {A = A} {B} P Q {f} {f'} H =
   ind-htpy f
     ( λ f' H →
       ( h : (b : B) → P b → Q b) (a : A) →
-      Id ( square-path-over-fam-maps (H a) (h (f a)) (h (f' a)) (apd h (H a)))
-         ( naturality-fam-maps h (H a)))
+      Id
+        ( square-path-over-fam-maps (H a) (h (f a)) (h (f' a)) (apd h (H a)))
+        ( naturality-fam-maps h (H a)))
     ( λ h a → refl)
     ( H)
 

--- a/src/synthetic-homotopy-theory/circle.lagda.md
+++ b/src/synthetic-homotopy-theory/circle.lagda.md
@@ -91,9 +91,10 @@ module _
     pr1 (pr2 apply-dependent-universal-property-𝕊¹)
 
   loop-dependent-universal-property-𝕊¹ :
-    Id ( apd function-apply-dependent-universal-property-𝕊¹ loop-𝕊¹ ∙
-         base-dependent-universal-property-𝕊¹)
-       ( ap (tr P loop-𝕊¹) base-dependent-universal-property-𝕊¹ ∙ α)
+    Id
+      ( apd function-apply-dependent-universal-property-𝕊¹ loop-𝕊¹ ∙
+        base-dependent-universal-property-𝕊¹)
+      ( ap (tr P loop-𝕊¹) base-dependent-universal-property-𝕊¹ ∙ α)
   loop-dependent-universal-property-𝕊¹ =
     pr2 (pr2 apply-dependent-universal-property-𝕊¹)
 ```
@@ -139,9 +140,10 @@ module _
     pr1 (pr2 apply-universal-property-𝕊¹)
 
   loop-universal-property-𝕊¹ :
-    Id ( ap map-apply-universal-property-𝕊¹ loop-𝕊¹ ∙
-         base-universal-property-𝕊¹)
-       ( base-universal-property-𝕊¹ ∙ α)
+    Id
+      ( ap map-apply-universal-property-𝕊¹ loop-𝕊¹ ∙
+        base-universal-property-𝕊¹)
+      ( base-universal-property-𝕊¹ ∙ α)
   loop-universal-property-𝕊¹ =
     pr2 (pr2 apply-universal-property-𝕊¹)
 ```

--- a/src/synthetic-homotopy-theory/cocones-under-spans.lagda.md
+++ b/src/synthetic-homotopy-theory/cocones-under-spans.lagda.md
@@ -183,8 +183,8 @@ cocone-comp-horizontal :
   ( f : A → X) (i : A → B) (k : B → C) ( c : cocone f i Y) →
   cocone (vertical-map-cocone f i c) k Z → cocone f (k ∘ i) Z
 pr1 (cocone-comp-horizontal f i k c d) =
-   ( horizontal-map-cocone (vertical-map-cocone f i c) k d) ∘
-   ( horizontal-map-cocone f i c)
+  ( horizontal-map-cocone (vertical-map-cocone f i c) k d) ∘
+  ( horizontal-map-cocone f i c)
 pr1 (pr2 (cocone-comp-horizontal f i k c d)) =
   vertical-map-cocone (vertical-map-cocone f i c) k d
 pr2 (pr2 (cocone-comp-horizontal f i k c d)) =

--- a/src/synthetic-homotopy-theory/double-loop-spaces.lagda.md
+++ b/src/synthetic-homotopy-theory/double-loop-spaces.lagda.md
@@ -79,8 +79,9 @@ right-unit-law-horizontal-concat-Ω² {α = α} =
 
 interchange-Ω² :
   {l : Level} {A : UU l} {a : A} (α β γ δ : type-Ω² a) →
-  Id ( horizontal-concat-Ω² (vertical-concat-Ω² α β) (vertical-concat-Ω² γ δ))
-     ( vertical-concat-Ω² (horizontal-concat-Ω² α γ) (horizontal-concat-Ω² β δ))
+  Id
+    ( horizontal-concat-Ω² (vertical-concat-Ω² α β) (vertical-concat-Ω² γ δ))
+    ( vertical-concat-Ω² (horizontal-concat-Ω² α γ) (horizontal-concat-Ω² β δ))
 interchange-Ω² α β γ δ = interchange-Id² α β γ δ
 
 outer-eckmann-hilton-connection-Ω² :

--- a/src/synthetic-homotopy-theory/hatchers-acyclic-type.lagda.md
+++ b/src/synthetic-homotopy-theory/hatchers-acyclic-type.lagda.md
@@ -137,12 +137,13 @@ module _
   is-contr-total-Eq-structure-Hatcher-Acyclic-Type =
     is-contr-total-Eq-structure
       ( λ (ω : type-Ω A) u (p : pr1 s ＝ ω) →
-          Σ (pr1 (pr2 s) ＝ pr1 u)
-          (λ q →
-             ((pr1 (pr2 (pr2 s)) ∙ ap (power-nat-Ω 3 A) q) ＝
-              (ap (power-nat-Ω 5 A) p ∙ pr1 (pr2 u))) ×
-             ((pr2 (pr2 (pr2 s)) ∙ ap (power-nat-Ω 2 A) (ap-binary _∙_ p q)) ＝
-              (ap (power-nat-Ω 3 A) q ∙ pr2 (pr2 u)))))
+          Σ ( pr1 (pr2 s) ＝ pr1 u)
+            ( λ q →
+              ( ( pr1 (pr2 (pr2 s)) ∙ ap (power-nat-Ω 3 A) q) ＝
+                ( ap (power-nat-Ω 5 A) p ∙ pr1 (pr2 u))) ×
+              ( ( pr2
+                  ( pr2 (pr2 s)) ∙ ap (power-nat-Ω 2 A) (ap-binary _∙_ p q)) ＝
+                ( ap (power-nat-Ω 3 A) q ∙ pr2 (pr2 u)))))
       ( is-contr-total-path (pr1 s))
       ( pr1 s , refl)
       ( is-contr-total-Eq-structure

--- a/src/synthetic-homotopy-theory/infinite-complex-projective-space.lagda.md
+++ b/src/synthetic-homotopy-theory/infinite-complex-projective-space.lagda.md
@@ -30,4 +30,6 @@ pr1 point-ℂP∞ = 𝕊¹
 pr2 point-ℂP∞ = unit-trunc-Set id-equiv
 ```
 
-### ℂP∞ as the 2-truncation of the 2-sphere
+### `ℂP∞` as the 2-truncation of the 2-sphere
+
+This remains to be defined.

--- a/src/synthetic-homotopy-theory/interval-type.lagda.md
+++ b/src/synthetic-homotopy-theory/interval-type.lagda.md
@@ -51,8 +51,9 @@ postulate
   compute-path-𝕀 :
     {l : Level} {P : 𝕀 → UU l} (u : P source-𝕀) (v : P target-𝕀)
     (q : Id (tr P path-𝕀 u) v) →
-    Id ( apd (ind-𝕀 P u v q) path-𝕀 ∙ compute-target-𝕀 u v q)
-       ( ap (tr P path-𝕀) (compute-source-𝕀 u v q) ∙ q)
+    Id
+      ( apd (ind-𝕀 P u v q) path-𝕀 ∙ compute-target-𝕀 u v q)
+      ( ap (tr P path-𝕀) (compute-source-𝕀 u v q) ∙ q)
 ```
 
 ## Properties

--- a/src/synthetic-homotopy-theory/loop-spaces.lagda.md
+++ b/src/synthetic-homotopy-theory/loop-spaces.lagda.md
@@ -144,14 +144,16 @@ module _
 
   preserves-mul-tr-Ω :
     (p : Id x y) (u v : type-Ω (pair A x)) →
-    Id ( tr-type-Ω p (mul-Ω (pair A x) u v))
-       ( mul-Ω (pair A y) (tr-type-Ω p u) (tr-type-Ω p v))
+    Id
+      ( tr-type-Ω p (mul-Ω (pair A x) u v))
+      ( mul-Ω (pair A y) (tr-type-Ω p u) (tr-type-Ω p v))
   preserves-mul-tr-Ω refl u v = refl
 
   preserves-inv-tr-Ω :
     (p : Id x y) (u : type-Ω (pair A x)) →
-    Id ( tr-type-Ω p (inv-Ω (pair A x) u))
-       ( inv-Ω (pair A y) (tr-type-Ω p u))
+    Id
+      ( tr-type-Ω p (inv-Ω (pair A x) u))
+      ( inv-Ω (pair A y) (tr-type-Ω p u))
   preserves-inv-tr-Ω refl u = refl
 
   eq-tr-type-Ω :

--- a/src/synthetic-homotopy-theory/triple-loop-spaces.lagda.md
+++ b/src/synthetic-homotopy-theory/triple-loop-spaces.lagda.md
@@ -138,20 +138,23 @@ right-unit-law-z-concat-Ω³ α =
 ```agda
 interchange-x-y-concat-Ω³ :
   {l : Level} {A : UU l} {a : A} (α β γ δ : type-Ω³ a) →
-  Id ( y-concat-Ω³ (x-concat-Ω³ α β) (x-concat-Ω³ γ δ))
-     ( x-concat-Ω³ (y-concat-Ω³ α γ) (y-concat-Ω³ β δ))
+  Id
+    ( y-concat-Ω³ (x-concat-Ω³ α β) (x-concat-Ω³ γ δ))
+    ( x-concat-Ω³ (y-concat-Ω³ α γ) (y-concat-Ω³ β δ))
 interchange-x-y-concat-Ω³ = interchange-x-y-concat-Id³
 
 interchange-x-z-concat-Ω³ :
   {l : Level} {A : UU l} {a : A} (α β γ δ : type-Ω³ a) →
-  Id ( z-concat-Ω³ (x-concat-Ω³ α β) (x-concat-Ω³ γ δ))
-     ( x-concat-Ω³ (z-concat-Ω³ α γ) (z-concat-Ω³ β δ))
+  Id
+    ( z-concat-Ω³ (x-concat-Ω³ α β) (x-concat-Ω³ γ δ))
+    ( x-concat-Ω³ (z-concat-Ω³ α γ) (z-concat-Ω³ β δ))
 interchange-x-z-concat-Ω³ = interchange-x-z-concat-Id³
 
 interchange-y-z-concat-Ω³ :
   {l : Level} {A : UU l} {a : A} (α β γ δ : type-Ω³ a) →
-  Id ( z-concat-Ω³ (y-concat-Ω³ α β) (y-concat-Ω³ γ δ))
-     ( y-concat-Ω³ (z-concat-Ω³ α γ) (z-concat-Ω³ β δ))
+  Id
+    ( z-concat-Ω³ (y-concat-Ω³ α β) (y-concat-Ω³ γ δ))
+    ( y-concat-Ω³ (z-concat-Ω³ α γ) (z-concat-Ω³ β δ))
 interchange-y-z-concat-Ω³ α β γ δ =
   inv right-unit ∙ interchange-y-z-concat-Id³ α β γ δ
 ```

--- a/src/synthetic-homotopy-theory/universal-cover-circle.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-cover-circle.lagda.md
@@ -67,9 +67,10 @@ coherence-square-functor-free-dependent-loop :
   { l1 l2 l3 : Level} {X : UU l1} {P : X → UU l2} {Q : X → UU l3}
   ( f : (x : X) → P x → Q x) {x y : X} (α : Id x y)
   ( h : (x : X) → P x) →
-  Id ( ( naturality-tr-fiberwise-transformation f α (h x)) ∙
-       ( ap (f y) (apd h α)))
-     ( apd (map-Π f h) α)
+  Id
+    ( ( naturality-tr-fiberwise-transformation f α (h x)) ∙
+      ( ap (f y) (apd h α)))
+    ( apd (map-Π f h) α)
 coherence-square-functor-free-dependent-loop f refl h = refl
 
 square-functor-free-dependent-loop :
@@ -216,8 +217,9 @@ path-total-path-fiber B x q = eq-pair-Σ refl (inv q)
 tr-path-total-path-fiber :
   { l1 l2 : Level} {A : UU l1} {B : A → UU l2} (c : Σ A B) (x : A) →
   { y y' : B x} (q : Id y' y) (α : Id c (pair x y')) →
-  Id ( tr (λ z → Id c (pair x z)) q α)
-     ( α ∙ (inv (path-total-path-fiber B x q)))
+  Id
+    ( tr (λ z → Id c (pair x z)) q α)
+    ( α ∙ (inv (path-total-path-fiber B x q)))
 tr-path-total-path-fiber c x refl α = inv right-unit
 
 segment-Σ :
@@ -257,8 +259,9 @@ tr-path-total-tr-coherence :
   { F : UU l3} {F' : UU l4} (f : F ≃ F') ( e : F ≃ B x) (e' : F' ≃ B x)
   ( H : ((map-equiv e') ∘ (map-equiv f)) ~ (map-equiv e)) →
   (y : F) (α : Id c (pair x (map-equiv e' (map-equiv f y)))) →
-  Id ( tr (λ z → Id c (pair x z)) (H y) α)
-     ( α ∙ (inv (segment-Σ refl f e e' H y)))
+  Id
+    ( tr (λ z → Id c (pair x z)) (H y) α)
+    ( α ∙ (inv (segment-Σ refl f e e' H y)))
 tr-path-total-tr-coherence c x f e e' H y α =
   tr-path-total-path-fiber c x (H y) α
 
@@ -390,28 +393,28 @@ center-total-fundamental-cover-circle :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
   ( dup-circle : {l2 : Level} → dependent-universal-property-circle l2 l) →
   Σ X (fundamental-cover-circle l dup-circle)
-center-total-fundamental-cover-circle l dup-circle =
-  pair
-    ( base-free-loop l)
-    ( map-equiv
-      ( compute-fiber-fundamental-cover-circle l dup-circle) zero-ℤ)
+pr1 (center-total-fundamental-cover-circle l dup-circle) = base-free-loop l
+pr2 (center-total-fundamental-cover-circle l dup-circle) =
+  map-equiv ( compute-fiber-fundamental-cover-circle l dup-circle) zero-ℤ
 
 path-over-loop-contraction-total-fundamental-cover-circle :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
   ( dup-circle : {l2 : Level} → dependent-universal-property-circle l2 l) →
-  ( h : contraction-total-space'
-        ( center-total-fundamental-cover-circle l dup-circle)
-        ( base-free-loop l)
-        ( compute-fiber-fundamental-cover-circle l dup-circle)) →
-  ( p : path-over-contraction-total-space'
-        ( center-total-fundamental-cover-circle l dup-circle)
-        ( loop-free-loop l)
-        ( equiv-succ-ℤ)
-        ( compute-fiber-fundamental-cover-circle l dup-circle)
-        ( compute-fiber-fundamental-cover-circle l dup-circle)
-        ( compute-tr-fundamental-cover-circle l dup-circle)
-        ( h)
-        ( h)) →
+  ( h :
+    contraction-total-space'
+      ( center-total-fundamental-cover-circle l dup-circle)
+      ( base-free-loop l)
+      ( compute-fiber-fundamental-cover-circle l dup-circle)) →
+  ( p :
+    path-over-contraction-total-space'
+      ( center-total-fundamental-cover-circle l dup-circle)
+      ( loop-free-loop l)
+      ( equiv-succ-ℤ)
+      ( compute-fiber-fundamental-cover-circle l dup-circle)
+      ( compute-fiber-fundamental-cover-circle l dup-circle)
+      ( compute-tr-fundamental-cover-circle l dup-circle)
+      ( h)
+      ( h)) →
   path-over
     ( contraction-total-space
       ( center-total-fundamental-cover-circle l dup-circle))
@@ -443,19 +446,21 @@ path-over-loop-contraction-total-fundamental-cover-circle l dup-circle h p =
 contraction-total-fundamental-cover-circle-data :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
   ( dup-circle : {l2 : Level} → dependent-universal-property-circle l2 l) →
-  ( h : contraction-total-space'
-        ( center-total-fundamental-cover-circle l dup-circle)
-        ( base-free-loop l)
-        ( compute-fiber-fundamental-cover-circle l dup-circle)) →
-  ( p : path-over-contraction-total-space'
-        ( center-total-fundamental-cover-circle l dup-circle)
-        ( loop-free-loop l)
-        ( equiv-succ-ℤ)
-        ( compute-fiber-fundamental-cover-circle l dup-circle)
-        ( compute-fiber-fundamental-cover-circle l dup-circle)
-        ( compute-tr-fundamental-cover-circle l dup-circle)
-        ( h)
-        ( h)) →
+  ( h :
+    contraction-total-space'
+      ( center-total-fundamental-cover-circle l dup-circle)
+      ( base-free-loop l)
+      ( compute-fiber-fundamental-cover-circle l dup-circle)) →
+  ( p :
+    path-over-contraction-total-space'
+      ( center-total-fundamental-cover-circle l dup-circle)
+      ( loop-free-loop l)
+      ( equiv-succ-ℤ)
+      ( compute-fiber-fundamental-cover-circle l dup-circle)
+      ( compute-fiber-fundamental-cover-circle l dup-circle)
+      ( compute-tr-fundamental-cover-circle l dup-circle)
+      ( h)
+      ( h)) →
   ( t : Σ X (fundamental-cover-circle l dup-circle)) →
   Id (center-total-fundamental-cover-circle l dup-circle) t
 contraction-total-fundamental-cover-circle-data
@@ -479,24 +484,26 @@ contraction-total-fundamental-cover-circle-data
 is-contr-total-fundamental-cover-circle-data :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
   ( dup-circle : {l2 : Level} → dependent-universal-property-circle l2 l) →
-  ( h : contraction-total-space'
-        ( center-total-fundamental-cover-circle l dup-circle)
-        ( base-free-loop l)
-        ( compute-fiber-fundamental-cover-circle l dup-circle)) →
-  ( p : path-over-contraction-total-space'
-        ( center-total-fundamental-cover-circle l dup-circle)
-        ( loop-free-loop l)
-        ( equiv-succ-ℤ)
-        ( compute-fiber-fundamental-cover-circle l dup-circle)
-        ( compute-fiber-fundamental-cover-circle l dup-circle)
-        ( compute-tr-fundamental-cover-circle l dup-circle)
-        ( h)
-        ( h)) →
+  ( h :
+    contraction-total-space'
+      ( center-total-fundamental-cover-circle l dup-circle)
+      ( base-free-loop l)
+      ( compute-fiber-fundamental-cover-circle l dup-circle)) →
+  ( p :
+    path-over-contraction-total-space'
+      ( center-total-fundamental-cover-circle l dup-circle)
+      ( loop-free-loop l)
+      ( equiv-succ-ℤ)
+      ( compute-fiber-fundamental-cover-circle l dup-circle)
+      ( compute-fiber-fundamental-cover-circle l dup-circle)
+      ( compute-tr-fundamental-cover-circle l dup-circle)
+      ( h)
+      ( h)) →
   is-contr (Σ X (fundamental-cover-circle l dup-circle))
-is-contr-total-fundamental-cover-circle-data l dup-circle h p =
-  pair
-    ( center-total-fundamental-cover-circle l dup-circle)
-    ( contraction-total-fundamental-cover-circle-data l dup-circle h p)
+pr1 (is-contr-total-fundamental-cover-circle-data l dup-circle h p) =
+  center-total-fundamental-cover-circle l dup-circle
+pr2 (is-contr-total-fundamental-cover-circle-data l dup-circle h p) =
+  contraction-total-fundamental-cover-circle-data l dup-circle h p
 ```
 
 ### Section 12.4 The dependent universal property of ℤ
@@ -529,8 +536,7 @@ abstract
   compute-succ-elim-ℤ :
     { l1 : Level} (P : ℤ → UU l1)
     ( p0 : P zero-ℤ) (pS : (k : ℤ) → (P k) ≃ (P (succ-ℤ k))) (k : ℤ) →
-    Id ( elim-ℤ P p0 pS (succ-ℤ k)) (map-equiv (pS k)
-      ( elim-ℤ P p0 pS k))
+    Id (elim-ℤ P p0 pS (succ-ℤ k)) (map-equiv (pS k) (elim-ℤ P p0 pS k))
   compute-succ-elim-ℤ P p0 pS (inl zero-ℕ) =
     inv
       ( issec-map-inv-is-equiv
@@ -548,19 +554,17 @@ ELIM-ℤ :
   { l1 : Level} (P : ℤ → UU l1)
   ( p0 : P zero-ℤ) (pS : (k : ℤ) → (P k) ≃ (P (succ-ℤ k))) → UU l1
 ELIM-ℤ P p0 pS =
-  Σ ( (k : ℤ) → P k) (λ f →
-    ( ( Id (f zero-ℤ) p0) ×
-      ( (k : ℤ) → Id (f (succ-ℤ k)) ((map-equiv (pS k)) (f k)))))
+  Σ ( (k : ℤ) → P k)
+    ( λ f →
+      ( ( Id (f zero-ℤ) p0) ×
+        ( (k : ℤ) → Id (f (succ-ℤ k)) ((map-equiv (pS k)) (f k)))))
 
 Elim-ℤ :
   { l1 : Level} (P : ℤ → UU l1)
   ( p0 : P zero-ℤ) (pS : (k : ℤ) → (P k) ≃ (P (succ-ℤ k))) → ELIM-ℤ P p0 pS
-Elim-ℤ P p0 pS =
-  pair
-    ( elim-ℤ P p0 pS)
-    ( pair
-      ( compute-zero-elim-ℤ P p0 pS)
-      ( compute-succ-elim-ℤ P p0 pS))
+pr1 (Elim-ℤ P p0 pS) = elim-ℤ P p0 pS
+pr1 (pr2 (Elim-ℤ P p0 pS)) = compute-zero-elim-ℤ P p0 pS
+pr2 (pr2 (Elim-ℤ P p0 pS)) = compute-succ-elim-ℤ P p0 pS
 
 equiv-comparison-map-Eq-ELIM-ℤ :
   { l1 : Level} (P : ℤ → UU l1)
@@ -584,7 +588,8 @@ succ-Eq-ELIM-ℤ :
   ( p0 : P zero-ℤ) (pS : (k : ℤ) → (P k) ≃ (P (succ-ℤ k))) →
   ( s t : ELIM-ℤ P p0 pS) (H : (pr1 s) ~ (pr1 t)) → UU l1
 succ-Eq-ELIM-ℤ P p0 pS s t H =
-  ( k : ℤ) → Id
+  ( k : ℤ) →
+  Id
     ( H (succ-ℤ k))
     ( map-equiv (equiv-comparison-map-Eq-ELIM-ℤ P p0 pS s t k) (H k))
 
@@ -602,12 +607,9 @@ reflexive-Eq-ELIM-ℤ :
   { l1 : Level} (P : ℤ → UU l1)
   ( p0 : P zero-ℤ) (pS : (k : ℤ) → (P k) ≃ (P (succ-ℤ k))) →
   ( s : ELIM-ℤ P p0 pS) → Eq-ELIM-ℤ P p0 pS s s
-reflexive-Eq-ELIM-ℤ P p0 pS (pair f (pair p H)) =
-  pair
-    ( refl-htpy)
-    ( pair
-      ( inv (right-inv p))
-      ( λ k → inv (right-inv (H k))))
+pr1 (reflexive-Eq-ELIM-ℤ P p0 pS (f , p , H)) = refl-htpy
+pr1 (pr2 (reflexive-Eq-ELIM-ℤ P p0 pS (f , p , H))) = inv (right-inv p)
+pr2 (pr2 (reflexive-Eq-ELIM-ℤ P p0 pS (f , p , H))) = inv ∘ (right-inv ∘ H)
 
 Eq-ELIM-ℤ-eq :
   { l1 : Level} (P : ℤ → UU l1) →
@@ -637,7 +639,7 @@ abstract
             ( refl-htpy))
         ( is-contr-is-equiv'
           ( Σ (Id (pr1 s zero-ℤ) p0) (λ α → Id α (pr1 (pr2 s))))
-             ( tot (λ α → con-inv refl α (pr1 (pr2 s))))
+          ( tot (λ α → con-inv refl α (pr1 (pr2 s))))
           ( is-equiv-tot-is-fiberwise-equiv
             ( λ α → is-equiv-con-inv refl α (pr1 (pr2 s))))
           ( is-contr-total-path' (pr1 (pr2 s))))
@@ -711,16 +713,17 @@ abstract
 path-total-fundamental-cover-circle :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
   ( dup-circle : {l2 : Level} → dependent-universal-property-circle l2 l)
-  (k : ℤ) →
-  Id {A = Σ X (fundamental-cover-circle l dup-circle)}
-     ( pair
-       ( base-free-loop l)
-       ( map-equiv (compute-fiber-fundamental-cover-circle l dup-circle) k))
-     ( pair
-       ( base-free-loop l)
-       ( map-equiv
-         ( compute-fiber-fundamental-cover-circle l dup-circle)
-         ( succ-ℤ k)))
+  ( k : ℤ) →
+  Id
+    { A = Σ X (fundamental-cover-circle l dup-circle)}
+    ( pair
+      ( base-free-loop l)
+      ( map-equiv (compute-fiber-fundamental-cover-circle l dup-circle) k))
+    ( pair
+      ( base-free-loop l)
+      ( map-equiv
+        ( compute-fiber-fundamental-cover-circle l dup-circle)
+        ( succ-ℤ k)))
 path-total-fundamental-cover-circle l dup-circle k =
   segment-Σ
     ( loop-free-loop l)
@@ -737,10 +740,11 @@ CONTRACTION-fundamental-cover-circle :
 CONTRACTION-fundamental-cover-circle l dup-circle =
   ELIM-ℤ
     ( λ k →
-      Id ( center-total-fundamental-cover-circle l dup-circle)
-         ( pair
-           ( base-free-loop l)
-           ( map-equiv
+      Id
+        ( center-total-fundamental-cover-circle l dup-circle)
+        ( pair
+          ( base-free-loop l)
+          ( map-equiv
             ( compute-fiber-fundamental-cover-circle l dup-circle)
             ( k))))
     ( refl)
@@ -755,10 +759,11 @@ Contraction-fundamental-cover-circle :
 Contraction-fundamental-cover-circle l dup-circle =
   Elim-ℤ
     ( λ k →
-      Id ( center-total-fundamental-cover-circle l dup-circle)
-         ( pair
-           ( base-free-loop l)
-           ( map-equiv
+      Id
+        ( center-total-fundamental-cover-circle l dup-circle)
+        ( pair
+          ( base-free-loop l)
+          ( map-equiv
             ( compute-fiber-fundamental-cover-circle l dup-circle)
             ( k))))
     ( refl)

--- a/src/trees/combinator-directed-trees.lagda.md
+++ b/src/trees/combinator-directed-trees.lagda.md
@@ -223,9 +223,10 @@ module _
         ( unique-direct-successor-is-proper-node-Directed-Tree (T i) x f))
 
   contraction-unique-direct-successor-combinator-Directed-Tree :
-    (x : node-combinator-Directed-Tree) →
-    (p : is-root-combinator-Directed-Tree x +
-         Σ node-combinator-Directed-Tree (edge-combinator-Directed-Tree x)) →
+    ( x : node-combinator-Directed-Tree) →
+    ( p :
+      is-root-combinator-Directed-Tree x +
+      Σ node-combinator-Directed-Tree (edge-combinator-Directed-Tree x)) →
     center-unique-direct-successor-combinator-Directed-Tree x ＝ p
   contraction-unique-direct-successor-combinator-Directed-Tree ._ (inl refl) =
     refl

--- a/src/trees/directed-trees.lagda.md
+++ b/src/trees/directed-trees.lagda.md
@@ -526,10 +526,11 @@ module _
       ( walk-to-root-Directed-Tree T x)
 
   contraction-walk-unique-direct-successor-Directed-Tree :
-    (x : node-Directed-Tree T)
-    (w : walk-Directed-Tree T x (root-Directed-Tree T)) →
-    (p : is-root-Directed-Tree T x +
-         Σ (node-Directed-Tree T) (edge-Directed-Tree T x)) →
+    ( x : node-Directed-Tree T)
+    ( w : walk-Directed-Tree T x (root-Directed-Tree T)) →
+    ( p :
+      is-root-Directed-Tree T x +
+      Σ (node-Directed-Tree T) (edge-Directed-Tree T x)) →
     center-walk-unique-direct-successor-Directed-Tree x w ＝ p
   contraction-walk-unique-direct-successor-Directed-Tree ._
     ( refl-walk-Directed-Graph)
@@ -558,9 +559,10 @@ module _
         ( eq-is-contr (unique-walk-to-root-Directed-Tree T x)))
 
   contraction-unique-direct-successor-Directed-Tree :
-    (x : node-Directed-Tree T) →
-    (p : is-root-Directed-Tree T x +
-         Σ (node-Directed-Tree T) (edge-Directed-Tree T x)) →
+    ( x : node-Directed-Tree T) →
+    ( p :
+      is-root-Directed-Tree T x +
+      Σ (node-Directed-Tree T) (edge-Directed-Tree T x)) →
     center-unique-direct-successor-Directed-Tree x ＝ p
   contraction-unique-direct-successor-Directed-Tree x =
     contraction-walk-unique-direct-successor-Directed-Tree x

--- a/src/trees/functoriality-w-types.lagda.md
+++ b/src/trees/functoriality-w-types.lagda.md
@@ -92,8 +92,9 @@ abstract
                           ( equiv-concat'
                             ( map-𝕎 D f e
                               ( α (map-inv-equiv (e a) d)))
-                            ( ap ( γ ∘ (tr D p))
-                                 ( inv (issec-map-inv-equiv (e a) d)))) ∘e
+                            ( ap
+                              ( γ ∘ (tr D p))
+                              ( inv (issec-map-inv-equiv (e a) d)))) ∘e
                           ( inv-equiv
                             ( equiv-Eq-𝕎-eq
                               ( map-𝕎 D f e

--- a/src/trees/induction-w-types.lagda.md
+++ b/src/trees/induction-w-types.lagda.md
@@ -164,11 +164,12 @@ no-infinite-descent-𝕎 {A = A} {B} f =
     ( λ x → (f : ℕ → 𝕎 A B) (p : f zero-ℕ ＝ x) →
             ¬ ((n : ℕ) → (f (succ-ℕ n)) <-𝕎 (f n)))
     ( λ x IH f p H →
-      IH ( f 1)
-         ( tr (λ t → (f 1) <-𝕎 t) p (H zero-ℕ))
-         ( f ∘ succ-ℕ)
-         ( refl)
-         ( λ n → H (succ-ℕ n)))
+      IH
+        ( f 1)
+        ( tr (λ t → (f 1) <-𝕎 t) p (H zero-ℕ))
+        ( f ∘ succ-ℕ)
+        ( refl)
+        ( λ n → H (succ-ℕ n)))
     ( f zero-ℕ)
     ( f)
     ( refl)

--- a/src/trees/morphisms-algebras-polynomial-endofunctors.lagda.md
+++ b/src/trees/morphisms-algebras-polynomial-endofunctors.lagda.md
@@ -109,15 +109,16 @@ module _
     htpy-hom-algebra-polynomial-endofunctor f
   pr1 refl-htpy-hom-algebra-polynomial-endofunctor = refl-htpy
   pr2 refl-htpy-hom-algebra-polynomial-endofunctor z =
-    ( ap ( λ t →
-           concat
-             ( structure-hom-algebra-polynomial-endofunctor X Y f z)
-             ( structure-algebra-polynomial-endofunctor Y
-               ( map-polynomial-endofunctor A B
-                 ( map-hom-algebra-polynomial-endofunctor X Y f) z))
-             ( ap (structure-algebra-polynomial-endofunctor Y) t))
-         ( coh-refl-htpy-polynomial-endofunctor A B
-           ( map-hom-algebra-polynomial-endofunctor X Y f) z)) ∙
+    ( ap
+      ( λ t →
+        concat
+          ( structure-hom-algebra-polynomial-endofunctor X Y f z)
+          ( structure-algebra-polynomial-endofunctor Y
+            ( map-polynomial-endofunctor A B
+              ( map-hom-algebra-polynomial-endofunctor X Y f) z))
+          ( ap (structure-algebra-polynomial-endofunctor Y) t))
+      ( coh-refl-htpy-polynomial-endofunctor A B
+        ( map-hom-algebra-polynomial-endofunctor X Y f) z)) ∙
     ( right-unit)
 
   htpy-eq-hom-algebra-polynomial-endofunctor :
@@ -149,12 +150,14 @@ module _
           ( λ H →
             ( equiv-concat-htpy
               ( λ x →
-                ap ( concat
-                     ( pr2 f x)
-                     ( structure-algebra-polynomial-endofunctor Y
-                       ( map-polynomial-endofunctor A B (pr1 f) x)))
-                   ( ap ( ap (pr2 Y))
-                        ( coh-refl-htpy-polynomial-endofunctor A B (pr1 f) x)))
+                ap
+                  ( concat
+                    ( pr2 f x)
+                    ( structure-algebra-polynomial-endofunctor Y
+                      ( map-polynomial-endofunctor A B (pr1 f) x)))
+                  ( ap
+                    ( ap (pr2 Y))
+                    ( coh-refl-htpy-polynomial-endofunctor A B (pr1 f) x)))
               ( H)) ∘e
             ( equiv-concat-htpy right-unit-htpy H)))
         ( is-contr-total-htpy (pr2 f)))

--- a/src/trees/morphisms-coalgebras-polynomial-endofunctors.lagda.md
+++ b/src/trees/morphisms-coalgebras-polynomial-endofunctors.lagda.md
@@ -56,9 +56,9 @@ hom-coalgebra-polynomial-endofunctor {A = A} {B} X Y =
       type-coalgebra-polynomial-endofunctor Y)
     ( λ f →
       ( coherence-square-maps f
-         ( structure-coalgebra-polynomial-endofunctor X)
-         ( structure-coalgebra-polynomial-endofunctor Y)
-         ( map-polynomial-endofunctor A B f)))
+          ( structure-coalgebra-polynomial-endofunctor X)
+          ( structure-coalgebra-polynomial-endofunctor Y)
+          ( map-polynomial-endofunctor A B f)))
 
 map-hom-coalgebra-polynomial-endofunctor :
   {l1 l2 l3 l4 : Level} {A : UU l1} {B : A → UU l2}

--- a/src/trees/ranks-of-elements-w-types.lagda.md
+++ b/src/trees/ranks-of-elements-w-types.lagda.md
@@ -203,9 +203,10 @@ module _
     intro-exists
       ( λ z → α u ≼-𝕎-Prop β z)
       ( v)
-      ( tr ( λ t → α u ≼-𝕎 t)
-           ( inv p)
-           ( ≼-∈-𝕎 {α u} {tree-𝕎 x α} (pair u refl)))
+      ( tr
+        ( λ t → α u ≼-𝕎 t)
+        ( inv p)
+        ( ≼-∈-𝕎 {α u} {tree-𝕎 x α} (pair u refl)))
 ```
 
 ### If `x ∈ y` then the rank of `x` is strictly lower than the rank of `y`

--- a/src/trees/universal-multiset.lagda.md
+++ b/src/trees/universal-multiset.lagda.md
@@ -54,9 +54,10 @@ is-small-universal-multiset-𝕍 l {l1} (pair (pair U e) H) =
         ( λ u → type-is-small (H (map-inv-equiv e u)))
         ( e)
         ( λ X →
-          tr ( λ t → X ≃ pr1 (H t))
-             ( inv (isretr-map-inv-equiv e X))
-             ( pr2 (H X)))))
+          tr
+            ( λ t → X ≃ pr1 (H t))
+            ( inv (isretr-map-inv-equiv e X))
+            ( pr2 (H X)))))
     ( f)
     where
     f :

--- a/src/trees/w-type-of-natural-numbers.lagda.md
+++ b/src/trees/w-type-of-natural-numbers.lagda.md
@@ -67,8 +67,9 @@ Nat-𝕎-ℕ (succ-ℕ x) = succ-Nat-𝕎 (Nat-𝕎-ℕ x)
 
 issec-ℕ-Nat-𝕎 : (Nat-𝕎-ℕ ∘ ℕ-Nat-𝕎) ~ id
 issec-ℕ-Nat-𝕎 (tree-𝕎 true α) =
-  ap ( tree-𝕎 true)
-     ( eq-htpy H)
+  ap
+    ( tree-𝕎 true)
+    ( eq-htpy H)
   where
   H : (z : unit) → Nat-𝕎-ℕ (ℕ-Nat-𝕎 (α star)) ＝ α z
   H star = issec-ℕ-Nat-𝕎 (α star)

--- a/src/trees/w-types.lagda.md
+++ b/src/trees/w-types.lagda.md
@@ -143,14 +143,15 @@ module _
     (w : 𝕎 A B) (t : Σ (𝕎 A B) (Eq-𝕎 w)) → center-total-Eq-𝕎 w ＝ t
   contraction-total-Eq-𝕎
     ( tree-𝕎 x α) (pair (tree-𝕎 .x β) (pair refl e)) =
-    ap ( ( aux-total-Eq-𝕎 x α) ∘
-         ( map-distributive-Π-Σ
-           { A = B x}
-           { B = λ y → 𝕎 A B}
-           { C = λ y → Eq-𝕎 (α y)}))
-       { x = λ y → pair (α y) (refl-Eq-𝕎 (α y))}
-       { y = λ y → pair (β y) (e y)}
-       ( eq-htpy (λ y → contraction-total-Eq-𝕎 (α y) (pair (β y) (e y))))
+    ap
+      ( ( aux-total-Eq-𝕎 x α) ∘
+        ( map-distributive-Π-Σ
+          { A = B x}
+          { B = λ y → 𝕎 A B}
+          { C = λ y → Eq-𝕎 (α y)}))
+      { x = λ y → pair (α y) (refl-Eq-𝕎 (α y))}
+      { y = λ y → pair (β y) (e y)}
+      ( eq-htpy (λ y → contraction-total-Eq-𝕎 (α y) (pair (β y) (e y))))
 
   is-contr-total-Eq-𝕎 : (w : 𝕎 A B) → is-contr (Σ (𝕎 A B) (Eq-𝕎 w))
   is-contr-total-Eq-𝕎 w =
@@ -272,8 +273,9 @@ htpy-htpy-hom-𝕎-Alg :
   map-hom-𝕎-Alg X ~
   map-hom-algebra-polynomial-endofunctor (𝕎-Alg A B) X f
 htpy-htpy-hom-𝕎-Alg {A = A} {B} X f (tree-𝕎 x α) =
-  ( ap ( λ t → structure-algebra-polynomial-endofunctor X (pair x t))
-       ( eq-htpy (λ z → htpy-htpy-hom-𝕎-Alg X f (α z)))) ∙
+  ( ap
+    ( λ t → structure-algebra-polynomial-endofunctor X (pair x t))
+    ( eq-htpy (λ z → htpy-htpy-hom-𝕎-Alg X f (α z)))) ∙
   ( inv
     ( structure-hom-algebra-polynomial-endofunctor (𝕎-Alg A B) X f
       ( pair x α)))
@@ -283,25 +285,31 @@ compute-structure-htpy-hom-𝕎-Alg :
   (X : algebra-polynomial-endofunctor l3 A B) (x : A) (α : B x → 𝕎 A B)
   {f : 𝕎 A B → type-algebra-polynomial-endofunctor X} →
   (H : map-hom-𝕎-Alg X ~ f) →
-  ( ap ( structure-algebra-polynomial-endofunctor X)
-       ( htpy-polynomial-endofunctor A B H (pair x α))) ＝
-  ( ap ( λ t → structure-algebra-polynomial-endofunctor X (pair x t))
-       ( eq-htpy (H ·r α)))
+  ( ap
+    ( structure-algebra-polynomial-endofunctor X)
+    ( htpy-polynomial-endofunctor A B H (pair x α))) ＝
+  ( ap
+    ( λ t → structure-algebra-polynomial-endofunctor X (pair x t))
+    ( eq-htpy (H ·r α)))
 compute-structure-htpy-hom-𝕎-Alg {A = A} {B} X x α =
   ind-htpy
     ( map-hom-𝕎-Alg X)
     ( λ f H →
-      ( ap ( structure-algebra-polynomial-endofunctor X)
-           ( htpy-polynomial-endofunctor A B H (pair x α))) ＝
-      ( ap ( λ t → structure-algebra-polynomial-endofunctor X (pair x t))
-           ( eq-htpy (H ·r α))))
-    ( ap ( ap (pr2 X))
-         ( coh-refl-htpy-polynomial-endofunctor A B
-           ( map-hom-𝕎-Alg X)
-           ( pair x α)) ∙
+      ( ap
+        ( structure-algebra-polynomial-endofunctor X)
+        ( htpy-polynomial-endofunctor A B H (pair x α))) ＝
+      ( ap
+        ( λ t → structure-algebra-polynomial-endofunctor X (pair x t))
+        ( eq-htpy (H ·r α))))
+    ( ap
+      ( ap (pr2 X))
+      ( coh-refl-htpy-polynomial-endofunctor A B
+        ( map-hom-𝕎-Alg X)
+        ( pair x α)) ∙
     ( inv
-      ( ap ( ap (λ t → pr2 X (pair x t)))
-           ( eq-htpy-refl-htpy (map-hom-𝕎-Alg X ∘ α)))))
+      ( ap
+        ( ap (λ t → pr2 X (pair x t)))
+        ( eq-htpy-refl-htpy (map-hom-𝕎-Alg X ∘ α)))))
 
 structure-htpy-hom-𝕎-Alg :
   {l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2}
@@ -316,16 +324,18 @@ structure-htpy-hom-𝕎-Alg {A = A} {B} X (pair f μ-f) (pair x α) =
   ( ( ( compute-structure-htpy-hom-𝕎-Alg X x α
         ( htpy-htpy-hom-𝕎-Alg X (pair f μ-f))) ∙
       ( inv right-unit)) ∙
-    ( ap ( concat
-           ( ap
-             ( λ t → pr2 X (pair x t))
-             ( eq-htpy (htpy-htpy-hom-𝕎-Alg X (pair f μ-f) ·r α)))
-         ( pr2 X (map-polynomial-endofunctor A B f (pair x α))))
-         ( inv (left-inv ( μ-f (pair x α)))))) ∙
+    ( ap
+      ( concat
+        ( ap
+          ( λ t → pr2 X (pair x t))
+          ( eq-htpy (htpy-htpy-hom-𝕎-Alg X (pair f μ-f) ·r α)))
+        ( pr2 X (map-polynomial-endofunctor A B f (pair x α))))
+      ( inv (left-inv ( μ-f (pair x α)))))) ∙
   ( inv
     ( assoc
-      ( ap ( λ t → pr2 X (pair x t))
-           ( eq-htpy (htpy-htpy-hom-𝕎-Alg X (pair f μ-f) ·r α)))
+      ( ap
+        ( λ t → pr2 X (pair x t))
+        ( eq-htpy (htpy-htpy-hom-𝕎-Alg X (pair f μ-f) ·r α)))
       ( inv (μ-f (pair x α)))
       ( μ-f (pair x α))))
 

--- a/src/type-theories/dependent-type-theories.lagda.md
+++ b/src/type-theories/dependent-type-theories.lagda.md
@@ -83,9 +83,10 @@ homotopies of sections of fibered systems.
   tr-fibered-system-slice :
     {l1 l2 l3 l4 : Level} {A : system l1 l2} {B B' : fibered-system l3 l4 A}
     (α : Id B B') (f : section-system B) (X : system.type A) →
-    Id ( fibered-system.slice B (section-system.type f X))
-       ( fibered-system.slice B'
-         ( section-system.type (tr section-system α f) X))
+    Id
+      ( fibered-system.slice B (section-system.type f X))
+      ( fibered-system.slice B'
+        ( section-system.type (tr section-system α f) X))
   tr-fibered-system-slice refl f X = refl
 
   Eq-fibered-system' :
@@ -93,13 +94,16 @@ homotopies of sections of fibered systems.
     (α : Id B B') (f : section-system B) (g : section-system B') →
     fibered-system l3 l4 A
   fibered-system.type (Eq-fibered-system' {A = A} α f g) X =
-    Id ( section-system.type (tr section-system α f) X)
-       ( section-system.type g X)
+    Id
+      ( section-system.type (tr section-system α f) X)
+      ( section-system.type g X)
   fibered-system.element (Eq-fibered-system' {A = A} {B} {B'} α f g) p x =
-    Id ( tr (λ t → fibered-system.element B' t x)
-            ( p)
-            ( section-system.element (tr section-system α f) x))
-       ( section-system.element g x)
+    Id
+      ( tr
+        ( λ t → fibered-system.element B' t x)
+        ( p)
+        ( section-system.element (tr section-system α f) x))
+      ( section-system.element g x)
   fibered-system.slice (Eq-fibered-system' {A = A} {B} {B'} α f g) {X} p =
     Eq-fibered-system'
       ( tr-fibered-system-slice α f X ∙ ap (fibered-system.slice B') p)
@@ -131,15 +135,18 @@ homotopies of sections of fibered systems.
       ( section-system.type G X)
       ( section-system.type H X)
       ( section-system.element f x)) ∙
-    ( ( ap ( tr ( λ t → fibered-system.element B t x)
-                ( section-system.type H X))
-           ( section-system.element G x)) ∙
+    ( ( ap
+        ( tr
+          ( λ t → fibered-system.element B t x)
+          ( section-system.type H X))
+        ( section-system.element G x)) ∙
       ( section-system.element H x))
   section-system.slice
     ( concat-htpy-section-system' {B = B} {α = refl} {refl} refl refl G H) X =
     concat-htpy-section-system'
-      ( ap ( fibered-system.slice B)
-           ( section-system.type G X ∙ section-system.type H X))
+      ( ap
+        ( fibered-system.slice B)
+        ( section-system.type G X ∙ section-system.type H X))
       ( inv
         ( ap-concat
           ( fibered-system.slice B)
@@ -358,11 +365,12 @@ We show that systems form a category.
           ( system.slice B)
           ( section-system.type H X)))
       ( ap (system.slice C ∘ section-system.type g) (section-system.type H X))
-      ( ( ap ( ap (constant-fibered-system (system.slice A X)))
-             ( ap-comp
-               ( system.slice C)
-               ( section-system.type g)
-               ( section-system.type H X))) ∙
+      ( ( ap
+          ( ap (constant-fibered-system (system.slice A X)))
+          ( ap-comp
+            ( system.slice C)
+            ( section-system.type g)
+            ( section-system.type H X))) ∙
         ( inv
           ( ap-comp
             ( constant-fibered-system (system.slice A X))
@@ -372,12 +380,14 @@ We show that systems form a category.
       ( section-system.slice H X)
       where
       γ : {Y Y' : system.type B} (p : Id Y Y') →
-          Id ( tr ( λ t → t)
-                  ( ap-binary hom-system
-                    ( ap (system.slice B) p)
-                    ( ap (system.slice C ∘ section-system.type g) p))
-                  ( section-system.slice g Y))
-             ( section-system.slice g Y')
+          Id
+            ( tr
+              ( λ t → t)
+              ( ap-binary hom-system
+                ( ap (system.slice B) p)
+                ( ap (system.slice C ∘ section-system.type g) p))
+              ( section-system.slice g Y))
+            ( section-system.slice g Y')
       γ refl = refl
 
   left-whisker-htpy-hom-system :
@@ -1035,12 +1045,13 @@ We introduce the slice of a dependent type theory.
       {A = A} {B} {C} {g} {f} {WA} {WB} {WC} {δA} {δB} {δC} {Wg} {Wf} δg δf) X =
     ( ap
       ( λ t →
-        tr ( system.element
-             ( system.slice C (section-system.type (comp-hom-system g f) X)))
-           ( t)
-           ( section-system.element
-             ( section-system.slice (comp-hom-system g f) X)
-             ( generic-element.type δA X)))
+        tr
+          ( system.element
+            ( system.slice C (section-system.type (comp-hom-system g f) X)))
+          ( t)
+          ( section-system.element
+            ( section-system.slice (comp-hom-system g f) X)
+            ( generic-element.type δA X)))
       ( ap (α ∙_) (right-unit))) ∙
     ( ( tr-concat
         { B =
@@ -1097,15 +1108,15 @@ We introduce the slice of a dependent type theory.
               ( section-system.type
                 ( section-system.slice g (section-system.type f X)))
               ( p))
-             ( section-system.element
-               ( section-system.slice g (section-system.type f X))
-               ( u)))
-           ( section-system.element
-             ( section-system.slice g (section-system.type f X))
-             ( tr
-               ( system.element (system.slice B (section-system.type f X)))
-               ( p)
-               ( u)))
+            ( section-system.element
+              ( section-system.slice g (section-system.type f X))
+              ( u)))
+          ( section-system.element
+            ( section-system.slice g (section-system.type f X))
+            ( tr
+              ( system.element (system.slice B (section-system.type f X)))
+              ( p)
+              ( u)))
     γ refl u = refl
   preserves-generic-element.slice
     ( preserves-generic-element-comp-hom-system {f = f} δg δf) X =

--- a/src/type-theories/fibered-dependent-type-theories.lagda.md
+++ b/src/type-theories/fibered-dependent-type-theories.lagda.md
@@ -136,18 +136,20 @@ module fibered where
     bifibered-system l7 l8 B (Eq-fibered-system' α f f')
   bifibered-system.type
     ( Eq-bifibered-system' D .D refl refl f f' g g') {X} Y p =
-    Id ( tr (bifibered-system.type D Y) p (section-fibered-system.type g Y))
-       ( section-fibered-system.type g' Y)
+    Id
+      ( tr (bifibered-system.type D Y) p (section-fibered-system.type g Y))
+      ( section-fibered-system.type g' Y)
   bifibered-system.element
     ( Eq-bifibered-system' {A = A} {C = C} D .D refl refl f f' g g')
     {X} {Y} {p} {x} α y q =
-      Id ( double-tr
-           ( λ Z u → bifibered-system.element D {Z = Z} u y)
-           ( p)
-           ( α)
-           ( q)
-           ( section-fibered-system.element g y))
-         ( section-fibered-system.element g' y)
+      Id
+        ( double-tr
+          ( λ Z u → bifibered-system.element D {Z = Z} u y)
+          ( p)
+          ( α)
+          ( q)
+          ( section-fibered-system.element g y))
+        ( section-fibered-system.element g' y)
   bifibered-system.slice
     ( Eq-bifibered-system' {C = C} D .D refl refl f f' g g') {X} {Y} {α} β =
     Eq-bifibered-system'

--- a/src/univalent-combinatorics/2-element-decidable-subtypes.lagda.md
+++ b/src/univalent-combinatorics/2-element-decidable-subtypes.lagda.md
@@ -348,14 +348,14 @@ pr2 (precomp-equiv-2-Element-Decidable-Subtype e (pair P H)) =
         ( inv-equiv e)
         ( subtype-decidable-subtype P)
         ( subtype-decidable-subtype (P ∘ (map-equiv e)))
-         λ x →
+        ( λ x →
           iff-equiv
             ( tr
               ( λ g →
                 ( type-Decidable-Prop (P x)) ≃
                 ( type-Decidable-Prop (P (map-equiv g x))))
               ( inv (right-inverse-law-equiv e))
-              ( id-equiv))))
+              ( id-equiv)))))
 
 preserves-comp-precomp-equiv-2-Element-Decidable-Subtype :
   { l1 l2 l3 l4 : Level} {X : UU l1} {Y : UU l2} {Z : UU l3} (e : X ≃ Y) →

--- a/src/univalent-combinatorics/2-element-types.lagda.md
+++ b/src/univalent-combinatorics/2-element-types.lagda.md
@@ -840,17 +840,9 @@ module _
 
 This remains to be shown.
 
-```agda
-
-```
-
 ### A map between 2-element types is not an equivalence if and only if its image is a singleton subtype of the codomain
 
 This remains to be shown.
-
-```agda
-
-```
 
 ### Any map between 2-element types that is not an equivalence is constant
 

--- a/src/univalent-combinatorics/classical-finite-types.lagda.md
+++ b/src/univalent-combinatorics/classical-finite-types.lagda.md
@@ -52,9 +52,10 @@ Eq-classical-Fin k x y = Id (nat-classical-Fin k x) (nat-classical-Fin k y)
 
 eq-succ-classical-Fin :
   (k : ℕ) (x y : classical-Fin k) → Id {A = classical-Fin k} x y →
-  Id {A = classical-Fin (succ-ℕ k)}
-     ( pair (succ-ℕ (pr1 x)) (pr2 x))
-     ( pair (succ-ℕ (pr1 y)) (pr2 y))
+  Id
+    { A = classical-Fin (succ-ℕ k)}
+    ( pair (succ-ℕ (pr1 x)) (pr2 x))
+    ( pair (succ-ℕ (pr1 y)) (pr2 y))
 eq-succ-classical-Fin k x .x refl = refl
 
 eq-Eq-classical-Fin :

--- a/src/univalent-combinatorics/complements-isolated-points.lagda.md
+++ b/src/univalent-combinatorics/complements-isolated-points.lagda.md
@@ -59,9 +59,9 @@ equiv-maybe-structure-point-UU-Fin :
   Maybe (type-complement-point-UU-Fin k (pair X x)) ≃
   type-UU-Fin (succ-ℕ k) X
 equiv-maybe-structure-point-UU-Fin k X x =
-   equiv-maybe-structure-isolated-point
-     ( type-UU-Fin (succ-ℕ k) X)
-     ( isolated-point-UU-Fin k X x)
+  equiv-maybe-structure-isolated-point
+    ( type-UU-Fin (succ-ℕ k) X)
+    ( isolated-point-UU-Fin k X x)
 
 has-cardinality-type-complement-point-UU-Fin :
   {l1 : Level} (k : ℕ)
@@ -121,3 +121,5 @@ equiv-complement-point-UU-Fin
 ## Properties
 
 ### The map from a pointed `k+1`-element type to the complement of the point is an equivalence
+
+This remains to be shown.

--- a/src/univalent-combinatorics/coproduct-types.lagda.md
+++ b/src/univalent-combinatorics/coproduct-types.lagda.md
@@ -150,8 +150,9 @@ abstract
   double-counting-coprod :
     { l1 l2 : Level} {A : UU l1} {B : UU l2}
     ( count-A : count A) (count-B : count B) (count-C : count (A + B)) →
-    Id ( number-of-elements-count count-C)
-       ( number-of-elements-count count-A +ℕ number-of-elements-count count-B)
+    Id
+      ( number-of-elements-count count-C)
+      ( number-of-elements-count count-A +ℕ number-of-elements-count count-B)
   double-counting-coprod count-A count-B count-C =
     ( double-counting count-C (count-coprod count-A count-B)) ∙
     ( number-of-elements-count-coprod count-A count-B)
@@ -159,9 +160,10 @@ abstract
 abstract
   sum-number-of-elements-coprod :
     {l1 l2 : Level} {A : UU l1} {B : UU l2} (e : count (A + B)) →
-    Id ( ( number-of-elements-count (count-left-summand e)) +ℕ
-               ( number-of-elements-count (count-right-summand e)))
-       ( number-of-elements-count e)
+    Id
+      ( ( number-of-elements-count (count-left-summand e)) +ℕ
+        ( number-of-elements-count (count-right-summand e)))
+      ( number-of-elements-count e)
   sum-number-of-elements-coprod e =
     ( inv
       ( number-of-elements-count-coprod

--- a/src/univalent-combinatorics/counting-dependent-pair-types.lagda.md
+++ b/src/univalent-combinatorics/counting-dependent-pair-types.lagda.md
@@ -223,8 +223,9 @@ abstract
   double-counting-Σ :
     {l1 l2 : Level} {A : UU l1} {B : A → UU l2} (count-A : count A)
     (count-B : (x : A) → count (B x)) (count-C : count (Σ A B)) →
-    Id ( number-of-elements-count count-C)
-       ( sum-count-ℕ count-A (λ x → number-of-elements-count (count-B x)))
+    Id
+      ( number-of-elements-count count-C)
+      ( sum-count-ℕ count-A (λ x → number-of-elements-count (count-B x)))
   double-counting-Σ count-A count-B count-C =
     ( double-counting count-C (count-Σ count-A count-B)) ∙
     ( number-of-elements-count-Σ count-A count-B)
@@ -233,10 +234,11 @@ abstract
   sum-number-of-elements-count-fiber-count-Σ :
     {l1 l2 : Level} {A : UU l1} {B : A → UU l2} (e : count A)
     (f : count (Σ A B)) →
-    Id ( sum-count-ℕ e
-         ( λ x → number-of-elements-count
-           (count-fiber-count-Σ-count-base e f x)))
-       ( number-of-elements-count f)
+    Id
+      ( sum-count-ℕ e
+        ( λ x → number-of-elements-count
+          (count-fiber-count-Σ-count-base e f x)))
+      ( number-of-elements-count f)
   sum-number-of-elements-count-fiber-count-Σ e f =
     ( inv
       ( number-of-elements-count-Σ e (count-fiber-count-Σ-count-base e f))) ∙
@@ -246,9 +248,10 @@ abstract
   double-counting-fiber-count-Σ :
     {l1 l2 : Level} {A : UU l1} {B : A → UU l2} (count-A : count A)
     (count-B : (x : A) → count (B x)) (count-C : count (Σ A B)) (x : A) →
-    Id ( number-of-elements-count (count-B x))
-       ( number-of-elements-count
-         ( count-fiber-count-Σ-count-base count-A count-C x))
+    Id
+      ( number-of-elements-count (count-B x))
+      ( number-of-elements-count
+        ( count-fiber-count-Σ-count-base count-A count-C x))
   double-counting-fiber-count-Σ count-A count-B count-C x =
     double-counting
       ( count-B x)
@@ -258,10 +261,11 @@ abstract
   sum-number-of-elements-count-base-count-Σ :
     {l1 l2 : Level} {A : UU l1} {B : A → UU l2} (b : (x : A) → B x) →
     (count-ΣAB : count (Σ A B)) (count-B : (x : A) → count (B x)) →
-    Id ( sum-count-ℕ
-         ( count-base-count-Σ b count-ΣAB count-B)
-         ( λ x → number-of-elements-count (count-B x)))
-       ( number-of-elements-count count-ΣAB)
+    Id
+      ( sum-count-ℕ
+        ( count-base-count-Σ b count-ΣAB count-B)
+        ( λ x → number-of-elements-count (count-B x)))
+      ( number-of-elements-count count-ΣAB)
   sum-number-of-elements-count-base-count-Σ b count-ΣAB count-B =
     ( inv
       ( number-of-elements-count-Σ
@@ -276,8 +280,9 @@ abstract
     {l1 l2 : Level} {A : UU l1} {B : A → UU l2} (b : (x : A) → B x) →
     (count-A : count A) (count-B : (x : A) → count (B x))
     (count-ΣAB : count (Σ A B)) →
-    Id ( number-of-elements-count (count-base-count-Σ b count-ΣAB count-B))
-       ( number-of-elements-count count-A)
+    Id
+      ( number-of-elements-count (count-base-count-Σ b count-ΣAB count-B))
+      ( number-of-elements-count count-A)
   double-counting-base-count-Σ b count-A count-B count-ΣAB =
     double-counting (count-base-count-Σ b count-ΣAB count-B) count-A
 
@@ -287,10 +292,11 @@ abstract
     ( count-B : (x : A) → count (B x)) →
     ( count-nB :
       count (Σ A (λ x → is-zero-ℕ (number-of-elements-count (count-B x))))) →
-    Id ( sum-count-ℕ
-         ( count-base-count-Σ' count-ΣAB count-B count-nB)
-         ( λ x → number-of-elements-count (count-B x)))
-       ( number-of-elements-count count-ΣAB)
+    Id
+      ( sum-count-ℕ
+        ( count-base-count-Σ' count-ΣAB count-B count-nB)
+        ( λ x → number-of-elements-count (count-B x)))
+      ( number-of-elements-count count-ΣAB)
   sum-number-of-elements-count-base-count-Σ' count-ΣAB count-B count-nB =
     ( inv
       ( number-of-elements-count-Σ
@@ -308,9 +314,10 @@ abstract
     ( count-B : (x : A) → count (B x)) (count-ΣAB : count (Σ A B)) →
     ( count-nB :
       count (Σ A (λ x → is-zero-ℕ (number-of-elements-count (count-B x))))) →
-    Id ( number-of-elements-count
-         ( count-base-count-Σ' count-ΣAB count-B count-nB))
-       ( number-of-elements-count count-A)
+    Id
+      ( number-of-elements-count
+        ( count-base-count-Σ' count-ΣAB count-B count-nB))
+      ( number-of-elements-count count-A)
   double-counting-base-count-Σ' count-A count-B count-ΣAB count-nB =
     double-counting (count-base-count-Σ' count-ΣAB count-B count-nB) count-A
 ```

--- a/src/univalent-combinatorics/cubes.lagda.md
+++ b/src/univalent-combinatorics/cubes.lagda.md
@@ -105,10 +105,10 @@ mere-equiv-standard-cube {k} (pair (pair X H) Y) =
 face-cube :
   (k : ℕ) (X : cube (succ-ℕ k)) (d : dim-cube (succ-ℕ k) X)
   (a : axis-cube (succ-ℕ k) X d) → cube k
-face-cube k X d a =
-  pair ( complement-point-UU-Fin k (pair (dim-cube-UU-Fin (succ-ℕ k) X) d))
-       ( λ d' →
-         axis-cube-UU-2 (succ-ℕ k) X
-           ( inclusion-complement-point-UU-Fin k
-             ( pair (dim-cube-UU-Fin (succ-ℕ k) X) d) d'))
+pr1 (face-cube k X d a) =
+  complement-point-UU-Fin k (pair (dim-cube-UU-Fin (succ-ℕ k) X) d)
+pr2 (face-cube k X d a) d' =
+  axis-cube-UU-2 (succ-ℕ k) X
+    ( inclusion-complement-point-UU-Fin k
+      ( pair (dim-cube-UU-Fin (succ-ℕ k) X) d) d')
 ```

--- a/src/univalent-combinatorics/cycle-prime-decomposition-natural-numbers.lagda.md
+++ b/src/univalent-combinatorics/cycle-prime-decomposition-natural-numbers.lagda.md
@@ -128,25 +128,25 @@ equiv-product-cycle-prime-decomposition-ℕ n m H I =
               ( list-fundamental-theorem-arithmetic-ℕ n H)
               ( list-fundamental-theorem-arithmetic-ℕ m I))))) ∘e
       ( ( inv-equiv
-           ( equiv-permutation-iterated-product-lists
-             ( map-list
-               ( Cyclic-Type lzero)
-               ( concat-list
-                 ( list-fundamental-theorem-arithmetic-ℕ n H)
-                 ( list-fundamental-theorem-arithmetic-ℕ m I)))
-             ( tr
-               ( Permutation)
-               ( inv
-                 ( length-map-list
-                   ( Cyclic-Type lzero)
-                   ( concat-list
-                     ( list-fundamental-theorem-arithmetic-ℕ n H)
-                     ( list-fundamental-theorem-arithmetic-ℕ m I))))
-               ( permutation-insertion-sort-list
-                 ( ℕ-Decidable-Total-Order)
-                 ( concat-list
-                   ( list-fundamental-theorem-arithmetic-ℕ n H)
-                   ( list-fundamental-theorem-arithmetic-ℕ m I)))))) ∘e
+          ( equiv-permutation-iterated-product-lists
+            ( map-list
+              ( Cyclic-Type lzero)
+              ( concat-list
+                ( list-fundamental-theorem-arithmetic-ℕ n H)
+                ( list-fundamental-theorem-arithmetic-ℕ m I)))
+            ( tr
+              ( Permutation)
+              ( inv
+                ( length-map-list
+                  ( Cyclic-Type lzero)
+                  ( concat-list
+                    ( list-fundamental-theorem-arithmetic-ℕ n H)
+                    ( list-fundamental-theorem-arithmetic-ℕ m I))))
+              ( permutation-insertion-sort-list
+                ( ℕ-Decidable-Total-Order)
+                ( concat-list
+                  ( list-fundamental-theorem-arithmetic-ℕ n H)
+                  ( list-fundamental-theorem-arithmetic-ℕ m I)))))) ∘e
         ( ( equiv-eq
             ( ap
               ( iterated-product-lists)

--- a/src/univalent-combinatorics/cyclic-types.lagda.md
+++ b/src/univalent-combinatorics/cyclic-types.lagda.md
@@ -147,7 +147,7 @@ module _
     map-equiv-Endo (endo-Cyclic-Type k X) (endo-Cyclic-Type k Y) e
 
   coherence-square-equiv-Cyclic-Type :
-    (e : equiv-Cyclic-Type) →
+    ( e : equiv-Cyclic-Type) →
     coherence-square-maps
       ( map-equiv-Cyclic-Type e)
       ( endomorphism-Cyclic-Type k X)
@@ -317,8 +317,9 @@ module _
       ( refl-htpy)
 
   left-inverse-law-comp-equiv-Cyclic-Type :
-    Id ( comp-equiv-Cyclic-Type k X Y X (inv-equiv-Cyclic-Type k X Y e) e)
-       ( id-equiv-Cyclic-Type k X)
+    Id
+      ( comp-equiv-Cyclic-Type k X Y X (inv-equiv-Cyclic-Type k X Y e) e)
+      ( id-equiv-Cyclic-Type k X)
   left-inverse-law-comp-equiv-Cyclic-Type =
     eq-htpy-equiv-Cyclic-Type k X X
       ( comp-equiv-Cyclic-Type k X Y X (inv-equiv-Cyclic-Type k X Y e) e)
@@ -326,8 +327,9 @@ module _
       ( isretr-map-inv-equiv (equiv-equiv-Cyclic-Type k X Y e))
 
   right-inverse-law-comp-equiv-Cyclic-Type :
-    Id ( comp-equiv-Cyclic-Type k Y X Y e (inv-equiv-Cyclic-Type k X Y e))
-       ( id-equiv-Cyclic-Type k Y)
+    Id
+      ( comp-equiv-Cyclic-Type k Y X Y e (inv-equiv-Cyclic-Type k X Y e))
+      ( id-equiv-Cyclic-Type k Y)
   right-inverse-law-comp-equiv-Cyclic-Type =
     eq-htpy-equiv-Cyclic-Type k Y Y
       ( comp-equiv-Cyclic-Type k Y X Y e (inv-equiv-Cyclic-Type k X Y e))
@@ -491,10 +493,11 @@ map-equiv-compute-Ω-Cyclic-Type k = map-equiv (equiv-compute-Ω-Cyclic-Type k)
 
 preserves-concat-equiv-eq-Cyclic-Type :
   (k : ℕ) (X Y Z : Cyclic-Type lzero k) (p : Id X Y) (q : Id Y Z) →
-  Id ( equiv-eq-Cyclic-Type k X Z (p ∙ q))
-     ( comp-equiv-Cyclic-Type k X Y Z
-       ( equiv-eq-Cyclic-Type k Y Z q)
-       ( equiv-eq-Cyclic-Type k X Y p))
+  Id
+    ( equiv-eq-Cyclic-Type k X Z (p ∙ q))
+    ( comp-equiv-Cyclic-Type k X Y Z
+      ( equiv-eq-Cyclic-Type k Y Z q)
+      ( equiv-eq-Cyclic-Type k X Y p))
 preserves-concat-equiv-eq-Cyclic-Type k X .X Z refl q =
   inv
     ( right-unit-law-comp-equiv-Cyclic-Type
@@ -503,17 +506,18 @@ preserves-concat-equiv-eq-Cyclic-Type k X .X Z refl q =
 preserves-comp-Eq-equiv-Cyclic-Type :
   (k : ℕ)
   (e f : equiv-Cyclic-Type k (ℤ-Mod-Cyclic-Type k) (ℤ-Mod-Cyclic-Type k)) →
-  Id ( Eq-equiv-Cyclic-Type k
-       ( ℤ-Mod-Cyclic-Type k)
-       ( comp-equiv-Cyclic-Type k
-         ( ℤ-Mod-Cyclic-Type k)
-         ( ℤ-Mod-Cyclic-Type k)
-         ( ℤ-Mod-Cyclic-Type k)
-         ( f)
-         ( e)))
-     ( add-ℤ-Mod k
-       ( Eq-equiv-Cyclic-Type k (ℤ-Mod-Cyclic-Type k) e)
-       ( Eq-equiv-Cyclic-Type k (ℤ-Mod-Cyclic-Type k) f))
+  Id
+    ( Eq-equiv-Cyclic-Type k
+      ( ℤ-Mod-Cyclic-Type k)
+      ( comp-equiv-Cyclic-Type k
+        ( ℤ-Mod-Cyclic-Type k)
+        ( ℤ-Mod-Cyclic-Type k)
+        ( ℤ-Mod-Cyclic-Type k)
+        ( f)
+        ( e)))
+    ( add-ℤ-Mod k
+      ( Eq-equiv-Cyclic-Type k (ℤ-Mod-Cyclic-Type k) e)
+      ( Eq-equiv-Cyclic-Type k (ℤ-Mod-Cyclic-Type k) f))
 preserves-comp-Eq-equiv-Cyclic-Type k e f =
   inv
   ( compute-map-preserves-succ-map-ℤ-Mod k
@@ -530,10 +534,11 @@ preserves-comp-Eq-equiv-Cyclic-Type k e f =
 
 preserves-concat-equiv-compute-Ω-Cyclic-Type :
   (k : ℕ) (p q : type-Ω (Cyclic-Type-Pointed-Type k)) →
-  Id ( map-equiv (equiv-compute-Ω-Cyclic-Type k) (p ∙ q))
-     ( add-ℤ-Mod k
-       ( map-equiv (equiv-compute-Ω-Cyclic-Type k) p)
-       ( map-equiv (equiv-compute-Ω-Cyclic-Type k) q))
+  Id
+    ( map-equiv (equiv-compute-Ω-Cyclic-Type k) (p ∙ q))
+    ( add-ℤ-Mod k
+      ( map-equiv (equiv-compute-Ω-Cyclic-Type k) p)
+      ( map-equiv (equiv-compute-Ω-Cyclic-Type k) q))
 preserves-concat-equiv-compute-Ω-Cyclic-Type k p q =
   ( ap
     ( Eq-equiv-Cyclic-Type k (ℤ-Mod-Cyclic-Type k))

--- a/src/univalent-combinatorics/decidable-equivalence-relations.lagda.md
+++ b/src/univalent-combinatorics/decidable-equivalence-relations.lagda.md
@@ -115,10 +115,10 @@ module _
   is-finite-relation-Decidable-Relation-𝔽 :
     (x : type-𝔽 A) → (y : type-𝔽 A) → is-finite (rel-Decidable-Relation R x y)
   is-finite-relation-Decidable-Relation-𝔽 x y =
-     unit-trunc-Prop
-       ( count-Decidable-Prop
-         ( relation-Decidable-Relation R x y)
-         ( is-decidable-Decidable-Relation R x y))
+    unit-trunc-Prop
+      ( count-Decidable-Prop
+        ( relation-Decidable-Relation R x y)
+        ( is-decidable-Decidable-Relation R x y))
 
   is-finite-is-reflexive-Dec-Rel-Prop-𝔽 :
     is-finite (is-reflexive-Rel-Prop (relation-Decidable-Relation R))
@@ -133,12 +133,12 @@ module _
     is-finite-Π'
       ( is-finite-type-𝔽 A)
       ( λ x →
-         is-finite-Π'
-           ( is-finite-type-𝔽 A)
-           ( λ y →
-             is-finite-function-type
-               ( is-finite-relation-Decidable-Relation-𝔽 x y)
-               ( is-finite-relation-Decidable-Relation-𝔽 y x)))
+        is-finite-Π'
+          ( is-finite-type-𝔽 A)
+          ( λ y →
+            is-finite-function-type
+              ( is-finite-relation-Decidable-Relation-𝔽 x y)
+              ( is-finite-relation-Decidable-Relation-𝔽 y x)))
 
   is-finite-is-transitive-Dec-Rel-Prop-𝔽 :
     is-finite (is-transitive-Rel-Prop (relation-Decidable-Relation R))
@@ -155,8 +155,8 @@ module _
                 is-finite-function-type
                   ( is-finite-relation-Decidable-Relation-𝔽 x y)
                   ( is-finite-function-type
-                     ( is-finite-relation-Decidable-Relation-𝔽 y z)
-                     ( is-finite-relation-Decidable-Relation-𝔽 x z)))))
+                    ( is-finite-relation-Decidable-Relation-𝔽 y z)
+                    ( is-finite-relation-Decidable-Relation-𝔽 x z)))))
 
   is-finite-is-equivalence-Dec-Rel-Prop-𝔽 :
     is-finite (is-equivalence-relation (relation-Decidable-Relation R))
@@ -212,17 +212,17 @@ equiv-Surjection-𝔽-Decidable-Equivalence-Relation-𝔽 {l1} A =
                     ( ( equiv-add-redundant-prop
                         ( is-prop-type-trunc-Prop)
                         ( λ x →
-                           apply-universal-property-trunc-Prop
-                             ( is-finite-type-𝔽 A)
-                             ( trunc-Prop ( Σ ℕ (λ n → Fin n ↠ X)))
-                             ( λ count-A →
-                               unit-trunc-Prop
-                                 ( number-of-elements-count count-A ,
-                                   ( ( map-surjection (pr1 x) ∘
-                                       map-equiv-count count-A) ,
-                                     is-surjective-precomp-equiv
-                                       ( is-surjective-map-surjection (pr1 x))
-                                       ( equiv-count count-A)))))))))))) ∘e
+                          apply-universal-property-trunc-Prop
+                            ( is-finite-type-𝔽 A)
+                            ( trunc-Prop ( Σ ℕ (λ n → Fin n ↠ X)))
+                            ( λ count-A →
+                              unit-trunc-Prop
+                                ( number-of-elements-count count-A ,
+                                  ( ( map-surjection (pr1 x) ∘
+                                      map-equiv-count count-A) ,
+                                    is-surjective-precomp-equiv
+                                      ( is-surjective-map-surjection (pr1 x))
+                                      ( equiv-count count-A)))))))))))) ∘e
         ( equiv-Surjection-Into-Set-Decidable-Equivalence-Relation
           ( type-𝔽 A))))))
 ```
@@ -247,7 +247,9 @@ is-finite-Decidable-Equivalence-Relation-𝔽 :
 is-finite-Decidable-Equivalence-Relation-𝔽 A =
   is-finite-Σ
     ( is-finite-Decidable-Relation-𝔽 A)
-    ( λ R → is-finite-is-equivalence-Dec-Rel-Prop-𝔽 A R)
+    ( is-finite-is-equivalence-Dec-Rel-Prop-𝔽 A)
 ```
 
 ### The number of decidable equivalence relations on a finite type is a Stirling number of the second kind
+
+This remains to be characterized.

--- a/src/univalent-combinatorics/decidable-propositions.lagda.md
+++ b/src/univalent-combinatorics/decidable-propositions.lagda.md
@@ -80,8 +80,9 @@ number-of-elements-count-eq' d x y =
 cases-number-of-elements-count-eq :
   {l : Level} {X : UU l} (d : has-decidable-equality X) {x y : X}
   (e : is-decidable (Id x y)) →
-  Id ( number-of-elements-count (cases-count-eq d e))
-     ( cases-number-of-elements-count-eq' e)
+  Id
+    ( number-of-elements-count (cases-count-eq d e))
+    ( cases-number-of-elements-count-eq' e)
 cases-number-of-elements-count-eq d (inl p) = refl
 cases-number-of-elements-count-eq d (inr f) = refl
 

--- a/src/univalent-combinatorics/distributivity-of-set-truncation-over-finite-products.lagda.md
+++ b/src/univalent-combinatorics/distributivity-of-set-truncation-over-finite-products.lagda.md
@@ -189,27 +189,29 @@ module _
             ( λ f →
               equiv-Π
                 ( λ h →
-                  Id ( map-equiv f
-                       ( map-equiv
-                         ( equiv-trunc-Set (equiv-precomp-Π e B))
-                         ( unit-trunc-Set h)))
-                     ( map-Π (λ x → unit-trunc-Set) (λ x → h (map-equiv e x))))
+                  Id
+                    ( map-equiv f
+                      ( map-equiv
+                        ( equiv-trunc-Set (equiv-precomp-Π e B))
+                        ( unit-trunc-Set h)))
+                    ( map-Π (λ x → unit-trunc-Set) (λ x → h (map-equiv e x))))
                 ( equiv-Π B e (λ x → id-equiv))
                 ( λ h →
                   ( ( inv-equiv equiv-funext) ∘e
                     ( equiv-Π
                       ( λ x →
-                        Id ( map-equiv f
-                             ( map-equiv-trunc-Set
-                               ( equiv-precomp-Π e B)
-                               ( unit-trunc-Set
-                                 ( map-equiv-Π B e (λ x → id-equiv) h)))
-                             ( x))
-                           ( unit-trunc-Set
-                             ( map-equiv-Π B e
-                               ( λ z → id-equiv)
-                               ( h)
-                               ( map-equiv e x))))
+                        Id
+                          ( map-equiv f
+                            ( map-equiv-trunc-Set
+                              ( equiv-precomp-Π e B)
+                              ( unit-trunc-Set
+                                ( map-equiv-Π B e (λ x → id-equiv) h)))
+                            ( x))
+                          ( unit-trunc-Set
+                            ( map-equiv-Π B e
+                              ( λ z → id-equiv)
+                              ( h)
+                              ( map-equiv e x))))
                       ( id-equiv)
                       ( λ x →
                         ( equiv-concat

--- a/src/univalent-combinatorics/ferrers-diagrams.lagda.md
+++ b/src/univalent-combinatorics/ferrers-diagrams.lagda.md
@@ -165,9 +165,9 @@ module _
       ( is-contr-total-Eq-subtype
         ( is-contr-total-equiv-fam (dot-ferrers-diagram D))
         ( λ Y →
-           is-prop-prod
-             ( is-prop-Π (λ x → is-prop-type-trunc-Prop))
-             ( is-prop-mere-equiv A (Σ (row-ferrers-diagram D) Y)))
+          is-prop-prod
+            ( is-prop-Π (λ x → is-prop-type-trunc-Prop))
+            ( is-prop-mere-equiv A (Σ (row-ferrers-diagram D) Y)))
         ( dot-ferrers-diagram D)
         ( λ x → id-equiv)
         ( pair

--- a/src/univalent-combinatorics/fibers-of-maps.lagda.md
+++ b/src/univalent-combinatorics/fibers-of-maps.lagda.md
@@ -57,9 +57,10 @@ abstract
   sum-number-of-elements-count-fib :
     {l1 l2 : Level} {A : UU l1} {B : UU l2} (f : A → B) →
     (count-A : count A) (count-B : count B) →
-    Id ( sum-count-ℕ count-B
-         ( λ x → number-of-elements-count (count-fib f count-A count-B x)))
-       ( number-of-elements-count count-A)
+    Id
+      ( sum-count-ℕ count-B
+        ( λ x → number-of-elements-count (count-fib f count-A count-B x)))
+      ( number-of-elements-count count-A)
   sum-number-of-elements-count-fib f count-A count-B =
     sum-number-of-elements-count-fiber-count-Σ count-B
       ( count-equiv' (equiv-total-fib f) count-A)
@@ -68,8 +69,9 @@ abstract
   double-counting-fib :
     {l1 l2 : Level} {A : UU l1} {B : UU l2} (f : A → B) (count-A : count A) →
     (count-B : count B) (count-fib-f : (y : B) → count (fib f y)) (y : B) →
-    Id ( number-of-elements-count (count-fib-f y))
-       ( number-of-elements-count (count-fib f count-A count-B y))
+    Id
+      ( number-of-elements-count (count-fib-f y))
+      ( number-of-elements-count (count-fib f count-A count-B y))
   double-counting-fib f count-A count-B count-fib-f y =
     double-counting (count-fib-f y) (count-fib f count-A count-B y)
 ```

--- a/src/univalent-combinatorics/finite-types.lagda.md
+++ b/src/univalent-combinatorics/finite-types.lagda.md
@@ -529,7 +529,7 @@ is-inhabited-type-UU-Fin-succ-ℕ :
   {l1 : Level} (n : ℕ) (A : UU-Fin l1 (succ-ℕ n)) →
   is-inhabited (type-UU-Fin (succ-ℕ n) A)
 is-inhabited-type-UU-Fin-succ-ℕ n A =
-   apply-universal-property-trunc-Prop
+  apply-universal-property-trunc-Prop
     ( pr2 A)
     ( is-inhabited-Prop (type-UU-Fin (succ-ℕ n) A))
     ( λ e → unit-trunc-Prop (map-equiv e (zero-Fin n)))

--- a/src/univalent-combinatorics/finite-types.lagda.md
+++ b/src/univalent-combinatorics/finite-types.lagda.md
@@ -694,7 +694,8 @@ abstract
       ( is-prop-type-trunc-Prop)
       ( is-set-ℕ (number-of-elements-is-finite H) n)
       ( λ p →
-        tr ( λ m → has-cardinality m X)
-           ( p)
-           ( pr2 (has-finite-cardinality-is-finite H)))
+        tr
+          ( λ m → has-cardinality m X)
+          ( p)
+          ( pr2 (has-finite-cardinality-is-finite H)))
 ```

--- a/src/univalent-combinatorics/inhabited-finite-types.lagda.md
+++ b/src/univalent-combinatorics/inhabited-finite-types.lagda.md
@@ -125,11 +125,11 @@ compute-Fam-Inhabited-𝔽 :
     Σ ( Fam-Inhabited-Types l2 (type-𝔽 X))
       ( λ Y → ((x : (type-𝔽 X)) → is-finite (type-Inhabited-Type (Y x))))
 compute-Fam-Inhabited-𝔽 X =
-   ( distributive-Π-Σ ∘e
-    ( equiv-Π
-      ( λ _ → Σ (Inhabited-Type _) ( is-finite ∘ type-Inhabited-Type))
-      ( id-equiv)
-      ( λ _ → compute-Inhabited-𝔽)))
+  ( distributive-Π-Σ) ∘e
+  ( equiv-Π
+    ( λ _ → Σ (Inhabited-Type _) (is-finite ∘ type-Inhabited-Type))
+    ( id-equiv)
+    ( λ _ → compute-Inhabited-𝔽))
 ```
 
 ## Proposition

--- a/src/univalent-combinatorics/isotopies-latin-squares.lagda.md
+++ b/src/univalent-combinatorics/isotopies-latin-squares.lagda.md
@@ -39,8 +39,9 @@ module _
             Σ ( symbol-Latin-Square L ≃ symbol-Latin-Square K)
               ( λ e-symbol →
                 ( x : row-Latin-Square L) (y : column-Latin-Square L) →
-                 Id ( map-equiv e-symbol (mul-Latin-Square L x y))
-                    ( mul-Latin-Square K
-                      ( map-equiv e-row x)
-                      ( map-equiv e-column y)))))
+                Id
+                  ( map-equiv e-symbol (mul-Latin-Square L x y))
+                  ( mul-Latin-Square K
+                    ( map-equiv e-row x)
+                    ( map-equiv e-column y)))))
 ```

--- a/src/univalent-combinatorics/orientations-complete-undirected-graph.lagda.md
+++ b/src/univalent-combinatorics/orientations-complete-undirected-graph.lagda.md
@@ -364,23 +364,23 @@ module _
                       ( 2-Element-Decidable-Subtype-subtype-pointwise-difference
                           d2 d3))
                     ( is-finite-2-Element-Decidable-Subtype n X)))
-               ( pair
-                 ( number-of-elements-is-finite
-                   ( is-finite-type-decidable-subtype
-                     ( 2-Element-Decidable-Subtype-subtype-pointwise-difference
-                        d1 d3)
-                     ( is-finite-2-Element-Decidable-Subtype n X)))
-                 ( transitive-mere-equiv
-                   ( pr2
-                    ( has-finite-cardinality-is-finite
-                      ( is-finite-type-decidable-subtype
-                        ( 2-Element-Decidable-Subtype-subtype-pointwise-difference
-                            d1 d3)
-                        ( is-finite-2-Element-Decidable-Subtype n X))))
-                   ( unit-trunc-Prop
-                     ( inv-equiv
-                       ( equiv-symmetric-difference-subtype-pointwise-difference
-                          d1 d2 d3))))))))))
+                ( pair
+                  ( number-of-elements-is-finite
+                    ( is-finite-type-decidable-subtype
+                      ( 2-Element-Decidable-Subtype-subtype-pointwise-difference
+                          d1 d3)
+                      ( is-finite-2-Element-Decidable-Subtype n X)))
+                  ( transitive-mere-equiv
+                    ( pr2
+                      ( has-finite-cardinality-is-finite
+                        ( is-finite-type-decidable-subtype
+                          ( 2-Element-Decidable-Subtype-subtype-pointwise-difference
+                              d1 d3)
+                          ( is-finite-2-Element-Decidable-Subtype n X))))
+                    ( unit-trunc-Prop
+                      ( inv-equiv
+                        ( equiv-symmetric-difference-subtype-pointwise-difference
+                            d1 d2 d3))))))))))
     where
     k : ℕ
     k =
@@ -1040,7 +1040,7 @@ module _
                 np
                   ( inv r1 ∙
                     ( inv s ∙
-                       tr
+                      tr
                         ( λ y →
                           Id
                             ( map-equiv
@@ -1335,7 +1335,7 @@ module _
         { y =
           pair
             ( inr
-               λ s →
+                λ s →
                 np
                   ( ( tr
                     ( λ y →
@@ -1834,7 +1834,7 @@ module _
           ( t)))) ∙
       ( Q ∙
         ( ( inv (eq-orientation-two-elements-count j i (np ∘ inv))) ∙
-           ap
+          ( ap
             ( pr1 ∘ orientation-two-elements-count j i (np ∘ inv))
             ( ( is-commutative-standard-2-Element-Decidable-Subtype
               ( has-decidable-equality-count eX)
@@ -1845,7 +1845,7 @@ module _
                 ( np')
                 ( inv q)
                 ( inv t)) ∙
-                ( P)))))
+                ( P))))))
   cases-eq-orientation-aut-orientation-two-elements-count-right
     i j np Q Y (pair x (pair y (pair np' P))) R (inl q) r s (inr nt) =
     ( inward-edge-left-transposition-orientation-count i j np Y y
@@ -1877,8 +1877,8 @@ module _
             ( Y')))
       ( inv P ∙
         ( ( is-commutative-standard-2-Element-Decidable-Subtype
-          ( has-decidable-equality-count eX)
-          ( np')) ∙
+            ( has-decidable-equality-count eX)
+            ( np')) ∙
           ( eq-equal-elements-standard-2-Element-Decidable-Subtype
             ( has-decidable-equality-count eX)
             ( λ p → np' (inv p))
@@ -2439,136 +2439,137 @@ module _
                     ( P)))))))
   cases-eq-map-orientation-transposition-orientation-two-elements-count
     i j np Y (pair x (pair y (pair np' P))) R (inr nq) (inl r) (inr ns) t =
-     ap
-      ( map-inv-equiv
-        ( transposition
-          ( standard-2-Element-Decidable-Subtype
-            ( has-decidable-equality-count eX)
-            ( np))))
-      ( inward-edge-left-two-elements-orientation-count i j np
-        ( precomp-equiv-2-Element-Decidable-Subtype
+      ap
+        ( map-inv-equiv
           ( transposition
             ( standard-2-Element-Decidable-Subtype
               ( has-decidable-equality-count eX)
-              ( np)))
-          ( Y))
-        ( y)
-        ( tr
-          ( λ Y' →
-            type-Decidable-Prop
-              ( ( pr1 Y' ∘
-                ( map-inv-equiv
-                  ( transposition
-                    ( standard-2-Element-Decidable-Subtype
-                      ( has-decidable-equality-count eX)
-                      ( np)))))
-                ( y)))
-          ( P)
-          ( inr
-            ( inv
-              ( is-fixed-point-standard-transposition
+              ( np))))
+        ( inward-edge-left-two-elements-orientation-count i j np
+          ( precomp-equiv-2-Element-Decidable-Subtype
+            ( transposition
+              ( standard-2-Element-Decidable-Subtype
                 ( has-decidable-equality-count eX)
-                ( np)
-                ( y)
-                ( λ s' → ns (inv s'))
-                ( λ t → np' (r ∙ t))))))
-        ( tr
-          ( λ Y' →
-            type-Decidable-Prop
-              ( ( pr1 Y' ∘
-                ( map-inv-equiv
-                  ( transposition
-                    ( standard-2-Element-Decidable-Subtype
-                      ( has-decidable-equality-count eX)
-                      ( np)))))
-                ( i)))
-          ( P)
-          ( inl
-            ( r ∙
-               inv
-                ( left-computation-standard-transposition
+                ( np)))
+            ( Y))
+          ( y)
+          ( tr
+            ( λ Y' →
+              type-Decidable-Prop
+                ( ( pr1 Y' ∘
+                  ( map-inv-equiv
+                    ( transposition
+                      ( standard-2-Element-Decidable-Subtype
+                        ( has-decidable-equality-count eX)
+                        ( np)))))
+                  ( y)))
+            ( P)
+            ( inr
+              ( inv
+                ( is-fixed-point-standard-transposition
                   ( has-decidable-equality-count eX)
-                  ( np)))))
-        ( ns)
-        ( λ t → np' (r ∙ inv t))) ∙
-      ( ( is-fixed-point-standard-transposition
-        ( has-decidable-equality-count eX)
-        ( np)
-        ( y)
-        ( λ s' → ns (inv s'))
-        ( λ t → np' (r ∙ t))) ∙
-        ( inv
-          ( inward-edge-left-two-elements-orientation-count j i (np ∘ inv) Y y
-            ( tr (λ Y' → type-Decidable-Prop (pr1 Y' y)) P (inr refl))
-            ( tr (λ Y' → type-Decidable-Prop (pr1 Y' j)) P (inl r))
-            ( λ t' → np' (r ∙ inv t'))
-            ( ns))))
+                  ( np)
+                  ( y)
+                  ( λ s' → ns (inv s'))
+                  ( λ t → np' (r ∙ t))))))
+          ( tr
+            ( λ Y' →
+              type-Decidable-Prop
+                ( ( ( pr1 Y') ∘
+                    ( map-inv-equiv
+                      ( transposition
+                        ( standard-2-Element-Decidable-Subtype
+                          ( has-decidable-equality-count eX)
+                          ( np)))))
+                  ( i)))
+            ( P)
+            ( inl
+              ( r ∙
+                inv
+                  ( left-computation-standard-transposition
+                    ( has-decidable-equality-count eX)
+                    ( np)))))
+          ( ns)
+          ( λ t → np' (r ∙ inv t))) ∙
+        ( ( is-fixed-point-standard-transposition
+            ( has-decidable-equality-count eX)
+            ( np)
+            ( y)
+            ( λ s' → ns (inv s'))
+            ( λ t → np' (r ∙ t))) ∙
+          ( inv
+            ( inward-edge-left-two-elements-orientation-count j i (np ∘ inv) Y y
+              ( tr (λ Y' → type-Decidable-Prop (pr1 Y' y)) P (inr refl))
+              ( tr (λ Y' → type-Decidable-Prop (pr1 Y' j)) P (inl r))
+              ( λ t' → np' (r ∙ inv t'))
+              ( ns))))
   cases-eq-map-orientation-transposition-orientation-two-elements-count
     i j np Y (pair x (pair y (pair np' P))) R (inr nq) (inr nr) (inl s) t =
-     ap
-      ( map-inv-equiv
-        ( transposition
-          ( standard-2-Element-Decidable-Subtype
-            ( has-decidable-equality-count eX)
-            ( np))))
-      ( inward-edge-right-two-elements-orientation-count i j np
-        ( precomp-equiv-2-Element-Decidable-Subtype
+      ap
+        ( map-inv-equiv
           ( transposition
             ( standard-2-Element-Decidable-Subtype
               ( has-decidable-equality-count eX)
-              ( np)))
-          ( Y))
-        ( x)
-        ( tr
-          ( λ Y' →
-            type-Decidable-Prop
-              ( ( pr1 Y' ∘
-                ( map-inv-equiv
-                  ( transposition
-                    ( standard-2-Element-Decidable-Subtype
-                      ( has-decidable-equality-count eX)
-                      ( np)))))
-                ( x)))
-          ( P)
-          ( inl
-            ( inv
-              ( is-fixed-point-standard-transposition
+              ( np))))
+        ( inward-edge-right-two-elements-orientation-count i j np
+          ( precomp-equiv-2-Element-Decidable-Subtype
+            ( transposition
+              ( standard-2-Element-Decidable-Subtype
                 ( has-decidable-equality-count eX)
-                ( np)
-                ( x)
-                ( λ q → nq (inv q))
-                ( λ r → nr (inv r))))))
-        ( tr
-          ( λ Y' →
-            type-Decidable-Prop
-              ( ( pr1 Y' ∘
-                ( map-inv-equiv
-                  ( transposition
-                    ( standard-2-Element-Decidable-Subtype
-                      ( has-decidable-equality-count eX)
-                      ( np)))))
-                ( j)))
-          ( P)
-          ( inr
-            ( s ∙
+                ( np)))
+            ( Y))
+          ( x)
+          ( tr
+            ( λ Y' →
+              type-Decidable-Prop
+                ( ( ( pr1 Y') ∘
+                    ( map-inv-equiv
+                      ( transposition
+                        ( standard-2-Element-Decidable-Subtype
+                          ( has-decidable-equality-count eX)
+                          ( np)))))
+                  ( x)))
+            ( P)
+            ( inl
               ( inv
-                ( right-computation-standard-transposition
+                ( is-fixed-point-standard-transposition
                   ( has-decidable-equality-count eX)
-                  ( np))))))
-        ( nq)
-        ( nr)) ∙
-      ( is-fixed-point-standard-transposition
-        ( has-decidable-equality-count eX)
-        ( np)
-        ( x)
-        ( λ q → nq (inv q))
-        ( λ r → nr (inv r)) ∙
-        ( inv
-          ( inward-edge-right-two-elements-orientation-count j i (np ∘ inv) Y x
-            ( tr (λ Y' → type-Decidable-Prop (pr1 Y' x)) P (inl refl))
-            ( tr (λ Y' → type-Decidable-Prop (pr1 Y' i)) P (inr s))
-            ( nr)
-            ( nq))))
+                  ( np)
+                  ( x)
+                  ( λ q → nq (inv q))
+                  ( λ r → nr (inv r))))))
+          ( tr
+            ( λ Y' →
+              type-Decidable-Prop
+                ( ( ( pr1 Y') ∘
+                    ( map-inv-equiv
+                      ( transposition
+                        ( standard-2-Element-Decidable-Subtype
+                          ( has-decidable-equality-count eX)
+                          ( np)))))
+                  ( j)))
+            ( P)
+            ( inr
+              ( s ∙
+                ( inv
+                  ( right-computation-standard-transposition
+                    ( has-decidable-equality-count eX)
+                    ( np))))))
+          ( nq)
+          ( nr)) ∙
+        ( is-fixed-point-standard-transposition
+          ( has-decidable-equality-count eX)
+          ( np)
+          ( x)
+          ( λ q → nq (inv q))
+          ( λ r → nr (inv r)) ∙
+          ( inv
+            ( inward-edge-right-two-elements-orientation-count
+              j i (np ∘ inv) Y x
+              ( tr (λ Y' → type-Decidable-Prop (pr1 Y' x)) P (inl refl))
+              ( tr (λ Y' → type-Decidable-Prop (pr1 Y' i)) P (inr s))
+              ( nr)
+              ( nq))))
   cases-eq-map-orientation-transposition-orientation-two-elements-count
     i j np Y (pair x (pair y (pair np' P)))
     R (inr nq) (inr nr) (inr ns) (inl t) =
@@ -2618,24 +2619,24 @@ module _
           ( P)
           ( inr
             ( t ∙
-               inv
+              inv
                 ( left-computation-standard-transposition
                   ( has-decidable-equality-count eX)
                   ( np)))))
         ( nq)
         ( nr))) ∙
-      ( ( is-fixed-point-standard-transposition
+    ( ( is-fixed-point-standard-transposition
         ( has-decidable-equality-count eX)
         ( np)
         ( x)
         ( λ q → nq (inv q))
         ( λ r → nr (inv r))) ∙
-        ( inv
-          ( inward-edge-left-two-elements-orientation-count j i (np ∘ inv) Y x
-            ( tr (λ Y' → type-Decidable-Prop (pr1 Y' x)) P (inl refl))
-            ( tr (λ Y' → type-Decidable-Prop (pr1 Y' j)) P (inr t))
-            ( nr)
-            ( nq))))
+      ( inv
+        ( inward-edge-left-two-elements-orientation-count j i (np ∘ inv) Y x
+          ( tr (λ Y' → type-Decidable-Prop (pr1 Y' x)) P (inl refl))
+          ( tr (λ Y' → type-Decidable-Prop (pr1 Y' j)) P (inr t))
+          ( nr)
+          ( nq))))
   cases-eq-map-orientation-transposition-orientation-two-elements-count
     i j np Y (pair x (pair y (pair np' P)))
     R (inr nq) (inr nr) (inr ns) (inr nt) =
@@ -2646,33 +2647,31 @@ module _
             ( has-decidable-equality-count eX)
             ( np))))
       ( ( ap
-        ( λ Y' →
-          pr1
-            ( orientation-two-elements-count i j np Y'))
-        ( ( ap
-          ( precomp-equiv-2-Element-Decidable-Subtype
-            ( transposition
-              ( standard-2-Element-Decidable-Subtype
+          ( λ Y' → pr1 (orientation-two-elements-count i j np Y'))
+          ( ( ap
+              ( precomp-equiv-2-Element-Decidable-Subtype
+                ( transposition
+                  ( standard-2-Element-Decidable-Subtype
+                    ( has-decidable-equality-count eX)
+                    ( np))))
+              ( inv P)) ∙
+            ( ( eq-transposition-precomp-ineq-standard-2-Element-Decidable-Subtype
                 ( has-decidable-equality-count eX)
-                ( np))))
-          ( inv P)) ∙
-          ( ( eq-transposition-precomp-ineq-standard-2-Element-Decidable-Subtype
-            ( has-decidable-equality-count eX)
-            ( np)
-            ( np')
-            ( λ q → nq (inv q))
-            ( λ s → ns (inv s))
-            ( λ r → nr (inv r))
-            ( λ t → nt (inv t))) ∙
-            ( P)))) ∙
+                ( np)
+                ( np')
+                ( λ q → nq (inv q))
+                ( λ s → ns (inv s))
+                ( λ r → nr (inv r))
+                ( λ t → nt (inv t))) ∙
+              ( P)))) ∙
         ( ( ap
-          ( λ k →
-            pr1
-              ( cases-orientation-two-elements-count i j Y k
-                ( has-decidable-equality-count eX (pr1 k) i)
-                ( has-decidable-equality-count eX (pr1 k) j)
-                ( has-decidable-equality-count eX (pr1 (pr2 k)) i)))
-          ( R)) ∙
+            ( λ k →
+              pr1
+                ( cases-orientation-two-elements-count i j Y k
+                  ( has-decidable-equality-count eX (pr1 k) i)
+                  ( has-decidable-equality-count eX (pr1 k) j)
+                  ( has-decidable-equality-count eX (pr1 (pr2 k)) i)))
+            ( R)) ∙
           ( ap
             ( λ w →
               pr1
@@ -2690,27 +2689,27 @@ module _
               ( eq-is-prop (is-prop-is-decidable (is-set-count eX x i)))
               ( eq-is-prop (is-prop-is-decidable (is-set-count eX x j)))))))) ∙
       ( ( is-fixed-point-standard-transposition
-        ( has-decidable-equality-count eX)
-        ( np)
-        ( x)
-        ( λ q → nq (inv q))
-        ( λ r → nr (inv r))) ∙
+          ( has-decidable-equality-count eX)
+          ( np)
+          ( x)
+          ( λ q → nq (inv q))
+          ( λ r → nr (inv r))) ∙
         ( ( ap
-          ( λ w →
-            pr1
-              ( cases-orientation-two-elements-count j i Y
-                ( pair x (pair y (pair np' P)))
-                ( pr1 w)
-                ( pr2 w)
-                ( has-decidable-equality-count eX y j)))
-          { x = pair (inr nr) (inr nq)}
-          { y =
-            pair
-              ( has-decidable-equality-count eX x j)
-              ( has-decidable-equality-count eX x i)}
-          ( eq-pair-Σ
-            ( eq-is-prop (is-prop-is-decidable (is-set-count eX x j)))
-            ( eq-is-prop (is-prop-is-decidable (is-set-count eX x i))))) ∙
+            ( λ w →
+              pr1
+                ( cases-orientation-two-elements-count j i Y
+                  ( pair x (pair y (pair np' P)))
+                  ( pr1 w)
+                  ( pr2 w)
+                  ( has-decidable-equality-count eX y j)))
+            { x = pair (inr nr) (inr nq)}
+            { y =
+              pair
+                ( has-decidable-equality-count eX x j)
+                ( has-decidable-equality-count eX x i)}
+            ( eq-pair-Σ
+              ( eq-is-prop (is-prop-is-decidable (is-set-count eX x j)))
+              ( eq-is-prop (is-prop-is-decidable (is-set-count eX x i))))) ∙
           ( ap
             ( λ k →
               pr1
@@ -2768,36 +2767,35 @@ module _
   equiv-fin-1-difference-orientation-two-elements-count :
     ( i j : X) (np : ¬ (Id i j)) →
     Fin 1 ≃
-    Σ (2-Element-Decidable-Subtype l X)
-    ( λ Y → type-Decidable-Prop
-      ( 2-Element-Decidable-Subtype-subtype-pointwise-difference
-        ( number-of-elements-count eX)
-        ( pair X (unit-trunc-Prop (equiv-count eX)))
-        ( orientation-two-elements-count i j np)
-        ( orientation-two-elements-count j i (np ∘ inv))
-        ( Y)))
+    Σ ( 2-Element-Decidable-Subtype l X)
+      ( λ Y → type-Decidable-Prop
+        ( 2-Element-Decidable-Subtype-subtype-pointwise-difference
+          ( number-of-elements-count eX)
+          ( pair X (unit-trunc-Prop (equiv-count eX)))
+          ( orientation-two-elements-count i j np)
+          ( orientation-two-elements-count j i (np ∘ inv))
+          ( Y)))
   pr1 (pr1 (equiv-fin-1-difference-orientation-two-elements-count i j np) x) =
     standard-2-Element-Decidable-Subtype (has-decidable-equality-count eX) np
   pr2 (pr1 (equiv-fin-1-difference-orientation-two-elements-count i j np) x) q =
     np
-      ( ( inv
-        ( eq-orientation-two-elements-count j i (np ∘ inv))) ∙
+      ( ( inv (eq-orientation-two-elements-count j i (np ∘ inv))) ∙
         ( ( ap
-          ( λ Y → pr1 (orientation-two-elements-count j i (np ∘ inv) Y))
-          { x =
-            standard-2-Element-Decidable-Subtype
-              ( has-decidable-equality-count eX)
-              ( np ∘ inv)}
-          { y =
-            standard-2-Element-Decidable-Subtype
-              ( has-decidable-equality-count eX)
-              ( np)}
-          ( inv
-            ( is-commutative-standard-2-Element-Decidable-Subtype
-              ( has-decidable-equality-count eX)
-              ( np)))) ∙
-          ( inv (ap pr1 q) ∙
-            eq-orientation-two-elements-count i j np)))
+            ( λ Y → pr1 (orientation-two-elements-count j i (np ∘ inv) Y))
+            { x =
+              standard-2-Element-Decidable-Subtype
+                ( has-decidable-equality-count eX)
+                ( np ∘ inv)}
+            { y =
+              standard-2-Element-Decidable-Subtype
+                ( has-decidable-equality-count eX)
+                ( np)}
+            ( inv
+              ( is-commutative-standard-2-Element-Decidable-Subtype
+                ( has-decidable-equality-count eX)
+                ( np)))) ∙
+            ( inv (ap pr1 q) ∙
+              eq-orientation-two-elements-count i j np)))
   pr2 (equiv-fin-1-difference-orientation-two-elements-count i j np) =
     is-equiv-has-inverse
       ( λ x → inr star)
@@ -2823,12 +2821,12 @@ module _
                 ( orientation-two-elements-count i j np)
                 ( orientation-two-elements-count j i (np ∘ inv))
                 ( pr1 T)))))
-       ( sec-fin-1-difference-orientation-two-elements-count)
+      ( sec-fin-1-difference-orientation-two-elements-count)
     where
     retr-fin-1-difference-orientation-two-elements-count :
       ( T :
-        Σ (2-Element-Decidable-Subtype l X)
-          (λ Y →
+        Σ ( 2-Element-Decidable-Subtype l X)
+          ( λ Y →
             type-Decidable-Prop
               ( 2-Element-Decidable-Subtype-subtype-pointwise-difference
                 ( number-of-elements-count eX)
@@ -2870,39 +2868,39 @@ module _
           ( inv q)
           ( eq-is-prop is-prop-neg)) ∙
         ( ( ap
-          ( λ w →
-            standard-2-Element-Decidable-Subtype
-              ( has-decidable-equality-count eX)
-              {x = x}
-              {y = pr1 w}
-              ( pr2 w))
-          { x = pair j (λ p → np (inv q ∙ p))}
-          { y = pair y np'}
-          ( eq-pair-Σ
-            ( inv t)
-            ( eq-is-prop is-prop-neg))) ∙
+            ( λ w →
+              standard-2-Element-Decidable-Subtype
+                ( has-decidable-equality-count eX)
+                {x = x}
+                {y = pr1 w}
+                ( pr2 w))
+            { x = pair j (λ p → np (inv q ∙ p))}
+            { y = pair y np'}
+            ( eq-pair-Σ
+              ( inv t)
+              ( eq-is-prop is-prop-neg))) ∙
           ( P))
     retr-fin-1-difference-orientation-two-elements-count
       T (pair x (pair y (pair np' P))) Q (inl q) r s (inr nt) =
-       ex-falso
+      ex-falso
         ( pr2 T
           ( eq-pair-Σ
             ( ( inward-edge-left-two-elements-orientation-count i j np
-              ( pr1 T)
-              ( y)
-              ( tr
-                ( λ Y → type-Decidable-Prop (pr1 Y y))
-                ( P)
-                ( inr refl))
-              ( tr
-                ( λ z → type-Decidable-Prop (pr1 (pr1 T) z))
-                ( q)
+                ( pr1 T)
+                ( y)
                 ( tr
-                  ( λ Y → type-Decidable-Prop (pr1 Y x))
+                  ( λ Y → type-Decidable-Prop (pr1 Y y))
                   ( P)
-                  ( inl refl)))
-              ( λ s → np' (q ∙ inv s))
-              ( nt)) ∙
+                  ( inr refl))
+                ( tr
+                  ( λ z → type-Decidable-Prop (pr1 (pr1 T) z))
+                  ( q)
+                  ( tr
+                    ( λ Y → type-Decidable-Prop (pr1 Y x))
+                    ( P)
+                    ( inl refl)))
+                ( λ s → np' (q ∙ inv s))
+                ( nt)) ∙
               ( inv
                 ( inward-edge-right-two-elements-orientation-count j i
                   ( np ∘ inv)
@@ -2930,7 +2928,7 @@ module _
                         j i (np ∘ inv) (pr1 T))))))))
     retr-fin-1-difference-orientation-two-elements-count
       T (pair x (pair y (pair np' P))) Q (inr nq) (inl r) (inl s) t =
-       ap
+      ap
         ( λ w →
           standard-2-Element-Decidable-Subtype
             ( has-decidable-equality-count eX)
@@ -2943,17 +2941,17 @@ module _
           ( inv s)
           ( eq-is-prop is-prop-neg)) ∙
         ( ( ap
-          ( λ w →
-            standard-2-Element-Decidable-Subtype
-              ( has-decidable-equality-count eX)
-              {x = y}
-              {y = pr1 w}
-              ( pr2 w))
-          { x = pair j (λ p → np (inv s ∙ p))}
-          { y = pair x (λ p → np' (inv p))}
-          ( eq-pair-Σ
-            ( inv r)
-            ( eq-is-prop is-prop-neg))) ∙
+            ( λ w →
+              standard-2-Element-Decidable-Subtype
+                ( has-decidable-equality-count eX)
+                {x = y}
+                {y = pr1 w}
+                ( pr2 w))
+            { x = pair j (λ p → np (inv s ∙ p))}
+            { y = pair x (λ p → np' (inv p))}
+            ( eq-pair-Σ
+              ( inv r)
+              ( eq-is-prop is-prop-neg))) ∙
           ( inv
             ( is-commutative-standard-2-Element-Decidable-Subtype
               ( has-decidable-equality-count eX)
@@ -2961,7 +2959,7 @@ module _
             ( P)))
     retr-fin-1-difference-orientation-two-elements-count
       T (pair x (pair y (pair np' P))) Q (inr nq) (inl r) (inr ns) t =
-       ex-falso
+      ex-falso
         ( pr2 T
           ( eq-pair-Σ
             ( inward-edge-right-two-elements-orientation-count i j np
@@ -3022,22 +3020,22 @@ module _
                   (pr1 (pr2 w)) i))
             ( inv Q) ∙
             ( ( ap
-              ( λ D →
-                cases-orientation-two-elements-count i j
-                  ( pr1 T)
-                  ( pair x (pair y (pair np' P)))
-                  ( pr1 D)
-                  ( pr2 D)
-                  ( has-decidable-equality-count eX y i))
-              { y = pair (inr nq) (inr nr)}
-              ( eq-pair-Σ
-                ( eq-is-prop (is-prop-is-decidable (is-set-count eX x i)))
-                ( eq-is-prop (is-prop-is-decidable (is-set-count eX x j))))) ∙
+                ( λ D →
+                  cases-orientation-two-elements-count i j
+                    ( pr1 T)
+                    ( pair x (pair y (pair np' P)))
+                    ( pr1 D)
+                    ( pr2 D)
+                    ( has-decidable-equality-count eX y i))
+                { y = pair (inr nq) (inr nr)}
+                ( eq-pair-Σ
+                  ( eq-is-prop (is-prop-is-decidable (is-set-count eX x i)))
+                  ( eq-is-prop (is-prop-is-decidable (is-set-count eX x j))))) ∙
               ( ap
                 ( λ D →
                   cases-orientation-two-elements-count j i
                     ( pr1 T)
-                    (pair x (pair y (pair np' P)))
+                    ( pair x (pair y (pair np' P)))
                     ( pr1 D)
                     ( pr2 D)
                     ( has-decidable-equality-count eX y j))
@@ -3065,9 +3063,9 @@ module _
     sec-fin-1-difference-orientation-two-elements-count (inr star) = refl
 
   eq-orientation-pointwise-difference-two-elements-count :
-    ( i j : X) (np : ¬ (Id i j)) →
+    (i j : X) (np : ¬ (Id i j)) →
     Id
-      1
+      ( 1)
       ( number-of-elements-is-finite
         ( is-finite-subtype-pointwise-difference
           ( number-of-elements-count eX)
@@ -3075,7 +3073,7 @@ module _
           ( orientation-two-elements-count i j np)
           ( orientation-two-elements-count j i (np ∘ inv))))
   eq-orientation-pointwise-difference-two-elements-count i j np =
-     ap
+    ap
       ( number-of-elements-has-finite-cardinality)
       ( all-elements-equal-has-finite-cardinality
         ( pair
@@ -3183,23 +3181,23 @@ module _
       ( tr
         ( λ d →
           ¬ ( sim-Eq-Rel
-            ( even-difference-orientation-Complete-Undirected-Graph
-              ( number-of-elements-count eX)
-              ( pair X (unit-trunc-Prop (equiv-count eX))))
-            ( orientation-two-elements-count j i (np ∘ inv))
-            ( d)))
+              ( even-difference-orientation-Complete-Undirected-Graph
+                ( number-of-elements-count eX)
+                ( pair X (unit-trunc-Prop (equiv-count eX))))
+              ( orientation-two-elements-count j i (np ∘ inv))
+              ( d)))
         ( inv
           ( ( ap
-            ( λ w →
-              map-orientation-complete-undirected-graph-equiv
-                ( number-of-elements-count eX)
-                ( pair X (unit-trunc-Prop (equiv-count eX)))
-                ( pair X (unit-trunc-Prop (equiv-count eX)))
-                ( transposition w)
-                ( orientation-two-elements-count j i (np ∘ inv)))
-            ( is-commutative-standard-2-Element-Decidable-Subtype
-              ( has-decidable-equality-count eX)
-              ( np))) ∙
+              ( λ w →
+                map-orientation-complete-undirected-graph-equiv
+                  ( number-of-elements-count eX)
+                  ( pair X (unit-trunc-Prop (equiv-count eX)))
+                  ( pair X (unit-trunc-Prop (equiv-count eX)))
+                  ( transposition w)
+                  ( orientation-two-elements-count j i (np ∘ inv)))
+              ( is-commutative-standard-2-Element-Decidable-Subtype
+                ( has-decidable-equality-count eX)
+                ( np))) ∙
             ( eq-map-orientation-transposition-orientation-two-elements-count
                 j i (np ∘ inv))))
         ( λ p →
@@ -3212,7 +3210,7 @@ module _
                     ( np ∘ inv)))))))
 
   not-even-difference-orientation-aut-transposition-count :
-    (Y : 2-Element-Decidable-Subtype l X) →
+    ( Y : 2-Element-Decidable-Subtype l X) →
     ¬ ( sim-Eq-Rel
       ( even-difference-orientation-Complete-Undirected-Graph
         ( number-of-elements-count eX)
@@ -3249,7 +3247,7 @@ module _
           ( pr1 (pr2 (pr2 (two-elements-transposition eX Y))))))
 
   inv-orientation :
-    (T :
+    ( T :
       quotient-sign
         ( number-of-elements-count eX)
         ( pair X (unit-trunc-Prop (equiv-count eX)))) →
@@ -3395,31 +3393,31 @@ module _
               ( canonical-orientation-count)
               ( inr star)
               ( is-symmetric-mod-two-number-of-differences-orientation-Complete-Undirected-Graph
-                  ( number-of-elements-count eX)
-                  ( pair X (unit-trunc-Prop (equiv-count eX)))
-                  ( canonical-orientation-count)
-                  ( trans-canonical-orientation-count)
-                  ( inr star)
-                  (ap
-                    ( mod-two-ℕ)
-                    { x = 1}
-                    { y =
-                      number-of-elements-is-finite
-                        ( is-finite-subtype-pointwise-difference
-                          ( number-of-elements-count eX)
-                          ( pair X (unit-trunc-Prop (equiv-count eX)))
-                          ( canonical-orientation-count)
-                          ( trans-canonical-orientation-count))}
-                    ( eq-orientation-pointwise-difference-two-elements-count
-                      ( first-element-count)
-                      ( second-element-count)
-                      ( distinct-two-elements-count))))))
+                ( number-of-elements-count eX)
+                ( pair X (unit-trunc-Prop (equiv-count eX)))
+                ( canonical-orientation-count)
+                ( trans-canonical-orientation-count)
+                ( inr star)
+                ( ap
+                  ( mod-two-ℕ)
+                  { x = 1}
+                  { y =
+                    number-of-elements-is-finite
+                      ( is-finite-subtype-pointwise-difference
+                        ( number-of-elements-count eX)
+                        ( pair X (unit-trunc-Prop (equiv-count eX)))
+                        ( canonical-orientation-count)
+                        ( trans-canonical-orientation-count))}
+                  ( eq-orientation-pointwise-difference-two-elements-count
+                    ( first-element-count)
+                    ( second-element-count)
+                    ( distinct-two-elements-count))))))
     retr-orientation :
-      (T :
+      ( T :
         quotient-sign
           ( number-of-elements-count eX)
           ( pair X (unit-trunc-Prop (equiv-count eX)))) →
-      (H :
+      ( H :
         is-decidable
           (is-in-equivalence-class
             ( even-difference-orientation-Complete-Undirected-Graph
@@ -3513,16 +3511,16 @@ module _
           ( Q ∙
             inv
               ( is-symmetric-mod-two-number-of-differences-orientation-Complete-Undirected-Graph
-                  ( number-of-elements-count eX)
-                  ( pair X (unit-trunc-Prop (equiv-count eX)))
-                  ( canonical-orientation-count)
-                  ( trans-canonical-orientation-count)
-                  ( inr star)
-                  ( ap mod-two-ℕ
-                    ( eq-orientation-pointwise-difference-two-elements-count
-                      ( first-element-count)
-                      ( second-element-count)
-                      ( distinct-two-elements-count))))))
+                ( number-of-elements-count eX)
+                ( pair X (unit-trunc-Prop (equiv-count eX)))
+                ( canonical-orientation-count)
+                ( trans-canonical-orientation-count)
+                ( inr star)
+                ( ap mod-two-ℕ
+                  ( eq-orientation-pointwise-difference-two-elements-count
+                    ( first-element-count)
+                    ( second-element-count)
+                    ( distinct-two-elements-count))))))
     sec-orientation (inr star) (inr NQ) = refl
 
 module _

--- a/src/univalent-combinatorics/set-quotients-of-index-two.lagda.md
+++ b/src/univalent-combinatorics/set-quotients-of-index-two.lagda.md
@@ -45,8 +45,9 @@ module _
     sim-Eq-Rel R x y ↔ sim-Eq-Rel R (h x) (h y))
   (h' : type-Set QR → type-Set QR)
   (x : A)
-  (P : h' (map-reflecting-map-Eq-Rel R f x) ＝
-       map-reflecting-map-Eq-Rel R f (h x))
+  (P :
+    h' (map-reflecting-map-Eq-Rel R f x) ＝
+    map-reflecting-map-Eq-Rel R f (h x))
   where
 
   cases-coherence-square-maps-eq-one-value-emb-is-set-quotient :
@@ -65,8 +66,9 @@ module _
             ( map-equiv
               ( is-effective-is-set-quotient R QR f Uf x y)
               ( map-inv-is-equiv
-                ( H' ( map-reflecting-map-Eq-Rel R f x)
-                     ( map-reflecting-map-Eq-Rel R f y))
+                ( H'
+                  ( map-reflecting-map-Eq-Rel R f x)
+                  ( map-reflecting-map-Eq-Rel R f y))
                 ( is-injective-map-equiv eA (p ∙ inv q))))))
   cases-coherence-square-maps-eq-one-value-emb-is-set-quotient H' y
     ( inl (inr star)) (inr star) (inl (inr star)) p q r =
@@ -109,8 +111,9 @@ module _
             ( map-equiv
               ( is-effective-is-set-quotient R QR f Uf x y)
               ( map-inv-is-equiv
-                ( H' ( map-reflecting-map-Eq-Rel R f x)
-                     ( map-reflecting-map-Eq-Rel R f y))
+                ( H'
+                  ( map-reflecting-map-Eq-Rel R f x)
+                  ( map-reflecting-map-Eq-Rel R f y))
                 ( is-injective-map-equiv eA (p ∙ inv q))))))
 
   coherence-square-maps-eq-one-value-emb-is-set-quotient :

--- a/src/univalent-combinatorics/sigma-decompositions.lagda.md
+++ b/src/univalent-combinatorics/sigma-decompositions.lagda.md
@@ -83,7 +83,7 @@ module _
     is-finite-type-𝔽 (finite-cotype-Σ-Decomposition-𝔽 x)
 
   is-inhabited-cotype-Σ-Decomposition-𝔽 :
-   (x : type-𝔽 finite-indexing-type-Σ-Decomposition-𝔽) →
+    (x : type-𝔽 finite-indexing-type-Σ-Decomposition-𝔽) →
     is-inhabited (cotype-Σ-Decomposition-𝔽 x)
   is-inhabited-cotype-Σ-Decomposition-𝔽 x =
     is-inhabited-type-Inhabited-𝔽

--- a/src/univalent-combinatorics/skipping-element-standard-finite-types.lagda.md
+++ b/src/univalent-combinatorics/skipping-element-standard-finite-types.lagda.md
@@ -33,9 +33,10 @@ abstract
   is-injective-skip-Fin :
     (k : ℕ) (x : Fin (succ-ℕ k)) → is-injective (skip-Fin k x)
   is-injective-skip-Fin (succ-ℕ k) (inl x) {inl y} {inl z} p =
-    ap ( inl)
-       ( is-injective-skip-Fin k x
-         ( is-injective-is-emb (is-emb-inl (Fin (succ-ℕ k)) unit) p))
+    ap
+      ( inl)
+      ( is-injective-skip-Fin k x
+        ( is-injective-is-emb (is-emb-inl (Fin (succ-ℕ k)) unit) p))
   is-injective-skip-Fin (succ-ℕ k) (inl x) {inr star} {inr star} p = refl
   is-injective-skip-Fin (succ-ℕ k) (inr star) {y} {z} p =
     is-injective-is-emb (is-emb-inl (Fin (succ-ℕ k)) unit) p

--- a/src/univalent-combinatorics/steiner-systems.lagda.md
+++ b/src/univalent-combinatorics/steiner-systems.lagda.md
@@ -43,9 +43,9 @@ Steiner-System t k n =
           ( Q : decidable-subtype lzero (type-UU-Fin n X)) →
           has-cardinality t (type-decidable-subtype Q) →
           is-contr
-            (Σ ( type-decidable-subtype P)
-               ( λ U →
-                 (x : type-UU-Fin n X) →
-                 is-in-decidable-subtype Q x →
-                 is-in-decidable-subtype (pr1 (pr1 U)) x))))
+            ( Σ ( type-decidable-subtype P)
+                ( λ U →
+                  (x : type-UU-Fin n X) →
+                  is-in-decidable-subtype Q x →
+                  is-in-decidable-subtype (pr1 (pr1 U)) x))))
 ```

--- a/src/univalent-combinatorics/sums-of-natural-numbers.lagda.md
+++ b/src/univalent-combinatorics/sums-of-natural-numbers.lagda.md
@@ -35,8 +35,9 @@ abstract
   associative-sum-count-ℕ :
     {l1 l2 : Level} {A : UU l1} {B : A → UU l2} (count-A : count A)
     (count-B : (x : A) → count (B x)) (f : (x : A) → B x → ℕ) →
-    Id ( sum-count-ℕ count-A (λ x → sum-count-ℕ (count-B x) (f x)))
-       ( sum-count-ℕ (count-Σ count-A count-B) (ind-Σ f))
+    Id
+      ( sum-count-ℕ count-A (λ x → sum-count-ℕ (count-B x) (f x)))
+      ( sum-count-ℕ (count-Σ count-A count-B) (ind-Σ f))
   associative-sum-count-ℕ {l1} {l2} {A} {B} count-A count-B f =
     ( ( htpy-sum-count-ℕ count-A
         ( λ x →

--- a/src/univalent-combinatorics/trivial-sigma-decompositions.lagda.md
+++ b/src/univalent-combinatorics/trivial-sigma-decompositions.lagda.md
@@ -97,14 +97,13 @@ is-contr-type-trivial-Σ-Decomposition-𝔽 :
 pr1 ( is-contr-type-trivial-Σ-Decomposition-𝔽 {l1} {l2} A p) =
   ( trivial-inhabited-Σ-Decomposition-𝔽 l2 A p ,
     is-trivial-trivial-inhabited-Σ-Decomposition-𝔽 A p)
-pr2 ( is-contr-type-trivial-Σ-Decomposition-𝔽 {l1} {l2} A p) =
-   ( λ x →
-     eq-type-subtype
-       ( is-trivial-Prop-Σ-Decomposition-𝔽 A)
-       ( inv
-         ( eq-equiv-Σ-Decomposition-𝔽
-           ( A)
-           ( pr1 x)
-           ( trivial-inhabited-Σ-Decomposition-𝔽 l2 A p)
-           ( equiv-trivial-is-trivial-Σ-Decomposition-𝔽 A (pr1 x) (pr2 x)))))
+pr2 ( is-contr-type-trivial-Σ-Decomposition-𝔽 {l1} {l2} A p) x =
+  eq-type-subtype
+    ( is-trivial-Prop-Σ-Decomposition-𝔽 A)
+    ( inv
+      ( eq-equiv-Σ-Decomposition-𝔽
+        ( A)
+        ( pr1 x)
+        ( trivial-inhabited-Σ-Decomposition-𝔽 l2 A p)
+        ( equiv-trivial-is-trivial-Σ-Decomposition-𝔽 A (pr1 x) (pr2 x))))
 ```

--- a/src/univalent-combinatorics/unlabeled-rooted-trees.lagda.md
+++ b/src/univalent-combinatorics/unlabeled-rooted-trees.lagda.md
@@ -18,6 +18,4 @@ An unlabelled rooted tree is an unlabelled tree equipped with a vertex.
 
 ## Definition
 
-```agda
-
-```
+This remains to be defined.

--- a/src/univalent-combinatorics/unlabeled-trees.lagda.md
+++ b/src/univalent-combinatorics/unlabeled-trees.lagda.md
@@ -16,9 +16,3 @@ module univalent-combinatorics.unlabeled-trees where
 
 An unlabelled tree is an undirected graph `G` such that any cycle in `G` must
 have length 1.
-
-## Definition
-
-```agda
-
-```

--- a/src/universal-algebra/algebraic-theory-of-groups.lagda.md
+++ b/src/universal-algebra/algebraic-theory-of-groups.lagda.md
@@ -155,31 +155,24 @@ equiv-group-Algebra-Group :
   {l : Level} →
   Algebra group-signature group-Theory l ≃
   Group l
-equiv-group-Algebra-Group =
-  pair
-    ( group-Algebra-Group)
-    ( pair
-      ( pair
-         ( Group-group-Algebra)
-         ( λ G →
-           ( eq-pair-Σ refl
-             ( eq-is-prop
-               ( is-prop-is-group (semigroup-Group G))))))
-      ( pair
-        ( Group-group-Algebra)
-        ( λ Alg →
-          ( eq-pair-Σ
-            ( eq-pair-Σ
-              ( refl)
-              ( eq-htpy
-                ( λ { unit-group-op →
-                      ( eq-htpy λ {empty-vec → refl}) ;
-                      mul-group-op →
-                      ( eq-htpy λ { (x ∷ y ∷ empty-vec) → refl}) ;
-                      inv-group-op →
-                      ( eq-htpy λ { (x ∷ empty-vec) → refl})}))))
-          ( eq-is-prop
-            ( is-prop-is-algebra
-              ( group-signature) ( group-Theory)
-              ( model-Algebra group-signature group-Theory Alg))))))
+pr1 equiv-group-Algebra-Group = group-Algebra-Group
+pr1 (pr1 (pr2 equiv-group-Algebra-Group)) = Group-group-Algebra
+pr2 (pr1 (pr2 equiv-group-Algebra-Group)) G =
+  eq-pair-Σ refl (eq-is-prop (is-prop-is-group (semigroup-Group G)))
+pr1 (pr2 (pr2 equiv-group-Algebra-Group)) = Group-group-Algebra
+pr2 (pr2 (pr2 equiv-group-Algebra-Group)) A =
+  eq-pair-Σ
+    ( eq-pair-Σ
+      ( refl)
+      ( eq-htpy
+        ( λ { unit-group-op →
+              ( eq-htpy λ {empty-vec → refl}) ;
+              mul-group-op →
+              ( eq-htpy λ { (x ∷ y ∷ empty-vec) → refl}) ;
+              inv-group-op →
+              ( eq-htpy λ { (x ∷ empty-vec) → refl})})))
+    ( eq-is-prop
+      ( is-prop-is-algebra
+        ( group-signature) ( group-Theory)
+        ( model-Algebra group-signature group-Theory A)))
 ```

--- a/src/universal-algebra/congruences.lagda.md
+++ b/src/universal-algebra/congruences.lagda.md
@@ -48,7 +48,7 @@ module _
     UU l4
   relation-holds-all-vec {l4} R {.zero-ℕ} empty-vec empty-vec = raise-unit l4
   relation-holds-all-vec {l4} R {.(succ-ℕ _)} (x ∷ v) (x' ∷ v') =
-     type-Prop (prop-Eq-Rel R x x') × (relation-holds-all-vec R v v')
+    type-Prop (prop-Eq-Rel R x x') × (relation-holds-all-vec R v v')
 
   preserves-operations :
     { l4 : Level} →

--- a/src/universal-algebra/kernels.lagda.md
+++ b/src/universal-algebra/kernels.lagda.md
@@ -78,11 +78,11 @@ module _
     where
     f = map-hom-Algebra Sg Th Alg1 Alg2 F
     map-hom-Algebra-lemma :
-     ( n : ℕ) →
-     ( v v' : vec (type-Algebra Sg Th Alg1) n) →
-     ( relation-holds-all-vec Sg Th Alg1 eq-rel-kernel-hom-Algebra v v') →
-     (map-vec f v) ＝ (map-vec f v')
+      ( n : ℕ) →
+      ( v v' : vec (type-Algebra Sg Th Alg1) n) →
+      ( relation-holds-all-vec Sg Th Alg1 eq-rel-kernel-hom-Algebra v v') →
+      (map-vec f v) ＝ (map-vec f v')
     map-hom-Algebra-lemma zero-ℕ empty-vec empty-vec p = refl
     map-hom-Algebra-lemma (succ-ℕ n) (x ∷ v) (x' ∷ v') (p , p') =
-     ap-binary (_∷_) p (map-hom-Algebra-lemma n v v' p')
+      ap-binary (_∷_) p (map-hom-Algebra-lemma n v v' p')
 ```


### PR DESCRIPTION
Wraps up the last PR on pre-commit stuff.

### Summary
- add detection for empty sections at the end of a file
- add autoremoval of empty code blocks
- add autoremoval of punctuation at the end of headers
- fix all uneven indentation in the library
- enable enforcing of even indentation
- pre-commit now properly fails when a misplaced top-level header is detected