### PR TITLE
Move public imports before "Imports" block

### DIFF
--- a/FILE-CONVENTIONS.md
+++ b/FILE-CONVENTIONS.md
@@ -88,7 +88,7 @@ contents of the file.
   `[The univalence axiom](foundation.univalence.md)`, which will be displayed as
   [The univalence axiom](foundation.univalence.md).
 - You can reference another module by module name using
-  `` [`foundation.univalence`](foundation.univalence.md) ``, which will be
+  ``[`foundation.univalence`](foundation.univalence.md)``, which will be
   displayed as [`foundation.univalence`](foundation.univalence.md).
 - If you just want to add a clickable link, use the pattern
   `<https://unimath.github.io/agda-unimath/>`. This will be displayed as

--- a/FILE-CONVENTIONS.md
+++ b/FILE-CONVENTIONS.md
@@ -35,8 +35,18 @@ Every file should begin with a header in the following format:
 # The title of the file
 ```
 
-and immediately after this, the module declaration and any option pragmas should
-be declared.
+and immediately after this, any option pragmas, then the module declaration then
+any public imports should be declared. E.g.
+
+````md
+```agda
+{-# OPTIONS --safe #-}
+
+module foundation.dependent-pair-types where
+
+open import foundation-core.dependent-pair-types public
+```
+````
 
 ### Imports block
 
@@ -78,7 +88,7 @@ contents of the file.
   `[The univalence axiom](foundation.univalence.md)`, which will be displayed as
   [The univalence axiom](foundation.univalence.md).
 - You can reference another module by module name using
-  ``[`foundation.univalence`](foundation.univalence.md)``, which will be
+  `` [`foundation.univalence`](foundation.univalence.md) ``, which will be
   displayed as [`foundation.univalence`](foundation.univalence.md).
 - If you just want to add a clickable link, use the pattern
   `<https://unimath.github.io/agda-unimath/>`. This will be displayed as

--- a/FILE-CONVENTIONS.md
+++ b/FILE-CONVENTIONS.md
@@ -36,7 +36,7 @@ Every file should begin with a header in the following format:
 ```
 
 and immediately after this, any option pragmas, then the module declaration then
-any public imports should be declared. E.g.
+public imports, if any, should be declared. E.g.
 
 ````md
 ```agda

--- a/TEMPLATE.lagda.md
+++ b/TEMPLATE.lagda.md
@@ -1,7 +1,11 @@
 # File title
 
 ```agda
-module template where
+{-# OPTIONS --safe #-}
+
+module foundation.template where
+
+open import foundation-core.template public
 ```
 
 <details><summary>Imports</summary>
@@ -14,7 +18,7 @@ open import ...
 
 ## Idea
 
-A **concept** $C$ is a _insert abstract idea of concept_, and is defined as
+A **concept** `C` is a _insert abstract idea of concept_, and is defined as
 _insert definition using words_.
 
 ## Definition
@@ -26,16 +30,16 @@ concept = ...
 
 ## Properties
 
-### Concept satisfies specific property
+### Concepts satisfy a property
 
 ```agda
-has-specific-property-concept : ...
-has-specific-property-concept = ...
+satisfies-property-concept : ...
+satisfies-property-concept = ...
 ```
 
 ## Examples
 
-### A subconcept is a concept
+### The following subconcept is a concept
 
 ```agda
 concept-subconcept : ...

--- a/src/elementary-number-theory/decidable-dependent-function-types.lagda.md
+++ b/src/elementary-number-theory/decidable-dependent-function-types.lagda.md
@@ -2,12 +2,14 @@
 
 ```agda
 module elementary-number-theory.decidable-dependent-function-types where
+
+open import foundation.decidable-dependent-function-types public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.decidable-dependent-function-types public
+
 ```
 
 </details>

--- a/src/elementary-number-theory/decidable-types.lagda.md
+++ b/src/elementary-number-theory/decidable-types.lagda.md
@@ -7,8 +7,6 @@ module elementary-number-theory.decidable-types where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.decidable-dependent-pair-types public
-
 open import elementary-number-theory.inequality-natural-numbers
 open import elementary-number-theory.natural-numbers
 open import elementary-number-theory.strict-inequality-natural-numbers
@@ -16,6 +14,7 @@ open import elementary-number-theory.upper-bounds-natural-numbers
 
 open import foundation.cartesian-product-types
 open import foundation.coproduct-types
+open import foundation.decidable-dependent-pair-types
 open import foundation.decidable-types
 open import foundation.dependent-pair-types
 open import foundation.empty-types

--- a/src/finite-group-theory/cartier-delooping-sign-homomorphism.lagda.md
+++ b/src/finite-group-theory/cartier-delooping-sign-homomorphism.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --lossy-unification #-}
-```
 
-```agda
 module finite-group-theory.cartier-delooping-sign-homomorphism where
 ```
 

--- a/src/finite-group-theory/delooping-sign-homomorphism.lagda.md
+++ b/src/finite-group-theory/delooping-sign-homomorphism.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --lossy-unification #-}
-```
 
-```agda
 module finite-group-theory.delooping-sign-homomorphism where
 ```
 

--- a/src/finite-group-theory/finite-type-groups.lagda.md
+++ b/src/finite-group-theory/finite-type-groups.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --lossy-unification #-}
-```
 
-```agda
 module finite-group-theory.finite-type-groups where
 ```
 

--- a/src/finite-group-theory/groups-of-order-2.lagda.md
+++ b/src/finite-group-theory/groups-of-order-2.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --lossy-unification #-}
-```
 
-```agda
 module finite-group-theory.groups-of-order-2 where
 ```
 

--- a/src/finite-group-theory/orbits-permutations.lagda.md
+++ b/src/finite-group-theory/orbits-permutations.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --lossy-unification #-}
-```
 
-```agda
 module finite-group-theory.orbits-permutations where
 ```
 

--- a/src/finite-group-theory/permutations-standard-finite-types.lagda.md
+++ b/src/finite-group-theory/permutations-standard-finite-types.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --lossy-unification #-}
-```
 
-```agda
 module finite-group-theory.permutations-standard-finite-types where
 ```
 

--- a/src/finite-group-theory/permutations.lagda.md
+++ b/src/finite-group-theory/permutations.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --lossy-unification #-}
-```
 
-```agda
 module finite-group-theory.permutations where
 ```
 

--- a/src/finite-group-theory/simpson-delooping-sign-homomorphism.lagda.md
+++ b/src/finite-group-theory/simpson-delooping-sign-homomorphism.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --lossy-unification #-}
-```
 
-```agda
 module finite-group-theory.simpson-delooping-sign-homomorphism where
 ```
 

--- a/src/finite-group-theory/transpositions-standard-finite-types.lagda.md
+++ b/src/finite-group-theory/transpositions-standard-finite-types.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --lossy-unification #-}
-```
 
-```agda
 module finite-group-theory.transpositions-standard-finite-types where
 ```
 

--- a/src/foundation-core/cartesian-product-types.lagda.md
+++ b/src/foundation-core/cartesian-product-types.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
-```
 
-```agda
 module foundation-core.cartesian-product-types where
 ```
 

--- a/src/foundation-core/coherently-invertible-maps.lagda.md
+++ b/src/foundation-core/coherently-invertible-maps.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
-```
 
-```agda
 module foundation-core.coherently-invertible-maps where
 ```
 

--- a/src/foundation-core/commuting-3-simplices-of-homotopies.lagda.md
+++ b/src/foundation-core/commuting-3-simplices-of-homotopies.lagda.md
@@ -2,6 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
+
 module foundation-core.commuting-3-simplices-of-homotopies where
 ```
 

--- a/src/foundation-core/commuting-3-simplices-of-maps.lagda.md
+++ b/src/foundation-core/commuting-3-simplices-of-maps.lagda.md
@@ -2,6 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
+
 module foundation-core.commuting-3-simplices-of-maps where
 ```
 

--- a/src/foundation-core/commuting-squares-of-maps.lagda.md
+++ b/src/foundation-core/commuting-squares-of-maps.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
-```
 
-```agda
 module foundation-core.commuting-squares-of-maps where
 ```
 

--- a/src/foundation-core/commuting-triangles-of-homotopies.lagda.md
+++ b/src/foundation-core/commuting-triangles-of-homotopies.lagda.md
@@ -2,6 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
+
 module foundation-core.commuting-triangles-of-homotopies where
 ```
 

--- a/src/foundation-core/commuting-triangles-of-maps.lagda.md
+++ b/src/foundation-core/commuting-triangles-of-maps.lagda.md
@@ -2,6 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
+
 module foundation-core.commuting-triangles-of-maps where
 ```
 

--- a/src/foundation-core/constant-maps.lagda.md
+++ b/src/foundation-core/constant-maps.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
-```
 
-```agda
 module foundation-core.constant-maps where
 ```
 

--- a/src/foundation-core/coproduct-types.lagda.md
+++ b/src/foundation-core/coproduct-types.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
-```
 
-```agda
 module foundation-core.coproduct-types where
 ```
 

--- a/src/foundation-core/cospans.lagda.md
+++ b/src/foundation-core/cospans.lagda.md
@@ -2,6 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
+
 module foundation-core.cospans where
 ```
 

--- a/src/foundation-core/dependent-pair-types.lagda.md
+++ b/src/foundation-core/dependent-pair-types.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
-```
 
-```agda
 module foundation-core.dependent-pair-types where
 ```
 

--- a/src/foundation-core/embeddings.lagda.md
+++ b/src/foundation-core/embeddings.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
-```
 
-```agda
 module foundation-core.embeddings where
 ```
 

--- a/src/foundation-core/equality-cartesian-product-types.lagda.md
+++ b/src/foundation-core/equality-cartesian-product-types.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
-```
 
-```agda
 module foundation-core.equality-cartesian-product-types where
 ```
 

--- a/src/foundation-core/equality-dependent-pair-types.lagda.md
+++ b/src/foundation-core/equality-dependent-pair-types.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
-```
 
-```agda
 module foundation-core.equality-dependent-pair-types where
 ```
 

--- a/src/foundation-core/equivalences.lagda.md
+++ b/src/foundation-core/equivalences.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
-```
 
-```agda
 module foundation-core.equivalences where
 ```
 

--- a/src/foundation-core/function-extensionality.lagda.md
+++ b/src/foundation-core/function-extensionality.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
-```
 
-```agda
 module foundation-core.function-extensionality where
 ```
 

--- a/src/foundation-core/functions.lagda.md
+++ b/src/foundation-core/functions.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
-```
 
-```agda
 module foundation-core.functions where
 ```
 

--- a/src/foundation-core/homotopies.lagda.md
+++ b/src/foundation-core/homotopies.lagda.md
@@ -2,6 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
+
 module foundation-core.homotopies where
 ```
 

--- a/src/foundation-core/identity-types.lagda.md
+++ b/src/foundation-core/identity-types.lagda.md
@@ -2,6 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
+
 module foundation-core.identity-types where
 ```
 

--- a/src/foundation-core/morphisms-cospans.lagda.md
+++ b/src/foundation-core/morphisms-cospans.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
-```
 
-```agda
 module foundation-core.morphisms-cospans where
 ```
 

--- a/src/foundation-core/retractions.lagda.md
+++ b/src/foundation-core/retractions.lagda.md
@@ -2,6 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
+
 module foundation-core.retractions where
 ```
 

--- a/src/foundation-core/sections.lagda.md
+++ b/src/foundation-core/sections.lagda.md
@@ -2,6 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
+
 module foundation-core.sections where
 ```
 

--- a/src/foundation-core/truncation-levels.lagda.md
+++ b/src/foundation-core/truncation-levels.lagda.md
@@ -2,6 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
+
 module foundation-core.truncation-levels where
 ```
 

--- a/src/foundation/0-maps.lagda.md
+++ b/src/foundation/0-maps.lagda.md
@@ -2,12 +2,14 @@
 
 ```agda
 module foundation.0-maps where
+
+open import foundation-core.0-maps public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.0-maps public
+
 ```
 
 </details>

--- a/src/foundation/1-types.lagda.md
+++ b/src/foundation/1-types.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.1-types where
+
+open import foundation-core.1-types public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.1-types public
-
 open import foundation.subuniverses
 
 open import foundation-core.contractible-types

--- a/src/foundation/automorphisms.lagda.md
+++ b/src/foundation/automorphisms.lagda.md
@@ -2,12 +2,14 @@
 
 ```agda
 module foundation.automorphisms where
+
+open import foundation-core.automorphisms public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.automorphisms public
+
 ```
 
 </details>

--- a/src/foundation/binary-functoriality-set-quotients.lagda.md
+++ b/src/foundation/binary-functoriality-set-quotients.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --lossy-unification #-}
-```
 
-```agda
 module foundation.binary-functoriality-set-quotients where
 ```
 

--- a/src/foundation/cartesian-product-types.lagda.md
+++ b/src/foundation/cartesian-product-types.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.cartesian-product-types where
+
+open import foundation-core.cartesian-product-types public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.cartesian-product-types public
-
 open import foundation.subuniverses
 
 open import foundation-core.universe-levels

--- a/src/foundation/coherently-invertible-maps.lagda.md
+++ b/src/foundation/coherently-invertible-maps.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.coherently-invertible-maps where
+
+open import foundation-core.coherently-invertible-maps public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.coherently-invertible-maps public
-
 open import foundation.equivalences
 open import foundation.identity-types
 open import foundation.type-theoretic-principle-of-choice

--- a/src/foundation/commuting-3-simplices-of-homotopies.lagda.md
+++ b/src/foundation/commuting-3-simplices-of-homotopies.lagda.md
@@ -2,12 +2,14 @@
 
 ```agda
 module foundation.commuting-3-simplices-of-homotopies where
+
+open import foundation-core.commuting-3-simplices-of-homotopies public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.commuting-3-simplices-of-homotopies public
+
 ```
 
 </details>

--- a/src/foundation/commuting-3-simplices-of-maps.lagda.md
+++ b/src/foundation/commuting-3-simplices-of-maps.lagda.md
@@ -2,12 +2,14 @@
 
 ```agda
 module foundation.commuting-3-simplices-of-maps where
+
+open import foundation-core.commuting-3-simplices-of-maps public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.commuting-3-simplices-of-maps public
+
 ```
 
 </details>

--- a/src/foundation/commuting-cubes-of-maps.lagda.md
+++ b/src/foundation/commuting-cubes-of-maps.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.commuting-cubes-of-maps where
+
+open import foundation-core.commuting-cubes-of-maps public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.commuting-cubes-of-maps public
-
 open import foundation-core.cones-over-cospans
 open import foundation-core.dependent-pair-types
 open import foundation-core.functions

--- a/src/foundation/commuting-squares-of-identifications.lagda.md
+++ b/src/foundation/commuting-squares-of-identifications.lagda.md
@@ -2,6 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
+
 module foundation.commuting-squares-of-identifications where
 ```
 

--- a/src/foundation/commuting-squares-of-maps.lagda.md
+++ b/src/foundation/commuting-squares-of-maps.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.commuting-squares-of-maps where
+
+open import foundation-core.commuting-squares-of-maps public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.commuting-squares-of-maps public
-
 open import foundation.equivalences
 open import foundation.functoriality-function-types
 

--- a/src/foundation/commuting-triangles-of-homotopies.lagda.md
+++ b/src/foundation/commuting-triangles-of-homotopies.lagda.md
@@ -2,12 +2,14 @@
 
 ```agda
 module foundation.commuting-triangles-of-homotopies where
+
+open import foundation-core.commuting-triangles-of-homotopies public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.commuting-triangles-of-homotopies public
+
 ```
 
 </details>

--- a/src/foundation/commuting-triangles-of-maps.lagda.md
+++ b/src/foundation/commuting-triangles-of-maps.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.commuting-triangles-of-maps where
+
+open import foundation-core.commuting-triangles-of-maps public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.commuting-triangles-of-maps public
-
 open import foundation.functoriality-dependent-function-types
 open import foundation.identity-types
 

--- a/src/foundation/cones-over-cospans.lagda.md
+++ b/src/foundation/cones-over-cospans.lagda.md
@@ -2,12 +2,14 @@
 
 ```agda
 module foundation.cones-over-cospans where
+
+open import foundation-core.cones-over-cospans public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.cones-over-cospans public
+
 ```
 
 </details>

--- a/src/foundation/constant-maps.lagda.md
+++ b/src/foundation/constant-maps.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.constant-maps where
+
+open import foundation-core.constant-maps public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.constant-maps public
-
 open import foundation.type-arithmetic-unit-type
 open import foundation.unit-type
 

--- a/src/foundation/contractible-maps.lagda.md
+++ b/src/foundation/contractible-maps.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.contractible-maps where
+
+open import foundation-core.contractible-maps public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.contractible-maps public
-
 open import foundation.equivalences
 open import foundation.truncated-maps
 

--- a/src/foundation/contractible-types.lagda.md
+++ b/src/foundation/contractible-types.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.contractible-types where
+
+open import foundation-core.contractible-types public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.contractible-types public
-
 open import foundation.function-extensionality
 open import foundation.subuniverses
 open import foundation.unit-type

--- a/src/foundation/coproduct-types.lagda.md
+++ b/src/foundation/coproduct-types.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.coproduct-types where
+
+open import foundation-core.coproduct-types public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.coproduct-types public
-
 open import foundation.noncontractible-types
 open import foundation.subuniverses
 open import foundation.unit-type

--- a/src/foundation/cospans.lagda.md
+++ b/src/foundation/cospans.lagda.md
@@ -2,12 +2,14 @@
 
 ```agda
 module foundation.cospans where
+
+open import foundation-core.cospans public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.cospans public
+
 ```
 
 </details>

--- a/src/foundation/decidable-propositions.lagda.md
+++ b/src/foundation/decidable-propositions.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.decidable-propositions where
+
+open import foundation-core.decidable-propositions public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.decidable-propositions public
-
 open import foundation.booleans
 open import foundation.decidable-types
 open import foundation.embeddings

--- a/src/foundation/dependent-pair-types.lagda.md
+++ b/src/foundation/dependent-pair-types.lagda.md
@@ -2,13 +2,16 @@
 
 ```agda
 {-# OPTIONS --safe #-}
+
 module foundation.dependent-pair-types where
+
+open import foundation-core.dependent-pair-types public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.dependent-pair-types public
+
 ```
 
 </details>

--- a/src/foundation/diagonal-maps-of-types.lagda.md
+++ b/src/foundation/diagonal-maps-of-types.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.diagonal-maps-of-types where
+
+open import foundation-core.diagonal-maps-of-types public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.diagonal-maps-of-types public
-
 open import foundation-core.0-maps
 open import foundation-core.1-types
 open import foundation-core.cartesian-product-types

--- a/src/foundation/discrete-types.lagda.md
+++ b/src/foundation/discrete-types.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.discrete-types where
+
+open import foundation-core.discrete-types public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.discrete-types public
-
 open import foundation.apartness-relations
 open import foundation.binary-relations
 open import foundation.decidable-types

--- a/src/foundation/embeddings.lagda.md
+++ b/src/foundation/embeddings.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.embeddings where
+
+open import foundation-core.embeddings public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.embeddings public
-
 open import foundation.commuting-squares-of-maps
 open import foundation.equivalences
 open import foundation.functoriality-cartesian-product-types

--- a/src/foundation/empty-types.lagda.md
+++ b/src/foundation/empty-types.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.empty-types where
+
+open import foundation-core.empty-types public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.empty-types public
-
 open import foundation.embeddings
 open import foundation.equivalences
 open import foundation.propositional-truncations

--- a/src/foundation/endomorphisms.lagda.md
+++ b/src/foundation/endomorphisms.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.endomorphisms where
+
+open import foundation-core.endomorphisms public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.endomorphisms public
-
 open import foundation.unit-type
 
 open import foundation-core.dependent-pair-types

--- a/src/foundation/equality-cartesian-product-types.lagda.md
+++ b/src/foundation/equality-cartesian-product-types.lagda.md
@@ -2,12 +2,14 @@
 
 ```agda
 module foundation.equality-cartesian-product-types where
+
+open import foundation-core.equality-cartesian-product-types public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.equality-cartesian-product-types public
+
 ```
 
 </details>

--- a/src/foundation/equality-dependent-pair-types.lagda.md
+++ b/src/foundation/equality-dependent-pair-types.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.equality-dependent-pair-types where
+
+open import foundation-core.equality-dependent-pair-types public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.equality-dependent-pair-types public
-
 open import foundation.identity-types
 
 open import foundation-core.dependent-pair-types

--- a/src/foundation/equality-fibers-of-maps.lagda.md
+++ b/src/foundation/equality-fibers-of-maps.lagda.md
@@ -2,12 +2,14 @@
 
 ```agda
 module foundation.equality-fibers-of-maps where
+
+open import foundation-core.equality-fibers-of-maps public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.equality-fibers-of-maps public
+
 ```
 
 </details>

--- a/src/foundation/equivalence-induction.lagda.md
+++ b/src/foundation/equivalence-induction.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.equivalence-induction where
+
+open import foundation-core.equivalence-induction public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.equivalence-induction public
-
 open import foundation.univalence
 
 open import foundation-core.dependent-pair-types

--- a/src/foundation/equivalence-relations.lagda.md
+++ b/src/foundation/equivalence-relations.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.equivalence-relations where
+
+open import foundation-core.equivalence-relations public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.equivalence-relations public
-
 open import foundation.binary-relations
 open import foundation.effective-maps-equivalence-relations
 open import foundation.equivalence-classes

--- a/src/foundation/equivalences.lagda.md
+++ b/src/foundation/equivalences.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.equivalences where
+
+open import foundation-core.equivalences public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.equivalences public
-
 open import foundation.equivalence-extensionality
 open import foundation.function-extensionality
 open import foundation.identity-types

--- a/src/foundation/exponents-set-quotients.lagda.md
+++ b/src/foundation/exponents-set-quotients.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --lossy-unification #-}
-```
 
-```agda
 module foundation.exponents-set-quotients where
 ```
 

--- a/src/foundation/faithful-maps.lagda.md
+++ b/src/foundation/faithful-maps.lagda.md
@@ -2,12 +2,14 @@
 
 ```agda
 module foundation.faithful-maps where
+
+open import foundation-core.faithful-maps public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.faithful-maps public
+
 ```
 
 </details>

--- a/src/foundation/fibers-of-maps.lagda.md
+++ b/src/foundation/fibers-of-maps.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.fibers-of-maps where
+
+open import foundation-core.fibers-of-maps public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.fibers-of-maps public
-
 open import foundation.type-arithmetic-unit-type
 open import foundation.unit-type
 

--- a/src/foundation/function-extensionality.lagda.md
+++ b/src/foundation/function-extensionality.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.function-extensionality where
+
+open import foundation-core.function-extensionality public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.function-extensionality public
-
 open import foundation-core.dependent-pair-types
 open import foundation-core.equivalences
 open import foundation-core.functions

--- a/src/foundation/functions.lagda.md
+++ b/src/foundation/functions.lagda.md
@@ -2,13 +2,16 @@
 
 ```agda
 {-# OPTIONS --safe #-}
+
 module foundation.functions where
+
+open import foundation-core.functions public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.functions public
+
 ```
 
 </details>

--- a/src/foundation/functoriality-dependent-function-types.lagda.md
+++ b/src/foundation/functoriality-dependent-function-types.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.functoriality-dependent-function-types where
+
+open import foundation-core.functoriality-dependent-function-types public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.functoriality-dependent-function-types public
-
 open import foundation.equivalence-extensionality
 open import foundation.equivalences
 open import foundation.function-extensionality

--- a/src/foundation/functoriality-dependent-pair-types.lagda.md
+++ b/src/foundation/functoriality-dependent-pair-types.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.functoriality-dependent-pair-types where
+
+open import foundation-core.functoriality-dependent-pair-types public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.functoriality-dependent-pair-types public
-
 open import foundation-core.cones-over-cospans
 open import foundation-core.dependent-pair-types
 open import foundation-core.equality-dependent-pair-types

--- a/src/foundation/functoriality-fibers-of-maps.lagda.md
+++ b/src/foundation/functoriality-fibers-of-maps.lagda.md
@@ -2,12 +2,14 @@
 
 ```agda
 module foundation.functoriality-fibers-of-maps where
+
+open import foundation-core.functoriality-fibers-of-maps public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.functoriality-fibers-of-maps public
+
 ```
 
 </details>

--- a/src/foundation/functoriality-function-types.lagda.md
+++ b/src/foundation/functoriality-function-types.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.functoriality-function-types where
+
+open import foundation-core.functoriality-function-types public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.functoriality-function-types public
-
 open import foundation.function-extensionality
 open import foundation.functoriality-dependent-function-types
 open import foundation.unit-type

--- a/src/foundation/functoriality-set-quotients.lagda.md
+++ b/src/foundation/functoriality-set-quotients.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --lossy-unification #-}
-```
 
-```agda
 module foundation.functoriality-set-quotients where
 ```
 

--- a/src/foundation/fundamental-theorem-of-identity-types.lagda.md
+++ b/src/foundation/fundamental-theorem-of-identity-types.lagda.md
@@ -2,12 +2,14 @@
 
 ```agda
 module foundation.fundamental-theorem-of-identity-types where
+
+open import foundation-core.fundamental-theorem-of-identity-types public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.fundamental-theorem-of-identity-types public
+
 ```
 
 </details>

--- a/src/foundation/homotopies.lagda.md
+++ b/src/foundation/homotopies.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.homotopies where
+
+open import foundation-core.homotopies public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.homotopies public
-
 open import foundation.function-extensionality
 open import foundation.identity-types
 

--- a/src/foundation/identity-systems.lagda.md
+++ b/src/foundation/identity-systems.lagda.md
@@ -2,12 +2,14 @@
 
 ```agda
 module foundation.identity-systems where
+
+open import foundation-core.identity-systems public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.identity-systems public
+
 ```
 
 </details>

--- a/src/foundation/identity-types.lagda.md
+++ b/src/foundation/identity-types.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.identity-types where
+
+open import foundation-core.identity-types public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.identity-types public
-
 open import foundation.binary-equivalences
 open import foundation.equivalence-extensionality
 open import foundation.function-extensionality

--- a/src/foundation/injective-maps.lagda.md
+++ b/src/foundation/injective-maps.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.injective-maps where
+
+open import foundation-core.injective-maps public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.injective-maps public
-
 open import foundation-core.empty-types
 open import foundation-core.negation
 open import foundation-core.universe-levels

--- a/src/foundation/involutions.lagda.md
+++ b/src/foundation/involutions.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.involutions where
+
+open import foundation-core.involutions public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.involutions public
-
 open import foundation.equivalence-extensionality
 open import foundation.equivalences
 

--- a/src/foundation/large-dependent-pair-types.lagda.md
+++ b/src/foundation/large-dependent-pair-types.lagda.md
@@ -2,6 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
+
 module foundation.large-dependent-pair-types where
 ```
 

--- a/src/foundation/large-homotopies.lagda.md
+++ b/src/foundation/large-homotopies.lagda.md
@@ -2,6 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
+
 module foundation.large-homotopies where
 ```
 

--- a/src/foundation/large-identity-types.lagda.md
+++ b/src/foundation/large-identity-types.lagda.md
@@ -2,6 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe #-}
+
 module foundation.large-identity-types where
 ```
 

--- a/src/foundation/logical-equivalences.lagda.md
+++ b/src/foundation/logical-equivalences.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.logical-equivalences where
+
+open import foundation-core.logical-equivalences public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.logical-equivalences public
-
 open import foundation-core.dependent-pair-types
 open import foundation-core.equivalences
 open import foundation-core.functions

--- a/src/foundation/morphisms-cospans.lagda.md
+++ b/src/foundation/morphisms-cospans.lagda.md
@@ -2,12 +2,14 @@
 
 ```agda
 module foundation.morphisms-cospans where
+
+open import foundation-core.morphisms-cospans public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.morphisms-cospans public
+
 ```
 
 </details>

--- a/src/foundation/negation.lagda.md
+++ b/src/foundation/negation.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.negation where
+
+open import foundation-core.negation public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.negation public
-
 open import foundation-core.dependent-pair-types
 open import foundation-core.empty-types
 open import foundation-core.equivalences

--- a/src/foundation/path-split-maps.lagda.md
+++ b/src/foundation/path-split-maps.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.path-split-maps where
+
+open import foundation-core.path-split-maps public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.path-split-maps public
-
 open import foundation.equivalences
 
 open import foundation-core.contractible-types

--- a/src/foundation/pi-decompositions.lagda.md
+++ b/src/foundation/pi-decompositions.lagda.md
@@ -2,6 +2,7 @@
 
 ```agda
 {-# OPTIONS --lossy-unification #-}
+
 module foundation.pi-decompositions where
 ```
 

--- a/src/foundation/propositional-maps.lagda.md
+++ b/src/foundation/propositional-maps.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.propositional-maps where
+
+open import foundation-core.propositional-maps public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.propositional-maps public
-
 open import foundation.embeddings
 open import foundation.truncated-maps
 

--- a/src/foundation/propositions.lagda.md
+++ b/src/foundation/propositions.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.propositions where
+
+open import foundation-core.propositions public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.propositions public
-
 open import foundation.contractible-types
 
 open import foundation-core.retractions

--- a/src/foundation/pullbacks.lagda.md
+++ b/src/foundation/pullbacks.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.pullbacks where
+
+open import foundation-core.pullbacks public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.pullbacks public
-
 open import foundation.commuting-cubes-of-maps
 open import foundation.descent-equivalences
 open import foundation.equivalences

--- a/src/foundation/relaxed-sigma-decompositions.lagda.md
+++ b/src/foundation/relaxed-sigma-decompositions.lagda.md
@@ -2,6 +2,7 @@
 
 ```agda
 {-# OPTIONS --lossy-unification #-}
+
 module foundation.relaxed-sigma-decompositions where
 ```
 

--- a/src/foundation/retractions.lagda.md
+++ b/src/foundation/retractions.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.retractions where
+
+open import foundation-core.retractions public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.retractions public
-
 open import foundation.coslice
 
 open import foundation-core.dependent-pair-types

--- a/src/foundation/russells-paradox.lagda.md
+++ b/src/foundation/russells-paradox.lagda.md
@@ -2,6 +2,7 @@
 
 ```agda
 {-# OPTIONS --lossy-unification #-}
+
 module foundation.russells-paradox where
 ```
 

--- a/src/foundation/sections.lagda.md
+++ b/src/foundation/sections.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.sections where
+
+open import foundation-core.sections public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.sections public
-
 open import foundation.function-extensionality
 open import foundation.structure-identity-principle
 open import foundation.type-theoretic-principle-of-choice

--- a/src/foundation/sets.lagda.md
+++ b/src/foundation/sets.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.sets where
+
+open import foundation-core.sets public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.sets public
-
 open import foundation.contractible-types
 open import foundation.subuniverses
 open import foundation.truncated-types

--- a/src/foundation/sigma-decompositions.lagda.md
+++ b/src/foundation/sigma-decompositions.lagda.md
@@ -2,6 +2,7 @@
 
 ```agda
 {-# OPTIONS --lossy-unification #-}
+
 module foundation.sigma-decompositions where
 ```
 

--- a/src/foundation/small-types.lagda.md
+++ b/src/foundation/small-types.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.small-types where
+
+open import foundation-core.small-types public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.small-types public
-
 open import foundation.images
 open import foundation.locally-small-types
 open import foundation.replacement

--- a/src/foundation/subtype-identity-principle.lagda.md
+++ b/src/foundation/subtype-identity-principle.lagda.md
@@ -2,12 +2,14 @@
 
 ```agda
 module foundation.subtype-identity-principle where
+
+open import foundation-core.subtype-identity-principle public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.subtype-identity-principle public
+
 ```
 
 </details>

--- a/src/foundation/subtypes.lagda.md
+++ b/src/foundation/subtypes.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.subtypes where
+
+open import foundation-core.subtypes public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.subtypes public
-
 open import foundation.equality-dependent-function-types
 open import foundation.propositional-extensionality
 

--- a/src/foundation/truncated-maps.lagda.md
+++ b/src/foundation/truncated-maps.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.truncated-maps where
+
+open import foundation-core.truncated-maps public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.truncated-maps public
-
 open import foundation-core.cones-over-cospans
 open import foundation-core.dependent-pair-types
 open import foundation-core.fibers-of-maps

--- a/src/foundation/truncated-types.lagda.md
+++ b/src/foundation/truncated-types.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.truncated-types where
+
+open import foundation-core.truncated-types public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.truncated-types public
-
 open import foundation.univalence
 
 open import foundation-core.contractible-types

--- a/src/foundation/truncation-levels.lagda.md
+++ b/src/foundation/truncation-levels.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.truncation-levels where
+
+open import foundation-core.truncation-levels public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.truncation-levels public
-
 open import elementary-number-theory.natural-numbers
 
 open import foundation-core.functions

--- a/src/foundation/type-arithmetic-cartesian-product-types.lagda.md
+++ b/src/foundation/type-arithmetic-cartesian-product-types.lagda.md
@@ -2,12 +2,14 @@
 
 ```agda
 module foundation.type-arithmetic-cartesian-product-types where
+
+open import foundation-core.type-arithmetic-cartesian-product-types public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.type-arithmetic-cartesian-product-types public
+
 ```
 
 </details>

--- a/src/foundation/type-arithmetic-dependent-pair-types.lagda.md
+++ b/src/foundation/type-arithmetic-dependent-pair-types.lagda.md
@@ -2,12 +2,14 @@
 
 ```agda
 module foundation.type-arithmetic-dependent-pair-types where
+
+open import foundation-core.type-arithmetic-dependent-pair-types public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.type-arithmetic-dependent-pair-types public
+
 ```
 
 </details>

--- a/src/foundation/univalence.lagda.md
+++ b/src/foundation/univalence.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.univalence where
+
+open import foundation-core.univalence public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.univalence public
-
 open import foundation.equality-dependent-function-types
 open import foundation.equivalences
 

--- a/src/foundation/universal-property-pullbacks.lagda.md
+++ b/src/foundation/universal-property-pullbacks.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.universal-property-pullbacks where
+
+open import foundation-core.universal-property-pullbacks public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.universal-property-pullbacks public
-
 open import foundation.equivalences
 
 open import foundation-core.cones-over-cospans

--- a/src/foundation/universal-property-set-quotients.lagda.md
+++ b/src/foundation/universal-property-set-quotients.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --lossy-unification #-}
-```
 
-```agda
 module foundation.universal-property-set-quotients where
 ```
 

--- a/src/foundation/universal-property-truncation.lagda.md
+++ b/src/foundation/universal-property-truncation.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module foundation.universal-property-truncation where
+
+open import foundation-core.universal-property-truncation public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.universal-property-truncation public
-
 open import foundation.contractible-types
 open import foundation.function-extensionality
 open import foundation.identity-types

--- a/src/foundation/universe-levels.lagda.md
+++ b/src/foundation/universe-levels.lagda.md
@@ -3,12 +3,14 @@
 ```agda
 {-# OPTIONS --safe --no-import-sorts #-}
 module foundation.universe-levels where
+
+open import foundation-core.universe-levels public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.universe-levels public
+
 ```
 
 </details>

--- a/src/foundation/universe-levels.lagda.md
+++ b/src/foundation/universe-levels.lagda.md
@@ -2,6 +2,7 @@
 
 ```agda
 {-# OPTIONS --safe --no-import-sorts #-}
+
 module foundation.universe-levels where
 
 open import foundation-core.universe-levels public

--- a/src/foundation/vectors-set-quotients.lagda.md
+++ b/src/foundation/vectors-set-quotients.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --lossy-unification #-}
-```
 
-```agda
 module foundation.vectors-set-quotients where
 ```
 

--- a/src/foundation/vectors-set-quotients.lagda.md
+++ b/src/foundation/vectors-set-quotients.lagda.md
@@ -11,8 +11,6 @@ module foundation.vectors-set-quotients where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation-core.identity-types public
-
 open import elementary-number-theory.natural-numbers
 
 open import foundation.cartesian-products-set-quotients
@@ -35,6 +33,7 @@ open import foundation-core.equivalence-relations
 open import foundation-core.equivalences
 open import foundation-core.functions
 open import foundation-core.homotopies
+open import foundation-core.identity-types
 open import foundation-core.propositions
 open import foundation-core.retractions
 open import foundation-core.sections

--- a/src/group-theory/quotient-groups.lagda.md
+++ b/src/group-theory/quotient-groups.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --lossy-unification #-}
-```
 
-```agda
 module group-theory.quotient-groups where
 ```
 

--- a/src/group-theory/quotients-abelian-groups.lagda.md
+++ b/src/group-theory/quotients-abelian-groups.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --lossy-unification #-}
-```
 
-```agda
 module group-theory.quotients-abelian-groups where
 ```
 

--- a/src/reflection/precategory-solver.lagda.md
+++ b/src/reflection/precategory-solver.lagda.md
@@ -2,6 +2,7 @@
 
 ```agda
 {-# OPTIONS --no-exact-split #-}
+
 module reflection.precategory-solver where
 ```
 

--- a/src/reflection/type-checking-monad.lagda.md
+++ b/src/reflection/type-checking-monad.lagda.md
@@ -2,6 +2,7 @@
 
 ```agda
 {-# OPTIONS --no-exact-split #-}
+
 module reflection.type-checking-monad where
 ```
 

--- a/src/type-theories/comprehension-type-theories.lagda.md
+++ b/src/type-theories/comprehension-type-theories.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --guardedness #-}
-```
 
-```agda
 module type-theories.comprehension-type-theories where
 ```
 

--- a/src/type-theories/dependent-type-theories.lagda.md
+++ b/src/type-theories/dependent-type-theories.lagda.md
@@ -2,6 +2,7 @@
 
 ```agda
 {-# OPTIONS --guardedness #-}
+
 module type-theories.dependent-type-theories where
 ```
 

--- a/src/type-theories/fibered-dependent-type-theories.lagda.md
+++ b/src/type-theories/fibered-dependent-type-theories.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --guardedness #-}
-```
 
-```agda
 module type-theories.fibered-dependent-type-theories where
 ```
 

--- a/src/type-theories/sections-dependent-type-theories.lagda.md
+++ b/src/type-theories/sections-dependent-type-theories.lagda.md
@@ -2,6 +2,7 @@
 
 ```agda
 {-# OPTIONS --guardedness #-}
+
 module type-theories.sections-dependent-type-theories where
 ```
 

--- a/src/type-theories/simple-type-theories.lagda.md
+++ b/src/type-theories/simple-type-theories.lagda.md
@@ -2,6 +2,7 @@
 
 ```agda
 {-# OPTIONS --guardedness --allow-unsolved-metas #-}
+
 module type-theories.simple-type-theories where
 ```
 

--- a/src/type-theories/unityped-type-theories.lagda.md
+++ b/src/type-theories/unityped-type-theories.lagda.md
@@ -2,6 +2,7 @@
 
 ```agda
 {-# OPTIONS --guardedness --allow-unsolved-metas #-}
+
 module type-theories.unityped-type-theories where
 ```
 

--- a/src/univalent-combinatorics/counting-decidable-subtypes.lagda.md
+++ b/src/univalent-combinatorics/counting-decidable-subtypes.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module univalent-combinatorics.counting-decidable-subtypes where
+
+open import foundation.decidable-subtypes public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.decidable-subtypes public
-
 open import elementary-number-theory.natural-numbers
 
 open import foundation.contractible-types

--- a/src/univalent-combinatorics/decidable-dependent-function-types.lagda.md
+++ b/src/univalent-combinatorics/decidable-dependent-function-types.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module univalent-combinatorics.decidable-dependent-function-types where
+
+open import elementary-number-theory.decidable-dependent-function-types public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import elementary-number-theory.decidable-dependent-function-types public
-
 open import elementary-number-theory.natural-numbers
 
 open import foundation.coproduct-types

--- a/src/univalent-combinatorics/decidable-propositions.lagda.md
+++ b/src/univalent-combinatorics/decidable-propositions.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module univalent-combinatorics.decidable-propositions where
+
+open import foundation.decidable-propositions public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.decidable-propositions public
-
 open import elementary-number-theory.natural-numbers
 
 open import foundation.coproduct-types

--- a/src/univalent-combinatorics/decidable-subtypes.lagda.md
+++ b/src/univalent-combinatorics/decidable-subtypes.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module univalent-combinatorics.decidable-subtypes where
+
+open import foundation.decidable-subtypes public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.decidable-subtypes public
-
 open import elementary-number-theory.natural-numbers
 
 open import foundation.coproduct-types

--- a/src/univalent-combinatorics/dependent-pair-types.lagda.md
+++ b/src/univalent-combinatorics/dependent-pair-types.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module univalent-combinatorics.dependent-pair-types where
+
+open import foundation.dependent-pair-types public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.dependent-pair-types public
-
 open import foundation.complements
 open import foundation.contractible-types
 open import foundation.decidable-types

--- a/src/univalent-combinatorics/discrete-sigma-decompositions.lagda.md
+++ b/src/univalent-combinatorics/discrete-sigma-decompositions.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module univalent-combinatorics.discrete-sigma-decompositions where
+
+open import foundation.discrete-sigma-decompositions public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.discrete-sigma-decompositions public
-
 open import foundation.contractible-types
 open import foundation.dependent-pair-types
 open import foundation.identity-types

--- a/src/univalent-combinatorics/embeddings.lagda.md
+++ b/src/univalent-combinatorics/embeddings.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module univalent-combinatorics.embeddings where
+
+open import foundation.embeddings public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.embeddings public
-
 open import elementary-number-theory.natural-numbers
 
 open import foundation.coproduct-types

--- a/src/univalent-combinatorics/equivalences.lagda.md
+++ b/src/univalent-combinatorics/equivalences.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module univalent-combinatorics.equivalences where
+
+open import foundation.equivalences public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.equivalences public
-
 open import foundation.decidable-types
 open import foundation.dependent-pair-types
 open import foundation.universe-levels

--- a/src/univalent-combinatorics/fibers-of-maps.lagda.md
+++ b/src/univalent-combinatorics/fibers-of-maps.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module univalent-combinatorics.fibers-of-maps where
+
+open import foundation.fibers-of-maps public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.fibers-of-maps public
-
 open import elementary-number-theory.natural-numbers
 open import elementary-number-theory.sums-of-natural-numbers
 

--- a/src/univalent-combinatorics/image-of-maps.lagda.md
+++ b/src/univalent-combinatorics/image-of-maps.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module univalent-combinatorics.image-of-maps where
+
+open import foundation.images public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.images public
-
 open import foundation.decidable-equality
 open import foundation.decidable-types
 open import foundation.fibers-of-maps

--- a/src/univalent-combinatorics/injective-maps.lagda.md
+++ b/src/univalent-combinatorics/injective-maps.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module univalent-combinatorics.injective-maps where
+
+open import foundation.injective-maps public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.injective-maps public
-
 open import foundation.decidable-types
 open import foundation.identity-types
 open import foundation.universe-levels

--- a/src/univalent-combinatorics/maybe.lagda.md
+++ b/src/univalent-combinatorics/maybe.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module univalent-combinatorics.maybe where
+
+open import foundation.maybe public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.maybe public
-
 open import elementary-number-theory.natural-numbers
 
 open import foundation.universe-levels

--- a/src/univalent-combinatorics/orientations-complete-undirected-graph.lagda.md
+++ b/src/univalent-combinatorics/orientations-complete-undirected-graph.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --lossy-unification #-}
-```
 
-```agda
 module univalent-combinatorics.orientations-complete-undirected-graph where
 ```
 

--- a/src/univalent-combinatorics/repetitions-of-values.lagda.md
+++ b/src/univalent-combinatorics/repetitions-of-values.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module univalent-combinatorics.repetitions-of-values where
+
+open import foundation.repetitions-of-values public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.repetitions-of-values public
-
 open import elementary-number-theory.natural-numbers
 open import elementary-number-theory.well-ordering-principle-standard-finite-types
 

--- a/src/univalent-combinatorics/set-quotients-of-index-two.lagda.md
+++ b/src/univalent-combinatorics/set-quotients-of-index-two.lagda.md
@@ -2,9 +2,7 @@
 
 ```agda
 {-# OPTIONS --lossy-unification #-}
-```
 
-```agda
 module univalent-combinatorics.set-quotients-of-index-two where
 ```
 

--- a/src/univalent-combinatorics/sigma-decompositions.lagda.md
+++ b/src/univalent-combinatorics/sigma-decompositions.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module univalent-combinatorics.sigma-decompositions where
+
+open import foundation.sigma-decompositions public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.sigma-decompositions public
-
 open import foundation.cartesian-product-types
 open import foundation.embeddings
 open import foundation.equivalences

--- a/src/univalent-combinatorics/small-types.lagda.md
+++ b/src/univalent-combinatorics/small-types.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module univalent-combinatorics.small-types where
+
+open import foundation.small-types public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.small-types public
-
 open import elementary-number-theory.natural-numbers
 
 open import foundation.dependent-pair-types

--- a/src/univalent-combinatorics/sums-of-natural-numbers.lagda.md
+++ b/src/univalent-combinatorics/sums-of-natural-numbers.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module univalent-combinatorics.sums-of-natural-numbers where
+
+open import elementary-number-theory.sums-of-natural-numbers public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import elementary-number-theory.sums-of-natural-numbers public
-
 open import elementary-number-theory.natural-numbers
 
 open import foundation.dependent-pair-types

--- a/src/univalent-combinatorics/surjective-maps.lagda.md
+++ b/src/univalent-combinatorics/surjective-maps.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module univalent-combinatorics.surjective-maps where
+
+open import foundation.surjective-maps public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.surjective-maps public
-
 open import elementary-number-theory.natural-numbers
 
 open import foundation.cartesian-product-types

--- a/src/univalent-combinatorics/symmetric-difference.lagda.md
+++ b/src/univalent-combinatorics/symmetric-difference.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module univalent-combinatorics.symmetric-difference where
+
+open import foundation.symmetric-difference public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.symmetric-difference public
-
 open import elementary-number-theory.addition-natural-numbers
 open import elementary-number-theory.multiplication-natural-numbers
 open import elementary-number-theory.natural-numbers

--- a/src/univalent-combinatorics/trivial-sigma-decompositions.lagda.md
+++ b/src/univalent-combinatorics/trivial-sigma-decompositions.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module univalent-combinatorics.trivial-sigma-decompositions where
+
+open import foundation.trivial-sigma-decompositions public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.trivial-sigma-decompositions public
-
 open import foundation.contractible-types
 open import foundation.dependent-pair-types
 open import foundation.identity-types

--- a/src/univalent-combinatorics/type-duality.lagda.md
+++ b/src/univalent-combinatorics/type-duality.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module univalent-combinatorics.type-duality where
+
+open import foundation.type-duality public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.type-duality public
-
 open import foundation.cartesian-product-types
 open import foundation.dependent-pair-types
 open import foundation.equivalences

--- a/src/univalent-combinatorics/unions-subtypes.lagda.md
+++ b/src/univalent-combinatorics/unions-subtypes.lagda.md
@@ -2,13 +2,13 @@
 
 ```agda
 module univalent-combinatorics.unions-subtypes where
+
+open import foundation.unions-subtypes public
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.unions-subtypes public
-
 open import foundation.decidable-equality
 open import foundation.propositional-truncations
 open import foundation.subtypes


### PR DESCRIPTION
### Summary
- Move public imports before "Imports" block
- Make start of file formatting consistent
- Update file conventions
- make nonpublic two rogue public imports that should not have been
- Prohibit public imports inside "Imports" block as part of the `fix_imports.py` hook