### PR TITLE
Torsorial type families

### DIFF
--- a/src/foundation-core/identity-types.lagda.md
+++ b/src/foundation-core/identity-types.lagda.md
@@ -66,7 +66,7 @@ identifications in arbitrary types.
 | Large identity types                             | [`foundation.large-identity-types`](foundation.large-identity-types.md)                                                   |
 | Path algebra                                     | [`foundation.path-algebra`](foundation.path-algebra.md)                                                                   |
 | Symmetric identity types                         | [`foundation.symmetric-identity-types`](foundation.symmetric-identity-types.md)                                           |
-| Torsorial type families | [`foundation.torsorial-type-families`](foundation.torsorial-type-families.md) |
+| Torsorial type families                          | [`foundation.torsorial-type-families`](foundation.torsorial-type-families.md)                                             |
 | Transport (foundation)                           | [`foundation.transport`](foundation.transport.md)                                                                         |
 | Transport (foundation-core)                      | [`foundation-core.transport`](foundation-core.transport.md)                                                               |
 | The universal property of identity types         | [`foundation.universal-property-identity-types`](foundation.universal-property-identity-types.md)                         |

--- a/src/foundation-core/identity-types.lagda.md
+++ b/src/foundation-core/identity-types.lagda.md
@@ -66,6 +66,7 @@ identifications in arbitrary types.
 | Large identity types                             | [`foundation.large-identity-types`](foundation.large-identity-types.md)                                                   |
 | Path algebra                                     | [`foundation.path-algebra`](foundation.path-algebra.md)                                                                   |
 | Symmetric identity types                         | [`foundation.symmetric-identity-types`](foundation.symmetric-identity-types.md)                                           |
+| Torsorial type families | [`foundation.torsorial-type-families`](foundation.torsorial-type-families.md) |
 | Transport (foundation)                           | [`foundation.transport`](foundation.transport.md)                                                                         |
 | Transport (foundation-core)                      | [`foundation-core.transport`](foundation-core.transport.md)                                                               |
 | The universal property of identity types         | [`foundation.universal-property-identity-types`](foundation.universal-property-identity-types.md)                         |

--- a/src/foundation-core/small-types.lagda.md
+++ b/src/foundation-core/small-types.lagda.md
@@ -53,6 +53,10 @@ equiv-is-small :
   {l l1 : Level} {A : UU l1} (H : is-small l A) → A ≃ type-is-small H
 equiv-is-small = pr2
 
+inv-equiv-is-small :
+  {l l1 : Level} {A : UU l1} (H : is-small l A) → type-is-small H ≃ A
+inv-equiv-is-small H = inv-equiv (equiv-is-small H)
+
 map-equiv-is-small :
   {l l1 : Level} {A : UU l1} (H : is-small l A) → A → type-is-small H
 map-equiv-is-small H = map-equiv (equiv-is-small H)

--- a/src/foundation.lagda.md
+++ b/src/foundation.lagda.md
@@ -188,6 +188,7 @@ open import foundation.path-split-maps public
 open import foundation.perfect-images public
 open import foundation.pi-decompositions public
 open import foundation.pi-decompositions-subuniverse public
+open import foundation.pointed-torsorial-type-families public
 open import foundation.powersets public
 open import foundation.preidempotent-maps public
 open import foundation.preimages-of-subtypes public
@@ -232,6 +233,7 @@ open import foundation.slice public
 open import foundation.small-maps public
 open import foundation.small-types public
 open import foundation.small-universes public
+open import foundation.sorial-type-families public
 open import foundation.split-surjective-maps public
 open import foundation.standard-apartness-relations public
 open import foundation.strongly-extensional-maps public
@@ -248,6 +250,7 @@ open import foundation.symmetric-difference public
 open import foundation.symmetric-identity-types public
 open import foundation.symmetric-operations public
 open import foundation.tight-apartness-relations public
+open import foundation.torsorial-type-families public
 open import foundation.transport public
 open import foundation.trivial-relaxed-sigma-decompositions public
 open import foundation.trivial-sigma-decompositions public

--- a/src/foundation/axiom-l.lagda.md
+++ b/src/foundation/axiom-l.lagda.md
@@ -7,26 +7,13 @@ module foundation.axiom-l where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
 open import foundation.embeddings
 open import foundation.equivalences
-open import foundation.full-subtypes
-open import foundation.function-extensionality
-open import foundation.functoriality-dependent-function-types
-open import foundation.fundamental-theorem-of-identity-types
 open import foundation.sets
-open import foundation.type-theoretic-principle-of-choice
-open import foundation.universal-property-identity-types
 open import foundation.universe-levels
 
-open import foundation-core.contractible-types
-open import foundation-core.fibers-of-maps
-open import foundation-core.function-types
-open import foundation-core.functoriality-dependent-pair-types
 open import foundation-core.identity-types
-open import foundation-core.injective-maps
-open import foundation-core.propositions
 open import foundation-core.univalence
 ```
 
@@ -71,44 +58,4 @@ axiom-L-axiom-K K K-UU A B =
     ( is-set-equiv-is-set
       ( is-set-axiom-K (K A))
       ( is-set-axiom-K (K B)))
-```
-
-### Axiom L implies that `Id : A → A → UU l` is an embedding
-
-```agda
-module _
-  {l : Level} (L : axiom-L l) (A : UU l)
-  where
-
-  is-emb-Id : is-emb (Id {A = A})
-  is-emb-Id x =
-    fundamental-theorem-id
-      ( pair
-        ( pair x refl)
-        ( λ _ →
-          is-injective-emb
-            ( emb-fib x)
-            ( eq-is-contr (is-contr-total-path x))))
-      ( λ _ → ap Id)
-    where
-    emb-fib : (x : A) → fib' Id (Id x) ↪ Σ A (Id x)
-    emb-fib x =
-      comp-emb
-        ( comp-emb
-          ( emb-equiv
-            ( equiv-tot
-              ( λ y →
-                ( equiv-ev-refl y) ∘e
-                ( ( equiv-inclusion-is-full-subtype
-                    ( Π-Prop A ∘ (is-equiv-Prop ∘_))
-                    ( fundamental-theorem-id (is-contr-total-path x))) ∘e
-                  ( distributive-Π-Σ)))))
-          ( emb-Σ
-            ( λ y → (z : A) → Id y z ≃ Id x z)
-            ( id-emb)
-            ( λ y →
-              comp-emb
-                ( emb-Π (λ z → emb-L L (Id y z) (Id x z)))
-                ( emb-equiv equiv-funext))))
-        ( emb-equiv (inv-equiv (equiv-fib Id (Id x))))
 ```

