### PR TITLE
Formatting of postulates

### DIFF
--- a/src/foundation/function-extensionality.lagda.md
+++ b/src/foundation/function-extensionality.lagda.md
@@ -40,7 +40,7 @@ module _
   where
 
   postulate
-      funext : (f : (x : A) → B x) → function-extensionality f
+    funext : (f : (x : A) → B x) → function-extensionality f
 ```
 
 ### Components of `funext`

--- a/src/foundation/function-extensionality.lagda.md
+++ b/src/foundation/function-extensionality.lagda.md
@@ -39,7 +39,8 @@ module _
   {l1 l2 : Level} {A : UU l1} {B : A → UU l2}
   where
 
-  postulate funext : (f : (x : A) → B x) → function-extensionality f
+  postulate
+      funext : (f : (x : A) → B x) → function-extensionality f
 ```
 
 ### Components of `funext`

--- a/src/foundation/replacement.lagda.md
+++ b/src/foundation/replacement.lagda.md
@@ -33,7 +33,8 @@ Replacement l =
 ## Postulate
 
 ```agda
-postulate replacement : {l : Level} → Replacement l
+postulate
+  replacement : {l : Level} → Replacement l
 ```
 
 ```agda

--- a/src/foundation/univalence.lagda.md
+++ b/src/foundation/univalence.lagda.md
@@ -39,7 +39,8 @@ In this file we postulate the univalence axiom. Its statement is defined in
 ## Postulate
 
 ```agda
-postulate univalence : {l : Level} → axiom-univalence-Level l
+postulate
+  univalence : axiom-univalence
 ```
 
 ## Properties

--- a/src/primitives/characters.lagda.md
+++ b/src/primitives/characters.lagda.md
@@ -23,7 +23,8 @@ manipulate them. Characters are written between single quotes, e.g. `'a'`.
 ## Definitions
 
 ```agda
-postulate Char : UU lzero
+postulate
+  Char : UU lzero
 {-# BUILTIN CHAR Char #-}
 
 primitive

--- a/src/primitives/characters.lagda.md
+++ b/src/primitives/characters.lagda.md
@@ -25,6 +25,7 @@ manipulate them. Characters are written between single quotes, e.g. `'a'`.
 ```agda
 postulate
   Char : UU lzero
+
 {-# BUILTIN CHAR Char #-}
 
 primitive

--- a/src/primitives/floats.lagda.md
+++ b/src/primitives/floats.lagda.md
@@ -28,7 +28,8 @@ manipulate them. Floats can be written as usual, using dots as separators, e.g.
 ## Definitions
 
 ```agda
-postulate Float : UU lzero
+postulate
+  Float : UU lzero
 {-# BUILTIN FLOAT Float #-}
 
 primitive

--- a/src/primitives/floats.lagda.md
+++ b/src/primitives/floats.lagda.md
@@ -30,6 +30,7 @@ manipulate them. Floats can be written as usual, using dots as separators, e.g.
 ```agda
 postulate
   Float : UU lzero
+
 {-# BUILTIN FLOAT Float #-}
 
 primitive

--- a/src/primitives/machine-integers.lagda.md
+++ b/src/primitives/machine-integers.lagda.md
@@ -25,6 +25,7 @@ functions to manipulate them.
 ```agda
 postulate
   Word64 : UU lzero
+
 {-# BUILTIN WORD64 Word64 #-}
 
 primitive

--- a/src/primitives/machine-integers.lagda.md
+++ b/src/primitives/machine-integers.lagda.md
@@ -23,7 +23,8 @@ functions to manipulate them.
 ## Definitions
 
 ```agda
-postulate Word64 : UU lzero
+postulate
+  Word64 : UU lzero
 {-# BUILTIN WORD64 Word64 #-}
 
 primitive

--- a/src/primitives/strings.lagda.md
+++ b/src/primitives/strings.lagda.md
@@ -32,6 +32,7 @@ manipulate them. Strings are written between double quotes, e.g.
 ```agda
 postulate
   String : UU lzero
+
 {-# BUILTIN STRING String #-}
 
 primitive

--- a/src/primitives/strings.lagda.md
+++ b/src/primitives/strings.lagda.md
@@ -30,7 +30,8 @@ manipulate them. Strings are written between double quotes, e.g.
 ## Definitions
 
 ```agda
-postulate String : UU lzero
+postulate
+  String : UU lzero
 {-# BUILTIN STRING String #-}
 
 primitive

--- a/src/reflection/metavariables.lagda.md
+++ b/src/reflection/metavariables.lagda.md
@@ -25,7 +25,9 @@ The `Meta` type represents metavariables in Agda.
 ## Definition
 
 ```agda
-postulate Meta : UU lzero
+postulate
+  Meta : UU lzero
+
 {-# BUILTIN AGDAMETA Meta #-}
 
 primitive

--- a/src/reflection/names.lagda.md
+++ b/src/reflection/names.lagda.md
@@ -29,7 +29,9 @@ name by means of the `quote` keyword, e.g. `quote bool`.
 ## Definition
 
 ```agda
-postulate Name : UU lzero
+postulate
+  Name : UU lzero
+
 {-# BUILTIN QNAME Name #-}
 
 primitive

--- a/src/synthetic-homotopy-theory/circle.lagda.md
+++ b/src/synthetic-homotopy-theory/circle.lagda.md
@@ -46,11 +46,14 @@ open import univalent-combinatorics.standard-finite-types
 ## Postulates
 
 ```agda
-postulate 𝕊¹ : UU lzero
+postulate
+  𝕊¹ : UU lzero
 
-postulate base-𝕊¹ : 𝕊¹
+postulate
+  base-𝕊¹ : 𝕊¹
 
-postulate loop-𝕊¹ : Id base-𝕊¹ base-𝕊¹
+postulate
+  loop-𝕊¹ : Id base-𝕊¹ base-𝕊¹
 
 free-loop-𝕊¹ : free-loop 𝕊¹
 pr1 free-loop-𝕊¹ = base-𝕊¹
@@ -60,7 +63,8 @@ pr2 free-loop-𝕊¹ = loop-𝕊¹
 pr1 𝕊¹-Pointed-Type = 𝕊¹
 pr2 𝕊¹-Pointed-Type = base-𝕊¹
 
-postulate ind-𝕊¹ : {l : Level} → induction-principle-circle l free-loop-𝕊¹
+postulate
+  ind-𝕊¹ : {l : Level} → induction-principle-circle l free-loop-𝕊¹
 ```
 
 ## Properties


### PR DESCRIPTION
I changed the formatting of postulates to make it consistent with how we format abstract definitions, i.e., with a line break immediately after the keyword `postulate`

I also changed the way univalence is assumed, following @VojtechStep's suggestion.