### PR TITLE
Whitespace after closing braces and before opening braces

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,9 +48,10 @@ Below is a summary of the tasks this tool performs:
 
 - **Agda space conventions**: Corrects some common spacing mistakes according to
   our conventions. This includes removing repeat whitespace characters between
-  two non-whitespace characters in a line, always having a space before and
-  after a semicolon, and never having a space before a closing parenthesis or
-  curly brace.
+  two non-whitespace characters in a line, having whitespace before an opening
+  brace or semicolon if it is not preceeded by a dot or another opening brace,
+  and having whitespace after a closing brace or semicolon if it is not
+  succeeded by a closing brace.
 
 - **Indentation conventions**: Verifies that the indentation level is always a
   multiple of two. If inconsistencies are found, it provides an error report

--- a/scripts/spaces_conventions_simple.py
+++ b/scripts/spaces_conventions_simple.py
@@ -15,11 +15,11 @@ def no_repeat_whitespace_inside_line(line):
 
 
 def space_after_special_symbols(line):
-    return re.sub(r'([;)}])(?![)}])(\S)', r'\1 \2', line)
+    return re.sub(r'([;)}])(?![@"\')}])(\S)', r'\1 \2', line)
 
 
 def space_before_special_symbols(line):
-    return re.sub(r'(?![.{(])(\S)([;{(])', r'\1 \2', line)
+    return re.sub(r'(?![.@"\'{(])(\S)([;{(])', r'\1 \2', line)
 
 
 def no_whitespace_before_closing_parenthesis(line):

--- a/scripts/spaces_conventions_simple.py
+++ b/scripts/spaces_conventions_simple.py
@@ -14,12 +14,12 @@ def no_repeat_whitespace_inside_line(line):
     return re.sub(r'(?<=\S)\s{2,}', ' ', line)
 
 
-def space_before_semicolon(line):
-    return re.sub(r'(?<=\S);', ' ;', line)
+def space_after_special_symbols(line):
+    return re.sub(r'([;)}])(?![)}])(\S)', r'\1 \2', line)
 
 
-def space_after_semicolon(line):
-    return re.sub(r';(?=\S)', '; ', line)
+def space_before_special_symbols(line):
+    return re.sub(r'(?![.{(])(\S)([;{(])', r'\1 \2', line)
 
 
 def no_whitespace_before_closing_parenthesis(line):
@@ -56,8 +56,8 @@ if __name__ == '__main__':
                 if block_comment_level == 0:
                     line = no_repeat_whitespace_inside_line(
                         line)
-                    line = space_before_semicolon(line)
-                    line = space_after_semicolon(line)
+                    line = space_after_special_symbols(line)
+                    line = space_before_special_symbols(line)
                     line = no_whitespace_before_closing_parenthesis(line)
                     line = no_whitespace_before_closing_curly_brace(line)
                     # line = space_after_opening_parenthesis_on_new_line(line)

--- a/src/commutative-algebra/sums-commutative-rings.lagda.md
+++ b/src/commutative-algebra/sums-commutative-rings.lagda.md
@@ -195,7 +195,7 @@ split-sum-Commutative-Ring A n zero-ℕ f =
   inv (right-unit-law-add-Commutative-Ring A (sum-Commutative-Ring A n f))
 split-sum-Commutative-Ring A n (succ-ℕ m) f =
   ( ap
-    ( add-Commutative-Ring' A (f (inr star)))
+    ( add-Commutative-Ring' A (f(inr star)))
     ( split-sum-Commutative-Ring A n m (f ∘ inl))) ∙
   ( associative-add-Commutative-Ring A _ _ _)
 ```

--- a/src/commutative-algebra/sums-commutative-rings.lagda.md
+++ b/src/commutative-algebra/sums-commutative-rings.lagda.md
@@ -195,7 +195,7 @@ split-sum-Commutative-Ring A n zero-ℕ f =
   inv (right-unit-law-add-Commutative-Ring A (sum-Commutative-Ring A n f))
 split-sum-Commutative-Ring A n (succ-ℕ m) f =
   ( ap
-    ( add-Commutative-Ring' A (f(inr star)))
+    ( add-Commutative-Ring' A (f (inr star)))
     ( split-sum-Commutative-Ring A n m (f ∘ inl))) ∙
   ( associative-add-Commutative-Ring A _ _ _)
 ```

--- a/src/elementary-number-theory/fundamental-theorem-of-arithmetic.lagda.md
+++ b/src/elementary-number-theory/fundamental-theorem-of-arithmetic.lagda.md
@@ -544,7 +544,7 @@ is-decomposition-list-fundamental-theorem-arithmetic-ℕ x H =
                 ( preserves-leq-succ-ℕ 1 n N))
               ( leq-quotient-div-least-prime-divisor-ℕ
                 ( n)
-                ( le-succ-leq-ℕ 1 n N))))∙
+                ( le-succ-leq-ℕ 1 n N)))) ∙
           eq-quotient-div-ℕ'
             ( nat-least-prime-divisor-ℕ
               ( succ-ℕ n)

--- a/src/elementary-number-theory/fundamental-theorem-of-arithmetic.lagda.md
+++ b/src/elementary-number-theory/fundamental-theorem-of-arithmetic.lagda.md
@@ -544,7 +544,7 @@ is-decomposition-list-fundamental-theorem-arithmetic-ℕ x H =
                 ( preserves-leq-succ-ℕ 1 n N))
               ( leq-quotient-div-least-prime-divisor-ℕ
                 ( n)
-                ( le-succ-leq-ℕ 1 n N)))) ∙
+                ( le-succ-leq-ℕ 1 n N))))∙
           eq-quotient-div-ℕ'
             ( nat-least-prime-divisor-ℕ
               ( succ-ℕ n)

--- a/src/elementary-number-theory/maximum-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/maximum-natural-numbers.lagda.md
@@ -91,7 +91,7 @@ is-least-upper-bound-max-ℕ m n =
     { m}
     { n}
     { max-ℕ m n}
-    ( leq-left-leq-max-ℕ (max-ℕ m n) m n (refl-leq-ℕ (max-ℕ m n)),
+    ( leq-left-leq-max-ℕ (max-ℕ m n) m n (refl-leq-ℕ (max-ℕ m n)) ,
       leq-right-leq-max-ℕ (max-ℕ m n) m n (refl-leq-ℕ (max-ℕ m n)))
     ( λ x (H , K) → leq-max-ℕ x m n H K)
 ```

--- a/src/elementary-number-theory/maximum-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/maximum-natural-numbers.lagda.md
@@ -91,7 +91,7 @@ is-least-upper-bound-max-ℕ m n =
     { m}
     { n}
     { max-ℕ m n}
-    ( leq-left-leq-max-ℕ (max-ℕ m n) m n (refl-leq-ℕ (max-ℕ m n)) ,
+    ( leq-left-leq-max-ℕ (max-ℕ m n) m n (refl-leq-ℕ (max-ℕ m n)),
       leq-right-leq-max-ℕ (max-ℕ m n) m n (refl-leq-ℕ (max-ℕ m n)))
     ( λ x (H , K) → leq-max-ℕ x m n H K)
 ```

--- a/src/elementary-number-theory/natural-numbers.lagda.md
+++ b/src/elementary-number-theory/natural-numbers.lagda.md
@@ -84,7 +84,7 @@ is-not-one-ℕ' n = ¬ (is-one-ℕ' n)
 ```agda
 ind-ℕ :
   {l : Level} {P : ℕ → UU l} →
-  P 0 → ((n : ℕ) → P n → P(succ-ℕ n)) → ((n : ℕ) → P n)
+  P 0 → ((n : ℕ) → P n → P (succ-ℕ n)) → ((n : ℕ) → P n)
 ind-ℕ p0 pS 0 = p0
 ind-ℕ p0 pS (succ-ℕ n) = pS n (ind-ℕ p0 pS n)
 ```

--- a/src/elementary-number-theory/natural-numbers.lagda.md
+++ b/src/elementary-number-theory/natural-numbers.lagda.md
@@ -84,7 +84,7 @@ is-not-one-ℕ' n = ¬ (is-one-ℕ' n)
 ```agda
 ind-ℕ :
   {l : Level} {P : ℕ → UU l} →
-  P 0 → ((n : ℕ) → P n → P (succ-ℕ n)) → ((n : ℕ) → P n)
+  P 0 → ((n : ℕ) → P n → P(succ-ℕ n)) → ((n : ℕ) → P n)
 ind-ℕ p0 pS 0 = p0
 ind-ℕ p0 pS (succ-ℕ n) = pS n (ind-ℕ p0 pS n)
 ```

