### PR TITLE
Construct ring congruence from two sided ideal

### DIFF
--- a/src/group-theory/abelian-groups.lagda.md
+++ b/src/group-theory/abelian-groups.lagda.md
@@ -247,7 +247,7 @@ module _
   is-equiv-add-Ab : (x : type-Ab A) → is-equiv (add-Ab A x)
   is-equiv-add-Ab = is-equiv-mul-Group (group-Ab A)
 
-  equiv-add-Ab : (x : type-Ab A) → type-Ab A ≃ type-Ab A
+  equiv-add-Ab : type-Ab A → (type-Ab A ≃ type-Ab A)
   equiv-add-Ab = equiv-mul-Group (group-Ab A)
 ```
 

--- a/src/ring-theory/congruence-relations-rings.lagda.md
+++ b/src/ring-theory/congruence-relations-rings.lagda.md
@@ -12,9 +12,9 @@ open import foundation.contractible-types
 open import foundation.dependent-pair-types
 open import foundation.equivalence-relations
 open import foundation.equivalences
+open import foundation.identity-types
 open import foundation.propositions
 open import foundation.universe-levels
-open import foundation.identity-types
 
 open import group-theory.congruence-relations-abelian-groups
 open import group-theory.congruence-relations-monoids

--- a/src/ring-theory/congruence-relations-rings.lagda.md
+++ b/src/ring-theory/congruence-relations-rings.lagda.md
@@ -14,6 +14,8 @@ open import foundation.equivalences
 open import foundation.propositions
 open import foundation.universe-levels
 
+open import foundation-core.identity-types
+
 open import group-theory.congruence-relations-abelian-groups
 open import group-theory.congruence-relations-monoids
 
@@ -70,6 +72,22 @@ module _
     (x y : type-Ring R) → is-prop (sim-congruence-Ring x y)
   is-prop-sim-congruence-Ring =
     is-prop-sim-congruence-Semiring (semiring-Ring R) S
+
+  concatenate-eq-sim-congruence-Ring :
+    {x1 x2 y : type-Ring R} →
+    x1 ＝ x2 → sim-congruence-Ring x2 y → sim-congruence-Ring x1 y
+  concatenate-eq-sim-congruence-Ring refl H = H
+
+  concatenate-sim-eq-congruence-Ring :
+    {x y1 y2 : type-Ring R} →
+    sim-congruence-Ring x y1 → y1 ＝ y2 → sim-congruence-Ring x y2
+  concatenate-sim-eq-congruence-Ring H refl = H
+
+  concatenate-sim-eq-sim-congruence-Ring :
+    {x1 x2 y1 y2 : type-Ring R} →
+    x1 ＝ x2 → sim-congruence-Ring x2 y1 →
+    y1 ＝ y2 → sim-congruence-Ring x1 y2
+  concatenate-sim-eq-sim-congruence-Ring refl H refl = H
 
   refl-congruence-Ring :
     is-reflexive-Relation-Prop prop-congruence-Ring

--- a/src/ring-theory/congruence-relations-rings.lagda.md
+++ b/src/ring-theory/congruence-relations-rings.lagda.md
@@ -14,8 +14,7 @@ open import foundation.equivalence-relations
 open import foundation.equivalences
 open import foundation.propositions
 open import foundation.universe-levels
-
-open import foundation-core.identity-types
+open import foundation.identity-types
 
 open import group-theory.congruence-relations-abelian-groups
 open import group-theory.congruence-relations-monoids

--- a/src/ring-theory/congruence-relations-rings.lagda.md
+++ b/src/ring-theory/congruence-relations-rings.lagda.md
@@ -8,6 +8,7 @@ module ring-theory.congruence-relations-rings where
 
 ```agda
 open import foundation.binary-relations
+open import foundation.contractible-types
 open import foundation.dependent-pair-types
 open import foundation.equivalence-relations
 open import foundation.equivalences
@@ -211,4 +212,56 @@ construct-congruence-Ring :
 pr1 (pr1 (construct-congruence-Ring R S H K)) = S
 pr2 (pr1 (construct-congruence-Ring R S H K)) = H
 pr2 (construct-congruence-Ring R S H K) = K
+```
+
+## Properties
+
+### Characterizing equality of congruence relations of rings
+
+```agda
+relate-same-elements-congruence-Ring :
+  {l1 l2 l3 : Level} (R : Ring l1) →
+  congruence-Ring l2 R → congruence-Ring l3 R → UU (l1 ⊔ l2 ⊔ l3)
+relate-same-elements-congruence-Ring R =
+  relate-same-elements-congruence-Semiring (semiring-Ring R)
+
+refl-relate-same-elements-congruence-Ring :
+  {l1 l2 : Level} (R : Ring l1) (S : congruence-Ring l2 R) →
+  relate-same-elements-congruence-Ring R S S
+refl-relate-same-elements-congruence-Ring R =
+  refl-relate-same-elements-congruence-Semiring (semiring-Ring R)
+
+is-contr-total-relate-same-elements-congruence-Ring :
+  {l1 l2 : Level} (R : Ring l1) (S : congruence-Ring l2 R) →
+  is-contr
+    ( Σ ( congruence-Ring l2 R)
+        ( relate-same-elements-congruence-Ring R S))
+is-contr-total-relate-same-elements-congruence-Ring R =
+  is-contr-total-relate-same-elements-congruence-Semiring
+    ( semiring-Ring R)
+
+relate-same-elements-eq-congruence-Ring :
+  {l1 l2 : Level} (R : Ring l1) (S T : congruence-Ring l2 R) →
+  S ＝ T → relate-same-elements-congruence-Ring R S T
+relate-same-elements-eq-congruence-Ring R =
+  relate-same-elements-eq-congruence-Semiring (semiring-Ring R)
+
+is-equiv-relate-same-elements-eq-congruence-Ring :
+  {l1 l2 : Level} (R : Ring l1) (S T : congruence-Ring l2 R) →
+  is-equiv (relate-same-elements-eq-congruence-Ring R S T)
+is-equiv-relate-same-elements-eq-congruence-Ring R =
+  is-equiv-relate-same-elements-eq-congruence-Semiring
+    ( semiring-Ring R)
+
+extensionality-congruence-Ring :
+  {l1 l2 : Level} (R : Ring l1) (S T : congruence-Ring l2 R) →
+  (S ＝ T) ≃ relate-same-elements-congruence-Ring R S T
+extensionality-congruence-Ring R =
+  extensionality-congruence-Semiring (semiring-Ring R)
+
+eq-relate-same-elements-congruence-Ring :
+  {l1 l2 : Level} (R : Ring l1) (S T : congruence-Ring l2 R) →
+  relate-same-elements-congruence-Ring R S T → S ＝ T
+eq-relate-same-elements-congruence-Ring R =
+  eq-relate-same-elements-congruence-Semiring (semiring-Ring R)
 ```

--- a/src/ring-theory/congruence-relations-rings.lagda.md
+++ b/src/ring-theory/congruence-relations-rings.lagda.md
@@ -188,6 +188,20 @@ module _
       ( eq-rel-congruence-Ring)
   mul-congruence-Ring = pr2 S
 
+  left-mul-congruence-Ring :
+    (x : type-Ring R) {y z : type-Ring R} →
+    sim-congruence-Ring y z →
+    sim-congruence-Ring (mul-Ring R x y) (mul-Ring R x z)
+  left-mul-congruence-Ring x H =
+    mul-congruence-Ring (refl-congruence-Ring x) H
+
+  right-mul-congruence-Ring :
+    {x y : type-Ring R} → sim-congruence-Ring x y →
+    (z : type-Ring R) →
+    sim-congruence-Ring (mul-Ring R x z) (mul-Ring R y z)
+  right-mul-congruence-Ring H z =
+    mul-congruence-Ring H (refl-congruence-Ring z)
+
 construct-congruence-Ring :
   {l1 l2 : Level} (R : Ring l1) →
   (S : Equivalence-Relation l2 (type-Ring R)) →

--- a/src/ring-theory/congruence-relations-semirings.lagda.md
+++ b/src/ring-theory/congruence-relations-semirings.lagda.md
@@ -12,8 +12,13 @@ open import foundation.cartesian-product-types
 open import foundation.dependent-pair-types
 open import foundation.equivalence-relations
 open import foundation.equivalences
+open import foundation.fundamental-theorem-of-identity-types
 open import foundation.propositions
+open import foundation.subtype-identity-principle
 open import foundation.universe-levels
+
+open import foundation-core.contractible-types
+open import foundation-core.identity-types
 
 open import group-theory.congruence-relations-monoids
 
@@ -40,6 +45,14 @@ module _
     (S : congruence-Monoid l2 (additive-monoid-Semiring R)) → UU (l1 ⊔ l2)
   is-congruence-Semiring S =
     is-congruence-Monoid
+      ( multiplicative-monoid-Semiring R)
+      ( eq-rel-congruence-Monoid (additive-monoid-Semiring R) S)
+
+  is-prop-is-congruence-Semiring :
+    {l2 : Level} (S : congruence-Monoid l2 (additive-monoid-Semiring R)) →
+    is-prop (is-congruence-Semiring S)
+  is-prop-is-congruence-Semiring S =
+    is-prop-is-congruence-Monoid
       ( multiplicative-monoid-Semiring R)
       ( eq-rel-congruence-Monoid (additive-monoid-Semiring R) S)
 
@@ -141,4 +154,69 @@ construct-congruence-Semiring :
 pr1 (pr1 (construct-congruence-Semiring R S H K)) = S
 pr2 (pr1 (construct-congruence-Semiring R S H K)) = H
 pr2 (construct-congruence-Semiring R S H K) = K
+```
+
+## Properties
+
+### Characterizing equality of congruence relations on semirings
+
+```agda
+relate-same-elements-congruence-Semiring :
+  {l1 l2 l3 : Level} (R : Semiring l1) →
+  congruence-Semiring l2 R → congruence-Semiring l3 R → UU (l1 ⊔ l2 ⊔ l3)
+relate-same-elements-congruence-Semiring R S T =
+  relate-same-elements-Equivalence-Relation
+    ( eq-rel-congruence-Semiring R S)
+    ( eq-rel-congruence-Semiring R T)
+
+refl-relate-same-elements-congruence-Semiring :
+  {l1 l2 : Level} (R : Semiring l1) (S : congruence-Semiring l2 R) →
+  relate-same-elements-congruence-Semiring R S S
+refl-relate-same-elements-congruence-Semiring R S =
+  refl-relate-same-elements-Equivalence-Relation
+    ( eq-rel-congruence-Semiring R S)
+
+is-contr-total-relate-same-elements-congruence-Semiring :
+  {l1 l2 : Level} (R : Semiring l1) (S : congruence-Semiring l2 R) →
+  is-contr
+    ( Σ ( congruence-Semiring l2 R)
+        ( relate-same-elements-congruence-Semiring R S))
+is-contr-total-relate-same-elements-congruence-Semiring R S =
+  is-contr-total-Eq-subtype
+    ( is-contr-total-relate-same-elements-congruence-Monoid
+      ( additive-monoid-Semiring R)
+      ( congruence-additive-monoid-congruence-Semiring R S))
+    ( is-prop-is-congruence-Semiring R)
+    ( congruence-additive-monoid-congruence-Semiring R S)
+    ( refl-relate-same-elements-congruence-Semiring R S)
+    ( mul-congruence-Semiring R S)
+
+relate-same-elements-eq-congruence-Semiring :
+  {l1 l2 : Level} (R : Semiring l1) (S T : congruence-Semiring l2 R) →
+  S ＝ T → relate-same-elements-congruence-Semiring R S T
+relate-same-elements-eq-congruence-Semiring R S .S refl =
+  refl-relate-same-elements-congruence-Semiring R S
+
+is-equiv-relate-same-elements-eq-congruence-Semiring :
+  {l1 l2 : Level} (R : Semiring l1) (S T : congruence-Semiring l2 R) →
+  is-equiv (relate-same-elements-eq-congruence-Semiring R S T)
+is-equiv-relate-same-elements-eq-congruence-Semiring R S T =
+    fundamental-theorem-id
+      ( is-contr-total-relate-same-elements-congruence-Semiring R S)
+      ( relate-same-elements-eq-congruence-Semiring R S)
+      ( T)
+
+extensionality-congruence-Semiring :
+  {l1 l2 : Level} (R : Semiring l1) (S T : congruence-Semiring l2 R) →
+  (S ＝ T) ≃ relate-same-elements-congruence-Semiring R S T
+pr1 (extensionality-congruence-Semiring R S T) =
+  relate-same-elements-eq-congruence-Semiring R S T
+pr2 (extensionality-congruence-Semiring R S T) =
+  is-equiv-relate-same-elements-eq-congruence-Semiring R S T
+
+eq-relate-same-elements-congruence-Semiring :
+  {l1 l2 : Level} (R : Semiring l1) (S T : congruence-Semiring l2 R) →
+  relate-same-elements-congruence-Semiring R S T → S ＝ T
+eq-relate-same-elements-congruence-Semiring R S T =
+  map-inv-equiv (extensionality-congruence-Semiring R S T)
 ```

