### PR TITLE
OLD -- suspension loop space adjunction

### DIFF
--- a/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
@@ -580,7 +580,7 @@ module _
           ( glue-pushout (λ x₁ → star) (λ x₁ → star) x))
   
   equiv-pointed-map-pointed-suspension-structure-pointed-function-type :
-      (pointed-map-Pointed-Type (suspension-Pointed-Type X) Y) 
+      (pointed-map-Pointed-Type (suspension-Pointed-Type X) Y)
     ≃∗
       pointed-suspension-structure-pointed-function-type
   pr1 equiv-pointed-map-pointed-suspension-structure-pointed-function-type =

--- a/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
@@ -417,8 +417,8 @@ module _
 
 Here we prove the universal property of the suspension of a pointed type: the
 suspension is left adjoint to the loop space. We do this by constructing an
-equivalence ((suspension A) →∗ B) ≃ (A →∗ Ω B) and showing this equivalence
-is given by λ f → Ω(f) ∘ unit
+equivalence ((suspension A) →∗ B) ≃ (A →∗ Ω B) and showing this equivalence is
+given by λ f → Ω(f) ∘ unit
 
 #### The unit and counit of the adjunction
 
@@ -532,7 +532,7 @@ module _
 
 #### The equivalence in the suspension-loop space adjunction is pointed
 