--- a/src/elementary-number-theory/prime-numbers.lagda.md
+++ b/src/elementary-number-theory/prime-numbers.lagda.md
@@ -95,7 +95,7 @@ is-nonzero-is-prime-ℕ n H p =
   is-not-one-two-ℕ
     ( pr1
       ( H 2)
-      ( tr (λ n → ¬ (2 ＝ n)) (inv (p)) ( is-nonzero-two-ℕ),
+      ( tr (λ n → ¬ (2 ＝ n)) (inv (p)) ( is-nonzero-two-ℕ) ,
         tr (λ n → div-ℕ 2 n) (inv p) (0 , refl)))
 ```
 

--- a/src/elementary-number-theory/prime-numbers.lagda.md
+++ b/src/elementary-number-theory/prime-numbers.lagda.md
@@ -95,7 +95,7 @@ is-nonzero-is-prime-ℕ n H p =
   is-not-one-two-ℕ
     ( pr1
       ( H 2)
-      ( tr (λ n → ¬ (2 ＝ n)) (inv (p)) ( is-nonzero-two-ℕ) ,
+      ( tr (λ n → ¬ (2 ＝ n)) (inv (p)) ( is-nonzero-two-ℕ),
         tr (λ n → div-ℕ 2 n) (inv p) (0 , refl)))
 ```
 

--- a/src/finite-group-theory/delooping-sign-homomorphism.lagda.md
+++ b/src/finite-group-theory/delooping-sign-homomorphism.lagda.md
@@ -118,7 +118,7 @@ module _
   ( quotient-aut-succ-succ-Fin : (n : ℕ) →
     ( raise-Fin l1 (n +ℕ 2) ≃ raise-Fin l1 (n +ℕ 2)) →
     D ( n +ℕ 2)
-      ( raise-Fin l1 (n +ℕ 2),
+      ( raise-Fin l1 (n +ℕ 2) ,
         unit-trunc-Prop (compute-raise-Fin l1 (n +ℕ 2))))
   ( not-R-transposition-fin-succ-succ : (n : ℕ) →
     ( Y : 2-Element-Decidable-Subtype l1 (raise-Fin l1 (n +ℕ 2))) →

--- a/src/finite-group-theory/delooping-sign-homomorphism.lagda.md
+++ b/src/finite-group-theory/delooping-sign-homomorphism.lagda.md
@@ -118,7 +118,7 @@ module _
   ( quotient-aut-succ-succ-Fin : (n : ℕ) →
     ( raise-Fin l1 (n +ℕ 2) ≃ raise-Fin l1 (n +ℕ 2)) →
     D ( n +ℕ 2)
-      ( raise-Fin l1 (n +ℕ 2) ,
+      ( raise-Fin l1 (n +ℕ 2),
         unit-trunc-Prop (compute-raise-Fin l1 (n +ℕ 2))))
   ( not-R-transposition-fin-succ-succ : (n : ℕ) →
     ( Y : 2-Element-Decidable-Subtype l1 (raise-Fin l1 (n +ℕ 2))) →

--- a/src/finite-group-theory/transpositions-standard-finite-types.lagda.md
+++ b/src/finite-group-theory/transpositions-standard-finite-types.lagda.md
@@ -616,7 +616,7 @@ htpy-permutation-snoc-list-adjacent-transpositions n (cons y l) x =
   htpy-permutation-snoc-list-adjacent-transpositions n l x
 
 htpy-permutation-list-adjacent-transpositions-transposition-Fin :
-  (n : ℕ) (i j : Fin (succ-ℕ n)) (neq : ¬ (i ＝ j))→
+  (n : ℕ) (i j : Fin (succ-ℕ n)) (neq : ¬ (i ＝ j)) →
   htpy-equiv
     ( permutation-list-adjacent-transpositions
       ( n)

--- a/src/finite-group-theory/transpositions-standard-finite-types.lagda.md
+++ b/src/finite-group-theory/transpositions-standard-finite-types.lagda.md
@@ -616,7 +616,7 @@ htpy-permutation-snoc-list-adjacent-transpositions n (cons y l) x =
   htpy-permutation-snoc-list-adjacent-transpositions n l x
 
 htpy-permutation-list-adjacent-transpositions-transposition-Fin :
-  (n : ℕ) (i j : Fin (succ-ℕ n)) (neq : ¬ (i ＝ j)) →
+  (n : ℕ) (i j : Fin (succ-ℕ n)) (neq : ¬ (i ＝ j))→
   htpy-equiv
     ( permutation-list-adjacent-transpositions
       ( n)

--- a/src/foundation-core/commuting-cubes-of-maps.lagda.md
+++ b/src/foundation-core/commuting-cubes-of-maps.lagda.md
@@ -402,7 +402,7 @@ rectangle-back-left-bottom-cube :
   (back-right : (g ∘ hA) ~ (hC ∘ g'))
   (front-left : (h ∘ hB) ~ (hD ∘ h'))
   (front-right : (k ∘ hC) ~ (hD ∘ k'))
-  (bottom : (h ∘ f) ~ (k ∘ g))→
+  (bottom : (h ∘ f) ~ (k ∘ g)) →
   ((h ∘ hB) ∘ f') ~ ((k ∘ g) ∘ hA)
 rectangle-back-left-bottom-cube
   f g h k f' g' h' k' hA hB hC hD

--- a/src/foundation-core/commuting-cubes-of-maps.lagda.md
+++ b/src/foundation-core/commuting-cubes-of-maps.lagda.md
@@ -402,7 +402,7 @@ rectangle-back-left-bottom-cube :
   (back-right : (g ∘ hA) ~ (hC ∘ g'))
   (front-left : (h ∘ hB) ~ (hD ∘ h'))
   (front-right : (k ∘ hC) ~ (hD ∘ k'))
-  (bottom : (h ∘ f) ~ (k ∘ g)) →
+  (bottom : (h ∘ f) ~ (k ∘ g))→
   ((h ∘ hB) ∘ f') ~ ((k ∘ g) ∘ hA)
 rectangle-back-left-bottom-cube
   f g h k f' g' h' k' hA hB hC hD

--- a/src/foundation-core/involutions.lagda.md
+++ b/src/foundation-core/involutions.lagda.md
@@ -81,7 +81,8 @@ pr2 (equiv-is-involution is-involution-f) =
 is-trunc-is-involution :
   {l : Level} {A : UU l} (k : 𝕋) →
   is-trunc (succ-𝕋 k) A → (f : A → A) → is-trunc k (is-involution f)
-is-trunc-is-involution k is-trunc-A f = is-trunc-Π k λ x → is-trunc-A (f(f x)) x
+is-trunc-is-involution k is-trunc-A f =
+  is-trunc-Π k λ x → is-trunc-A (f (f x)) x
 
 is-involution-Truncated-Type :
   {l : Level} {A : UU l} (k : 𝕋) →

--- a/src/foundation-core/involutions.lagda.md
+++ b/src/foundation-core/involutions.lagda.md
@@ -81,8 +81,7 @@ pr2 (equiv-is-involution is-involution-f) =
 is-trunc-is-involution :
   {l : Level} {A : UU l} (k : 𝕋) →
   is-trunc (succ-𝕋 k) A → (f : A → A) → is-trunc k (is-involution f)
-is-trunc-is-involution k is-trunc-A f =
-  is-trunc-Π k λ x → is-trunc-A (f (f x)) x
+is-trunc-is-involution k is-trunc-A f = is-trunc-Π k λ x → is-trunc-A (f(f x)) x
 
 is-involution-Truncated-Type :
   {l : Level} {A : UU l} (k : 𝕋) →

--- a/src/foundation-core/truncated-types.lagda.md
+++ b/src/foundation-core/truncated-types.lagda.md
@@ -93,7 +93,7 @@ abstract
   is-trunc-Id :
     {l : Level} {k : 𝕋} {A : UU l} →
     is-trunc k A → (x y : A) → is-trunc k (x ＝ y)
-  is-trunc-Id {l} {k}= is-trunc-succ-is-trunc k
+  is-trunc-Id {l} {k} = is-trunc-succ-is-trunc k
 
 Id-Truncated-Type :
   {l : Level} {k : 𝕋} (A : Truncated-Type l (succ-𝕋 k)) →

--- a/src/foundation-core/truncated-types.lagda.md
+++ b/src/foundation-core/truncated-types.lagda.md
@@ -93,7 +93,7 @@ abstract
   is-trunc-Id :
     {l : Level} {k : 𝕋} {A : UU l} →
     is-trunc k A → (x y : A) → is-trunc k (x ＝ y)
-  is-trunc-Id {l} {k} = is-trunc-succ-is-trunc k
+  is-trunc-Id {l} {k}= is-trunc-succ-is-trunc k
 
 Id-Truncated-Type :
   {l : Level} {k : 𝕋} (A : Truncated-Type l (succ-𝕋 k)) →

--- a/src/foundation/coproduct-decompositions.lagda.md
+++ b/src/foundation/coproduct-decompositions.lagda.md
@@ -348,7 +348,7 @@ module _
               ( inv
                   ( inv-map-eq-transpose-equiv
                     ( left-unit-law-Σ-is-contr is-contr-unit star)
-                    ( refl))))) ,
+                    ( refl))))),
           refl)
 
     compute-right-inv-matching-correspondence-binary-coporducd-Decomposition-map-into-Fin-Two-ℕ :
@@ -681,7 +681,7 @@ module _
               ( compute-right-map-inv-equiv-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ
                 ( d)
                 ( x)
-                ( inv p))) ,
+                ( inv p))),
             refl)}
         ( inv
           ( pr2

--- a/src/foundation/coproduct-decompositions.lagda.md
+++ b/src/foundation/coproduct-decompositions.lagda.md
@@ -348,7 +348,7 @@ module _
               ( inv
                   ( inv-map-eq-transpose-equiv
                     ( left-unit-law-Σ-is-contr is-contr-unit star)
-                    ( refl))))),
+                    ( refl))))) ,
           refl)
 
     compute-right-inv-matching-correspondence-binary-coporducd-Decomposition-map-into-Fin-Two-ℕ :
@@ -681,7 +681,7 @@ module _
               ( compute-right-map-inv-equiv-binary-coproduct-Decomposition-map-into-Fin-Two-ℕ
                 ( d)
                 ( x)
-                ( inv p))),
+                ( inv p))) ,
             refl)}
         ( inv
           ( pr2

--- a/src/foundation/decidable-equivalence-relations.lagda.md
+++ b/src/foundation/decidable-equivalence-relations.lagda.md
@@ -485,14 +485,14 @@ has-decidable-equality-type-Surjection-Into-Set surj is-dec-rel x y =
     ( map-Surjection-Into-Set surj)
     ( is-surjective-Surjection-Into-Set surj)
     ( λ (s t : (type-Surjection-Into-Set surj)) →
-      ( is-decidable (s ＝ t) ,
+      ( is-decidable (s ＝ t),
         is-prop-is-decidable ( is-set-type-Surjection-Into-Set surj s t)))
     ( λ a1 a2 → is-dec-rel a1 a2)
     ( x)
     ( y)
 
 is-decidable-Eq-Rel-Surjection-Into-Set :
-  {l1 : Level} {A : UU l1} (surj : Surjection-Into-Set l1 A) →
+  {l1 : Level} {A : UU l1} (surj : Surjection-Into-Set l1 A)→
   has-decidable-equality (type-Surjection-Into-Set surj) →
   is-decidable-Eq-Rel (eq-rel-Surjection-Into-Set surj)
 is-decidable-Eq-Rel-Surjection-Into-Set surj dec-eq x y =

--- a/src/foundation/decidable-equivalence-relations.lagda.md
+++ b/src/foundation/decidable-equivalence-relations.lagda.md
@@ -485,14 +485,14 @@ has-decidable-equality-type-Surjection-Into-Set surj is-dec-rel x y =
     ( map-Surjection-Into-Set surj)
     ( is-surjective-Surjection-Into-Set surj)
     ( λ (s t : (type-Surjection-Into-Set surj)) →
-      ( is-decidable (s ＝ t),
+      ( is-decidable (s ＝ t) ,
         is-prop-is-decidable ( is-set-type-Surjection-Into-Set surj s t)))
     ( λ a1 a2 → is-dec-rel a1 a2)
     ( x)
     ( y)
 
 is-decidable-Eq-Rel-Surjection-Into-Set :
-  {l1 : Level} {A : UU l1} (surj : Surjection-Into-Set l1 A)→
+  {l1 : Level} {A : UU l1} (surj : Surjection-Into-Set l1 A) →
   has-decidable-equality (type-Surjection-Into-Set surj) →
   is-decidable-Eq-Rel (eq-rel-Surjection-Into-Set surj)
 is-decidable-Eq-Rel-Surjection-Into-Set surj dec-eq x y =

--- a/src/foundation/relaxed-sigma-decompositions.lagda.md
+++ b/src/foundation/relaxed-sigma-decompositions.lagda.md
@@ -682,7 +682,7 @@ module _
   matching-correspondence-inv-displayed-fibered-Relaxed-Σ-Decomposition =
     equivalence-reasoning
     A ≃ Σ M N by s
-      ≃ Σ M (λ m → Σ (P m) (Q m))by equiv-Σ (λ m → Σ (P m) (Q m)) id-equiv t
+      ≃ Σ M (λ m → Σ (P m) (Q m)) by equiv-Σ (λ m → Σ (P m) (Q m)) id-equiv t
       ≃ Σ (Σ M P) (λ (m , p) → Q m p)
       by inv-associative-Σ
         ( M)

--- a/src/foundation/relaxed-sigma-decompositions.lagda.md
+++ b/src/foundation/relaxed-sigma-decompositions.lagda.md
@@ -682,7 +682,7 @@ module _
   matching-correspondence-inv-displayed-fibered-Relaxed-Σ-Decomposition =
     equivalence-reasoning
     A ≃ Σ M N by s
-      ≃ Σ M (λ m → Σ (P m) (Q m)) by equiv-Σ (λ m → Σ (P m) (Q m)) id-equiv t
+      ≃ Σ M (λ m → Σ (P m) (Q m))by equiv-Σ (λ m → Σ (P m) (Q m)) id-equiv t
       ≃ Σ (Σ M P) (λ (m , p) → Q m p)
       by inv-associative-Σ
         ( M)

--- a/src/foundation/sigma-decompositions.lagda.md
+++ b/src/foundation/sigma-decompositions.lagda.md
@@ -872,7 +872,7 @@ module _
   matching-correspondence-inv-displayed-fibered-Σ-Decomposition =
     equivalence-reasoning
     A ≃ Σ M N by s
-      ≃ Σ M (λ m → Σ (P m) (Q m))by equiv-Σ (λ m → Σ (P m) (Q m)) id-equiv t
+      ≃ Σ M (λ m → Σ (P m) (Q m)) by equiv-Σ (λ m → Σ (P m) (Q m)) id-equiv t
       ≃ Σ (Σ M P) (λ (m , p) → Q m p)
       by inv-associative-Σ
         ( M)

--- a/src/foundation/sigma-decompositions.lagda.md
+++ b/src/foundation/sigma-decompositions.lagda.md
@@ -872,7 +872,7 @@ module _
   matching-correspondence-inv-displayed-fibered-Σ-Decomposition =
     equivalence-reasoning
     A ≃ Σ M N by s
-      ≃ Σ M (λ m → Σ (P m) (Q m)) by equiv-Σ (λ m → Σ (P m) (Q m)) id-equiv t
+      ≃ Σ M (λ m → Σ (P m) (Q m))by equiv-Σ (λ m → Σ (P m) (Q m)) id-equiv t
       ≃ Σ (Σ M P) (λ (m , p) → Q m p)
       by inv-associative-Σ
         ( M)

--- a/src/foundation/symmetric-identity-types.lagda.md
+++ b/src/foundation/symmetric-identity-types.lagda.md
@@ -216,7 +216,7 @@ module _
   refl-Eq-unordered-pair-tr-symmetric-Id :
     (p : unordered-pair A) →
     tr-symmetric-Id p p id-equiv refl-htpy ~ id
-  refl-Eq-unordered-pair-tr-symmetric-Id p (a , K)=
+  refl-Eq-unordered-pair-tr-symmetric-Id p (a , K) =
     eq-pair-Σ refl
       ( eq-htpy
         ( ( compute-pr2-tr-symmetric-Id p p id-equiv refl-htpy K) ∙h

--- a/src/foundation/symmetric-identity-types.lagda.md
+++ b/src/foundation/symmetric-identity-types.lagda.md
@@ -216,7 +216,7 @@ module _
   refl-Eq-unordered-pair-tr-symmetric-Id :
     (p : unordered-pair A) →
     tr-symmetric-Id p p id-equiv refl-htpy ~ id
-  refl-Eq-unordered-pair-tr-symmetric-Id p (a , K) =
+  refl-Eq-unordered-pair-tr-symmetric-Id p (a , K)=
     eq-pair-Σ refl
       ( eq-htpy
         ( ( compute-pr2-tr-symmetric-Id p p id-equiv refl-htpy K) ∙h

--- a/src/foundation/trivial-sigma-decompositions.lagda.md
+++ b/src/foundation/trivial-sigma-decompositions.lagda.md
@@ -66,13 +66,13 @@ module _
   is-trivial-Σ-Decomposition = type-Prop is-trivial-Prop-Σ-Decomposition
 
 is-trivial-trivial-inhabited-Σ-Decomposition :
-  {l1 l2 : Level} {A : UU l1} (p : is-inhabited A) →
+  {l1 l2 : Level} {A : UU l1} (p : is-inhabited A)→
   is-trivial-Σ-Decomposition (trivial-inhabited-Σ-Decomposition l2 A p)
 is-trivial-trivial-inhabited-Σ-Decomposition p = is-contr-raise-unit
 
 type-trivial-Σ-Decomposition :
   {l1 l2 l3 : Level} {A : UU l1} → UU (l1 ⊔ lsuc l2 ⊔ lsuc l3)
-type-trivial-Σ-Decomposition {l1} {l2} {l3} {A} =
+type-trivial-Σ-Decomposition {l1} {l2} {l3} {A}=
   type-subtype (is-trivial-Prop-Σ-Decomposition {l1} {l2} {l3} {A})
 ```
 

--- a/src/foundation/trivial-sigma-decompositions.lagda.md
+++ b/src/foundation/trivial-sigma-decompositions.lagda.md
@@ -66,13 +66,13 @@ module _
   is-trivial-Σ-Decomposition = type-Prop is-trivial-Prop-Σ-Decomposition
 
 is-trivial-trivial-inhabited-Σ-Decomposition :
-  {l1 l2 : Level} {A : UU l1} (p : is-inhabited A)→
+  {l1 l2 : Level} {A : UU l1} (p : is-inhabited A) →
   is-trivial-Σ-Decomposition (trivial-inhabited-Σ-Decomposition l2 A p)
 is-trivial-trivial-inhabited-Σ-Decomposition p = is-contr-raise-unit
 
 type-trivial-Σ-Decomposition :
   {l1 l2 l3 : Level} {A : UU l1} → UU (l1 ⊔ lsuc l2 ⊔ lsuc l3)
-type-trivial-Σ-Decomposition {l1} {l2} {l3} {A}=
+type-trivial-Σ-Decomposition {l1} {l2} {l3} {A} =
   type-subtype (is-trivial-Prop-Σ-Decomposition {l1} {l2} {l3} {A})
 ```
 

--- a/src/foundation/universal-property-cartesian-product-types.lagda.md
+++ b/src/foundation/universal-property-cartesian-product-types.lagda.md
@@ -38,7 +38,7 @@ product
 ```agda
 universal-property-product :
   {l1 l2 l3 : Level} {X : UU l1} {A : X → UU l2} {B : X → UU l3} →
-  ((x : X) → A x × B x) ≃ (((x : X) → A x) × ((x : X) → B x))
+  ((x : X)→ A x × B x) ≃ (((x : X) → A x) × ((x : X) → B x))
 pr1 universal-property-product f = (λ x → pr1 (f x)) , (λ x → pr2 (f x))
 pr2 universal-property-product =
   is-equiv-has-inverse

--- a/src/foundation/universal-property-cartesian-product-types.lagda.md
+++ b/src/foundation/universal-property-cartesian-product-types.lagda.md
@@ -38,7 +38,7 @@ product
 ```agda
 universal-property-product :
   {l1 l2 l3 : Level} {X : UU l1} {A : X → UU l2} {B : X → UU l3} →
-  ((x : X)→ A x × B x) ≃ (((x : X) → A x) × ((x : X) → B x))
+  ((x : X) → A x × B x) ≃ (((x : X) → A x) × ((x : X) → B x))
 pr1 universal-property-product f = (λ x → pr1 (f x)) , (λ x → pr2 (f x))
 pr2 universal-property-product =
   is-equiv-has-inverse

--- a/src/group-theory/normal-submonoids-commutative-monoids.lagda.md
+++ b/src/group-theory/normal-submonoids-commutative-monoids.lagda.md
@@ -449,7 +449,7 @@ module _
         ( x))
       ( H)
       ( u))
-    ( K)=
+    ( K) =
     is-closed-under-eq-Normal-Commutative-Submonoid' M N
       ( is-normal-Normal-Commutative-Submonoid M N u x H K)
       ( right-unit-law-mul-Commutative-Monoid M u)

--- a/src/group-theory/normal-submonoids-commutative-monoids.lagda.md
+++ b/src/group-theory/normal-submonoids-commutative-monoids.lagda.md
@@ -449,7 +449,7 @@ module _
         ( x))
       ( H)
       ( u))
-    ( K) =
+    ( K)=
     is-closed-under-eq-Normal-Commutative-Submonoid' M N
       ( is-normal-Normal-Commutative-Submonoid M N u x H K)
       ( right-unit-law-mul-Commutative-Monoid M u)

--- a/src/linear-algebra/vectors.lagda.md
+++ b/src/linear-algebra/vectors.lagda.md
@@ -270,7 +270,7 @@ module _
   is-in-functional-vec-is-in-vec (succ-ℕ n) (y ∷ l) x (is-head .x l) =
     (inr star) , refl
   is-in-functional-vec-is-in-vec (succ-ℕ n) (y ∷ l) x (is-in-tail .x x₁ l I) =
-    inl (pr1 (is-in-functional-vec-is-in-vec n l x I)),
+    inl (pr1 (is-in-functional-vec-is-in-vec n l x I)) ,
     pr2 (is-in-functional-vec-is-in-vec n l x I)
 
   is-in-vec-is-in-functional-vec :

--- a/src/linear-algebra/vectors.lagda.md
+++ b/src/linear-algebra/vectors.lagda.md
@@ -270,7 +270,7 @@ module _
   is-in-functional-vec-is-in-vec (succ-ℕ n) (y ∷ l) x (is-head .x l) =
     (inr star) , refl
   is-in-functional-vec-is-in-vec (succ-ℕ n) (y ∷ l) x (is-in-tail .x x₁ l I) =
-    inl (pr1 (is-in-functional-vec-is-in-vec n l x I)) ,
+    inl (pr1 (is-in-functional-vec-is-in-vec n l x I)),
     pr2 (is-in-functional-vec-is-in-vec n l x I)
 
   is-in-vec-is-in-functional-vec :

--- a/src/lists/permutation-vectors.lagda.md
+++ b/src/lists/permutation-vectors.lagda.md
@@ -65,7 +65,7 @@ module _
       ( λ t → f v ＝ permute-vec n v t)
 
   permutation-is-permutation-vec :
-    (n : ℕ)(f : vec A n → vec A n) → is-permutation-vec n f →
+    (n : ℕ) (f : vec A n → vec A n) → is-permutation-vec n f →
     (v : vec A n) → Permutation n
   permutation-is-permutation-vec n f P v = pr1 (P v)
 
@@ -300,7 +300,7 @@ module _
   invariant-transposition-fold-vec {n} v i j neq =
     ( ( invariant-list-adjacent-transpositions-fold-vec
         ( v)
-        ( list-adjacent-transpositions-transposition-Fin n i j))∙
+        ( list-adjacent-transpositions-transposition-Fin n i j)) ∙
       ( ap
         ( λ t → fold-vec b μ (permute-vec (succ-ℕ n) v t))
         ( eq-htpy-equiv

--- a/src/lists/permutation-vectors.lagda.md
+++ b/src/lists/permutation-vectors.lagda.md
@@ -65,7 +65,7 @@ module _
       ( λ t → f v ＝ permute-vec n v t)
 
   permutation-is-permutation-vec :
-    (n : ℕ) (f : vec A n → vec A n) → is-permutation-vec n f →
+    (n : ℕ)(f : vec A n → vec A n) → is-permutation-vec n f →
     (v : vec A n) → Permutation n
   permutation-is-permutation-vec n f P v = pr1 (P v)
 
@@ -300,7 +300,7 @@ module _
   invariant-transposition-fold-vec {n} v i j neq =
     ( ( invariant-list-adjacent-transpositions-fold-vec
         ( v)
-        ( list-adjacent-transpositions-transposition-Fin n i j)) ∙
+        ( list-adjacent-transpositions-transposition-Fin n i j))∙
       ( ap
         ( λ t → fold-vec b μ (permute-vec (succ-ℕ n) v t))
         ( eq-htpy-equiv

--- a/src/reflection/definitions.lagda.md
+++ b/src/reflection/definitions.lagda.md
@@ -146,7 +146,7 @@ private
                 -- Clause
                 ( absurd-clause
                   ( unit-list
-                    ( " () " , visible-Arg (def (quote empty) nil)))
+                    ( "()" , visible-Arg (def (quote empty) nil)))
                   ( unit-list
                     ( visible-Arg (absurd 0)))))
               ( nil)))))

--- a/src/reflection/definitions.lagda.md
+++ b/src/reflection/definitions.lagda.md
@@ -146,7 +146,7 @@ private
                 -- Clause
                 ( absurd-clause
                   ( unit-list
-                    ( "()" , visible-Arg (def (quote empty) nil)))
+                    ( " () " , visible-Arg (def (quote empty) nil)))
                   ( unit-list
                     ( visible-Arg (absurd 0)))))
               ( nil)))))