--- a/src/ring-theory/congruence-relations-semirings.lagda.md
+++ b/src/ring-theory/congruence-relations-semirings.lagda.md
@@ -158,7 +158,7 @@ pr2 (construct-congruence-Semiring R S H K) = K
 
 ## Properties
 
-### Characterizing equality of congruence relations on semirings
+### Characterizing equality of congruence relations of semirings
 
 ```agda
 relate-same-elements-congruence-Semiring :
@@ -200,11 +200,10 @@ relate-same-elements-eq-congruence-Semiring R S .S refl =
 is-equiv-relate-same-elements-eq-congruence-Semiring :
   {l1 l2 : Level} (R : Semiring l1) (S T : congruence-Semiring l2 R) →
   is-equiv (relate-same-elements-eq-congruence-Semiring R S T)
-is-equiv-relate-same-elements-eq-congruence-Semiring R S T =
+is-equiv-relate-same-elements-eq-congruence-Semiring R S =
     fundamental-theorem-id
       ( is-contr-total-relate-same-elements-congruence-Semiring R S)
       ( relate-same-elements-eq-congruence-Semiring R S)
-      ( T)
 
 extensionality-congruence-Semiring :
   {l1 l2 : Level} (R : Semiring l1) (S T : congruence-Semiring l2 R) →

--- a/src/ring-theory/congruence-relations-semirings.lagda.md
+++ b/src/ring-theory/congruence-relations-semirings.lagda.md
@@ -16,9 +16,8 @@ open import foundation.fundamental-theorem-of-identity-types
 open import foundation.propositions
 open import foundation.subtype-identity-principle
 open import foundation.universe-levels
-
-open import foundation-core.contractible-types
-open import foundation-core.identity-types
+open import foundation.contractible-types
+open import foundation.identity-types
 
 open import group-theory.congruence-relations-monoids
 

--- a/src/ring-theory/congruence-relations-semirings.lagda.md
+++ b/src/ring-theory/congruence-relations-semirings.lagda.md
@@ -9,15 +9,15 @@ module ring-theory.congruence-relations-semirings where
 ```agda
 open import foundation.binary-relations
 open import foundation.cartesian-product-types
+open import foundation.contractible-types
 open import foundation.dependent-pair-types
 open import foundation.equivalence-relations
 open import foundation.equivalences
 open import foundation.fundamental-theorem-of-identity-types
+open import foundation.identity-types
 open import foundation.propositions
 open import foundation.subtype-identity-principle
 open import foundation.universe-levels
-open import foundation.contractible-types
-open import foundation.identity-types
 
 open import group-theory.congruence-relations-monoids
 

--- a/src/ring-theory/ideals-rings.lagda.md
+++ b/src/ring-theory/ideals-rings.lagda.md
@@ -535,4 +535,4 @@ module _
   relate-same-elements-congruence-ideal-congruence-Ring = ?-}
 ```
 
-Characterisation of ring congruences remains to be defined.
+Characterisation of equality of ring congruences remains to be defined.

--- a/src/ring-theory/ideals-rings.lagda.md
+++ b/src/ring-theory/ideals-rings.lagda.md
@@ -330,7 +330,8 @@ module _
       ( ab-Ring R)
       ( subgroup-ideal-Ring R I))
 
-  mul-congruence-lemma : {x y u v : type-Ring R} →
+  mul-congruence-lemma :
+    { x y u v : type-Ring R} →
     ( is-in-ideal-Ring R I (add-Ring R (neg-Ring R x) y)) →
     ( is-in-ideal-Ring R I (add-Ring R (neg-Ring R u) v)) →
     ( is-in-ideal-Ring R I

--- a/src/ring-theory/ideals-rings.lagda.md
+++ b/src/ring-theory/ideals-rings.lagda.md
@@ -483,7 +483,8 @@ module _
     is-closed-under-negatives-subset-congruence-Ring
 
   ideal-congruence-Ring : ideal-Ring l2 R
-  pr1 ideal-congruence-Ring = subset-congruence-Ring
+  pr1 ideal-congruence-Ring =
+    subset-congruence-Ring
   pr1 (pr2 ideal-congruence-Ring) =
     is-additive-subgroup-congruence-Ring
   pr1 (pr2 (pr2 ideal-congruence-Ring)) =
@@ -521,7 +522,7 @@ module _
       ( has-same-elements-ideal-congruence-Ring)
 ```
 