-The below code is progress towards this, to it still remains to be shown
+The below code is progress towards this, though it still remains to be shown
    
 ```agda
 module _

--- a/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
@@ -609,7 +609,7 @@ module _
             point-suspension-structure-Pointed-Type
             htpy-ev-const-point-suspension-structure)
           refl))
-```         
+```
 
 ### The suspension of a contractible type is contractible
 

--- a/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
@@ -12,6 +12,7 @@ open import foundation.constant-maps
 open import foundation.contractible-types
 open import foundation.dependent-pair-types
 open import foundation.equivalences
+open import foundation.equality-dependent-pair-types
 open import foundation.function-extensionality
 open import foundation.function-types
 open import foundation.functoriality-dependent-pair-types
@@ -20,6 +21,7 @@ open import foundation.identity-systems
 open import foundation.identity-types
 open import foundation.structure-identity-principle
 open import foundation.type-arithmetic-dependent-pair-types
+open import foundation.transport
 open import foundation.unit-type
 open import foundation.universal-property-unit-type
 open import foundation.universe-levels
@@ -529,6 +531,67 @@ module _
 #### The equivalence in the suspension-loop space adjunction is pointed
 
 This remains to be shown.
+
+```agda
+module _
+  {l1 l2 : Level} (X : Pointed-Type l1) (Y : Pointed-Type l2)
+  where
+
+  point-suspension-structure-Pointed-Types : (suspension-structure (pr1 X) (pr1 Y))
+  pr1 point-suspension-structure-Pointed-Types  = point-Pointed-Type Y
+  pr1 (pr2 point-suspension-structure-Pointed-Types) = point-Pointed-Type Y
+  pr2 (pr2 point-suspension-structure-Pointed-Types) = const (type-Pointed-Type X) _ refl
+
+  pointed-suspension-structure-Pointed-Types : Pointed-Type (l1 ⊔ l2)
+  pr1 pointed-suspension-structure-Pointed-Types = (suspension-structure (pr1 X) (pr1 Y))
+  pr2 pointed-suspension-structure-Pointed-Types = point-suspension-structure-Pointed-Types
+
+  pointed-suspension-structure-pointed-function : Pointed-Type (l1 ⊔ l2)
+  pr1 pointed-suspension-structure-pointed-function =
+    Σ (suspension-structure (type-Pointed-Type X) (type-Pointed-Type Y))
+      (λ (y₀ , y₁ , meridY) → y₀ ＝ (point-Pointed-Type Y))
+  pr1 (pr2 pointed-suspension-structure-pointed-function) = point-suspension-structure-Pointed-Types
+  pr2 (pr2 pointed-suspension-structure-pointed-function) = refl
+
+
+  htpy-ev-const-point-suspension-structure : htpy-suspension-structure
+      (ev-suspension (suspension-structure-suspension (pr1 X)) (pr1 Y)
+       (λ x → pr2 Y))
+      point-suspension-structure-Pointed-Types
+  pr1 htpy-ev-const-point-suspension-structure = refl
+  pr1 (pr2 htpy-ev-const-point-suspension-structure) = refl
+  pr2 (pr2 htpy-ev-const-point-suspension-structure) = λ x → right-unit ∙
+    ap-const (point-Pointed-Type Y) (glue-pushout (λ x₁ → star) (λ x₁ → star) x)
+
+  htpy-ev-const-point-suspension-structurey :  ap pr1 (eq-htpy-suspension-structure htpy-ev-const-point-suspension-structure) ＝ refl
+  htpy-ev-const-point-suspension-structurey =
+    ap-pr1-eq-htpy-suspension-structure
+      (ev-suspension (suspension-structure-suspension (pr1 X)) (pr1 Y) (λ x → pr2 Y))
+      point-suspension-structure-Pointed-Types htpy-ev-const-point-suspension-structure
+  
+  equiv-pointed-map-pointed-suspension-structure-pointed-function :
+    (pointed-map-Pointed-Type (suspension-Pointed-Type X) Y) 
+    ≃∗
+    pointed-suspension-structure-pointed-function
+  pr1 equiv-pointed-map-pointed-suspension-structure-pointed-function =
+    equiv-Σ-equiv-base
+      ( λ c → (pr1 c) ＝ (point-Pointed-Type Y))
+      ( equiv-up-suspension
+        ( type-Pointed-Type X)
+        ( type-Pointed-Type Y))
+  pr2 equiv-pointed-map-pointed-suspension-structure-pointed-function =
+    eq-pair-Σ
+      (eq-htpy-suspension-structure htpy-ev-const-point-suspension-structure)
+      ( inv (tr-subst (λ t → t ＝ (point-Pointed-Type Y))
+                                   pr1
+                                   (eq-htpy-suspension-structure htpy-ev-const-point-suspension-structure)) ∙
+       tr² (λ t → (t ＝ point-Pointed-Type Y))
+         (ap-pr1-eq-htpy-suspension-structure
+           (ev-suspension (suspension-structure-suspension (pr1 X)) (pr1 Y) (λ x → pr2 Y))
+           point-suspension-structure-Pointed-Types htpy-ev-const-point-suspension-structure)       
+         refl )
+
+```
 
 ### The suspension of a contractible type is contractible
 

--- a/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
@@ -11,8 +11,8 @@ open import foundation.action-on-identifications-functions
 open import foundation.constant-maps
 open import foundation.contractible-types
 open import foundation.dependent-pair-types
-open import foundation.equivalences
 open import foundation.equality-dependent-pair-types
+open import foundation.equivalences
 open import foundation.function-extensionality
 open import foundation.function-types
 open import foundation.functoriality-dependent-pair-types
@@ -20,8 +20,8 @@ open import foundation.homotopies
 open import foundation.identity-systems
 open import foundation.identity-types
 open import foundation.structure-identity-principle
-open import foundation.type-arithmetic-dependent-pair-types
 open import foundation.transport
+open import foundation.type-arithmetic-dependent-pair-types
 open import foundation.unit-type
 open import foundation.universal-property-unit-type
 open import foundation.universe-levels
@@ -417,8 +417,8 @@ module _
 
 Here we prove the universal property of the suspension of a pointed type: the
 suspension is left adjoint to the loop space. We do this by constructing an
-equivalence ((suspension A) →∗ B) ≃ (A →∗ Ω B) and showing this
-equivalences is given by λ f → Ω(f) ∘ unit
+equivalence ((suspension A) →∗ B) ≃ (A →∗ Ω B) and showing this equivalence
+is given by λ f → Ω(f) ∘ unit
 
 #### The unit and counit of the adjunction
 
@@ -541,7 +541,7 @@ module _
 
   point-suspension-structure-Pointed-Type :
     (suspension-structure (type-Pointed-Type X) (type-Pointed-Type Y))
-  pr1 point-suspension-structure-Pointed-Type  = point-Pointed-Type Y
+  pr1 point-suspension-structure-Pointed-Type = point-Pointed-Type Y
   pr1 (pr2 point-suspension-structure-Pointed-Type) = point-Pointed-Type Y
   pr2 (pr2 point-suspension-structure-Pointed-Type) =
     const
@@ -608,7 +608,7 @@ module _
               ( λ x → pr2 Y))
             point-suspension-structure-Pointed-Type
             htpy-ev-const-point-suspension-structure)
-         refl ))
+         refl))
 ```         
 
 ### The suspension of a contractible type is contractible

