### PR TITLE
Update Nix packages and the website's catppuccin theme assets

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -21,7 +21,7 @@ inline-delimiter = {left = "$", right = "$"}
 macros = "theme/latex-macros.txt"
 
 [preprocessor.catppuccin]
-assets_version = "0.1.1" # DO NOT EDIT: Managed by `mdbook-catppuccin install`
+assets_version = "0.2.0" # DO NOT EDIT: Managed by `mdbook-catppuccin install`
 
 [output.linkcheck]
 follow-web-links = false
@@ -30,7 +30,7 @@ follow-web-links = false
 default-theme = "light"
 preferred-dark-theme = "Ayu"
 copy-fonts = true
-additional-css = ["theme/Agda.css", "theme/pagetoc.css", "theme/catppuccin.css", "theme/catppuccin-highlight.css", "theme/agda-logo.css"]
+additional-css = ["theme/Agda.css", "theme/pagetoc.css", "theme/agda-logo.css", "./theme/catppuccin.css", "./theme/catppuccin-highlight.css"]
 additional-js = ["theme/js/custom.js", "theme/pagetoc.js"]
 no-section-label = false
 git-repository-url = "https://github.com/UniMath/agda-unimath"

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,55 @@
 {
   "nodes": {
-    "flake-utils": {
+    "crane": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "mdbook-catppuccin",
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      },
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "lastModified": 1686621798,
+        "narHash": "sha256-FUwWszmSiDzUdTk8f69xwMoYlhdPaLvDaIYOE/y6VXc=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "75f7d715f8088f741be9981405f6444e2d49efdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
@@ -15,13 +58,71 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "mdbook-catppuccin": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1689783639,
+        "narHash": "sha256-k6ExUOrKdlqfdhbdRLHYay0tAqSLcteQj/78qQ+l7kI=",
+        "owner": "catppuccin",
+        "repo": "mdBook",
+        "rev": "7616df4bfc8f63e44e4a9f6fc1849c975fd0fc03",
+        "type": "github"
+      },
+      "original": {
+        "owner": "catppuccin",
+        "repo": "mdBook",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1676928847,
-        "narHash": "sha256-FIqk+DHRICsWozlOdRxOXO/g9hCqjPYpmr8wQGrpUCA=",
+        "lastModified": 1689631193,
+        "narHash": "sha256-AGSkBZaiTODQc8eT1rZDrQIjtb8JtFwJ0wVPzArlrnM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5ab8b5ae26e6a4b781bdebdfd131c054f0b96e70",
+        "rev": "57695599bdc4f7bfe5d28cfa23f14b3d8bdf8a5f",
         "type": "github"
       },
       "original": {
@@ -34,7 +135,80 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "mdbook-catppuccin": "mdbook-catppuccin",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "mdbook-catppuccin",
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "mdbook-catppuccin",
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1685759304,
+        "narHash": "sha256-I3YBH6MS3G5kGzNuc1G0f9uYfTcNY9NYoRc3QsykLk4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "c535b4f3327910c96dcf21851bbdd074d0760290",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -5,9 +5,13 @@
     # Unstable is needed for Agda 2.6.3, latest stable 22.11 only has 2.6.2.2
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    mdbook-catppuccin = {
+      url = "github:catppuccin/mdBook";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils, mdbook-catppuccin }:
     flake-utils.lib.eachDefaultSystem
       (system:
         let
@@ -34,6 +38,7 @@
               pkgs.mdbook-katex
               pkgs.mdbook-pagetoc
               pkgs.mdbook-linkcheck
+              mdbook-catppuccin.packages."${system}".default
               # pre-commit checks
               pkgs.pre-commit
             ];

--- a/theme/catppuccin-highlight.css
+++ b/theme/catppuccin-highlight.css
@@ -1,359 +1,607 @@
-.mocha code,
-.mocha .hljs {
-  background: #181825;
+.mocha code .hljs-keyword {
+  color: #cba6f7;
 }
-.mocha code .hljs-attr,
+.mocha code .hljs-built_in {
+  color: #f38ba8;
+}
+.mocha code .hljs-type {
+  color: #f9e2af;
+}
+.mocha code .hljs-literal {
+  color: #fab387;
+}
+.mocha code .hljs-number {
+  color: #fab387;
+}
+.mocha code .hljs-operator {
+  color: #94e2d5;
+}
+.mocha code .hljs-punctuation {
+  color: #bac2de;
+}
+.mocha code .hljs-property {
+  color: #94e2d5;
+}
+.mocha code .hljs-regexp {
+  color: #f5c2e7;
+}
 .mocha code .hljs-string {
   color: #a6e3a1;
 }
-.mocha code .hljs-tag {
-  color: #f38ba8;
+.mocha code .hljs-char.escape_ {
+  color: #a6e3a1;
 }
-.mocha code .hljs-name {
+.mocha code .hljs-subst {
+  color: #a6adc8;
+}
+.mocha code .hljs-symbol {
   color: #f2cdcd;
 }
-.mocha pre .hljs {
-  background: #181825 !important;
+.mocha code .hljs-variable {
+  color: #cba6f7;
 }
-.mocha pre .hljs-params {
-  color: #f38ba8 !important;
+.mocha code .hljs-variable.language_ {
+  color: #cba6f7;
 }
-.mocha pre .hljs-built_in,
-.mocha pre .hljs-selector-tag,
-.mocha pre .hljs-section,
-.mocha pre .hljs-link {
-  color: #74c7ec !important;
+.mocha code .hljs-variable.constant_ {
+  color: #fab387;
 }
-.mocha pre .hljs-keyword {
-  color: #cba6f7 !important;
+.mocha code .hljs-title {
+  color: #89b4fa;
 }
-.mocha pre .hljs,
-.mocha pre .hljs-subst {
-  color: #a6adc8 !important;
+.mocha code .hljs-title.class_ {
+  color: #f9e2af;
 }
-.mocha pre .hljs-title {
-  color: #89b4fa !important;
+.mocha code .hljs-title.function_ {
+  color: #89b4fa;
 }
-.mocha pre .hljs-attr,
-.mocha pre .hljs-meta-keyword {
-  color: #a6e3a1 !important;
+.mocha code .hljs-params {
+  color: #cdd6f4;
 }
-.mocha pre .hljs-type {
-  color: #89b4fa !important;
+.mocha code .hljs-comment {
+  color: #585b70;
 }
-.mocha pre .hljs-string {
-  color: #a6e3a1 !important;
+.mocha code .hljs-doctag {
+  color: #f38ba8;
 }
-.mocha pre .hljs-tag {
-  color: #f38ba8 !important;
+.mocha code .hljs-meta {
+  color: #fab387;
 }
-.mocha pre .hljs-meta,
-.mocha pre .hljs-name,
-.mocha pre .hljs-symbol,
-.mocha pre .hljs-bullet,
-.mocha pre .hljs-addition,
-.mocha pre .hljs-variable,
-.mocha pre .hljs-template-tag,
-.mocha pre .hljs-template-variable {
-  color: #f2cdcd !important;
+.mocha code .hljs-section {
+  color: #89b4fa;
 }
-.mocha pre .hljs-addition {
-  background-color: #181825 !important;
-  color: #a6e3a1 !important;
+.mocha code .hljs-tag {
+  color: #a6adc8;
 }
-.mocha pre .hljs-deletion {
-  background-color: #181825 !important;
-  color: #f38ba8 !important;
+.mocha code .hljs-name {
+  color: #cba6f7;
 }
-.mocha pre .hljs-comment,
-.mocha pre .hljs-quote {
-  color: #585b70 !important;
+.mocha code .hljs-attr {
+  color: #89b4fa;
 }
-.mocha pre .hljs-keyword,
-.mocha pre .hljs-selector-tag,
-.mocha pre .hljs-literal,
-.mocha pre .hljs-title,
-.mocha pre .hljs-section,
-.mocha pre .hljs-doctag,
-.mocha pre .hljs-type,
-.mocha pre .hljs-name,
-.mocha pre .hljs-strong {
-  font-weight: bold !important;
+.mocha code .hljs-attribute {
+  color: #a6e3a1;
 }
-.mocha pre .hljs-literal,
-.mocha pre .hljs-number {
-  color: #fab387 !important;
+.mocha code .hljs-bullet {
+  color: #94e2d5;
 }
-.mocha pre .hljs-emphasis {
-  font-style: italic !important;
+.mocha code .hljs-code {
+  color: #a6e3a1;
+}
+.mocha code .hljs-emphasis {
+  color: #f38ba8;
+  font-style: italic;
+}
+.mocha code .hljs-strong {
+  color: #f38ba8;
+  font-weight: bold;
+}
+.mocha code .hljs-formula {
+  color: #94e2d5;
+}
+.mocha code .hljs-link {
+  color: #74c7ec;
+  font-style: italic;
+}
+.mocha code .hljs-quote {
+  color: #a6e3a1;
+  font-style: italic;
+}
+.mocha code .hljs-selector-tag {
+  color: #f9e2af;
+}
+.mocha code .hljs-selector-id {
+  color: #89b4fa;
+}
+.mocha code .hljs-selector-class {
+  color: #94e2d5;
+}
+.mocha code .hljs-selector-attr {
+  color: #cba6f7;
+}
+.mocha code .hljs-selector-pseudo {
+  color: #94e2d5;
+}
+.mocha code .hljs-template-tag {
+  color: #f2cdcd;
+}
+.mocha code .hljs-template-variable {
+  color: #f2cdcd;
+}
+.mocha code .hljs-diff-addition {
+  color: #a6e3a1;
+  background: rgba(166, 227, 161, 0.15);
+}
+.mocha code .hljs-diff-deletion {
+  color: #f38ba8;
+  background: rgba(243, 139, 168, 0.15);
 }
 
-.macchiato code,
-.macchiato .hljs {
-  background: #1e2030;
+.macchiato code .hljs-keyword {
+  color: #c6a0f6;
 }
-.macchiato code .hljs-attr,
+.macchiato code .hljs-built_in {
+  color: #ed8796;
+}
+.macchiato code .hljs-type {
+  color: #eed49f;
+}
+.macchiato code .hljs-literal {
+  color: #f5a97f;
+}
+.macchiato code .hljs-number {
+  color: #f5a97f;
+}
+.macchiato code .hljs-operator {
+  color: #8bd5ca;
+}
+.macchiato code .hljs-punctuation {
+  color: #b8c0e0;
+}
+.macchiato code .hljs-property {
+  color: #8bd5ca;
+}
+.macchiato code .hljs-regexp {
+  color: #f5bde6;
+}
 .macchiato code .hljs-string {
   color: #a6da95;
 }
-.macchiato code .hljs-tag {
-  color: #ed8796;
+.macchiato code .hljs-char.escape_ {
+  color: #a6da95;
 }
-.macchiato code .hljs-name {
+.macchiato code .hljs-subst {
+  color: #a5adcb;
+}
+.macchiato code .hljs-symbol {
   color: #f0c6c6;
 }
-.macchiato pre .hljs {
-  background: #1e2030 !important;
+.macchiato code .hljs-variable {
+  color: #c6a0f6;
 }
-.macchiato pre .hljs-params {
-  color: #ed8796 !important;
+.macchiato code .hljs-variable.language_ {
+  color: #c6a0f6;
 }
-.macchiato pre .hljs-built_in,
-.macchiato pre .hljs-selector-tag,
-.macchiato pre .hljs-section,
-.macchiato pre .hljs-link {
-  color: #7dc4e4 !important;
+.macchiato code .hljs-variable.constant_ {
+  color: #f5a97f;
 }
-.macchiato pre .hljs-keyword {
-  color: #c6a0f6 !important;
+.macchiato code .hljs-title {
+  color: #8aadf4;
 }
-.macchiato pre .hljs,
-.macchiato pre .hljs-subst {
-  color: #a5adcb !important;
+.macchiato code .hljs-title.class_ {
+  color: #eed49f;
 }
-.macchiato pre .hljs-title {
-  color: #8aadf4 !important;
+.macchiato code .hljs-title.function_ {
+  color: #8aadf4;
 }
-.macchiato pre .hljs-attr,
-.macchiato pre .hljs-meta-keyword {
-  color: #a6da95 !important;
+.macchiato code .hljs-params {
+  color: #cad3f5;
 }
-.macchiato pre .hljs-type {
-  color: #8aadf4 !important;
+.macchiato code .hljs-comment {
+  color: #5b6078;
 }
-.macchiato pre .hljs-string {
-  color: #a6da95 !important;
+.macchiato code .hljs-doctag {
+  color: #ed8796;
 }
-.macchiato pre .hljs-tag {
-  color: #ed8796 !important;
+.macchiato code .hljs-meta {
+  color: #f5a97f;
 }
-.macchiato pre .hljs-meta,
-.macchiato pre .hljs-name,
-.macchiato pre .hljs-symbol,
-.macchiato pre .hljs-bullet,
-.macchiato pre .hljs-addition,
-.macchiato pre .hljs-variable,
-.macchiato pre .hljs-template-tag,
-.macchiato pre .hljs-template-variable {
-  color: #f0c6c6 !important;
+.macchiato code .hljs-section {
+  color: #8aadf4;
 }
-.macchiato pre .hljs-addition {
-  background-color: #1e2030 !important;
-  color: #a6da95 !important;
+.macchiato code .hljs-tag {
+  color: #a5adcb;
 }
-.macchiato pre .hljs-deletion {
-  background-color: #1e2030 !important;
-  color: #ed8796 !important;
+.macchiato code .hljs-name {
+  color: #c6a0f6;
 }
-.macchiato pre .hljs-comment,
-.macchiato pre .hljs-quote {
-  color: #5b6078 !important;
+.macchiato code .hljs-attr {
+  color: #8aadf4;
 }
-.macchiato pre .hljs-keyword,
-.macchiato pre .hljs-selector-tag,
-.macchiato pre .hljs-literal,
-.macchiato pre .hljs-title,
-.macchiato pre .hljs-section,
-.macchiato pre .hljs-doctag,
-.macchiato pre .hljs-type,
-.macchiato pre .hljs-name,
-.macchiato pre .hljs-strong {
-  font-weight: bold !important;
+.macchiato code .hljs-attribute {
+  color: #a6da95;
 }
-.macchiato pre .hljs-literal,
-.macchiato pre .hljs-number {
-  color: #f5a97f !important;
+.macchiato code .hljs-bullet {
+  color: #8bd5ca;
 }
-.macchiato pre .hljs-emphasis {
-  font-style: italic !important;
+.macchiato code .hljs-code {
+  color: #a6da95;
+}
+.macchiato code .hljs-emphasis {
+  color: #ed8796;
+  font-style: italic;
+}
+.macchiato code .hljs-strong {
+  color: #ed8796;
+  font-weight: bold;
+}
+.macchiato code .hljs-formula {
+  color: #8bd5ca;
+}
+.macchiato code .hljs-link {
+  color: #7dc4e4;
+  font-style: italic;
+}
+.macchiato code .hljs-quote {
+  color: #a6da95;
+  font-style: italic;
+}
+.macchiato code .hljs-selector-tag {
+  color: #eed49f;
+}
+.macchiato code .hljs-selector-id {
+  color: #8aadf4;
+}
+.macchiato code .hljs-selector-class {
+  color: #8bd5ca;
+}
+.macchiato code .hljs-selector-attr {
+  color: #c6a0f6;
+}
+.macchiato code .hljs-selector-pseudo {
+  color: #8bd5ca;
+}
+.macchiato code .hljs-template-tag {
+  color: #f0c6c6;
+}
+.macchiato code .hljs-template-variable {
+  color: #f0c6c6;
+}
+.macchiato code .hljs-diff-addition {
+  color: #a6da95;
+  background: rgba(166, 218, 149, 0.15);
+}
+.macchiato code .hljs-diff-deletion {
+  color: #ed8796;
+  background: rgba(237, 135, 150, 0.15);
 }
 
-.frappe code,
-.frappe .hljs {
-  background: #292c3c;
+.frappe code .hljs-keyword {
+  color: #ca9ee6;
 }
-.frappe code .hljs-attr,
+.frappe code .hljs-built_in {
+  color: #e78284;
+}
+.frappe code .hljs-type {
+  color: #e5c890;
+}
+.frappe code .hljs-literal {
+  color: #ef9f76;
+}
+.frappe code .hljs-number {
+  color: #ef9f76;
+}
+.frappe code .hljs-operator {
+  color: #81c8be;
+}
+.frappe code .hljs-punctuation {
+  color: #b5bfe2;
+}
+.frappe code .hljs-property {
+  color: #81c8be;
+}
+.frappe code .hljs-regexp {
+  color: #f4b8e4;
+}
 .frappe code .hljs-string {
   color: #a6d189;
 }
-.frappe code .hljs-tag {
-  color: #e78284;
+.frappe code .hljs-char.escape_ {
+  color: #a6d189;
 }
-.frappe code .hljs-name {
+.frappe code .hljs-subst {
+  color: #a5adce;
+}
+.frappe code .hljs-symbol {
   color: #eebebe;
 }
-.frappe pre .hljs {
-  background: #292c3c !important;
+.frappe code .hljs-variable {
+  color: #ca9ee6;
 }
-.frappe pre .hljs-params {
-  color: #e78284 !important;
+.frappe code .hljs-variable.language_ {
+  color: #ca9ee6;
 }
-.frappe pre .hljs-built_in,
-.frappe pre .hljs-selector-tag,
-.frappe pre .hljs-section,
-.frappe pre .hljs-link {
-  color: #85c1dc !important;
+.frappe code .hljs-variable.constant_ {
+  color: #ef9f76;
 }
-.frappe pre .hljs-keyword {
-  color: #ca9ee6 !important;
+.frappe code .hljs-title {
+  color: #8caaee;
 }
-.frappe pre .hljs,
-.frappe pre .hljs-subst {
-  color: #a5adce !important;
+.frappe code .hljs-title.class_ {
+  color: #e5c890;
 }
-.frappe pre .hljs-title {
-  color: #8caaee !important;
+.frappe code .hljs-title.function_ {
+  color: #8caaee;
 }
-.frappe pre .hljs-attr,
-.frappe pre .hljs-meta-keyword {
-  color: #a6d189 !important;
+.frappe code .hljs-params {
+  color: #c6d0f5;
 }
-.frappe pre .hljs-type {
-  color: #8caaee !important;
+.frappe code .hljs-comment {
+  color: #626880;
 }
-.frappe pre .hljs-string {
-  color: #a6d189 !important;
+.frappe code .hljs-doctag {
+  color: #e78284;
 }
-.frappe pre .hljs-tag {
-  color: #e78284 !important;
+.frappe code .hljs-meta {
+  color: #ef9f76;
 }
-.frappe pre .hljs-meta,
-.frappe pre .hljs-name,
-.frappe pre .hljs-symbol,
-.frappe pre .hljs-bullet,
-.frappe pre .hljs-addition,
-.frappe pre .hljs-variable,
-.frappe pre .hljs-template-tag,
-.frappe pre .hljs-template-variable {
-  color: #eebebe !important;
+.frappe code .hljs-section {
+  color: #8caaee;
 }
-.frappe pre .hljs-addition {
-  background-color: #292c3c !important;
-  color: #a6d189 !important;
+.frappe code .hljs-tag {
+  color: #a5adce;
 }
-.frappe pre .hljs-deletion {
-  background-color: #292c3c !important;
-  color: #e78284 !important;
+.frappe code .hljs-name {
+  color: #ca9ee6;
 }
-.frappe pre .hljs-comment,
-.frappe pre .hljs-quote {
-  color: #626880 !important;
+.frappe code .hljs-attr {
+  color: #8caaee;
 }
-.frappe pre .hljs-keyword,
-.frappe pre .hljs-selector-tag,
-.frappe pre .hljs-literal,
-.frappe pre .hljs-title,
-.frappe pre .hljs-section,
-.frappe pre .hljs-doctag,
-.frappe pre .hljs-type,
-.frappe pre .hljs-name,
-.frappe pre .hljs-strong {
-  font-weight: bold !important;
+.frappe code .hljs-attribute {
+  color: #a6d189;
 }
-.frappe pre .hljs-literal,
-.frappe pre .hljs-number {
-  color: #ef9f76 !important;
+.frappe code .hljs-bullet {
+  color: #81c8be;
 }
-.frappe pre .hljs-emphasis {
-  font-style: italic !important;
+.frappe code .hljs-code {
+  color: #a6d189;
+}
+.frappe code .hljs-emphasis {
+  color: #e78284;
+  font-style: italic;
+}
+.frappe code .hljs-strong {
+  color: #e78284;
+  font-weight: bold;
+}
+.frappe code .hljs-formula {
+  color: #81c8be;
+}
+.frappe code .hljs-link {
+  color: #85c1dc;
+  font-style: italic;
+}
+.frappe code .hljs-quote {
+  color: #a6d189;
+  font-style: italic;
+}
+.frappe code .hljs-selector-tag {
+  color: #e5c890;
+}
+.frappe code .hljs-selector-id {
+  color: #8caaee;
+}
+.frappe code .hljs-selector-class {
+  color: #81c8be;
+}
+.frappe code .hljs-selector-attr {
+  color: #ca9ee6;
+}
+.frappe code .hljs-selector-pseudo {
+  color: #81c8be;
+}
+.frappe code .hljs-template-tag {
+  color: #eebebe;
+}
+.frappe code .hljs-template-variable {
+  color: #eebebe;
+}
+.frappe code .hljs-diff-addition {
+  color: #a6d189;
+  background: rgba(166, 209, 137, 0.15);
+}
+.frappe code .hljs-diff-deletion {
+  color: #e78284;
+  background: rgba(231, 130, 132, 0.15);
 }
 
-.latte code,
-.latte .hljs {
-  background: #e6e9ef;
+.latte code .hljs-keyword {
+  color: #8839ef;
 }
-.latte code .hljs-attr,
+.latte code .hljs-built_in {
+  color: #d20f39;
+}
+.latte code .hljs-type {
+  color: #df8e1d;
+}
+.latte code .hljs-literal {
+  color: #fe640b;
+}
+.latte code .hljs-number {
+  color: #fe640b;
+}
+.latte code .hljs-operator {
+  color: #179299;
+}
+.latte code .hljs-punctuation {
+  color: #5c5f77;
+}
+.latte code .hljs-property {
+  color: #179299;
+}
+.latte code .hljs-regexp {
+  color: #ea76cb;
+}
 .latte code .hljs-string {
   color: #40a02b;
 }
-.latte code .hljs-tag {
-  color: #d20f39;
+.latte code .hljs-char.escape_ {
+  color: #40a02b;
 }
-.latte code .hljs-name {
+.latte code .hljs-subst {
+  color: #6c6f85;
+}
+.latte code .hljs-symbol {
   color: #dd7878;
 }
-.latte pre .hljs {
-  background: #e6e9ef !important;
+.latte code .hljs-variable {
+  color: #8839ef;
 }
-.latte pre .hljs-params {
-  color: #d20f39 !important;
+.latte code .hljs-variable.language_ {
+  color: #8839ef;
 }
-.latte pre .hljs-built_in,
-.latte pre .hljs-selector-tag,
-.latte pre .hljs-section,
-.latte pre .hljs-link {
-  color: #209fb5 !important;
+.latte code .hljs-variable.constant_ {
+  color: #fe640b;
 }
-.latte pre .hljs-keyword {
-  color: #8839ef !important;
+.latte code .hljs-title {
+  color: #1e66f5;
 }
-.latte pre .hljs,
-.latte pre .hljs-subst {
-  color: #6c6f85 !important;
+.latte code .hljs-title.class_ {
+  color: #df8e1d;
 }
-.latte pre .hljs-title {
-  color: #1e66f5 !important;
+.latte code .hljs-title.function_ {
+  color: #1e66f5;
 }
-.latte pre .hljs-attr,
-.latte pre .hljs-meta-keyword {
-  color: #40a02b !important;
+.latte code .hljs-params {
+  color: #4c4f69;
 }
-.latte pre .hljs-type {
-  color: #1e66f5 !important;
+.latte code .hljs-comment {
+  color: #acb0be;
 }
-.latte pre .hljs-string {
-  color: #40a02b !important;
+.latte code .hljs-doctag {
+  color: #d20f39;
 }
-.latte pre .hljs-tag {
-  color: #d20f39 !important;
+.latte code .hljs-meta {
+  color: #fe640b;
 }
-.latte pre .hljs-meta,
-.latte pre .hljs-name,
-.latte pre .hljs-symbol,
-.latte pre .hljs-bullet,
-.latte pre .hljs-addition,
-.latte pre .hljs-variable,
-.latte pre .hljs-template-tag,
-.latte pre .hljs-template-variable {
-  color: #dd7878 !important;
+.latte code .hljs-section {
+  color: #1e66f5;
 }
-.latte pre .hljs-addition {
-  background-color: #e6e9ef !important;
-  color: #40a02b !important;
+.latte code .hljs-tag {
+  color: #6c6f85;
 }
-.latte pre .hljs-deletion {
-  background-color: #e6e9ef !important;
-  color: #d20f39 !important;
+.latte code .hljs-name {
+  color: #8839ef;
 }
-.latte pre .hljs-comment,
-.latte pre .hljs-quote {
-  color: #acb0be !important;
+.latte code .hljs-attr {
+  color: #1e66f5;
 }
-.latte pre .hljs-keyword,
-.latte pre .hljs-selector-tag,
-.latte pre .hljs-literal,
-.latte pre .hljs-title,
-.latte pre .hljs-section,
-.latte pre .hljs-doctag,
-.latte pre .hljs-type,
-.latte pre .hljs-name,
-.latte pre .hljs-strong {
-  font-weight: bold !important;
+.latte code .hljs-attribute {
+  color: #40a02b;
 }
-.latte pre .hljs-literal,
-.latte pre .hljs-number {
-  color: #fe640b !important;
+.latte code .hljs-bullet {
+  color: #179299;
 }
-.latte pre .hljs-emphasis {
-  font-style: italic !important;
+.latte code .hljs-code {
+  color: #40a02b;
+}
+.latte code .hljs-emphasis {
+  color: #d20f39;
+  font-style: italic;
+}
+.latte code .hljs-strong {
+  color: #d20f39;
+  font-weight: bold;
+}
+.latte code .hljs-formula {
+  color: #179299;
+}
+.latte code .hljs-link {
+  color: #209fb5;
+  font-style: italic;
+}
+.latte code .hljs-quote {
+  color: #40a02b;
+  font-style: italic;
+}
+.latte code .hljs-selector-tag {
+  color: #df8e1d;
+}
+.latte code .hljs-selector-id {
+  color: #1e66f5;
+}
+.latte code .hljs-selector-class {
+  color: #179299;
+}
+.latte code .hljs-selector-attr {
+  color: #8839ef;
+}
+.latte code .hljs-selector-pseudo {
+  color: #179299;
+}
+.latte code .hljs-template-tag {
+  color: #dd7878;
+}
+.latte code .hljs-template-variable {
+  color: #dd7878;
+}
+.latte code .hljs-diff-addition {
+  color: #40a02b;
+  background: rgba(64, 160, 43, 0.15);
+}
+.latte code .hljs-diff-deletion {
+  color: #d20f39;
+  background: rgba(210, 15, 57, 0.15);
+}
+
+.mocha code {
+  color: #a6adc8;
+  background: #181825;
+}
+.mocha .ace_gutter {
+  color: #7f849c;
+  background: #181825;
+}
+.mocha .ace_gutter-active-line.ace_gutter-cell {
+  color: #f5c2e7;
+  background: #181825;
+}
+
+.macchiato code {
+  color: #a5adcb;
+  background: #1e2030;
+}
+.macchiato .ace_gutter {
+  color: #8087a2;
+  background: #1e2030;
+}
+.macchiato .ace_gutter-active-line.ace_gutter-cell {
+  color: #f5bde6;
+  background: #1e2030;
+}
+
+.frappe code {
+  color: #a5adce;
+  background: #292c3c;
+}
+.frappe .ace_gutter {
+  color: #838ba7;
+  background: #292c3c;
+}
+.frappe .ace_gutter-active-line.ace_gutter-cell {
+  color: #f4b8e4;
+  background: #292c3c;
+}
+
+.latte code {
+  color: #6c6f85;
+  background: #e6e9ef;
+}
+.latte .ace_gutter {
+  color: #8c8fa1;
+  background: #e6e9ef;
+}
+.latte .ace_gutter-active-line.ace_gutter-cell {
+  color: #ea76cb;
+  background: #e6e9ef;
 }

--- a/theme/catppuccin.css
+++ b/theme/catppuccin.css
@@ -4,7 +4,7 @@
   --sidebar-bg: #181825;
   --sidebar-fg: #cdd6f4;
   --sidebar-non-existant: #6c7086;
-  --sidebar-active: #f5e0dc;
+  --sidebar-active: #89b4fa;
   --sidebar-spacer: #6c7086;
   --scrollbar: #6c7086;
   --icons: #6c7086;
@@ -35,7 +35,7 @@
   --sidebar-bg: #1e2030;
   --sidebar-fg: #cad3f5;
   --sidebar-non-existant: #6e738d;
-  --sidebar-active: #f4dbd6;
+  --sidebar-active: #8aadf4;
   --sidebar-spacer: #6e738d;
   --scrollbar: #6e738d;
   --icons: #6e738d;
@@ -66,7 +66,7 @@
   --sidebar-bg: #292c3c;
   --sidebar-fg: #c6d0f5;
   --sidebar-non-existant: #737994;
-  --sidebar-active: #f2d5cf;
+  --sidebar-active: #8caaee;
   --sidebar-spacer: #737994;
   --scrollbar: #737994;
   --icons: #737994;
@@ -97,7 +97,7 @@
   --sidebar-bg: #e6e9ef;
   --sidebar-fg: #4c4f69;
   --sidebar-non-existant: #9ca0b0;
-  --sidebar-active: #dc8a78;
+  --sidebar-active: #1e66f5;
   --sidebar-spacer: #9ca0b0;
   --scrollbar: #9ca0b0;
   --icons: #9ca0b0;


### PR DESCRIPTION
The current version of mdbook-catppuccin that's used in the CI is 0.2.0, while the assets were for version 0.1.1, and the CI was complaining (but it didn't fail the build, so I guess it went unnoticed).
Also the pinned version of nixpkgs-unstable was bumped, because the current version of mdbook-katex wasn't compatible with the current book.toml.