--- a/src/foundation/axiom-l.lagda.md
+++ b/src/foundation/axiom-l.lagda.md
@@ -59,3 +59,9 @@ axiom-L-axiom-K K K-UU A B =
       ( is-set-axiom-K (K A))
       ( is-set-axiom-K (K B)))
 ```
+
+## See also
+
+- Axiom L is sufficient to prove that `Id : A → (A → 𝒰)` is an embedding. This
+  fact is proven in
+  [`foundation.universal-property-identity-types`](foundation.universal-property-identity-types.md)

--- a/src/foundation/identity-types.lagda.md
+++ b/src/foundation/identity-types.lagda.md
@@ -55,6 +55,7 @@ identifications in arbitrary types.
 | Large identity types                             | [`foundation.large-identity-types`](foundation.large-identity-types.md)                                                   |
 | Path algebra                                     | [`foundation.path-algebra`](foundation.path-algebra.md)                                                                   |
 | Symmetric identity types                         | [`foundation.symmetric-identity-types`](foundation.symmetric-identity-types.md)                                           |
+| Torsorial type families | [`foundation.torsorial-type-families`](foundation.torsorial-type-families.md) |
 | Transport (foundation)                           | [`foundation.transport`](foundation.transport.md)                                                                         |
 | Transport (foundation-core)                      | [`foundation-core.transport`](foundation-core.transport.md)                                                               |
 | The universal property of identity types         | [`foundation.universal-property-identity-types`](foundation.universal-property-identity-types.md)                         |

--- a/src/foundation/identity-types.lagda.md
+++ b/src/foundation/identity-types.lagda.md
@@ -55,7 +55,7 @@ identifications in arbitrary types.
 | Large identity types                             | [`foundation.large-identity-types`](foundation.large-identity-types.md)                                                   |
 | Path algebra                                     | [`foundation.path-algebra`](foundation.path-algebra.md)                                                                   |
 | Symmetric identity types                         | [`foundation.symmetric-identity-types`](foundation.symmetric-identity-types.md)                                           |
-| Torsorial type families | [`foundation.torsorial-type-families`](foundation.torsorial-type-families.md) |
+| Torsorial type families                          | [`foundation.torsorial-type-families`](foundation.torsorial-type-families.md)                                             |
 | Transport (foundation)                           | [`foundation.transport`](foundation.transport.md)                                                                         |
 | Transport (foundation-core)                      | [`foundation-core.transport`](foundation-core.transport.md)                                                               |
 | The universal property of identity types         | [`foundation.universal-property-identity-types`](foundation.universal-property-identity-types.md)                         |

--- a/src/foundation/pointed-torsorial-type-families.lagda.md
+++ b/src/foundation/pointed-torsorial-type-families.lagda.md
@@ -32,19 +32,28 @@ open import structured-types.pointed-types
 
 ## Idea
 
-A type family `E` over a [pointed type](structured-types.pointed-types.md) `B` is said to be **pointed torsorial** if it comes equipped with a family of equivalences
+A type family `E` over a [pointed type](structured-types.pointed-types.md) `B`
+is said to be **pointed torsorial** if it comes equipped with a family of
+equivalences
 
 ```text
   E x ≃ (pt ＝ x)
 ```
 
-indexed by `x : B`. Note that the type of such a **torsorial structure** on the type family `E` is [equivalent](foundation.equivalences.md) to the type
+indexed by `x : B`. Note that the type of such a **torsorial structure** on the
+type family `E` is [equivalent](foundation.equivalences.md) to the type
 
 ```text
   E pt × is-contr (Σ B E)
 ```
 
-Indeed, if `E` is pointed torsorial, then `refl : pt ＝ pt` induces an element in `E pt`, and the [total space](foundation.dependent-pair-types.md) of `E` is [contractible](foundation.contractible-types.md) by the [fundamental theorem of identity types](foundation.fundamental-theorem-of-identity-types.md). Conversely, if we are given an element `y : E pt` and the total space of `E` is contractible, then the unique family of maps `(pt ＝ x) → E x` mapping `refl` to `y` is a family of equivalences.
+Indeed, if `E` is pointed torsorial, then `refl : pt ＝ pt` induces an element
+in `E pt`, and the [total space](foundation.dependent-pair-types.md) of `E` is
+[contractible](foundation.contractible-types.md) by the
+[fundamental theorem of identity types](foundation.fundamental-theorem-of-identity-types.md).
+Conversely, if we are given an element `y : E pt` and the total space of `E` is
+contractible, then the unique family of maps `(pt ＝ x) → E x` mapping `refl` to
+`y` is a family of equivalences.
 
 ## Definitions
 

--- a/src/foundation/pointed-torsorial-type-families.lagda.md
+++ b/src/foundation/pointed-torsorial-type-families.lagda.md
@@ -1,0 +1,190 @@
+# Pointed torsorial type families
+
+```agda
+module foundation.pointed-torsorial-type-families where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.0-connected-types
+open import foundation.cartesian-product-types
+open import foundation.contractible-types
+open import foundation.dependent-pair-types
+open import foundation.equivalences
+open import foundation.functoriality-dependent-pair-types
+open import foundation.fundamental-theorem-of-identity-types
+open import foundation.identity-types
+open import foundation.locally-small-types
+open import foundation.logical-equivalences
+open import foundation.propositional-truncations
+open import foundation.propositions
+open import foundation.small-types
+open import foundation.sorial-type-families
+open import foundation.transport
+open import foundation.type-theoretic-principle-of-choice
+open import foundation.universe-levels
+
+open import structured-types.pointed-types
+```
+
+</details>
+
+## Idea
+
+A type family `E` over a [pointed type](structured-types.pointed-types.md) `B` is said to be **pointed torsorial** if it comes equipped with a family of equivalences
+
+```text
+  E x ≃ (pt ＝ x)
+```
+
+indexed by `x : B`. Note that the type of such a **torsorial structure** on the type family `E` is [equivalent](foundation.equivalences.md) to the type
+
+```text
+  E pt × is-contr (Σ B E)
+```
+
+Indeed, if `E` is pointed torsorial, then `refl : pt ＝ pt` induces an element in `E pt`, and the [total space](foundation.dependent-pair-types.md) of `E` is [contractible](foundation.contractible-types.md) by the [fundamental theorem of identity types](foundation.fundamental-theorem-of-identity-types.md). Conversely, if we are given an element `y : E pt` and the total space of `E` is contractible, then the unique family of maps `(pt ＝ x) → E x` mapping `refl` to `y` is a family of equivalences.
+
+## Definitions
+
+### The predicate of being a pointed torsorial type family
+
+```agda
+module _
+  {l1 l2 : Level} (B : Pointed-Type l1) (E : type-Pointed-Type B → UU l2)
+  where
+
+  is-pointed-torsorial-family-of-types : UU (l1 ⊔ l2)
+  is-pointed-torsorial-family-of-types =
+    (x : type-Pointed-Type B) → E x ≃ (point-Pointed-Type B ＝ x)
+
+module _
+  {l1 l2 : Level} (B : Pointed-Type l1) {E : type-Pointed-Type B → UU l2}
+  (T : is-pointed-torsorial-family-of-types B E)
+  where
+
+  point-is-pointed-torsorial-family-of-types : E (point-Pointed-Type B)
+  point-is-pointed-torsorial-family-of-types =
+    map-inv-equiv (T (point-Pointed-Type B)) refl
+
+  is-contr-total-space-is-pointed-torsorial-family-of-types :
+    is-contr (Σ (type-Pointed-Type B) E)
+  is-contr-total-space-is-pointed-torsorial-family-of-types =
+    fundamental-theorem-id'
+      ( λ x → map-inv-equiv (T x))
+      ( λ x → is-equiv-map-inv-equiv (T x))
+```
+
+### Torsorial families of types
+
+```agda
+pointed-torsorial-family-of-types :
+  {l1 : Level} (l2 : Level) (B : Pointed-Type l1) → UU (l1 ⊔ lsuc l2)
+pointed-torsorial-family-of-types l2 B =
+  Σ (type-Pointed-Type B → UU l2) (is-pointed-torsorial-family-of-types B)
+```
+
+## Properties
+
+### Any torsorial type family is sorial
+
+```agda
+is-sorial-is-pointed-torsorial-family-of-types :
+  {l1 l2 : Level} (B : Pointed-Type l1) {E : type-Pointed-Type B → UU l2} →
+  is-pointed-torsorial-family-of-types B E → is-sorial-family-of-types B E
+is-sorial-is-pointed-torsorial-family-of-types B {E} H x y =
+  equiv-tr E (map-equiv (H x) y)
+```
+
+### Being pointed torsorial is equivalent to being pointed and having contractible total space
+
+```agda
+module _
+  {l1 l2 : Level} (B : Pointed-Type l1) {E : type-Pointed-Type B → UU l2}
+  where
+
+  point-and-contractible-total-space-is-pointed-torsorial-family-of-types :
+    is-pointed-torsorial-family-of-types B E →
+    E (point-Pointed-Type B) × is-contr (Σ (type-Pointed-Type B) E)
+  pr1
+    ( point-and-contractible-total-space-is-pointed-torsorial-family-of-types H)
+    =
+    point-is-pointed-torsorial-family-of-types B H
+  pr2
+    ( point-and-contractible-total-space-is-pointed-torsorial-family-of-types H)
+    =
+    is-contr-total-space-is-pointed-torsorial-family-of-types B H
+```
+
+### Pointed connected types equipped with a pointed torsorial family of types of universe level `l` are locally `l`-small
+
+```agda
+module _
+  {l1 l2 : Level} (B : Pointed-Type l1) {E : type-Pointed-Type B → UU l2}
+  (T : is-pointed-torsorial-family-of-types B E)
+  where
+
+  is-locally-small-is-pointed-torsorial-family-of-types :
+    is-0-connected (type-Pointed-Type B) →
+    is-locally-small l2 (type-Pointed-Type B)
+  is-locally-small-is-pointed-torsorial-family-of-types H x y =
+    apply-universal-property-trunc-Prop
+      ( mere-eq-is-0-connected H (point-Pointed-Type B) x)
+      ( is-small-Prop l2 (x ＝ y))
+      ( λ { refl → (E y , inv-equiv (T y))})
+```
+
+### The type of pointed torsorial type families of universe level `l` over a pointed connected type is equivalent to the proposition that `B` is locally `l`-small
+
+```agda
+module _
+  {l1 l2 : Level} (B : Pointed-Type l1)
+  where
+
+  is-locally-small-pointed-torsorial-family-of-types :
+    is-0-connected (type-Pointed-Type B) →
+    pointed-torsorial-family-of-types l2 B →
+    is-locally-small l2 (type-Pointed-Type B)
+  is-locally-small-pointed-torsorial-family-of-types H (E , T) =
+    is-locally-small-is-pointed-torsorial-family-of-types B T H
+
+  pointed-torsorial-family-of-types-is-locally-small :
+    is-locally-small l2 (type-Pointed-Type B) →
+    pointed-torsorial-family-of-types l2 B
+  pr1 (pointed-torsorial-family-of-types-is-locally-small H) x =
+    type-is-small (H (point-Pointed-Type B) x)
+  pr2 (pointed-torsorial-family-of-types-is-locally-small H) x =
+    inv-equiv-is-small (H (point-Pointed-Type B) x)
+
+  is-prop-pointed-torsorial-family-of-types :
+    is-prop (pointed-torsorial-family-of-types l2 B)
+  is-prop-pointed-torsorial-family-of-types =
+    is-prop-equiv'
+      ( distributive-Π-Σ)
+      ( is-prop-Π
+        ( λ x →
+          is-prop-equiv
+            ( equiv-tot (λ X → equiv-inv-equiv))
+            ( is-prop-is-small l2 (point-Pointed-Type B ＝ x))))
+
+  compute-pointed-torsorial-family-of-types-is-0-connected :
+    is-0-connected (type-Pointed-Type B) →
+    is-locally-small l2 (type-Pointed-Type B) ≃
+    pointed-torsorial-family-of-types l2 B
+  compute-pointed-torsorial-family-of-types-is-0-connected H =
+    equiv-iff
+      ( is-locally-small-Prop l2 (type-Pointed-Type B))
+      ( pointed-torsorial-family-of-types l2 B ,
+        is-prop-pointed-torsorial-family-of-types)
+      ( pointed-torsorial-family-of-types-is-locally-small)
+      ( is-locally-small-pointed-torsorial-family-of-types H)
+
+  is-contr-pointed-torsorial-family-of-types :
+    is-locally-small l2 (type-Pointed-Type B) →
+    is-contr (pointed-torsorial-family-of-types l2 B)
+  is-contr-pointed-torsorial-family-of-types H =
+    is-proof-irrelevant-is-prop
+      ( is-prop-pointed-torsorial-family-of-types)
+      ( pointed-torsorial-family-of-types-is-locally-small H)
+```

--- a/src/foundation/sorial-type-families.lagda.md
+++ b/src/foundation/sorial-type-families.lagda.md
@@ -1,0 +1,40 @@
+# Sorial type families
+
+```agda
+module foundation.sorial-type-families where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.equivalences
+open import foundation.universe-levels
+
+open import structured-types.pointed-types
+```
+
+</details>
+
+## Idea
+
+The notion of _sorial type family_ is a generalization of the notion of [torsorial type family]. Recall that if a type family `E` over a [pointed type](structured-types.pointed-types.md) `B` is torsorial, then we obtain in a canonical way, for each `x : B` an action
+
+```text
+  E x → (E pt ≃ E x)
+```
+
+A **sorial type family** is a type family `E` over a pointed type `B` for which we have such an action.
+
+## Definitions
+
+### Sorial type families
+
+```agda
+module _
+  {l1 l2 : Level} (B : Pointed-Type l1) (E : type-Pointed-Type B → UU l2)
+  where
+
+  is-sorial-family-of-types : UU (l1 ⊔ l2)
+  is-sorial-family-of-types =
+    (x : type-Pointed-Type B) → E x → (E (point-Pointed-Type B) ≃ E x)
+```

--- a/src/foundation/sorial-type-families.lagda.md
+++ b/src/foundation/sorial-type-families.lagda.md
@@ -18,9 +18,9 @@ open import structured-types.pointed-types
 ## Idea
 
 The notion of _sorial type family_ is a generalization of the notion of
-[torsorial type family]. Recall that if a type family `E` over a
-[pointed type](structured-types.pointed-types.md) `B` is torsorial, then we
-obtain in a canonical way, for each `x : B` an action
+[torsorial type family](foundation.torsorial-type-families.md). Recall that if a
+type family `E` over a [pointed type](structured-types.pointed-types.md) `B` is
+torsorial, then we obtain in a canonical way, for each `x : B` an action
 
 ```text
   E x → (E pt ≃ E x)