-#### The congruence relation of the ideal obtained from a congruence relation `S is  `S itself
+#### The congruence relation of the ideal obtained from a congruence relation `S is `S itself
 
 ```agda
 module _

--- a/src/ring-theory/ideals-rings.lagda.md
+++ b/src/ring-theory/ideals-rings.lagda.md
@@ -15,13 +15,13 @@ open import foundation.contractible-types
 open import foundation.dependent-pair-types
 open import foundation.equivalence-relations
 open import foundation.equivalences
+open import foundation.function-types
 open import foundation.fundamental-theorem-of-identity-types
 open import foundation.identity-types
 open import foundation.propositions
 open import foundation.subtype-identity-principle
 open import foundation.subtypes
 open import foundation.universe-levels
-open import foundation.function-types
 
 open import group-theory.congruence-relations-abelian-groups
 open import group-theory.congruence-relations-monoids
@@ -352,7 +352,7 @@ module _
       ( add-Ring R
         ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
         ( mul-Ring R y (add-Ring R (neg-Ring R u) v)))
-   ＝ ( add-Ring R
+    ＝ ( add-Ring R
         ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
         ( add-Ring R (mul-Ring R y (neg-Ring R u)) (mul-Ring R y v)))
       by
@@ -361,7 +361,7 @@ module _
           ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
           ( a)))
         ( left-distributive-mul-add-Ring R y (neg-Ring R u) v))
-   ＝ ( add-Ring R
+    ＝ ( add-Ring R
         ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
         ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v)))
       by
@@ -370,7 +370,7 @@ module _
           ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
           ( add-Ring R a (mul-Ring R y v))))
         ( right-negative-law-mul-Ring R y u))
-   ＝ ( add-Ring R
+    ＝ ( add-Ring R
         ( add-Ring R (mul-Ring R (neg-Ring R x) u) (mul-Ring R y u))
         ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v)))
       by
@@ -379,7 +379,7 @@ module _
           ( a)
           ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v))))
         ( right-distributive-mul-add-Ring R (neg-Ring R x) y u))
-   ＝ ( add-Ring R
+    ＝ ( add-Ring R
         ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y u))
         ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v)))
       by
@@ -388,7 +388,7 @@ module _
           ( add-Ring R a (mul-Ring R y u))
           ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v))))
         ( left-negative-law-mul-Ring R x u))
-   ＝ ( add-Ring R
+    ＝ ( add-Ring R
         ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y u))
         ( add-Ring R (mul-Ring R y v) (neg-Ring R (mul-Ring R y u))))
       by
@@ -399,7 +399,7 @@ module _
         ( commutative-add-Ring R
           ( neg-Ring R (mul-Ring R y u))
           ( mul-Ring R y v)))
-   ＝ ( add-Ring R
+    ＝ ( add-Ring R
         ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))
         ( add-Ring R (mul-Ring R y u) (neg-Ring R (mul-Ring R y u))))
       by
@@ -408,7 +408,7 @@ module _
         ( mul-Ring R y u)
         ( mul-Ring R y v)
         ( neg-Ring R (mul-Ring R y u)))
-   ＝ ( add-Ring R
+    ＝ ( add-Ring R
         ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))
         ( zero-Ring R))
       by
@@ -417,7 +417,7 @@ module _
           ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))
           ( a)))
         ( right-inverse-law-add-Ring R (mul-Ring R y u)))
-   ＝ ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))
+    ＝ ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))
       by
       ( right-unit-law-add-Ring R
         ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))))

--- a/src/ring-theory/ideals-rings.lagda.md
+++ b/src/ring-theory/ideals-rings.lagda.md
@@ -21,6 +21,8 @@ open import foundation.subtype-identity-principle
 open import foundation.subtypes
 open import foundation.universe-levels
 
+open import foundation-core.function-types
+
 open import group-theory.congruence-relations-abelian-groups
 open import group-theory.congruence-relations-monoids
 open import group-theory.subgroups-abelian-groups
@@ -427,10 +429,65 @@ module _
 
 #### The ideal obtained from a congruence relation
 
-#### The ideal obtained from the congruence relalation of an ideal `I` is `I` itself
+```agda
+module _
+  {l1 l2 : Level} (R : Ring l1) (S : congruence-Ring l2 R)
+  where
 
-#### The congruence relation of the ideal obtained from a congruence relation `S` is `S` itself
+  subset-congruence-Ring : subset-Ring l2 R
+  subset-congruence-Ring = prop-congruence-Ring R S (zero-Ring R)
 
-#### The equivalence of ideals and congruence relations
+  is-in-subset-congruence-Ring : (type-Ring R) → UU l2
+  is-in-subset-congruence-Ring = type-Prop ∘ subset-congruence-Ring
 
-This remains to be shown.
+  contains-zero-subset-congruence-Ring :
+    contains-zero-subset-Ring R subset-congruence-Ring
+  contains-zero-subset-congruence-Ring =
+    refl-congruence-Ring R S (zero-Ring R)
+
+  is-closed-under-addition-subset-congruence-Ring :
+    is-closed-under-addition-subset-Ring R subset-congruence-Ring
+  is-closed-under-addition-subset-congruence-Ring x y H K =
+    concatenate-eq-sim-congruence-Ring R S
+      ( inv (left-unit-law-add-Ring R (zero-Ring R)))
+      ( add-congruence-Ring R S H K)
+
+  is-closed-under-negatives-subset-congruence-Ring :
+    is-closed-under-negatives-subset-Ring R subset-congruence-Ring
+  is-closed-under-negatives-subset-congruence-Ring x H =
+      concatenate-eq-sim-congruence-Ring R S
+        ( inv (neg-zero-Ring R))
+        ( neg-congruence-Ring R S H)
+
+  is-closed-under-left-multiplication-subset-congruence-Ring :
+    is-closed-under-left-multiplication-subset-Ring R subset-congruence-Ring
+  is-closed-under-left-multiplication-subset-congruence-Ring x y H =
+    concatenate-eq-sim-congruence-Ring R S
+      ( inv (right-zero-law-mul-Ring R x))
+      ( mul-congruence-Ring R S (refl-congruence-Ring R S x) H)
+
+  is-closed-under-right-multiplication-subset-congruence-Ring :
+    is-closed-under-right-multiplication-subset-Ring R subset-congruence-Ring
+  is-closed-under-right-multiplication-subset-congruence-Ring x y H =
+    concatenate-eq-sim-congruence-Ring R S
+      ( inv (left-zero-law-mul-Ring R y))
+      ( mul-congruence-Ring R S H (refl-congruence-Ring R S y))
+
+  is-additive-subgroup-congruence-Ring :
+    is-additive-subgroup-subset-Ring R subset-congruence-Ring
+  pr1 is-additive-subgroup-congruence-Ring =
+    contains-zero-subset-congruence-Ring
+  pr1 (pr2 is-additive-subgroup-congruence-Ring) =
+    is-closed-under-addition-subset-congruence-Ring
+  pr2 (pr2 is-additive-subgroup-congruence-Ring) =
+    is-closed-under-negatives-subset-congruence-Ring
+
+  ideal-congruence-Ring : ideal-Ring l2 R
+  pr1 ideal-congruence-Ring = subset-congruence-Ring
+  pr1 (pr2 ideal-congruence-Ring) =
+    is-additive-subgroup-congruence-Ring
+  pr1 (pr2 (pr2 ideal-congruence-Ring)) =
+    is-closed-under-left-multiplication-subset-congruence-Ring
+  pr2 (pr2 (pr2 ideal-congruence-Ring)) =
+    is-closed-under-right-multiplication-subset-congruence-Ring
+```

--- a/src/ring-theory/ideals-rings.lagda.md
+++ b/src/ring-theory/ideals-rings.lagda.md
@@ -21,8 +21,7 @@ open import foundation.propositions
 open import foundation.subtype-identity-principle
 open import foundation.subtypes
 open import foundation.universe-levels
-
-open import foundation-core.function-types
+open import foundation.function-types
 
 open import group-theory.congruence-relations-abelian-groups
 open import group-theory.congruence-relations-monoids
@@ -352,66 +351,74 @@ module _
     ( equational-reasoning
       ( add-Ring R
         ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
-        ( mul-Ring R y (add-Ring R (neg-Ring R u) v))) ＝
-      ( add-Ring R
+        ( mul-Ring R y (add-Ring R (neg-Ring R u) v)))
+   ＝ ( add-Ring R
         ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
-        ( add-Ring R (mul-Ring R y (neg-Ring R u)) (mul-Ring R y v))) by
+        ( add-Ring R (mul-Ring R y (neg-Ring R u)) (mul-Ring R y v)))
+      by
       ( ap (λ a →
         ( add-Ring R
           ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
           ( a)))
-        ( left-distributive-mul-add-Ring R y (neg-Ring R u) v)) ＝
-      ( add-Ring R
+        ( left-distributive-mul-add-Ring R y (neg-Ring R u) v))
+   ＝ ( add-Ring R
         ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
-        ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v))) by
+        ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v)))
+      by
       ( ap (λ a →
         ( add-Ring R
           ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
           ( add-Ring R a (mul-Ring R y v))))
-        ( right-negative-law-mul-Ring R y u)) ＝
-      ( add-Ring R
+        ( right-negative-law-mul-Ring R y u))
+   ＝ ( add-Ring R
         ( add-Ring R (mul-Ring R (neg-Ring R x) u) (mul-Ring R y u))
-        ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v))) by
+        ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v)))
+      by
       ( ap (λ a →
         ( add-Ring R
           ( a)
           ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v))))
-        ( right-distributive-mul-add-Ring R (neg-Ring R x) y u)) ＝
-      ( add-Ring R
+        ( right-distributive-mul-add-Ring R (neg-Ring R x) y u))
+   ＝ ( add-Ring R
         ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y u))
-      ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v))) by
-        ( ap (λ a →
-          ( add-Ring R
-            ( add-Ring R a (mul-Ring R y u))
-            ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v))))
-        ( left-negative-law-mul-Ring R x u)) ＝
-      ( add-Ring R
+        ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v)))
+      by
+      ( ap (λ a →
+        ( add-Ring R
+          ( add-Ring R a (mul-Ring R y u))
+          ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v))))
+        ( left-negative-law-mul-Ring R x u))
+   ＝ ( add-Ring R
         ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y u))
-        ( add-Ring R (mul-Ring R y v) (neg-Ring R (mul-Ring R y u)))) by
+        ( add-Ring R (mul-Ring R y v) (neg-Ring R (mul-Ring R y u))))
+      by
       ( ap (λ a →
         ( add-Ring R
           ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y u))
           ( a)))
         ( commutative-add-Ring R
           ( neg-Ring R (mul-Ring R y u))
-          ( mul-Ring R y v))) ＝
-      ( add-Ring R
+          ( mul-Ring R y v)))
+   ＝ ( add-Ring R
         ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))
-        ( add-Ring R (mul-Ring R y u) (neg-Ring R (mul-Ring R y u)))) by
+        ( add-Ring R (mul-Ring R y u) (neg-Ring R (mul-Ring R y u))))
+      by
       ( interchange-add-add-Ring R
         ( neg-Ring R (mul-Ring R x u))
         ( mul-Ring R y u)
         ( mul-Ring R y v)
-        ( neg-Ring R (mul-Ring R y u))) ＝
-      ( add-Ring R
+        ( neg-Ring R (mul-Ring R y u)))
+   ＝ ( add-Ring R
         ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))
-        ( zero-Ring R)) by
+        ( zero-Ring R))
+      by
       ( ap (λ a →
         ( add-Ring R
           ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))
           ( a)))
-        ( right-inverse-law-add-Ring R (mul-Ring R y u))) ＝
-      ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v)) by
+        ( right-inverse-law-add-Ring R (mul-Ring R y u)))
+   ＝ ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))
+      by
       ( right-unit-law-add-Ring R
         ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))))
 

--- a/src/ring-theory/ideals-rings.lagda.md
+++ b/src/ring-theory/ideals-rings.lagda.md
@@ -531,7 +531,7 @@ module _
       ( has-same-elements-ideal-congruence-Ring)
 ```
 