--- a/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
@@ -417,8 +417,8 @@ module _
 
 Here we prove the universal property of the suspension of a pointed type: the
 suspension is left adjoint to the loop space. We do this by constructing an
-equivalence ((suspension A) →∗ B) ≃ (A →∗ Ω B) and showing this equivalences is
-given by λ f → Ω(f) ∘ unit
+equivalence ((suspension A) →∗ B) ≃ (A →∗ Ω B) and showing this
+equivalences is given by λ f → Ω(f) ∘ unit
 
 #### The unit and counit of the adjunction
 
@@ -455,14 +455,16 @@ module _
   pr2 (pr1 pointed-equiv-shift) = is-equiv-shift
   pr2 pointed-equiv-shift = preserves-point-pointed-map shift∗
 
-  merid-susp∗ : X →∗ ((N-susp ＝ S-susp) , (merid-susp (point-Pointed-Type X)))
+  merid-susp∗ :
+    X →∗ ((N-susp ＝ S-susp) , (merid-susp (point-Pointed-Type X)))
   pr1 merid-susp∗ = merid-susp
   pr2 merid-susp∗ = refl
 
   unit-susp-loop-adj∗ : X →∗ Ω (suspension-Pointed-Type X)
   unit-susp-loop-adj∗ = unshift∗ ∘∗ merid-susp∗
 
-  unit-susp-loop-adj : type-Pointed-Type X → type-Ω (suspension-Pointed-Type X)
+  unit-susp-loop-adj :
+    type-Pointed-Type X → type-Ω (suspension-Pointed-Type X)
   unit-susp-loop-adj = map-pointed-map unit-susp-loop-adj∗
 
   counit-susp-loop-adj : (suspension (type-Ω X)) → type-Pointed-Type X
@@ -484,7 +486,8 @@ module _
         ( id))
 ```
 
-#### The equivalence between pointed maps out of the suspension of X and pointed maps into the loop space of Y
+#### The equivalence between pointed maps out of the suspension of X and
+pointed maps into the loop space of Y
 
 ```agda
 module _
@@ -537,36 +540,50 @@ module _
   {l1 l2 : Level} (X : Pointed-Type l1) (Y : Pointed-Type l2)
   where
 
-  point-suspension-structure-Pointed-Type : (suspension-structure (type-Pointed-Type X) (type-Pointed-Type Y))
+  point-suspension-structure-Pointed-Type :
+    (suspension-structure (type-Pointed-Type X) (type-Pointed-Type Y))
   pr1 point-suspension-structure-Pointed-Type  = point-Pointed-Type Y
   pr1 (pr2 point-suspension-structure-Pointed-Type) = point-Pointed-Type Y
   pr2 (pr2 point-suspension-structure-Pointed-Type) =
-    const (type-Pointed-Type X) (point-Pointed-Type Y ＝ point-Pointed-Type Y) refl
+    const
+      (type-Pointed-Type X)
+      (point-Pointed-Type Y ＝ point-Pointed-Type Y) refl
 
   pointed-suspension-structure-Pointed-Type : Pointed-Type (l1 ⊔ l2)
