### PR TITLE
Universal property of smash products

### DIFF
--- a/src/structured-types/commuting-squares-of-pointed-maps.lagda.md
+++ b/src/structured-types/commuting-squares-of-pointed-maps.lagda.md
@@ -7,6 +7,8 @@ module structured-types.commuting-squares-of-pointed-maps where
 <details><summary>Imports</summary>
 
 ```agda
+open import foundation.commuting-squares-of-maps
+open import foundation.function-types
 open import foundation.universe-levels
 
 open import structured-types.pointed-homotopies
@@ -35,12 +37,24 @@ between the pointedness preservation proofs.
 ## Definition
 
 ```agda
-coherence-square-pointed-maps :
+module _
   {l1 l2 l3 l4 : Level}
   {A : Pointed-Type l1} {B : Pointed-Type l2}
   {C : Pointed-Type l3} {X : Pointed-Type l4}
-  (top : C →∗ B) (left : C →∗ A) (right : B →∗ X) (bottom : A →∗ X) →
-  UU (l3 ⊔ l4)
-coherence-square-pointed-maps top left right bottom =
-  (bottom ∘∗ left) ~∗ (right ∘∗ top)
+  (top : C →∗ B) (left : C →∗ A) (right : B →∗ X) (bottom : A →∗ X)
+  where
+
+  coherence-square-pointed-maps : UU (l3 ⊔ l4)
+  coherence-square-pointed-maps =
+    (bottom ∘∗ left) ~∗ (right ∘∗ top)
+
+  coherence-square-maps-coherence-square-pointed-maps :
+    coherence-square-pointed-maps →
+    coherence-square-maps
+      ( map-pointed-map top)
+      ( map-pointed-map left)
+      ( map-pointed-map right)
+      ( map-pointed-map bottom)
+  coherence-square-maps-coherence-square-pointed-maps =
+    ( htpy-pointed-htpy (bottom ∘∗ left) (right ∘∗ top))
 ```

--- a/src/synthetic-homotopy-theory/pushouts-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/pushouts-of-pointed-types.lagda.md
@@ -114,3 +114,44 @@ module _
     ( preserves-point-pointed-map
       ( horizontal-pointed-map-cocone-Pointed-Type f g c))
 ```
+
+### Computation with the cogap map for pointed types
+
+```agda
+module _
+  { l1 l2 l3 l4 : Level}
+  {S : Pointed-Type l1} {A : Pointed-Type l2} {B : Pointed-Type l3}
+  ( f : S →∗ A) (g : S →∗ B)
+  { X : Pointed-Type l4} (c : type-cocone-Pointed-Type f g X)
+  where
+
+  compute-inl-cogap-Pointed-Type :
+    ( x : type-Pointed-Type A) →
+      map-cogap-Pointed-Type
+        ( f)
+        ( g)
+        ( c)
+        ( map-pointed-map (inl-pushout-Pointed-Type f g) x) ＝
+      horizontal-map-cocone-Pointed-Type f g c x
+  compute-inl-cogap-Pointed-Type x =
+    compute-inl-cogap
+      ( map-pointed-map f)
+      ( map-pointed-map g)
+      ( cocone-type-cocone-Pointed-Type f g c)
+      ( x)
+
+  compute-inr-cogap-Pointed-Type :
+    ( y : type-Pointed-Type B) →
+      map-cogap-Pointed-Type
+        ( f)
+        ( g)
+        ( c)
+        ( map-pointed-map (inr-pushout-Pointed-Type f g) y) ＝
+      vertical-map-cocone-Pointed-Type f g c y
+  compute-inr-cogap-Pointed-Type y =
+    compute-inr-cogap
+      ( map-pointed-map f)
+      ( map-pointed-map g)
+      ( cocone-type-cocone-Pointed-Type f g c)
+      ( y)
+```

--- a/src/synthetic-homotopy-theory/smash-products-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/smash-products-of-pointed-types.lagda.md
@@ -7,15 +7,24 @@ module synthetic-homotopy-theory.smash-products-of-pointed-types where
 <details><summary>Imports</summary>
 
 ```agda
+open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
+open import foundation.equality-dependent-pair-types
+open import foundation.function-extensionality
+open import foundation.function-types
+open import foundation.homotopies
+open import foundation.identity-types
+open import foundation.transport-along-identifications
 open import foundation.universe-levels
 
 open import structured-types.pointed-cartesian-product-types
+open import structured-types.pointed-families-of-types
 open import structured-types.pointed-maps
 open import structured-types.pointed-types
 open import structured-types.pointed-unit-type
 
 open import synthetic-homotopy-theory.cocones-under-spans-of-pointed-types
+open import synthetic-homotopy-theory.pushouts
 open import synthetic-homotopy-theory.pushouts-of-pointed-types
 open import synthetic-homotopy-theory.wedges-of-pointed-types
 ```