-#### The congruence relation of the ideal obtained from a congruence relation `S is `S itself
+#### The congruence relation of the ideal obtained from a congruence relation `S` is `S` itself
 
 ```agda
 module _

--- a/src/ring-theory/ideals-rings.lagda.md
+++ b/src/ring-theory/ideals-rings.lagda.md
@@ -330,13 +330,13 @@ module _
       ( ab-Ring R)
       ( subgroup-ideal-Ring R I))
 
-  mul-congruence-lemma :
+  is-congruence-monoid-mul-congruence-ideal-Ring :
     { x y u v : type-Ring R} →
     ( is-in-ideal-Ring R I (add-Ring R (neg-Ring R x) y)) →
     ( is-in-ideal-Ring R I (add-Ring R (neg-Ring R u) v)) →
     ( is-in-ideal-Ring R I
       ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v)))
-  mul-congruence-lemma {x} {y} {u} {v} e f =
+  is-congruence-monoid-mul-congruence-ideal-Ring {x} {y} {u} {v} e f =
     ( is-closed-under-eq-ideal-Ring R I
       ( is-closed-under-addition-ideal-Ring R I
         ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
@@ -357,77 +357,50 @@ module _
         ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
         ( add-Ring R (mul-Ring R y (neg-Ring R u)) (mul-Ring R y v)))
       by
-      ( ap (λ a →
-        ( add-Ring R
-          ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
-          ( a)))
+      ( ap
+        ( add-Ring R ( mul-Ring R (add-Ring R (neg-Ring R x) y) u))
         ( left-distributive-mul-add-Ring R y (neg-Ring R u) v))
     ＝ ( add-Ring R
         ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
         ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v)))
       by
-      ( ap (λ a →
-        ( add-Ring R
-          ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
-          ( add-Ring R a (mul-Ring R y v))))
+      ( ap
+        ( λ a →
+          add-Ring R
+            ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
+            ( add-Ring R a (mul-Ring R y v)))
         ( right-negative-law-mul-Ring R y u))
     ＝ ( add-Ring R
         ( add-Ring R (mul-Ring R (neg-Ring R x) u) (mul-Ring R y u))
         ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v)))
       by
-      ( ap (λ a →
-        ( add-Ring R
-          ( a)
-          ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v))))
+      ( ap
+        ( add-Ring' R
+          ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v)))
         ( right-distributive-mul-add-Ring R (neg-Ring R x) y u))
     ＝ ( add-Ring R
         ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y u))
         ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v)))
       by
-      ( ap (λ a →
-        ( add-Ring R
-          ( add-Ring R a (mul-Ring R y u))
-          ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v))))
+      ( ap
+        ( λ a →
+          add-Ring R
+            ( add-Ring R a (mul-Ring R y u))
+            ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v)))
         ( left-negative-law-mul-Ring R x u))
-    ＝ ( add-Ring R
-        ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y u))
-        ( add-Ring R (mul-Ring R y v) (neg-Ring R (mul-Ring R y u))))
-      by
-      ( ap (λ a →
-        ( add-Ring R
-          ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y u))
-          ( a)))
-        ( commutative-add-Ring R
-          ( neg-Ring R (mul-Ring R y u))
-          ( mul-Ring R y v)))
-    ＝ ( add-Ring R
-        ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))
-        ( add-Ring R (mul-Ring R y u) (neg-Ring R (mul-Ring R y u))))
-      by
-      ( interchange-add-add-Ring R
-        ( neg-Ring R (mul-Ring R x u))
-        ( mul-Ring R y u)
-        ( mul-Ring R y v)
-        ( neg-Ring R (mul-Ring R y u)))
-    ＝ ( add-Ring R
-        ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))
-        ( zero-Ring R))
-      by
-      ( ap (λ a →
-        ( add-Ring R
-          ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))
-          ( a)))
-        ( right-inverse-law-add-Ring R (mul-Ring R y u)))
     ＝ ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))
       by
-      ( right-unit-law-add-Ring R
-        ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))))
+      ( add-and-subtract-Ring R
+        ( neg-Ring R (mul-Ring R x u))
+        ( mul-Ring R y u)
+        ( mul-Ring R y v)))
 
   mul-congruence-ideal-Ring :
-    (is-congruence-Monoid
+    ( is-congruence-Monoid
       ( multiplicative-monoid-Ring R)
       ( eq-rel-congruence-ideal-Ring))
-  mul-congruence-ideal-Ring = mul-congruence-lemma
+  mul-congruence-ideal-Ring =
+    is-congruence-monoid-mul-congruence-ideal-Ring
 
   congruence-ideal-Ring : congruence-Ring l2 R
   congruence-ideal-Ring = construct-congruence-Ring R

--- a/src/ring-theory/ideals-rings.lagda.md
+++ b/src/ring-theory/ideals-rings.lagda.md
@@ -464,14 +464,14 @@ module _
   is-closed-under-left-multiplication-subset-congruence-Ring x y H =
     concatenate-eq-sim-congruence-Ring R S
       ( inv (right-zero-law-mul-Ring R x))
-      ( mul-congruence-Ring R S (refl-congruence-Ring R S x) H)
+      ( left-mul-congruence-Ring R S x H)
 
   is-closed-under-right-multiplication-subset-congruence-Ring :
     is-closed-under-right-multiplication-subset-Ring R subset-congruence-Ring
   is-closed-under-right-multiplication-subset-congruence-Ring x y H =
     concatenate-eq-sim-congruence-Ring R S
       ( inv (left-zero-law-mul-Ring R y))
-      ( mul-congruence-Ring R S H (refl-congruence-Ring R S y))
+      ( right-mul-congruence-Ring R S H y)
 
   is-additive-subgroup-congruence-Ring :
     is-additive-subgroup-subset-Ring R subset-congruence-Ring
@@ -491,3 +491,48 @@ module _
   pr2 (pr2 (pr2 ideal-congruence-Ring)) =
     is-closed-under-right-multiplication-subset-congruence-Ring
 ```
+
+#### The ideal obtained from the congruence relation of an ideal `I is `I itself
+
+```agda
+module _
+  {l1 l2 : Level} (R : Ring l1) (I : ideal-Ring l2 R)
+  where
+
+  has-same-elements-ideal-congruence-Ring :
+    has-same-elements-ideal-Ring R
+      ( ideal-congruence-Ring R (congruence-ideal-Ring R I))
+      ( I)
+  pr1 (has-same-elements-ideal-congruence-Ring x) H =
+    is-closed-under-eq-ideal-Ring R I H
+      ( ( ap (add-Ring' R x) (neg-zero-Ring R)) ∙
+        ( left-unit-law-add-Ring R x))
+  pr2 (has-same-elements-ideal-congruence-Ring x) H =
+    is-closed-under-eq-ideal-Ring' R I H
+      ( ( ap (add-Ring' R x) (neg-zero-Ring R)) ∙
+        ( left-unit-law-add-Ring R x))
+
+  is-retraction-ideal-congruence-Ring :
+    ideal-congruence-Ring R (congruence-ideal-Ring R I) ＝ I
+  is-retraction-ideal-congruence-Ring =
+    eq-has-same-elements-ideal-Ring R
+      ( ideal-congruence-Ring R (congruence-ideal-Ring R I))
+      ( I)
+      ( has-same-elements-ideal-congruence-Ring)
+```
+
+#### The congruence relation of the ideal obtained from a congruence relation `S is  `S itself
+
+```agda
+module _
+  {l1 l2 : Level} (R : Ring l1) (S : congruence-Ring l2 R)
+  where
+
+  {-relate-same-elements-congruence-ideal-congruence-Ring :
+    relate-same-elements-congruence-Ring R
+      ( congruence-ideal-Ring R (ideal-congruence-Ring R S))
+      ( S)
+  relate-same-elements-congruence-ideal-congruence-Ring = ?-}
+```
+
+Characterisation of ring congruences remains to be defined.