--- a/src/foundation/sorial-type-families.lagda.md
+++ b/src/foundation/sorial-type-families.lagda.md
@@ -17,13 +17,17 @@ open import structured-types.pointed-types
 
 ## Idea
 
-The notion of _sorial type family_ is a generalization of the notion of [torsorial type family]. Recall that if a type family `E` over a [pointed type](structured-types.pointed-types.md) `B` is torsorial, then we obtain in a canonical way, for each `x : B` an action
+The notion of _sorial type family_ is a generalization of the notion of
+[torsorial type family]. Recall that if a type family `E` over a
+[pointed type](structured-types.pointed-types.md) `B` is torsorial, then we
+obtain in a canonical way, for each `x : B` an action
 
 ```text
   E x → (E pt ≃ E x)
 ```
 
-A **sorial type family** is a type family `E` over a pointed type `B` for which we have such an action.
+A **sorial type family** is a type family `E` over a pointed type `B` for which
+we have such an action.
 
 ## Definitions
 

--- a/src/foundation/torsorial-type-families.lagda.md
+++ b/src/foundation/torsorial-type-families.lagda.md
@@ -1,0 +1,57 @@
+# Torsorial type families
+
+```agda
+module foundation.torsorial-type-families where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.contractible-types
+open import foundation.dependent-pair-types
+open import foundation.propositions
+open import foundation.universe-levels
+```
+
+</details>
+
+## Idea
+
+A type family `E` over `B` is said to be **torsorial** if its [total space](foundation.dependent-pair-types.md) is [contractible](foundation.contractible-types.md). By the [fundamental theorem of identity types](foundation.fundamental-theorem-of-identity-types.md) it follows that a type family `E` is torsorial if and only if it is in the [image](foundation.images.md) of `Id : B → (B → 𝒰)`.
+
+## Definition
+
+### The predicate of being a torsorial type family over `B`
+
+```agda
+is-torsorial-Prop :
+  {l1 l2 : Level} {B : UU l1} → (B → UU l2) → Prop (l1 ⊔ l2)
+is-torsorial-Prop E = is-contr-Prop (Σ _ E)
+
+is-torsorial :
+  {l1 l2 : Level} {B : UU l1} → (B → UU l2) → UU (l1 ⊔ l2)
+is-torsorial E = type-Prop (is-torsorial-Prop E)
+
+is-prop-is-torsorial :
+  {l1 l2 : Level} {B : UU l1} (E : B → UU l2) → is-prop (is-torsorial E)
+is-prop-is-torsorial E = is-prop-type-Prop (is-torsorial-Prop E)
+```
+
+### The type of torsorial type families over `B`
+
+```agda
+torsorial-family-of-types :
+  {l1 : Level} (l2 : Level) → UU l1 → UU (l1 ⊔ lsuc l2)
+torsorial-family-of-types l2 B = Σ (B → UU l2) is-torsorial
+
+module _
+  {l1 l2 : Level} {B : UU l1} (T : torsorial-family-of-types l2 B)
+  where
+  
+  type-torsorial-family-of-types : B → UU l2
+  type-torsorial-family-of-types = pr1 T
+
+  is-torsorial-torsorial-family-of-types :
+    is-torsorial type-torsorial-family-of-types
+  is-torsorial-torsorial-family-of-types = pr2 T
+```

