### PR TITLE
Commutativity of pasting squares and transposing by precomposition

### DIFF
--- a/src/foundation-core/homotopies.lagda.md
+++ b/src/foundation-core/homotopies.lagda.md
@@ -377,6 +377,47 @@ module _
     inv-htpy (right-whisk-inv-htpy H f)
 ```
 
+### Distributivity of whiskering over composition of homotopies
+
+```agda
+module _
+  { l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
+  where
+
+  distributive-left-whisk-concat-htpy :
+    { f g h : A → B} (k : B → C) →
+    ( H : f ~ g) (K : g ~ h) →
+    ( k ·l (H ∙h K)) ~ ((k ·l H) ∙h (k ·l K))
+  distributive-left-whisk-concat-htpy k H K a =
+    ap-concat k (H a) (K a)
+
+  distributive-right-whisk-concat-htpy :
+    ( k : A → B) {f g h : B → C} →
+    ( H : f ~ g) (K : g ~ h) →
+    ( (H ∙h K) ·r k) ~ ((H ·r k) ∙h (K ·r k))
+  distributive-right-whisk-concat-htpy k H K = refl-htpy
+```
+
+### Associativity of whiskering and function composition
+
+```agda
+module _
+  { l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {C : UU l3} {D : UU l4}
+  where
+
+  associative-left-whisk-comp :
+    ( k : C → D) (h : B → C) {f g : A → B} →
+    ( H : f ~ g) →
+    ( k ·l (h ·l H)) ~ ((k ∘ h) ·l H)
+  associative-left-whisk-comp k h H x = inv (ap-comp k h (H x))
+
+  associative-right-whisk-comp :
+    { f g : C → D} (h : B → C) (k : A → B) →
+    ( H : f ~ g) →
+    ( (H ·r h) ·r k) ~ (H ·r (h ∘ k))
+  associative-right-whisk-comp h k H = refl-htpy
+```
+
 ## Reasoning with homotopies
 
 Homotopies can be constructed by equational reasoning in the following way:

--- a/src/foundation/commuting-squares-of-maps.lagda.md
+++ b/src/foundation/commuting-squares-of-maps.lagda.md
@@ -97,9 +97,9 @@ precomp-coherence-square-maps top leeft right bottom H X =
 
 ### Commutativity of pasting squares and transposing by precomposition
 
-Given two commuting squares which can be composed horizontally (vertically),
-we know that composing them and then transposing them by precomposition gives
-the same homotopies as first transposing the squares and then composing them.
+Given two commuting squares which can be composed horizontally (vertically), we
+know that composing them and then transposing them by precomposition gives the
+same homotopies as first transposing the squares and then composing them.
 
 ```text
       tl       tr                tr ∘ tl

--- a/src/foundation/commuting-squares-of-maps.lagda.md
+++ b/src/foundation/commuting-squares-of-maps.lagda.md
@@ -286,7 +286,7 @@ module _
       ＝ eq-htpy
           ( ((h ·l K) ·r left-top) ∙h (h ·l (right-bottom ·l H)))
         by
-          ap
+        ap
           ( eq-htpy)
           ( eq-htpy
             ( distributive-left-whisk-concat-htpy
@@ -298,17 +298,17 @@ module _
         eq-htpy
           ( h ·l (right-bottom ·l H))
         by
-          eq-htpy-concat-htpy
-            ( (h ·l K) ·r left-top)
-            ( h ·l (right-bottom ·l H))
+        eq-htpy-concat-htpy
+          ( (h ·l K) ·r left-top)
+          ( h ·l (right-bottom ·l H))
       ＝ ap
           ( precomp left-top W)
           ( eq-htpy (h ·l K)) ∙
         eq-htpy
           ( (h ∘ right-bottom) ·l H)
         by
-          ap-binary
-            ( λ p L → p ∙ eq-htpy L)
-            ( compute-eq-htpy-right-whisk left-top (h ·l K))
-            ( eq-htpy (associative-left-whisk-comp h right-bottom H))
+        ap-binary
+          ( λ p L → p ∙ eq-htpy L)
+          ( compute-eq-htpy-right-whisk left-top (h ·l K))
+          ( eq-htpy (associative-left-whisk-comp h right-bottom H))
 ```

--- a/src/foundation/commuting-squares-of-maps.lagda.md
+++ b/src/foundation/commuting-squares-of-maps.lagda.md
@@ -9,12 +9,15 @@ open import foundation-core.commuting-squares-of-maps public
 <details><summary>Imports</summary>
 
 ```agda
+open import foundation.action-on-identifications-binary-functions
 open import foundation.action-on-identifications-functions
 open import foundation.equivalences
+open import foundation.function-extensionality
 open import foundation.universe-levels
 
 open import foundation-core.function-types
 open import foundation-core.functoriality-function-types
+open import foundation-core.homotopies
 open import foundation-core.identity-types
 ```
 
@@ -90,4 +93,189 @@ precomp-coherence-square-maps :
     ( precomp left X)
 precomp-coherence-square-maps top leeft right bottom H X =
   htpy-precomp H X
+```
+
+### Commutativity of pasting squares and transposing by precomposition
+
+```agda
+module _
+  { l1 l2 l3 l4 l5 l6 l7 : Level}
+  { A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4} {Y : UU l5} {Z : UU l6}
+  ( W : UU l7)
+  where
+
+  commutative-precomp-pasting-coherence-square-maps :
+    ( top-left : A → B) (top-right : B → C)
+    ( left : A → X) (middle : B → Y) (right : C → Z)
+    ( bottom-left : X → Y) (bottom-right : Y → Z) →
+    ( H : coherence-square-maps top-left left middle bottom-left) →
+    ( K : coherence-square-maps top-right middle right bottom-right) →
+    precomp-coherence-square-maps
+      ( top-right ∘ top-left)
+      ( left)
+      ( right)
+      ( bottom-right ∘ bottom-left)
+      ( pasting-horizontal-coherence-square-maps
+        ( top-left)
+        ( top-right)
+        ( left)
+        ( middle)
+        ( right)
+        ( bottom-left)
+        ( bottom-right)
+        ( H)
+        ( K))
+      ( W) ~
+    pasting-vertical-coherence-square-maps
+      ( precomp right W)
+      ( precomp bottom-right W)
+      ( precomp top-right W)
+      ( precomp middle W)
+      ( precomp bottom-left W)
+      ( precomp top-left W)
+      ( precomp left W)
+      ( precomp-coherence-square-maps
+        ( top-right)
+        ( middle)
+        ( right)
+        ( bottom-right)
+        ( K)
+        ( W))
+      ( precomp-coherence-square-maps
+        ( top-left)
+        ( left)
+        ( middle)
+        ( bottom-left)
+        ( H)
+        ( W))
+  commutative-precomp-pasting-coherence-square-maps
+    ( top-left)
+    ( top-right)
+    ( left)
+    ( middle)
+    ( right)
+    ( bottom-left)
+    ( bottom-right)
+    ( H)
+    ( K)
+    ( h) =
+    equational-reasoning
+      eq-htpy
+        ( h ·l ((bottom-right ·l H) ∙h (K ·r top-left)))
+      ＝ eq-htpy
+          ( (h ·l (bottom-right ·l H)) ∙h ((h ·l K) ·r top-left))
+        by
+          ap
+            ( eq-htpy)
+            ( eq-htpy
+              ( distributive-left-whisk-concat-htpy
+                ( h)
+                ( bottom-right ·l H)
+                ( K ·r top-left)))
+      ＝ eq-htpy
+          ( h ·l (bottom-right ·l H)) ∙
+        eq-htpy
+          ( (h ·l K) ·r top-left)
+        by
+          eq-htpy-concat-htpy
+            ( h ·l (bottom-right ·l H))
+            ( (h ·l K) ·r top-left)
+      ＝ eq-htpy
+          ( (h ∘ bottom-right) ·l H) ∙
+          ap
+            ( precomp top-left W)
+            ( eq-htpy (h ·l K))
+        by
+          ap-binary
+            ( λ L q → eq-htpy L ∙ q)
+            ( eq-htpy (associative-left-whisk-comp h bottom-right H))
+            ( compute-eq-htpy-right-whisk
+              ( top-left)
+              ( (h ·l K)))
+
+  commutative-precomp-pasting-coherence-square-maps' :
+    ( top : A → X) (left-top : A → B) (right-top : X → Y) (middle : B → Y) →
+    ( left-bottom : B → C) (right-bottom : Y → Z) (bottom : C → Z) →
+    ( H : coherence-square-maps top left-top right-top middle) →
+    ( K : coherence-square-maps middle left-bottom right-bottom bottom) →
+    precomp-coherence-square-maps
+      ( top)
+      ( left-bottom ∘ left-top)
+      ( right-bottom ∘ right-top)
+      ( bottom)
+      ( pasting-vertical-coherence-square-maps
+        ( top)
+        ( left-top)
+        ( right-top)
+        ( middle)
+        ( left-bottom)
+        ( right-bottom)
+        ( bottom)
+        ( H)
+        ( K))
+      ( W) ~
+    pasting-horizontal-coherence-square-maps
+      ( precomp right-bottom W)
+      ( precomp right-top W)
+      ( precomp bottom W)
+      ( precomp middle W)
+      ( precomp top W)
+      ( precomp left-bottom W)
+      ( precomp left-top W)
+      ( precomp-coherence-square-maps
+        ( middle)
+        ( left-bottom)
+        ( right-bottom)
+        ( bottom)
+        ( K)
+        ( W))
+      ( precomp-coherence-square-maps
+        ( top)
+        ( left-top)
+        ( right-top)
+        ( middle)
+        ( H)
+        ( W))
+  commutative-precomp-pasting-coherence-square-maps'
+    ( top)
+    ( left-top)
+    ( right-top)
+    ( middle)
+    ( left-bottom)
+    ( right-bottom)
+    ( bottom)
+    ( H)
+    ( K)
+    ( h) =
+    equational-reasoning
+      eq-htpy
+        (h ·l ((K ·r left-top) ∙h (right-bottom ·l H)))
+      ＝ eq-htpy
+          ( ((h ·l K) ·r left-top) ∙h (h ·l (right-bottom ·l H)))
+        by
+          ap
+          ( eq-htpy)
+          ( eq-htpy
+            ( distributive-left-whisk-concat-htpy
+            ( h)
+            ( K ·r left-top)
+            ( right-bottom ·l H)))
+      ＝ eq-htpy
+          ( (h ·l K) ·r left-top) ∙
+        eq-htpy
+          ( h ·l (right-bottom ·l H))
+        by
+          eq-htpy-concat-htpy
+            ( (h ·l K) ·r left-top)
+            ( h ·l (right-bottom ·l H))
+      ＝ ap
+          ( precomp left-top W)
+          ( eq-htpy (h ·l K)) ∙
+        eq-htpy
+          ( (h ∘ right-bottom) ·l H)
+        by
+          ap-binary
+            ( λ p L → p ∙ eq-htpy L)
+            ( compute-eq-htpy-right-whisk left-top (h ·l K))
+            ( eq-htpy (associative-left-whisk-comp h right-bottom H))
 ```

--- a/src/foundation/commuting-squares-of-maps.lagda.md
+++ b/src/foundation/commuting-squares-of-maps.lagda.md
@@ -95,7 +95,7 @@ precomp-coherence-square-maps top leeft right bottom H X =
   htpy-precomp H X
 ```
 
-### Commutativity of pasting squares and transposing by precomposition
+### Distributivity of pasting squares and transposing by precomposition
 
 Given two commuting squares which can be composed horizontally (vertically), we
 know that composing them and then transposing them by precomposition gives the
@@ -137,7 +137,7 @@ module _
   ( W : UU l7)
   where
 
-  commutative-precomp-pasting-coherence-square-maps :
+  distributive-precomp-pasting-horizontal-coherence-square-maps :
     ( top-left : A → B) (top-right : B → C)
     ( left : A → X) (middle : B → Y) (right : C → Z)
     ( bottom-left : X → Y) (bottom-right : Y → Z) →
@@ -181,7 +181,7 @@ module _
         ( bottom-left)
         ( H)
         ( W))
-  commutative-precomp-pasting-coherence-square-maps
+  distributive-precomp-pasting-horizontal-coherence-square-maps
     ( top-left)
     ( top-right)
     ( left)
@@ -226,7 +226,7 @@ module _
             ( top-left)
             ( h ·l K))
 
-  commutative-precomp-pasting-coherence-square-maps' :
+  distributive-precomp-pasting-vertical-coherence-square-maps :
     ( top : A → X) (left-top : A → B) (right-top : X → Y) (middle : B → Y) →
     ( left-bottom : B → C) (right-bottom : Y → Z) (bottom : C → Z) →
     ( H : coherence-square-maps top left-top right-top middle) →
@@ -269,7 +269,7 @@ module _
         ( middle)
         ( H)
         ( W))
-  commutative-precomp-pasting-coherence-square-maps'
+  distributive-precomp-pasting-vertical-coherence-square-maps
     ( top)
     ( left-top)
     ( right-top)

--- a/src/foundation/commuting-squares-of-maps.lagda.md
+++ b/src/foundation/commuting-squares-of-maps.lagda.md
@@ -198,33 +198,33 @@ module _
       ＝ eq-htpy
           ( (h ·l (bottom-right ·l H)) ∙h ((h ·l K) ·r top-left))
         by
-          ap
-            ( eq-htpy)
-            ( eq-htpy
-              ( distributive-left-whisk-concat-htpy
-                ( h)
-                ( bottom-right ·l H)
-                ( K ·r top-left)))
+        ap
+          ( eq-htpy)
+          ( eq-htpy
+            ( distributive-left-whisk-concat-htpy
+              ( h)
+              ( bottom-right ·l H)
+              ( K ·r top-left)))
       ＝ eq-htpy
           ( h ·l (bottom-right ·l H)) ∙
         eq-htpy
           ( (h ·l K) ·r top-left)
         by
-          eq-htpy-concat-htpy
-            ( h ·l (bottom-right ·l H))
-            ( (h ·l K) ·r top-left)
+        eq-htpy-concat-htpy
+          ( h ·l (bottom-right ·l H))
+          ( (h ·l K) ·r top-left)
       ＝ eq-htpy
           ( (h ∘ bottom-right) ·l H) ∙
           ap
             ( precomp top-left W)
             ( eq-htpy (h ·l K))
         by
-          ap-binary
-            ( λ L q → eq-htpy L ∙ q)
-            ( eq-htpy (associative-left-whisk-comp h bottom-right H))
-            ( compute-eq-htpy-right-whisk
-              ( top-left)
-              ( (h ·l K)))
+        ap-binary
+          ( λ L q → eq-htpy L ∙ q)
+          ( eq-htpy (associative-left-whisk-comp h bottom-right H))
+          ( compute-eq-htpy-right-whisk
+            ( top-left)
+            ( h ·l K))
 
   commutative-precomp-pasting-coherence-square-maps' :
     ( top : A → X) (left-top : A → B) (right-top : X → Y) (middle : B → Y) →

--- a/src/foundation/commuting-squares-of-maps.lagda.md
+++ b/src/foundation/commuting-squares-of-maps.lagda.md
@@ -97,6 +97,39 @@ precomp-coherence-square-maps top leeft right bottom H X =
 
 ### Commutativity of pasting squares and transposing by precomposition
 
+Given two commuting squares which can be composed horizontally (vertically),
+we know that composing them and then transposing them by precomposition gives
+the same homotopies as first transposing the squares and then composing them.
+
+```text
+      tl       tr                tr ∘ tl
+  A -----> B -----> C         A --------> C
+  |        |        |         |           |
+l |       m|        | r |->  l|          r|
+  |   H    |   K    |         |   H | K   |
+  v        v        v         v           v
+  X -----> Y -----> Z         X --------> Z
+      bl       br                br ∘ bl
+
+         -                          -
+         |                          |
+         v                          v
+
+           -∘r
+    W^Z ------> W^C
+     |           |
+-∘br |    W^K    | -∘tr           W^(H | K)
+     |           |
+     v     -∘m   v                   ~
+    W^Y ------> W^B   |->
+     |           |                  W^K
+-∘bl |    W^H    | -∘tl             ---
+     |           |                  W^H
+     v           v
+    W^X ------> W^A
+          -∘l
+```
+
 ```agda
 module _
   { l1 l2 l3 l4 l5 l6 l7 : Level}

--- a/src/foundation/function-extensionality.lagda.md
+++ b/src/foundation/function-extensionality.lagda.md
@@ -131,10 +131,10 @@ module _
     ( H : f ~ g) →
     eq-htpy (H ·r h) ＝ ap (precomp h C) (eq-htpy H)
   compute-eq-htpy-right-whisk H =
-    ap
+    ( ap
       ( λ K → eq-htpy (K ·r h))
-      ( inv (is-section-eq-htpy H)) ∙
-    compute-eq-htpy-htpy-eq-right-whisk (eq-htpy H)
+      ( inv (is-section-eq-htpy H))) ∙
+    ( compute-eq-htpy-htpy-eq-right-whisk (eq-htpy H))
 ```
 
 ```agda

--- a/src/foundation/function-extensionality.lagda.md
+++ b/src/foundation/function-extensionality.lagda.md
@@ -113,6 +113,52 @@ module _
         is-retraction-eq-htpy (eq-htpy H ∙ eq-htpy K)
 ```
 
+### Computation of function extensionality on whiskerings
+
+```agda
+module _
+  { l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
+  { f g : B → C} (h : A → B)
+  where
+
+  compute-eq-htpy-htpy-eq-right-whisk :
+    ( p : f ＝ g) →
+    eq-htpy ((htpy-eq p) ·r h) ＝ ap (precomp h C) p
+  compute-eq-htpy-htpy-eq-right-whisk refl =
+    eq-htpy-refl-htpy (f ∘ h)
+
+  compute-eq-htpy-right-whisk :
+    ( H : f ~ g) →
+    eq-htpy (H ·r h) ＝ ap (precomp h C) (eq-htpy H)
+  compute-eq-htpy-right-whisk H =
+    ap
+      ( λ K → eq-htpy (K ·r h))
+      ( inv (is-section-eq-htpy H)) ∙
+    compute-eq-htpy-htpy-eq-right-whisk (eq-htpy H)
+```
+
+```agda
+module _
+  { l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
+  { f g : A → B} (h : B → C)
+  where
+
+  compute-eq-htpy-htpy-eq-left-whisk :
+    ( p : f ＝ g) →
+    eq-htpy ( h ·l (htpy-eq p)) ＝ ap (postcomp A h) p
+  compute-eq-htpy-htpy-eq-left-whisk refl =
+    eq-htpy-refl-htpy (h ∘ f)
+
+  compute-eq-htpy-left-whisk :
+    (H : f ~ g) →
+    eq-htpy (h ·l H) ＝ ap (postcomp A h) (eq-htpy H)
+  compute-eq-htpy-left-whisk H =
+    ap
+      ( λ K → eq-htpy (h ·l K))
+      ( inv (is-section-eq-htpy H)) ∙
+    compute-eq-htpy-htpy-eq-left-whisk (eq-htpy H)
+```
+
 ## See also
 
 - That the univalence axiom implies function extensionality is proven in

--- a/src/foundation/function-extensionality.lagda.md
+++ b/src/foundation/function-extensionality.lagda.md
@@ -153,10 +153,10 @@ module _
     (H : f ~ g) →
     eq-htpy (h ·l H) ＝ ap (postcomp A h) (eq-htpy H)
   compute-eq-htpy-left-whisk H =
-    ap
+    ( ap
       ( λ K → eq-htpy (h ·l K))
-      ( inv (is-section-eq-htpy H)) ∙
-    compute-eq-htpy-htpy-eq-left-whisk (eq-htpy H)
+      ( inv (is-section-eq-htpy H))) ∙
+    ( compute-eq-htpy-htpy-eq-left-whisk (eq-htpy H))
 ```
 
 ## See also


### PR DESCRIPTION
This PR adds a few lemmas about computations with whiskerings, and proves that given two pastable squares, one can either first transpose them by precomposition and then paste them, or first paste them and then transpose them, which results in homotopic squares.