### PR TITLE
The Legendre symbol

### DIFF
--- a/CONTRIBUTORS.toml
+++ b/CONTRIBUTORS.toml
@@ -221,3 +221,8 @@ github = "Petkomat"
 displayName = "Gregor Perčič"
 usernames = [ "Gregor Perčič", "izak" ]
 github = "GregorPercic"
+
+[[contributors]]
+displayName = "Alec Barreto"
+usernames = [ "Alec Barreto" ]
+github = "wrest64"

--- a/src/elementary-number-theory.lagda.md
+++ b/src/elementary-number-theory.lagda.md
@@ -66,6 +66,7 @@ open import elementary-number-theory.integer-fractions public
 open import elementary-number-theory.integer-partitions public
 open import elementary-number-theory.integers public
 open import elementary-number-theory.kolakoski-sequence public
+open import elementary-number-theory.legendre-symbol public
 open import elementary-number-theory.lower-bounds-natural-numbers public
 open import elementary-number-theory.maximum-natural-numbers public
 open import elementary-number-theory.maximum-standard-finite-types public

--- a/src/elementary-number-theory.lagda.md
+++ b/src/elementary-number-theory.lagda.md
@@ -106,6 +106,9 @@ open import elementary-number-theory.ring-of-integers public
 open import elementary-number-theory.rings-of-modular-arithmetic public
 open import elementary-number-theory.sieve-of-eratosthenes public
 open import elementary-number-theory.square-free-natural-numbers public
+open import elementary-number-theory.squares-integers public
+open import elementary-number-theory.squares-modular-arithmetic public
+open import elementary-number-theory.squares-natural-numbers public
 open import elementary-number-theory.stirling-numbers-of-the-second-kind public
 open import elementary-number-theory.strict-inequality-natural-numbers public
 open import elementary-number-theory.strictly-ordered-pairs-of-natural-numbers public

--- a/src/elementary-number-theory/legendre-symbol.lagda.md
+++ b/src/elementary-number-theory/legendre-symbol.lagda.md
@@ -1,0 +1,286 @@
+# Legendre Symbol
+
+```agda
+module elementary-number-theory.legendre-symbol where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import elementary-number-theory.absolute-value-integers
+open import elementary-number-theory.addition-natural-numbers
+open import elementary-number-theory.decidable-types
+open import elementary-number-theory.equality-natural-numbers
+open import elementary-number-theory.inequality-natural-numbers
+open import elementary-number-theory.integers
+open import elementary-number-theory.modular-arithmetic
+open import elementary-number-theory.multiplication-integers
+open import elementary-number-theory.multiplication-natural-numbers
+open import elementary-number-theory.natural-numbers
+open import elementary-number-theory.prime-numbers
+
+open import foundation.action-on-identifications-functions
+open import foundation.coproduct-types
+open import foundation.decidable-equality
+open import foundation.decidable-types
+open import foundation.dependent-pair-types
+open import foundation.identity-types
+open import foundation.logical-equivalences
+open import foundation.negation
+open import foundation.unit-type
+open import foundation.universe-levels
+
+open import foundation-core.cartesian-product-types
+open import foundation-core.transport-along-identifications
+
+open import univalent-combinatorics.fibers-of-maps
+```
+
+</details>
+
+## Idea
+
+The **Legendre Symbol** is a function which determines whether or not an integer
+is a perfect square in `ℤₚ` (i.e. whether or not it is a quadratic residue).
+Specifically, let `p : ℕ` be a natural and `a : ℤ` be an integer. If `a` is a
+square in `ℤₚ` then `legendre(p,a) = 1`. Similarly if `a` is not a square in
+`ℤₚ` then `legendre(p,a) = -1`. Finally if `a` is congruent to `0` in `ℤₚ` then
+`legendre(p,a) = 0`. Typically `p` is taken to be prime.
+
+## Natural Numbers
+
+### Definition for squareness in ℕ
+
+```agda
+is-square-ℕ : ℕ → UU lzero
+is-square-ℕ n = Σ ℕ (λ x → n ＝ square-ℕ x)
+```
+
+### n > √n for n > 1
+
+The idea is to assume `n = m + 2 ≤ sqrt(m + 2)` for some `m : ℕ` and derive a
+contradiction by squaring both sides of the inequality
+
+```agda
+greater-than-square-root-ℕ :
+  (n root : ℕ) → ¬ ((n +ℕ 2 ≤-ℕ root) × (n +ℕ 2 ＝ square-ℕ root))
+greater-than-square-root-ℕ n root (pf-leq , pf-eq) =
+  reflects-order-add-ℕ
+    ( square-ℕ root)
+    ( n *ℕ (n +ℕ 2) +ℕ n +ℕ 2)
+    0
+    ( tr
+      ( leq-ℕ (n *ℕ (n +ℕ 2) +ℕ n +ℕ 2 +ℕ square-ℕ root))
+      ( inv (left-unit-law-add-ℕ (square-ℕ root)))
+      ( concatenate-eq-leq-ℕ
+        ( square-ℕ root)
+        ( inv
+          ( helper ∙
+            ( ap
+              ( add-ℕ (n *ℕ (n +ℕ 2) +ℕ n +ℕ 2))
+              pf-eq)))
+        ( preserves-leq-mul-ℕ (n +ℕ 2) root (n +ℕ 2) root pf-leq pf-leq)))
+  where
+  helper : square-ℕ (n +ℕ 2) ＝ n *ℕ (n +ℕ 2) +ℕ n +ℕ 2 +ℕ n +ℕ 2
+  helper =
+    equational-reasoning
+    square-ℕ (n +ℕ 2)
+    ＝ n *ℕ (n +ℕ 2) +ℕ (2 *ℕ (n +ℕ 2))
+      by (right-distributive-mul-add-ℕ n 2 (n +ℕ 2))
+    ＝ n *ℕ (n +ℕ 2) +ℕ 2 *ℕ n +ℕ 4
+      by
+        ( ap
+          ( add-ℕ (n *ℕ (n +ℕ 2)))
+          ( left-distributive-mul-add-ℕ 2 n 2))
+    ＝ n *ℕ (n +ℕ 2) +ℕ (n +ℕ 2 +ℕ (n +ℕ 2))
+      by
+        ( ap
+          ( add-ℕ (n *ℕ (n +ℕ 2)))
+          ( equational-reasoning
+            2 *ℕ n +ℕ 4
+            ＝ 4 +ℕ 2 *ℕ n
+              by (commutative-add-ℕ (2 *ℕ n) 4)
+            ＝ 2 +ℕ 2 +ℕ (n +ℕ n)
+              by
+                ( ap
+                  ( add-ℕ 4)
+                  ( left-two-law-mul-ℕ n))
+            ＝ (2 +ℕ 2 +ℕ n) +ℕ n
+              by
+                ( inv
+                  ( associative-add-ℕ 4 n n))
+            ＝ n +ℕ (2 +ℕ 2 +ℕ n)
+              by (commutative-add-ℕ (2 +ℕ 2 +ℕ n) n)
+            ＝ n +ℕ (2 +ℕ (2 +ℕ n))
+              by
+                ( ap
+                  ( add-ℕ n)
+                  ( associative-add-ℕ 2 2 n))
+            ＝ n +ℕ (2 +ℕ (n +ℕ 2))
+              by
+                ( ap-add-ℕ {n} {2 +ℕ (2 +ℕ n)}
+                  refl
+                  ( ap
+                    ( add-ℕ 2)
+                    ( commutative-add-ℕ 2 n)))
+            ＝ n +ℕ 2 +ℕ (n +ℕ 2)
+              by
+                ( inv
+                  ( associative-add-ℕ n 2 (n +ℕ 2)))))
+    ＝ n *ℕ (n +ℕ 2) +ℕ n +ℕ 2 +ℕ (n +ℕ 2)
+      by
+        ( inv
+          ( associative-add-ℕ
+            ( n *ℕ (n +ℕ 2))
+            ( n +ℕ 2)
+            ( n +ℕ 2)))
+```
+
+### Squareness in ℕ is decidable
+
+```agda
+is-decidable-big-root :
+  (n : ℕ) → is-decidable (Σ ℕ (λ root → (n ≤-ℕ root) × (n ＝ square-ℕ root)))
+is-decidable-big-root 0 = inl (0 , star , refl)
+is-decidable-big-root 1 = inl (1 , star , refl)
+is-decidable-big-root (succ-ℕ (succ-ℕ n)) =
+  inr (λ H → greater-than-square-root-ℕ n (pr1 H) (pr2 H))
+
+is-decidable-square-ℕ : (n : ℕ) → is-decidable (is-square-ℕ n)
+is-decidable-square-ℕ n =
+  is-decidable-Σ-ℕ n
+    ( λ x → n ＝ square-ℕ x)
+    ( λ x → has-decidable-equality-ℕ n (square-ℕ x))
+    ( is-decidable-big-root n)
+```
+
+## Integers
+
+### Definitions for squareness in ℤ
+
+```agda
+square-ℤ : ℤ → ℤ
+square-ℤ a = mul-ℤ a a
+
+is-square-ℤ : ℤ → UU lzero
+is-square-ℤ a = Σ ℤ (λ x → a ＝ square-ℤ x)
+```
+
+### Squares in ℤ are nonnegative
+
+```agda
+is-decidable-nonnegative-square-ℤ :
+  (a : ℤ) →
+  (is-nonnegative-ℤ a) + (is-nonnegative-ℤ (neg-ℤ a)) →
+  is-nonnegative-ℤ (square-ℤ a)
+is-decidable-nonnegative-square-ℤ _ (inl x) = is-nonnegative-mul-ℤ x x
+is-decidable-nonnegative-square-ℤ a (inr x) =
+  tr
+    is-nonnegative-ℤ
+    ( double-negative-law-mul-ℤ a a)
+    ( is-nonnegative-mul-ℤ x x)
+
+is-nonnegative-square-ℤ : (a : ℤ) → is-nonnegative-ℤ (square-ℤ a)
+is-nonnegative-square-ℤ a =
+  is-decidable-nonnegative-square-ℤ a decide-is-nonnegative-ℤ
+```
+
+### The squares in ℤ are exactly the squares in ℕ
+
+```agda
+is-square-int-if-is-square-nat : {n : ℕ} → is-square-ℕ n → is-square-ℤ (int-ℕ n)
+is-square-int-if-is-square-nat (root , pf-square) =
+  ( pair
+    ( int-ℕ root)
+    ( ( ap int-ℕ pf-square) ∙
+      ( inv (mul-int-ℕ root root))))
+
+is-square-nat-if-is-square-int : {a : ℤ} → is-square-ℤ a → is-square-ℕ (abs-ℤ a)
+is-square-nat-if-is-square-int (root , pf-square) =
+  ( pair
+    ( abs-ℤ root)
+    ( ( ap abs-ℤ pf-square) ∙
+      ( multiplicative-abs-ℤ root root)))
+
+is-nat-square-iff-is-int-square :
+  (n : ℕ) → is-square-ℕ n ↔ is-square-ℤ (int-ℕ n)
+pr1 (is-nat-square-iff-is-int-square n) = is-square-int-if-is-square-nat
+pr2 (is-nat-square-iff-is-int-square n) H =
+  tr is-square-ℕ (abs-int-ℕ n) (is-square-nat-if-is-square-int H)
+
+is-int-square-iff-nonneg-nat-square :
+  (a : ℤ) → is-square-ℤ a ↔ is-nonnegative-ℤ a × is-square-ℕ (abs-ℤ a)
+pr1 (is-int-square-iff-nonneg-nat-square a) (root , pf-square) =
+  ( pair
+    ( tr is-nonnegative-ℤ (inv pf-square) (is-nonnegative-square-ℤ root))
+    ( is-square-nat-if-is-square-int (root , pf-square)))
+pr2 (is-int-square-iff-nonneg-nat-square a) (pf-nonneg , (root , pf-square)) =
+  ( pair
+    ( int-ℕ root)
+    ( ( inv (int-abs-is-nonnegative-ℤ a pf-nonneg)) ∙
+      ( pr2 (is-square-int-if-is-square-nat (root , pf-square)))))
+```
+
+### Squareness in ℤ is decidable
+
+```agda
+is-decidable-square-ℤ : (a : ℤ) → is-decidable (is-square-ℤ a)
+is-decidable-square-ℤ (inl n) =
+  inr (map-neg (pr1 (is-int-square-iff-nonneg-nat-square (inl n))) pr1)
+is-decidable-square-ℤ (inr (inl n)) =
+  inl (zero-ℤ , refl)
+is-decidable-square-ℤ (inr (inr n)) =
+  is-decidable-iff
+    is-square-int-if-is-square-nat
+    is-square-nat-if-is-square-int
+    ( is-decidable-square-ℕ (succ-ℕ n))
+```
+
+## ℤₚ
+
+### Definitions for squareness in ℤₚ
+
+```agda
+square-ℤ-Mod : (p : ℕ) → ℤ-Mod p → ℤ-Mod p
+square-ℤ-Mod 0 a = mul-ℤ a a
+square-ℤ-Mod (succ-ℕ p) a = mul-ℤ-Mod (succ-ℕ p) a a
+
+is-square-ℤ-Mod : (p : ℕ) → ℤ-Mod p → UU lzero
+is-square-ℤ-Mod 0 k = is-square-ℤ k
+is-square-ℤ-Mod (succ-ℕ p) k =
+  Σ (ℤ-Mod (succ-ℕ p)) (λ x → square-ℤ-Mod (succ-ℕ p) x ＝ k)
+```
+
+### Squareness in ℤₚ is decidable
+
+```agda
+is-decidable-square-ℤ-Mod :
+  (p : ℕ) (k : ℤ-Mod p) → is-decidable (is-square-ℤ-Mod p k)
+is-decidable-square-ℤ-Mod 0 k = is-decidable-square-ℤ k
+is-decidable-square-ℤ-Mod (succ-ℕ p) k =
+  is-decidable-fiber-Fin {succ-ℕ p} {succ-ℕ p} (square-ℤ-Mod (succ-ℕ p)) k
+```
+
+## Legendre Symbol
+
+### Definitions for the Legendre Symbol
+
+```agda
+int-is-square-ℤ-Mod :
+  {p : ℕ} {k : ℤ-Mod p} →
+  is-decidable (is-zero-ℤ-Mod p k) →
+  is-decidable (is-square-ℤ-Mod p k) →
+  ℤ
+int-is-square-ℤ-Mod (inl _) _ = zero-ℤ
+int-is-square-ℤ-Mod (inr _) (inl _) = one-ℤ
+int-is-square-ℤ-Mod (inr _) (inr _) = neg-one-ℤ
+
+legendre : ℕ → ℤ → ℤ
+legendre p a =
+  int-is-square-ℤ-Mod
+    ( has-decidable-equality-ℤ-Mod p arg-mod-p (zero-ℤ-Mod p))
+    ( is-decidable-square-ℤ-Mod p arg-mod-p)
+  where
+  arg-mod-p : ℤ-Mod p
+  arg-mod-p = mod-ℤ p a
+```