-  pr1 pointed-suspension-structure-Pointed-Type = (suspension-structure (pr1 X) (pr1 Y))
-  pr2 pointed-suspension-structure-Pointed-Type = point-suspension-structure-Pointed-Type
+  pr1 pointed-suspension-structure-Pointed-Type =
+    (suspension-structure (pr1 X) (pr1 Y))
+  pr2 pointed-suspension-structure-Pointed-Type =
+    point-suspension-structure-Pointed-Type
 
   pointed-suspension-structure-pointed-function-type : Pointed-Type (l1 ⊔ l2)
   pr1 pointed-suspension-structure-pointed-function-type =
-    Σ (suspension-structure (type-Pointed-Type X) (type-Pointed-Type Y))
+    Σ
+      (suspension-structure (type-Pointed-Type X) (type-Pointed-Type Y))
       (λ (y₀ , y₁ , meridY) → y₀ ＝ (point-Pointed-Type Y))
-  pr1 (pr2 pointed-suspension-structure-pointed-function-type) = point-suspension-structure-Pointed-Type
+  pr1 (pr2 pointed-suspension-structure-pointed-function-type) =
+    point-suspension-structure-Pointed-Type
   pr2 (pr2 pointed-suspension-structure-pointed-function-type) = refl
 
-  htpy-ev-const-point-suspension-structure : htpy-suspension-structure
+  htpy-ev-const-point-suspension-structure :
+    htpy-suspension-structure
       (ev-suspension (suspension-structure-suspension (pr1 X)) (pr1 Y)
         (λ x → pr2 Y))
       point-suspension-structure-Pointed-Type
   pr1 htpy-ev-const-point-suspension-structure = refl
   pr1 (pr2 htpy-ev-const-point-suspension-structure) = refl
-  pr2 (pr2 htpy-ev-const-point-suspension-structure) = λ x → right-unit ∙
-    ap-const (point-Pointed-Type Y) (glue-pushout (λ x₁ → star) (λ x₁ → star) x)
+  pr2 (pr2 htpy-ev-const-point-suspension-structure) =
+    λ x →
+      concat
+        right-unit
+        refl
+        (ap-const
+          (point-Pointed-Type Y)
+          (glue-pushout (λ x₁ → star) (λ x₁ → star) x))
   
   equiv-pointed-map-pointed-suspension-structure-pointed-function-type :
-    (pointed-map-Pointed-Type (suspension-Pointed-Type X) Y) 
+      (pointed-map-Pointed-Type (suspension-Pointed-Type X) Y) 
     ≃∗
-    pointed-suspension-structure-pointed-function-type
+      pointed-suspension-structure-pointed-function-type
   pr1 equiv-pointed-map-pointed-suspension-structure-pointed-function-type =
     equiv-Σ-equiv-base
       ( λ c → (pr1 c) ＝ (point-Pointed-Type Y))
@@ -576,15 +593,24 @@ module _
   pr2 equiv-pointed-map-pointed-suspension-structure-pointed-function-type =
     eq-pair-Σ
       (eq-htpy-suspension-structure htpy-ev-const-point-suspension-structure)
-      ( inv (tr-subst (λ t → t ＝ (point-Pointed-Type Y))
-                                   pr1
-                                   (eq-htpy-suspension-structure htpy-ev-const-point-suspension-structure)) ∙
-       tr² (λ t → (t ＝ point-Pointed-Type Y))
-         (ap-pr1-eq-htpy-suspension-structure
-           (ev-suspension (suspension-structure-suspension (pr1 X)) (pr1 Y) (λ x → pr2 Y))
-           point-suspension-structure-Pointed-Type htpy-ev-const-point-suspension-structure)       
-         refl )
-```
+      (concat
+        (inv
+          (tr-subst
+            (λ t → t ＝ (point-Pointed-Type Y))
+            pr1
+            (eq-htpy-suspension-structure
+              htpy-ev-const-point-suspension-structure)))
+        refl
+        (tr² (λ t → (t ＝ point-Pointed-Type Y))
+          (ap-pr1-eq-htpy-suspension-structure
+            (ev-suspension
+              (suspension-structure-suspension (pr1 X))
+              (pr1 Y)
+              (λ x → pr2 Y))
+            point-suspension-structure-Pointed-Type
+            htpy-ev-const-point-suspension-structure)
+         refl ))
+```         
 
 ### The suspension of a contractible type is contractible
 