--- a/src/foundation/torsorial-type-families.lagda.md
+++ b/src/foundation/torsorial-type-families.lagda.md
@@ -72,13 +72,20 @@ module _
 
 #### `fib Id B ≃ is-contr (Σ A B)` for any type family `B` over `A`
 
-In other words, a type family `B` over `A` is in the [image](foundation.images.md) of `Id : A → (A → 𝒰)` if and only if `B` is torsorial. Since being contractible is a [proposition](foundation.propositions.md), this observation leads to an alternative proof of the above claim that `Id : A → (A → 𝒰)` is an [embedding](foundation.embeddings.md). Our previous proof of the fact that `Id : A → (A → 𝒰)` is an embedding can be found in [`foundation.universal-property-identity-types`](foundation.universal-property-identity-types.md).
+In other words, a type family `B` over `A` is in the
+[image](foundation.images.md) of `Id : A → (A → 𝒰)` if and only if `B` is
+torsorial. Since being contractible is a
+[proposition](foundation.propositions.md), this observation leads to an
+alternative proof of the above claim that `Id : A → (A → 𝒰)` is an
+[embedding](foundation.embeddings.md). Our previous proof of the fact that
+`Id : A → (A → 𝒰)` is an embedding can be found in
+[`foundation.universal-property-identity-types`](foundation.universal-property-identity-types.md).
 
 ```agda
 module _
   {l1 l2 : Level} {A : UU l1} {B : A → UU l2}
   where
-  
+
   is-torsorial-fib-Id :
     {a : A} → ((x : A) → (a ＝ x) ≃ B x) → is-torsorial B
   is-torsorial-fib-Id H =

--- a/src/foundation/torsorial-type-families.lagda.md
+++ b/src/foundation/torsorial-type-families.lagda.md
@@ -17,7 +17,12 @@ open import foundation.universe-levels
 
 ## Idea
 
-A type family `E` over `B` is said to be **torsorial** if its [total space](foundation.dependent-pair-types.md) is [contractible](foundation.contractible-types.md). By the [fundamental theorem of identity types](foundation.fundamental-theorem-of-identity-types.md) it follows that a type family `E` is torsorial if and only if it is in the [image](foundation.images.md) of `Id : B → (B → 𝒰)`.
+A type family `E` over `B` is said to be **torsorial** if its
+[total space](foundation.dependent-pair-types.md) is
+[contractible](foundation.contractible-types.md). By the
+[fundamental theorem of identity types](foundation.fundamental-theorem-of-identity-types.md)
+it follows that a type family `E` is torsorial if and only if it is in the
+[image](foundation.images.md) of `Id : B → (B → 𝒰)`.
 
 ## Definition
 
@@ -47,7 +52,7 @@ torsorial-family-of-types l2 B = Σ (B → UU l2) is-torsorial
 module _
   {l1 l2 : Level} {B : UU l1} (T : torsorial-family-of-types l2 B)
   where
-  
+
   type-torsorial-family-of-types : B → UU l2
   type-torsorial-family-of-types = pr1 T
 

--- a/src/foundation/torsorial-type-families.lagda.md
+++ b/src/foundation/torsorial-type-families.lagda.md
@@ -9,7 +9,14 @@ module foundation.torsorial-type-families where
 ```agda
 open import foundation.contractible-types
 open import foundation.dependent-pair-types