--- a/src/reflection/group-solver.lagda.md
+++ b/src/reflection/group-solver.lagda.md
@@ -84,14 +84,14 @@ module _ {n : ℕ} where
 
   elim-inverses : SimpleElem n → Simple n → Simple n
   elim-inverses x nil = cons x nil
-  elim-inverses xi@(inv-SE x) yxs@(cons (inv-SE y) xs) = cons xi yxs
-  elim-inverses xi@(inv-SE x) yxs@(cons (pure-SE y) xs) with finEq x y
+  elim-inverses xi@ (inv-SE x) yxs@ (cons (inv-SE y) xs) = cons xi yxs
+  elim-inverses xi@ (inv-SE x) yxs@ (cons (pure-SE y) xs) with finEq x y
   ... | inl eq = xs
   ... | inr neq = cons xi yxs
-  elim-inverses xi@(pure-SE x) yxs@(cons (inv-SE y) xs) with finEq x y
+  elim-inverses xi@ (pure-SE x) yxs@ (cons (inv-SE y) xs) with finEq x y
   ... | inl eq = xs
   ... | inr neq = cons xi yxs
-  elim-inverses xi@(pure-SE x) yxs@(cons (pure-SE y) xs) = cons xi yxs
+  elim-inverses xi@ (pure-SE x) yxs@ (cons (pure-SE y) xs) = cons xi yxs
 
   concat-simplify : Simple n → Simple n → Simple n
   concat-simplify nil b = b