--- a/src/elementary-number-theory/legendre-symbol.lagda.md
+++ b/src/elementary-number-theory/legendre-symbol.lagda.md
@@ -47,5 +47,5 @@ legendre-symbol : Prime-ℕ → ℤ → ℤ
 legendre-symbol (p , _) a =
   int-is-square-ℤ-Mod
     ( has-decidable-equality-ℤ-Mod p (mod-ℤ p a) (zero-ℤ-Mod p))
-    ( is-decidable-square-ℤ-Mod p (mod-ℤ p a))
+    ( is-decidable-is-square-ℤ-Mod p (mod-ℤ p a))
 ```

--- a/src/elementary-number-theory/legendre-symbol.lagda.md
+++ b/src/elementary-number-theory/legendre-symbol.lagda.md
@@ -43,8 +43,8 @@ int-is-square-ℤ-Mod (inl _) _ = zero-ℤ
 int-is-square-ℤ-Mod (inr _) (inl _) = one-ℤ
 int-is-square-ℤ-Mod (inr _) (inr _) = neg-one-ℤ
 
-legendre : Prime-ℕ → ℤ → ℤ
-legendre (p , _) a =
+legendre-symbol : Prime-ℕ → ℤ → ℤ
+legendre-symbol (p , _) a =
   int-is-square-ℤ-Mod
     ( has-decidable-equality-ℤ-Mod p (mod-ℤ p a) (zero-ℤ-Mod p))
     ( is-decidable-square-ℤ-Mod p (mod-ℤ p a))

--- a/src/elementary-number-theory/legendre-symbol.lagda.md
+++ b/src/elementary-number-theory/legendre-symbol.lagda.md
@@ -1,4 +1,4 @@
-# Legendre Symbol
+# The Legendre symbol
 
 ```agda
 module elementary-number-theory.legendre-symbol where
