### PR TITLE
Compatibility patch agda-mode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -56,8 +56,6 @@
 
   // File type specific
   "files.associations": {
-    "*.agda": "agda",
-    "*.lagda.md": "literate agda markdown",
     "*.lock": "json"
   },
 


### PR DESCRIPTION
A compatibility patch for version `0.4.0` of agda-mode. With this version, agda-mode defined its own file format for literate agda markdown files, conflicting with the file format defined by agda-syntax.