--- a/src/ring-theory/ideals-rings.lagda.md
+++ b/src/ring-theory/ideals-rings.lagda.md
@@ -7,9 +7,12 @@ module ring-theory.ideals-rings where
 <details><summary>Imports</summary>
 
 ```agda
+open import foundation.action-on-identifications-functions
+open import foundation.binary-relations
 open import foundation.cartesian-product-types
 open import foundation.contractible-types
 open import foundation.dependent-pair-types
+open import foundation.equivalence-relations
 open import foundation.equivalences
 open import foundation.fundamental-theorem-of-identity-types
 open import foundation.identity-types
@@ -18,8 +21,11 @@ open import foundation.subtype-identity-principle
 open import foundation.subtypes
 open import foundation.universe-levels
 
+open import group-theory.congruence-relations-abelian-groups
+open import group-theory.congruence-relations-monoids
 open import group-theory.subgroups-abelian-groups
 
+open import ring-theory.congruence-relations-rings
 open import ring-theory.left-ideals-rings
 open import ring-theory.right-ideals-rings
 open import ring-theory.rings
@@ -204,3 +210,227 @@ module _
   eq-has-same-elements-ideal-Ring J =
     map-inv-equiv (extensionality-ideal-Ring J)
 ```
+
+### Two sided ideals of rings are in 1-1 correspondence with congruence relations
+
+#### The standard similarity relation obtained from an ideal
+
+```agda
+module _
+  {l1 l2 : Level} (R : Ring l1) (I : ideal-Ring l2 R)
+  where
+
+  sim-congruence-ideal-Ring : (x y : type-Ring R) → UU l2
+  sim-congruence-ideal-Ring =
+    sim-congruence-Subgroup-Ab
+      ( ab-Ring R)
+      ( subgroup-ideal-Ring R I)
+
+  is-prop-sim-congruence-ideal-Ring :
+    (x y : type-Ring R) → is-prop (sim-congruence-ideal-Ring x y)
+  is-prop-sim-congruence-ideal-Ring =
+    is-prop-sim-congruence-Subgroup-Ab
+      ( ab-Ring R)
+      ( subgroup-ideal-Ring R I)
+
+  prop-congruence-ideal-Ring : (x y : type-Ring R) → Prop l2
+  prop-congruence-ideal-Ring =
+    prop-congruence-Subgroup-Ab
+      ( ab-Ring R)
+      ( subgroup-ideal-Ring R I)
+```
+
+#### The left equivalence relation obtained from an ideal
+
+```agda
+  left-eq-rel-congruence-ideal-Ring :
+    Equivalence-Relation l2 (type-Ring R)
+  left-eq-rel-congruence-ideal-Ring =
+    left-eq-rel-congruence-Subgroup-Ab
+      ( ab-Ring R)
+      ( subgroup-ideal-Ring R I)
+
+  left-sim-congruence-ideal-Ring :
+    type-Ring R → type-Ring R → UU l2
+  left-sim-congruence-ideal-Ring =
+    left-sim-congruence-Subgroup-Ab
+      ( ab-Ring R)
+      ( subgroup-ideal-Ring R I)
+```
+
+#### The left similarity relation of an ideal relates the same elements as the standard similarity relation
+
+```agda
+  left-sim-sim-congruence-ideal-Ring :
+    (x y : type-Ring R) →
+    sim-congruence-ideal-Ring x y →
+    left-sim-congruence-ideal-Ring x y
+  left-sim-sim-congruence-ideal-Ring =
+    left-sim-sim-congruence-Subgroup-Ab
+      ( ab-Ring R)
+      ( subgroup-ideal-Ring R I)
+
+  sim-left-sim-congruence-ideal-Ring :
+    (x y : type-Ring R) →
+    left-sim-congruence-ideal-Ring x y →
+    sim-congruence-ideal-Ring x y
+  sim-left-sim-congruence-ideal-Ring =
+    sim-left-sim-congruence-Subgroup-Ab
+      ( ab-Ring R)
+      ( subgroup-ideal-Ring R I)
+```
+
+#### The standard similarity relation is a congruence relation
+
+```agda
+  refl-congruence-ideal-Ring :
+    is-reflexive sim-congruence-ideal-Ring
+  refl-congruence-ideal-Ring =
+    refl-congruence-Subgroup-Ab
+      ( ab-Ring R)
+      ( subgroup-ideal-Ring R I)
+
+  symmetric-congruence-ideal-Ring :
+    is-symmetric sim-congruence-ideal-Ring
+  symmetric-congruence-ideal-Ring =
+    symmetric-congruence-Subgroup-Ab
+      ( ab-Ring R)
+      ( subgroup-ideal-Ring R I)
+
+  transitive-congruence-ideal-Ring :
+    is-transitive sim-congruence-ideal-Ring
+  transitive-congruence-ideal-Ring =
+    transitive-congruence-Subgroup-Ab
+      ( ab-Ring R)
+      ( subgroup-ideal-Ring R I)
+
+  eq-rel-congruence-ideal-Ring : Equivalence-Relation l2 (type-Ring R)
+  eq-rel-congruence-ideal-Ring =
+    eq-rel-congruence-Subgroup-Ab
+      ( ab-Ring R)
+      ( subgroup-ideal-Ring R I)
+
+  relate-same-elements-left-sim-congruence-ideal-Ring :
+    relate-same-elements-Equivalence-Relation
+      ( eq-rel-congruence-ideal-Ring)
+      ( left-eq-rel-congruence-ideal-Ring)
+  relate-same-elements-left-sim-congruence-ideal-Ring =
+    relate-same-elements-left-sim-congruence-Subgroup-Ab
+      ( ab-Ring R)
+      ( subgroup-ideal-Ring R I)
+
+  add-congruence-ideal-Ring :
+    ( is-congruence-Ab
+      ( ab-Ring R)
+      ( eq-rel-congruence-ideal-Ring))
+  add-congruence-ideal-Ring =
+    ( add-congruence-Subgroup-Ab
+      ( ab-Ring R)
+      ( subgroup-ideal-Ring R I))
+
+  mul-congruence-lemma : {x y u v : type-Ring R} →
+    ( is-in-ideal-Ring R I (add-Ring R (neg-Ring R x) y)) →
+    ( is-in-ideal-Ring R I (add-Ring R (neg-Ring R u) v)) →
+    ( is-in-ideal-Ring R I
+      ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v)))
+  mul-congruence-lemma {x} {y} {u} {v} e f =
+    ( is-closed-under-eq-ideal-Ring R I
+      ( is-closed-under-addition-ideal-Ring R I
+        ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
+        ( mul-Ring R y (add-Ring R (neg-Ring R u) v))
+        ( is-closed-under-right-multiplication-ideal-Ring R I
+          ( add-Ring R (neg-Ring R x) y)
+          ( u)
+          ( e))
+        ( is-closed-under-left-multiplication-ideal-Ring R I
+          ( y)
+          ( add-Ring R (neg-Ring R u) v)
+          ( f))))
+    ( equational-reasoning
+      ( add-Ring R
+        ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
+        ( mul-Ring R y (add-Ring R (neg-Ring R u) v))) ＝
+      ( add-Ring R
+        ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
+        ( add-Ring R (mul-Ring R y (neg-Ring R u)) (mul-Ring R y v))) by
+      ( ap (λ a →
+        ( add-Ring R
+          ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
+          ( a)))
+        ( left-distributive-mul-add-Ring R y (neg-Ring R u) v)) ＝
+      ( add-Ring R
+        ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
+        ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v))) by
+      ( ap (λ a →
+        ( add-Ring R
+          ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
+          ( add-Ring R a (mul-Ring R y v))))
+        ( right-negative-law-mul-Ring R y u)) ＝
+      ( add-Ring R
+        ( add-Ring R (mul-Ring R (neg-Ring R x) u) (mul-Ring R y u))
+        ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v))) by
+      ( ap (λ a →
+        ( add-Ring R
+          ( a)
+          ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v))))
+        ( right-distributive-mul-add-Ring R (neg-Ring R x) y u)) ＝
+      ( add-Ring R
+        ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y u))
+      ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v))) by
+        ( ap (λ a →
+          ( add-Ring R
+            ( add-Ring R a (mul-Ring R y u))
+            ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v))))
+        ( left-negative-law-mul-Ring R x u)) ＝
+      ( add-Ring R
+        ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y u))
+        ( add-Ring R (mul-Ring R y v) (neg-Ring R (mul-Ring R y u)))) by
+      ( ap (λ a →
+        ( add-Ring R
+          ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y u))
+          ( a)))
+        ( commutative-add-Ring R
+          ( neg-Ring R (mul-Ring R y u))
+          ( mul-Ring R y v))) ＝
+      ( add-Ring R
+        ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))
+        ( add-Ring R (mul-Ring R y u) (neg-Ring R (mul-Ring R y u)))) by
+      ( interchange-add-add-Ring R
+        ( neg-Ring R (mul-Ring R x u))
+        ( mul-Ring R y u)
+        ( mul-Ring R y v)
+        ( neg-Ring R (mul-Ring R y u))) ＝
+      ( add-Ring R
+        ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))
+        ( zero-Ring R)) by
+      ( ap (λ a →
+        ( add-Ring R
+          ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))
+          ( a)))
+        ( right-inverse-law-add-Ring R (mul-Ring R y u))) ＝
+      ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v)) by
+      ( right-unit-law-add-Ring R
+        ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))))
+
+  mul-congruence-ideal-Ring :
+    (is-congruence-Monoid
+      ( multiplicative-monoid-Ring R)
+      ( eq-rel-congruence-ideal-Ring))
+  mul-congruence-ideal-Ring = mul-congruence-lemma
+
+  congruence-ideal-Ring : congruence-Ring l2 R
+  congruence-ideal-Ring = construct-congruence-Ring R
+    ( eq-rel-congruence-ideal-Ring)
+    ( add-congruence-ideal-Ring)
+    ( mul-congruence-ideal-Ring)
+```
+
+#### The ideal obtained from a congruence relation
+
+#### The ideal obtained from the congruence relalation of an ideal `I` is `I` itself
+
+#### The congruence relation of the ideal obtained from a congruence relation `S` is `S` itself
+
+#### The equivalence of ideals and congruence relations
+
+This remains to be shown.