@@ -7,263 +7,31 @@ module elementary-number-theory.legendre-symbol where
 <details><summary>Imports</summary>
 
 ```agda
-open import elementary-number-theory.absolute-value-integers
-open import elementary-number-theory.addition-natural-numbers
-open import elementary-number-theory.decidable-types
-open import elementary-number-theory.equality-natural-numbers
-open import elementary-number-theory.inequality-natural-numbers
 open import elementary-number-theory.integers
 open import elementary-number-theory.modular-arithmetic
-open import elementary-number-theory.multiplication-integers
-open import elementary-number-theory.multiplication-natural-numbers
 open import elementary-number-theory.natural-numbers
 open import elementary-number-theory.prime-numbers
+open import elementary-number-theory.squares-modular-arithmetic
 
-open import foundation.action-on-identifications-functions
 open import foundation.coproduct-types
-open import foundation.decidable-equality
 open import foundation.decidable-types
 open import foundation.dependent-pair-types
-open import foundation.identity-types
-open import foundation.logical-equivalences
-open import foundation.negation
-open import foundation.unit-type
-open import foundation.universe-levels
-
-open import foundation-core.cartesian-product-types
-open import foundation-core.transport-along-identifications
-
-open import univalent-combinatorics.fibers-of-maps
 ```
 
 </details>
 
 ## Idea
 
-The **Legendre Symbol** is a function which determines whether or not an integer
-is a perfect square in `ℤₚ` (i.e. whether or not it is a quadratic residue).
-Specifically, let `p : ℕ` be a natural and `a : ℤ` be an integer. If `a` is a
-square in `ℤₚ` then `legendre(p,a) = 1`. Similarly if `a` is not a square in
-`ℤₚ` then `legendre(p,a) = -1`. Finally if `a` is congruent to `0` in `ℤₚ` then
-`legendre(p,a) = 0`. Typically `p` is taken to be prime.
+The **Legendre symbol** is a function which determines whether or not an
+[integer](elementary-number-theory.integers.md) is a perfect square in the ring
+`ℤₚ` of [integers modulo `p`](elementary-number-theory.modular-arithmetic.md)
+(i.e. whether or not it is a quadratic residue). Specifically, let `p : Prime-ℕ`
+be a [prime number](elementary-number-theory.prime-numbers.md) and `a : ℤ` be an
+integer. If `a` is a square in `ℤₚ` then `legendre(p,a) = 1`. Similarly if `a`
+is not a square in `ℤₚ` then `legendre(p,a) = -1`. Finally if `a` is congruent
+to `0` in `ℤₚ` then `legendre(p,a) = 0`.
 
-## Natural Numbers
-
-### Definition for squareness in ℕ
-
-```agda
-is-square-ℕ : ℕ → UU lzero
-is-square-ℕ n = Σ ℕ (λ x → n ＝ square-ℕ x)
-```
-
-### n > √n for n > 1
-
-The idea is to assume `n = m + 2 ≤ sqrt(m + 2)` for some `m : ℕ` and derive a
-contradiction by squaring both sides of the inequality
-
-```agda
-greater-than-square-root-ℕ :
-  (n root : ℕ) → ¬ ((n +ℕ 2 ≤-ℕ root) × (n +ℕ 2 ＝ square-ℕ root))
-greater-than-square-root-ℕ n root (pf-leq , pf-eq) =
-  reflects-order-add-ℕ
-    ( square-ℕ root)
-    ( n *ℕ (n +ℕ 2) +ℕ n +ℕ 2)
-    0
-    ( tr
-      ( leq-ℕ (n *ℕ (n +ℕ 2) +ℕ n +ℕ 2 +ℕ square-ℕ root))
-      ( inv (left-unit-law-add-ℕ (square-ℕ root)))
-      ( concatenate-eq-leq-ℕ
-        ( square-ℕ root)
-        ( inv
-          ( helper ∙
-            ( ap
-              ( add-ℕ (n *ℕ (n +ℕ 2) +ℕ n +ℕ 2))
-              pf-eq)))
-        ( preserves-leq-mul-ℕ (n +ℕ 2) root (n +ℕ 2) root pf-leq pf-leq)))
-  where
-  helper : square-ℕ (n +ℕ 2) ＝ n *ℕ (n +ℕ 2) +ℕ n +ℕ 2 +ℕ n +ℕ 2
-  helper =
-    equational-reasoning
-    square-ℕ (n +ℕ 2)
-    ＝ n *ℕ (n +ℕ 2) +ℕ (2 *ℕ (n +ℕ 2))
-      by (right-distributive-mul-add-ℕ n 2 (n +ℕ 2))
-    ＝ n *ℕ (n +ℕ 2) +ℕ 2 *ℕ n +ℕ 4
-      by
-        ( ap
-          ( add-ℕ (n *ℕ (n +ℕ 2)))
-          ( left-distributive-mul-add-ℕ 2 n 2))
-    ＝ n *ℕ (n +ℕ 2) +ℕ (n +ℕ 2 +ℕ (n +ℕ 2))
-      by
-        ( ap
-          ( add-ℕ (n *ℕ (n +ℕ 2)))
-          ( equational-reasoning
-            2 *ℕ n +ℕ 4
-            ＝ 4 +ℕ 2 *ℕ n
-              by (commutative-add-ℕ (2 *ℕ n) 4)
-            ＝ 2 +ℕ 2 +ℕ (n +ℕ n)
-              by
-                ( ap
-                  ( add-ℕ 4)
-                  ( left-two-law-mul-ℕ n))
-            ＝ (2 +ℕ 2 +ℕ n) +ℕ n
-              by
-                ( inv
-                  ( associative-add-ℕ 4 n n))
-            ＝ n +ℕ (2 +ℕ 2 +ℕ n)
-              by (commutative-add-ℕ (2 +ℕ 2 +ℕ n) n)
-            ＝ n +ℕ (2 +ℕ (2 +ℕ n))
-              by
-                ( ap
-                  ( add-ℕ n)
-                  ( associative-add-ℕ 2 2 n))
-            ＝ n +ℕ (2 +ℕ (n +ℕ 2))
-              by
-                ( ap-add-ℕ {n} {2 +ℕ (2 +ℕ n)}
-                  refl
-                  ( ap
-                    ( add-ℕ 2)
-                    ( commutative-add-ℕ 2 n)))
-            ＝ n +ℕ 2 +ℕ (n +ℕ 2)
-              by
-                ( inv
-                  ( associative-add-ℕ n 2 (n +ℕ 2)))))
-    ＝ n *ℕ (n +ℕ 2) +ℕ n +ℕ 2 +ℕ (n +ℕ 2)
-      by
-        ( inv
-          ( associative-add-ℕ
-            ( n *ℕ (n +ℕ 2))
-            ( n +ℕ 2)
-            ( n +ℕ 2)))
-```
-
-### Squareness in ℕ is decidable
-
-```agda
-is-decidable-big-root :
-  (n : ℕ) → is-decidable (Σ ℕ (λ root → (n ≤-ℕ root) × (n ＝ square-ℕ root)))
-is-decidable-big-root 0 = inl (0 , star , refl)
-is-decidable-big-root 1 = inl (1 , star , refl)
-is-decidable-big-root (succ-ℕ (succ-ℕ n)) =
-  inr (λ H → greater-than-square-root-ℕ n (pr1 H) (pr2 H))
-
-is-decidable-square-ℕ : (n : ℕ) → is-decidable (is-square-ℕ n)
-is-decidable-square-ℕ n =
-  is-decidable-Σ-ℕ n
-    ( λ x → n ＝ square-ℕ x)
-    ( λ x → has-decidable-equality-ℕ n (square-ℕ x))
-    ( is-decidable-big-root n)
-```
-
-## Integers
-
-### Definitions for squareness in ℤ
-
-```agda
-square-ℤ : ℤ → ℤ
-square-ℤ a = mul-ℤ a a
-
-is-square-ℤ : ℤ → UU lzero
-is-square-ℤ a = Σ ℤ (λ x → a ＝ square-ℤ x)
-```
-
-### Squares in ℤ are nonnegative
-
-```agda
-is-decidable-nonnegative-square-ℤ :
-  (a : ℤ) →
-  (is-nonnegative-ℤ a) + (is-nonnegative-ℤ (neg-ℤ a)) →
-  is-nonnegative-ℤ (square-ℤ a)
-is-decidable-nonnegative-square-ℤ _ (inl x) = is-nonnegative-mul-ℤ x x
-is-decidable-nonnegative-square-ℤ a (inr x) =
-  tr
-    is-nonnegative-ℤ
-    ( double-negative-law-mul-ℤ a a)
-    ( is-nonnegative-mul-ℤ x x)
-
-is-nonnegative-square-ℤ : (a : ℤ) → is-nonnegative-ℤ (square-ℤ a)
-is-nonnegative-square-ℤ a =
-  is-decidable-nonnegative-square-ℤ a decide-is-nonnegative-ℤ
-```
-
-### The squares in ℤ are exactly the squares in ℕ
-
-```agda
-is-square-int-if-is-square-nat : {n : ℕ} → is-square-ℕ n → is-square-ℤ (int-ℕ n)
-is-square-int-if-is-square-nat (root , pf-square) =
-  ( pair
-    ( int-ℕ root)
-    ( ( ap int-ℕ pf-square) ∙
-      ( inv (mul-int-ℕ root root))))
-
-is-square-nat-if-is-square-int : {a : ℤ} → is-square-ℤ a → is-square-ℕ (abs-ℤ a)
-is-square-nat-if-is-square-int (root , pf-square) =
-  ( pair
-    ( abs-ℤ root)
-    ( ( ap abs-ℤ pf-square) ∙
-      ( multiplicative-abs-ℤ root root)))
-
-is-nat-square-iff-is-int-square :
-  (n : ℕ) → is-square-ℕ n ↔ is-square-ℤ (int-ℕ n)
-pr1 (is-nat-square-iff-is-int-square n) = is-square-int-if-is-square-nat
-pr2 (is-nat-square-iff-is-int-square n) H =
-  tr is-square-ℕ (abs-int-ℕ n) (is-square-nat-if-is-square-int H)
-
-is-int-square-iff-nonneg-nat-square :
-  (a : ℤ) → is-square-ℤ a ↔ is-nonnegative-ℤ a × is-square-ℕ (abs-ℤ a)
-pr1 (is-int-square-iff-nonneg-nat-square a) (root , pf-square) =
-  ( pair
-    ( tr is-nonnegative-ℤ (inv pf-square) (is-nonnegative-square-ℤ root))
-    ( is-square-nat-if-is-square-int (root , pf-square)))
-pr2 (is-int-square-iff-nonneg-nat-square a) (pf-nonneg , (root , pf-square)) =
-  ( pair
-    ( int-ℕ root)
-    ( ( inv (int-abs-is-nonnegative-ℤ a pf-nonneg)) ∙
-      ( pr2 (is-square-int-if-is-square-nat (root , pf-square)))))
-```
-
-### Squareness in ℤ is decidable
-
-```agda
-is-decidable-square-ℤ : (a : ℤ) → is-decidable (is-square-ℤ a)
-is-decidable-square-ℤ (inl n) =
-  inr (map-neg (pr1 (is-int-square-iff-nonneg-nat-square (inl n))) pr1)
-is-decidable-square-ℤ (inr (inl n)) =
-  inl (zero-ℤ , refl)
-is-decidable-square-ℤ (inr (inr n)) =
-  is-decidable-iff
-    is-square-int-if-is-square-nat
-    is-square-nat-if-is-square-int
-    ( is-decidable-square-ℕ (succ-ℕ n))
-```
-
-## ℤₚ
-
-### Definitions for squareness in ℤₚ
-
-```agda
-square-ℤ-Mod : (p : ℕ) → ℤ-Mod p → ℤ-Mod p
-square-ℤ-Mod 0 a = mul-ℤ a a
-square-ℤ-Mod (succ-ℕ p) a = mul-ℤ-Mod (succ-ℕ p) a a
-
-is-square-ℤ-Mod : (p : ℕ) → ℤ-Mod p → UU lzero
-is-square-ℤ-Mod 0 k = is-square-ℤ k
-is-square-ℤ-Mod (succ-ℕ p) k =
-  Σ (ℤ-Mod (succ-ℕ p)) (λ x → square-ℤ-Mod (succ-ℕ p) x ＝ k)
-```
-
-### Squareness in ℤₚ is decidable
-
-```agda
-is-decidable-square-ℤ-Mod :
-  (p : ℕ) (k : ℤ-Mod p) → is-decidable (is-square-ℤ-Mod p k)
-is-decidable-square-ℤ-Mod 0 k = is-decidable-square-ℤ k
-is-decidable-square-ℤ-Mod (succ-ℕ p) k =
-  is-decidable-fiber-Fin {succ-ℕ p} {succ-ℕ p} (square-ℤ-Mod (succ-ℕ p)) k
-```
-
-## Legendre Symbol
-
-### Definitions for the Legendre Symbol
+## Definition
 
 ```agda
 int-is-square-ℤ-Mod :
@@ -275,12 +43,9 @@ int-is-square-ℤ-Mod (inl _) _ = zero-ℤ
 int-is-square-ℤ-Mod (inr _) (inl _) = one-ℤ
 int-is-square-ℤ-Mod (inr _) (inr _) = neg-one-ℤ
 
-legendre : ℕ → ℤ → ℤ
-legendre p a =
+legendre : Prime-ℕ → ℤ → ℤ
+legendre (p , _) a =
   int-is-square-ℤ-Mod
-    ( has-decidable-equality-ℤ-Mod p arg-mod-p (zero-ℤ-Mod p))
-    ( is-decidable-square-ℤ-Mod p arg-mod-p)
-  where
-  arg-mod-p : ℤ-Mod p
-  arg-mod-p = mod-ℤ p a
+    ( has-decidable-equality-ℤ-Mod p (mod-ℤ p a) (zero-ℤ-Mod p))
+    ( is-decidable-square-ℤ-Mod p (mod-ℤ p a))
 ```