--- a/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
@@ -417,8 +417,8 @@ module _
 
 Here we prove the universal property of the suspension of a pointed type: the
 suspension is left adjoint to the loop space. We do this by constructing an
-equivalence ((suspension A) →∗ B) ≃ (A →∗ Ω B) and showing this equivalence is
-given by λ f → Ω(f) ∘ unit
+equivalence `(suspension A →∗ B) ≃ (A →∗ Ω B)` and showing this equivalence is
+given by `λ f → Ω f ∘ unit`
 
 #### The unit and counit of the adjunction
 

--- a/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
@@ -486,8 +486,7 @@ module _
         ( id))
 ```
 
-#### The equivalence between pointed maps out of the suspension of X and
-pointed maps into the loop space of Y
+#### The equivalence between pointed maps out of the suspension of X and pointed maps into the loop space of Y
 
 ```agda
 module _
@@ -533,7 +532,7 @@ module _
 
 #### The equivalence in the suspension-loop space adjunction is pointed
 
-This remains to be shown.
+The below code is progress towards this, to it still remains to be shown
    
 ```agda
 module _
@@ -546,12 +545,12 @@ module _
   pr1 (pr2 point-suspension-structure-Pointed-Type) = point-Pointed-Type Y
   pr2 (pr2 point-suspension-structure-Pointed-Type) =
     const
-      (type-Pointed-Type X)
-      (point-Pointed-Type Y ＝ point-Pointed-Type Y) refl
+      ( type-Pointed-Type X)
+      ( point-Pointed-Type Y ＝ point-Pointed-Type Y) refl
 
   pointed-suspension-structure-Pointed-Type : Pointed-Type (l1 ⊔ l2)
   pr1 pointed-suspension-structure-Pointed-Type =
-    (suspension-structure (pr1 X) (pr1 Y))
+    ( suspension-structure (pr1 X) (pr1 Y))
   pr2 pointed-suspension-structure-Pointed-Type =
     point-suspension-structure-Pointed-Type
 
@@ -566,8 +565,8 @@ module _
 
   htpy-ev-const-point-suspension-structure :
     htpy-suspension-structure
-      (ev-suspension (suspension-structure-suspension (pr1 X)) (pr1 Y)
-        (λ x → pr2 Y))
+      ( ev-suspension (suspension-structure-suspension (pr1 X)) (pr1 Y)
+        ( λ x → pr2 Y))
       point-suspension-structure-Pointed-Type
   pr1 htpy-ev-const-point-suspension-structure = refl
   pr1 (pr2 htpy-ev-const-point-suspension-structure) = refl
@@ -576,9 +575,9 @@ module _
       concat
         right-unit
         refl
-        (ap-const
-          (point-Pointed-Type Y)
-          (glue-pushout (λ x₁ → star) (λ x₁ → star) x))
+        ( ap-const
+          ( point-Pointed-Type Y)
+          ( glue-pushout (λ x₁ → star) (λ x₁ → star) x))
   
   equiv-pointed-map-pointed-suspension-structure-pointed-function-type :
       (pointed-map-Pointed-Type (suspension-Pointed-Type X) Y) 
@@ -592,21 +591,21 @@ module _
         ( type-Pointed-Type Y))
   pr2 equiv-pointed-map-pointed-suspension-structure-pointed-function-type =
     eq-pair-Σ
-      (eq-htpy-suspension-structure htpy-ev-const-point-suspension-structure)
-      (concat
-        (inv
-          (tr-subst
+      ( eq-htpy-suspension-structure htpy-ev-const-point-suspension-structure)
+      ( concat
+        ( inv
+          ( tr-subst
             (λ t → t ＝ (point-Pointed-Type Y))
             pr1
-            (eq-htpy-suspension-structure
+            ( eq-htpy-suspension-structure
               htpy-ev-const-point-suspension-structure)))
         refl
-        (tr² (λ t → (t ＝ point-Pointed-Type Y))
-          (ap-pr1-eq-htpy-suspension-structure
-            (ev-suspension
-              (suspension-structure-suspension (pr1 X))
-              (pr1 Y)
-              (λ x → pr2 Y))
+        ( tr² (λ t → (t ＝ point-Pointed-Type Y))
+          ( ap-pr1-eq-htpy-suspension-structure
+            ( ev-suspension
+              ( suspension-structure-suspension (pr1 X))
+              ( pr1 Y)
+              ( λ x → pr2 Y))
             point-suspension-structure-Pointed-Type
             htpy-ev-const-point-suspension-structure)
          refl ))

--- a/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
@@ -550,15 +550,14 @@ module _
 
   pointed-suspension-structure-Pointed-Type : Pointed-Type (l1 ⊔ l2)
   pr1 pointed-suspension-structure-Pointed-Type =
-    ( suspension-structure (pr1 X) (pr1 Y))
+    suspension-structure (pr1 X) (pr1 Y)
   pr2 pointed-suspension-structure-Pointed-Type =
     point-suspension-structure-Pointed-Type
 
   pointed-suspension-structure-pointed-function-type : Pointed-Type (l1 ⊔ l2)
   pr1 pointed-suspension-structure-pointed-function-type =
-    Σ
-      (suspension-structure (type-Pointed-Type X) (type-Pointed-Type Y))
-      (λ (y₀ , y₁ , meridY) → y₀ ＝ (point-Pointed-Type Y))
+    Σ ( suspension-structure (type-Pointed-Type X) (type-Pointed-Type Y))
+      ( λ (y₀ , y₁ , meridY) → y₀ ＝ (point-Pointed-Type Y))
   pr1 (pr2 pointed-suspension-structure-pointed-function-type) =
     point-suspension-structure-Pointed-Type
   pr2 (pr2 pointed-suspension-structure-pointed-function-type) = refl
@@ -570,18 +569,16 @@ module _
       point-suspension-structure-Pointed-Type
   pr1 htpy-ev-const-point-suspension-structure = refl
   pr1 (pr2 htpy-ev-const-point-suspension-structure) = refl
-  pr2 (pr2 htpy-ev-const-point-suspension-structure) =
-    λ x →
-      concat
-        right-unit
-        refl
-        ( ap-const
-          ( point-Pointed-Type Y)
-          ( glue-pushout (λ x₁ → star) (λ x₁ → star) x))
+  pr2 (pr2 htpy-ev-const-point-suspension-structure) x =
+    concat
+      ( right-unit)
+      ( refl)
+      ( ap-const
+        ( point-Pointed-Type Y)
+        ( glue-pushout (λ _ → star) (λ _ → star) x))
 
   equiv-pointed-map-pointed-suspension-structure-pointed-function-type :
-      (pointed-map-Pointed-Type (suspension-Pointed-Type X) Y)
-    ≃∗
+    ( pointed-map-Pointed-Type (suspension-Pointed-Type X) Y) ≃∗
       pointed-suspension-structure-pointed-function-type
   pr1 equiv-pointed-map-pointed-suspension-structure-pointed-function-type =
     equiv-Σ-equiv-base
@@ -595,20 +592,20 @@ module _
       ( concat
         ( inv
           ( tr-subst
-            (λ t → t ＝ (point-Pointed-Type Y))
-            pr1
+            ( λ t → t ＝ (point-Pointed-Type Y))
+            ( pr1)
             ( eq-htpy-suspension-structure
               htpy-ev-const-point-suspension-structure)))
-        refl
-        ( tr² (λ t → (t ＝ point-Pointed-Type Y))
+        ( refl)
+        ( tr² (λ t → t ＝ point-Pointed-Type Y)
           ( ap-pr1-eq-htpy-suspension-structure
             ( ev-suspension
               ( suspension-structure-suspension (pr1 X))
               ( pr1 Y)
               ( λ x → pr2 Y))
-            point-suspension-structure-Pointed-Type
-            htpy-ev-const-point-suspension-structure)
-          refl))
+            ( point-suspension-structure-Pointed-Type)
+            ( htpy-ev-const-point-suspension-structure))
+          ( refl)))
 ```
 
 ### The suspension of a contractible type is contractible