--- a/src/ring-theory/ideals-rings.lagda.md
+++ b/src/ring-theory/ideals-rings.lagda.md
@@ -9,6 +9,7 @@ module ring-theory.ideals-rings where
 ```agda
 open import foundation.action-on-identifications-functions
 open import foundation.binary-relations
+open import foundation.binary-transport
 open import foundation.cartesian-product-types
 open import foundation.contractible-types
 open import foundation.dependent-pair-types
@@ -529,11 +530,63 @@ module _
   {l1 l2 : Level} (R : Ring l1) (S : congruence-Ring l2 R)
   where
 
-  {-relate-same-elements-congruence-ideal-congruence-Ring :
+  relate-same-elements-congruence-ideal-congruence-Ring :
     relate-same-elements-congruence-Ring R
       ( congruence-ideal-Ring R (ideal-congruence-Ring R S))
       ( S)
-  relate-same-elements-congruence-ideal-congruence-Ring = ?-}
+  pr1
+    ( relate-same-elements-congruence-ideal-congruence-Ring x y) H =
+    binary-tr
+      ( sim-congruence-Ring R S)
+      ( right-unit-law-add-Ring R x)
+      ( is-section-add-neg-Ring R x y)
+      ( left-add-congruence-Ring R S x H)
+  pr2
+    ( relate-same-elements-congruence-ideal-congruence-Ring x y) H =
+    symmetric-congruence-Ring R S
+      ( left-subtraction-Ring R x y)
+      ( zero-Ring R)
+      ( map-sim-left-subtraction-zero-congruence-Ring R S H)
+
+  is-section-ideal-congruence-Ring :
+    congruence-ideal-Ring R (ideal-congruence-Ring R S) ＝ S
+  is-section-ideal-congruence-Ring =
+    eq-relate-same-elements-congruence-Ring R
+      ( congruence-ideal-Ring R (ideal-congruence-Ring R S))
+      ( S)
+      ( relate-same-elements-congruence-ideal-congruence-Ring)
 ```
 
-Characterisation of equality of ring congruences remains to be defined.
+#### The equivalence of two sided ideals and congruence relations
+
+```agda
+module _
+  {l1 l2 : Level} (R : Ring l1)
+  where
+
+  is-equiv-congruence-ideal-Ring :
+    is-equiv (congruence-ideal-Ring {l1} {l2} R)
+  is-equiv-congruence-ideal-Ring =
+    is-equiv-has-inverse
+      ( ideal-congruence-Ring R)
+      ( is-section-ideal-congruence-Ring R)
+      ( is-retraction-ideal-congruence-Ring R)
+
+  equiv-congruence-ideal-Ring :
+    ideal-Ring l2 R ≃ congruence-Ring l2 R
+  pr1 equiv-congruence-ideal-Ring = congruence-ideal-Ring R
+  pr2 equiv-congruence-ideal-Ring = is-equiv-congruence-ideal-Ring
+
+  is-equiv-ideal-congruence-Ring :
+    is-equiv (ideal-congruence-Ring {l1} {l2} R)
+  is-equiv-ideal-congruence-Ring =
+    is-equiv-has-inverse
+      ( congruence-ideal-Ring R)
+      ( is-retraction-ideal-congruence-Ring R)
+      ( is-section-ideal-congruence-Ring R)
+
+  equiv-ideal-congruence-Ring :
+    congruence-Ring l2 R ≃ ideal-Ring l2 R
+  pr1 equiv-ideal-congruence-Ring = ideal-congruence-Ring R
+  pr2 equiv-ideal-congruence-Ring = is-equiv-ideal-congruence-Ring
+```

--- a/src/ring-theory/ideals-rings.lagda.md
+++ b/src/ring-theory/ideals-rings.lagda.md
@@ -502,7 +502,7 @@ module _
     is-closed-under-right-multiplication-subset-congruence-Ring
 ```
 
-#### The ideal obtained from the congruence relation of an ideal `I is `I itself
+#### The ideal obtained from the congruence relation of an ideal `I` is `I` itself
 
 ```agda
 module _

--- a/src/ring-theory/quotient-rings.lagda.md
+++ b/src/ring-theory/quotient-rings.lagda.md
@@ -49,11 +49,3 @@ universal-property-quotient-Ring :
 universal-property-quotient-Ring l R I S f H =
   (T : Ring l) → is-equiv (precomp-quotient-Ring R I S T f H)
 ```
-
-### The equivalence relation obtained from an ideal
-
-### The quotient ring
-
-#### The universal property of the quotient ring
-
-This remains to be defined.

--- a/src/ring-theory/quotient-rings.lagda.md
+++ b/src/ring-theory/quotient-rings.lagda.md
@@ -13,6 +13,13 @@ open import foundation.equivalences
 open import foundation.identity-types
 open import foundation.universe-levels
 
+open import foundation-core.equivalence-relations
+
+open import group-theory.congruence-relations-abelian-groups
+open import group-theory.congruence-relations-monoids
+open import group-theory.subgroups-abelian-groups
+
+open import ring-theory.congruence-relations-rings
 open import ring-theory.homomorphisms-rings
 open import ring-theory.ideals-rings
 open import ring-theory.rings
@@ -53,17 +60,120 @@ universal-property-quotient-Ring l R I S f H =
 ### The equivalence relation obtained from an ideal
 
 ```agda
-{-
-sim-congruence-ideal-Ring :
-  {l1 l2 : Level} (R : Ring l1) (I : ideal-Ring l2 R) →
-  type-Ring R → type-Ring R → UU {!!}
-sim-congruence-ideal-Ring R I x y =
-  sim-congruence-Normal-Subgroup
-    ( group-Ring R)
-    {!!}
-    {!!}
-    {!!}
-    -}
+module _
+  {l1 l2 : Level} (R : Ring l1) (I : ideal-Ring l2 R)
+  where
+
+  eq-rel-congruence-ideal-Ring : Equivalence-Relation l2 (type-Ring R)
+  eq-rel-congruence-ideal-Ring =
+    eq-rel-congruence-Subgroup-Ab
+      ( ab-Ring R)
+      ( subgroup-ideal-Ring R I)
+
+  add-congruence-ideal-Ring :
+    ( is-congruence-Ab
+      ( ab-Ring R)
+      ( eq-rel-congruence-ideal-Ring))
+  add-congruence-ideal-Ring =
+    ( add-congruence-Subgroup-Ab
+      ( ab-Ring R)
+      ( subgroup-ideal-Ring R I))
+
+  mul-congruence-lemma : {x y u v : type-Ring R} →
+    ( is-in-ideal-Ring R I (add-Ring R (neg-Ring R x) y)) →
+    ( is-in-ideal-Ring R I (add-Ring R (neg-Ring R u) v)) →
+    ( is-in-ideal-Ring R I
+      ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v)))
+  mul-congruence-lemma {x} {y} {u} {v} e f =
+    ( is-closed-under-eq-ideal-Ring R I
+      ( is-closed-under-addition-ideal-Ring R I
+        ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
+        ( mul-Ring R y (add-Ring R (neg-Ring R u) v))
+        ( is-closed-under-right-multiplication-ideal-Ring R I
+          ( add-Ring R (neg-Ring R x) y)
+          ( u)
+          ( e))
+        ( is-closed-under-left-multiplication-ideal-Ring R I
+          ( y)
+          ( add-Ring R (neg-Ring R u) v)
+          ( f))))
+    ( equational-reasoning
+      ( add-Ring R
+        ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
+        ( mul-Ring R y (add-Ring R (neg-Ring R u) v))) ＝
+      ( add-Ring R
+        ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
+        ( add-Ring R (mul-Ring R y (neg-Ring R u)) (mul-Ring R y v))) by
+      ( ap (λ a →
+        ( add-Ring R
+          ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
+          ( a)))
+        ( left-distributive-mul-add-Ring R y (neg-Ring R u) v)) ＝
+      ( add-Ring R
+        ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
+        ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v))) by
+      ( ap (λ a →
+        ( add-Ring R
+          ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
+          ( add-Ring R a (mul-Ring R y v))))
+        ( right-negative-law-mul-Ring R y u)) ＝
+      ( add-Ring R
+        ( add-Ring R (mul-Ring R (neg-Ring R x) u) (mul-Ring R y u))
+        ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v))) by
+      ( ap (λ a →
+        ( add-Ring R
+          ( a)
+          ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v))))
+        ( right-distributive-mul-add-Ring R (neg-Ring R x) y u)) ＝
+      ( add-Ring R
+        ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y u))
+      ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v))) by
+        ( ap (λ a →
+          ( add-Ring R
+            ( add-Ring R a (mul-Ring R y u))
+            ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v))))
+        ( left-negative-law-mul-Ring R x u)) ＝
+      ( add-Ring R
+        ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y u))
+        ( add-Ring R (mul-Ring R y v) (neg-Ring R (mul-Ring R y u)))) by
+      ( ap (λ a →
+        ( add-Ring R
+          ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y u))
+          ( a)))
+        ( commutative-add-Ring R
+          ( neg-Ring R (mul-Ring R y u))
+          ( mul-Ring R y v))) ＝
+      ( add-Ring R
+        ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))
+        ( add-Ring R (mul-Ring R y u) (neg-Ring R (mul-Ring R y u)))) by
+      ( interchange-add-add-Ring R
+        ( neg-Ring R (mul-Ring R x u))
+        ( mul-Ring R y u)
+        ( mul-Ring R y v)
+        ( neg-Ring R (mul-Ring R y u))) ＝
+      ( add-Ring R
+        ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))
+        ( zero-Ring R)) by
+      ( ap (λ a →
+        ( add-Ring R
+          ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))
+          ( a)))
+        ( right-inverse-law-add-Ring R (mul-Ring R y u))) ＝
+      ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v)) by
+      ( right-unit-law-add-Ring R
+        ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))))
+
+  mul-congruence-ideal-Ring :
+    (is-congruence-Monoid
+      ( multiplicative-monoid-Ring R)
+      ( eq-rel-congruence-ideal-Ring))
+  mul-congruence-ideal-Ring = mul-congruence-lemma
+
+  congruence-ideal-Ring : congruence-Ring l2 R
+  congruence-ideal-Ring = construct-congruence-Ring R
+    ( eq-rel-congruence-ideal-Ring)
+    ( add-congruence-ideal-Ring)
+    ( mul-congruence-ideal-Ring)
 ```
 
 ### The quotient ring

--- a/src/ring-theory/quotient-rings.lagda.md
+++ b/src/ring-theory/quotient-rings.lagda.md
@@ -13,13 +13,6 @@ open import foundation.equivalences
 open import foundation.identity-types
 open import foundation.universe-levels
 
-open import foundation-core.equivalence-relations
-
-open import group-theory.congruence-relations-abelian-groups
-open import group-theory.congruence-relations-monoids
-open import group-theory.subgroups-abelian-groups
-
-open import ring-theory.congruence-relations-rings
 open import ring-theory.homomorphisms-rings
 open import ring-theory.ideals-rings
 open import ring-theory.rings
@@ -58,123 +51,6 @@ universal-property-quotient-Ring l R I S f H =
 ```
 
 ### The equivalence relation obtained from an ideal
