### PR TITLE
Fix 404 page

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -33,6 +33,7 @@ copy-fonts = true
 additional-css = ["theme/Agda.css", "theme/pagetoc.css", "theme/agda-logo.css", "./theme/catppuccin.css", "./theme/catppuccin-highlight.css"]
 additional-js = ["theme/js/custom.js", "theme/pagetoc.js"]
 no-section-label = false
+site-url = "/agda-unimath/"
 git-repository-url = "https://github.com/UniMath/agda-unimath"
 git-repository-icon = "fa-github"
 


### PR DESCRIPTION
The website is currently hosted at
https://unimath.github.io/agda-unimath/, and all the pages are located in that directory, since Agda flattens the folder structure during build, so relative links to files such as `theme/Agda.css` always work. However the 404 HTML is served for all missing pages, even in nested directories, where these files are not found anymore.

MdBook can be told to fix-up the behavior using the output.html.site-url setting, which tells the 404 page to resolve all relative paths from a fixed path.

This doesn't break local development, since mdBook overrides the value to `/` for `mdbook serve`.

Fixes #668