@@ -353,7 +353,7 @@ module _ {n : ℕ} where
       GroupEquality x y → unQuoteGS x env ＝ unQuoteGS y env
     useGroupEquality env refl-GE = refl
     useGroupEquality env (x ∷GE refl-GE) = useGroupEqualityElem env x
-    useGroupEquality env (x ∷GE xs@(_ ∷GE _)) =
+    useGroupEquality env (x ∷GE xs@ (_ ∷GE _)) =
       useGroupEqualityElem env x ∙ useGroupEquality env xs
 
     -- simplifyExpression :

--- a/src/reflection/group-solver.lagda.md
+++ b/src/reflection/group-solver.lagda.md
@@ -84,14 +84,14 @@ module _ {n : ℕ} where
 
   elim-inverses : SimpleElem n → Simple n → Simple n
   elim-inverses x nil = cons x nil
-  elim-inverses xi@ (inv-SE x) yxs@ (cons (inv-SE y) xs) = cons xi yxs
-  elim-inverses xi@ (inv-SE x) yxs@ (cons (pure-SE y) xs) with finEq x y
+  elim-inverses xi@(inv-SE x) yxs@(cons (inv-SE y) xs) = cons xi yxs
+  elim-inverses xi@(inv-SE x) yxs@(cons (pure-SE y) xs) with finEq x y
   ... | inl eq = xs
   ... | inr neq = cons xi yxs