--- a/src/elementary-number-theory/multiplication-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/multiplication-natural-numbers.lagda.md
@@ -50,12 +50,6 @@ double-ℕ x = 2 *ℕ x
 
 triple-ℕ : ℕ → ℕ
 triple-ℕ x = 3 *ℕ x
-
-square-ℕ : ℕ → ℕ
-square-ℕ x = x *ℕ x
-
-cube-ℕ : ℕ → ℕ
-cube-ℕ x = (square-ℕ x) *ℕ x
 ```
 
 ## Properties
@@ -95,13 +89,6 @@ abstract
     ( ( ap (λ t → succ-ℕ (t +ℕ y)) (right-successor-law-mul-ℕ x y)) ∙
       ( ap succ-ℕ (associative-add-ℕ x (x *ℕ y) y))) ∙
     ( inv (left-successor-law-add-ℕ x ((x *ℕ y) +ℕ y)))
-
-square-succ-ℕ :
-  (k : ℕ) →
-  square-ℕ (succ-ℕ k) ＝ succ-ℕ ((succ-ℕ (succ-ℕ k)) *ℕ k)
-square-succ-ℕ k =
-  ( right-successor-law-mul-ℕ (succ-ℕ k) k) ∙
-  ( commutative-add-ℕ (succ-ℕ k) ((succ-ℕ k) *ℕ k))
 
 abstract
   commutative-mul-ℕ :

--- a/src/elementary-number-theory/pythagorean-triples.lagda.md
+++ b/src/elementary-number-theory/pythagorean-triples.lagda.md
@@ -8,8 +8,8 @@ module elementary-number-theory.pythagorean-triples where
 
 ```agda
 open import elementary-number-theory.addition-natural-numbers
-open import elementary-number-theory.multiplication-natural-numbers
 open import elementary-number-theory.natural-numbers
+open import elementary-number-theory.squares-natural-numbers
 
 open import foundation.identity-types
 open import foundation.universe-levels

--- a/src/elementary-number-theory/square-free-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/square-free-natural-numbers.lagda.md
@@ -8,8 +8,8 @@ module elementary-number-theory.square-free-natural-numbers where
 
 ```agda
 open import elementary-number-theory.divisibility-natural-numbers
-open import elementary-number-theory.multiplication-natural-numbers
 open import elementary-number-theory.natural-numbers
+open import elementary-number-theory.squares-natural-numbers
 
 open import foundation.universe-levels
 ```

