### PR TITLE
Add agda-unimath as a Nix package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,21 +16,53 @@
       (system:
         let
           pkgs = nixpkgs.legacyPackages."${system}";
-          agda = pkgs.agda;
           python = pkgs.python38.withPackages (p: with p; [
             # Keep in sync with scripts/requirements.txt
             requests
           ]);
+
+          agda-unimath-package = { lib, mkDerivation, time }: mkDerivation {
+            pname = "agda-unimath";
+
+            # For the version format of unreleased packages, see
+            # https://nixos.org/manual/nixpkgs/stable/#sec-package-naming
+            version = "unstable-2023-09-05";
+
+            # We can reference the directory since we're using flakes,
+            # which copies the version-tracked files into the nix store
+            # before evaluation, # so we don't run into the issue with
+            # non-reproducible source paths as outlined here:
+            # https://nix.dev/recipes/best-practices#reproducible-source-paths
+            src = ./.;
+
+            nativeBuildInputs = [ time ];
+
+            buildPhase = ''
+              runHook preBuild
+              make check
+              runHook postBuild
+            '';
+
+            meta = with lib; {
+              description = "Univalent mathematics in Agda";
+              homepage = "https://github.com/UniMath/agda-unimath";
+              license = licenses.mit;
+              platforms = platforms.unix;
+            };
+          };
         in
         {
+          packages.agda-unimath = pkgs.agdaPackages.callPackage agda-unimath-package { };
+          packages.default = self.packages."${system}".agda-unimath;
+
           devShells.default = pkgs.mkShell {
             name = "agda-unimath";
 
-            # Build tools
+            # Dependencies for building the library
+            inputsFrom = [ self.packages."${system}".agda-unimath ];
+
+            # Development tools
             packages = [
-              agda
-              # part of `make check`
-              pkgs.time
               # maintanance scripts
               python
               # working on the website


### PR DESCRIPTION
This PR adds agda-unimath as a Nix package which can be consumed by the nixpkgs infrastructure.

To test it out, create a `flake.nix` file with the following contents:
```nix
{
  # Pin nixpkgs to the same version as current agda-unimath,
  # just to prevent potential rebuilds for the demo
  inputs.nixpkgs.url = "github:NixOS/nixpkgs/57695599bdc4f7bfe5d28cfa23f14b3d8bdf8a5f";
  inputs.agda-unimath.url = "github:VojtechStep/agda-unimath/feature/nix-packaging";
  outputs = { self, nixpkgs, agda-unimath }:
    let
      pkgs = nixpkgs.legacyPackages.x86_64-linux;
    in
    {
      devShells.x86_64-linux.default = pkgs.mkShell {
        name = "test-agda-unimath-shell";
        packages = [
          (pkgs.agda.withPackages [ agda-unimath.packages.x86_64-linux.agda-unimath ])
        ];
      };
    };
}
```

 Then create a `test.agda` file containing
```agda
{-# OPTIONS --guardedness #-}
open import synthetic-homotopy-theory
```

You can compile the file by running `nix develop`, which drops you into a shell with `agda` and `agda-unimath` available, and then run `agda -l agda-unimath -i . test.agda`, which should correctly import agda-unimath's `synthetic-homotopy-theory` module.

This method of installation should probably be documented somewhere, but we don't even really have proper docs for just installing agda-unimath for purely consumption (i.e. https://agda.readthedocs.io/en/v2.6.3/tools/package-system.html), so I left it out of this PR.

Also a thing worth considering is whether we want to put our development into a common namespace; for example all modules from https://github.com/agda/cubical have a common prefix `Cubical.`. Some libraries do it and some don't, there doesn't appear to be a consensus.