-  elim-inverses xi@ (pure-SE x) yxs@ (cons (inv-SE y) xs) with finEq x y
+  elim-inverses xi@(pure-SE x) yxs@(cons (inv-SE y) xs) with finEq x y
   ... | inl eq = xs
   ... | inr neq = cons xi yxs
-  elim-inverses xi@ (pure-SE x) yxs@ (cons (pure-SE y) xs) = cons xi yxs
+  elim-inverses xi@(pure-SE x) yxs@(cons (pure-SE y) xs) = cons xi yxs
 
   concat-simplify : Simple n → Simple n → Simple n
   concat-simplify nil b = b
@@ -353,7 +353,7 @@ module _ {n : ℕ} where
       GroupEquality x y → unQuoteGS x env ＝ unQuoteGS y env
     useGroupEquality env refl-GE = refl
     useGroupEquality env (x ∷GE refl-GE) = useGroupEqualityElem env x
-    useGroupEquality env (x ∷GE xs@ (_ ∷GE _)) =
+    useGroupEquality env (x ∷GE xs@(_ ∷GE _)) =
       useGroupEqualityElem env x ∙ useGroupEquality env xs
 
     -- simplifyExpression :

--- a/src/ring-theory/products-subsets-rings.lagda.md
+++ b/src/ring-theory/products-subsets-rings.lagda.md
@@ -75,7 +75,7 @@ module _
       ( λ (i , u) →
         apply-universal-property-trunc-Prop u
           ( product-subset-Ring A S (union-family-of-subtypes T) x)
-          ( λ {((s , Hs) , (t , Ht) , refl) →
+          ( λ {((s , Hs) , (t , Ht), refl) →
             unit-trunc-Prop
               ( (s , Hs) , (t , unit-trunc-Prop (i , Ht)) , refl)}))
 

--- a/src/ring-theory/products-subsets-rings.lagda.md
+++ b/src/ring-theory/products-subsets-rings.lagda.md
@@ -75,7 +75,7 @@ module _
       ( λ (i , u) →
         apply-universal-property-trunc-Prop u
           ( product-subset-Ring A S (union-family-of-subtypes T) x)
-          ( λ {((s , Hs) , (t , Ht), refl) →
+          ( λ {((s , Hs) , (t , Ht) , refl) →
             unit-trunc-Prop
               ( (s , Hs) , (t , unit-trunc-Prop (i , Ht)) , refl)}))
 

--- a/src/ring-theory/sums-semirings.lagda.md
+++ b/src/ring-theory/sums-semirings.lagda.md
@@ -262,7 +262,7 @@ split-sum-Semiring R n zero-ℕ f =
   inv (right-unit-law-add-Semiring R (sum-Semiring R n f))
 split-sum-Semiring R n (succ-ℕ m) f =
   ( ap
-    ( add-Semiring' R (f (inr star)))
+    ( add-Semiring' R (f(inr star)))
     ( split-sum-Semiring R n m (f ∘ inl))) ∙
   ( associative-add-Semiring R _ _ _)
 ```

--- a/src/ring-theory/sums-semirings.lagda.md
+++ b/src/ring-theory/sums-semirings.lagda.md
@@ -262,7 +262,7 @@ split-sum-Semiring R n zero-ℕ f =
   inv (right-unit-law-add-Semiring R (sum-Semiring R n f))
 split-sum-Semiring R n (succ-ℕ m) f =
   ( ap
-    ( add-Semiring' R (f(inr star)))
+    ( add-Semiring' R (f (inr star)))
     ( split-sum-Semiring R n m (f ∘ inl))) ∙
   ( associative-add-Semiring R _ _ _)
 ```

--- a/src/species/cauchy-exponentials-species-of-types-in-subuniverses.lagda.md
+++ b/src/species/cauchy-exponentials-species-of-types-in-subuniverses.lagda.md
@@ -162,7 +162,7 @@ module _
       ((U , ((λ u → pr1 (V u)) , e)) , ((pU , (λ u → pr2 (V u))) , pX) , s)
     pr2 reassociate =
       is-equiv-has-inverse
-        ( λ ((U , V , e) , ( ((pU , pV) , pX) , s)) →
+        ( λ ((U , V , e) , ( ((pU , pV), pX) , s)) →
           ( pX , ((U , pU) , (λ u → V u , pV u) , e) , s))
         ( refl-htpy)
         ( refl-htpy)

--- a/src/species/cauchy-exponentials-species-of-types-in-subuniverses.lagda.md
+++ b/src/species/cauchy-exponentials-species-of-types-in-subuniverses.lagda.md
@@ -162,7 +162,7 @@ module _
       ((U , ((λ u → pr1 (V u)) , e)) , ((pU , (λ u → pr2 (V u))) , pX) , s)
     pr2 reassociate =
       is-equiv-has-inverse
-        ( λ ((U , V , e) , ( ((pU , pV), pX) , s)) →
+        ( λ ((U , V , e) , ( ((pU , pV) , pX) , s)) →
           ( pX , ((U , pU) , (λ u → V u , pV u) , e) , s))
         ( refl-htpy)
         ( refl-htpy)

--- a/src/species/dirichlet-exponentials-species-of-types-in-subuniverses.lagda.md
+++ b/src/species/dirichlet-exponentials-species-of-types-in-subuniverses.lagda.md
@@ -132,7 +132,7 @@ module _
       ((U , ((λ u → pr1 (V u)) , e)) , ((pU , (λ u → pr2 (V u))) , pX) , s)
     pr2 reassociate =
       is-equiv-has-inverse
-        ( λ ((U , V , e) , ( ((pU , pV), pX) , s)) →
+        ( λ ((U , V , e) , ( ((pU , pV) , pX) , s)) →
           ( pX , ((U , pU) , (λ u → V u , pV u) , e) , s))
         ( refl-htpy)
         ( refl-htpy)

--- a/src/species/dirichlet-exponentials-species-of-types-in-subuniverses.lagda.md
+++ b/src/species/dirichlet-exponentials-species-of-types-in-subuniverses.lagda.md
@@ -132,7 +132,7 @@ module _
       ((U , ((λ u → pr1 (V u)) , e)) , ((pU , (λ u → pr2 (V u))) , pX) , s)
     pr2 reassociate =
       is-equiv-has-inverse
-        ( λ ((U , V , e) , ( ((pU , pV) , pX) , s)) →
+        ( λ ((U , V , e) , ( ((pU , pV), pX) , s)) →
           ( pX , ((U , pU) , (λ u → V u , pV u) , e) , s))
         ( refl-htpy)
         ( refl-htpy)

--- a/src/species/products-dirichlet-series-species-of-types-in-subuniverses.lagda.md
+++ b/src/species/products-dirichlet-series-species-of-types-in-subuniverses.lagda.md
@@ -111,10 +111,10 @@ module _
                     ( inclusion-subuniverse
                       ( subuniverse-global-subuniverse Q l4)
                       ( T B))) × (X → H (pr1 F)))))
-    pr1 reassociate (F , ((A , B , e) , x) , y) = (A , B , (F , e) , x , y)
+    pr1 reassociate (F , ((A , B , e) , x) , y) = (A , B , (F , e), x , y)
     pr2 reassociate =
       is-equiv-has-inverse
-        ( λ (A , B , (F , e) , x , y) → (F , ((A , B , e) , x) , y))
+        ( λ (A , B , (F , e), x , y) → (F , ((A , B , e) , x) , y))
         ( refl-htpy)
         ( refl-htpy)
 
@@ -171,7 +171,7 @@ module _
                 ( ( inclusion-subuniverse P A × inclusion-subuniverse P B ,
                     C1
                       ( is-in-subuniverse-inclusion-subuniverse P A)
-                      ( is-in-subuniverse-inclusion-subuniverse P B)) ,
+                      ( is-in-subuniverse-inclusion-subuniverse P B)),
                   id-equiv)))) ∘e
       ( reassociate))
 ```

--- a/src/species/products-dirichlet-series-species-of-types-in-subuniverses.lagda.md
+++ b/src/species/products-dirichlet-series-species-of-types-in-subuniverses.lagda.md
@@ -111,10 +111,10 @@ module _
                     ( inclusion-subuniverse
                       ( subuniverse-global-subuniverse Q l4)
                       ( T B))) × (X → H (pr1 F)))))
-    pr1 reassociate (F , ((A , B , e) , x) , y) = (A , B , (F , e), x , y)
+    pr1 reassociate (F , ((A , B , e) , x) , y) = (A , B , (F , e) , x , y)
     pr2 reassociate =
       is-equiv-has-inverse
-        ( λ (A , B , (F , e), x , y) → (F , ((A , B , e) , x) , y))
+        ( λ (A , B , (F , e) , x , y) → (F , ((A , B , e) , x) , y))
         ( refl-htpy)
         ( refl-htpy)
 
@@ -171,7 +171,7 @@ module _
                 ( ( inclusion-subuniverse P A × inclusion-subuniverse P B ,
                     C1
                       ( is-in-subuniverse-inclusion-subuniverse P A)
-                      ( is-in-subuniverse-inclusion-subuniverse P B)),
+                      ( is-in-subuniverse-inclusion-subuniverse P B)) ,
                   id-equiv)))) ∘e
       ( reassociate))
 ```

--- a/src/species/small-cauchy-composition-species-of-finite-inhabited-types.lagda.md
+++ b/src/species/small-cauchy-composition-species-of-finite-inhabited-types.lagda.md
@@ -195,7 +195,7 @@ module _
 
   small-cauchy-composition-species-Inhabited-𝔽 :
     species-Inhabited-𝔽 l1 (l1 ⊔ l2) →
-    species-Inhabited-𝔽 l1 (l1 ⊔ l2)→
+    species-Inhabited-𝔽 l1 (l1 ⊔ l2) →
     species-Inhabited-𝔽 l1 (l1 ⊔ l2)
   small-cauchy-composition-species-Inhabited-𝔽 =
     small-cauchy-composition-species-subuniverse

--- a/src/species/small-cauchy-composition-species-of-finite-inhabited-types.lagda.md
+++ b/src/species/small-cauchy-composition-species-of-finite-inhabited-types.lagda.md
@@ -195,7 +195,7 @@ module _
 
   small-cauchy-composition-species-Inhabited-𝔽 :
     species-Inhabited-𝔽 l1 (l1 ⊔ l2) →
-    species-Inhabited-𝔽 l1 (l1 ⊔ l2) →
+    species-Inhabited-𝔽 l1 (l1 ⊔ l2)→
     species-Inhabited-𝔽 l1 (l1 ⊔ l2)
   small-cauchy-composition-species-Inhabited-𝔽 =
     small-cauchy-composition-species-subuniverse

--- a/src/species/small-cauchy-composition-species-of-types-in-subuniverses.lagda.md
+++ b/src/species/small-cauchy-composition-species-of-types-in-subuniverses.lagda.md
@@ -203,7 +203,7 @@ module _
                   ( ( inv-equiv
                         ( terminal-map , is-equiv-terminal-map-is-contr S)) ∘e
                     inv-equiv (compute-raise-unit l1)))