--- a/src/elementary-number-theory/squares-integers.lagda.md
+++ b/src/elementary-number-theory/squares-integers.lagda.md
@@ -49,12 +49,12 @@ square-root-ℤ _ (root , _) = root
 ### Squares in ℤ are nonnegative
 
 ```agda
-is-decidable-nonnegative-square-ℤ :
+is-decidable-is-nonnegative-square-ℤ :
   (a : ℤ) →
   (is-nonnegative-ℤ a) + (is-nonnegative-ℤ (neg-ℤ a)) →
   is-nonnegative-ℤ (square-ℤ a)
-is-decidable-nonnegative-square-ℤ _ (inl x) = is-nonnegative-mul-ℤ x x
-is-decidable-nonnegative-square-ℤ a (inr x) =
+is-decidable-is-nonnegative-square-ℤ _ (inl x) = is-nonnegative-mul-ℤ x x
+is-decidable-is-nonnegative-square-ℤ a (inr x) =
   tr
     ( is-nonnegative-ℤ)
     ( double-negative-law-mul-ℤ a a)
@@ -62,52 +62,53 @@ is-decidable-nonnegative-square-ℤ a (inr x) =
 
 is-nonnegative-square-ℤ : (a : ℤ) → is-nonnegative-ℤ (square-ℤ a)
 is-nonnegative-square-ℤ a =
-  is-decidable-nonnegative-square-ℤ a decide-is-nonnegative-ℤ
+  is-decidable-is-nonnegative-square-ℤ a decide-is-nonnegative-ℤ
 ```
 
 ### The squares in ℤ are exactly the squares in ℕ
 
 ```agda
-is-square-int-if-is-square-nat : {n : ℕ} → is-square-ℕ n → is-square-ℤ (int-ℕ n)
-is-square-int-if-is-square-nat (root , pf-square) =
+is-square-int-is-square-nat : {n : ℕ} → is-square-ℕ n → is-square-ℤ (int-ℕ n)
+is-square-int-is-square-nat (root , pf-square) =
   ( ( int-ℕ root) ,
     ( ( ap int-ℕ pf-square) ∙
       ( inv (mul-int-ℕ root root))))
 
-is-square-nat-if-is-square-int : {a : ℤ} → is-square-ℤ a → is-square-ℕ (abs-ℤ a)
-is-square-nat-if-is-square-int (root , pf-square) =
+is-square-nat-is-square-int : {a : ℤ} → is-square-ℤ a → is-square-ℕ (abs-ℤ a)
+is-square-nat-is-square-int (root , pf-square) =
   ( ( abs-ℤ root) ,
     ( ( ap abs-ℤ pf-square) ∙
       ( multiplicative-abs-ℤ root root)))
 
-is-nat-square-iff-is-int-square :
+iff-is-square-int-is-square-nat :
   (n : ℕ) → is-square-ℕ n ↔ is-square-ℤ (int-ℕ n)
-pr1 (is-nat-square-iff-is-int-square n) = is-square-int-if-is-square-nat
-pr2 (is-nat-square-iff-is-int-square n) H =
-  tr is-square-ℕ (abs-int-ℕ n) (is-square-nat-if-is-square-int H)
+pr1 (iff-is-square-int-is-square-nat n) = is-square-int-is-square-nat
+pr2 (iff-is-square-int-is-square-nat n) H =
+  tr is-square-ℕ (abs-int-ℕ n) (is-square-nat-is-square-int H)
 
-is-int-square-iff-nonneg-nat-square :
+iff-is-nonneg-square-nat-is-square-int :
   (a : ℤ) → is-square-ℤ a ↔ is-nonnegative-ℤ a × is-square-ℕ (abs-ℤ a)
-pr1 (is-int-square-iff-nonneg-nat-square a) (root , pf-square) =
+pr1 (iff-is-nonneg-square-nat-is-square-int a) (root , pf-square) =
   ( ( tr is-nonnegative-ℤ (inv pf-square) (is-nonnegative-square-ℤ root)) ,
-    ( is-square-nat-if-is-square-int (root , pf-square)))
-pr2 (is-int-square-iff-nonneg-nat-square a) (pf-nonneg , (root , pf-square)) =
+    ( is-square-nat-is-square-int (root , pf-square)))
+pr2 (iff-is-nonneg-square-nat-is-square-int a)
+  ( pf-nonneg , (root , pf-square)) =
   ( ( int-ℕ root) ,
     ( ( inv (int-abs-is-nonnegative-ℤ a pf-nonneg)) ∙
-      ( pr2 (is-square-int-if-is-square-nat (root , pf-square)))))
+      ( pr2 (is-square-int-is-square-nat (root , pf-square)))))
 ```
 
 ### Squareness in ℤ is decidable
 
 ```agda
-is-decidable-square-ℤ : (a : ℤ) → is-decidable (is-square-ℤ a)
-is-decidable-square-ℤ (inl n) =
-  inr (map-neg (pr1 (is-int-square-iff-nonneg-nat-square (inl n))) pr1)
-is-decidable-square-ℤ (inr (inl n)) =
+is-decidable-is-square-ℤ : (a : ℤ) → is-decidable (is-square-ℤ a)
+is-decidable-is-square-ℤ (inl n) =
+  inr (map-neg (pr1 (iff-is-nonneg-square-nat-is-square-int (inl n))) pr1)
+is-decidable-is-square-ℤ (inr (inl n)) =
   inl (zero-ℤ , refl)
-is-decidable-square-ℤ (inr (inr n)) =
+is-decidable-is-square-ℤ (inr (inr n)) =
   is-decidable-iff
-    is-square-int-if-is-square-nat
-    is-square-nat-if-is-square-int
-    ( is-decidable-square-ℕ (succ-ℕ n))
+    is-square-int-is-square-nat
+    is-square-nat-is-square-int
+    ( is-decidable-is-square-ℕ (succ-ℕ n))
 ```

--- a/src/elementary-number-theory/squares-integers.lagda.md
+++ b/src/elementary-number-theory/squares-integers.lagda.md
@@ -35,7 +35,7 @@ square-ℤ : ℤ → ℤ
 square-ℤ a = mul-ℤ a a
 
 cube-ℤ : ℤ → ℤ
-cube-ℤ a = mul-ℕ (square-ℤ a) a
+cube-ℤ a = mul-ℤ (square-ℤ a) a
 
 is-square-ℤ : ℤ → UU lzero
 is-square-ℤ a = Σ ℤ (λ x → a ＝ square-ℤ x)

--- a/src/elementary-number-theory/squares-integers.lagda.md
+++ b/src/elementary-number-theory/squares-integers.lagda.md
@@ -1,0 +1,117 @@
+# Squares in the Integers
+
+```agda
+module elementary-number-theory.squares-integers where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import elementary-number-theory.absolute-value-integers
+open import elementary-number-theory.integers
+open import elementary-number-theory.multiplication-integers
+open import elementary-number-theory.natural-numbers
+open import elementary-number-theory.squares-natural-numbers
+
+open import foundation.action-on-identifications-functions
+open import foundation.coproduct-types
+open import foundation.decidable-types
+open import foundation.dependent-pair-types
+open import foundation.identity-types
+open import foundation.logical-equivalences
+open import foundation.negation
+open import foundation.universe-levels
+
+open import foundation-core.cartesian-product-types
+open import foundation-core.transport-along-identifications
+```
+
+</details>
+
+## Definition
+
+```agda
+square-ℤ : ℤ → ℤ
+square-ℤ a = mul-ℤ a a
+
+cube-ℤ : ℤ → ℤ
+cube-ℤ a = mul-ℕ (square-ℤ a) a
+
+is-square-ℤ : ℤ → UU lzero
+is-square-ℤ a = Σ ℤ (λ x → a ＝ square-ℤ x)
+
+square-root-ℤ : (a : ℤ) → is-square-ℤ a → ℤ
+square-root-ℤ _ (root , _) = root
+```
+
+## Properties
+
+### Squares in ℤ are nonnegative
+
+```agda
+is-decidable-nonnegative-square-ℤ :
+  (a : ℤ) →
+  (is-nonnegative-ℤ a) + (is-nonnegative-ℤ (neg-ℤ a)) →
+  is-nonnegative-ℤ (square-ℤ a)
+is-decidable-nonnegative-square-ℤ _ (inl x) = is-nonnegative-mul-ℤ x x
+is-decidable-nonnegative-square-ℤ a (inr x) =
+  tr
+    is-nonnegative-ℤ
+    ( double-negative-law-mul-ℤ a a)
+    ( is-nonnegative-mul-ℤ x x)
+
+is-nonnegative-square-ℤ : (a : ℤ) → is-nonnegative-ℤ (square-ℤ a)
+is-nonnegative-square-ℤ a =
+  is-decidable-nonnegative-square-ℤ a decide-is-nonnegative-ℤ
+```
+
+### The squares in ℤ are exactly the squares in ℕ
+
+```agda
+is-square-int-if-is-square-nat : {n : ℕ} → is-square-ℕ n → is-square-ℤ (int-ℕ n)
+is-square-int-if-is-square-nat (root , pf-square) =
+  ( pair
+    ( int-ℕ root)
+    ( ( ap int-ℕ pf-square) ∙
+      ( inv (mul-int-ℕ root root))))
+
+is-square-nat-if-is-square-int : {a : ℤ} → is-square-ℤ a → is-square-ℕ (abs-ℤ a)
+is-square-nat-if-is-square-int (root , pf-square) =
+  ( pair
+    ( abs-ℤ root)
+    ( ( ap abs-ℤ pf-square) ∙
+      ( multiplicative-abs-ℤ root root)))
+
+is-nat-square-iff-is-int-square :
+  (n : ℕ) → is-square-ℕ n ↔ is-square-ℤ (int-ℕ n)
+pr1 (is-nat-square-iff-is-int-square n) = is-square-int-if-is-square-nat
+pr2 (is-nat-square-iff-is-int-square n) H =
+  tr is-square-ℕ (abs-int-ℕ n) (is-square-nat-if-is-square-int H)
+
+is-int-square-iff-nonneg-nat-square :
+  (a : ℤ) → is-square-ℤ a ↔ is-nonnegative-ℤ a × is-square-ℕ (abs-ℤ a)
+pr1 (is-int-square-iff-nonneg-nat-square a) (root , pf-square) =
+  ( pair
+    ( tr is-nonnegative-ℤ (inv pf-square) (is-nonnegative-square-ℤ root))
+    ( is-square-nat-if-is-square-int (root , pf-square)))
+pr2 (is-int-square-iff-nonneg-nat-square a) (pf-nonneg , (root , pf-square)) =
+  ( pair
+    ( int-ℕ root)
+    ( ( inv (int-abs-is-nonnegative-ℤ a pf-nonneg)) ∙
+      ( pr2 (is-square-int-if-is-square-nat (root , pf-square)))))
+```
+
+### Squareness in ℤ is decidable
+
+```agda
+is-decidable-square-ℤ : (a : ℤ) → is-decidable (is-square-ℤ a)
+is-decidable-square-ℤ (inl n) =
+  inr (map-neg (pr1 (is-int-square-iff-nonneg-nat-square (inl n))) pr1)
+is-decidable-square-ℤ (inr (inl n)) =
+  inl (zero-ℤ , refl)
+is-decidable-square-ℤ (inr (inr n)) =
+  is-decidable-iff
+    is-square-int-if-is-square-nat
+    is-square-nat-if-is-square-int
+    ( is-decidable-square-ℕ (succ-ℕ n))
+```