@@ -88,13 +97,20 @@ map-cogap-smash-prod-Pointed-Type c =
 ### The canonical pointed map from the product to the smash product
 
 ```agda
-pointed-map-smash-prod-prod-Pointed-Type :
-  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) →
-  (A ×∗ B) →∗ (A ∧∗ B)
-pointed-map-smash-prod-prod-Pointed-Type A B =
-  inl-pushout-Pointed-Type
-    ( pointed-map-prod-wedge-Pointed-Type A B)
-    ( terminal-pointed-map (A ∨∗ B))
+module _
+  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2)
+  where
+
+  pointed-map-smash-prod-prod-Pointed-Type : (A ×∗ B) →∗ (A ∧∗ B)
+  pointed-map-smash-prod-prod-Pointed-Type =
+    inl-pushout-Pointed-Type
+      ( pointed-map-prod-wedge-Pointed-Type A B)
+      ( terminal-pointed-map (A ∨∗ B))
+
+  map-pointed-map-smash-prod-prod-Pointed-Type :
+    type-Pointed-Type (A ×∗ B) → type-Pointed-Type (A ∧∗ B)
+  map-pointed-map-smash-prod-prod-Pointed-Type =
+    map-pointed-map pointed-map-smash-prod-prod-Pointed-Type
 ```
 
 ### The smash product is the product in the category of pointed types
@@ -117,8 +133,78 @@ module _
     pr1 (gap-smash-prod-Pointed-Type f g)
 ```
 
-It remains to show that this is the correct map, and that it is unique.
+```agda
+module _
+  {l1 l2 : Level}
+  {A : Pointed-Type l1} {B : Pointed-Type l2}
+  where
+
+  glue-smash-prod-Pointed-Type :
+    (x : type-Pointed-Type A) (y : type-Pointed-Type B) →
+    map-pointed-map-smash-prod-prod-Pointed-Type A B
+      ( x , point-Pointed-Type B) ＝
+    map-pointed-map-smash-prod-prod-Pointed-Type A B
+      ( point-Pointed-Type A , y)
+  glue-smash-prod-Pointed-Type x y =
+    ( ap
+      ( map-pointed-map-smash-prod-prod-Pointed-Type A B)
+      ( inv
+        ( compute-inl-cogap-Pointed-Type
+          ( inclusion-point-Pointed-Type A)
+          ( inclusion-point-Pointed-Type B)
+          ( cocone-prod-wedge-Pointed-Type A B)
+          ( x)))) ∙
+    ( glue-pushout
+      ( map-prod-wedge-Pointed-Type A B)
+      ( map-pointed-map {A = A ∨∗ B} {B = unit-Pointed-Type}
+        ( terminal-pointed-map (A ∨∗ B)))
+      ( map-inl-wedge-Pointed-Type A B x)) ∙
+    ( inv
+      ( glue-pushout
+        ( map-prod-wedge-Pointed-Type A B)
+        ( map-pointed-map {A = A ∨∗ B} {B = unit-Pointed-Type}
+          ( terminal-pointed-map (A ∨∗ B)))
+        ( map-inr-wedge-Pointed-Type A B y))) ∙
+    ( ap
+      ( map-pointed-map-smash-prod-prod-Pointed-Type A B)
+      ( compute-inr-cogap-Pointed-Type
+        ( inclusion-point-Pointed-Type A)
+        ( inclusion-point-Pointed-Type B)
+        ( cocone-prod-wedge-Pointed-Type A B)
+        ( y)))
+
+{-eval-smash-prod-Pointed-Type :
+  {l1 l2 l3 : Level}
+  (A : Pointed-Type l1) (B : Pointed-Type l2) (C : Pointed-Type l3) →
+  ((A ∧∗ B) →∗ C) → (A →∗ (pointed-map-Pointed-Type B C))
+pr1 (pr1 (eval-smash-prod-Pointed-Type A B C f) x) y =
+  map-pointed-map f
+    ( map-pointed-map
+      ( pointed-map-smash-prod-prod-Pointed-Type A B) (x , y))
+pr2 (pr1 (eval-smash-prod-Pointed-Type A B C f) x) =
+  ( ap
+    ( map-pointed-map f)
+    ( glue-smash-prod-Pointed-Type x (point-Pointed-Type B))) ∙
+  ( preserves-point-pointed-map f)
+pr2 (eval-smash-prod-Pointed-Type A B C f) =
+  eq-pair-Σ
+    ( eq-htpy
+      ( λ y →
+        ( ap
+          ( map-pointed-map f)
+          ( inv
+            ( glue-smash-prod-Pointed-Type (point-Pointed-Type A) y))) ∙
+        ( preserves-point-pointed-map f)))
+    {!!}-}
+```
+
+foundation-core.dependent-identifications.dependent-identification (λ x → x (pr2
+B) ＝ pr2 (constant-Pointed-Fam B C)) (eq-htpy (λ y → ap (pr1 f) (inv
+(glue-smash-prod-Pointed-Type (pr2 A) y)) ∙ pr2 f)) (pr2 (pr1
+(eval-smash-prod-Pointed-Type A B C f) (pr2 A))) (pr2 (constant-pointed-map B
+C))
 
 ## See also
 
 - [Wedges of pointed types](synthetic-homotopy-theory.wedges-of-pointed-types.md)
+  (λ x → x (pr2 B) ＝ pr2 (constant-Pointed-Fam B C))

--- a/src/synthetic-homotopy-theory/smash-products-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/smash-products-of-pointed-types.lagda.md
@@ -198,12 +198,6 @@ pr2 (eval-smash-prod-Pointed-Type A B C f) =
     {!!}-}
 ```
 
