### PR TITLE
Patch file generation scripts to ignore `MAlonzo`

### DIFF
--- a/scripts/generate_main_index_file.py
+++ b/scripts/generate_main_index_file.py
@@ -67,7 +67,7 @@ def generate_index(root, header):
     namespaces = sorted(set(utils.get_subdirectories_recursive(root)))
 
     for namespace in namespaces:
-        if namespace == 'temp':
+        if namespace == 'temp' or 'MAlonzo' in namespace:
             continue
         entry_list, s = generate_namespace_entry_list(namespace)
         entry_lists.append(entry_list)

--- a/scripts/generate_namespace_index_modules.py
+++ b/scripts/generate_namespace_index_modules.py
@@ -45,7 +45,7 @@ if __name__ == '__main__':
     root = 'src'
 
     for namespace in utils.get_subdirectories_recursive(root):
-        if namespace == 'temp':
+        if namespace == 'temp' or 'MAlonzo' in namespace:
             continue
 
         namespace_filename = os.path.join(root, namespace) + '.lagda.md'


### PR DESCRIPTION
This is a temporary fix while we wait for #664, for the special case of the `MAlonzo` folder that appears sometimes when type checking Agda files.