+open import foundation.equivalences
+open import foundation.fundamental-theorem-of-identity-types
+open import foundation.identity-types
+open import foundation.logical-equivalences
+open import foundation.propositional-maps
 open import foundation.propositions
+open import foundation.type-theoretic-principle-of-choice
+open import foundation.universal-property-identity-types
 open import foundation.universe-levels
 ```
 
@@ -59,4 +66,42 @@ module _
   is-torsorial-torsorial-family-of-types :
     is-torsorial type-torsorial-family-of-types
   is-torsorial-torsorial-family-of-types = pr2 T
+```
+
+## Properties
+
+#### `fib Id B ≃ is-contr (Σ A B)` for any type family `B` over `A`
+
+In other words, a type family `B` over `A` is in the [image](foundation.images.md) of `Id : A → (A → 𝒰)` if and only if `B` is torsorial. Since being contractible is a [proposition](foundation.propositions.md), this observation leads to an alternative proof of the above claim that `Id : A → (A → 𝒰)` is an [embedding](foundation.embeddings.md). Our previous proof of the fact that `Id : A → (A → 𝒰)` is an embedding can be found in [`foundation.universal-property-identity-types`](foundation.universal-property-identity-types.md).
+
+```agda
+module _
+  {l1 l2 : Level} {A : UU l1} {B : A → UU l2}
+  where
+  
+  is-torsorial-fib-Id :
+    {a : A} → ((x : A) → (a ＝ x) ≃ B x) → is-torsorial B
+  is-torsorial-fib-Id H =
+    fundamental-theorem-id'
+      ( λ x → map-equiv (H x))
+      ( λ x → is-equiv-map-equiv (H x))
+
+  fib-Id-is-torsorial :
+    is-torsorial B → Σ A (λ a → (x : A) → (a ＝ x) ≃ B x)
+  pr1 (fib-Id-is-torsorial ((a , b) , H)) = a
+  pr2 (fib-Id-is-torsorial ((a , b) , H)) =
+    map-inv-distributive-Π-Σ (f , fundamental-theorem-id ((a , b) , H) f)
+    where
+    f : (x : A) → (a ＝ x) → B x
+    f x refl = b
+
+  compute-fib-Id :
+    (Σ A (λ a → (x : A) → (a ＝ x) ≃ B x)) ≃ is-contr (Σ A B)
+  compute-fib-Id =
+    equiv-iff
+      ( Σ A (λ a → (x : A) → (a ＝ x) ≃ B x) ,
+        is-prop-total-family-of-equivalences-Id)
+      ( is-contr-Prop (Σ A B))
+      ( λ u → is-torsorial-fib-Id (pr2 u))
+      ( fib-Id-is-torsorial)
 ```