-foundation-core.dependent-identifications.dependent-identification (λ x → x (pr2
-B) ＝ pr2 (constant-Pointed-Fam B C)) (eq-htpy (λ y → ap (pr1 f) (inv
-(glue-smash-prod-Pointed-Type (pr2 A) y)) ∙ pr2 f)) (pr2 (pr1
-(eval-smash-prod-Pointed-Type A B C f) (pr2 A))) (pr2 (constant-pointed-map B
-C))
-
 ## See also
 
 - [Wedges of pointed types](synthetic-homotopy-theory.wedges-of-pointed-types.md)

--- a/src/synthetic-homotopy-theory/smash-products-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/smash-products-of-pointed-types.lagda.md
@@ -201,4 +201,3 @@ pr2 (eval-smash-prod-Pointed-Type A B C f) =
 ## See also
 
 - [Wedges of pointed types](synthetic-homotopy-theory.wedges-of-pointed-types.md)
-  (λ x → x (pr2 B) ＝ pr2 (constant-Pointed-Fam B C))

--- a/src/synthetic-homotopy-theory/wedges-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/wedges-of-pointed-types.lagda.md
@@ -55,6 +55,34 @@ wedge-Pointed-Type A B =
 infixr 10 _∨∗_
 _∨∗_ = wedge-Pointed-Type
 
+inl-wedge-Pointed-Type :
+  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) →
+  A →∗ A ∨∗ B
+inl-wedge-Pointed-Type A B =
+  inl-pushout-Pointed-Type
+    ( inclusion-point-Pointed-Type A)
+    ( inclusion-point-Pointed-Type B)
+
+map-inl-wedge-Pointed-Type :
+  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) →
+  type-Pointed-Type A → type-Pointed-Type (A ∨∗ B)
+map-inl-wedge-Pointed-Type A B =
+  map-pointed-map (inl-wedge-Pointed-Type A B)
+
+inr-wedge-Pointed-Type :
+  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) →
+  B →∗ A ∨∗ B
+inr-wedge-Pointed-Type A B =
+  inr-pushout-Pointed-Type
+    ( inclusion-point-Pointed-Type A)
+    ( inclusion-point-Pointed-Type B)
+
+map-inr-wedge-Pointed-Type :
+  {l1 l2 : Level} (A : Pointed-Type l1) (B : Pointed-Type l2) →
+  type-Pointed-Type B → type-Pointed-Type (A ∨∗ B)
+map-inr-wedge-Pointed-Type A B =
+  map-pointed-map (inr-wedge-Pointed-Type A B)
+
 indexed-wedge-Pointed-Type :
   {l1 l2 : Level} (I : UU l1) (A : I → Pointed-Type l2) → Pointed-Type (l1 ⊔ l2)
 pr1 (indexed-wedge-Pointed-Type I A) =


### PR DESCRIPTION
I added some functions for computing with the universal property of pushouts of pointed types and a function that computes the identifications created by the map from the product to the smash product. 
I also started working on one of the sides of the universal property, but the last hole ended up as a very complicated dependent identification that I'm not sure how to handle. If anyone wants to look at it, you are welcome to do so :)