-              ( C4) ,
+              ( C4),
             map-equiv-is-small (C5 X) S))
         ( λ x → eq-is-prop is-property-is-contr)
         ( λ x →
@@ -381,7 +381,7 @@ module _
   associative-small-cauchy-composition-species-subuniverse :
     (S : species-subuniverse P Q)
     (T : species-subuniverse P Q)
-    (U : species-subuniverse P Q) →
+    (U : species-subuniverse P Q)→
     small-cauchy-composition-species-subuniverse
       ( S)
       ( small-cauchy-composition-species-subuniverse T U) ＝

--- a/src/species/small-cauchy-composition-species-of-types-in-subuniverses.lagda.md
+++ b/src/species/small-cauchy-composition-species-of-types-in-subuniverses.lagda.md
@@ -203,7 +203,7 @@ module _
                   ( ( inv-equiv
                         ( terminal-map , is-equiv-terminal-map-is-contr S)) ∘e
                     inv-equiv (compute-raise-unit l1)))
-              ( C4),
+              ( C4) ,
             map-equiv-is-small (C5 X) S))
         ( λ x → eq-is-prop is-property-is-contr)
         ( λ x →
@@ -381,7 +381,7 @@ module _
   associative-small-cauchy-composition-species-subuniverse :
     (S : species-subuniverse P Q)
     (T : species-subuniverse P Q)
-    (U : species-subuniverse P Q)→
+    (U : species-subuniverse P Q) →
     small-cauchy-composition-species-subuniverse
       ( S)
       ( small-cauchy-composition-species-subuniverse T U) ＝

--- a/src/species/species-of-types-in-subuniverses.lagda.md
+++ b/src/species/species-of-types-in-subuniverses.lagda.md
@@ -38,7 +38,7 @@ species-subuniverse :
 species-subuniverse P Q = type-subuniverse P → type-subuniverse Q
 
 species-subuniverse-domain :
-  {l1 l2 : Level} (l3 : Level)→ subuniverse l1 l2 →
+  {l1 l2 : Level} (l3 : Level) → subuniverse l1 l2 →
   UU (lsuc l1 ⊔ l2 ⊔ lsuc l3)
 species-subuniverse-domain l3 P = type-subuniverse P → UU l3
 ```

--- a/src/species/species-of-types-in-subuniverses.lagda.md
+++ b/src/species/species-of-types-in-subuniverses.lagda.md
@@ -38,7 +38,7 @@ species-subuniverse :
 species-subuniverse P Q = type-subuniverse P → type-subuniverse Q
 
 species-subuniverse-domain :
-  {l1 l2 : Level} (l3 : Level) → subuniverse l1 l2 →
+  {l1 l2 : Level} (l3 : Level)→ subuniverse l1 l2 →
   UU (lsuc l1 ⊔ l2 ⊔ lsuc l3)
 species-subuniverse-domain l3 P = type-subuniverse P → UU l3
 ```

--- a/src/structured-types/types-equipped-with-endomorphisms.lagda.md
+++ b/src/structured-types/types-equipped-with-endomorphisms.lagda.md
@@ -46,6 +46,6 @@ module _
 
 ```agda
 trivial-Endo : {l : Level} → Endo l
-pr1 (trivial-Endo {l})= raise-unit l
+pr1 (trivial-Endo {l}) = raise-unit l
 pr2 trivial-Endo = id
 ```

--- a/src/structured-types/types-equipped-with-endomorphisms.lagda.md
+++ b/src/structured-types/types-equipped-with-endomorphisms.lagda.md
@@ -46,6 +46,6 @@ module _
 
 ```agda
 trivial-Endo : {l : Level} → Endo l
-pr1 (trivial-Endo {l}) = raise-unit l
+pr1 (trivial-Endo {l})= raise-unit l
 pr2 trivial-Endo = id
 ```

--- a/src/type-theories/unityped-type-theories.lagda.md
+++ b/src/type-theories/unityped-type-theories.lagda.md
@@ -373,7 +373,7 @@ module unityped where
       {l : Level} {A : type-theory l} {m n : ℕ} →
       El A n → El A (succ-ℕ (m +ℕ n))
     iterated-weakening {l} {A} {zero-ℕ} {n} x =
-      {!hom-system.element (weakening.element (type-theory.W A)) !}
+      {!hom-system.element (weakening.element (type-theory.W A))!}
     iterated-weakening {l} {A} {succ-ℕ m} {n} x = {!!}
 ```
 

--- a/src/type-theories/unityped-type-theories.lagda.md
+++ b/src/type-theories/unityped-type-theories.lagda.md
@@ -373,7 +373,7 @@ module unityped where
       {l : Level} {A : type-theory l} {m n : ℕ} →
       El A n → El A (succ-ℕ (m +ℕ n))
     iterated-weakening {l} {A} {zero-ℕ} {n} x =
-      {!hom-system.element (weakening.element (type-theory.W A))!}
+      {!hom-system.element (weakening.element (type-theory.W A)) !}
     iterated-weakening {l} {A} {succ-ℕ m} {n} x = {!!}
 ```
 

--- a/src/univalent-combinatorics/sigma-decompositions.lagda.md
+++ b/src/univalent-combinatorics/sigma-decompositions.lagda.md
@@ -337,7 +337,7 @@ module _
             pr1
               ( is-in-subtype-inclusion-subtype
                 ( is-finite-Σ-Decomposition A)
-                (x))))∘e
+                (x)))) ∘e
       interchange-Σ-Σ
         ( λ D D' p →
           type-Prop

--- a/src/univalent-combinatorics/sigma-decompositions.lagda.md
+++ b/src/univalent-combinatorics/sigma-decompositions.lagda.md
@@ -337,7 +337,7 @@ module _
             pr1
               ( is-in-subtype-inclusion-subtype
                 ( is-finite-Σ-Decomposition A)
-                (x)))) ∘e
+                (x))))∘e
       interchange-Σ-Σ
         ( λ D D' p →
           type-Prop

--- a/src/univalent-combinatorics/type-duality.lagda.md
+++ b/src/univalent-combinatorics/type-duality.lagda.md
@@ -55,7 +55,7 @@ equiv-surjection-𝔽-family-finite-inhabited-type {l} A B =
             ( λ _ → commutative-prod)))
       ( λ b → id-equiv)) ∘e
     ( ( equiv-fixed-Slice-structure
-        ( λ x → (is-inhabited x) × (is-finite x))
+        ( λ x → (is-inhabited x)× (is-finite x))
         ( type-𝔽 A)
         ( type-𝔽 B)) ∘e
       ( ( equiv-Σ

--- a/src/univalent-combinatorics/type-duality.lagda.md
+++ b/src/univalent-combinatorics/type-duality.lagda.md
@@ -55,7 +55,7 @@ equiv-surjection-𝔽-family-finite-inhabited-type {l} A B =
             ( λ _ → commutative-prod)))
       ( λ b → id-equiv)) ∘e
     ( ( equiv-fixed-Slice-structure
-        ( λ x → (is-inhabited x)× (is-finite x))
+        ( λ x → (is-inhabited x) × (is-finite x))
         ( type-𝔽 A)
         ( type-𝔽 B)) ∘e
       ( ( equiv-Σ


### PR DESCRIPTION
Adds autoformatting that ensures whitespace after closing braces and before opening braces except for in special cases. From the updated documentation:

> - **Agda space conventions**: Corrects some common spacing mistakes according to
>   our conventions. This includes removing repeat whitespace characters between
>   two non-whitespace characters in a line, having whitespace before an opening
>   brace or semicolon if it is not preceeded by a dot or another opening brace,
>   and having whitespace after a closing brace or semicolon if it is not
>   succeeded by a closing brace.

There are also special cases for the characters `"'@` that I didn't think was necessary to mention there.