--- a/src/foundation/universal-property-identity-types.lagda.md
+++ b/src/foundation/universal-property-identity-types.lagda.md
@@ -26,7 +26,6 @@ open import foundation-core.contractible-types
 open import foundation-core.dependent-pair-types
 open import foundation-core.fibers-of-maps
 open import foundation-core.function-types
-open import foundation-core.functoriality-dependent-pair-types
 open import foundation-core.injective-maps
 open import foundation-core.propositions
 ```
@@ -76,11 +75,39 @@ equiv-ev-refl' a {B} =
 
 ### `Id : A → (A → 𝒰)` is an embedding
 
-We first show that [axiom L](foundation.axiom-l.md) implies that the map `Id : A → (A → 𝒰)` is an [embedding](foundation.embeddings.md). Since the [univalence axiom](foundation.univalence.md) implies axiom L, it follows that `Id : A → (A → 𝒰)` is an embedding under the postulates of agda-unimath.
+We first show that [axiom L](foundation.axiom-l.md) implies that the map
+`Id : A → (A → 𝒰)` is an [embedding](foundation.embeddings.md). Since the
+[univalence axiom](foundation.univalence.md) implies axiom L, it follows that
+`Id : A → (A → 𝒰)` is an embedding under the postulates of agda-unimath.
 
 #### Axiom L implies that `Id : A → (A → 𝒰)` is an embedding
 
-The proof that axiom L implies that `Id : A → (A → 𝒰)` is an embedding proceeds via the [fundamental theorem of identity types](foundation.fundamental-theorem-of-identity-types.md) by showing that the [fiber](foundation.fibers-of-maps.md) of `Id` at `Id x` is [contractible](foundation.contractible-types.md) for each `x : A`. 
+The proof that axiom L implies that `Id : A → (A → 𝒰)` is an embedding proceeds
+via the
+[fundamental theorem of identity types](foundation.fundamental-theorem-of-identity-types.md)
+by showing that the [fiber](foundation.fibers-of-maps.md) of `Id` at `Id a` is
+[contractible](foundation.contractible-types.md) for each `a : A`. To see this,
+we first note that this fiber has an element `(a , refl)`. Therefore it suffices
+to show that thsi fiber is a proposition. We do this by constructing an
+embedding
+
+```text
+  fib Id (Id a) ↪ Σ A (Id a).
+```
+
+Since the codomain of this embedding is contractible, the claim follows. The
+above embedding is constructed as the composite of the following embeddings
+
+```text
+  Σ (x : A), Id x ＝ Id a
+    ↪ Σ (x : A), (y : A) → (x ＝ y) ＝ (a ＝ y)
+    ↪ Σ (x : A), (y : A) → (x ＝ y) ≃ (a ＝ y)
+    ↪ Σ (x : A), Σ (e : (y : A) → (x ＝ y) → (a ＝ y)), (y : A) → is-equiv (e y)
+    ↪ Σ (x : A), (y : A) → (x ＝ y) → (a ＝ y)
+    ↪ Σ (x : A), a ＝ x.
+```
+
+In this composite, we used axiom L at the second step.
 
 ```agda
 module _
@@ -88,36 +115,36 @@ module _
   where
 
   is-emb-Id-axiom-L : is-emb (Id {A = A})
-  is-emb-Id-axiom-L x =
+  is-emb-Id-axiom-L a =
     fundamental-theorem-id
       ( pair
-        ( pair x refl)
+        ( pair a refl)
         ( λ _ →
           is-injective-emb
-            ( emb-fib x)
-            ( eq-is-contr (is-contr-total-path x))))
+            ( emb-fib a)
+            ( eq-is-contr (is-contr-total-path a))))
       ( λ _ → ap Id)
     where
