### PR TITLE
A map is an embedding if and only if it has contractible fibers at values

### DIFF
--- a/src/foundation/embeddings.lagda.md
+++ b/src/foundation/embeddings.lagda.md
@@ -357,7 +357,8 @@ module _
 ### A map is an embedding if and only if it has contractible fibers at values
 
 ```agda
-module _ {l1 l2 : Level} {A : UU l1} {B : UU l2} (f : A → B)
+module _
+  {l1 l2 : Level} {A : UU l1} {B : UU l2} (f : A → B)
   where
 
   is-emb-is-contr-fibers-values' :

--- a/src/foundation/embeddings.lagda.md
+++ b/src/foundation/embeddings.lagda.md
@@ -363,7 +363,7 @@ module _ {l1 l2 : Level} {A : UU l1} {B : UU l2} (f : A → B)
   is-emb-is-contr-fibers-values' :
     ((a : A) → is-contr (fiber' f (f a))) → is-emb f
   is-emb-is-contr-fibers-values' c a =
-    fundamental-theorem-id (c a) (λ x → ap f)
+    fundamental-theorem-id (c a) (λ x → ap f {a} {x})
 
   is-emb-is-contr-fibers-values :
     ((a : A) → is-contr (fiber f (f a))) → is-emb f
@@ -378,7 +378,7 @@ module _ {l1 l2 : Level} {A : UU l1} {B : UU l2} (f : A → B)
   is-contr-fibers-values-is-emb' :
     is-emb f → ((a : A) → is-contr (fiber' f (f a)))
   is-contr-fibers-values-is-emb' e a =
-    fundamental-theorem-id' (λ x → ap f {a} {x}) (λ x → e a x)
+    fundamental-theorem-id' (λ x → ap f {a} {x}) (e a)
 
   is-contr-fibers-values-is-emb :
     is-emb f → ((a : A) → is-contr (fiber f (f a)))

--- a/src/foundation/embeddings.lagda.md
+++ b/src/foundation/embeddings.lagda.md
@@ -14,6 +14,7 @@ open import foundation.commuting-squares-of-maps
 open import foundation.cones-over-cospans
 open import foundation.dependent-pair-types
 open import foundation.equivalences
+open import foundation.fibers-of-maps
 open import foundation.functoriality-cartesian-product-types
 open import foundation.fundamental-theorem-of-identity-types
 open import foundation.identity-types
@@ -21,6 +22,7 @@ open import foundation.truncated-maps
 open import foundation.universe-levels
 
 open import foundation-core.cartesian-product-types
+open import foundation-core.contractible-types
 open import foundation-core.function-types
 open import foundation-core.functoriality-dependent-pair-types
 open import foundation-core.homotopies
@@ -350,4 +352,39 @@ module _
       ( is-equiv-map-inv-is-equiv K)
       ( is-equiv-map-inv-is-equiv L)
       ( M)
+```
+
+### A map is an embedding if and only if it has contractible fibers at values
+
+```agda
+module _ {l1 l2 : Level} {A : UU l1} {B : UU l2} (f : A → B)
+  where
+
+  is-emb-is-contr-fibers-values' :
+    ((a : A) → is-contr (fiber' f (f a))) → is-emb f
+  is-emb-is-contr-fibers-values' c a =
+    fundamental-theorem-id (c a) (λ x → ap f)
+
+  is-emb-is-contr-fibers-values :
+    ((a : A) → is-contr (fiber f (f a))) → is-emb f
+  is-emb-is-contr-fibers-values c =
+    is-emb-is-contr-fibers-values'
+      ( λ a →
+        is-contr-equiv'
+          ( fiber f (f a))
+          ( equiv-fiber f (f a))
+          ( c a))
+
+  is-contr-fibers-values-is-emb' :
+    is-emb f → ((a : A) → is-contr (fiber' f (f a)))
+  is-contr-fibers-values-is-emb' e a =
+    fundamental-theorem-id' (λ x → ap f {a} {x}) (λ x → e a x)
+
+  is-contr-fibers-values-is-emb :
+    is-emb f → ((a : A) → is-contr (fiber f (f a)))
+  is-contr-fibers-values-is-emb e a =
+    is-contr-equiv
+      ( fiber' f (f a))
+      ( equiv-fiber f (f a))
+      ( is-contr-fibers-values-is-emb' e a)
 ```


### PR DESCRIPTION
The versions with `fiber'` likely come in useful too, so I included them separately.