--- a/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
@@ -546,7 +546,8 @@ module _
   pr2 (pr2 point-suspension-structure-Pointed-Type) =
     const
       ( type-Pointed-Type X)
-      ( point-Pointed-Type Y ＝ point-Pointed-Type Y) refl
+      ( point-Pointed-Type Y ＝ point-Pointed-Type Y)
+      ( refl)
 
   pointed-suspension-structure-Pointed-Type : Pointed-Type (l1 ⊔ l2)
   pr1 pointed-suspension-structure-Pointed-Type =

--- a/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
@@ -608,7 +608,7 @@ module _
               ( λ x → pr2 Y))
             point-suspension-structure-Pointed-Type
             htpy-ev-const-point-suspension-structure)
-         refl))
+          refl))
 ```         
 
 ### The suspension of a contractible type is contractible

--- a/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
@@ -533,7 +533,7 @@ module _
 #### The equivalence in the suspension-loop space adjunction is pointed
 
 The below code is progress towards this, though it still remains to be shown
-   
+
 ```agda
 module _
   {l1 l2 : Level} (X : Pointed-Type l1) (Y : Pointed-Type l2)
@@ -578,7 +578,7 @@ module _
         ( ap-const
           ( point-Pointed-Type Y)
           ( glue-pushout (λ x₁ → star) (λ x₁ → star) x))