-    emb-fib : (x : A) → fib' Id (Id x) ↪ Σ A (Id x)
-    emb-fib x =
+    emb-fib : (a : A) → fib' Id (Id a) ↪ Σ A (Id a)
+    emb-fib a =
       comp-emb
         ( comp-emb
           ( emb-equiv
             ( equiv-tot
-              ( λ y →
-                ( equiv-ev-refl y) ∘e
+              ( λ x →
+                ( equiv-ev-refl x) ∘e
                 ( ( equiv-inclusion-is-full-subtype
                     ( Π-Prop A ∘ (is-equiv-Prop ∘_))
-                    ( fundamental-theorem-id (is-contr-total-path x))) ∘e
+                    ( fundamental-theorem-id (is-contr-total-path a))) ∘e
                   ( distributive-Π-Σ)))))
           ( emb-Σ
-            ( λ y → (z : A) → Id y z ≃ Id x z)
+            ( λ x → (y : A) → Id x y ≃ Id a y)
             ( id-emb)
-            ( λ y →
+            ( λ x →
               comp-emb
-                ( emb-Π (λ z → emb-L L (Id y z) (Id x z)))
+                ( emb-Π (λ y → emb-L L (Id x y) (Id a y)))
                 ( emb-equiv equiv-funext))))
-        ( emb-equiv (inv-equiv (equiv-fib Id (Id x))))
+        ( emb-equiv (inv-equiv (equiv-fib Id (Id a))))
 ```
 
 #### `Id : A → (A → 𝒰)` is an embedding
@@ -131,7 +158,7 @@ module _
   is-emb-Id = is-emb-Id-axiom-L (axiom-L-univalence univalence) A
 ```
 
-#### For any type family `B` over `A`, the type of pairs `(a , e)` consisting of `a : A` and a family of equivalences `e : (x : A) → (a ＝ x) ≃ B x` is a proposition.
+#### For any type family `B` over `A`, the type of pairs `(a , e)` consisting of `a : A` and a family of equivalences `e : (x : A) → (a ＝ x) ≃ B x` is a proposition
 
 ```agda
 module _
@@ -161,3 +188,16 @@ module _
     is-prop-is-proof-irrelevant
       ( is-proof-irrelevant-total-family-of-equivalences-Id)
 ```
+
+## See also
+
+- In
+  [`foundation.torsorial-type-families`](foundation.torsorial-type-families.md)
+  we will show that the fiber of `Id : A → (A → 𝒰)`at`B : A → 𝒰`is equivalent
+  to`is-contr (Σ A B)`.
+
+## References
+
+- The fact that axiom L is sufficient to prove that `Id : A → (A → 𝒰)` is an
+  embedding was first observed and formalized by Martín Escardó,
+  [https://www.cs.bham.ac.uk//~mhe/TypeTopology/UF.IdEmbedding.html](https://www.cs.bham.ac.uk//~mhe/TypeTopology/UF.IdEmbedding.html).

--- a/src/foundation/universal-property-identity-types.lagda.md
+++ b/src/foundation/universal-property-identity-types.lagda.md
@@ -7,13 +7,28 @@ module foundation.universal-property-identity-types where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.dependent-pair-types
+open import foundation.action-on-identifications-functions
+open import foundation.axiom-l
+open import foundation.embeddings
+open import foundation.equivalences
+open import foundation.full-subtypes
 open import foundation.function-extensionality
+open import foundation.functoriality-dependent-function-types
+open import foundation.functoriality-dependent-pair-types
+open import foundation.fundamental-theorem-of-identity-types
 open import foundation.identity-types
+open import foundation.propositional-maps
+open import foundation.type-theoretic-principle-of-choice
+open import foundation.univalence
 open import foundation.universe-levels
 
-open import foundation-core.equivalences
-open import foundation-core.functoriality-dependent-function-types
+open import foundation-core.contractible-types
+open import foundation-core.dependent-pair-types
+open import foundation-core.fibers-of-maps
+open import foundation-core.function-types
+open import foundation-core.functoriality-dependent-pair-types
+open import foundation-core.injective-maps
+open import foundation-core.propositions
 ```
 
 </details>
@@ -57,4 +72,92 @@ equiv-ev-refl' :
   ((x : A) (p : x ＝ a) → B x p) ≃ B a refl
 equiv-ev-refl' a {B} =
   equiv-ev-refl a ∘e equiv-map-Π (λ x → equiv-precomp-Π (equiv-inv a x) (B x))
+```
+
+### `Id : A → (A → 𝒰)` is an embedding
+
+We first show that [axiom L](foundation.axiom-l.md) implies that the map `Id : A → (A → 𝒰)` is an [embedding](foundation.embeddings.md). Since the [univalence axiom](foundation.univalence.md) implies axiom L, it follows that `Id : A → (A → 𝒰)` is an embedding under the postulates of agda-unimath.
+
+#### Axiom L implies that `Id : A → (A → 𝒰)` is an embedding
+
+The proof that axiom L implies that `Id : A → (A → 𝒰)` is an embedding proceeds via the [fundamental theorem of identity types](foundation.fundamental-theorem-of-identity-types.md) by showing that the [fiber](foundation.fibers-of-maps.md) of `Id` at `Id x` is [contractible](foundation.contractible-types.md) for each `x : A`. 
+
+```agda
+module _
+  {l : Level} (L : axiom-L l) (A : UU l)
+  where
+
+  is-emb-Id-axiom-L : is-emb (Id {A = A})
+  is-emb-Id-axiom-L x =
+    fundamental-theorem-id
+      ( pair
+        ( pair x refl)
+        ( λ _ →
+          is-injective-emb
+            ( emb-fib x)
+            ( eq-is-contr (is-contr-total-path x))))
+      ( λ _ → ap Id)
+    where
+    emb-fib : (x : A) → fib' Id (Id x) ↪ Σ A (Id x)
+    emb-fib x =
+      comp-emb
+        ( comp-emb
+          ( emb-equiv
+            ( equiv-tot
+              ( λ y →
+                ( equiv-ev-refl y) ∘e
+                ( ( equiv-inclusion-is-full-subtype
+                    ( Π-Prop A ∘ (is-equiv-Prop ∘_))
+                    ( fundamental-theorem-id (is-contr-total-path x))) ∘e
+                  ( distributive-Π-Σ)))))
+          ( emb-Σ
+            ( λ y → (z : A) → Id y z ≃ Id x z)
+            ( id-emb)
+            ( λ y →
+              comp-emb
+                ( emb-Π (λ z → emb-L L (Id y z) (Id x z)))
+                ( emb-equiv equiv-funext))))
+        ( emb-equiv (inv-equiv (equiv-fib Id (Id x))))
+```
+
+#### `Id : A → (A → 𝒰)` is an embedding
+
+```agda
+module _
+  {l : Level} (A : UU l)
+  where
+
+  is-emb-Id : is-emb (Id {A = A})
+  is-emb-Id = is-emb-Id-axiom-L (axiom-L-univalence univalence) A
+```
+
+#### For any type family `B` over `A`, the type of pairs `(a , e)` consisting of `a : A` and a family of equivalences `e : (x : A) → (a ＝ x) ≃ B x` is a proposition.
+
+```agda
+module _
+  {l1 l2 : Level} {A : UU l1} {B : A → UU l2}
+  where
+
+  is-proof-irrelevant-total-family-of-equivalences-Id :
+    is-proof-irrelevant (Σ A (λ a → (x : A) → (a ＝ x) ≃ B x))
+  is-proof-irrelevant-total-family-of-equivalences-Id (a , e) =
+    is-contr-equiv
+      ( Σ A (λ b → (x : A) → (b ＝ x) ≃ (a ＝ x)))
+      ( equiv-tot
+        ( λ b →
+          equiv-map-Π
+            ( λ x → equiv-postcomp-equiv (inv-equiv (e x)) (b ＝ x))))
+      ( is-contr-equiv'
+        ( fib Id (Id a))
+        ( equiv-tot
+          ( λ b → equiv-map-Π (λ x → equiv-univalence) ∘e equiv-funext))
+        ( is-proof-irrelevant-is-prop
+          ( is-prop-map-is-emb (is-emb-Id A) (Id a))
+          ( a , refl)))
+
+  is-prop-total-family-of-equivalences-Id :
+    is-prop (Σ A (λ a → (x : A) → (a ＝ x) ≃ B x))
+  is-prop-total-family-of-equivalences-Id =
+    is-prop-is-proof-irrelevant
+      ( is-proof-irrelevant-total-family-of-equivalences-Id)
 ```

--- a/src/synthetic-homotopy-theory.lagda.md
+++ b/src/synthetic-homotopy-theory.lagda.md
@@ -29,6 +29,7 @@ open import synthetic-homotopy-theory.infinite-complex-projective-space public
 open import synthetic-homotopy-theory.infinite-cyclic-types public
 open import synthetic-homotopy-theory.interval-type public
 open import synthetic-homotopy-theory.iterated-loop-spaces public
+open import synthetic-homotopy-theory.join-powers-of-types public
 open import synthetic-homotopy-theory.joins-of-types public
 open import synthetic-homotopy-theory.loop-spaces public
 open import synthetic-homotopy-theory.multiplication-circle public

--- a/src/synthetic-homotopy-theory/join-powers-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/join-powers-of-types.lagda.md
@@ -1,0 +1,40 @@
+# Join powers of types
+
+```agda
+module synthetic-homotopy-theory.join-powers-of-types where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import elementary-number-theory.natural-numbers
+
+open import foundation.empty-types
+open import foundation.iterating-functions
+open import foundation.universe-levels
+
+open import synthetic-homotopy-theory.joins-of-types
+```
+
+</details>
+
+## Idea
+
+The `n`-th **join power** of a type `A` is defined by taking the [`n`-fold](foundation.interating-functions.md) [join](synthetic-homotopy-theory.joins-of-types.md) of `A` with itself.
+
+## Definitions
+
+### Join powers of types
+
+```agda
+join-power : {l1 : Level} → ℕ → UU l1 → UU l1
+join-power n A = iterate n (join A) (raise-empty _)
+```
+
+### Join powers of type families
+
+```agda
+join-power-family-of-types :
+  {l1 l2 : Level} → ℕ → {A : UU l1} → (A → UU l2) → (A → UU l2)
+join-power-family-of-types n B a = join-power n (B a)
+```

--- a/src/synthetic-homotopy-theory/join-powers-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/join-powers-of-types.lagda.md
@@ -21,7 +21,7 @@ open import synthetic-homotopy-theory.joins-of-types
 ## Idea
 
 The `n`-th **join power** of a type `A` is defined by taking the
-[`n`-fold](foundation.interating-functions.md)
+[`n`-fold](foundation.iterating-functions.md)
 [join](synthetic-homotopy-theory.joins-of-types.md) of `A` with itself.
 
 ## Definitions

--- a/src/synthetic-homotopy-theory/join-powers-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/join-powers-of-types.lagda.md
@@ -20,7 +20,9 @@ open import synthetic-homotopy-theory.joins-of-types
 
 ## Idea
 
-The `n`-th **join power** of a type `A` is defined by taking the [`n`-fold](foundation.interating-functions.md) [join](synthetic-homotopy-theory.joins-of-types.md) of `A` with itself.
+The `n`-th **join power** of a type `A` is defined by taking the
+[`n`-fold](foundation.interating-functions.md)
+[join](synthetic-homotopy-theory.joins-of-types.md) of `A` with itself.
 
 ## Definitions
 


### PR DESCRIPTION
This PR adds:

- torsorial type families
- pointed torsorial type families
- sorial type families
- join powers of types

following a project that I'm doing with Buchholtz, Christensen, Myers, and Taxeras Flaten.