-
-```agda
-module _
-  {l1 l2 : Level} (R : Ring l1) (I : ideal-Ring l2 R)
-  where
-
-  eq-rel-congruence-ideal-Ring : Equivalence-Relation l2 (type-Ring R)
-  eq-rel-congruence-ideal-Ring =
-    eq-rel-congruence-Subgroup-Ab
-      ( ab-Ring R)
-      ( subgroup-ideal-Ring R I)
-
-  add-congruence-ideal-Ring :
-    ( is-congruence-Ab
-      ( ab-Ring R)
-      ( eq-rel-congruence-ideal-Ring))
-  add-congruence-ideal-Ring =
-    ( add-congruence-Subgroup-Ab
-      ( ab-Ring R)
-      ( subgroup-ideal-Ring R I))
-
-  mul-congruence-lemma : {x y u v : type-Ring R} →
-    ( is-in-ideal-Ring R I (add-Ring R (neg-Ring R x) y)) →
-    ( is-in-ideal-Ring R I (add-Ring R (neg-Ring R u) v)) →
-    ( is-in-ideal-Ring R I
-      ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v)))
-  mul-congruence-lemma {x} {y} {u} {v} e f =
-    ( is-closed-under-eq-ideal-Ring R I
-      ( is-closed-under-addition-ideal-Ring R I
-        ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
-        ( mul-Ring R y (add-Ring R (neg-Ring R u) v))
-        ( is-closed-under-right-multiplication-ideal-Ring R I
-          ( add-Ring R (neg-Ring R x) y)
-          ( u)
-          ( e))
-        ( is-closed-under-left-multiplication-ideal-Ring R I
-          ( y)
-          ( add-Ring R (neg-Ring R u) v)
-          ( f))))
-    ( equational-reasoning
-      ( add-Ring R
-        ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
-        ( mul-Ring R y (add-Ring R (neg-Ring R u) v))) ＝
-      ( add-Ring R
-        ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
-        ( add-Ring R (mul-Ring R y (neg-Ring R u)) (mul-Ring R y v))) by
-      ( ap (λ a →
-        ( add-Ring R
-          ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
-          ( a)))
-        ( left-distributive-mul-add-Ring R y (neg-Ring R u) v)) ＝
-      ( add-Ring R
-        ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
-        ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v))) by
-      ( ap (λ a →
-        ( add-Ring R
-          ( mul-Ring R (add-Ring R (neg-Ring R x) y) u)
-          ( add-Ring R a (mul-Ring R y v))))
-        ( right-negative-law-mul-Ring R y u)) ＝
-      ( add-Ring R
-        ( add-Ring R (mul-Ring R (neg-Ring R x) u) (mul-Ring R y u))
-        ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v))) by
-      ( ap (λ a →
-        ( add-Ring R
-          ( a)
-          ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v))))
-        ( right-distributive-mul-add-Ring R (neg-Ring R x) y u)) ＝
-      ( add-Ring R
-        ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y u))
-      ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v))) by
-        ( ap (λ a →
-          ( add-Ring R
-            ( add-Ring R a (mul-Ring R y u))
-            ( add-Ring R (neg-Ring R (mul-Ring R y u)) (mul-Ring R y v))))
-        ( left-negative-law-mul-Ring R x u)) ＝
-      ( add-Ring R
-        ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y u))
-        ( add-Ring R (mul-Ring R y v) (neg-Ring R (mul-Ring R y u)))) by
-      ( ap (λ a →
-        ( add-Ring R
-          ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y u))
-          ( a)))
-        ( commutative-add-Ring R
-          ( neg-Ring R (mul-Ring R y u))
-          ( mul-Ring R y v))) ＝
-      ( add-Ring R
-        ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))
-        ( add-Ring R (mul-Ring R y u) (neg-Ring R (mul-Ring R y u)))) by
-      ( interchange-add-add-Ring R
-        ( neg-Ring R (mul-Ring R x u))
-        ( mul-Ring R y u)
-        ( mul-Ring R y v)
-        ( neg-Ring R (mul-Ring R y u))) ＝
-      ( add-Ring R
-        ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))
-        ( zero-Ring R)) by
-      ( ap (λ a →
-        ( add-Ring R
-          ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))
-          ( a)))
-        ( right-inverse-law-add-Ring R (mul-Ring R y u))) ＝
-      ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v)) by
-      ( right-unit-law-add-Ring R
-        ( add-Ring R (neg-Ring R (mul-Ring R x u)) (mul-Ring R y v))))
-
-  mul-congruence-ideal-Ring :
-    (is-congruence-Monoid
-      ( multiplicative-monoid-Ring R)
-      ( eq-rel-congruence-ideal-Ring))
-  mul-congruence-ideal-Ring = mul-congruence-lemma
-
-  congruence-ideal-Ring : congruence-Ring l2 R
-  congruence-ideal-Ring = construct-congruence-Ring R
-    ( eq-rel-congruence-ideal-Ring)
-    ( add-congruence-ideal-Ring)
-    ( mul-congruence-ideal-Ring)
-```
 
 ### The quotient ring
 

--- a/src/ring-theory/rings.lagda.md
+++ b/src/ring-theory/rings.lagda.md
@@ -230,6 +230,9 @@ module _
     (x y : type-Ring R) →
     neg-Ring (add-Ring R x y) ＝ add-Ring R (neg-Ring x) (neg-Ring y)
   distributive-neg-add-Ring = distributive-neg-add-Ab (ab-Ring R)