-  
+
   equiv-pointed-map-pointed-suspension-structure-pointed-function-type :
       (pointed-map-Pointed-Type (suspension-Pointed-Type X) Y)
     ≃∗

--- a/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
@@ -531,55 +531,49 @@ module _
 #### The equivalence in the suspension-loop space adjunction is pointed
 
 This remains to be shown.
-
+   
 ```agda
 module _
   {l1 l2 : Level} (X : Pointed-Type l1) (Y : Pointed-Type l2)
   where
 
-  point-suspension-structure-Pointed-Types : (suspension-structure (pr1 X) (pr1 Y))
-  pr1 point-suspension-structure-Pointed-Types  = point-Pointed-Type Y
-  pr1 (pr2 point-suspension-structure-Pointed-Types) = point-Pointed-Type Y
-  pr2 (pr2 point-suspension-structure-Pointed-Types) = const (type-Pointed-Type X) _ refl
+  point-suspension-structure-Pointed-Type : (suspension-structure (type-Pointed-Type X) (type-Pointed-Type Y))
+  pr1 point-suspension-structure-Pointed-Type  = point-Pointed-Type Y
+  pr1 (pr2 point-suspension-structure-Pointed-Type) = point-Pointed-Type Y
+  pr2 (pr2 point-suspension-structure-Pointed-Type) =
+    const (type-Pointed-Type X) (point-Pointed-Type Y ＝ point-Pointed-Type Y) refl
 
-  pointed-suspension-structure-Pointed-Types : Pointed-Type (l1 ⊔ l2)
-  pr1 pointed-suspension-structure-Pointed-Types = (suspension-structure (pr1 X) (pr1 Y))
-  pr2 pointed-suspension-structure-Pointed-Types = point-suspension-structure-Pointed-Types
+  pointed-suspension-structure-Pointed-Type : Pointed-Type (l1 ⊔ l2)
+  pr1 pointed-suspension-structure-Pointed-Type = (suspension-structure (pr1 X) (pr1 Y))
+  pr2 pointed-suspension-structure-Pointed-Type = point-suspension-structure-Pointed-Type
 
-  pointed-suspension-structure-pointed-function : Pointed-Type (l1 ⊔ l2)
-  pr1 pointed-suspension-structure-pointed-function =
+  pointed-suspension-structure-pointed-function-type : Pointed-Type (l1 ⊔ l2)
+  pr1 pointed-suspension-structure-pointed-function-type =
     Σ (suspension-structure (type-Pointed-Type X) (type-Pointed-Type Y))
       (λ (y₀ , y₁ , meridY) → y₀ ＝ (point-Pointed-Type Y))
-  pr1 (pr2 pointed-suspension-structure-pointed-function) = point-suspension-structure-Pointed-Types
-  pr2 (pr2 pointed-suspension-structure-pointed-function) = refl
-
+  pr1 (pr2 pointed-suspension-structure-pointed-function-type) = point-suspension-structure-Pointed-Type
+  pr2 (pr2 pointed-suspension-structure-pointed-function-type) = refl
 
   htpy-ev-const-point-suspension-structure : htpy-suspension-structure
       (ev-suspension (suspension-structure-suspension (pr1 X)) (pr1 Y)
-       (λ x → pr2 Y))
-      point-suspension-structure-Pointed-Types
+        (λ x → pr2 Y))
+      point-suspension-structure-Pointed-Type
   pr1 htpy-ev-const-point-suspension-structure = refl
   pr1 (pr2 htpy-ev-const-point-suspension-structure) = refl
   pr2 (pr2 htpy-ev-const-point-suspension-structure) = λ x → right-unit ∙
     ap-const (point-Pointed-Type Y) (glue-pushout (λ x₁ → star) (λ x₁ → star) x)
-
-  htpy-ev-const-point-suspension-structurey :  ap pr1 (eq-htpy-suspension-structure htpy-ev-const-point-suspension-structure) ＝ refl
-  htpy-ev-const-point-suspension-structurey =
-    ap-pr1-eq-htpy-suspension-structure
-      (ev-suspension (suspension-structure-suspension (pr1 X)) (pr1 Y) (λ x → pr2 Y))
-      point-suspension-structure-Pointed-Types htpy-ev-const-point-suspension-structure
   
-  equiv-pointed-map-pointed-suspension-structure-pointed-function :
+  equiv-pointed-map-pointed-suspension-structure-pointed-function-type :
     (pointed-map-Pointed-Type (suspension-Pointed-Type X) Y) 
     ≃∗
-    pointed-suspension-structure-pointed-function
-  pr1 equiv-pointed-map-pointed-suspension-structure-pointed-function =
+    pointed-suspension-structure-pointed-function-type
+  pr1 equiv-pointed-map-pointed-suspension-structure-pointed-function-type =
     equiv-Σ-equiv-base
       ( λ c → (pr1 c) ＝ (point-Pointed-Type Y))
       ( equiv-up-suspension
         ( type-Pointed-Type X)
         ( type-Pointed-Type Y))
-  pr2 equiv-pointed-map-pointed-suspension-structure-pointed-function =
+  pr2 equiv-pointed-map-pointed-suspension-structure-pointed-function-type =
     eq-pair-Σ
       (eq-htpy-suspension-structure htpy-ev-const-point-suspension-structure)
       ( inv (tr-subst (λ t → t ＝ (point-Pointed-Type Y))
@@ -588,9 +582,8 @@ module _
        tr² (λ t → (t ＝ point-Pointed-Type Y))
          (ap-pr1-eq-htpy-suspension-structure
            (ev-suspension (suspension-structure-suspension (pr1 X)) (pr1 Y) (λ x → pr2 Y))
-           point-suspension-structure-Pointed-Types htpy-ev-const-point-suspension-structure)       
+           point-suspension-structure-Pointed-Type htpy-ev-const-point-suspension-structure)       
          refl )
-
 ```
 
 ### The suspension of a contractible type is contractible


### PR DESCRIPTION
This pr contains partial progess towards constructing the pointed equivalence of the suspension loop space adjunction. The construction of the pointed equivalence is according to the following strategy:
- constructed the main pointed equivalence as the pointed composite of "stepping stone" pointed equivalences
- construct the stepping stone pointed equivalences as lemmas in such a way that they they are reusable
- create definitions to make the code readable

This pr contains:
- the first stepping stone equivalence, named `equiv-pointed-map-pointed-suspension-structure-pointed-function-type`
- related lemmas and definitions

I decided to construct the pointed equivalence this way since proving the previously constructed equivalence is pointed proved to be too hard; it has very bad reduction behavior. 