### PR TITLE
Allow misc. binary operators over max line length

### DIFF
--- a/scripts/max_line_length_conventions.py
+++ b/scripts/max_line_length_conventions.py
@@ -13,7 +13,7 @@ import utils
 named_module = r'^module\s\S+\swhere$'
 open_import = r'^\s*open import '
 # Forgives lines like this `( ( {{ my-very.long-token.that-is-too-long}})) =`
-irreducible_line1 = r'^\s*([({] ?)*[^\s;{}()@"]+[)}]*( ?[;:=→])?$'
+irreducible_line1 = r'^\s*([({⦃] ?)*[^\s;{}()@"]+[)}⦄]*( ?[^a-zA-Z\d\s"_({⦃]\S?)?$'
 
 forgive_patterns = (named_module, open_import, irreducible_line1)
 

--- a/scripts/max_line_length_conventions.py
+++ b/scripts/max_line_length_conventions.py
@@ -13,7 +13,7 @@ import utils
 named_module = r'^module\s\S+\swhere$'
 open_import = r'^\s*open import '
 # Forgives lines like this `( ( {{ my-very.long-token.that-is-too-long}})) =`
-irreducible_line1 = r'^\s*([({⦃] ?)*[^\s;{}()@"]+[)}⦄]*( ?[^a-zA-Z\d\s"_({⦃]\S?)?$'
+irreducible_line1 = r'^\s*([({⦃] ?)*[^\s;{}()@"]+[)}⦄]*( ?[^a-zA-Z\d\s"_({⦃][^\s"_.;(){}⦃@]?)?$'
 
 forgive_patterns = (named_module, open_import, irreducible_line1)
 


### PR DESCRIPTION
Relaxes the max line length checker to allow for lines ending with miscellaneous binary operators. The criteria I have placed is that the binary operator is at most two characters, and starts with a character that is not alphanumeric. To be precise, it must satisfy:
```regexp
[^a-zA-Z\d\s"_({⦃][^\s"_.;(){}⦃@]?
```
This describes that the first character is not a character between `a` and `z`, not a character between `A` and `Z`, not a digit (`\d`), not whitespace (`\s`) and none of the characters `"_({⦃`. The `[^\s"_.;(){}@⦃]?`-part says that the second character is optional, and must be non-whitespace and none of the characters `"_.;(){}⦃@`.