### PR TITLE
Check for broken links in the CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
       # We need to run the sources through Agda not only to get the highlighting
       # (which is irrelevant for checking links), but because it flattens the
       # directory structure to a format which is expected in the links we write.
-      # We don't need to produce this artefact for more then one configuration.
+      # We don't need to produce this artifact for more than one configuration.
       - name: Produce syntax highlighted markdown
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,6 +140,9 @@ jobs:
           set +e
           gh actions-cache delete pre-website-${{ github.run_id }} -R $REPO -B $BRANCH --confirm
 
+          # The previous command failing would report an error even with `set -e`
+          exit 0
+
   pre-commit:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,10 +129,15 @@ jobs:
         if: ${{ always() }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Note that the cleanup currently fails, because we don't give the
+        # `actions:write` permission to actions; hence the `set +e` to ignore
+        # the error
         run: |
           gh extension install actions/gh-actions-cache
           REPO=${{ github.repository }}
           BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+
+          set +e
           gh actions-cache delete pre-website-${{ github.run_id }} -R $REPO -B $BRANCH --confirm
 
   pre-commit:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,6 +96,8 @@ jobs:
   # fail the build.
   link-check:
     needs: typecheck
+    permissions:
+      actions: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,6 +71,68 @@ jobs:
           path: master/_build
           key: '${{ steps.cache-agda-formalization.outputs.cache-primary-key }}'
 
+      # We need to run the sources through Agda not only to get the highlighting
+      # (which is irrelevant for checking links), but because it flattens the
+      # directory structure to a format which is expected in the links we write.
+      # We don't need to produce this artefact for more then one configuration.
+      - name: Produce syntax highlighted markdown
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          cd master
+          make website-prepare
+
+      # The lifetime of this cache is for one CI run only, so it's indexed by
+      # the run ID. According to the docs, caches are immutable, so we can't
+      # keep the same key for a branch and update it on pushes.
+      - name: Save pre-website cache
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        uses: actions/cache/save@v3
+        with:
+          key: pre-website-${{ github.run_id }}
+          path: master/docs
+
+  # We're only running the linkcheck renderer, so we don't need to install
+  # any other packages; that gives a warning during building, but doesn't
+  # fail the build.
+  link-check:
+    needs: typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: master
+
+      - uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: 'latest'
+
+      - uses: baptiste0928/cargo-install@v2
+        with:
+          crate: mdbook-linkcheck
+
+      - uses: actions/cache/restore@v3
+        with:
+          key: pre-website-${{ github.run_id }}
+          path: master/docs
+
+      # Tell mdbook to use only the linkcheck backend
+      - name: Check website links
+        env:
+          MDBOOK_OUTPUT: '{"linkcheck":{}}'
+        run: |
+          cd master
+          mdbook build
+
+      - name: Delete website cache
+        if: ${{ always() }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh extension install actions/gh-actions-cache
+          REPO=${{ github.repository }}
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+          gh actions-cache delete pre-website-${{ github.run_id }} -R $REPO -B $BRANCH --confirm
+
   pre-commit:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -68,11 +68,13 @@ agda-html: ./src/everything.lagda.md
 SUMMARY.md: ${AGDAFILES}
 	@python3 ./scripts/generate_main_index_file.py
 
-.PHONY: website
-website: agda-html \
-		./SUMMARY.md
+.PHONY: website-prepare
+website-prepare: agda-html ./SUMMARY.md
 	@cp $(METAFILES) ./docs/
-	@cp ./theme/images/agda-unimath-logo.svg  ./docs/
+	@cp ./theme/images/agda-unimath-logo.svg ./docs/
+
+.PHONY: website
+website: website-prepare
 	@mdbook build
 
 .PHONY: serve-website

--- a/src/synthetic-homotopy-theory/sections-descent-circle.lagda.md
+++ b/src/synthetic-homotopy-theory/sections-descent-circle.lagda.md
@@ -37,8 +37,7 @@ open import synthetic-homotopy-theory.universal-property-circle
 
 Sections of type families over the [circle](synthetic-homotopy-theory.circle.md)
 are exactly the fixpoints of the [automorphism](foundation.automorphisms.md)
-from the corresponding
-[descent data](synthetic-homotopy-theory.descent-circle).
+from the corresponding [descent data](synthetic-homotopy-theory.descent-circle).
 
 ## Definitions
 

--- a/src/synthetic-homotopy-theory/sections-descent-circle.lagda.md
+++ b/src/synthetic-homotopy-theory/sections-descent-circle.lagda.md
@@ -37,7 +37,8 @@ open import synthetic-homotopy-theory.universal-property-circle
 
 Sections of type families over the [circle](synthetic-homotopy-theory.circle.md)
 are exactly the fixpoints of the [automorphism](foundation.automorphisms.md)
-from the corresponding [descent data](synthetic-homotopy-theory.descent-circle).
+from the corresponding
+[descent data](synthetic-homotopy-theory.descent-circle.md).
 
 ## Definitions
 

--- a/src/synthetic-homotopy-theory/sections-descent-circle.lagda.md
+++ b/src/synthetic-homotopy-theory/sections-descent-circle.lagda.md
@@ -38,7 +38,7 @@ open import synthetic-homotopy-theory.universal-property-circle
 Sections of type families over the [circle](synthetic-homotopy-theory.circle.md)
 are exactly the fixpoints of the [automorphism](foundation.automorphisms.md)
 from the corresponding
-[descent data](synthetic-homotopy-theory.descent-circle.md).
+[descent data](synthetic-homotopy-theory.descent-circle).
 
 ## Definitions
 


### PR DESCRIPTION
Adds a few steps to the CI:
- during one of the typechecking runs it also runs Agda to generate some minimal amount of website artifacts
- runs mdbook-linkcheck on the Agda output

If this works correctly it should fix #595, but I expect some iteration to be necessary, as is always the case with CI.