+
+  neg-zero-Ring : neg-Ring (zero-Ring R) ＝ (zero-Ring R)
+  neg-zero-Ring = neg-zero-Ab (ab-Ring R)
 ```
 
 ### Multiplication in a ring

--- a/src/ring-theory/rings.lagda.md
+++ b/src/ring-theory/rings.lagda.md
@@ -18,6 +18,8 @@ open import foundation.cartesian-product-types
 open import foundation.dependent-pair-types
 open import foundation.embeddings
 open import foundation.equivalences
+open import foundation.function-types
+open import foundation.homotopies
 open import foundation.identity-types
 open import foundation.injective-maps
 open import foundation.involutions
@@ -26,8 +28,6 @@ open import foundation.propositions
 open import foundation.sets
 open import foundation.unital-binary-operations
 open import foundation.universe-levels
-open import foundation.function-types
-open import foundation.homotopies
 
 open import group-theory.abelian-groups
 open import group-theory.commutative-monoids

--- a/src/ring-theory/rings.lagda.md
+++ b/src/ring-theory/rings.lagda.md
@@ -305,20 +305,20 @@ module _
   add-and-subtract-Ring x y z =
     equational-reasoning
       add-Ring R (add-Ring R x y) (add-Ring R (neg-Ring y) z)
-    ＝ add-Ring R (add-Ring R y x) (add-Ring R (neg-Ring y) z)
-    by
-    ( ap
-      ( add-Ring' R (add-Ring R (neg-Ring y) z))
-      ( commutative-add-Ring R x y))
-    ＝ add-Ring R (add-Ring R y (neg-Ring y)) (add-Ring R x z)
-    by interchange-add-add-Ring R y x (neg-Ring y) z
-    ＝ add-Ring R (zero-Ring R) (add-Ring R x z)
-    by
-    ( ap
-      ( add-Ring' R (add-Ring R x z))
-      ( right-inverse-law-add-Ring y))
-    ＝ add-Ring R x z
-    by left-unit-law-add-Ring R (add-Ring R x z)
+      ＝ add-Ring R (add-Ring R y x) (add-Ring R (neg-Ring y) z)
+        by
+        ( ap
+          ( add-Ring' R (add-Ring R (neg-Ring y) z))
+          ( commutative-add-Ring R x y))
+      ＝ add-Ring R (add-Ring R y (neg-Ring y)) (add-Ring R x z)
+        by interchange-add-add-Ring R y x (neg-Ring y) z
+      ＝ add-Ring R (zero-Ring R) (add-Ring R x z)
+        by
+        ( ap
+          ( add-Ring' R (add-Ring R x z))
+          ( right-inverse-law-add-Ring y))
+      ＝ add-Ring R x z
+        by left-unit-law-add-Ring R (add-Ring R x z)
 ```
 
 ### Multiplication in a ring

--- a/src/ring-theory/rings.lagda.md
+++ b/src/ring-theory/rings.lagda.md
@@ -298,6 +298,27 @@ module _
 
   neg-zero-Ring : neg-Ring (zero-Ring R) ＝ (zero-Ring R)
   neg-zero-Ring = neg-zero-Ab (ab-Ring R)
+
+  add-and-subtract-Ring :
+    (x y z : type-Ring R) →
+    add-Ring R (add-Ring R x y) (add-Ring R (neg-Ring y) z) ＝ add-Ring R x z
+  add-and-subtract-Ring x y z =
+    equational-reasoning
+      add-Ring R (add-Ring R x y) (add-Ring R (neg-Ring y) z)
+    ＝ add-Ring R (add-Ring R y x) (add-Ring R (neg-Ring y) z)
+    by
+    ( ap
+      ( add-Ring' R (add-Ring R (neg-Ring y) z))
+      ( commutative-add-Ring R x y))
+    ＝ add-Ring R (add-Ring R y (neg-Ring y)) (add-Ring R x z)
+    by interchange-add-add-Ring R y x (neg-Ring y) z
+    ＝ add-Ring R (zero-Ring R) (add-Ring R x z)
+    by
+    ( ap
+      ( add-Ring' R (add-Ring R x z))
+      ( right-inverse-law-add-Ring y))
+    ＝ add-Ring R x z
+    by left-unit-law-add-Ring R (add-Ring R x z)
 ```
 
 ### Multiplication in a ring

--- a/src/ring-theory/rings.lagda.md
+++ b/src/ring-theory/rings.lagda.md
@@ -26,9 +26,8 @@ open import foundation.propositions
 open import foundation.sets
 open import foundation.unital-binary-operations
 open import foundation.universe-levels
-
-open import foundation-core.function-types
-open import foundation-core.homotopies
+open import foundation.function-types
+open import foundation.homotopies
 
 open import group-theory.abelian-groups
 open import group-theory.commutative-monoids

--- a/src/ring-theory/rings.lagda.md
+++ b/src/ring-theory/rings.lagda.md
@@ -27,6 +27,9 @@ open import foundation.sets
 open import foundation.unital-binary-operations
 open import foundation.universe-levels
 
+open import foundation-core.function-types
+open import foundation-core.homotopies
+
 open import group-theory.abelian-groups
 open import group-theory.commutative-monoids
 open import group-theory.groups
@@ -143,30 +146,93 @@ module _
     (x y z : type-Ring R) →
     add-Ring x (add-Ring y z) ＝ add-Ring y (add-Ring x z)
   left-swap-add-Ring = left-swap-add-Ab (ab-Ring R)
+```
 
-  is-equiv-add-Ring : (x : type-Ring R) → is-equiv (add-Ring x)
+### Addition in a ring is a binary equivalence
+
+#### Addition on the left is an equivalence
+
+```agda
+module _
+  {l : Level} (R : Ring l)
+  where
+
+  left-subtraction-Ring : type-Ring R → type-Ring R → type-Ring R
+  left-subtraction-Ring = left-subtraction-Ab (ab-Ring R)
+
+  is-section-add-neg-Ring :
+    (x : type-Ring R) → (add-Ring R x ∘ left-subtraction-Ring x) ~ id
+  is-section-add-neg-Ring = is-section-add-neg-Ab (ab-Ring R)
+
+  is-retraction-add-neg-Ring :
+    (x : type-Ring R) → (left-subtraction-Ring x ∘ add-Ring R x) ~ id
+  is-retraction-add-neg-Ring = is-retraction-add-neg-Ab (ab-Ring R)
+
+  is-equiv-add-Ring : (x : type-Ring R) → is-equiv (add-Ring R x)
   is-equiv-add-Ring = is-equiv-add-Ab (ab-Ring R)
 
-  is-equiv-add-Ring' : (x : type-Ring R) → is-equiv (add-Ring' x)
+  equiv-add-Ring : type-Ring R → (type-Ring R ≃ type-Ring R)
+  equiv-add-Ring = equiv-add-Ab (ab-Ring R)
+```
+
+#### Addition on the right is an equivalence
+
+```agda
+module _
+  {l : Level} (R : Ring l)
+  where
+
+  right-subtraction-Ring : type-Ring R → type-Ring R → type-Ring R
+  right-subtraction-Ring = right-subtraction-Ab (ab-Ring R)
+
+  is-section-add-neg-Ring' :
+    (x : type-Ring R) →
+    (add-Ring' R x ∘ (λ y → right-subtraction-Ring y x)) ~ id
+  is-section-add-neg-Ring' = is-section-add-neg-Ab' (ab-Ring R)
+
+  is-retraction-add-neg-Ring' :
+    (x : type-Ring R) →
+    ((λ y → right-subtraction-Ring y x) ∘ add-Ring' R x) ~ id
+  is-retraction-add-neg-Ring' = is-retraction-add-neg-Ab' (ab-Ring R)
+
+  is-equiv-add-Ring' : (x : type-Ring R) → is-equiv (add-Ring' R x)
   is-equiv-add-Ring' = is-equiv-add-Ab' (ab-Ring R)
 
-  is-binary-equiv-add-Ring : is-binary-equiv add-Ring
-  pr1 is-binary-equiv-add-Ring = is-equiv-add-Ring'
-  pr2 is-binary-equiv-add-Ring = is-equiv-add-Ring
+  equiv-add-Ring' : type-Ring R → (type-Ring R ≃ type-Ring R)
+  equiv-add-Ring' = equiv-add-Ab' (ab-Ring R)
+```
 
-  is-binary-emb-add-Ring : is-binary-emb add-Ring
+#### Addition in a ring is a binary equivalence
+
+```agda
+module _
+  {l : Level} (R : Ring l)
+  where
+
+  is-binary-equiv-add-Ring : is-binary-equiv (add-Ring R)
+  is-binary-equiv-add-Ring = is-binary-equiv-add-Ab (ab-Ring R)
+```
+
+#### Addition in a ring is a binary embedding
+
+```agda
+  is-binary-emb-add-Ring : is-binary-emb (add-Ring R)
   is-binary-emb-add-Ring = is-binary-emb-add-Ab (ab-Ring R)
 
-  is-emb-add-Ring : (x : type-Ring R) → is-emb (add-Ring x)
+  is-emb-add-Ring : (x : type-Ring R) → is-emb (add-Ring R x)
   is-emb-add-Ring = is-emb-add-Ab (ab-Ring R)
 
-  is-emb-add-Ring' : (x : type-Ring R) → is-emb (add-Ring' x)
+  is-emb-add-Ring' : (x : type-Ring R) → is-emb (add-Ring' R x)
   is-emb-add-Ring' = is-emb-add-Ab' (ab-Ring R)
+```
 
-  is-injective-add-Ring : (x : type-Ring R) → is-injective (add-Ring x)
+#### Addition in a ring is pointwise injective from both sides
+
+```agda
+  is-injective-add-Ring : (x : type-Ring R) → is-injective (add-Ring R x)
   is-injective-add-Ring = is-injective-add-Ab (ab-Ring R)
 
-  is-injective-add-Ring' : (x : type-Ring R) → is-injective (add-Ring' x)
+  is-injective-add-Ring' : (x : type-Ring R) → is-injective (add-Ring' R x)
   is-injective-add-Ring' = is-injective-add-Ab' (ab-Ring R)
 ```
 


### PR DESCRIPTION
The ring congruence obtained from an ideal is a congruence on the underlying abelian group, obtained from the underlying subgroup of the ideal. The multiplicative laws for the ideal make sure that this is also a congruence on the underlying monoid, which is proved in the mul-congruence-lemma. It came out a little long but that was the simplest way I could think to do things.
This whole section could be moved to the ideals-rings module, to be more in line with the normal-subgroups and subgroups-of-abelian-groups modules, where their congruences are developed. I'm pretty sure there is also an analogous equivalence between ideals and ring congruences, which could be proved.