--- a/src/elementary-number-theory/squares-integers.lagda.md
+++ b/src/elementary-number-theory/squares-integers.lagda.md
@@ -1,4 +1,4 @@
-# Squares in the Integers
+# Squares in the integers
 
 ```agda
 module elementary-number-theory.squares-integers where
@@ -56,7 +56,7 @@ is-decidable-nonnegative-square-ℤ :
 is-decidable-nonnegative-square-ℤ _ (inl x) = is-nonnegative-mul-ℤ x x
 is-decidable-nonnegative-square-ℤ a (inr x) =
   tr
-    is-nonnegative-ℤ
+    ( is-nonnegative-ℤ)
     ( double-negative-law-mul-ℤ a a)
     ( is-nonnegative-mul-ℤ x x)
 
@@ -70,15 +70,13 @@ is-nonnegative-square-ℤ a =
 ```agda
 is-square-int-if-is-square-nat : {n : ℕ} → is-square-ℕ n → is-square-ℤ (int-ℕ n)
 is-square-int-if-is-square-nat (root , pf-square) =
-  ( pair
-    ( int-ℕ root)
+  ( ( int-ℕ root) ,
     ( ( ap int-ℕ pf-square) ∙
       ( inv (mul-int-ℕ root root))))
 
 is-square-nat-if-is-square-int : {a : ℤ} → is-square-ℤ a → is-square-ℕ (abs-ℤ a)
 is-square-nat-if-is-square-int (root , pf-square) =
-  ( pair
-    ( abs-ℤ root)
+  ( ( abs-ℤ root) ,
     ( ( ap abs-ℤ pf-square) ∙
       ( multiplicative-abs-ℤ root root)))
 
@@ -91,12 +89,10 @@ pr2 (is-nat-square-iff-is-int-square n) H =
 is-int-square-iff-nonneg-nat-square :
   (a : ℤ) → is-square-ℤ a ↔ is-nonnegative-ℤ a × is-square-ℕ (abs-ℤ a)
 pr1 (is-int-square-iff-nonneg-nat-square a) (root , pf-square) =
-  ( pair
-    ( tr is-nonnegative-ℤ (inv pf-square) (is-nonnegative-square-ℤ root))
+  ( ( tr is-nonnegative-ℤ (inv pf-square) (is-nonnegative-square-ℤ root)) ,
     ( is-square-nat-if-is-square-int (root , pf-square)))
 pr2 (is-int-square-iff-nonneg-nat-square a) (pf-nonneg , (root , pf-square)) =
-  ( pair
-    ( int-ℕ root)
+  ( ( int-ℕ root) ,
     ( ( inv (int-abs-is-nonnegative-ℤ a pf-nonneg)) ∙
       ( pr2 (is-square-int-if-is-square-nat (root , pf-square)))))
 ```

--- a/src/elementary-number-theory/squares-modular-arithmetic.lagda.md
+++ b/src/elementary-number-theory/squares-modular-arithmetic.lagda.md
@@ -45,10 +45,10 @@ square-root-ℤ-Mod {succ-ℕ p} _ (root , _) = root
 ### Squareness in ℤₚ is decidable
 
 ```agda
-is-decidable-square-ℤ-Mod :
+is-decidable-is-square-ℤ-Mod :
   (p : ℕ) (k : ℤ-Mod p) →
   is-decidable (is-square-ℤ-Mod p k)
-is-decidable-square-ℤ-Mod 0 k = is-decidable-square-ℤ k
-is-decidable-square-ℤ-Mod (succ-ℕ p) k =
+is-decidable-is-square-ℤ-Mod 0 k = is-decidable-is-square-ℤ k
+is-decidable-is-square-ℤ-Mod (succ-ℕ p) k =
   is-decidable-fiber-Fin {succ-ℕ p} {succ-ℕ p} (square-ℤ-Mod (succ-ℕ p)) k
 ```

--- a/src/elementary-number-theory/squares-modular-arithmetic.lagda.md
+++ b/src/elementary-number-theory/squares-modular-arithmetic.lagda.md
@@ -1,0 +1,54 @@
+# Squares in ℤₚ
+
+```agda
+module elementary-number-theory.squares-modular-arithmetic where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import elementary-number-theory.modular-arithmetic
+open import elementary-number-theory.natural-numbers
+open import elementary-number-theory.squares-integers
+
+open import foundation.decidable-types
+open import foundation.dependent-pair-types
+open import foundation.identity-types
+open import foundation.universe-levels
+
+open import univalent-combinatorics.fibers-of-maps
+```
+
+</details>
+
+## Definition
+
+```agda
+square-ℤ-Mod : (p : ℕ) → ℤ-Mod p → ℤ-Mod p
+square-ℤ-Mod p a = mul-ℤ-Mod p a a
+
+cube-ℤ-Mod : (p : ℕ) → ℤ-Mod p → ℤ-Mod p
+cube-ℤ-Mod p k = mul-ℤ-Mod p (square-ℤ-Mod p k) k
+
+is-square-ℤ-Mod : (p : ℕ) → ℤ-Mod p → UU lzero
+is-square-ℤ-Mod 0 k = is-square-ℤ k
+is-square-ℤ-Mod (succ-ℕ p) k =
+  Σ (ℤ-Mod (succ-ℕ p)) (λ x → square-ℤ-Mod (succ-ℕ p) x ＝ k)
+
+square-root-ℤ-Mod : {p : ℕ} → (k : ℤ-Mod p) → is-square-ℤ-Mod p k → ℤ-Mod p
+square-root-ℤ-Mod {0} _ (root , _) = root
+square-root-ℤ-Mod {succ-ℕ p} _ (root , _) = root
+```
+
+## Properties
+
+### Squareness in ℤₚ is decidable
+
+```agda
+is-decidable-square-ℤ-Mod :
+  (p : ℕ) (k : ℤ-Mod p) →
+  is-decidable (is-square-ℤ-Mod p k)
+is-decidable-square-ℤ-Mod 0 k = is-decidable-square-ℤ k
+is-decidable-square-ℤ-Mod (succ-ℕ p) k =
+  is-decidable-fiber-Fin {succ-ℕ p} {succ-ℕ p} (square-ℤ-Mod (succ-ℕ p)) k
+```

--- a/src/elementary-number-theory/squares-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/squares-natural-numbers.lagda.md
@@ -1,0 +1,157 @@
+# Squares in the Natural Numbers
+
+```agda
+module elementary-number-theory.squares-natural-numbers where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import elementary-number-theory.addition-natural-numbers
+open import elementary-number-theory.decidable-types
+open import elementary-number-theory.equality-natural-numbers
+open import elementary-number-theory.inequality-natural-numbers
+open import elementary-number-theory.multiplication-natural-numbers
+open import elementary-number-theory.natural-numbers
+
+open import foundation.action-on-identifications-functions
+open import foundation.coproduct-types
+open import foundation.decidable-types
+open import foundation.dependent-pair-types
+open import foundation.identity-types
+open import foundation.negation
+open import foundation.unit-type
+open import foundation.universe-levels
+
+open import foundation-core.cartesian-product-types
+open import foundation-core.transport-along-identifications
+```
+
+</details>
+
+## Definition
+
+```agda
+square-ℕ : ℕ → ℕ
+square-ℕ n = mul-ℕ n n
+
+cube-ℕ : ℕ → ℕ
+cube-ℕ n = (square-ℕ n) *ℕ n
+
+is-square-ℕ : ℕ → UU lzero
+is-square-ℕ n = Σ ℕ (λ x → n ＝ square-ℕ x)
+
+square-root-ℕ : (n : ℕ) → is-square-ℕ n → ℕ
+square-root-ℕ _ (root , _) = root
+```
+
+## Properties
+
+### Squares of successors
+
+```agda
+square-succ-ℕ :
+  (k : ℕ) →
+  square-ℕ (succ-ℕ k) ＝ succ-ℕ ((succ-ℕ (succ-ℕ k)) *ℕ k)
+square-succ-ℕ k =
+  ( right-successor-law-mul-ℕ (succ-ℕ k) k) ∙
+  ( commutative-add-ℕ (succ-ℕ k) ((succ-ℕ k) *ℕ k))
+```
+
+### n > √n for n > 1
+
+The idea is to assume `n = m + 2 ≤ sqrt(m + 2)` for some `m : ℕ` and derive a
+contradiction by squaring both sides of the inequality
+
+```agda
+greater-than-square-root-ℕ :
+  (n root : ℕ) → ¬ ((n +ℕ 2 ≤-ℕ root) × (n +ℕ 2 ＝ square-ℕ root))
+greater-than-square-root-ℕ n root (pf-leq , pf-eq) =
+  reflects-order-add-ℕ
+    ( square-ℕ root)
+    ( n *ℕ (n +ℕ 2) +ℕ n +ℕ 2)
+    0
+    ( tr
+      ( leq-ℕ (n *ℕ (n +ℕ 2) +ℕ n +ℕ 2 +ℕ square-ℕ root))
+      ( inv (left-unit-law-add-ℕ (square-ℕ root)))
+      ( concatenate-eq-leq-ℕ
+        ( square-ℕ root)
+        ( inv
+          ( helper ∙
+            ( ap
+              ( add-ℕ (n *ℕ (n +ℕ 2) +ℕ n +ℕ 2))
+              pf-eq)))
+        ( preserves-leq-mul-ℕ (n +ℕ 2) root (n +ℕ 2) root pf-leq pf-leq)))
+  where
+  helper : square-ℕ (n +ℕ 2) ＝ n *ℕ (n +ℕ 2) +ℕ n +ℕ 2 +ℕ n +ℕ 2
+  helper =
+    equational-reasoning
+    square-ℕ (n +ℕ 2)
+    ＝ n *ℕ (n +ℕ 2) +ℕ (2 *ℕ (n +ℕ 2))
+      by (right-distributive-mul-add-ℕ n 2 (n +ℕ 2))
+    ＝ n *ℕ (n +ℕ 2) +ℕ 2 *ℕ n +ℕ 4
+      by
+        ( ap
+          ( add-ℕ (n *ℕ (n +ℕ 2)))
+          ( left-distributive-mul-add-ℕ 2 n 2))
+    ＝ n *ℕ (n +ℕ 2) +ℕ (n +ℕ 2 +ℕ (n +ℕ 2))
+      by
+        ( ap
+          ( add-ℕ (n *ℕ (n +ℕ 2)))
+          ( equational-reasoning
+            2 *ℕ n +ℕ 4
+            ＝ 4 +ℕ 2 *ℕ n
+              by (commutative-add-ℕ (2 *ℕ n) 4)
+            ＝ 2 +ℕ 2 +ℕ (n +ℕ n)
+              by
+                ( ap
+                  ( add-ℕ 4)
+                  ( left-two-law-mul-ℕ n))
+            ＝ (2 +ℕ 2 +ℕ n) +ℕ n
+              by
+                ( inv
+                  ( associative-add-ℕ 4 n n))
+            ＝ n +ℕ (2 +ℕ 2 +ℕ n)
+              by (commutative-add-ℕ (2 +ℕ 2 +ℕ n) n)
+            ＝ n +ℕ (2 +ℕ (2 +ℕ n))
+              by
+                ( ap
+                  ( add-ℕ n)
+                  ( associative-add-ℕ 2 2 n))
+            ＝ n +ℕ (2 +ℕ (n +ℕ 2))
+              by
+                ( ap-add-ℕ {n} {2 +ℕ (2 +ℕ n)}
+                  refl
+                  ( ap
+                    ( add-ℕ 2)
+                    ( commutative-add-ℕ 2 n)))
+            ＝ n +ℕ 2 +ℕ (n +ℕ 2)
+              by
+                ( inv
+                  ( associative-add-ℕ n 2 (n +ℕ 2)))))
+    ＝ n *ℕ (n +ℕ 2) +ℕ n +ℕ 2 +ℕ (n +ℕ 2)
+      by
+        ( inv
+          ( associative-add-ℕ
+            ( n *ℕ (n +ℕ 2))
+            ( n +ℕ 2)
+            ( n +ℕ 2)))
+```
+
+### Squareness in ℕ is decidable
+
+```agda
+is-decidable-big-root :
+  (n : ℕ) → is-decidable (Σ ℕ (λ root → (n ≤-ℕ root) × (n ＝ square-ℕ root)))
+is-decidable-big-root 0 = inl (0 , star , refl)
+is-decidable-big-root 1 = inl (1 , star , refl)
+is-decidable-big-root (succ-ℕ (succ-ℕ n)) =
+  inr (λ H → greater-than-square-root-ℕ n (pr1 H) (pr2 H))
+
+is-decidable-square-ℕ : (n : ℕ) → is-decidable (is-square-ℕ n)
+is-decidable-square-ℕ n =
+  is-decidable-Σ-ℕ n
+    ( λ x → n ＝ square-ℕ x)
+    ( λ x → has-decidable-equality-ℕ n (square-ℕ x))
+    ( is-decidable-big-root n)
+```

--- a/src/elementary-number-theory/squares-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/squares-natural-numbers.lagda.md
@@ -147,8 +147,8 @@ is-decidable-big-root 1 = inl (1 , star , refl)
 is-decidable-big-root (succ-ℕ (succ-ℕ n)) =
   inr (λ H → greater-than-square-root-ℕ n (pr1 H) (pr2 H))
 
-is-decidable-square-ℕ : (n : ℕ) → is-decidable (is-square-ℕ n)
-is-decidable-square-ℕ n =
+is-decidable-is-square-ℕ : (n : ℕ) → is-decidable (is-square-ℕ n)
+is-decidable-is-square-ℕ n =
   is-decidable-Σ-ℕ n
     ( λ x → n ＝ square-ℕ x)
     ( λ x → has-decidable-equality-ℕ n (square-ℕ x))

--- a/src/elementary-number-theory/squares-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/squares-natural-numbers.lagda.md
@@ -75,7 +75,6 @@ square-succ-succ-ℕ n =
       ( ap-add-ℕ {square-ℕ n +ℕ 2 *ℕ n} {2 *ℕ (n +ℕ 2)}
         ( refl)
         ( left-distributive-mul-add-ℕ 2 n 2))
-  
 ```
 
 ### `n > √n` for `n > 1`

--- a/src/elementary-number-theory/squares-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/squares-natural-numbers.lagda.md
@@ -1,4 +1,4 @@
-# Squares in the Natural Numbers
+# Squares in the natural numbers
 
 ```agda
 module elementary-number-theory.squares-natural-numbers where
@@ -51,14 +51,34 @@ square-root-ℕ _ (root , _) = root
 
 ```agda
 square-succ-ℕ :
-  (k : ℕ) →
-  square-ℕ (succ-ℕ k) ＝ succ-ℕ ((succ-ℕ (succ-ℕ k)) *ℕ k)
-square-succ-ℕ k =
-  ( right-successor-law-mul-ℕ (succ-ℕ k) k) ∙
-  ( commutative-add-ℕ (succ-ℕ k) ((succ-ℕ k) *ℕ k))
+  (n : ℕ) →
+  square-ℕ (succ-ℕ n) ＝ succ-ℕ ((succ-ℕ (succ-ℕ n)) *ℕ n)
+square-succ-ℕ n =
+  ( right-successor-law-mul-ℕ (succ-ℕ n) n) ∙
+  ( commutative-add-ℕ (succ-ℕ n) ((succ-ℕ n) *ℕ n))
+
+square-succ-succ-ℕ :
+  (n : ℕ) →
+  square-ℕ (succ-ℕ (succ-ℕ n)) ＝ square-ℕ n +ℕ 2 *ℕ n +ℕ 2 *ℕ n +ℕ 4
+square-succ-succ-ℕ n =
+  equational-reasoning
+  square-ℕ (n +ℕ 2)
+  ＝ (n +ℕ 2) *ℕ n +ℕ (n +ℕ 2) *ℕ 2
+    by (left-distributive-mul-add-ℕ (n +ℕ 2) n 2)
+  ＝ square-ℕ n +ℕ 2 *ℕ n +ℕ 2 *ℕ (n +ℕ 2)
+    by
+      ( ap-add-ℕ {(n +ℕ 2) *ℕ n} {(n +ℕ 2) *ℕ 2}
+        ( right-distributive-mul-add-ℕ n 2 n)
+        ( commutative-mul-ℕ (n +ℕ 2) 2))
+  ＝ square-ℕ n +ℕ 2 *ℕ n +ℕ 2 *ℕ n +ℕ 4
+    by
+      ( ap-add-ℕ {square-ℕ n +ℕ 2 *ℕ n} {2 *ℕ (n +ℕ 2)}
+        ( refl)
+        ( left-distributive-mul-add-ℕ 2 n 2))
+  
 ```
 
-### n > √n for n > 1
+### `n > √n` for `n > 1`
 
 The idea is to assume `n = m + 2 ≤ sqrt(m + 2)` for some `m : ℕ` and derive a
 contradiction by squaring both sides of the inequality
@@ -69,71 +89,51 @@ greater-than-square-root-ℕ :
 greater-than-square-root-ℕ n root (pf-leq , pf-eq) =
   reflects-order-add-ℕ
     ( square-ℕ root)
-    ( n *ℕ (n +ℕ 2) +ℕ n +ℕ 2)
+    ( square-ℕ n +ℕ 2 *ℕ n +ℕ n +ℕ 2)
     0
     ( tr
-      ( leq-ℕ (n *ℕ (n +ℕ 2) +ℕ n +ℕ 2 +ℕ square-ℕ root))
+      ( leq-ℕ (square-ℕ n +ℕ 2 *ℕ n +ℕ n +ℕ 2 +ℕ square-ℕ root))
       ( inv (left-unit-law-add-ℕ (square-ℕ root)))
       ( concatenate-eq-leq-ℕ
         ( square-ℕ root)
         ( inv
-          ( helper ∙
-            ( ap
-              ( add-ℕ (n *ℕ (n +ℕ 2) +ℕ n +ℕ 2))
-              pf-eq)))
+          ( lemma ∙
+            ( ap-add-ℕ {square-ℕ n +ℕ 2 *ℕ n +ℕ n +ℕ 2} {n +ℕ 2}
+              ( refl)
+              ( pf-eq))))
         ( preserves-leq-mul-ℕ (n +ℕ 2) root (n +ℕ 2) root pf-leq pf-leq)))
   where
-  helper : square-ℕ (n +ℕ 2) ＝ n *ℕ (n +ℕ 2) +ℕ n +ℕ 2 +ℕ n +ℕ 2
-  helper =
+  lemma : square-ℕ (n +ℕ 2) ＝ square-ℕ n +ℕ 2 *ℕ n +ℕ n +ℕ 2 +ℕ n +ℕ 2
+  lemma =
     equational-reasoning
     square-ℕ (n +ℕ 2)
-    ＝ n *ℕ (n +ℕ 2) +ℕ (2 *ℕ (n +ℕ 2))
-      by (right-distributive-mul-add-ℕ n 2 (n +ℕ 2))
-    ＝ n *ℕ (n +ℕ 2) +ℕ 2 *ℕ n +ℕ 4
+    ＝ square-ℕ n +ℕ 2 *ℕ n +ℕ 2 *ℕ n +ℕ 4
+      by (square-succ-succ-ℕ n)
+    ＝ square-ℕ n +ℕ 2 *ℕ n +ℕ (n +ℕ 2 +ℕ n +ℕ 2)
       by
-        ( ap
-          ( add-ℕ (n *ℕ (n +ℕ 2)))
-          ( left-distributive-mul-add-ℕ 2 n 2))
-    ＝ n *ℕ (n +ℕ 2) +ℕ (n +ℕ 2 +ℕ (n +ℕ 2))
-      by
-        ( ap
-          ( add-ℕ (n *ℕ (n +ℕ 2)))
+        ( ap-add-ℕ {square-ℕ n +ℕ 2 *ℕ n} {2 *ℕ n +ℕ 4}
+          ( refl)
           ( equational-reasoning
             2 *ℕ n +ℕ 4
-            ＝ 4 +ℕ 2 *ℕ n
-              by (commutative-add-ℕ (2 *ℕ n) 4)
-            ＝ 2 +ℕ 2 +ℕ (n +ℕ n)
+            ＝ n +ℕ n +ℕ 2 +ℕ 2
               by
-                ( ap
-                  ( add-ℕ 4)
-                  ( left-two-law-mul-ℕ n))
-            ＝ (2 +ℕ 2 +ℕ n) +ℕ n
-              by
-                ( inv
-                  ( associative-add-ℕ 4 n n))
-            ＝ n +ℕ (2 +ℕ 2 +ℕ n)
-              by (commutative-add-ℕ (2 +ℕ 2 +ℕ n) n)
-            ＝ n +ℕ (2 +ℕ (2 +ℕ n))
-              by
-                ( ap
-                  ( add-ℕ n)
-                  ( associative-add-ℕ 2 2 n))
-            ＝ n +ℕ (2 +ℕ (n +ℕ 2))
-              by
-                ( ap-add-ℕ {n} {2 +ℕ (2 +ℕ n)}
-                  refl
-                  ( ap
-                    ( add-ℕ 2)
-                    ( commutative-add-ℕ 2 n)))
+                ( ap-add-ℕ {2 *ℕ n} {4}
+                  ( left-two-law-mul-ℕ n)
+                  ( refl))
+            ＝ n +ℕ 2 +ℕ 2 +ℕ n
+              by (commutative-add-ℕ n (n +ℕ 2 +ℕ 2))
+            ＝ n +ℕ 2 +ℕ (2 +ℕ n)
+              by (associative-add-ℕ (n +ℕ 2) 2 n)
             ＝ n +ℕ 2 +ℕ (n +ℕ 2)
               by
-                ( inv
-                  ( associative-add-ℕ n 2 (n +ℕ 2)))))
-    ＝ n *ℕ (n +ℕ 2) +ℕ n +ℕ 2 +ℕ (n +ℕ 2)
+                ( ap-add-ℕ {n +ℕ 2} {2 +ℕ n}
+                  ( refl)
+                  ( commutative-add-ℕ 2 n))))
+    ＝ square-ℕ n +ℕ 2 *ℕ n +ℕ n +ℕ 2 +ℕ n +ℕ 2
       by
         ( inv
           ( associative-add-ℕ
-            ( n *ℕ (n +ℕ 2))
+            ( square-ℕ n +ℕ 2 *ℕ n)
             ( n +ℕ 2)
             ( n +ℕ 2)))
 ```

--- a/src/elementary-number-theory/unit-elements-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/unit-elements-standard-finite-types.lagda.md
@@ -13,6 +13,7 @@ open import elementary-number-theory.divisibility-standard-finite-types
 open import elementary-number-theory.modular-arithmetic-standard-finite-types
 open import elementary-number-theory.multiplication-natural-numbers
 open import elementary-number-theory.natural-numbers
+open import elementary-number-theory.squares-natural-numbers
 
 open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types


### PR DESCRIPTION
A few things to point out:

1) The function here `legendre` does not actually care whether or not `p` is prime, it just generally characterizes whether or not a number is a square in `Zp` for any natural `p`. I'm not sure whether or not this is confusing. Most interesting/important facts about the legendre symbol leverage the fact that `p` is prime, but I felt that fact should be invoked in those theorems, not in the definition of the function itself, seeing as there is no type of prime numbers.

2) Most of this file is definitions and theorems about squareness in `N`, `Z`, and `Zp`. It might be better if these are in separate files, but I wasn't sure where they should go. These didn't exist before as far as I could tell, and the basic justification for their existence is that the legendre symbol needs to decide whether or not a number is a square in` Zp`, which for `p=0` (see above) requires deciding squareness in `Z`, which in turn requires deciding squareness in `N`. At least, that was the most straightforward way I could think of for defining and proving these things. Maybe at least the functions `square-Z` and `square-Z-Mod` should be in the files where `mul-Z` and `mul-Z-Mod` are, since `square-N` was already defined and is where `mul-N` is.

3) There's a pretty long proof of an elementary algebraic identity: `(n+2)^2 = n(n+2) + (n+2) + (n+2)`. I didn't feel this was a general enough fact to warrant being in the top level, so it's in a `where` clause. There also might be a way to prove the theorem it's used for without it, not sure.