### PR TITLE
Rename `is-contr-total` to `is-torsorial`

### DIFF
--- a/src/category-theory/full-large-subprecategories.lagda.md
+++ b/src/category-theory/full-large-subprecategories.lagda.md
@@ -208,8 +208,8 @@ module _
   is-large-category-large-precategory-is-large-category-Full-Large-Subprecategory
     is-large-category-C X =
     fundamental-theorem-id
-      ( is-contr-total-Eq-subtype
-        ( is-contr-total-iso-Large-Category
+      ( is-torsorial-Eq-subtype
+        ( is-torsorial-iso-Large-Category
           ( make-Large-Category C is-large-category-C)
           ( inclusion-subtype P X))
         ( is-prop-is-in-subtype P)

--- a/src/category-theory/full-subprecategories.lagda.md
+++ b/src/category-theory/full-subprecategories.lagda.md
@@ -245,8 +245,8 @@ module _
     is-category-Precategory (precategory-Full-Subprecategory C P)
   is-category-precategory-is-category-Full-Subprecategory is-category-C X =
     fundamental-theorem-id
-      ( is-contr-total-Eq-subtype
-        ( is-contr-total-iso-Category
+      ( is-torsorial-Eq-subtype
+        ( is-torsorial-iso-Category
           ( C , is-category-C)
           ( inclusion-subtype P X))
         ( is-prop-is-in-subtype P)

--- a/src/category-theory/groupoids.lagda.md
+++ b/src/category-theory/groupoids.lagda.md
@@ -152,14 +152,14 @@ module _
               Σ ( Σ (pr1 yp ＝ x) (λ q → (q ∙ pr2 yp) ＝ refl))
                 ( λ ql → (pr2 yp ∙ pr1 ql) ＝ refl))))
         ( is-contr-Σ
-          ( is-contr-total-path x)
+          ( is-torsorial-path x)
           ( x , refl)
           ( is-contr-Σ
             ( is-contr-equiv
               ( Σ (x ＝ x) (λ q → q ＝ refl))
               ( equiv-tot
                 ( λ q → equiv-concat (inv right-unit) refl))
-              ( is-contr-total-path' refl))
+              ( is-torsorial-path' refl))
             ( refl , refl)
             ( is-proof-irrelevant-is-prop
               ( is-1-type-type-1-Type X x x refl refl)

--- a/src/category-theory/isomorphism-induction-categories.lagda.md
+++ b/src/category-theory/isomorphism-induction-categories.lagda.md
@@ -86,12 +86,12 @@ module _
   where
 
   abstract
-    is-identity-system-iso-is-contr-total-iso-Category :
+    is-identity-system-iso-is-torsorial-iso-Category :
       is-contr (Σ (obj-Category C) (iso-Category C A)) →
       {l : Level} →
       is-identity-system l (iso-Category C A) A (id-iso-Category C)
-    is-identity-system-iso-is-contr-total-iso-Category =
-      is-identity-system-iso-is-contr-total-iso-Precategory
+    is-identity-system-iso-is-torsorial-iso-Category =
+      is-identity-system-iso-is-torsorial-iso-Precategory
         ( precategory-Category C)
 ```
 
@@ -102,12 +102,12 @@ module _
   {l1 l2 : Level} (C : Category l1 l2) {A : obj-Category C}
   where
 
-  is-contr-total-equiv-induction-principle-iso-Category :
+  is-torsorial-equiv-induction-principle-iso-Category :
     ( {l : Level} →
       is-identity-system l (iso-Category C A) A (id-iso-Category C)) →
     is-contr (Σ (obj-Category C) (iso-Category C A))
-  is-contr-total-equiv-induction-principle-iso-Category =
-    is-contr-total-equiv-induction-principle-iso-Precategory
+  is-torsorial-equiv-induction-principle-iso-Category =
+    is-torsorial-equiv-induction-principle-iso-Precategory
       ( precategory-Category C)
 ```
 
@@ -122,8 +122,8 @@ module _
   abstract
     is-identity-system-iso-Category : section (ev-id-iso-Category C P)
     is-identity-system-iso-Category =
-      is-identity-system-iso-is-contr-total-iso-Category C
-        ( is-contr-total-iso-Category C A) P
+      is-identity-system-iso-is-torsorial-iso-Category C
+        ( is-torsorial-iso-Category C A) P
 
   ind-iso-Category :
     P A (id-iso-Category C) →
@@ -147,7 +147,7 @@ module _
   is-equiv-ev-id-iso-Category =
     dependent-universal-property-identity-system-is-torsorial
       ( id-iso-Category C)
-      ( is-contr-total-iso-Category C A)
+      ( is-torsorial-iso-Category C A)
       ( P)
 
   is-contr-map-ev-id-iso-Category :

--- a/src/category-theory/isomorphism-induction-precategories.lagda.md
+++ b/src/category-theory/isomorphism-induction-precategories.lagda.md
@@ -81,11 +81,11 @@ module _
   where
 
   abstract
-    is-identity-system-iso-is-contr-total-iso-Precategory :
+    is-identity-system-iso-is-torsorial-iso-Precategory :
       is-contr (Σ (obj-Precategory C) (iso-Precategory C A)) →
       {l : Level} →
       is-identity-system l (iso-Precategory C A) A (id-iso-Precategory C)
-    is-identity-system-iso-is-contr-total-iso-Precategory =
+    is-identity-system-iso-is-torsorial-iso-Precategory =
       is-identity-system-is-torsorial A (id-iso-Precategory C)
 ```
 
@@ -96,10 +96,10 @@ module _
   {l1 l2 : Level} (C : Precategory l1 l2) {A : obj-Precategory C}
   where
 
-  is-contr-total-equiv-induction-principle-iso-Precategory :
+  is-torsorial-equiv-induction-principle-iso-Precategory :
     ( {l : Level} →
       is-identity-system l (iso-Precategory C A) A (id-iso-Precategory C)) →
     is-contr (Σ (obj-Precategory C) (iso-Precategory C A))
-  is-contr-total-equiv-induction-principle-iso-Precategory =
+  is-torsorial-equiv-induction-principle-iso-Precategory =
     is-torsorial-is-identity-system A (id-iso-Precategory C)
 ```

--- a/src/category-theory/isomorphisms-in-categories.lagda.md
+++ b/src/category-theory/isomorphisms-in-categories.lagda.md
@@ -657,21 +657,21 @@ module _
   (X : obj-Category C)
   where
 
-  is-contr-total-iso-Category :
+  is-torsorial-iso-Category :
     is-contr (Σ (obj-Category C) (iso-Category C X))
-  is-contr-total-iso-Category =
+  is-torsorial-iso-Category =
     is-contr-equiv'
       ( Σ (obj-Category C) (X ＝_))
       ( equiv-tot (extensionality-obj-Category C X))
-      ( is-contr-total-path X)
+      ( is-torsorial-path X)
 
-  is-contr-total-iso-Category' :
+  is-torsorial-iso-Category' :
     is-contr (Σ (obj-Category C) (λ Y → iso-Category C Y X))
-  is-contr-total-iso-Category' =
+  is-torsorial-iso-Category' =
     is-contr-equiv'
       ( Σ (obj-Category C) (_＝ X))
       ( equiv-tot (λ Y → extensionality-obj-Category C Y X))
-      ( is-contr-total-path' X)
+      ( is-torsorial-path' X)
 ```
 
 ### Functoriality of `eq-iso`

--- a/src/category-theory/isomorphisms-in-large-categories.lagda.md
+++ b/src/category-theory/isomorphisms-in-large-categories.lagda.md
@@ -191,21 +191,21 @@ module _
   (X : obj-Large-Category C l1)
   where
 
-  is-contr-total-iso-Large-Category :
+  is-torsorial-iso-Large-Category :
     is-contr (Σ (obj-Large-Category C l1) (iso-Large-Category C X))
-  is-contr-total-iso-Large-Category =
+  is-torsorial-iso-Large-Category =
     is-contr-equiv'
       ( Σ (obj-Large-Category C l1) (X ＝_))
       ( equiv-tot (extensionality-obj-Large-Category C X))
-      ( is-contr-total-path X)
+      ( is-torsorial-path X)
 
-  is-contr-total-iso-Large-Category' :
+  is-torsorial-iso-Large-Category' :
     is-contr (Σ (obj-Large-Category C l1) (λ Y → iso-Large-Category C Y X))
-  is-contr-total-iso-Large-Category' =
+  is-torsorial-iso-Large-Category' =
     is-contr-equiv'
       ( Σ (obj-Large-Category C l1) (_＝ X))
       ( equiv-tot (λ Y → extensionality-obj-Large-Category C Y X))
-      ( is-contr-total-path' X)
+      ( is-torsorial-path' X)
 ```
 
 ## Properties

--- a/src/category-theory/maps-categories.lagda.md
+++ b/src/category-theory/maps-categories.lagda.md
@@ -96,11 +96,11 @@ module _
       ( precategory-Category C)
       ( precategory-Category D)
 
-  is-contr-total-htpy-map-Category :
+  is-torsorial-htpy-map-Category :
     (f : map-Category C D) →
     is-contr (Σ (map-Category C D) (htpy-map-Category f))
-  is-contr-total-htpy-map-Category =
-    is-contr-total-htpy-map-Precategory
+  is-torsorial-htpy-map-Category =
+    is-torsorial-htpy-map-Precategory
       ( precategory-Category C)
       ( precategory-Category D)
 

--- a/src/category-theory/maps-from-small-to-large-categories.lagda.md
+++ b/src/category-theory/maps-from-small-to-large-categories.lagda.md
@@ -89,13 +89,13 @@ module _
       ( precategory-Category C)
       ( large-precategory-Large-Category D)
 
-  is-contr-total-htpy-map-Small-Large-Category :
+  is-torsorial-htpy-map-Small-Large-Category :
     (f : map-Small-Large-Category C D γ) →
     is-contr
       ( Σ ( map-Small-Large-Category C D γ)
           ( htpy-map-Small-Large-Category f))
-  is-contr-total-htpy-map-Small-Large-Category =
-    is-contr-total-htpy-map-Small-Large-Precategory
+  is-torsorial-htpy-map-Small-Large-Category =
+    is-torsorial-htpy-map-Small-Large-Precategory
       ( precategory-Category C)
       ( large-precategory-Large-Category D)
 

--- a/src/category-theory/maps-from-small-to-large-precategories.lagda.md
+++ b/src/category-theory/maps-from-small-to-large-precategories.lagda.md
@@ -79,13 +79,13 @@ module _
   htpy-eq-map-Small-Large-Precategory =
     htpy-eq-map-Precategory C (precategory-Large-Precategory D γ)
 
-  is-contr-total-htpy-map-Small-Large-Precategory :
+  is-torsorial-htpy-map-Small-Large-Precategory :
     (f : map-Small-Large-Precategory C D γ) →
     is-contr
       ( Σ ( map-Small-Large-Precategory C D γ)
           ( htpy-map-Small-Large-Precategory f))
-  is-contr-total-htpy-map-Small-Large-Precategory =
-    is-contr-total-htpy-map-Precategory C (precategory-Large-Precategory D γ)
+  is-torsorial-htpy-map-Small-Large-Precategory =
+    is-torsorial-htpy-map-Precategory C (precategory-Large-Precategory D γ)
 
   is-equiv-htpy-eq-map-Small-Large-Precategory :
     (f g : map-Small-Large-Precategory C D γ) →

--- a/src/category-theory/maps-precategories.lagda.md
+++ b/src/category-theory/maps-precategories.lagda.md
@@ -161,16 +161,16 @@ module _
     (f g : map-Precategory C D) → (f ＝ g) → htpy-map-Precategory f g
   htpy-eq-map-Precategory f .f refl = refl-htpy-map-Precategory f
 
-  is-contr-total-htpy-map-Precategory :
+  is-torsorial-htpy-map-Precategory :
     (f : map-Precategory C D) →
     is-contr (Σ (map-Precategory C D) (htpy-map-Precategory f))
-  is-contr-total-htpy-map-Precategory f =
-    is-contr-total-Eq-structure _
-      ( is-contr-total-htpy (obj-map-Precategory C D f))
+  is-torsorial-htpy-map-Precategory f =
+    is-torsorial-Eq-structure _
+      ( is-torsorial-htpy (obj-map-Precategory C D f))
       ( obj-map-Precategory C D f , refl-htpy)
-      ( is-contr-total-Eq-implicit-Π _
+      ( is-torsorial-Eq-implicit-Π _
         ( λ x →
-          is-contr-total-Eq-implicit-Π _
+          is-torsorial-Eq-implicit-Π _
             ( λ y →
               is-contr-equiv
                 ( Σ
@@ -185,13 +185,13 @@ module _
                       ( inv-htpy (right-unit-law-comp-hom-Precategory D ∘ g₁))
                       ( left-unit-law-comp-hom-Precategory D ∘
                         hom-map-Precategory C D f)))
-                ( is-contr-total-htpy' (hom-map-Precategory C D f)))))
+                ( is-torsorial-htpy' (hom-map-Precategory C D f)))))
 
   is-equiv-htpy-eq-map-Precategory :
     (f g : map-Precategory C D) → is-equiv (htpy-eq-map-Precategory f g)
   is-equiv-htpy-eq-map-Precategory f =
     fundamental-theorem-id
-      ( is-contr-total-htpy-map-Precategory f)
+      ( is-torsorial-htpy-map-Precategory f)
       ( htpy-eq-map-Precategory f)
 
   equiv-htpy-eq-map-Precategory :

--- a/src/category-theory/slice-precategories.lagda.md
+++ b/src/category-theory/slice-precategories.lagda.md
@@ -197,7 +197,7 @@ module _
       ( Σ (hom-Precategory C A X) (λ g → f ＝ g))
       ( equiv-tot
         ( λ g → equiv-concat' f (left-unit-law-comp-hom-Precategory C g)))
-      ( is-contr-total-path f)
+      ( is-torsorial-path f)
 ```
 
 ### Products in slice precategories are pullbacks in the original category

--- a/src/commutative-algebra/homomorphisms-commutative-rings.lagda.md
+++ b/src/commutative-algebra/homomorphisms-commutative-rings.lagda.md
@@ -336,11 +336,11 @@ module _
       ( ring-Commutative-Ring B)
       ( f)
 
-  is-contr-total-htpy-hom-Commutative-Ring :
+  is-torsorial-htpy-hom-Commutative-Ring :
     is-contr
       ( Σ (hom-Commutative-Ring A B) (htpy-hom-Commutative-Ring A B f))
-  is-contr-total-htpy-hom-Commutative-Ring =
-    is-contr-total-htpy-hom-Ring
+  is-torsorial-htpy-hom-Commutative-Ring =
+    is-torsorial-htpy-hom-Ring
       ( ring-Commutative-Ring A)
       ( ring-Commutative-Ring B)
       ( f)

--- a/src/commutative-algebra/homomorphisms-commutative-semirings.lagda.md
+++ b/src/commutative-algebra/homomorphisms-commutative-semirings.lagda.md
@@ -287,12 +287,12 @@ module _
   (f : hom-Commutative-Semiring A B)
   where
 
-  is-contr-total-htpy-hom-Commutative-Semiring :
+  is-torsorial-htpy-hom-Commutative-Semiring :
     is-contr
       ( Σ ( hom-Commutative-Semiring A B)
           ( htpy-hom-Commutative-Semiring A B f))
-  is-contr-total-htpy-hom-Commutative-Semiring =
-    is-contr-total-htpy-hom-Semiring
+  is-torsorial-htpy-hom-Commutative-Semiring =
+    is-torsorial-htpy-hom-Semiring
       ( semiring-Commutative-Semiring A)
       ( semiring-Commutative-Semiring B)
       ( f)

--- a/src/commutative-algebra/ideals-commutative-rings.lagda.md
+++ b/src/commutative-algebra/ideals-commutative-rings.lagda.md
@@ -237,12 +237,12 @@ module _
   refl-has-same-elements-ideal-Commutative-Ring =
     refl-has-same-elements-ideal-Ring (ring-Commutative-Ring R) I
 
-  is-contr-total-has-same-elements-ideal-Commutative-Ring :
+  is-torsorial-has-same-elements-ideal-Commutative-Ring :
     is-contr
       ( Σ ( ideal-Commutative-Ring l2 R)
           ( has-same-elements-ideal-Commutative-Ring R I))
-  is-contr-total-has-same-elements-ideal-Commutative-Ring =
-    is-contr-total-has-same-elements-ideal-Ring (ring-Commutative-Ring R) I
+  is-torsorial-has-same-elements-ideal-Commutative-Ring =
+    is-torsorial-has-same-elements-ideal-Ring (ring-Commutative-Ring R) I
 
   has-same-elements-eq-ideal-Commutative-Ring :
     (J : ideal-Commutative-Ring l2 R) →

--- a/src/commutative-algebra/isomorphisms-commutative-rings.lagda.md
+++ b/src/commutative-algebra/isomorphisms-commutative-rings.lagda.md
@@ -398,11 +398,11 @@ module _
   where
 
   abstract
-    is-contr-total-iso-Commutative-Ring :
+    is-torsorial-iso-Commutative-Ring :
       is-contr (Σ (Commutative-Ring l) (iso-Commutative-Ring A))
-    is-contr-total-iso-Commutative-Ring =
-      is-contr-total-Eq-subtype
-        ( is-contr-total-iso-Ring (ring-Commutative-Ring A))
+    is-torsorial-iso-Commutative-Ring =
+      is-torsorial-Eq-subtype
+        ( is-torsorial-iso-Ring (ring-Commutative-Ring A))
         ( is-prop-is-commutative-Ring)
         ( ring-Commutative-Ring A)
         ( id-iso-Ring (ring-Commutative-Ring A))
@@ -412,7 +412,7 @@ module _
     (B : Commutative-Ring l) → is-equiv (iso-eq-Commutative-Ring A B)
   is-equiv-iso-eq-Commutative-Ring =
     fundamental-theorem-id
-      ( is-contr-total-iso-Commutative-Ring)
+      ( is-torsorial-iso-Commutative-Ring)
       ( iso-eq-Commutative-Ring A)
 
   extensionality-Commutative-Ring :

--- a/src/commutative-algebra/radical-ideals-commutative-rings.lagda.md
+++ b/src/commutative-algebra/radical-ideals-commutative-rings.lagda.md
@@ -183,14 +183,14 @@ module _
     refl-has-same-elements-ideal-Commutative-Ring A
       ( ideal-radical-ideal-Commutative-Ring A I)
 
-  is-contr-total-has-same-elements-radical-ideal-Commutative-Ring :
+  is-torsorial-has-same-elements-radical-ideal-Commutative-Ring :
     {l2 : Level} (I : radical-ideal-Commutative-Ring l2 A) →
     is-contr
       ( Σ ( radical-ideal-Commutative-Ring l2 A)
           ( has-same-elements-radical-ideal-Commutative-Ring I))
-  is-contr-total-has-same-elements-radical-ideal-Commutative-Ring I =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-has-same-elements-ideal-Commutative-Ring A
+  is-torsorial-has-same-elements-radical-ideal-Commutative-Ring I =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-has-same-elements-ideal-Commutative-Ring A
         ( ideal-radical-ideal-Commutative-Ring A I))
       ( is-prop-is-radical-ideal-Commutative-Ring A)
       ( ideal-radical-ideal-Commutative-Ring A I)
@@ -208,7 +208,7 @@ module _
     is-equiv (has-same-elements-eq-radical-ideal-Commutative-Ring I J)
   is-equiv-has-same-elements-eq-radical-ideal-Commutative-Ring I =
     fundamental-theorem-id
-      ( is-contr-total-has-same-elements-radical-ideal-Commutative-Ring I)
+      ( is-torsorial-has-same-elements-radical-ideal-Commutative-Ring I)
       ( has-same-elements-eq-radical-ideal-Commutative-Ring I)
 
   extensionality-radical-ideal-Commutative-Ring :

--- a/src/elementary-number-theory/equality-integers.lagda.md
+++ b/src/elementary-number-theory/equality-integers.lagda.md
@@ -130,15 +130,15 @@ contraction-total-Eq-ℤ (inr (inr x)) (pair (inr (inr y)) e) =
     ( ap (inr ∘ inr) (eq-Eq-ℕ x y e))
     ( eq-is-prop (is-prop-Eq-ℕ x y))
 
-is-contr-total-Eq-ℤ :
+is-torsorial-Eq-ℤ :
   (x : ℤ) → is-contr (Σ ℤ (Eq-ℤ x))
-is-contr-total-Eq-ℤ x =
+is-torsorial-Eq-ℤ x =
   pair (pair x (refl-Eq-ℤ x)) (contraction-total-Eq-ℤ x)
 
 is-equiv-Eq-ℤ-eq :
   (x y : ℤ) → is-equiv (Eq-ℤ-eq {x} {y})
 is-equiv-Eq-ℤ-eq x =
   fundamental-theorem-id
-    ( is-contr-total-Eq-ℤ x)
+    ( is-torsorial-Eq-ℤ x)
     ( λ y → Eq-ℤ-eq {x} {y})
 ```

--- a/src/elementary-number-theory/equality-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/equality-natural-numbers.lagda.md
@@ -79,19 +79,19 @@ map-total-Eq-ℕ :
 pr1 (map-total-Eq-ℕ m (pair n e)) = succ-ℕ n
 pr2 (map-total-Eq-ℕ m (pair n e)) = e
 
-is-contr-total-Eq-ℕ :
+is-torsorial-Eq-ℕ :
   (m : ℕ) → is-contr (Σ ℕ (Eq-ℕ m))
-pr1 (pr1 (is-contr-total-Eq-ℕ m)) = m
-pr2 (pr1 (is-contr-total-Eq-ℕ m)) = refl-Eq-ℕ m
-pr2 (is-contr-total-Eq-ℕ zero-ℕ) (pair zero-ℕ star) = refl
-pr2 (is-contr-total-Eq-ℕ (succ-ℕ m)) (pair (succ-ℕ n) e) =
-  ap (map-total-Eq-ℕ m) (pr2 (is-contr-total-Eq-ℕ m) (pair n e))
+pr1 (pr1 (is-torsorial-Eq-ℕ m)) = m
+pr2 (pr1 (is-torsorial-Eq-ℕ m)) = refl-Eq-ℕ m
+pr2 (is-torsorial-Eq-ℕ zero-ℕ) (pair zero-ℕ star) = refl
+pr2 (is-torsorial-Eq-ℕ (succ-ℕ m)) (pair (succ-ℕ n) e) =
+  ap (map-total-Eq-ℕ m) (pr2 (is-torsorial-Eq-ℕ m) (pair n e))
 
 is-equiv-Eq-eq-ℕ :
   {m n : ℕ} → is-equiv (Eq-eq-ℕ {m} {n})
 is-equiv-Eq-eq-ℕ {m} {n} =
   fundamental-theorem-id
-    ( is-contr-total-Eq-ℕ m)
+    ( is-torsorial-Eq-ℕ m)
     ( λ y → Eq-eq-ℕ {m} {y})
     ( n)
 ```

--- a/src/elementary-number-theory/universal-property-integers.lagda.md
+++ b/src/elementary-number-theory/universal-property-integers.lagda.md
@@ -146,18 +146,18 @@ Eq-ELIM-ℤ-eq :
 Eq-ELIM-ℤ-eq P p0 pS s .s refl = reflexive-Eq-ELIM-ℤ P p0 pS s
 
 abstract
-  is-contr-total-Eq-ELIM-ℤ :
+  is-torsorial-Eq-ELIM-ℤ :
     { l1 : Level} (P : ℤ → UU l1) →
     ( p0 : P zero-ℤ) (pS : (k : ℤ) → (P k) ≃ (P (succ-ℤ k))) →
     ( s : ELIM-ℤ P p0 pS) → is-contr (Σ (ELIM-ℤ P p0 pS) (Eq-ELIM-ℤ P p0 pS s))
-  is-contr-total-Eq-ELIM-ℤ P p0 pS s =
-    is-contr-total-Eq-structure
+  is-torsorial-Eq-ELIM-ℤ P p0 pS s =
+    is-torsorial-Eq-structure
       ( λ f t H →
         ( zero-Eq-ELIM-ℤ P p0 pS s (pair f t) H) ×
         ( succ-Eq-ELIM-ℤ P p0 pS s (pair f t) H))
-      ( is-contr-total-htpy (pr1 s))
+      ( is-torsorial-htpy (pr1 s))
       ( pair (pr1 s) refl-htpy)
-      ( is-contr-total-Eq-structure
+      ( is-torsorial-Eq-structure
         ( λ p K
           ( q : zero-Eq-ELIM-ℤ P p0 pS s
             ( pair (pr1 s) (pair p K))
@@ -170,7 +170,7 @@ abstract
           ( tot (λ α → right-transpose-eq-concat refl α (pr1 (pr2 s))))
           ( is-equiv-tot-is-fiberwise-equiv
             ( λ α → is-equiv-right-transpose-eq-concat refl α (pr1 (pr2 s))))
-          ( is-contr-total-path' (pr1 (pr2 s))))
+          ( is-torsorial-path' (pr1 (pr2 s))))
         ( pair (pr1 (pr2 s)) (inv (right-inv (pr1 (pr2 s)))))
         ( is-contr-is-equiv'
           ( Σ ( ( k : ℤ) → Id (pr1 s (succ-ℤ k)) (pr1 (pS k) (pr1 s k)))
@@ -179,7 +179,7 @@ abstract
           ( is-equiv-tot-is-fiberwise-equiv
             ( λ β →
               is-equiv-right-transpose-htpy-concat refl-htpy β (pr2 (pr2 s))))
-          ( is-contr-total-htpy' (pr2 (pr2 s)))))
+          ( is-torsorial-htpy' (pr2 (pr2 s)))))
 
 abstract
   is-equiv-Eq-ELIM-ℤ-eq :
@@ -188,7 +188,7 @@ abstract
     ( s t : ELIM-ℤ P p0 pS) → is-equiv (Eq-ELIM-ℤ-eq P p0 pS s t)
   is-equiv-Eq-ELIM-ℤ-eq P p0 pS s =
     fundamental-theorem-id
-      ( is-contr-total-Eq-ELIM-ℤ P p0 pS s)
+      ( is-torsorial-Eq-ELIM-ℤ P p0 pS s)
       ( Eq-ELIM-ℤ-eq P p0 pS s)
 
 eq-Eq-ELIM-ℤ :

--- a/src/elementary-number-theory/universal-property-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/universal-property-natural-numbers.lagda.md
@@ -60,30 +60,30 @@ module _
   htpy-eq-structure-preserving-map-ℕ {h} refl =
     refl-htpy-structure-preserving-map-ℕ h
 
-  is-contr-total-htpy-structure-preserving-map-ℕ :
+  is-torsorial-htpy-structure-preserving-map-ℕ :
     (h : structure-preserving-map-ℕ) →
     is-contr (Σ structure-preserving-map-ℕ (htpy-structure-preserving-map-ℕ h))
-  is-contr-total-htpy-structure-preserving-map-ℕ h =
-    is-contr-total-Eq-structure
+  is-torsorial-htpy-structure-preserving-map-ℕ h =
+    is-torsorial-Eq-structure
       ( λ g p (H : pr1 h ~ g) →
         ( pr1 (pr2 h) ＝ (H zero-ℕ ∙ pr1 p)) ×
         ( (n : ℕ) →
           (pr2 (pr2 h) n ∙ ap f (H n)) ＝ (H (succ-ℕ n) ∙ pr2 p n)))
-      ( is-contr-total-htpy (pr1 h))
+      ( is-torsorial-htpy (pr1 h))
       ( pair (pr1 h) refl-htpy)
-      ( is-contr-total-Eq-structure
+      ( is-torsorial-Eq-structure
         ( λ p0 pS q →
           (n : ℕ) → (pr2 (pr2 h) n ∙ refl) ＝ pS n)
-        ( is-contr-total-path (pr1 (pr2 h)))
+        ( is-torsorial-path (pr1 (pr2 h)))
         ( pair (pr1 (pr2 h)) refl)
-        ( is-contr-total-htpy (λ n → (pr2 (pr2 h) n ∙ refl))))
+        ( is-torsorial-htpy (λ n → (pr2 (pr2 h) n ∙ refl))))
 
   is-equiv-htpy-eq-structure-preserving-map-ℕ :
     (h k : structure-preserving-map-ℕ) →
     is-equiv (htpy-eq-structure-preserving-map-ℕ {h} {k})
   is-equiv-htpy-eq-structure-preserving-map-ℕ h =
     fundamental-theorem-id
-      ( is-contr-total-htpy-structure-preserving-map-ℕ h)
+      ( is-torsorial-htpy-structure-preserving-map-ℕ h)
       ( λ k → htpy-eq-structure-preserving-map-ℕ {h} {k})
 
   eq-htpy-structure-preserving-map-ℕ :

--- a/src/finite-algebra/homomorphisms-commutative-finite-rings.lagda.md
+++ b/src/finite-algebra/homomorphisms-commutative-finite-rings.lagda.md
@@ -353,11 +353,11 @@ module _
       ( ring-Commutative-Ring-𝔽 B)
       ( f)
 
-  is-contr-total-htpy-hom-Commutative-Ring-𝔽 :
+  is-torsorial-htpy-hom-Commutative-Ring-𝔽 :
     is-contr
       ( Σ (hom-Commutative-Ring-𝔽 A B) (htpy-hom-Commutative-Ring-𝔽 A B f))
-  is-contr-total-htpy-hom-Commutative-Ring-𝔽 =
-    is-contr-total-htpy-hom-Ring
+  is-torsorial-htpy-hom-Commutative-Ring-𝔽 =
+    is-torsorial-htpy-hom-Ring
       ( ring-Commutative-Ring-𝔽 A)
       ( ring-Commutative-Ring-𝔽 B)
       ( f)

--- a/src/finite-algebra/homomorphisms-finite-rings.lagda.md
+++ b/src/finite-algebra/homomorphisms-finite-rings.lagda.md
@@ -321,11 +321,11 @@ module _
       ( ring-Ring-𝔽 B)
       ( f)
 
-  is-contr-total-htpy-hom-Ring-𝔽 :
+  is-torsorial-htpy-hom-Ring-𝔽 :
     is-contr
       ( Σ (hom-Ring-𝔽 A B) (htpy-hom-Ring-𝔽 A B f))
-  is-contr-total-htpy-hom-Ring-𝔽 =
-    is-contr-total-htpy-hom-Ring
+  is-torsorial-htpy-hom-Ring-𝔽 =
+    is-torsorial-htpy-hom-Ring
       ( ring-Ring-𝔽 A)
       ( ring-Ring-𝔽 B)
       ( f)

--- a/src/finite-group-theory/groups-of-order-2.lagda.md
+++ b/src/finite-group-theory/groups-of-order-2.lagda.md
@@ -116,11 +116,11 @@ module _
       ( group-Group-of-Order-2 H)
       ( ap pr1 p)
 
-  is-contr-total-iso-Group-of-Order-2 :
+  is-torsorial-iso-Group-of-Order-2 :
     is-contr (Σ (Group-of-Order-2 l) (iso-Group-of-Order-2 G))
-  is-contr-total-iso-Group-of-Order-2 =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-iso-Group (group-Group-of-Order-2 G))
+  is-torsorial-iso-Group-of-Order-2 =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-iso-Group (group-Group-of-Order-2 G))
       ( λ H → is-prop-type-trunc-Prop)
       ( group-Group-of-Order-2 G)
       ( id-iso-Group (group-Group-of-Order-2 G))
@@ -130,7 +130,7 @@ module _
     (H : Group-of-Order-2 l) → is-equiv (iso-eq-Group-of-Order-2 H)
   is-equiv-iso-eq-Group-of-Order-2 =
     fundamental-theorem-id
-      ( is-contr-total-iso-Group-of-Order-2)
+      ( is-torsorial-iso-Group-of-Order-2)
       ( iso-eq-Group-of-Order-2)
 
   eq-iso-Group-of-Order-2 :

--- a/src/foundation-core/contractible-types.lagda.md
+++ b/src/foundation-core/contractible-types.lagda.md
@@ -73,16 +73,16 @@ module _
   where
 
   abstract
-    is-contr-total-path : (a : A) → is-contr (Σ A (λ x → a ＝ x))
-    pr1 (pr1 (is-contr-total-path a)) = a
-    pr2 (pr1 (is-contr-total-path a)) = refl
-    pr2 (is-contr-total-path a) (pair .a refl) = refl
+    is-torsorial-path : (a : A) → is-contr (Σ A (λ x → a ＝ x))
+    pr1 (pr1 (is-torsorial-path a)) = a
+    pr2 (pr1 (is-torsorial-path a)) = refl
+    pr2 (is-torsorial-path a) (pair .a refl) = refl
 
   abstract
-    is-contr-total-path' : (a : A) → is-contr (Σ A (λ x → x ＝ a))
-    pr1 (pr1 (is-contr-total-path' a)) = a
-    pr2 (pr1 (is-contr-total-path' a)) = refl
-    pr2 (is-contr-total-path' a) (pair .a refl) = refl
+    is-torsorial-path' : (a : A) → is-contr (Σ A (λ x → x ＝ a))
+    pr1 (pr1 (is-torsorial-path' a)) = a
+    pr2 (pr1 (is-torsorial-path' a)) = refl
+    pr2 (is-torsorial-path' a) (pair .a refl) = refl
 ```
 
 ## Properties

--- a/src/foundation-core/small-types.lagda.md
+++ b/src/foundation-core/small-types.lagda.md
@@ -102,7 +102,7 @@ is-prop-is-small l A =
       is-contr-equiv'
         ( Σ (UU l) (λ Y → (pr1 Xe) ≃ Y))
         ( equiv-tot ((λ Y → equiv-precomp-equiv (pr2 Xe) Y)))
-        ( is-contr-total-equiv (pr1 Xe)))
+        ( is-torsorial-equiv (pr1 Xe)))
 
 is-small-Prop :
   (l : Level) {l1 : Level} (A : UU l1) → Prop (lsuc l ⊔ l1)

--- a/src/foundation-core/univalence.lagda.md
+++ b/src/foundation-core/univalence.lagda.md
@@ -58,10 +58,10 @@ axiom-univalence = {l : Level} → axiom-univalence-Level l
 
 ```agda
 abstract
-  is-contr-total-equiv-based-univalence :
+  is-torsorial-equiv-based-univalence :
     {l : Level} (A : UU l) →
     axiom-based-univalence A → is-contr (Σ (UU l) (A ≃_))
-  is-contr-total-equiv-based-univalence A UA =
+  is-torsorial-equiv-based-univalence A UA =
     fundamental-theorem-id' (λ B → equiv-eq) UA
 ```
 
@@ -69,10 +69,10 @@ abstract
 
 ```agda
 abstract
-  based-univalence-is-contr-total-equiv :
+  based-univalence-is-torsorial-equiv :
     {l : Level} (A : UU l) →
     is-contr (Σ (UU l) (A ≃_)) → axiom-based-univalence A
-  based-univalence-is-contr-total-equiv A c =
+  based-univalence-is-torsorial-equiv A c =
     fundamental-theorem-id c (λ B → equiv-eq)
 ```
 

--- a/src/foundation/1-types.lagda.md
+++ b/src/foundation/1-types.lagda.md
@@ -129,9 +129,9 @@ module _
   equiv-eq-1-Type = equiv-eq-subuniverse is-1-type-Prop X
 
   abstract
-    is-contr-total-equiv-1-Type : is-contr (Σ (1-Type l) type-equiv-1-Type)
-    is-contr-total-equiv-1-Type =
-      is-contr-total-equiv-subuniverse is-1-type-Prop X
+    is-torsorial-equiv-1-Type : is-contr (Σ (1-Type l) type-equiv-1-Type)
+    is-torsorial-equiv-1-Type =
+      is-torsorial-equiv-subuniverse is-1-type-Prop X
 
   abstract
     is-equiv-equiv-eq-1-Type : (Y : 1-Type l) → is-equiv (equiv-eq-1-Type Y)

--- a/src/foundation/arithmetic-law-coproduct-and-sigma-decompositions.lagda.md
+++ b/src/foundation/arithmetic-law-coproduct-and-sigma-decompositions.lagda.md
@@ -127,10 +127,10 @@ module _
                                         ( inv-equiv (pr2 B')))
                                       ( X))) ∘e
                             ( ( inv-left-unit-law-Σ-is-contr
-                                  ( is-contr-total-equiv' (Σ A YA))
+                                  ( is-torsorial-equiv' (Σ A YA))
                                   ( Σ A YA , id-equiv)) ∘e
                               ( inv-left-unit-law-Σ-is-contr
-                                  ( is-contr-total-equiv' (Σ B YB))
+                                  ( is-torsorial-equiv' (Σ B YB))
                                   ( Σ B YB , id-equiv)))))) ∘e
                     ( ( equiv-Σ-equiv-base
                           ( λ (YA , YB) → X ≃ (Σ A YA + Σ B YB))
@@ -141,7 +141,7 @@ module _
                                 ( right-distributive-Σ-coprod A B Y)
                                 ( X))) ∘e
                           ( left-unit-law-Σ-is-contr
-                              ( is-contr-total-equiv' (A + B))
+                              ( is-torsorial-equiv' (A + B))
                               ((A + B) , id-equiv))))))))) ∘e
       ( reassociate)))
 
@@ -192,10 +192,10 @@ module _
         ( matching-correspondence-binary-coproduct-Decomposition (pr2 D))
         ( inv
             ( contraction
-                ( is-contr-total-equiv' (pr1 (pr2 D) + pr1 (pr2 (pr2 D))))
+                ( is-torsorial-equiv' (pr1 (pr2 D) + pr1 (pr2 (pr2 D))))
                 ( (pr1 (pr2 D) + pr1 (pr2 (pr2 D))) , id-equiv)) ∙
           contraction
-            ( is-contr-total-equiv' (pr1 (pr2 D) + pr1 (pr2 (pr2 D))))
+            ( is-torsorial-equiv' (pr1 (pr2 D) + pr1 (pr2 (pr2 D))))
                 ( pr1 (pr1 D) , pr2 (pr2 (pr2 D))))
         ( inl a)
 
@@ -216,10 +216,10 @@ module _
           ( matching-correspondence-binary-coproduct-Decomposition (pr2 D))
           ( inv
               ( contraction
-                  ( is-contr-total-equiv' (pr1 (pr2 D) + pr1 (pr2 (pr2 D))))
+                  ( is-torsorial-equiv' (pr1 (pr2 D) + pr1 (pr2 (pr2 D))))
                   ( (pr1 (pr2 D) + pr1 (pr2 (pr2 D))) , id-equiv)) ∙
             contraction
-              ( is-contr-total-equiv' (pr1 (pr2 D) + pr1 (pr2 (pr2 D))))
+              ( is-torsorial-equiv' (pr1 (pr2 D) + pr1 (pr2 (pr2 D))))
                   ( pr1 (pr1 D) , pr2 (pr2 (pr2 D))))
           ( inr b)
 ```

--- a/src/foundation/arithmetic-law-product-and-pi-decompositions.lagda.md
+++ b/src/foundation/arithmetic-law-product-and-pi-decompositions.lagda.md
@@ -127,10 +127,10 @@ module _
                                         ( inv-equiv (pr2 B')))
                                       ( X))) ∘e
                             ( ( inv-left-unit-law-Σ-is-contr
-                                  ( is-contr-total-equiv' (Π A YA))
+                                  ( is-torsorial-equiv' (Π A YA))
                                   ( Π A YA , id-equiv)) ∘e
                               ( inv-left-unit-law-Σ-is-contr
-                                  ( is-contr-total-equiv' (Π B YB))
+                                  ( is-torsorial-equiv' (Π B YB))
                                   ( Π B YB , id-equiv)))))) ∘e
                     ( ( equiv-Σ-equiv-base
                         ( λ z → X ≃ (Π A (pr1 z) × Π B (pr2 z)))
@@ -141,7 +141,7 @@ module _
                                 ( equiv-dependent-universal-property-coprod Y)
                                 ( X))) ∘e
                           ( left-unit-law-Σ-is-contr
-                              ( is-contr-total-equiv' (A + B))
+                              ( is-torsorial-equiv' (A + B))
                               ((A + B) , id-equiv))))))))) ∘e
       ( reassociate)))
 
@@ -192,10 +192,10 @@ module _
         ( matching-correspondence-binary-coproduct-Decomposition (pr2 D))
         ( inv
             ( contraction
-                ( is-contr-total-equiv' (pr1 (pr2 D) + pr1 (pr2 (pr2 D))))
+                ( is-torsorial-equiv' (pr1 (pr2 D) + pr1 (pr2 (pr2 D))))
                 ( (pr1 (pr2 D) + pr1 (pr2 (pr2 D))) , id-equiv)) ∙
           contraction
-            ( is-contr-total-equiv' (pr1 (pr2 D) + pr1 (pr2 (pr2 D))))
+            ( is-torsorial-equiv' (pr1 (pr2 D) + pr1 (pr2 (pr2 D))))
                 ( pr1 (pr1 D) , pr2 (pr2 (pr2 D))))
         ( inl a)
 
@@ -216,10 +216,10 @@ module _
           ( matching-correspondence-binary-coproduct-Decomposition (pr2 D))
           ( inv
               ( contraction
-                  ( is-contr-total-equiv' (pr1 (pr2 D) + pr1 (pr2 (pr2 D))))
+                  ( is-torsorial-equiv' (pr1 (pr2 D) + pr1 (pr2 (pr2 D))))
                   ( (pr1 (pr2 D) + pr1 (pr2 (pr2 D))) , id-equiv)) ∙
             contraction
-              ( is-contr-total-equiv' (pr1 (pr2 D) + pr1 (pr2 (pr2 D))))
+              ( is-torsorial-equiv' (pr1 (pr2 D) + pr1 (pr2 (pr2 D))))
                   ( pr1 (pr1 D) , pr2 (pr2 (pr2 D))))
           ( inr b)
 ```

--- a/src/foundation/binary-functoriality-set-quotients.lagda.md
+++ b/src/foundation/binary-functoriality-set-quotients.lagda.md
@@ -131,15 +131,15 @@ module _
   binary-htpy-eq-hom-Equivalence-Relation f .f refl =
     refl-binary-htpy-hom-Equivalence-Relation f
 
-  is-contr-total-binary-htpy-hom-Equivalence-Relation :
+  is-torsorial-binary-htpy-hom-Equivalence-Relation :
     (f : binary-hom-Equivalence-Relation R S T) →
     is-contr
       ( Σ
         ( binary-hom-Equivalence-Relation R S T)
         ( binary-htpy-hom-Equivalence-Relation f))
-  is-contr-total-binary-htpy-hom-Equivalence-Relation f =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-binary-htpy
+  is-torsorial-binary-htpy-hom-Equivalence-Relation f =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-binary-htpy
         ( map-binary-hom-Equivalence-Relation R S T f))
       ( is-prop-preserves-sim-binary-map-Equivalence-Relation R S T)
       ( map-binary-hom-Equivalence-Relation R S T f)
@@ -151,7 +151,7 @@ module _
     is-equiv (binary-htpy-eq-hom-Equivalence-Relation f g)
   is-equiv-binary-htpy-eq-hom-Equivalence-Relation f =
     fundamental-theorem-id
-      ( is-contr-total-binary-htpy-hom-Equivalence-Relation f)
+      ( is-torsorial-binary-htpy-hom-Equivalence-Relation f)
       ( binary-htpy-eq-hom-Equivalence-Relation f)
 
   extensionality-binary-hom-Equivalence-Relation :

--- a/src/foundation/binary-homotopies.lagda.md
+++ b/src/foundation/binary-homotopies.lagda.md
@@ -46,19 +46,19 @@ module _
     (f g : (x : A) (y : B x) → C x y) → (f ＝ g) → binary-htpy f g
   binary-htpy-eq f .f refl = refl-binary-htpy f
 
-  is-contr-total-binary-htpy :
+  is-torsorial-binary-htpy :
     (f : (x : A) (y : B x) → C x y) →
     is-contr (Σ ((x : A) (y : B x) → C x y) (binary-htpy f))
-  is-contr-total-binary-htpy f =
-    is-contr-total-Eq-Π
+  is-torsorial-binary-htpy f =
+    is-torsorial-Eq-Π
       ( λ x g → f x ~ g)
-      ( λ x → is-contr-total-htpy (f x))
+      ( λ x → is-torsorial-htpy (f x))
 
   is-equiv-binary-htpy-eq :
     (f g : (x : A) (y : B x) → C x y) → is-equiv (binary-htpy-eq f g)
   is-equiv-binary-htpy-eq f =
     fundamental-theorem-id
-      ( is-contr-total-binary-htpy f)
+      ( is-torsorial-binary-htpy f)
       ( binary-htpy-eq f)
 
   extensionality-binary-Π :

--- a/src/foundation/binary-reflecting-maps-equivalence-relations.lagda.md
+++ b/src/foundation/binary-reflecting-maps-equivalence-relations.lagda.md
@@ -112,16 +112,16 @@ module _
   htpy-eq-binary-reflecting-map-Equivalence-Relation .f refl =
     refl-htpy-binary-reflecting-map-Equivalence-Relation
 
-  is-contr-total-htpy-binary-reflecting-map-Equivalence-Relation :
+  is-torsorial-htpy-binary-reflecting-map-Equivalence-Relation :
     is-contr
       ( Σ ( binary-reflecting-map-Equivalence-Relation R S (type-Set C))
           ( htpy-binary-reflecting-map-Equivalence-Relation))
-  is-contr-total-htpy-binary-reflecting-map-Equivalence-Relation =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-Eq-Π
+  is-torsorial-htpy-binary-reflecting-map-Equivalence-Relation =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-Eq-Π
         ( λ x g → map-binary-reflecting-map-Equivalence-Relation R S f x ~ g)
         ( λ x →
-          is-contr-total-htpy
+          is-torsorial-htpy
             ( map-binary-reflecting-map-Equivalence-Relation R S f x)))
       ( is-prop-binary-reflects-Equivalence-Relation R S C)
       ( map-binary-reflecting-map-Equivalence-Relation R S f)
@@ -133,7 +133,7 @@ module _
     is-equiv (htpy-eq-binary-reflecting-map-Equivalence-Relation g)
   is-equiv-htpy-eq-binary-reflecting-map-Equivalence-Relation =
     fundamental-theorem-id
-      is-contr-total-htpy-binary-reflecting-map-Equivalence-Relation
+      is-torsorial-htpy-binary-reflecting-map-Equivalence-Relation
       htpy-eq-binary-reflecting-map-Equivalence-Relation
 
   extensionality-binary-reflecting-map-Equivalence-Relation :

--- a/src/foundation/binary-relations.lagda.md
+++ b/src/foundation/binary-relations.lagda.md
@@ -135,15 +135,15 @@ module _
   id-equiv-Relation : equiv-Relation R R
   id-equiv-Relation x y = id-equiv
 
-  is-contr-total-equiv-Relation :
+  is-torsorial-equiv-Relation :
     is-contr (Σ (Relation l2 A) (equiv-Relation R))
-  is-contr-total-equiv-Relation =
-    is-contr-total-Eq-Π
+  is-torsorial-equiv-Relation =
+    is-torsorial-Eq-Π
       ( λ x P → (y : A) → R x y ≃ P y)
       ( λ x →
-        is-contr-total-Eq-Π
+        is-torsorial-Eq-Π
           ( λ y P → R x y ≃ P)
-          ( λ y → is-contr-total-equiv (R x y)))
+          ( λ y → is-torsorial-equiv (R x y)))
 
   equiv-eq-Relation : (S : Relation l2 A) → (R ＝ S) → equiv-Relation R S
   equiv-eq-Relation .R refl = id-equiv-Relation
@@ -151,7 +151,7 @@ module _
   is-equiv-equiv-eq-Relation :
     (S : Relation l2 A) → is-equiv (equiv-eq-Relation S)
   is-equiv-equiv-eq-Relation =
-    fundamental-theorem-id is-contr-total-equiv-Relation equiv-eq-Relation
+    fundamental-theorem-id is-torsorial-equiv-Relation equiv-eq-Relation
 
   extensionality-Relation : (S : Relation l2 A) → (R ＝ S) ≃ equiv-Relation R S
   pr1 (extensionality-Relation S) = equiv-eq-Relation S
@@ -180,12 +180,12 @@ module _
   refl-relates-same-elements-Relation-Prop x =
     refl-has-same-elements-subtype (R x)
 
-  is-contr-total-relates-same-elements-Relation-Prop :
+  is-torsorial-relates-same-elements-Relation-Prop :
     is-contr (Σ (Relation-Prop l2 A) (relates-same-elements-Relation-Prop R))
-  is-contr-total-relates-same-elements-Relation-Prop =
-    is-contr-total-Eq-Π
+  is-torsorial-relates-same-elements-Relation-Prop =
+    is-torsorial-Eq-Π
       ( λ x P → has-same-elements-subtype (R x) P)
-      ( λ x → is-contr-total-has-same-elements-subtype (R x))
+      ( λ x → is-torsorial-has-same-elements-subtype (R x))
 
   relates-same-elements-eq-Relation-Prop :
     (S : Relation-Prop l2 A) →
@@ -198,7 +198,7 @@ module _
     is-equiv (relates-same-elements-eq-Relation-Prop S)
   is-equiv-relates-same-elements-eq-Relation-Prop =
     fundamental-theorem-id
-      is-contr-total-relates-same-elements-Relation-Prop
+      is-torsorial-relates-same-elements-Relation-Prop
       relates-same-elements-eq-Relation-Prop
 
   extensionality-Relation-Prop :

--- a/src/foundation/category-of-sets.lagda.md
+++ b/src/foundation/category-of-sets.lagda.md
@@ -67,7 +67,7 @@ is-large-category-Set-Large-Precategory {l} X =
     ( is-contr-equiv'
       ( Σ (Set l) (type-equiv-Set X))
       ( equiv-tot (equiv-iso-equiv-Set X))
-      ( is-contr-total-equiv-Set X))
+      ( is-torsorial-equiv-Set X))
     ( iso-eq-Set X)
 
 Set-Large-Category : Large-Category lsuc (_⊔_)

--- a/src/foundation/cones-over-cospans.lagda.md
+++ b/src/foundation/cones-over-cospans.lagda.md
@@ -122,27 +122,27 @@ module _
   htpy-eq-cone : (c c' : cone f g C) → c ＝ c' → htpy-cone c c'
   htpy-eq-cone c .c refl = refl-htpy-cone c
 
-  is-contr-total-htpy-cone :
+  is-torsorial-htpy-cone :
     (c : cone f g C) → is-contr (Σ (cone f g C) (htpy-cone c))
-  is-contr-total-htpy-cone c =
-    is-contr-total-Eq-structure
+  is-torsorial-htpy-cone c =
+    is-torsorial-Eq-structure
       ( λ p qH K →
         Σ ( horizontal-map-cone f g c ~ pr1 qH)
           ( coherence-htpy-cone c (p , qH) K))
-      ( is-contr-total-htpy (vertical-map-cone f g c))
+      ( is-torsorial-htpy (vertical-map-cone f g c))
       ( vertical-map-cone f g c , refl-htpy)
-      ( is-contr-total-Eq-structure
+      ( is-torsorial-Eq-structure
         ( λ q H →
           coherence-htpy-cone c
             ( vertical-map-cone f g c , q , H)
             ( refl-htpy))
-        ( is-contr-total-htpy (horizontal-map-cone f g c))
+        ( is-torsorial-htpy (horizontal-map-cone f g c))
         ( horizontal-map-cone f g c , refl-htpy)
-        ( is-contr-total-htpy (coherence-square-cone f g c ∙h refl-htpy)))
+        ( is-torsorial-htpy (coherence-square-cone f g c ∙h refl-htpy)))
 
   is-equiv-htpy-eq-cone : (c c' : cone f g C) → is-equiv (htpy-eq-cone c c')
   is-equiv-htpy-eq-cone c =
-    fundamental-theorem-id (is-contr-total-htpy-cone c) (htpy-eq-cone c)
+    fundamental-theorem-id (is-torsorial-htpy-cone c) (htpy-eq-cone c)
 
   extensionality-cone : (c c' : cone f g C) → (c ＝ c') ≃ htpy-cone c c'
   pr1 (extensionality-cone c c') = htpy-eq-cone c c'

--- a/src/foundation/cones-over-towers.lagda.md
+++ b/src/foundation/cones-over-towers.lagda.md
@@ -99,22 +99,22 @@ module _
   htpy-eq-cone-tower : (c c' : cone-tower A X) → c ＝ c' → htpy-cone-tower c c'
   htpy-eq-cone-tower c .c refl = refl-htpy-cone-tower c
 
-  is-contr-total-htpy-cone-tower :
+  is-torsorial-htpy-cone-tower :
     (c : cone-tower A X) → is-contr (Σ (cone-tower A X) (htpy-cone-tower c))
-  is-contr-total-htpy-cone-tower c =
-    is-contr-total-Eq-structure
+  is-torsorial-htpy-cone-tower c =
+    is-torsorial-Eq-structure
       ( λ x z → coherence-htpy-cone-tower c (x , z))
-      ( is-contr-total-binary-htpy (map-cone-tower A c))
+      ( is-torsorial-binary-htpy (map-cone-tower A c))
       ( map-cone-tower A c , (λ n → refl-htpy))
-      ( is-contr-total-Eq-Π
+      ( is-torsorial-Eq-Π
         ( λ n → (coherence-cone-tower A c n ∙h refl-htpy) ~_)
-        ( λ n → is-contr-total-htpy (coherence-cone-tower A c n ∙h refl-htpy)))
+        ( λ n → is-torsorial-htpy (coherence-cone-tower A c n ∙h refl-htpy)))
 
   is-equiv-htpy-eq-cone-tower :
     (c c' : cone-tower A X) → is-equiv (htpy-eq-cone-tower c c')
   is-equiv-htpy-eq-cone-tower c =
     fundamental-theorem-id
-      ( is-contr-total-htpy-cone-tower c)
+      ( is-torsorial-htpy-cone-tower c)
       ( htpy-eq-cone-tower c)
 
   extensionality-cone-tower :

--- a/src/foundation/connected-components-universes.lagda.md
+++ b/src/foundation/connected-components-universes.lagda.md
@@ -95,12 +95,12 @@ equiv-eq-component-UU-Level {X = X} refl =
   id-equiv-component-UU-Level X
 
 abstract
-  is-contr-total-equiv-component-UU-Level :
+  is-torsorial-equiv-component-UU-Level :
     {l1 l2 : Level} {A : UU l2} (X : component-UU-Level l1 A) →
     is-contr (Σ (component-UU-Level l1 A) (equiv-component-UU-Level X))
-  is-contr-total-equiv-component-UU-Level X =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-equiv (type-component-UU-Level X))
+  is-torsorial-equiv-component-UU-Level X =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-equiv (type-component-UU-Level X))
       ( λ Y → is-prop-mere-equiv _ Y)
       ( type-component-UU-Level X)
       ( id-equiv)
@@ -112,7 +112,7 @@ abstract
     is-equiv (equiv-eq-component-UU-Level {X = X} {Y})
   is-equiv-equiv-eq-component-UU-Level X =
     fundamental-theorem-id
-      ( is-contr-total-equiv-component-UU-Level X)
+      ( is-torsorial-equiv-component-UU-Level X)
       ( λ Y → equiv-eq-component-UU-Level {X = X} {Y})
 
 eq-equiv-component-UU-Level :
@@ -135,11 +135,11 @@ equiv-eq-component-UU :
 equiv-eq-component-UU p = equiv-eq-component-UU-Level p
 
 abstract
-  is-contr-total-equiv-component-UU :
+  is-torsorial-equiv-component-UU :
     {l1 : Level} {A : UU l1} (X : component-UU A) →
     is-contr (Σ (component-UU A) (equiv-component-UU X))
-  is-contr-total-equiv-component-UU X =
-    is-contr-total-equiv-component-UU-Level X
+  is-torsorial-equiv-component-UU X =
+    is-torsorial-equiv-component-UU-Level X
 
 abstract
   is-equiv-equiv-eq-component-UU :

--- a/src/foundation/connected-maps.lagda.md
+++ b/src/foundation/connected-maps.lagda.md
@@ -85,12 +85,12 @@ module _
   refl-htpy-connected-map : (f : connected-map k A B) → htpy-connected-map f f
   refl-htpy-connected-map f = refl-htpy
 
-  is-contr-total-htpy-connected-map :
+  is-torsorial-htpy-connected-map :
     (f : connected-map k A B) →
     is-contr (Σ (connected-map k A B) (htpy-connected-map f))
-  is-contr-total-htpy-connected-map f =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-htpy (map-connected-map f))
+  is-torsorial-htpy-connected-map f =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-htpy (map-connected-map f))
       ( is-prop-is-connected-map k)
       ( map-connected-map f)
       ( refl-htpy-connected-map f)
@@ -104,7 +104,7 @@ module _
     (f g : connected-map k A B) → is-equiv (htpy-eq-connected-map f g)
   is-equiv-htpy-eq-connected-map f =
     fundamental-theorem-id
-      ( is-contr-total-htpy-connected-map f)
+      ( is-torsorial-htpy-connected-map f)
       ( htpy-eq-connected-map f)
 
   extensionality-connected-map :
@@ -254,14 +254,14 @@ module _
   pr1 id-equiv-Connected-Map = id-equiv
   pr2 id-equiv-Connected-Map = refl-htpy
 
-  is-contr-total-equiv-Connected-Map :
+  is-torsorial-equiv-Connected-Map :
     is-contr (Σ (Connected-Map l2 k A) (equiv-Connected-Map f))
-  is-contr-total-equiv-Connected-Map =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-Connected-Map =
+    is-torsorial-Eq-structure
       ( λ Y g e → (map-equiv e ∘ map-Connected-Map f) ~ map-connected-map g)
-      ( is-contr-total-equiv (type-Connected-Map f))
+      ( is-torsorial-equiv (type-Connected-Map f))
       ( pair (type-Connected-Map f) id-equiv)
-      ( is-contr-total-htpy-connected-map (connected-map-Connected-Map f))
+      ( is-torsorial-htpy-connected-map (connected-map-Connected-Map f))
 
   equiv-eq-Connected-Map :
     (g : Connected-Map l2 k A) → (f ＝ g) → equiv-Connected-Map f g
@@ -271,7 +271,7 @@ module _
     (g : Connected-Map l2 k A) → is-equiv (equiv-eq-Connected-Map g)
   is-equiv-equiv-eq-Connected-Map =
     fundamental-theorem-id
-      is-contr-total-equiv-Connected-Map
+      is-torsorial-equiv-Connected-Map
       equiv-eq-Connected-Map
 
   extensionality-Connected-Map :
@@ -308,19 +308,19 @@ module _
   pr1 id-equiv-Connected-Map-Into-Truncated-Type = id-equiv
   pr2 id-equiv-Connected-Map-Into-Truncated-Type = refl-htpy
 
-  is-contr-total-equiv-Connected-Map-Into-Truncated-Type :
+  is-torsorial-equiv-Connected-Map-Into-Truncated-Type :
     is-contr
       ( Σ ( Connected-Map-Into-Truncated-Type l2 k l A)
           ( equiv-Connected-Map-Into-Truncated-Type f))
-  is-contr-total-equiv-Connected-Map-Into-Truncated-Type =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-Connected-Map-Into-Truncated-Type =
+    is-torsorial-Eq-structure
       ( λ Y g e →
         ( map-equiv e ∘ map-Connected-Map-Into-Truncated-Type f) ~
         ( map-connected-map g))
-      ( is-contr-total-equiv-Truncated-Type
+      ( is-torsorial-equiv-Truncated-Type
         ( truncated-type-Connected-Map-Into-Truncated-Type f))
       ( pair (truncated-type-Connected-Map-Into-Truncated-Type f) id-equiv)
-      ( is-contr-total-htpy-connected-map
+      ( is-torsorial-htpy-connected-map
         ( connected-map-Connected-Map-Into-Truncated-Type f))
 
   equiv-eq-Connected-Map-Into-Truncated-Type :
@@ -334,7 +334,7 @@ module _
     is-equiv (equiv-eq-Connected-Map-Into-Truncated-Type g)
   is-equiv-equiv-eq-Connected-Map-Into-Truncated-Type =
     fundamental-theorem-id
-      is-contr-total-equiv-Connected-Map-Into-Truncated-Type
+      is-torsorial-equiv-Connected-Map-Into-Truncated-Type
       equiv-eq-Connected-Map-Into-Truncated-Type
 
   extensionality-Connected-Map-Into-Truncated-Type :

--- a/src/foundation/coproduct-decompositions-subuniverse.lagda.md
+++ b/src/foundation/coproduct-decompositions-subuniverse.lagda.md
@@ -236,24 +236,24 @@ module _
           P A X)
         ( x))
 
-  is-contr-total-equiv-binary-coproduct-Decomposition-subuniverse :
+  is-torsorial-equiv-binary-coproduct-Decomposition-subuniverse :
     is-contr
       ( Σ ( binary-coproduct-Decomposition-subuniverse P A)
           ( equiv-binary-coproduct-Decomposition-subuniverse P A X))
-  is-contr-total-equiv-binary-coproduct-Decomposition-subuniverse =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-binary-coproduct-Decomposition-subuniverse =
+    is-torsorial-Eq-structure
       ( _)
-      ( is-contr-total-equiv-subuniverse P
+      ( is-torsorial-equiv-subuniverse P
         ( left-summand-binary-coproduct-Decomposition-subuniverse P A X))
       ( left-summand-binary-coproduct-Decomposition-subuniverse P A X ,
         id-equiv)
-      ( is-contr-total-Eq-structure
+      ( is-torsorial-Eq-structure
         ( _)
-        ( is-contr-total-equiv-subuniverse P
+        ( is-torsorial-equiv-subuniverse P
           ( right-summand-binary-coproduct-Decomposition-subuniverse P A X))
         ( right-summand-binary-coproduct-Decomposition-subuniverse P A X ,
           id-equiv)
-        ( is-contr-total-htpy-equiv
+        ( is-torsorial-htpy-equiv
           ( equiv-coprod id-equiv id-equiv ∘e
             matching-correspondence-binary-coproduct-Decomposition-subuniverse
               P A X)))
@@ -269,7 +269,7 @@ module _
     is-equiv (equiv-eq-binary-coproduct-Decomposition-subuniverse Y)
   is-equiv-equiv-eq-binary-coproduct-Decomposition-subuniverse =
     fundamental-theorem-id
-      is-contr-total-equiv-binary-coproduct-Decomposition-subuniverse
+      is-torsorial-equiv-binary-coproduct-Decomposition-subuniverse
       equiv-eq-binary-coproduct-Decomposition-subuniverse
 
   extensionality-binary-coproduct-Decomposition-subuniverse :
@@ -391,7 +391,7 @@ module _
             ( commutative-coprod _ _)
             ( inclusion-subuniverse P X)) ∘e
         ( ( left-unit-law-Σ-is-contr
-            ( is-contr-total-equiv-subuniverse' P
+            ( is-torsorial-equiv-subuniverse' P
               ( ( inclusion-subuniverse P (pr1 (pr2 x)) +
                   inclusion-subuniverse P (pr2 (pr2 x))) ,
                 ( C1 (pr2 (pr1 (pr2 x))) (pr2 (pr2 (pr2 x)))))))
@@ -464,7 +464,7 @@ module _
     ( equiv-tot
       ( λ x →
         left-unit-law-Σ-is-contr
-          ( is-contr-total-equiv-subuniverse' P
+          ( is-torsorial-equiv-subuniverse' P
             ( ( inclusion-subuniverse P (pr1 (pr2 x)) +
                 inclusion-subuniverse P (pr2 (pr2 x))) ,
               ( C1 (pr2 (pr1 (pr2 x))) (pr2 (pr2 (pr2 x))))))

--- a/src/foundation/coproduct-decompositions.lagda.md
+++ b/src/foundation/coproduct-decompositions.lagda.md
@@ -184,20 +184,20 @@ module _
         ( matching-correspondence-binary-coproduct-Decomposition X)
         ( x))
 
-  is-contr-total-equiv-binary-coproduct-Decomposition :
+  is-torsorial-equiv-binary-coproduct-Decomposition :
     is-contr
       ( Σ ( binary-coproduct-Decomposition l2 l3 A)
           ( equiv-binary-coproduct-Decomposition X))
-  is-contr-total-equiv-binary-coproduct-Decomposition =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-binary-coproduct-Decomposition =
+    is-torsorial-Eq-structure
       ( _)
-      ( is-contr-total-equiv ( left-summand-binary-coproduct-Decomposition X))
+      ( is-torsorial-equiv ( left-summand-binary-coproduct-Decomposition X))
       ( left-summand-binary-coproduct-Decomposition X , id-equiv)
-      ( is-contr-total-Eq-structure
+      ( is-torsorial-Eq-structure
         ( _)
-        ( is-contr-total-equiv (right-summand-binary-coproduct-Decomposition X))
+        ( is-torsorial-equiv (right-summand-binary-coproduct-Decomposition X))
         ( right-summand-binary-coproduct-Decomposition X , id-equiv)
-        ( is-contr-total-htpy-equiv
+        ( is-torsorial-htpy-equiv
           ( equiv-coprod id-equiv id-equiv ∘e
             matching-correspondence-binary-coproduct-Decomposition X)))
 
@@ -212,7 +212,7 @@ module _
     is-equiv (equiv-eq-binary-coproduct-Decomposition Y)
   is-equiv-equiv-eq-binary-coproduct-Decomposition =
     fundamental-theorem-id
-      is-contr-total-equiv-binary-coproduct-Decomposition
+      is-torsorial-equiv-binary-coproduct-Decomposition
       equiv-eq-binary-coproduct-Decomposition
 
   extensionality-binary-coproduct-Decomposition :

--- a/src/foundation/cospans.lagda.md
+++ b/src/foundation/cospans.lagda.md
@@ -109,23 +109,23 @@ module _
   htpy-eq-cospan : (c d : cospan l A B) → c ＝ d → htpy-cospan c d
   htpy-eq-cospan c .c refl = refl-htpy-cospan c
 
-  is-contr-total-htpy-cospan :
+  is-torsorial-htpy-cospan :
     (c : cospan l A B) → is-contr (Σ (cospan l A B) (htpy-cospan c))
-  is-contr-total-htpy-cospan c =
-    is-contr-total-Eq-structure
+  is-torsorial-htpy-cospan c =
+    is-torsorial-Eq-structure
       ( λ X d e → coherence-hom-codomain-cospan c (X , d) (map-equiv e))
-      ( is-contr-total-equiv (pr1 c))
+      ( is-torsorial-equiv (pr1 c))
       ( codomain-cospan c , id-equiv)
-      ( is-contr-total-Eq-structure
+      ( is-torsorial-Eq-structure
         ( λ x f a → coherence-triangle-maps f id (right-map-cospan c))
-        ( is-contr-total-htpy' (left-map-cospan c))
+        ( is-torsorial-htpy' (left-map-cospan c))
         ( left-map-cospan c , refl-htpy)
-        (is-contr-total-htpy' (right-map-cospan c)))
+        (is-torsorial-htpy' (right-map-cospan c)))
 
   is-equiv-htpy-eq-cospan :
     (c d : cospan l A B) → is-equiv (htpy-eq-cospan c d)
   is-equiv-htpy-eq-cospan c =
-    fundamental-theorem-id (is-contr-total-htpy-cospan c) (htpy-eq-cospan c)
+    fundamental-theorem-id (is-torsorial-htpy-cospan c) (htpy-eq-cospan c)
 
   extensionality-cospan :
     (c d : cospan l A B) → (c ＝ d) ≃ (htpy-cospan c d)

--- a/src/foundation/decidable-embeddings.lagda.md
+++ b/src/foundation/decidable-embeddings.lagda.md
@@ -284,12 +284,12 @@ htpy-eq-decidable-emb :
 htpy-eq-decidable-emb f .f refl = refl-htpy-decidable-emb f
 
 abstract
-  is-contr-total-htpy-decidable-emb :
+  is-torsorial-htpy-decidable-emb :
     {l1 l2 : Level} {A : UU l1} {B : UU l2} (f : A ↪ᵈ B) →
     is-contr (Σ (A ↪ᵈ B) (htpy-decidable-emb f))
-  is-contr-total-htpy-decidable-emb f =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-htpy (map-decidable-emb f))
+  is-torsorial-htpy-decidable-emb f =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-htpy (map-decidable-emb f))
       ( is-prop-is-decidable-emb)
       ( map-decidable-emb f)
       ( refl-htpy)
@@ -301,7 +301,7 @@ abstract
     is-equiv (htpy-eq-decidable-emb f g)
   is-equiv-htpy-eq-decidable-emb f =
     fundamental-theorem-id
-      ( is-contr-total-htpy-decidable-emb f)
+      ( is-torsorial-htpy-decidable-emb f)
       ( htpy-eq-decidable-emb f)
 
 eq-htpy-decidable-emb :

--- a/src/foundation/decidable-equivalence-relations.lagda.md
+++ b/src/foundation/decidable-equivalence-relations.lagda.md
@@ -298,17 +298,17 @@ module _
                 ( λ K → transitive-Decidable-Equivalence-Relation R a x y K
                   ( symmetric-Decidable-Equivalence-Relation R x a H))))
 
-    is-contr-total-subtype-equivalence-class-Decidable-Equivalence-Relation :
+    is-torsorial-subtype-equivalence-class-Decidable-Equivalence-Relation :
       is-contr
         ( Σ ( equivalence-class-Decidable-Equivalence-Relation R)
             ( λ P →
               is-in-subtype-equivalence-class-Decidable-Equivalence-Relation
                 R P a))
     pr1
-      is-contr-total-subtype-equivalence-class-Decidable-Equivalence-Relation =
+      is-torsorial-subtype-equivalence-class-Decidable-Equivalence-Relation =
       center-total-subtype-equivalence-class-Decidable-Equivalence-Relation
     pr2
-      is-contr-total-subtype-equivalence-class-Decidable-Equivalence-Relation =
+      is-torsorial-subtype-equivalence-class-Decidable-Equivalence-Relation =
       contraction-total-subtype-equivalence-class-Decidable-Equivalence-Relation
 
   related-eq-quotient-Decidable-Equivalence-Relation :
@@ -325,7 +325,7 @@ module _
       is-equiv (related-eq-quotient-Decidable-Equivalence-Relation q)
     is-equiv-related-eq-quotient-Decidable-Equivalence-Relation =
       fundamental-theorem-id
-        ( is-contr-total-subtype-equivalence-class-Decidable-Equivalence-Relation)
+        ( is-torsorial-subtype-equivalence-class-Decidable-Equivalence-Relation)
         ( related-eq-quotient-Decidable-Equivalence-Relation)
 
   abstract

--- a/src/foundation/decidable-propositions.lagda.md
+++ b/src/foundation/decidable-propositions.lagda.md
@@ -99,9 +99,9 @@ module _
   is-retraction-map-inv-equiv-bool-Decidable-Prop' :
     (map-inv-equiv-bool-Decidable-Prop' ∘ map-equiv-bool-Decidable-Prop') ~ id
   is-retraction-map-inv-equiv-bool-Decidable-Prop' (inl x) =
-    ap inl (eq-is-contr is-contr-total-true-Prop)
+    ap inl (eq-is-contr is-torsorial-true-Prop)
   is-retraction-map-inv-equiv-bool-Decidable-Prop' (inr x) =
-    ap inr (eq-is-contr is-contr-total-false-Prop)
+    ap inr (eq-is-contr is-torsorial-false-Prop)
 
   is-equiv-map-equiv-bool-Decidable-Prop' :
     is-equiv map-equiv-bool-Decidable-Prop'

--- a/src/foundation/equality-coproduct-types.lagda.md
+++ b/src/foundation/equality-coproduct-types.lagda.md
@@ -73,23 +73,23 @@ module _
   eq-Eq-coprod .(inl x) .(inl x) (Eq-eq-coprod-inl {x} {.x} refl) = refl
   eq-Eq-coprod .(inr x) .(inr x) (Eq-eq-coprod-inr {x} {.x} refl) = refl
 
-  is-contr-total-Eq-coprod :
+  is-torsorial-Eq-coprod :
     (x : A + B) → is-contr (Σ (A + B) (Eq-coprod x))
-  pr1 (pr1 (is-contr-total-Eq-coprod (inl x))) = inl x
-  pr2 (pr1 (is-contr-total-Eq-coprod (inl x))) = Eq-eq-coprod-inl refl
+  pr1 (pr1 (is-torsorial-Eq-coprod (inl x))) = inl x
+  pr2 (pr1 (is-torsorial-Eq-coprod (inl x))) = Eq-eq-coprod-inl refl
   pr2
-    ( is-contr-total-Eq-coprod (inl x))
+    ( is-torsorial-Eq-coprod (inl x))
     ( pair (inl .x) (Eq-eq-coprod-inl refl)) = refl
-  pr1 (pr1 (is-contr-total-Eq-coprod (inr x))) = inr x
-  pr2 (pr1 (is-contr-total-Eq-coprod (inr x))) = Eq-eq-coprod-inr refl
+  pr1 (pr1 (is-torsorial-Eq-coprod (inr x))) = inr x
+  pr2 (pr1 (is-torsorial-Eq-coprod (inr x))) = Eq-eq-coprod-inr refl
   pr2
-    ( is-contr-total-Eq-coprod (inr x))
+    ( is-torsorial-Eq-coprod (inr x))
     ( pair .(inr x) (Eq-eq-coprod-inr refl)) = refl
 
   is-equiv-Eq-eq-coprod : (x y : A + B) → is-equiv (Eq-eq-coprod x y)
   is-equiv-Eq-eq-coprod x =
     fundamental-theorem-id
-      ( is-contr-total-Eq-coprod x)
+      ( is-torsorial-Eq-coprod x)
       ( Eq-eq-coprod x)
 
   extensionality-coprod : (x y : A + B) → (x ＝ y) ≃ Eq-coprod x y
@@ -234,7 +234,7 @@ module _
         ( is-contr-equiv
           ( Σ A (Id x))
           ( equiv-tot (compute-eq-coprod-inl-inl x))
-          ( is-contr-total-path x))
+          ( is-torsorial-path x))
         ( λ y → ap inl)
 
   emb-inl : A ↪ (A + B)
@@ -248,7 +248,7 @@ module _
         ( is-contr-equiv
           ( Σ B (Id x))
           ( equiv-tot (compute-eq-coprod-inr-inr x))
-          ( is-contr-total-path x))
+          ( is-torsorial-path x))
         ( λ y → ap inr)
 
   emb-inr : B ↪ (A + B)

--- a/src/foundation/equality-dependent-function-types.lagda.md
+++ b/src/foundation/equality-dependent-function-types.lagda.md
@@ -30,28 +30,28 @@ characterize the identity types of `(x : A) → B x`.
 ### Contractibility
 
 ```agda
-is-contr-total-Eq-Π :
+is-torsorial-Eq-Π :
   { l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2} (C : (x : A) → B x → UU l3) →
-  ( is-contr-total-C : (x : A) → is-contr (Σ (B x) (C x))) →
+  ( is-torsorial-C : (x : A) → is-contr (Σ (B x) (C x))) →
   is-contr (Σ ((x : A) → B x) (λ g → (x : A) → C x (g x)))
-is-contr-total-Eq-Π {A = A} {B} C is-contr-total-C =
+is-torsorial-Eq-Π {A = A} {B} C is-torsorial-C =
   is-contr-equiv'
     ( (x : A) → Σ (B x) (C x))
     ( distributive-Π-Σ)
-    ( is-contr-Π is-contr-total-C)
+    ( is-contr-Π is-torsorial-C)
 
-is-contr-total-Eq-implicit-Π :
+is-torsorial-Eq-implicit-Π :
   { l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2} (C : (x : A) → B x → UU l3) →
-  ( is-contr-total-C : (x : A) → is-contr (Σ (B x) (C x))) →
+  ( is-torsorial-C : (x : A) → is-contr (Σ (B x) (C x))) →
   is-contr (Σ ({x : A} → B x) (λ g → {x : A} → C x (g {x})))
-is-contr-total-Eq-implicit-Π {A = A} {B} C is-contr-total-C =
+is-torsorial-Eq-implicit-Π {A = A} {B} C is-torsorial-C =
   is-contr-equiv
     ( Σ ((x : A) → B x) (λ g → (x : A) → C x (g x)))
     ( equiv-Σ
       ( λ g → (x : A) → C x (g x))
       ( equiv-explicit-implicit-Π)
       ( λ _ → equiv-explicit-implicit-Π))
-    ( is-contr-total-Eq-Π C is-contr-total-C)
+    ( is-torsorial-Eq-Π C is-torsorial-C)
 ```
 
 ### Extensionality
@@ -74,7 +74,7 @@ module _
       (g : (x : A) → B x) → is-equiv (map-extensionality-Π e g)
     is-equiv-map-extensionality-Π e =
       fundamental-theorem-id
-        ( is-contr-total-Eq-Π Eq-B
+        ( is-torsorial-Eq-Π Eq-B
           ( λ x →
             fundamental-theorem-id'
               ( λ y → map-equiv (e x y))

--- a/src/foundation/equivalence-classes.lagda.md
+++ b/src/foundation/equivalence-classes.lagda.md
@@ -195,12 +195,12 @@ module _
   refl-has-same-elements-equivalence-class C =
     refl-has-same-elements-subtype (subtype-equivalence-class R C)
 
-  is-contr-total-has-same-elements-equivalence-class :
+  is-torsorial-has-same-elements-equivalence-class :
     (C : equivalence-class R) →
     is-contr (Σ (equivalence-class R) (has-same-elements-equivalence-class C))
-  is-contr-total-has-same-elements-equivalence-class C =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-has-same-elements-subtype
+  is-torsorial-has-same-elements-equivalence-class C =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-has-same-elements-subtype
         ( subtype-equivalence-class R C))
       ( is-prop-is-equivalence-class R)
       ( subtype-equivalence-class R C)
@@ -218,7 +218,7 @@ module _
     is-equiv (has-same-elements-eq-equivalence-class C D)
   is-equiv-has-same-elements-eq-equivalence-class C =
     fundamental-theorem-id
-      ( is-contr-total-has-same-elements-equivalence-class C)
+      ( is-torsorial-has-same-elements-equivalence-class C)
       ( has-same-elements-eq-equivalence-class C)
 
   extensionality-equivalence-class :
@@ -313,13 +313,13 @@ module _
       ( λ D → is-in-equivalence-class-Prop R D a)
       ( eq-class-equivalence-class R C H)
 
-  is-contr-total-is-in-equivalence-class :
+  is-torsorial-is-in-equivalence-class :
     is-contr
       ( Σ ( equivalence-class R)
           ( λ P → is-in-equivalence-class R P a))
-  pr1 is-contr-total-is-in-equivalence-class =
+  pr1 is-torsorial-is-in-equivalence-class =
     center-total-is-in-equivalence-class
-  pr2 is-contr-total-is-in-equivalence-class =
+  pr2 is-torsorial-is-in-equivalence-class =
     contraction-total-is-in-equivalence-class
 
   is-in-equivalence-class-eq-equivalence-class :
@@ -334,7 +334,7 @@ module _
       is-equiv (is-in-equivalence-class-eq-equivalence-class q)
     is-equiv-is-in-equivalence-class-eq-equivalence-class =
       fundamental-theorem-id
-        ( is-contr-total-is-in-equivalence-class)
+        ( is-torsorial-is-in-equivalence-class)
         ( is-in-equivalence-class-eq-equivalence-class)
 ```
 

--- a/src/foundation/equivalence-extensionality.lagda.md
+++ b/src/foundation/equivalence-extensionality.lagda.md
@@ -70,9 +70,9 @@ module _
         ( H)
 
   abstract
-    is-contr-total-htpy-equiv :
+    is-torsorial-htpy-equiv :
       (e : A ≃ B) → is-contr (Σ (A ≃ B) (htpy-equiv e))
-    is-contr-total-htpy-equiv e =
+    is-torsorial-htpy-equiv e =
       fundamental-theorem-id'
         ( map-equiv ∘ extensionality-equiv e)
         ( is-equiv-map-equiv ∘ extensionality-equiv e)
@@ -108,7 +108,7 @@ module _
     induction-principle-htpy-equiv e =
       is-identity-system-is-torsorial e
         ( refl-htpy-equiv e)
-        ( is-contr-total-htpy-equiv e)
+        ( is-torsorial-htpy-equiv e)
 
   ind-htpy-equiv :
     {l3 : Level} (e : A ≃ B) (P : (e' : A ≃ B) (H : htpy-equiv e e') → UU l3) →

--- a/src/foundation/equivalence-induction.lagda.md
+++ b/src/foundation/equivalence-induction.lagda.md
@@ -136,7 +136,7 @@ module _
   abstract
     is-identity-system-equiv : section (ev-id-equiv P)
     is-identity-system-equiv =
-      is-identity-system-is-torsorial-equiv (is-contr-total-equiv A) P
+      is-identity-system-is-torsorial-equiv (is-torsorial-equiv A) P
 
   ind-equiv :
     P A id-equiv → {B : UU l1} (e : A ≃ B) → P B e
@@ -174,7 +174,7 @@ module _
       section (ev-id-equiv-subuniverse {F})
     is-identity-system-equiv-subuniverse =
       is-identity-system-is-torsorial A id-equiv
-        ( is-contr-total-equiv-subuniverse P A)
+        ( is-torsorial-equiv-subuniverse P A)
 
   ind-equiv-subuniverse :
     (F : (B : type-subuniverse P) → equiv-subuniverse P A B → UU l3) →
@@ -201,7 +201,7 @@ module _
   is-equiv-ev-id-equiv : is-equiv (ev-id-equiv P)
   is-equiv-ev-id-equiv =
     dependent-universal-property-identity-system-is-torsorial
-      ( id-equiv) (is-contr-total-equiv A) P
+      ( id-equiv) (is-torsorial-equiv A) P
 
   is-contr-map-ev-id-equiv : is-contr-map (ev-id-equiv P)
   is-contr-map-ev-id-equiv = is-contr-map-is-equiv is-equiv-ev-id-equiv
@@ -219,7 +219,7 @@ module _
     is-equiv (ev-id-equiv-subuniverse P X {F})
   is-equiv-ev-id-equiv-subuniverse =
     dependent-universal-property-identity-system-is-torsorial
-    ( id-equiv) (is-contr-total-equiv-subuniverse P X) F
+    ( id-equiv) (is-torsorial-equiv-subuniverse P X) F
 
   is-contr-map-ev-id-equiv-subuniverse :
     is-contr-map (ev-id-equiv-subuniverse P X {F})

--- a/src/foundation/equivalence-relations.lagda.md
+++ b/src/foundation/equivalence-relations.lagda.md
@@ -66,14 +66,14 @@ module _
   refl-relate-same-elements-Equivalence-Relation =
     refl-relates-same-elements-Relation-Prop (prop-Equivalence-Relation R)
 
-  is-contr-total-relate-same-elements-Equivalence-Relation :
+  is-torsorial-relate-same-elements-Equivalence-Relation :
     is-contr
       ( Σ
         ( Equivalence-Relation l2 A)
         ( relate-same-elements-Equivalence-Relation R))
-  is-contr-total-relate-same-elements-Equivalence-Relation =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-relates-same-elements-Relation-Prop
+  is-torsorial-relate-same-elements-Equivalence-Relation =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-relates-same-elements-Relation-Prop
         ( prop-Equivalence-Relation R))
       ( is-prop-is-equivalence-relation)
       ( prop-Equivalence-Relation R)
@@ -91,7 +91,7 @@ module _
     is-equiv (relate-same-elements-eq-Equivalence-Relation S)
   is-equiv-relate-same-elements-eq-Equivalence-Relation =
     fundamental-theorem-id
-      is-contr-total-relate-same-elements-Equivalence-Relation
+      is-torsorial-relate-same-elements-Equivalence-Relation
       relate-same-elements-eq-Equivalence-Relation
 
   extensionality-Equivalence-Relation :
@@ -141,7 +141,7 @@ module _
           ( equiv-right-swap-Σ)
           ( λ Q → id-equiv)))
       ( is-contr-Σ
-        ( is-contr-total-is-in-equivalence-class R x)
+        ( is-torsorial-is-in-equivalence-class R x)
         ( center-total-is-in-equivalence-class R x)
         ( is-proof-irrelevant-is-prop
           ( is-prop-type-trunc-Prop)

--- a/src/foundation/equivalences-towers.lagda.md
+++ b/src/foundation/equivalences-towers.lagda.md
@@ -72,23 +72,23 @@ equiv-eq-tower :
   {l : Level} (A B : tower l) → A ＝ B → equiv-tower A B
 equiv-eq-tower A .A refl = id-equiv-tower A
 
-is-contr-total-equiv-tower :
+is-torsorial-equiv-tower :
   {l : Level} (A : tower l) →
   is-contr (Σ (tower l) (equiv-tower A))
-is-contr-total-equiv-tower A =
-  is-contr-total-Eq-structure _
-    ( is-contr-total-Eq-Π
+is-torsorial-equiv-tower A =
+  is-torsorial-Eq-structure _
+    ( is-torsorial-Eq-Π
       ( λ n → type-tower A n ≃_)
-      ( λ n → is-contr-total-equiv (type-tower A n)))
+      ( λ n → is-torsorial-equiv (type-tower A n)))
     ( type-tower A , λ n → id-equiv)
-    ( is-contr-total-Eq-Π _
-      ( λ n → is-contr-total-htpy (map-tower A n)))
+    ( is-torsorial-Eq-Π _
+      ( λ n → is-torsorial-htpy (map-tower A n)))
 
 is-equiv-equiv-eq-tower :
   {l : Level} (A B : tower l) → is-equiv (equiv-eq-tower A B)
 is-equiv-equiv-eq-tower A =
   fundamental-theorem-id
-    ( is-contr-total-equiv-tower A)
+    ( is-torsorial-equiv-tower A)
     ( equiv-eq-tower A)
 
 eq-equiv-tower :

--- a/src/foundation/fibered-maps.lagda.md
+++ b/src/foundation/fibered-maps.lagda.md
@@ -135,20 +135,20 @@ module _
   htpy-eq-map-over : (m m' : map-over f g i) → m ＝ m' → htpy-map-over m m'
   htpy-eq-map-over m .m refl = refl-htpy-map-over m
 
-  is-contr-total-htpy-map-over :
+  is-torsorial-htpy-map-over :
     (m : map-over f g i) → is-contr (Σ (map-over f g i) (htpy-map-over m))
-  is-contr-total-htpy-map-over m =
-    is-contr-total-Eq-structure
+  is-torsorial-htpy-map-over m =
+    is-torsorial-Eq-structure
       ( λ g G → coherence-htpy-map-over m (g , G))
-      ( is-contr-total-htpy (map-total-map-over f g i m))
+      ( is-torsorial-htpy (map-total-map-over f g i m))
       ( map-total-map-over f g i m , refl-htpy)
-      ( is-contr-total-htpy
+      ( is-torsorial-htpy
         ( is-map-over-map-total-map-over f g i m ∙h refl-htpy))
 
   is-equiv-htpy-eq-map-over :
     (m m' : map-over f g i) → is-equiv (htpy-eq-map-over m m')
   is-equiv-htpy-eq-map-over m =
-    fundamental-theorem-id (is-contr-total-htpy-map-over m) (htpy-eq-map-over m)
+    fundamental-theorem-id (is-torsorial-htpy-map-over m) (htpy-eq-map-over m)
 
   extensionality-map-over :
     (m m' : map-over f g i) → (m ＝ m') ≃ (htpy-map-over m m')
@@ -192,31 +192,31 @@ module _
     (m m' : fibered-map f g) → m ＝ m' → htpy-fibered-map m m'
   htpy-eq-fibered-map m .m refl = refl-htpy-fibered-map m
 
-  is-contr-total-htpy-fibered-map :
+  is-torsorial-htpy-fibered-map :
     (m : fibered-map f g) → is-contr (Σ (fibered-map f g) (htpy-fibered-map m))
-  is-contr-total-htpy-fibered-map m =
-    is-contr-total-Eq-structure
+  is-torsorial-htpy-fibered-map m =
+    is-torsorial-Eq-structure
       ( λ i hH I →
           Σ ( map-total-fibered-map f g m ~ map-total-fibered-map f g (i , hH))
             ( coherence-htpy-fibered-map m (i , hH) I))
-      ( is-contr-total-htpy (map-base-fibered-map f g m))
+      ( is-torsorial-htpy (map-base-fibered-map f g m))
       ( map-base-fibered-map f g m , refl-htpy)
-      ( is-contr-total-Eq-structure
+      ( is-torsorial-Eq-structure
         ( λ h H →
           coherence-htpy-fibered-map
             ( m)
             ( map-base-fibered-map f g m , h , H)
             ( refl-htpy))
-        ( is-contr-total-htpy (map-total-fibered-map f g m))
+        ( is-torsorial-htpy (map-total-fibered-map f g m))
         ( map-total-fibered-map f g m , refl-htpy)
-        ( is-contr-total-htpy
+        ( is-torsorial-htpy
           ( is-map-over-map-total-fibered-map f g m ∙h refl-htpy)))
 
   is-equiv-htpy-eq-fibered-map :
     (m m' : fibered-map f g) → is-equiv (htpy-eq-fibered-map m m')
   is-equiv-htpy-eq-fibered-map m =
     fundamental-theorem-id
-      ( is-contr-total-htpy-fibered-map m)
+      ( is-torsorial-htpy-fibered-map m)
       ( htpy-eq-fibered-map m)
 
   extensionality-fibered-map :

--- a/src/foundation/functional-correspondences.lagda.md
+++ b/src/foundation/functional-correspondences.lagda.md
@@ -100,19 +100,19 @@ module _
     equiv-functional-correspondence C C
   id-equiv-functional-correspondence x y = id-equiv
 
-  is-contr-total-equiv-functional-correspondence :
+  is-torsorial-equiv-functional-correspondence :
     is-contr
       ( Σ ( functional-correspondence l3 A B)
           ( equiv-functional-correspondence C))
-  is-contr-total-equiv-functional-correspondence =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-Eq-Π
+  is-torsorial-equiv-functional-correspondence =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-Eq-Π
         ( λ x D →
           (y : B x) →
           correspondence-functional-correspondence C x y ≃
           D y)
         ( λ x →
-          is-contr-total-equiv-fam
+          is-torsorial-equiv-fam
             ( correspondence-functional-correspondence
               C x)))
       ( is-prop-is-functional-correspondence)
@@ -131,7 +131,7 @@ module _
     is-equiv (equiv-eq-functional-correspondence D)
   is-equiv-equiv-eq-functional-correspondence =
     fundamental-theorem-id
-      is-contr-total-equiv-functional-correspondence
+      is-torsorial-equiv-functional-correspondence
       equiv-eq-functional-correspondence
 
   extensionality-functional-correspondence :
@@ -160,7 +160,7 @@ module _
     ((x : A) → B x) → functional-correspondence l2 A B
   pr1 (functional-correspondence-function f) x y = f x ＝ y
   pr2 (functional-correspondence-function f) x =
-    is-contr-total-path (f x)
+    is-torsorial-path (f x)
 
   function-functional-correspondence :
     {l3 : Level} → functional-correspondence l3 A B → ((x : A) → B x)

--- a/src/foundation/functoriality-coproduct-types.lagda.md
+++ b/src/foundation/functoriality-coproduct-types.lagda.md
@@ -280,11 +280,11 @@ is-contr-fiber-map-coprod {A = A} {B} {C} {D} f g =
             ( λ x →
               map-coprod (pr1 fg') (pr2 fg') x ＝ map-coprod f g x))) ∘e
         ( equiv-funext)))
-    ( is-contr-total-Eq-structure
+    ( is-torsorial-Eq-structure
       ( λ f' g' (H : f' ~ f) → (c : C) → g' c ＝ g c)
-      ( is-contr-total-htpy' f)
+      ( is-torsorial-htpy' f)
       ( pair f refl-htpy)
-      ( is-contr-total-htpy' g))
+      ( is-torsorial-htpy' g))
 
 {-
 is-emb-map-coprod :

--- a/src/foundation/functoriality-set-quotients.lagda.md
+++ b/src/foundation/functoriality-set-quotients.lagda.md
@@ -320,13 +320,13 @@ module _
   htpy-eq-hom-Equivalence-Relation f .f refl =
     refl-htpy-hom-Equivalence-Relation f
 
-  is-contr-total-htpy-hom-Equivalence-Relation :
+  is-torsorial-htpy-hom-Equivalence-Relation :
     (f : hom-Equivalence-Relation R S) →
     is-contr
       ( Σ (hom-Equivalence-Relation R S) (htpy-hom-Equivalence-Relation f))
-  is-contr-total-htpy-hom-Equivalence-Relation f =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-htpy (map-hom-Equivalence-Relation R S f))
+  is-torsorial-htpy-hom-Equivalence-Relation f =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-htpy (map-hom-Equivalence-Relation R S f))
       ( is-prop-preserves-sim-Equivalence-Relation R S)
       ( map-hom-Equivalence-Relation R S f)
       ( refl-htpy-hom-Equivalence-Relation f)
@@ -337,7 +337,7 @@ module _
     is-equiv (htpy-eq-hom-Equivalence-Relation f g)
   is-equiv-htpy-eq-hom-Equivalence-Relation f =
     fundamental-theorem-id
-      ( is-contr-total-htpy-hom-Equivalence-Relation f)
+      ( is-torsorial-htpy-hom-Equivalence-Relation f)
       ( htpy-eq-hom-Equivalence-Relation f)
 
   extensionality-hom-Equivalence-Relation :

--- a/src/foundation/fundamental-theorem-of-identity-types.lagda.md
+++ b/src/foundation/fundamental-theorem-of-identity-types.lagda.md
@@ -48,7 +48,7 @@ module _
       is-contr (Σ A B) → (f : (x : A) → a ＝ x → B x) → is-fiberwise-equiv f
     fundamental-theorem-id is-contr-AB f =
       is-fiberwise-equiv-is-equiv-tot
-        ( is-equiv-is-contr (tot f) (is-contr-total-path a) is-contr-AB)
+        ( is-equiv-is-contr (tot f) (is-torsorial-path a) is-contr-AB)
 
   abstract
     fundamental-theorem-id' :
@@ -58,7 +58,7 @@ module _
         ( Σ A (Id a))
         ( tot f)
         ( is-equiv-tot-is-fiberwise-equiv is-fiberwise-equiv-f)
-        ( is-contr-total-path a)
+        ( is-torsorial-path a)
 ```
 
 ## Corollaries
@@ -82,7 +82,7 @@ module _
         ( Σ A (Id a))
         ( tot (ind-Id a (λ x p → B x) b))
         ( is-equiv-tot-is-fiberwise-equiv H)
-        ( is-contr-total-path a)
+        ( is-torsorial-path a)
 ```
 
 ### Retracts of the identity type are equivalent to the identity type
@@ -104,8 +104,8 @@ module _
               ( pair (tot λ x → pr1 (R x))
                 ( ( inv-htpy (preserves-comp-tot i (λ x → pr1 (R x)))) ∙h
                   ( ( tot-htpy λ x → pr2 (R x)) ∙h (tot-id B)))))
-            ( is-contr-total-path a))
-          ( is-contr-total-path a))
+            ( is-torsorial-path a))
+          ( is-torsorial-path a))
 ```
 
 ### The fundamental theorem of identity types, using sections

--- a/src/foundation/homotopy-induction.lagda.md
+++ b/src/foundation/homotopy-induction.lagda.md
@@ -51,20 +51,20 @@ module _
   where
 
   abstract
-    is-contr-total-htpy : is-contr (Σ ((x : A) → B x) (λ g → f ~ g))
-    is-contr-total-htpy =
+    is-torsorial-htpy : is-contr (Σ ((x : A) → B x) (λ g → f ~ g))
+    is-torsorial-htpy =
       is-contr-equiv'
         ( Σ ((x : A) → B x) (Id f))
         ( equiv-tot (λ g → equiv-funext))
-        ( is-contr-total-path f)
+        ( is-torsorial-path f)
 
   abstract
-    is-contr-total-htpy' : is-contr (Σ ((x : A) → B x) (λ g → g ~ f))
-    is-contr-total-htpy' =
+    is-torsorial-htpy' : is-contr (Σ ((x : A) → B x) (λ g → g ~ f))
+    is-torsorial-htpy' =
       is-contr-equiv'
         ( Σ ((x : A) → B x) (λ g → g ＝ f))
         ( equiv-tot (λ g → equiv-funext))
-        ( is-contr-total-path' f)
+        ( is-torsorial-path' f)
 ```
 
 ### Homotopy induction is equivalent to function extensionality
@@ -79,7 +79,7 @@ abstract
     {A = A} {B} f funext-f l3 =
     is-identity-system-is-torsorial f
       ( refl-htpy)
-      ( is-contr-total-htpy f)
+      ( is-torsorial-htpy f)
 
 abstract
   function-extensionality-induction-principle-homotopies :

--- a/src/foundation/images.lagda.md
+++ b/src/foundation/images.lagda.md
@@ -85,11 +85,11 @@ module _
   Eq-eq-im x .x refl = refl-Eq-im x
 
   abstract
-    is-contr-total-Eq-im :
+    is-torsorial-Eq-im :
       (x : im f) → is-contr (Σ (im f) (Eq-im x))
-    is-contr-total-Eq-im x =
-      is-contr-total-Eq-subtype
-        ( is-contr-total-path (pr1 x))
+    is-torsorial-Eq-im x =
+      is-torsorial-Eq-subtype
+        ( is-torsorial-path (pr1 x))
         ( λ x → is-prop-type-trunc-Prop)
         ( pr1 x)
         ( refl)
@@ -99,7 +99,7 @@ module _
     is-equiv-Eq-eq-im : (x y : im f) → is-equiv (Eq-eq-im x y)
     is-equiv-Eq-eq-im x =
       fundamental-theorem-id
-        ( is-contr-total-Eq-im x)
+        ( is-torsorial-Eq-im x)
         ( Eq-eq-im x)
 
   equiv-Eq-eq-im : (x y : im f) → (x ＝ y) ≃ Eq-im x y

--- a/src/foundation/inhabited-subtypes.lagda.md
+++ b/src/foundation/inhabited-subtypes.lagda.md
@@ -118,12 +118,12 @@ module _
   refl-has-same-elements-inhabited-subtype =
     refl-has-same-elements-subtype (subtype-inhabited-subtype P)
 
-  is-contr-total-has-same-elements-inhabited-subtype :
+  is-torsorial-has-same-elements-inhabited-subtype :
     is-contr
       ( Σ (inhabited-subtype l2 A) (has-same-elements-inhabited-subtype P))
-  is-contr-total-has-same-elements-inhabited-subtype =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-has-same-elements-subtype
+  is-torsorial-has-same-elements-inhabited-subtype =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-has-same-elements-subtype
         ( subtype-inhabited-subtype P))
       ( λ Q → is-prop-type-trunc-Prop)
       ( subtype-inhabited-subtype P)

--- a/src/foundation/inhabited-types.lagda.md
+++ b/src/foundation/inhabited-types.lagda.md
@@ -98,11 +98,11 @@ module _
   {l : Level} (X : Inhabited-Type l)
   where
 
-  is-contr-total-equiv-Inhabited-Type :
+  is-torsorial-equiv-Inhabited-Type :
     is-contr (Σ (Inhabited-Type l) (equiv-Inhabited-Type X))
-  is-contr-total-equiv-Inhabited-Type =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-equiv (type-Inhabited-Type X))
+  is-torsorial-equiv-Inhabited-Type =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-equiv (type-Inhabited-Type X))
       ( λ X → is-prop-type-trunc-Prop)
       ( type-Inhabited-Type X)
       ( id-equiv)
@@ -116,7 +116,7 @@ module _
     (Y : Inhabited-Type l) → is-equiv (equiv-eq-Inhabited-Type Y)
   is-equiv-equiv-eq-Inhabited-Type =
     fundamental-theorem-id
-      is-contr-total-equiv-Inhabited-Type
+      is-torsorial-equiv-Inhabited-Type
       equiv-eq-Inhabited-Type
 
   extensionality-Inhabited-Type :
@@ -146,12 +146,12 @@ module _
   id-equiv-Fam-Inhabited-Types : equiv-Fam-Inhabited-Types Y Y
   id-equiv-Fam-Inhabited-Types = id-equiv-fam (type-Fam-Inhabited-Types Y)
 
-  is-contr-total-equiv-Fam-Inhabited-Types :
+  is-torsorial-equiv-Fam-Inhabited-Types :
     is-contr (Σ (Fam-Inhabited-Types l2 X) (equiv-Fam-Inhabited-Types Y))
-  is-contr-total-equiv-Fam-Inhabited-Types =
-    is-contr-total-Eq-Π
+  is-torsorial-equiv-Fam-Inhabited-Types =
+    is-torsorial-Eq-Π
       ( λ x → equiv-Inhabited-Type (Y x))
-      ( λ x → is-contr-total-equiv-Inhabited-Type (Y x))
+      ( λ x → is-torsorial-equiv-Inhabited-Type (Y x))
 
   equiv-eq-Fam-Inhabited-Types :
     (Z : Fam-Inhabited-Types l2 X) → (Y ＝ Z) → equiv-Fam-Inhabited-Types Y Z
@@ -161,7 +161,7 @@ module _
     (Z : Fam-Inhabited-Types l2 X) → is-equiv (equiv-eq-Fam-Inhabited-Types Z)
   is-equiv-equiv-eq-Fam-Inhabited-Types =
     fundamental-theorem-id
-      is-contr-total-equiv-Fam-Inhabited-Types
+      is-torsorial-equiv-Fam-Inhabited-Types
       equiv-eq-Fam-Inhabited-Types
 ```
 

--- a/src/foundation/invertible-maps.lagda.md
+++ b/src/foundation/invertible-maps.lagda.md
@@ -102,29 +102,29 @@ module _
     (s t : is-invertible f) → s ＝ t → htpy-is-invertible s t
   htpy-eq-is-invertible s .s refl = refl-htpy-is-invertible s
 
-  is-contr-total-htpy-is-invertible :
+  is-torsorial-htpy-is-invertible :
     (s : is-invertible f) →
     is-contr (Σ (is-invertible f) (htpy-is-invertible s))
-  is-contr-total-htpy-is-invertible s =
-    is-contr-total-Eq-structure
+  is-torsorial-htpy-is-invertible s =
+    is-torsorial-Eq-structure
       ( λ x z → coherence-htpy-is-invertible s (x , z))
-      ( is-contr-total-htpy (map-inv-is-invertible s))
+      ( is-torsorial-htpy (map-inv-is-invertible s))
       ( map-inv-is-invertible s , refl-htpy)
-      ( is-contr-total-Eq-structure
+      ( is-torsorial-Eq-structure
         ( λ x z a →
           coherence-htpy-retraction
             ( retraction-is-invertible s)
             ( retraction-is-invertible (map-inv-is-invertible s , x , z))
             ( refl-htpy))
-        ( is-contr-total-htpy (is-retraction-is-invertible s))
+        ( is-torsorial-htpy (is-retraction-is-invertible s))
         ( is-retraction-is-invertible s , refl-htpy)
-        (is-contr-total-htpy (is-section-is-invertible s)))
+        (is-torsorial-htpy (is-section-is-invertible s)))
 
   is-equiv-htpy-eq-is-invertible :
     (s t : is-invertible f) → is-equiv (htpy-eq-is-invertible s t)
   is-equiv-htpy-eq-is-invertible s =
     fundamental-theorem-id
-      ( is-contr-total-htpy-is-invertible s)
+      ( is-torsorial-htpy-is-invertible s)
       ( htpy-eq-is-invertible s)
 
   extensionality-is-invertible :
@@ -175,37 +175,37 @@ module _
     (s t : invertible-map A B) → s ＝ t → htpy-invertible-map s t
   htpy-eq-invertible-map s .s refl = refl-htpy-invertible-map s
 
-  is-contr-total-htpy-invertible-map :
+  is-torsorial-htpy-invertible-map :
     (s : invertible-map A B) →
     is-contr (Σ (invertible-map A B) (htpy-invertible-map s))
-  is-contr-total-htpy-invertible-map s =
-    is-contr-total-Eq-structure
+  is-torsorial-htpy-invertible-map s =
+    is-torsorial-Eq-structure
       ( λ x z H →
         Σ ( map-inv-invertible-map s ~ map-inv-invertible-map (x , z))
           ( coherence-htpy-invertible-map s (x , z) H))
-      ( is-contr-total-htpy (map-invertible-map s))
+      ( is-torsorial-htpy (map-invertible-map s))
       ( map-invertible-map s , refl-htpy)
-      ( is-contr-total-Eq-structure
+      ( is-torsorial-Eq-structure
         ( λ x z →
           coherence-htpy-invertible-map s
             ( map-invertible-map s , x , z)
             ( refl-htpy))
-        ( is-contr-total-htpy (map-inv-invertible-map s))
+        ( is-torsorial-htpy (map-inv-invertible-map s))
         ( map-inv-invertible-map s , refl-htpy)
-        ( is-contr-total-Eq-structure
+        ( is-torsorial-Eq-structure
           ( λ x z a →
             ( is-section-map-invertible-map s) ~
             ( is-section-map-invertible-map
               ( map-invertible-map s , map-inv-invertible-map s , x , z)))
-          ( is-contr-total-htpy (is-retraction-map-invertible-map s))
+          ( is-torsorial-htpy (is-retraction-map-invertible-map s))
           ( is-retraction-map-invertible-map s , refl-htpy)
-          ( is-contr-total-htpy (is-section-map-invertible-map s))))
+          ( is-torsorial-htpy (is-section-map-invertible-map s))))
 
   is-equiv-htpy-eq-invertible-map :
     (s t : invertible-map A B) → is-equiv (htpy-eq-invertible-map s t)
   is-equiv-htpy-eq-invertible-map s =
     fundamental-theorem-id
-      ( is-contr-total-htpy-invertible-map s)
+      ( is-torsorial-htpy-invertible-map s)
       ( htpy-eq-invertible-map s)
 
   extensionality-invertible-map :

--- a/src/foundation/involutions.lagda.md
+++ b/src/foundation/involutions.lagda.md
@@ -135,20 +135,20 @@ module _
   htpy-eq-involution : (s t : involution A) → s ＝ t → htpy-involution s t
   htpy-eq-involution s .s refl = refl-htpy-involution s
 
-  is-contr-total-htpy-involution :
+  is-torsorial-htpy-involution :
     (s : involution A) → is-contr (Σ (involution A) (htpy-involution s))
-  is-contr-total-htpy-involution s =
-    is-contr-total-Eq-structure
+  is-torsorial-htpy-involution s =
+    is-torsorial-Eq-structure
       ( λ x z → coherence-htpy-involution s (x , z))
-      ( is-contr-total-htpy (map-involution s))
+      ( is-torsorial-htpy (map-involution s))
       ( map-involution s , refl-htpy)
-      ( is-contr-total-htpy (is-involution-map-involution s))
+      ( is-torsorial-htpy (is-involution-map-involution s))
 
   is-equiv-htpy-eq-involution :
     (s t : involution A) → is-equiv (htpy-eq-involution s t)
   is-equiv-htpy-eq-involution s =
     fundamental-theorem-id
-      ( is-contr-total-htpy-involution s)
+      ( is-torsorial-htpy-involution s)
       ( htpy-eq-involution s)
 
   extensionality-involution :

--- a/src/foundation/isolated-elements.lagda.md
+++ b/src/foundation/isolated-elements.lagda.md
@@ -161,11 +161,11 @@ module _
         ( Eq-isolated-element-Prop d)
         ( cases-contraction-total-Eq-isolated-element d x (d x) e)
 
-    is-contr-total-Eq-isolated-element :
+    is-torsorial-Eq-isolated-element :
       (d : is-isolated a) → is-contr (Σ A (Eq-isolated-element d))
-    pr1 (is-contr-total-Eq-isolated-element d) =
+    pr1 (is-torsorial-Eq-isolated-element d) =
       center-total-Eq-isolated-element d
-    pr2 (is-contr-total-Eq-isolated-element d) =
+    pr2 (is-torsorial-Eq-isolated-element d) =
       contraction-total-Eq-isolated-element d
 
   abstract
@@ -173,7 +173,7 @@ module _
       (d : is-isolated a) (x : A) → is-equiv (Eq-eq-isolated-element d {x})
     is-equiv-Eq-eq-isolated-element d =
       fundamental-theorem-id
-        ( is-contr-total-Eq-isolated-element d)
+        ( is-torsorial-Eq-isolated-element d)
         ( λ x → Eq-eq-isolated-element d {x})
 
   abstract

--- a/src/foundation/logical-equivalences.lagda.md
+++ b/src/foundation/logical-equivalences.lagda.md
@@ -162,7 +162,7 @@ compute-fiber-iff-equiv :
   fiber (iff-equiv) (f , g) ≃ Σ (is-equiv f) (λ f' → map-inv-is-equiv f' ~ g)
 compute-fiber-iff-equiv {A = A} {B} (f , g) =
   ( ( ( ( ( equiv-tot (λ _ → equiv-funext)) ∘e
-          ( left-unit-law-Σ-is-contr (is-contr-total-path' f) (f , refl))) ∘e
+          ( left-unit-law-Σ-is-contr (is-torsorial-path' f) (f , refl))) ∘e
         ( inv-associative-Σ (A → B) (_＝ f) _)) ∘e
       ( equiv-tot (λ _ → equiv-left-swap-Σ))) ∘e
     ( associative-Σ (A → B) _ _)) ∘e

--- a/src/foundation/morphisms-towers.lagda.md
+++ b/src/foundation/morphisms-towers.lagda.md
@@ -129,21 +129,21 @@ module _
   htpy-eq-hom-tower : (f g : hom-tower A B) → f ＝ g → htpy-hom-tower f g
   htpy-eq-hom-tower f .f refl = refl-htpy-hom-tower f
 
-  is-contr-total-htpy-hom-tower :
+  is-torsorial-htpy-hom-tower :
     (f : hom-tower A B) → is-contr (Σ (hom-tower A B) (htpy-hom-tower f))
-  is-contr-total-htpy-hom-tower f =
-    is-contr-total-Eq-structure _
-      ( is-contr-total-binary-htpy (map-hom-tower A B f))
+  is-torsorial-htpy-hom-tower f =
+    is-torsorial-Eq-structure _
+      ( is-torsorial-binary-htpy (map-hom-tower A B f))
       ( map-hom-tower A B f , refl-binary-htpy (map-hom-tower A B f))
-      ( is-contr-total-Eq-Π _
+      ( is-torsorial-Eq-Π _
         ( λ n →
-          is-contr-total-htpy (naturality-map-hom-tower A B f n ∙h refl-htpy)))
+          is-torsorial-htpy (naturality-map-hom-tower A B f n ∙h refl-htpy)))
 
   is-equiv-htpy-eq-hom-tower :
     (f g : hom-tower A B) → is-equiv (htpy-eq-hom-tower f g)
   is-equiv-htpy-eq-hom-tower f =
     fundamental-theorem-id
-      ( is-contr-total-htpy-hom-tower f)
+      ( is-torsorial-htpy-hom-tower f)
       ( htpy-eq-hom-tower f)
 
   extensionality-hom-tower :

--- a/src/foundation/pairs-of-distinct-elements.lagda.md
+++ b/src/foundation/pairs-of-distinct-elements.lagda.md
@@ -78,16 +78,16 @@ module _
   Eq-eq-pair-of-distinct-elements p .p refl =
     refl-Eq-pair-of-distinct-elements p
 
-  is-contr-total-Eq-pair-of-distinct-elements :
+  is-torsorial-Eq-pair-of-distinct-elements :
     (p : pair-of-distinct-elements A) →
     is-contr (Σ (pair-of-distinct-elements A) (Eq-pair-of-distinct-elements p))
-  is-contr-total-Eq-pair-of-distinct-elements p =
-    is-contr-total-Eq-structure
+  is-torsorial-Eq-pair-of-distinct-elements p =
+    is-torsorial-Eq-structure
       ( λ x ynp α → second-pair-of-distinct-elements p ＝ pr1 ynp)
-      ( is-contr-total-path (first-pair-of-distinct-elements p))
+      ( is-torsorial-path (first-pair-of-distinct-elements p))
       ( pair (first-pair-of-distinct-elements p) refl)
-      ( is-contr-total-Eq-subtype
-        ( is-contr-total-path (second-pair-of-distinct-elements p))
+      ( is-torsorial-Eq-subtype
+        ( is-torsorial-path (second-pair-of-distinct-elements p))
         ( λ x → is-prop-neg)
         ( second-pair-of-distinct-elements p)
         ( refl)
@@ -98,7 +98,7 @@ module _
     is-equiv (Eq-eq-pair-of-distinct-elements p q)
   is-equiv-Eq-eq-pair-of-distinct-elements p =
     fundamental-theorem-id
-      ( is-contr-total-Eq-pair-of-distinct-elements p)
+      ( is-torsorial-Eq-pair-of-distinct-elements p)
       ( Eq-eq-pair-of-distinct-elements p)
 
   eq-Eq-pair-of-distinct-elements :

--- a/src/foundation/partitions.lagda.md
+++ b/src/foundation/partitions.lagda.md
@@ -414,10 +414,10 @@ module _
     refl-has-same-elements-inhabited-subtype
       ( inhabited-subtype-block-partition P B)
 
-  is-contr-total-has-same-elements-block-partition :
+  is-torsorial-has-same-elements-block-partition :
     is-contr
       ( Σ (block-partition P) has-same-elements-block-partition)
-  is-contr-total-has-same-elements-block-partition =
+  is-torsorial-has-same-elements-block-partition =
     is-contr-equiv'
       ( Σ ( block-partition P)
           ( λ C →
@@ -443,7 +443,7 @@ module _
     is-equiv (has-same-elements-eq-block-partition C)
   is-equiv-has-same-elements-eq-block-partition =
     fundamental-theorem-id
-      is-contr-total-has-same-elements-block-partition
+      is-torsorial-has-same-elements-block-partition
       has-same-elements-eq-block-partition
 
   extensionality-block-partition :
@@ -641,7 +641,7 @@ module _
                         ( subtype-inhabited-subtype Q x)) ∘e
                     ( equiv-inv-equiv))) ∘e
                 ( left-unit-law-Σ-is-contr
-                  ( is-contr-total-path (index-Set-Indexed-Σ-Decomposition D a))
+                  ( is-torsorial-path (index-Set-Indexed-Σ-Decomposition D a))
                   ( pair
                     ( index-Set-Indexed-Σ-Decomposition D a)
                     ( refl)))) ∘e
@@ -651,7 +651,7 @@ module _
           ( inhabited-subtype l2 A)
           ( is-block-partition-Set-Indexed-Σ-Decomposition)
           ( λ B → is-in-inhabited-subtype (pr1 B) a)))
-      ( is-contr-total-has-same-elements-inhabited-subtype
+      ( is-torsorial-has-same-elements-inhabited-subtype
         ( pair
           ( λ x →
             Id-Prop

--- a/src/foundation/pi-decompositions.lagda.md
+++ b/src/foundation/pi-decompositions.lagda.md
@@ -306,11 +306,11 @@ module _
     id-map-equiv-Π (λ x → cotype-Π-Decomposition X x) ·r
     map-matching-correspondence-Π-Decomposition X
 
-  is-contr-total-equiv-Π-Decomposition :
+  is-torsorial-equiv-Π-Decomposition :
     is-contr
       ( Σ ( Π-Decomposition l2 l3 A) (equiv-Π-Decomposition X))
-  is-contr-total-equiv-Π-Decomposition =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-Π-Decomposition =
+    is-torsorial-Eq-structure
       ( λ U Vf e →
         Σ ( (x : indexing-type-Π-Decomposition X) →
             cotype-Π-Decomposition X x ≃
@@ -320,20 +320,20 @@ module _
                 ( equiv-Π (λ u → pr1 Vf u) e f)) ∘
               ( map-matching-correspondence-Π-Decomposition X)) ~
             ( map-equiv (pr2 Vf))))
-      ( is-contr-total-equiv (indexing-type-Π-Decomposition X))
+      ( is-torsorial-equiv (indexing-type-Π-Decomposition X))
       ( pair (indexing-type-Π-Decomposition X) id-equiv)
-      ( is-contr-total-Eq-structure
+      ( is-torsorial-Eq-structure
         ( λ V g f →
           ( ( map-equiv
               ( equiv-Π (λ y → V y) id-equiv f)) ∘
             ( map-matching-correspondence-Π-Decomposition X)) ~
           ( map-equiv g))
-        ( is-contr-total-equiv-fam
+        ( is-torsorial-equiv-fam
           ( cotype-Π-Decomposition X))
         ( pair
           ( cotype-Π-Decomposition X)
           ( id-equiv-fam (cotype-Π-Decomposition X)))
-        ( is-contr-total-htpy-equiv
+        ( is-torsorial-htpy-equiv
           ( ( equiv-Π
               ( cotype-Π-Decomposition X)
               ( id-equiv)
@@ -350,7 +350,7 @@ module _
     is-equiv (equiv-eq-Π-Decomposition Y)
   is-equiv-equiv-eq-Π-Decomposition =
     fundamental-theorem-id
-      is-contr-total-equiv-Π-Decomposition
+      is-torsorial-equiv-Π-Decomposition
       equiv-eq-Π-Decomposition
 
   extensionality-Π-Decomposition :
@@ -448,17 +448,17 @@ module _
     X = fst-fibered-Π-Decomposition D
     Y = snd-fibered-Π-Decomposition D
 
-  is-contr-total-equiv-fibered-Π-Decomposition :
+  is-torsorial-equiv-fibered-Π-Decomposition :
     is-contr
       ( Σ ( fibered-Π-Decomposition l2 l3 l4 l5 A)
           ( equiv-fibered-Π-Decomposition D))
-  is-contr-total-equiv-fibered-Π-Decomposition =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-fibered-Π-Decomposition =
+    is-torsorial-Eq-structure
       ( λ X' Y' e →
         equiv-snd-fibered-Π-Decomposition D (X' , Y') e)
-      ( is-contr-total-equiv-Π-Decomposition X)
+      ( is-torsorial-equiv-Π-Decomposition X)
       ( X , id-equiv-Π-Decomposition X)
-      ( is-contr-total-Eq-structure
+      ( is-torsorial-Eq-structure
         ( λ U Vs e →
           ( Σ ( ( u : indexing-type-Π-Decomposition Y) →
                 cotype-Π-Decomposition Y u ≃ pr1 Vs (map-equiv e u))
@@ -466,20 +466,20 @@ module _
                 ( ( ( map-equiv-Π (λ u → pr1 Vs u) e f) ∘
                     ( map-matching-correspondence-Π-Decomposition Y)) ~
                   ( map-equiv (pr2 Vs))))))
-        ( is-contr-total-equiv (indexing-type-Π-Decomposition Y))
+        ( is-torsorial-equiv (indexing-type-Π-Decomposition Y))
         ( pair (indexing-type-Π-Decomposition Y) id-equiv)
-        ( is-contr-total-Eq-structure
+        ( is-torsorial-Eq-structure
           ( λ V f g →
             ( ( map-equiv-Π (λ u → V u) id-equiv g) ∘
               ( map-matching-correspondence-Π-Decomposition Y)) ~
               ( pr1 f))
-          ( is-contr-total-equiv-fam
+          ( is-torsorial-equiv-fam
             ( cotype-Π-Decomposition Y))
           ( pair
             ( cotype-Π-Decomposition Y)
             ( id-equiv-fam
               ( cotype-Π-Decomposition Y)))
-            ( is-contr-total-htpy-equiv
+            ( is-torsorial-htpy-equiv
               ( ( equiv-Π
                   ( cotype-Π-Decomposition Y)
                   ( id-equiv)
@@ -507,7 +507,7 @@ module _
     is-equiv (equiv-eq-fibered-Π-Decomposition D')
   is-equiv-equiv-eq-fibered-Π-Decomposition =
     fundamental-theorem-id
-      is-contr-total-equiv-fibered-Π-Decomposition
+      is-torsorial-equiv-fibered-Π-Decomposition
       equiv-eq-fibered-Π-Decomposition
 
   extensionality-fibered-Π-Decomposition :
@@ -587,23 +587,23 @@ module _
     X = fst-displayed-Π-Decomposition disp-D
     f-Y = snd-displayed-Π-Decomposition disp-D
 
-  is-contr-total-equiv-displayed-Π-Decomposition :
+  is-torsorial-equiv-displayed-Π-Decomposition :
     is-contr
       ( Σ ( displayed-Π-Decomposition l2 l3 l4 l5 A)
           ( equiv-displayed-Π-Decomposition disp-D))
-  is-contr-total-equiv-displayed-Π-Decomposition =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-displayed-Π-Decomposition =
+    is-torsorial-Eq-structure
       ( λ X' f-Y' e → equiv-snd-displayed-Π-Decomposition
         ( disp-D)
         ( pair X' f-Y')
         ( e))
-      ( is-contr-total-equiv-Π-Decomposition X)
+      ( is-torsorial-equiv-Π-Decomposition X)
       ( pair X (id-equiv-Π-Decomposition X))
       ( is-contr-equiv
         ( Π-total-fam (λ x → _))
         ( inv-distributive-Π-Σ)
         ( is-contr-Π
-          ( λ x → is-contr-total-equiv-Π-Decomposition (f-Y x))))
+          ( λ x → is-torsorial-equiv-Π-Decomposition (f-Y x))))
 
   id-equiv-displayed-Π-Decomposition :
     equiv-displayed-Π-Decomposition disp-D disp-D
@@ -627,7 +627,7 @@ module _
     is-equiv (equiv-eq-displayed-Π-Decomposition disp-D')
   is-equiv-equiv-eq-displayed-Π-Decomposition =
     fundamental-theorem-id
-      is-contr-total-equiv-displayed-Π-Decomposition
+      is-torsorial-equiv-displayed-Π-Decomposition
       equiv-eq-displayed-Π-Decomposition
 
   extensionality-displayed-Π-Decomposition :

--- a/src/foundation/pointed-torsorial-type-families.lagda.md
+++ b/src/foundation/pointed-torsorial-type-families.lagda.md
@@ -78,9 +78,9 @@ module _
   point-is-pointed-torsorial-family-of-types =
     map-inv-equiv (T (point-Pointed-Type B)) refl
 
-  is-contr-total-space-is-pointed-torsorial-family-of-types :
+  is-torsorial-space-is-pointed-torsorial-family-of-types :
     is-contr (Σ (type-Pointed-Type B) E)
-  is-contr-total-space-is-pointed-torsorial-family-of-types =
+  is-torsorial-space-is-pointed-torsorial-family-of-types =
     fundamental-theorem-id'
       ( λ x → map-inv-equiv (T x))
       ( λ x → is-equiv-map-inv-equiv (T x))
@@ -124,7 +124,7 @@ module _
   pr2
     ( point-and-contractible-total-space-is-pointed-torsorial-family-of-types H)
     =
-    is-contr-total-space-is-pointed-torsorial-family-of-types B H
+    is-torsorial-space-is-pointed-torsorial-family-of-types B H
 ```
 
 ### Pointed connected types equipped with a pointed torsorial family of types of universe level `l` are locally `l`-small

--- a/src/foundation/product-decompositions-subuniverse.lagda.md
+++ b/src/foundation/product-decompositions-subuniverse.lagda.md
@@ -256,7 +256,7 @@ module _
               ( commutative-prod)
               ( inclusion-subuniverse P X)) ∘e
             ( ( left-unit-law-Σ-is-contr
-                ( is-contr-total-equiv-subuniverse'
+                ( is-torsorial-equiv-subuniverse'
                   ( P)
                   ( ( inclusion-subuniverse P (pr1 (pr2 x)) ×
                       inclusion-subuniverse P (pr2 (pr2 x))) ,
@@ -330,7 +330,7 @@ module _
     ( ( equiv-tot
         ( λ x →
           left-unit-law-Σ-is-contr
-            ( is-contr-total-equiv-subuniverse'
+            ( is-torsorial-equiv-subuniverse'
               ( P)
               ( ( inclusion-subuniverse P (pr1 (pr2 x)) ×
                   inclusion-subuniverse P (pr2 (pr2 x))) ,

--- a/src/foundation/propositional-extensionality.lagda.md
+++ b/src/foundation/propositional-extensionality.lagda.md
@@ -48,14 +48,14 @@ module _
   where
 
   abstract
-    is-contr-total-iff :
+    is-torsorial-iff :
       (P : Prop l1) → is-contr (Σ (Prop l1) (λ Q → P ⇔ Q))
-    is-contr-total-iff P =
+    is-torsorial-iff P =
       is-contr-equiv
         ( Σ (Prop l1) (λ Q → type-Prop P ≃ type-Prop Q))
         ( equiv-tot (equiv-equiv-iff P))
-        ( is-contr-total-Eq-subtype
-          ( is-contr-total-equiv (type-Prop P))
+        ( is-torsorial-Eq-subtype
+          ( is-torsorial-equiv (type-Prop P))
           ( is-prop-is-prop)
           ( type-Prop P)
           ( id-equiv)
@@ -65,7 +65,7 @@ module _
     is-equiv-iff-eq : (P Q : Prop l1) → is-equiv (iff-eq {l1} {P} {Q})
     is-equiv-iff-eq P =
       fundamental-theorem-id
-        ( is-contr-total-iff P)
+        ( is-torsorial-iff P)
         ( λ Q → iff-eq {P = P} {Q})
 
   propositional-extensionality :
@@ -90,14 +90,14 @@ module _
     {P Q : Prop l1} → P ＝ Q → type-Prop P ≃ type-Prop Q
   equiv-eq-Prop {P} refl = id-equiv
 
-  is-contr-total-equiv-Prop :
+  is-torsorial-equiv-Prop :
     (P : Prop l1) →
     is-contr (Σ (Prop l1) (λ Q → type-Prop P ≃ type-Prop Q))
-  is-contr-total-equiv-Prop P =
+  is-torsorial-equiv-Prop P =
     is-contr-equiv'
       ( Σ (Prop l1) (λ Q → P ⇔ Q))
       ( equiv-tot (equiv-equiv-iff P))
-      ( is-contr-total-iff P)
+      ( is-torsorial-iff P)
 ```
 
 ### The type of propositions is a set
@@ -120,7 +120,7 @@ pr2 (Prop-Set l) = is-set-type-Prop
 is-univalent-type-Prop : {l : Level} → is-univalent (type-Prop {l})
 is-univalent-type-Prop {l} P =
   fundamental-theorem-id
-    ( is-contr-total-equiv-Prop P)
+    ( is-torsorial-equiv-Prop P)
     ( λ Q → equiv-tr type-Prop)
 ```
 
@@ -128,9 +128,9 @@ is-univalent-type-Prop {l} P =
 
 ```agda
 abstract
-  is-contr-total-true-Prop :
+  is-torsorial-true-Prop :
     {l1 : Level} → is-contr (Σ (Prop l1) (λ P → type-Prop P))
-  is-contr-total-true-Prop {l1} =
+  is-torsorial-true-Prop {l1} =
     is-contr-equiv
       ( Σ (Prop l1) (λ P → raise-unit-Prop l1 ⇔ P))
       ( equiv-tot
@@ -146,16 +146,16 @@ abstract
                     is-proof-irrelevant-is-prop
                       ( is-prop-raise-unit)
                       ( raise-star)))))))
-      ( is-contr-total-iff (raise-unit-Prop l1))
+      ( is-torsorial-iff (raise-unit-Prop l1))
 ```
 
 ### The type of false propositions is contractible
 
 ```agda
 abstract
-  is-contr-total-false-Prop :
+  is-torsorial-false-Prop :
     {l1 : Level} → is-contr (Σ (Prop l1) (λ P → type-Prop (neg-Prop P)))
-  is-contr-total-false-Prop {l1} =
+  is-torsorial-false-Prop {l1} =
     is-contr-equiv
       ( Σ (Prop l1) (λ P → raise-empty-Prop l1 ⇔ P))
       ( equiv-tot
@@ -168,5 +168,5 @@ abstract
                   ( raise-empty l1)
                   ( is-empty-raise-empty)
                   ( type-Prop P))))))
-      ( is-contr-total-iff (raise-empty-Prop l1))
+      ( is-torsorial-iff (raise-empty-Prop l1))
 ```

--- a/src/foundation/pullbacks.lagda.md
+++ b/src/foundation/pullbacks.lagda.md
@@ -366,40 +366,40 @@ abstract
             ( (f ·l K) ∙h refl-htpy ∙h H'))))
 
 abstract
-  is-contr-total-htpy-parallel-cone-refl-htpy-refl-htpy :
+  is-torsorial-htpy-parallel-cone-refl-htpy-refl-htpy :
     {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {C : UU l4}
     (f : A → X) (g : B → X) →
     (c : cone f g C) →
     is-contr
       ( Σ (cone f g C) (htpy-parallel-cone (refl-htpy' f) (refl-htpy' g) c))
-  is-contr-total-htpy-parallel-cone-refl-htpy-refl-htpy {C = C} f g c =
+  is-torsorial-htpy-parallel-cone-refl-htpy-refl-htpy {C = C} f g c =
     is-contr-is-equiv'
       ( Σ (cone f g C) (htpy-cone f g c))
       ( tot (htpy-parallel-cone-refl-htpy-htpy-cone f g c))
       ( is-equiv-tot-is-fiberwise-equiv
         ( is-equiv-htpy-parallel-cone-refl-htpy-htpy-cone f g c))
-      ( is-contr-total-htpy-cone f g c)
+      ( is-torsorial-htpy-cone f g c)
 
 abstract
-  is-contr-total-htpy-parallel-cone-refl-htpy :
+  is-torsorial-htpy-parallel-cone-refl-htpy :
     {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {C : UU l4}
     (f : A → X) {g g' : B → X} (Hg : g ~ g') →
     (c : cone f g C) →
     is-contr (Σ (cone f g' C) (htpy-parallel-cone (refl-htpy' f) Hg c))
-  is-contr-total-htpy-parallel-cone-refl-htpy {C = C} f {g} =
+  is-torsorial-htpy-parallel-cone-refl-htpy {C = C} f {g} =
     ind-htpy g
       ( λ g'' Hg' →
         ( c : cone f g C) →
         is-contr (Σ (cone f g'' C) (htpy-parallel-cone (refl-htpy' f) Hg' c)))
-      ( is-contr-total-htpy-parallel-cone-refl-htpy-refl-htpy f g)
+      ( is-torsorial-htpy-parallel-cone-refl-htpy-refl-htpy f g)
 
 abstract
-  is-contr-total-htpy-parallel-cone :
+  is-torsorial-htpy-parallel-cone :
     {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {C : UU l4}
     {f f' : A → X} (Hf : f ~ f') {g g' : B → X} (Hg : g ~ g') →
     (c : cone f g C) →
     is-contr (Σ (cone f' g' C) (htpy-parallel-cone Hf Hg c))
-  is-contr-total-htpy-parallel-cone
+  is-torsorial-htpy-parallel-cone
     {A = A} {B} {X} {C} {f} {f'} Hf {g} {g'} Hg =
     ind-htpy
       { A = A}
@@ -407,7 +407,7 @@ abstract
       ( f)
       ( λ f'' Hf' → (g g' : B → X) (Hg : g ~ g') (c : cone f g C) →
         is-contr (Σ (cone f'' g' C) (htpy-parallel-cone Hf' Hg c)))
-      ( λ g g' Hg → is-contr-total-htpy-parallel-cone-refl-htpy f Hg)
+      ( λ g g' Hg → is-torsorial-htpy-parallel-cone-refl-htpy f Hg)
       Hf g g' Hg
 
 tr-tr-refl-htpy-cone :
@@ -564,7 +564,7 @@ abstract
               ( concat (tr-tr-refl-htpy-cone f g c) c')
               ( inv-htpy (comp-htpy-parallel-cone-eq f g c c'))
               ( fundamental-theorem-id
-                ( is-contr-total-htpy-parallel-cone
+                ( is-torsorial-htpy-parallel-cone
                   ( refl-htpy' f)
                   ( refl-htpy' g)
                   ( c))
@@ -1052,11 +1052,11 @@ is-pullback-cone-ap f g (p , q , H) is-pb-c c1 c2 =
           ( p , q , H)
           ( cone-ap' f g (p , q , H) c1))
         ( is-equiv-is-contr _
-          ( is-contr-total-path (q c1))
-          ( is-contr-total-path (f (p c1))))
+          ( is-torsorial-path (q c1))
+          ( is-torsorial-path (f (p c1))))
         ( is-equiv-is-contr _
-          ( is-contr-total-path c1)
-          ( is-contr-total-path (p c1))))
+          ( is-torsorial-path c1)
+          ( is-torsorial-path (p c1))))
       ( c2))
 ```
 

--- a/src/foundation/reflecting-maps-equivalence-relations.lagda.md
+++ b/src/foundation/reflecting-maps-equivalence-relations.lagda.md
@@ -120,14 +120,14 @@ module _
   htpy-eq-reflecting-map-Equivalence-Relation .f refl =
     refl-htpy-reflecting-map-Equivalence-Relation
 
-  is-contr-total-htpy-reflecting-map-Equivalence-Relation :
+  is-torsorial-htpy-reflecting-map-Equivalence-Relation :
     is-contr
       ( Σ
         ( reflecting-map-Equivalence-Relation R (type-Set B))
         ( htpy-reflecting-map-Equivalence-Relation))
-  is-contr-total-htpy-reflecting-map-Equivalence-Relation =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-htpy (pr1 f))
+  is-torsorial-htpy-reflecting-map-Equivalence-Relation =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-htpy (pr1 f))
       ( is-prop-reflects-Equivalence-Relation R B)
       ( pr1 f)
       ( refl-htpy)
@@ -138,7 +138,7 @@ module _
     is-equiv (htpy-eq-reflecting-map-Equivalence-Relation g)
   is-equiv-htpy-eq-reflecting-map-Equivalence-Relation =
     fundamental-theorem-id
-      is-contr-total-htpy-reflecting-map-Equivalence-Relation
+      is-torsorial-htpy-reflecting-map-Equivalence-Relation
       htpy-eq-reflecting-map-Equivalence-Relation
 
   extensionality-reflecting-map-Equivalence-Relation :

--- a/src/foundation/relaxed-sigma-decompositions.lagda.md
+++ b/src/foundation/relaxed-sigma-decompositions.lagda.md
@@ -294,11 +294,11 @@ module _
   pr1 (pr2 id-equiv-Relaxed-Σ-Decomposition) x = id-equiv
   pr2 (pr2 id-equiv-Relaxed-Σ-Decomposition) = refl-htpy
 
-  is-contr-total-equiv-Relaxed-Σ-Decomposition :
+  is-torsorial-equiv-Relaxed-Σ-Decomposition :
     is-contr
       ( Σ ( Relaxed-Σ-Decomposition l2 l3 A) (equiv-Relaxed-Σ-Decomposition X))
-  is-contr-total-equiv-Relaxed-Σ-Decomposition =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-Relaxed-Σ-Decomposition =
+    is-torsorial-Eq-structure
       ( λ U Vf e →
         Σ ( (x : indexing-type-Relaxed-Σ-Decomposition X) →
             cotype-Relaxed-Σ-Decomposition X x ≃
@@ -308,20 +308,20 @@ module _
                 ( equiv-Σ (λ u → pr1 Vf u) e f)) ∘
               ( map-matching-correspondence-Relaxed-Σ-Decomposition X)) ~
             ( map-equiv (pr2 Vf))))
-      ( is-contr-total-equiv (indexing-type-Relaxed-Σ-Decomposition X))
+      ( is-torsorial-equiv (indexing-type-Relaxed-Σ-Decomposition X))
       ( pair (indexing-type-Relaxed-Σ-Decomposition X) id-equiv)
-      ( is-contr-total-Eq-structure
+      ( is-torsorial-Eq-structure
         ( λ V g f →
           ( ( map-equiv
               ( equiv-Σ (λ y → V y) id-equiv f)) ∘
             ( map-matching-correspondence-Relaxed-Σ-Decomposition X)) ~
           ( map-equiv g))
-        ( is-contr-total-equiv-fam
+        ( is-torsorial-equiv-fam
           ( cotype-Relaxed-Σ-Decomposition X))
         ( pair
           ( cotype-Relaxed-Σ-Decomposition X)
           ( id-equiv-fam (cotype-Relaxed-Σ-Decomposition X)))
-        ( is-contr-total-htpy-equiv
+        ( is-torsorial-htpy-equiv
           ( matching-correspondence-Relaxed-Σ-Decomposition X)))
 
   equiv-eq-Relaxed-Σ-Decomposition :
@@ -334,7 +334,7 @@ module _
     is-equiv (equiv-eq-Relaxed-Σ-Decomposition Y)
   is-equiv-equiv-eq-Relaxed-Σ-Decomposition =
     fundamental-theorem-id
-      is-contr-total-equiv-Relaxed-Σ-Decomposition
+      is-torsorial-equiv-Relaxed-Σ-Decomposition
       equiv-eq-Relaxed-Σ-Decomposition
 
   extensionality-Relaxed-Σ-Decomposition :
@@ -433,17 +433,17 @@ module _
     X = fst-fibered-Relaxed-Σ-Decomposition D
     Y = snd-fibered-Relaxed-Σ-Decomposition D
 
-  is-contr-total-equiv-fibered-Relaxed-Σ-Decomposition :
+  is-torsorial-equiv-fibered-Relaxed-Σ-Decomposition :
     is-contr
       ( Σ ( fibered-Relaxed-Σ-Decomposition l2 l3 l4 l5 A)
           ( equiv-fibered-Relaxed-Σ-Decomposition D))
-  is-contr-total-equiv-fibered-Relaxed-Σ-Decomposition =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-fibered-Relaxed-Σ-Decomposition =
+    is-torsorial-Eq-structure
       ( λ X' Y' e →
         equiv-snd-fibered-Relaxed-Σ-Decomposition D (X' , Y') e)
-      ( is-contr-total-equiv-Relaxed-Σ-Decomposition X)
+      ( is-torsorial-equiv-Relaxed-Σ-Decomposition X)
       ( X , id-equiv-Relaxed-Σ-Decomposition X)
-      ( is-contr-total-Eq-structure
+      ( is-torsorial-Eq-structure
         ( λ U Vs e →
           ( Σ ( ( u : indexing-type-Relaxed-Σ-Decomposition Y) →
                 cotype-Relaxed-Σ-Decomposition Y u ≃ pr1 Vs (map-equiv e u))
@@ -451,20 +451,20 @@ module _
                 ( ( ( map-equiv-Σ (λ u → pr1 Vs u) e f) ∘
                     ( map-matching-correspondence-Relaxed-Σ-Decomposition Y)) ~
                   ( map-equiv (pr2 Vs))))))
-        ( is-contr-total-equiv (indexing-type-Relaxed-Σ-Decomposition Y))
+        ( is-torsorial-equiv (indexing-type-Relaxed-Σ-Decomposition Y))
         ( pair (indexing-type-Relaxed-Σ-Decomposition Y) id-equiv)
-        ( is-contr-total-Eq-structure
+        ( is-torsorial-Eq-structure
           ( λ V f g →
             ( ( map-equiv-Σ (λ u → V u) id-equiv g) ∘
               ( map-matching-correspondence-Relaxed-Σ-Decomposition Y)) ~
               ( pr1 f))
-          ( is-contr-total-equiv-fam
+          ( is-torsorial-equiv-fam
             ( cotype-Relaxed-Σ-Decomposition Y))
           ( pair
             ( cotype-Relaxed-Σ-Decomposition Y)
             ( id-equiv-fam
               ( cotype-Relaxed-Σ-Decomposition Y)))
-            ( is-contr-total-htpy-equiv
+            ( is-torsorial-htpy-equiv
               ( matching-correspondence-Relaxed-Σ-Decomposition Y))))
 
   id-equiv-fibered-Relaxed-Σ-Decomposition :
@@ -486,7 +486,7 @@ module _
     is-equiv (equiv-eq-fibered-Relaxed-Σ-Decomposition D')
   is-equiv-equiv-eq-fibered-Relaxed-Σ-Decomposition =
     fundamental-theorem-id
-      is-contr-total-equiv-fibered-Relaxed-Σ-Decomposition
+      is-torsorial-equiv-fibered-Relaxed-Σ-Decomposition
       equiv-eq-fibered-Relaxed-Σ-Decomposition
 
   extensionality-fibered-Relaxed-Σ-Decomposition :
@@ -566,23 +566,23 @@ module _
     X = fst-displayed-Relaxed-Σ-Decomposition disp-D
     f-Y = snd-displayed-Relaxed-Σ-Decomposition disp-D
 
-  is-contr-total-equiv-displayed-Relaxed-Σ-Decomposition :
+  is-torsorial-equiv-displayed-Relaxed-Σ-Decomposition :
     is-contr
       ( Σ ( displayed-Relaxed-Σ-Decomposition l2 l3 l4 l5 A)
           ( equiv-displayed-Relaxed-Σ-Decomposition disp-D))
-  is-contr-total-equiv-displayed-Relaxed-Σ-Decomposition =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-displayed-Relaxed-Σ-Decomposition =
+    is-torsorial-Eq-structure
       ( λ X' f-Y' e → equiv-snd-displayed-Relaxed-Σ-Decomposition
         ( disp-D)
         ( pair X' f-Y')
         ( e))
-      ( is-contr-total-equiv-Relaxed-Σ-Decomposition X)
+      ( is-torsorial-equiv-Relaxed-Σ-Decomposition X)
       ( pair X (id-equiv-Relaxed-Σ-Decomposition X))
       ( is-contr-equiv
         ( Π-total-fam (λ x → _))
         ( inv-distributive-Π-Σ)
         ( is-contr-Π
-          ( λ x → is-contr-total-equiv-Relaxed-Σ-Decomposition (f-Y x))))
+          ( λ x → is-torsorial-equiv-Relaxed-Σ-Decomposition (f-Y x))))
 
   id-equiv-displayed-Relaxed-Σ-Decomposition :
     equiv-displayed-Relaxed-Σ-Decomposition disp-D disp-D
@@ -603,7 +603,7 @@ module _
     is-equiv (equiv-eq-displayed-Relaxed-Σ-Decomposition disp-D')
   is-equiv-equiv-eq-displayed-Relaxed-Σ-Decomposition =
     fundamental-theorem-id
-      is-contr-total-equiv-displayed-Relaxed-Σ-Decomposition
+      is-torsorial-equiv-displayed-Relaxed-Σ-Decomposition
       equiv-eq-displayed-Relaxed-Σ-Decomposition
 
   extensionality-displayed-Relaxed-Σ-Decomposition :

--- a/src/foundation/russells-paradox.lagda.md
+++ b/src/foundation/russells-paradox.lagda.md
@@ -129,7 +129,7 @@ paradox-Russell {l} H =
     β = ( equiv-precomp α empty) ∘e
         ( ( left-unit-law-Σ-is-contr
             { B = λ t → (pr1 t) ∉-𝕍 (pr1 t)}
-            ( is-contr-total-path' R')
+            ( is-torsorial-path' R')
             ( pair R' refl)) ∘e
           ( ( inv-associative-Σ (𝕍 l) (_＝ R') (λ t → (pr1 t) ∉-𝕍 (pr1 t))) ∘e
             ( ( equiv-tot

--- a/src/foundation/sections.lagda.md
+++ b/src/foundation/sections.lagda.md
@@ -143,7 +143,7 @@ module _
       ( is-contr-equiv
         ( Π-total-fam (λ x y → y ＝ x))
         ( inv-distributive-Π-Σ)
-        ( is-contr-Π is-contr-total-path'))
+        ( is-contr-Π is-torsorial-path'))
       ( id , refl-htpy)) ∘e
     ( equiv-right-swap-Σ) ∘e
     ( equiv-Σ-equiv-base ( λ s → pr1 s ~ id) ( distributive-Π-Σ))

--- a/src/foundation/sequential-limits.lagda.md
+++ b/src/foundation/sequential-limits.lagda.md
@@ -173,21 +173,21 @@ module _
   Eq-eq-standard-sequential-limit s .s refl =
     refl-Eq-standard-sequential-limit s
 
-  is-contr-total-Eq-standard-sequential-limit :
+  is-torsorial-Eq-standard-sequential-limit :
     (s : standard-sequential-limit A) →
     is-contr (Σ (standard-sequential-limit A) (Eq-standard-sequential-limit s))
-  is-contr-total-Eq-standard-sequential-limit s =
-    is-contr-total-Eq-structure _
-      ( is-contr-total-htpy (pr1 s))
+  is-torsorial-Eq-standard-sequential-limit s =
+    is-torsorial-Eq-structure _
+      ( is-torsorial-htpy (pr1 s))
       ( pr1 s , refl-htpy)
-      ( is-contr-total-Eq-Π _ (λ n → is-contr-total-path (pr2 s n ∙ refl)))
+      ( is-torsorial-Eq-Π _ (λ n → is-torsorial-path (pr2 s n ∙ refl)))
 
   is-equiv-Eq-eq-standard-sequential-limit :
     (s t : standard-sequential-limit A) →
     is-equiv (Eq-eq-standard-sequential-limit s t)
   is-equiv-Eq-eq-standard-sequential-limit s =
     fundamental-theorem-id
-      ( is-contr-total-Eq-standard-sequential-limit s)
+      ( is-torsorial-Eq-standard-sequential-limit s)
       ( Eq-eq-standard-sequential-limit s)
 
   extensionality-standard-sequential-limit :

--- a/src/foundation/sets.lagda.md
+++ b/src/foundation/sets.lagda.md
@@ -205,9 +205,9 @@ module _
   equiv-eq-Set = equiv-eq-subuniverse is-set-Prop X
 
   abstract
-    is-contr-total-equiv-Set : is-contr (Σ (Set l) (type-equiv-Set X))
-    is-contr-total-equiv-Set =
-      is-contr-total-equiv-subuniverse is-set-Prop X
+    is-torsorial-equiv-Set : is-contr (Σ (Set l) (type-equiv-Set X))
+    is-torsorial-equiv-Set =
+      is-torsorial-equiv-subuniverse is-set-Prop X
 
   abstract
     is-equiv-equiv-eq-Set : (Y : Set l) → is-equiv (equiv-eq-Set Y)

--- a/src/foundation/sigma-decompositions.lagda.md
+++ b/src/foundation/sigma-decompositions.lagda.md
@@ -401,10 +401,10 @@ module _
   pr1 (pr2 id-equiv-Σ-Decomposition) x = id-equiv
   pr2 (pr2 id-equiv-Σ-Decomposition) = refl-htpy
 
-  is-contr-total-equiv-Σ-Decomposition :
+  is-torsorial-equiv-Σ-Decomposition :
     is-contr (Σ (Σ-Decomposition l2 l3 A) (equiv-Σ-Decomposition X))
-  is-contr-total-equiv-Σ-Decomposition =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-Σ-Decomposition =
+    is-torsorial-Eq-structure
       ( λ U Vf e →
         Σ ( (x : indexing-type-Σ-Decomposition X) →
             cotype-Σ-Decomposition X x ≃
@@ -414,20 +414,20 @@ module _
                 ( equiv-Σ (λ u → type-Inhabited-Type (pr1 Vf u)) e f)) ∘
               ( map-matching-correspondence-Σ-Decomposition X)) ~
             ( map-equiv (pr2 Vf))))
-      ( is-contr-total-equiv (indexing-type-Σ-Decomposition X))
+      ( is-torsorial-equiv (indexing-type-Σ-Decomposition X))
       ( pair (indexing-type-Σ-Decomposition X) id-equiv)
-      ( is-contr-total-Eq-structure
+      ( is-torsorial-Eq-structure
         ( λ V g f →
           ( ( map-equiv
               ( equiv-Σ (λ y → type-Inhabited-Type (V y)) id-equiv f)) ∘
             ( map-matching-correspondence-Σ-Decomposition X)) ~
           ( map-equiv g))
-        ( is-contr-total-equiv-Fam-Inhabited-Types
+        ( is-torsorial-equiv-Fam-Inhabited-Types
           ( inhabited-cotype-Σ-Decomposition X))
         ( pair
           ( inhabited-cotype-Σ-Decomposition X)
           ( id-equiv-Fam-Inhabited-Types (inhabited-cotype-Σ-Decomposition X)))
-        ( is-contr-total-htpy-equiv
+        ( is-torsorial-htpy-equiv
           ( matching-correspondence-Σ-Decomposition X)))
 
   equiv-eq-Σ-Decomposition :
@@ -438,7 +438,7 @@ module _
     (Y : Σ-Decomposition l2 l3 A) → is-equiv (equiv-eq-Σ-Decomposition Y)
   is-equiv-equiv-eq-Σ-Decomposition =
     fundamental-theorem-id
-      is-contr-total-equiv-Σ-Decomposition
+      is-torsorial-equiv-Σ-Decomposition
       equiv-eq-Σ-Decomposition
 
   extensionality-Σ-Decomposition :
@@ -502,12 +502,12 @@ module _
   pr1 (pr2 id-equiv-Set-Indexed-Σ-Decomposition) x = id-equiv
   pr2 (pr2 id-equiv-Set-Indexed-Σ-Decomposition) = refl-htpy
 
-  is-contr-total-equiv-Set-Indexed-Σ-Decomposition :
+  is-torsorial-equiv-Set-Indexed-Σ-Decomposition :
     is-contr
       ( Σ ( Set-Indexed-Σ-Decomposition l2 l3 A)
           ( equiv-Set-Indexed-Σ-Decomposition X))
-  is-contr-total-equiv-Set-Indexed-Σ-Decomposition =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-Set-Indexed-Σ-Decomposition =
+    is-torsorial-Eq-structure
       ( λ U Vf e →
         Σ ( (x : indexing-type-Set-Indexed-Σ-Decomposition X) →
             cotype-Set-Indexed-Σ-Decomposition X x ≃
@@ -517,21 +517,21 @@ module _
                 ( equiv-Σ (λ u → type-Inhabited-Type (pr1 Vf u)) e f)) ∘
               ( map-matching-correspondence-Set-Indexed-Σ-Decomposition X)) ~
             ( map-equiv (pr2 Vf))))
-      ( is-contr-total-equiv-Set (indexing-set-Set-Indexed-Σ-Decomposition X))
+      ( is-torsorial-equiv-Set (indexing-set-Set-Indexed-Σ-Decomposition X))
       ( pair (indexing-set-Set-Indexed-Σ-Decomposition X) id-equiv)
-      ( is-contr-total-Eq-structure
+      ( is-torsorial-Eq-structure
         ( λ V g f →
           ( ( map-equiv
               ( equiv-Σ (λ y → type-Inhabited-Type (V y)) id-equiv f)) ∘
             ( map-matching-correspondence-Set-Indexed-Σ-Decomposition X)) ~
           ( map-equiv g))
-        ( is-contr-total-equiv-Fam-Inhabited-Types
+        ( is-torsorial-equiv-Fam-Inhabited-Types
           ( inhabited-cotype-Set-Indexed-Σ-Decomposition X))
         ( pair
           ( inhabited-cotype-Set-Indexed-Σ-Decomposition X)
           ( id-equiv-Fam-Inhabited-Types
             ( inhabited-cotype-Set-Indexed-Σ-Decomposition X)))
-        ( is-contr-total-htpy-equiv
+        ( is-torsorial-htpy-equiv
           ( matching-correspondence-Set-Indexed-Σ-Decomposition X)))
 
   equiv-eq-Set-Indexed-Σ-Decomposition :
@@ -545,7 +545,7 @@ module _
     is-equiv (equiv-eq-Set-Indexed-Σ-Decomposition Y)
   is-equiv-equiv-eq-Set-Indexed-Σ-Decomposition =
     fundamental-theorem-id
-      is-contr-total-equiv-Set-Indexed-Σ-Decomposition
+      is-torsorial-equiv-Set-Indexed-Σ-Decomposition
       equiv-eq-Set-Indexed-Σ-Decomposition
 
   extensionality-Set-Indexed-Σ-Decomposition :
@@ -620,17 +620,17 @@ module _
     X = fst-fibered-Σ-Decomposition D
     Y = snd-fibered-Σ-Decomposition D
 
-  is-contr-total-equiv-fibered-Σ-Decomposition :
+  is-torsorial-equiv-fibered-Σ-Decomposition :
     is-contr
       ( Σ ( fibered-Σ-Decomposition l2 l3 l4 l5 A)
           ( equiv-fibered-Σ-Decomposition D))
-  is-contr-total-equiv-fibered-Σ-Decomposition =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-fibered-Σ-Decomposition =
+    is-torsorial-Eq-structure
       ( λ X' Y' e →
         equiv-snd-fibered-Σ-Decomposition D (X' , Y') e)
-      ( is-contr-total-equiv-Σ-Decomposition X)
+      ( is-torsorial-equiv-Σ-Decomposition X)
       ( X , id-equiv-Σ-Decomposition X)
-      ( is-contr-total-Eq-structure
+      ( is-torsorial-Eq-structure
         ( λ U Vs e →
           ( Σ ( ( u : indexing-type-Σ-Decomposition Y) →
                 cotype-Σ-Decomposition Y u ≃
@@ -639,20 +639,20 @@ module _
                 ( ( ( map-equiv-Σ (λ u → type-Inhabited-Type (pr1 Vs u)) e f) ∘
                     ( map-matching-correspondence-Σ-Decomposition Y)) ~
                   ( map-equiv (pr2 Vs))))))
-        ( is-contr-total-equiv (indexing-type-Σ-Decomposition Y))
+        ( is-torsorial-equiv (indexing-type-Σ-Decomposition Y))
         ( pair (indexing-type-Σ-Decomposition Y) id-equiv)
-        ( is-contr-total-Eq-structure
+        ( is-torsorial-Eq-structure
           ( λ V f g →
             ( ( map-equiv-Σ (λ u → type-Inhabited-Type (V u)) id-equiv g) ∘
               ( map-matching-correspondence-Σ-Decomposition Y)) ~
               ( pr1 f))
-          ( is-contr-total-equiv-Fam-Inhabited-Types
+          ( is-torsorial-equiv-Fam-Inhabited-Types
             ( inhabited-cotype-Σ-Decomposition Y))
           ( pair
             ( inhabited-cotype-Σ-Decomposition Y)
             ( id-equiv-Fam-Inhabited-Types
               ( inhabited-cotype-Σ-Decomposition Y)))
-            ( is-contr-total-htpy-equiv
+            ( is-torsorial-htpy-equiv
               ( matching-correspondence-Σ-Decomposition Y))))
 
   id-equiv-fibered-Σ-Decomposition :
@@ -673,7 +673,7 @@ module _
     is-equiv (equiv-eq-fibered-Σ-Decomposition D')
   is-equiv-equiv-eq-fibered-Σ-Decomposition =
     fundamental-theorem-id
-      is-contr-total-equiv-fibered-Σ-Decomposition
+      is-torsorial-equiv-fibered-Σ-Decomposition
       equiv-eq-fibered-Σ-Decomposition
 
   extensionality-fibered-Σ-Decomposition :
@@ -753,22 +753,22 @@ module _
     X = fst-displayed-Σ-Decomposition disp-D
     f-Y = snd-displayed-Σ-Decomposition disp-D
 
-  is-contr-total-equiv-displayed-Σ-Decomposition :
+  is-torsorial-equiv-displayed-Σ-Decomposition :
     is-contr
       ( Σ ( displayed-Σ-Decomposition l2 l3 l4 l5 A)
           ( equiv-displayed-Σ-Decomposition disp-D))
-  is-contr-total-equiv-displayed-Σ-Decomposition =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-displayed-Σ-Decomposition =
+    is-torsorial-Eq-structure
       ( λ X' f-Y' e → equiv-snd-displayed-Σ-Decomposition
         ( disp-D)
         ( pair X' f-Y')
         ( e))
-      ( is-contr-total-equiv-Σ-Decomposition X)
+      ( is-torsorial-equiv-Σ-Decomposition X)
       ( pair X (id-equiv-Σ-Decomposition X))
       ( is-contr-equiv
         ( Π-total-fam (λ x → _))
         ( inv-distributive-Π-Σ)
-        ( is-contr-Π (λ x → is-contr-total-equiv-Σ-Decomposition (f-Y x))))
+        ( is-contr-Π (λ x → is-torsorial-equiv-Σ-Decomposition (f-Y x))))
 
   id-equiv-displayed-Σ-Decomposition :
     equiv-displayed-Σ-Decomposition disp-D disp-D
@@ -788,7 +788,7 @@ module _
     is-equiv (equiv-eq-displayed-Σ-Decomposition disp-D')
   is-equiv-equiv-eq-displayed-Σ-Decomposition =
     fundamental-theorem-id
-      is-contr-total-equiv-displayed-Σ-Decomposition
+      is-torsorial-equiv-displayed-Σ-Decomposition
       equiv-eq-displayed-Σ-Decomposition
 
   extensionality-displayed-Σ-Decomposition :

--- a/src/foundation/singleton-subtypes.lagda.md
+++ b/src/foundation/singleton-subtypes.lagda.md
@@ -71,7 +71,7 @@ subtype-standard-singleton-subtype X x y = Id-Prop X x y
 standard-singleton-subtype :
   {l : Level} (X : Set l) → type-Set X → singleton-subtype l (type-Set X)
 pr1 (standard-singleton-subtype X x) = subtype-standard-singleton-subtype X x
-pr2 (standard-singleton-subtype X x) = is-contr-total-path x
+pr2 (standard-singleton-subtype X x) = is-torsorial-path x
 
 inhabited-subtype-standard-singleton-subtype :
   {l : Level} (X : Set l) → type-Set X → inhabited-subtype l (type-Set X)

--- a/src/foundation/slice.lagda.md
+++ b/src/foundation/slice.lagda.md
@@ -343,21 +343,21 @@ module _
   where
 
   abstract
-    is-contr-total-equiv-slice' :
+    is-torsorial-equiv-slice' :
       (f : Slice l2 A) → is-contr (Σ (Slice l2 A) (equiv-slice' f))
-    is-contr-total-equiv-slice' (pair X f) =
-      is-contr-total-Eq-structure
+    is-torsorial-equiv-slice' (pair X f) =
+      is-torsorial-Eq-structure
         ( λ Y g e → f ~ (g ∘ map-equiv e))
-        ( is-contr-total-equiv X)
+        ( is-torsorial-equiv X)
         ( pair X id-equiv)
-        ( is-contr-total-htpy f)
+        ( is-torsorial-htpy f)
 
   abstract
     is-equiv-equiv-eq-Slice :
       (f g : Slice l2 A) → is-equiv (equiv-eq-Slice f g)
     is-equiv-equiv-eq-Slice f =
       fundamental-theorem-id
-        ( is-contr-total-equiv-slice' f)
+        ( is-torsorial-equiv-slice' f)
         ( equiv-eq-Slice f)
 
   extensionality-Slice :

--- a/src/foundation/spans.lagda.md
+++ b/src/foundation/spans.lagda.md
@@ -105,23 +105,23 @@ module _
   htpy-eq-span : (c d : span l A B) → c ＝ d → htpy-span c d
   htpy-eq-span c .c refl = refl-htpy-span c
 
-  is-contr-total-htpy-span :
+  is-torsorial-htpy-span :
     (c : span l A B) → is-contr (Σ (span l A B) (htpy-span c))
-  is-contr-total-htpy-span c =
-    is-contr-total-Eq-structure
+  is-torsorial-htpy-span c =
+    is-torsorial-Eq-structure
       ( λ X d e → coherence-hom-domain-span c (X , d) (map-equiv e))
-      ( is-contr-total-equiv (pr1 c))
+      ( is-torsorial-equiv (pr1 c))
       ( domain-span c , id-equiv)
-      ( is-contr-total-Eq-structure
+      ( is-torsorial-Eq-structure
         ( λ _ f a → coherence-triangle-maps (right-map-span c) f id)
-        ( is-contr-total-htpy (left-map-span c))
+        ( is-torsorial-htpy (left-map-span c))
         ( left-map-span c , refl-htpy)
-        (is-contr-total-htpy (right-map-span c)))
+        (is-torsorial-htpy (right-map-span c)))
 
   is-equiv-htpy-eq-span :
     (c d : span l A B) → is-equiv (htpy-eq-span c d)
   is-equiv-htpy-eq-span c =
-    fundamental-theorem-id (is-contr-total-htpy-span c) (htpy-eq-span c)
+    fundamental-theorem-id (is-torsorial-htpy-span c) (htpy-eq-span c)
 
   extensionality-span :
     (c d : span l A B) → (c ＝ d) ≃ (htpy-span c d)

--- a/src/foundation/structure-identity-principle.lagda.md
+++ b/src/foundation/structure-identity-principle.lagda.md
@@ -36,11 +36,11 @@ module _
   where
 
   abstract
-    is-contr-total-Eq-structure :
+    is-torsorial-Eq-structure :
       (is-contr-AC : is-contr (Σ A C)) (t : Σ A C) →
       is-contr (Σ (B (pr1 t)) (λ y → D (pr1 t) y (pr2 t))) →
       is-contr (Σ (Σ A B) (λ t → Σ (C (pr1 t)) (D (pr1 t) (pr2 t))))
-    is-contr-total-Eq-structure is-contr-AC t is-contr-BD =
+    is-torsorial-Eq-structure is-contr-AC t is-contr-BD =
       is-contr-equiv
         ( Σ (Σ A C) (λ t → Σ (B (pr1 t)) (λ y → D (pr1 t) y (pr2 t))))
         ( interchange-Σ-Σ D)
@@ -67,7 +67,7 @@ module _
       (z : Σ A B) → is-equiv (h z)
     structure-identity-principle {f} {g} h H K =
       fundamental-theorem-id
-        ( is-contr-total-Eq-structure
+        ( is-torsorial-Eq-structure
           ( λ x → Eq-B)
           ( fundamental-theorem-id' f H)
           ( pair a refl-A)

--- a/src/foundation/structured-type-duality.lagda.md
+++ b/src/foundation/structured-type-duality.lagda.md
@@ -63,6 +63,6 @@ equiv-fixed-Slice-structure {l} P X A =
           ( equiv-postcomp-equiv (equiv-total-fiber (pr1 (pr2 s))) X))) ∘e
     ( ( equiv-right-swap-Σ) ∘e
       ( ( inv-left-unit-law-Σ-is-contr
-          ( is-contr-total-equiv X)
+          ( is-torsorial-equiv X)
           ( X , id-equiv)))))
 ```

--- a/src/foundation/subtype-identity-principle.lagda.md
+++ b/src/foundation/subtype-identity-principle.lagda.md
@@ -43,12 +43,12 @@ module _
   where
 
   abstract
-    is-contr-total-Eq-subtype :
+    is-torsorial-Eq-subtype :
       {l3 : Level} {P : A → UU l3} →
       is-contr (Σ A B) → ((x : A) → is-prop (P x)) →
       (a : A) (b : B a) (p : P a) →
       is-contr (Σ (Σ A P) (B ∘ pr1))
-    is-contr-total-Eq-subtype {l3} {P}
+    is-torsorial-Eq-subtype {l3} {P}
       is-contr-AB is-subtype-P a b p =
       is-contr-equiv
         ( Σ (Σ A B) (P ∘ pr1))
@@ -79,7 +79,7 @@ module _
       ((x : A) → is-equiv (f x)) → (z : Σ A P) → is-equiv (h z)
     subtype-identity-principle {f} h H =
       fundamental-theorem-id
-        ( is-contr-total-Eq-subtype
+        ( is-torsorial-Eq-subtype
           ( fundamental-theorem-id' f H)
           ( is-prop-P)
           ( a)

--- a/src/foundation/subtypes.lagda.md
+++ b/src/foundation/subtypes.lagda.md
@@ -83,12 +83,12 @@ module _
   pr1 (refl-has-same-elements-subtype x) = id
   pr2 (refl-has-same-elements-subtype x) = id
 
-  is-contr-total-has-same-elements-subtype :
+  is-torsorial-has-same-elements-subtype :
     is-contr (Σ (subtype l2 A) has-same-elements-subtype)
-  is-contr-total-has-same-elements-subtype =
-    is-contr-total-Eq-Π
+  is-torsorial-has-same-elements-subtype =
+    is-torsorial-Eq-Π
       ( λ x Q → P x ⇔ Q)
-      ( λ x → is-contr-total-iff (P x))
+      ( λ x → is-torsorial-iff (P x))
 
   has-same-elements-eq-subtype :
     (Q : subtype l2 A) → (P ＝ Q) → has-same-elements-subtype Q
@@ -99,7 +99,7 @@ module _
     (Q : subtype l2 A) → is-equiv (has-same-elements-eq-subtype Q)
   is-equiv-has-same-elements-eq-subtype =
     fundamental-theorem-id
-      is-contr-total-has-same-elements-subtype
+      is-torsorial-has-same-elements-subtype
       has-same-elements-eq-subtype
 
   extensionality-subtype :

--- a/src/foundation/subuniverses.lagda.md
+++ b/src/foundation/subuniverses.lagda.md
@@ -103,11 +103,11 @@ module _
   is-prop-is-essentially-in-subuniverse X =
     is-prop-is-proof-irrelevant
       ( λ ((X' , p) , e) →
-        is-contr-total-Eq-subtype
+        is-torsorial-Eq-subtype
           ( is-contr-equiv'
             ( Σ (UU _) (λ T → T ≃ X'))
             ( equiv-tot (equiv-postcomp-equiv e))
-            ( is-contr-total-equiv' X'))
+            ( is-torsorial-equiv' X'))
           ( is-prop-is-in-subuniverse P)
           ( X')
           ( e)
@@ -179,23 +179,23 @@ module _
   equiv-eq-subuniverse (pair X p) .(pair X p) refl = id-equiv
 
   abstract
-    is-contr-total-equiv-subuniverse :
+    is-torsorial-equiv-subuniverse :
       (s : type-subuniverse P) →
       is-contr (Σ (type-subuniverse P) (λ t → equiv-subuniverse s t))
-    is-contr-total-equiv-subuniverse (pair X p) =
-      is-contr-total-Eq-subtype
-        ( is-contr-total-equiv X)
+    is-torsorial-equiv-subuniverse (pair X p) =
+      is-torsorial-Eq-subtype
+        ( is-torsorial-equiv X)
         ( is-subtype-subuniverse P)
         ( X)
         ( id-equiv)
         ( p)
 
-    is-contr-total-equiv-subuniverse' :
+    is-torsorial-equiv-subuniverse' :
       (s : type-subuniverse P) →
       is-contr (Σ (type-subuniverse P) (λ t → equiv-subuniverse t s))
-    is-contr-total-equiv-subuniverse' (pair X p) =
-      is-contr-total-Eq-subtype
-        ( is-contr-total-equiv' X)
+    is-torsorial-equiv-subuniverse' (pair X p) =
+      is-torsorial-Eq-subtype
+        ( is-torsorial-equiv' X)
         ( is-subtype-subuniverse P)
         ( X)
         ( id-equiv)
@@ -206,7 +206,7 @@ module _
       (s t : type-subuniverse P) → is-equiv (equiv-eq-subuniverse s t)
     is-equiv-equiv-eq-subuniverse (pair X p) =
       fundamental-theorem-id
-        ( is-contr-total-equiv-subuniverse (pair X p))
+        ( is-torsorial-equiv-subuniverse (pair X p))
         ( equiv-eq-subuniverse (pair X p))
 
   extensionality-subuniverse :
@@ -246,13 +246,13 @@ module _
     (Y : fam-subuniverse P X) → equiv-fam-subuniverse Y Y
   id-equiv-fam-subuniverse Y x = id-equiv
 
-  is-contr-total-equiv-fam-subuniverse :
+  is-torsorial-equiv-fam-subuniverse :
     (Y : fam-subuniverse P X) →
     is-contr (Σ (fam-subuniverse P X) (equiv-fam-subuniverse Y))
-  is-contr-total-equiv-fam-subuniverse Y =
-    is-contr-total-Eq-Π
+  is-torsorial-equiv-fam-subuniverse Y =
+    is-torsorial-Eq-Π
       ( λ x → equiv-subuniverse P (Y x))
-      ( λ x → is-contr-total-equiv-subuniverse P (Y x))
+      ( λ x → is-torsorial-equiv-subuniverse P (Y x))
 
   equiv-eq-fam-subuniverse :
     (Y Z : fam-subuniverse P X) → Y ＝ Z → equiv-fam-subuniverse Y Z
@@ -262,7 +262,7 @@ module _
     (Y Z : fam-subuniverse P X) → is-equiv (equiv-eq-fam-subuniverse Y Z)
   is-equiv-equiv-eq-fam-subuniverse Y =
     fundamental-theorem-id
-      ( is-contr-total-equiv-fam-subuniverse Y)
+      ( is-torsorial-equiv-fam-subuniverse Y)
       ( equiv-eq-fam-subuniverse Y)
 
   extensionality-fam-subuniverse :

--- a/src/foundation/surjective-maps.lagda.md
+++ b/src/foundation/surjective-maps.lagda.md
@@ -531,10 +531,10 @@ module _
   refl-htpy-surjection : htpy-surjection f
   refl-htpy-surjection = refl-htpy
 
-  is-contr-total-htpy-surjection : is-contr (Σ (A ↠ B) htpy-surjection)
-  is-contr-total-htpy-surjection =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-htpy (map-surjection f))
+  is-torsorial-htpy-surjection : is-contr (Σ (A ↠ B) htpy-surjection)
+  is-torsorial-htpy-surjection =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-htpy (map-surjection f))
       ( is-prop-is-surjective)
       ( map-surjection f)
       ( refl-htpy)
@@ -547,7 +547,7 @@ module _
   is-equiv-htpy-eq-surjection :
     (g : A ↠ B) → is-equiv (htpy-eq-surjection g)
   is-equiv-htpy-eq-surjection =
-    fundamental-theorem-id is-contr-total-htpy-surjection htpy-eq-surjection
+    fundamental-theorem-id is-torsorial-htpy-surjection htpy-eq-surjection
 
   extensionality-surjection :
     (g : A ↠ B) → (f ＝ g) ≃ htpy-surjection g
@@ -577,14 +577,14 @@ module _
   pr1 id-equiv-Surjection = id-equiv
   pr2 id-equiv-Surjection = refl-htpy
 
-  is-contr-total-equiv-Surjection :
+  is-torsorial-equiv-Surjection :
     is-contr (Σ (Surjection l2 A) (equiv-Surjection f))
-  is-contr-total-equiv-Surjection =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-Surjection =
+    is-torsorial-Eq-structure
       ( λ Y g e → (map-equiv e ∘ map-Surjection f) ~ map-surjection g)
-      ( is-contr-total-equiv (type-Surjection f))
+      ( is-torsorial-equiv (type-Surjection f))
       ( type-Surjection f , id-equiv)
-      ( is-contr-total-htpy-surjection (surjection-Surjection f))
+      ( is-torsorial-htpy-surjection (surjection-Surjection f))
 
   equiv-eq-Surjection :
     (g : Surjection l2 A) → (f ＝ g) → equiv-Surjection f g
@@ -594,7 +594,7 @@ module _
     (g : Surjection l2 A) → is-equiv (equiv-eq-Surjection g)
   is-equiv-equiv-eq-Surjection =
     fundamental-theorem-id
-      is-contr-total-equiv-Surjection
+      is-torsorial-equiv-Surjection
       equiv-eq-Surjection
 
   extensionality-Surjection :

--- a/src/foundation/symmetric-identity-types.lagda.md
+++ b/src/foundation/symmetric-identity-types.lagda.md
@@ -62,14 +62,14 @@ module _
     pr1 (refl-Eq-symmetric-Id (x , H)) = refl
     pr2 (refl-Eq-symmetric-Id (x , H)) i = refl
 
-    is-contr-total-Eq-symmetric-Id :
+    is-torsorial-Eq-symmetric-Id :
       (p : symmetric-Id a) → is-contr (Σ (symmetric-Id a) (Eq-symmetric-Id p))
-    is-contr-total-Eq-symmetric-Id (x , H) =
-      is-contr-total-Eq-structure
+    is-torsorial-Eq-symmetric-Id (x , H) =
+      is-torsorial-Eq-structure
         ( λ y K p → (i : type-unordered-pair a) → H i ＝ (p ∙ K i))
-        ( is-contr-total-path x)
+        ( is-torsorial-path x)
         ( x , refl)
-        ( is-contr-total-htpy H)
+        ( is-torsorial-htpy H)
 
     Eq-eq-symmetric-Id :
       (p q : symmetric-Id a) → (p ＝ q) → Eq-symmetric-Id p q
@@ -79,7 +79,7 @@ module _
       (p q : symmetric-Id a) → is-equiv (Eq-eq-symmetric-Id p q)
     is-equiv-Eq-eq-symmetric-Id p =
       fundamental-theorem-id
-        ( is-contr-total-Eq-symmetric-Id p)
+        ( is-torsorial-Eq-symmetric-Id p)
         ( Eq-eq-symmetric-Id p)
 
     extensionality-symmetric-Id :

--- a/src/foundation/symmetric-operations.lagda.md
+++ b/src/foundation/symmetric-operations.lagda.md
@@ -210,13 +210,13 @@ module _
               ( Id-Prop B (f p) (g p))
               ( λ where (x , y , refl) → H x y)))
 
-  is-contr-total-htpy-symmetric-operation-Set :
+  is-torsorial-htpy-symmetric-operation-Set :
     is-contr
       ( Σ ( symmetric-operation A (type-Set B))
           ( htpy-symmetric-operation-Set))
-  pr1 is-contr-total-htpy-symmetric-operation-Set =
+  pr1 is-torsorial-htpy-symmetric-operation-Set =
     center-total-htpy-symmetric-operation-Set
-  pr2 is-contr-total-htpy-symmetric-operation-Set =
+  pr2 is-torsorial-htpy-symmetric-operation-Set =
     contraction-total-htpy-symmetric-operation-Set
 
   htpy-eq-symmetric-operation-Set :
@@ -229,7 +229,7 @@ module _
     is-equiv (htpy-eq-symmetric-operation-Set g)
   is-equiv-htpy-eq-symmetric-operation-Set =
     fundamental-theorem-id
-      is-contr-total-htpy-symmetric-operation-Set
+      is-torsorial-htpy-symmetric-operation-Set
       htpy-eq-symmetric-operation-Set
 
   extensionality-symmetric-operation-Set :

--- a/src/foundation/truncated-types.lagda.md
+++ b/src/foundation/truncated-types.lagda.md
@@ -29,12 +29,12 @@ open import foundation-core.truncation-levels
 ### The subuniverse of truncated types is itself truncated
 
 ```agda
-is-contr-total-equiv-Truncated-Type :
+is-torsorial-equiv-Truncated-Type :
   {l : Level} {k : 𝕋} (A : Truncated-Type l k) →
   is-contr (Σ (Truncated-Type l k) (type-equiv-Truncated-Type A))
-is-contr-total-equiv-Truncated-Type A =
-  is-contr-total-Eq-subtype
-    ( is-contr-total-equiv (type-Truncated-Type A))
+is-torsorial-equiv-Truncated-Type A =
+  is-torsorial-Eq-subtype
+    ( is-torsorial-equiv (type-Truncated-Type A))
     ( is-prop-is-trunc _)
     ( type-Truncated-Type A)
     ( id-equiv)

--- a/src/foundation/truncations.lagda.md
+++ b/src/foundation/truncations.lagda.md
@@ -392,10 +392,10 @@ module _
     map-compute-Eq-trunc a (unit-trunc refl) ＝ refl-Eq-trunc
   refl-compute-Eq-trunc = refl
 
-  is-contr-total-Eq-trunc : is-contr (Σ (type-trunc (succ-𝕋 k) A) Eq-trunc)
-  pr1 (pr1 is-contr-total-Eq-trunc) = unit-trunc a
-  pr2 (pr1 is-contr-total-Eq-trunc) = refl-Eq-trunc
-  pr2 is-contr-total-Eq-trunc =
+  is-torsorial-Eq-trunc : is-contr (Σ (type-trunc (succ-𝕋 k) A) Eq-trunc)
+  pr1 (pr1 is-torsorial-Eq-trunc) = unit-trunc a
+  pr2 (pr1 is-torsorial-Eq-trunc) = refl-Eq-trunc
+  pr2 is-torsorial-Eq-trunc =
     function-dependent-universal-property-total-truncated-fam-trunc
       ( λ y → trunc k (a ＝ y))
       ( Id-Truncated-Type
@@ -433,7 +433,7 @@ module _
     (x : type-trunc (succ-𝕋 k) A) → is-equiv (Eq-eq-trunc x)
   is-equiv-Eq-eq-trunc =
     fundamental-theorem-id
-      ( is-contr-total-Eq-trunc)
+      ( is-torsorial-Eq-trunc)
       ( Eq-eq-trunc)
 
   extensionality-trunc :

--- a/src/foundation/type-duality.lagda.md
+++ b/src/foundation/type-duality.lagda.md
@@ -138,7 +138,7 @@ is-emb-map-type-duality
             ≃ ( (X , f) ＝ (Y , g))
               by
               inv-equiv (extensionality-Slice (X , f) (Y , g))))
-      ( is-contr-total-path (X , f)))
+      ( is-torsorial-path (X , f)))
     ( λ Y → ap (map-type-duality H))
 
 emb-type-duality :

--- a/src/foundation/uniqueness-set-quotients.lagda.md
+++ b/src/foundation/uniqueness-set-quotients.lagda.md
@@ -180,7 +180,7 @@ module _
             ( map-equiv e ∘ map-reflecting-map-Equivalence-Relation R f) ~
             ( map-reflecting-map-Equivalence-Relation R g)))
   uniqueness-set-quotient =
-    is-contr-total-Eq-subtype
+    is-torsorial-Eq-subtype
       ( universal-property-set-quotient-is-set-quotient R B f Uf C g)
       ( is-property-is-equiv)
       ( map-universal-property-set-quotient-is-set-quotient R B f Uf C g)

--- a/src/foundation/univalence.lagda.md
+++ b/src/foundation/univalence.lagda.md
@@ -84,18 +84,18 @@ module _
 
 ```agda
   abstract
-    is-contr-total-equiv :
+    is-torsorial-equiv :
       (A : UU l) → is-contr (Σ (UU l) (λ X → A ≃ X))
-    is-contr-total-equiv A =
-      is-contr-total-equiv-based-univalence A (univalence A)
+    is-torsorial-equiv A =
+      is-torsorial-equiv-based-univalence A (univalence A)
 
-    is-contr-total-equiv' :
+    is-torsorial-equiv' :
       (A : UU l) → is-contr (Σ (UU l) (λ X → X ≃ A))
-    is-contr-total-equiv' A =
+    is-torsorial-equiv' A =
       is-contr-equiv'
         ( Σ (UU l) (λ X → X ＝ A))
         ( equiv-tot (λ X → equiv-univalence))
-        ( is-contr-total-path' A)
+        ( is-torsorial-path' A)
 ```
 
 ### Univalence for type families
@@ -115,20 +115,20 @@ equiv-eq-fam :
 equiv-eq-fam B .B refl = id-equiv-fam B
 
 abstract
-  is-contr-total-equiv-fam :
+  is-torsorial-equiv-fam :
     {l1 l2 : Level} {A : UU l1} (B : A → UU l2) →
     is-contr (Σ (A → UU l2) (equiv-fam B))
-  is-contr-total-equiv-fam B =
-    is-contr-total-Eq-Π
+  is-torsorial-equiv-fam B =
+    is-torsorial-Eq-Π
       ( λ x X → (B x) ≃ X)
-      ( λ x → is-contr-total-equiv (B x))
+      ( λ x → is-torsorial-equiv (B x))
 
 abstract
   is-equiv-equiv-eq-fam :
     {l1 l2 : Level} {A : UU l1} (B C : A → UU l2) → is-equiv (equiv-eq-fam B C)
   is-equiv-equiv-eq-fam B =
     fundamental-theorem-id
-      ( is-contr-total-equiv-fam B)
+      ( is-torsorial-equiv-fam B)
       ( equiv-eq-fam B)
 
 extensionality-fam :

--- a/src/foundation/universal-property-identity-types.lagda.md
+++ b/src/foundation/universal-property-identity-types.lagda.md
@@ -123,7 +123,7 @@ module _
         ( λ _ →
           is-injective-emb
             ( emb-fiber a)
-            ( eq-is-contr (is-contr-total-path a))))
+            ( eq-is-contr (is-torsorial-path a))))
       ( λ _ → ap Id)
     where
     emb-fiber : (a : A) → fiber' Id (Id a) ↪ Σ A (Id a)
@@ -136,7 +136,7 @@ module _
                 ( equiv-ev-refl x) ∘e
                 ( ( equiv-inclusion-is-full-subtype
                     ( Π-Prop A ∘ (is-equiv-Prop ∘_))
-                    ( fundamental-theorem-id (is-contr-total-path a))) ∘e
+                    ( fundamental-theorem-id (is-torsorial-path a))) ∘e
                   ( distributive-Π-Σ)))))
           ( emb-Σ
             ( λ x → (y : A) → Id x y ≃ Id a y)

--- a/src/foundation/universal-property-propositional-truncation.lagda.md
+++ b/src/foundation/universal-property-propositional-truncation.lagda.md
@@ -203,7 +203,7 @@ abstract
     ({l : Level} → is-propositional-truncation l P' f') →
     is-contr (Σ (type-equiv-Prop P P') (λ e → (map-equiv e ∘ f) ~ f'))
   is-uniquely-unique-propositional-truncation P P' f f' is-ptr-f is-ptr-f' =
-    is-contr-total-Eq-subtype
+    is-torsorial-Eq-subtype
       ( universal-property-is-propositional-truncation _ P f is-ptr-f P' f')
       ( is-property-is-equiv)
       ( map-is-propositional-truncation P f is-ptr-f P' f')

--- a/src/foundation/universal-property-pullbacks.lagda.md
+++ b/src/foundation/universal-property-pullbacks.lagda.md
@@ -99,7 +99,7 @@ module _
       is-contr
         ( Σ (C' ≃ C) (λ e → htpy-cone f g (cone-map f g c (map-equiv e)) c'))
     uniquely-unique-pullback c' c up-c' up-c =
-      is-contr-total-Eq-subtype
+      is-torsorial-Eq-subtype
         ( uniqueness-universal-property-pullback f g c up-c C' c')
         ( is-property-is-equiv)
         ( map-universal-property-pullback f g c up-c c')

--- a/src/foundation/universal-property-sequential-limits.lagda.md
+++ b/src/foundation/universal-property-sequential-limits.lagda.md
@@ -225,7 +225,7 @@ module _
         ( Σ (Y ≃ X)
             ( λ e → htpy-cone-tower A (cone-map-tower A c (map-equiv e)) c'))
     uniquely-unique-sequential-limit c' c up-c' up-c =
-      is-contr-total-Eq-subtype
+      is-torsorial-Eq-subtype
         ( uniqueness-universal-property-sequential-limit A c up-c Y c')
         ( is-property-is-equiv)
         ( map-universal-property-sequential-limit A c up-c c')

--- a/src/foundation/universal-property-set-quotients.lagda.md
+++ b/src/foundation/universal-property-set-quotients.lagda.md
@@ -463,14 +463,14 @@ module _
                 ( compute-P (pr1 v))
                 ( inv-tr (type-Prop ∘ P) (pr2 v) p))) ∙
             ( pr2 v)))
-    is-contr-total-P : is-contr (Σ (type-Set B) (λ b → type-Prop (P b)))
-    is-contr-total-P = pair center-total-P contraction-total-P
+    is-torsorial-P : is-contr (Σ (type-Set B) (λ b → type-Prop (P b)))
+    is-torsorial-P = pair center-total-P contraction-total-P
     β :
       (b : type-Set B) →
       map-reflecting-map-Equivalence-Relation R q x ＝ b → type-Prop (P b)
     β .(map-reflecting-map-Equivalence-Relation R q x) refl = point-P
     γ : (b : type-Set B) → is-equiv (β b)
-    γ = fundamental-theorem-id is-contr-total-P β
+    γ = fundamental-theorem-id is-torsorial-P β
     δ :
       (b : type-Set B) →
       (map-reflecting-map-Equivalence-Relation R q x ＝ b) ≃ type-Prop (P b)

--- a/src/foundation/universal-property-truncation.lagda.md
+++ b/src/foundation/universal-property-truncation.lagda.md
@@ -69,7 +69,7 @@ module _
                       ( K x' x)
                       ( Id-Truncated-Type C (g x') z)))) ∘e
               ( equiv-ev-pair)))
-          ( is-contr-total-path (g x)))
+          ( is-torsorial-path (g x)))
 
   is-truncation-is-truncation-ap :
     {l : Level} → is-truncation l B f

--- a/src/foundation/unordered-pairs-of-types.lagda.md
+++ b/src/foundation/unordered-pairs-of-types.lagda.md
@@ -86,22 +86,22 @@ module _
     (B : unordered-pair-types l) → A ＝ B → equiv-unordered-pair-types A B
   equiv-eq-unordered-pair-types .A refl = id-equiv-unordered-pair-types
 
-  is-contr-total-equiv-unordered-pair-types :
+  is-torsorial-equiv-unordered-pair-types :
     is-contr (Σ (unordered-pair-types l) (equiv-unordered-pair-types A))
-  is-contr-total-equiv-unordered-pair-types =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-unordered-pair-types =
+    is-torsorial-Eq-structure
       ( λ I B e →
         (i : type-unordered-pair A) →
         element-unordered-pair A i ≃ B (map-equiv e i))
-      ( is-contr-total-equiv-2-Element-Type (2-element-type-unordered-pair A))
+      ( is-torsorial-equiv-2-Element-Type (2-element-type-unordered-pair A))
       ( pair (2-element-type-unordered-pair A) id-equiv)
-      ( is-contr-total-equiv-fam (element-unordered-pair A))
+      ( is-torsorial-equiv-fam (element-unordered-pair A))
 
   is-equiv-equiv-eq-unordered-pair-types :
     (B : unordered-pair-types l) → is-equiv (equiv-eq-unordered-pair-types B)
   is-equiv-equiv-eq-unordered-pair-types =
     fundamental-theorem-id
-      is-contr-total-equiv-unordered-pair-types
+      is-torsorial-equiv-unordered-pair-types
       equiv-eq-unordered-pair-types
 
   extensionality-unordered-pair-types :

--- a/src/foundation/unordered-pairs.lagda.md
+++ b/src/foundation/unordered-pairs.lagda.md
@@ -183,21 +183,21 @@ module _
     (p q : unordered-pair A) → p ＝ q → Eq-unordered-pair p q
   Eq-eq-unordered-pair p .p refl = refl-Eq-unordered-pair p
 
-  is-contr-total-Eq-unordered-pair :
+  is-torsorial-Eq-unordered-pair :
     (p : unordered-pair A) →
     is-contr (Σ (unordered-pair A) (Eq-unordered-pair p))
-  is-contr-total-Eq-unordered-pair (pair X p) =
-    is-contr-total-Eq-structure
+  is-torsorial-Eq-unordered-pair (pair X p) =
+    is-torsorial-Eq-structure
       ( λ Y q e → p ~ (q ∘ map-equiv e))
-      ( is-contr-total-equiv-UU-Fin {k = 2} X)
+      ( is-torsorial-equiv-UU-Fin {k = 2} X)
       ( pair X (id-equiv-UU-Fin {k = 2} X))
-      ( is-contr-total-htpy p)
+      ( is-torsorial-htpy p)
 
   is-equiv-Eq-eq-unordered-pair :
     (p q : unordered-pair A) → is-equiv (Eq-eq-unordered-pair p q)
   is-equiv-Eq-eq-unordered-pair p =
     fundamental-theorem-id
-      ( is-contr-total-Eq-unordered-pair p)
+      ( is-torsorial-Eq-unordered-pair p)
       ( Eq-eq-unordered-pair p)
 
   extensionality-unordered-pair :
@@ -264,7 +264,7 @@ module _
         ( triangle-ev-refl-Eq-unordered-pair)
         ( dependent-universal-property-contr-is-contr
           ( p , refl-Eq-unordered-pair p)
-          ( is-contr-total-Eq-unordered-pair p)
+          ( is-torsorial-Eq-unordered-pair p)
           ( λ u → B (pr1 u) (pr2 u)))
         ( is-equiv-ev-pair)
 

--- a/src/foundation/unordered-tuples-of-types.lagda.md
+++ b/src/foundation/unordered-tuples-of-types.lagda.md
@@ -91,23 +91,23 @@ module _
     (B : unordered-tuple-types l n) → A ＝ B → equiv-unordered-tuple-types n A B
   equiv-eq-unordered-tuple-types .A refl = id-equiv-unordered-tuple-types
 
-  is-contr-total-equiv-unordered-tuple-types :
+  is-torsorial-equiv-unordered-tuple-types :
     is-contr (Σ (unordered-tuple-types l n) (equiv-unordered-tuple-types n A))
-  is-contr-total-equiv-unordered-tuple-types =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-unordered-tuple-types =
+    is-torsorial-Eq-structure
       ( λ I B e →
         (i : type-unordered-tuple n A) →
         element-unordered-tuple n A i ≃ B (map-equiv e i))
-      ( is-contr-total-equiv-UU-Fin {k = n} (type-unordered-tuple-UU-Fin n A))
+      ( is-torsorial-equiv-UU-Fin {k = n} (type-unordered-tuple-UU-Fin n A))
       ( pair (type-unordered-tuple-UU-Fin n A) id-equiv)
-      ( is-contr-total-equiv-fam (element-unordered-tuple n A))
+      ( is-torsorial-equiv-fam (element-unordered-tuple n A))
 
   is-equiv-equiv-eq-unordered-tuple-types :
     (B : unordered-tuple-types l n) →
     is-equiv (equiv-eq-unordered-tuple-types B)
   is-equiv-equiv-eq-unordered-tuple-types =
     fundamental-theorem-id
-      is-contr-total-equiv-unordered-tuple-types
+      is-torsorial-equiv-unordered-tuple-types
       equiv-eq-unordered-tuple-types
 
   extensionality-unordered-tuple-types :

--- a/src/foundation/unordered-tuples.lagda.md
+++ b/src/foundation/unordered-tuples.lagda.md
@@ -141,21 +141,21 @@ module _
     (x y : unordered-tuple n A) → x ＝ y → Eq-unordered-tuple x y
   Eq-eq-unordered-tuple x .x refl = refl-Eq-unordered-tuple x
 
-  is-contr-total-Eq-unordered-tuple :
+  is-torsorial-Eq-unordered-tuple :
     (x : unordered-tuple n A) →
     is-contr (Σ (unordered-tuple n A) (Eq-unordered-tuple x))
-  is-contr-total-Eq-unordered-tuple x =
-    is-contr-total-Eq-structure
+  is-torsorial-Eq-unordered-tuple x =
+    is-torsorial-Eq-structure
       ( λ i f e → element-unordered-tuple n x ~ (f ∘ map-equiv e))
-      ( is-contr-total-equiv-UU-Fin {k = n} (type-unordered-tuple-UU-Fin n x))
+      ( is-torsorial-equiv-UU-Fin {k = n} (type-unordered-tuple-UU-Fin n x))
       ( pair (type-unordered-tuple-UU-Fin n x) id-equiv)
-      ( is-contr-total-htpy (element-unordered-tuple n x))
+      ( is-torsorial-htpy (element-unordered-tuple n x))
 
   is-equiv-Eq-eq-unordered-tuple :
     (x y : unordered-tuple n A) → is-equiv (Eq-eq-unordered-tuple x y)
   is-equiv-Eq-eq-unordered-tuple x =
     fundamental-theorem-id
-      ( is-contr-total-Eq-unordered-tuple x)
+      ( is-torsorial-Eq-unordered-tuple x)
       ( Eq-eq-unordered-tuple x)
 
   extensionality-unordered-tuple :

--- a/src/foundation/weak-function-extensionality.lagda.md
+++ b/src/foundation/weak-function-extensionality.lagda.md
@@ -86,7 +86,7 @@ abstract
           ( λ t → eq-pair-Σ refl refl))
         ( weak-funext A
           ( λ x → Σ (B x) (λ b → f x ＝ b))
-          ( λ x → is-contr-total-path (f x))))
+          ( λ x → is-torsorial-path (f x))))
       ( λ g → htpy-eq {g = g})
 ```
 

--- a/src/graph-theory/equivalences-directed-graphs.lagda.md
+++ b/src/graph-theory/equivalences-directed-graphs.lagda.md
@@ -254,10 +254,10 @@ module _
   (e : equiv-Directed-Graph G H)
   where
 
-  is-contr-total-htpy-equiv-Directed-Graph :
+  is-torsorial-htpy-equiv-Directed-Graph :
     is-contr (Σ (equiv-Directed-Graph G H) (htpy-equiv-Directed-Graph G H e))
-  is-contr-total-htpy-equiv-Directed-Graph =
-    is-contr-total-Eq-structure
+  is-torsorial-htpy-equiv-Directed-Graph =
+    is-torsorial-Eq-structure
       ( λ α β γ →
         (x y : vertex-Directed-Graph G) (u : edge-Directed-Graph G x y) →
         ( binary-tr
@@ -266,19 +266,19 @@ module _
             ( γ y)
             ( edge-equiv-Directed-Graph G H e x y u)) ＝
         ( map-equiv (β x y) u))
-      ( is-contr-total-htpy-equiv (equiv-vertex-equiv-Directed-Graph G H e))
+      ( is-torsorial-htpy-equiv (equiv-vertex-equiv-Directed-Graph G H e))
       ( equiv-vertex-equiv-Directed-Graph G H e , refl-htpy)
-      ( is-contr-total-Eq-Π
+      ( is-torsorial-Eq-Π
         ( λ x β →
           (y : vertex-Directed-Graph G) (u : edge-Directed-Graph G x y) →
           edge-equiv-Directed-Graph G H e x y u ＝ map-equiv (β y) u)
         ( λ x →
-          is-contr-total-Eq-Π
+          is-torsorial-Eq-Π
             ( λ y β →
               (u : edge-Directed-Graph G x y) →
               edge-equiv-Directed-Graph G H e x y u ＝ map-equiv β u)
             ( λ y →
-              is-contr-total-htpy-equiv
+              is-torsorial-htpy-equiv
                 ( equiv-edge-equiv-Directed-Graph G H e x y))))
 
   htpy-eq-equiv-Directed-Graph :
@@ -290,7 +290,7 @@ module _
     is-equiv (htpy-eq-equiv-Directed-Graph f)
   is-equiv-htpy-eq-equiv-Directed-Graph =
     fundamental-theorem-id
-      is-contr-total-htpy-equiv-Directed-Graph
+      is-torsorial-htpy-equiv-Directed-Graph
       htpy-eq-equiv-Directed-Graph
 
   extensionality-equiv-Directed-Graph :
@@ -342,13 +342,13 @@ module _
     (H : Directed-Graph l1 l2) → equiv-Directed-Graph G H → (G ＝ H)
   eq-equiv-Directed-Graph H = map-inv-equiv (extensionality-Directed-Graph H)
 
-  is-contr-total-equiv-Directed-Graph :
+  is-torsorial-equiv-Directed-Graph :
     is-contr (Σ (Directed-Graph l1 l2) (equiv-Directed-Graph G))
-  is-contr-total-equiv-Directed-Graph =
+  is-torsorial-equiv-Directed-Graph =
     is-contr-equiv'
       ( Σ (Directed-Graph l1 l2) (λ H → G ＝ H))
       ( equiv-tot extensionality-Directed-Graph)
-      ( is-contr-total-path G)
+      ( is-torsorial-path G)
 ```
 
 ### The inverse of an equivalence of directed trees

--- a/src/graph-theory/equivalences-enriched-undirected-graphs.lagda.md
+++ b/src/graph-theory/equivalences-enriched-undirected-graphs.lagda.md
@@ -188,12 +188,12 @@ module _
   (G : Enriched-Undirected-Graph l3 l4 A B)
   where
 
-  is-contr-total-equiv-Enriched-Undirected-Graph :
+  is-torsorial-equiv-Enriched-Undirected-Graph :
     is-contr
       ( Σ ( Enriched-Undirected-Graph l3 l4 A B)
           ( equiv-Enriched-Undirected-Graph A B G))
-  is-contr-total-equiv-Enriched-Undirected-Graph =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-Enriched-Undirected-Graph =
+    is-torsorial-Eq-structure
       ( λ H fn e →
         Σ ( ( shape-vertex-Enriched-Undirected-Graph A B G) ~
             ( ( shape-vertex-Enriched-Undirected-Graph A B (H , fn)) ∘
@@ -216,13 +216,13 @@ module _
                     ( e)
                     ( x))) ∘e
                 ( equiv-tr B (α x)))))
-      ( is-contr-total-equiv-Undirected-Graph
+      ( is-torsorial-equiv-Undirected-Graph
         ( undirected-graph-Enriched-Undirected-Graph A B G))
       ( pair
         ( undirected-graph-Enriched-Undirected-Graph A B G)
         ( id-equiv-Undirected-Graph
           ( undirected-graph-Enriched-Undirected-Graph A B G)))
-      ( is-contr-total-Eq-structure
+      ( is-torsorial-Eq-structure
         ( λ f α K →
           ( x : vertex-Enriched-Undirected-Graph A B G) →
           htpy-equiv
@@ -244,12 +244,12 @@ module _
                     ( undirected-graph-Enriched-Undirected-Graph A B G))
                 ( x)) ∘e
               ( equiv-tr B (K x))))
-        ( is-contr-total-htpy
+        ( is-torsorial-htpy
           ( shape-vertex-Enriched-Undirected-Graph A B G))
         ( pair
           ( shape-vertex-Enriched-Undirected-Graph A B G)
           ( refl-htpy))
-        ( is-contr-total-Eq-Π
+        ( is-torsorial-Eq-Π
           ( λ x →
             htpy-equiv
               ( ( equiv-neighbor-equiv-Undirected-Graph
@@ -260,7 +260,7 @@ module _
                     ( x)) ∘e
                 ( equiv-neighbor-Enriched-Undirected-Graph A B G x)))
           ( λ x →
-            is-contr-total-htpy-equiv
+            is-torsorial-htpy-equiv
               ( equiv-neighbor-equiv-Undirected-Graph
                   ( undirected-graph-Enriched-Undirected-Graph A B G)
                   ( undirected-graph-Enriched-Undirected-Graph A B G)
@@ -280,7 +280,7 @@ module _
     is-equiv (equiv-eq-Enriched-Undirected-Graph H)
   is-equiv-equiv-eq-Enriched-Undirected-Graph =
     fundamental-theorem-id
-      ( is-contr-total-equiv-Enriched-Undirected-Graph)
+      ( is-torsorial-equiv-Enriched-Undirected-Graph)
       ( equiv-eq-Enriched-Undirected-Graph)
 
   extensionality-Enriched-Undirected-Graph :

--- a/src/graph-theory/equivalences-undirected-graphs.lagda.md
+++ b/src/graph-theory/equivalences-undirected-graphs.lagda.md
@@ -190,11 +190,11 @@ module _
     htpy-equiv-Undirected-Graph f g
   htpy-eq-equiv-Undirected-Graph f .f refl = refl-htpy-equiv-Undirected-Graph f
 
-  is-contr-total-htpy-equiv-Undirected-Graph :
+  is-torsorial-htpy-equiv-Undirected-Graph :
     (f : equiv-Undirected-Graph G H) →
     is-contr (Σ (equiv-Undirected-Graph G H) (htpy-equiv-Undirected-Graph f))
-  is-contr-total-htpy-equiv-Undirected-Graph f =
-    is-contr-total-Eq-structure
+  is-torsorial-htpy-equiv-Undirected-Graph f =
+    is-torsorial-Eq-structure
       ( λ gV gE α →
         ( p : unordered-pair-vertices-Undirected-Graph G) →
           ( e : edge-Undirected-Graph G p) →
@@ -204,7 +204,7 @@ module _
               ( htpy-unordered-pair α p)
               ( edge-equiv-Undirected-Graph G H f p e))
             ( map-equiv (gE p) e))
-      ( is-contr-total-htpy-equiv (equiv-vertex-equiv-Undirected-Graph G H f))
+      ( is-torsorial-htpy-equiv (equiv-vertex-equiv-Undirected-Graph G H f))
       ( pair (equiv-vertex-equiv-Undirected-Graph G H f) refl-htpy)
       ( is-contr-equiv'
         ( Σ ( (p : unordered-pair-vertices-Undirected-Graph G) →
@@ -224,13 +224,13 @@ module _
                     equiv-concat
                       ( pr2 (refl-htpy-equiv-Undirected-Graph f) p e)
                       ( map-equiv (gE p) e)))))
-        ( is-contr-total-Eq-Π
+        ( is-torsorial-Eq-Π
           ( λ p e →
             htpy-equiv
               ( equiv-edge-equiv-Undirected-Graph G H f p)
               ( e))
           ( λ p →
-            is-contr-total-htpy-equiv
+            is-torsorial-htpy-equiv
               ( equiv-edge-equiv-Undirected-Graph G H f p))))
 
   is-equiv-htpy-eq-equiv-Undirected-Graph :
@@ -238,7 +238,7 @@ module _
     is-equiv (htpy-eq-equiv-Undirected-Graph f g)
   is-equiv-htpy-eq-equiv-Undirected-Graph f =
     fundamental-theorem-id
-      ( is-contr-total-htpy-equiv-Undirected-Graph f)
+      ( is-torsorial-htpy-equiv-Undirected-Graph f)
       ( htpy-eq-equiv-Undirected-Graph f)
 
   extensionality-equiv-Undirected-Graph :
@@ -267,24 +267,24 @@ module _
     (H : Undirected-Graph l1 l2) → Id G H → equiv-Undirected-Graph G H
   equiv-eq-Undirected-Graph .G refl = id-equiv-Undirected-Graph G
 
-  is-contr-total-equiv-Undirected-Graph :
+  is-torsorial-equiv-Undirected-Graph :
     is-contr (Σ (Undirected-Graph l1 l2) (equiv-Undirected-Graph G))
-  is-contr-total-equiv-Undirected-Graph =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-Undirected-Graph =
+    is-torsorial-Eq-structure
       ( λ VH VE e →
         ( p : unordered-pair-vertices-Undirected-Graph G) →
         edge-Undirected-Graph G p ≃ VE (map-equiv-unordered-pair e p))
-      ( is-contr-total-equiv (vertex-Undirected-Graph G))
+      ( is-torsorial-equiv (vertex-Undirected-Graph G))
       ( pair (vertex-Undirected-Graph G) id-equiv)
-      ( is-contr-total-Eq-Π
+      ( is-torsorial-Eq-Π
         ( λ p X → (edge-Undirected-Graph G p) ≃ X)
-        ( λ p → is-contr-total-equiv (edge-Undirected-Graph G p)))
+        ( λ p → is-torsorial-equiv (edge-Undirected-Graph G p)))
 
   is-equiv-equiv-eq-Undirected-Graph :
     (H : Undirected-Graph l1 l2) → is-equiv (equiv-eq-Undirected-Graph H)
   is-equiv-equiv-eq-Undirected-Graph =
     fundamental-theorem-id
-      ( is-contr-total-equiv-Undirected-Graph)
+      ( is-torsorial-equiv-Undirected-Graph)
       ( equiv-eq-Undirected-Graph)
 
   extensionality-Undirected-Graph :

--- a/src/graph-theory/fibers-directed-graphs.lagda.md
+++ b/src/graph-theory/fibers-directed-graphs.lagda.md
@@ -200,7 +200,7 @@ module _
     direct-predecessor-Directed-Graph G
       ( node-inclusion-fiber-Directed-Graph G x y)
   compute-direct-predecessor-fiber-Directed-Graph y =
-    ( right-unit-law-Σ-is-contr (λ (u , e) → is-contr-total-path' _)) ∘e
+    ( right-unit-law-Σ-is-contr (λ (u , e) → is-torsorial-path' _)) ∘e
     ( interchange-Σ-Σ _)
 
   map-compute-direct-predecessor-fiber-Directed-Graph :

--- a/src/graph-theory/morphisms-directed-graphs.lagda.md
+++ b/src/graph-theory/morphisms-directed-graphs.lagda.md
@@ -178,11 +178,11 @@ module _
     (f g : hom-Directed-Graph G H) → f ＝ g → htpy-hom-Directed-Graph f g
   htpy-eq-hom-Directed-Graph f .f refl = refl-htpy-hom-Directed-Graph f
 
-  is-contr-total-htpy-hom-Directed-Graph :
+  is-torsorial-htpy-hom-Directed-Graph :
     (f : hom-Directed-Graph G H) →
     is-contr (Σ (hom-Directed-Graph G H) (htpy-hom-Directed-Graph f))
-  is-contr-total-htpy-hom-Directed-Graph f =
-    is-contr-total-Eq-structure
+  is-torsorial-htpy-hom-Directed-Graph f =
+    is-torsorial-Eq-structure
       ( λ gV gE α →
         (x y : vertex-Directed-Graph G) (e : edge-Directed-Graph G x y) →
         binary-tr
@@ -191,24 +191,24 @@ module _
           ( α y)
           ( edge-hom-Directed-Graph G H f e) ＝
         gE x y e)
-      ( is-contr-total-htpy (vertex-hom-Directed-Graph G H f))
+      ( is-torsorial-htpy (vertex-hom-Directed-Graph G H f))
       ( pair
         ( vertex-hom-Directed-Graph G H f)
         ( refl-htpy))
-      ( is-contr-total-Eq-Π
+      ( is-torsorial-Eq-Π
         ( λ x g →
           ( y : vertex-Directed-Graph G) →
           ( λ e → edge-hom-Directed-Graph G H f e) ~ g y)
         ( λ x →
-          is-contr-total-Eq-Π
+          is-torsorial-Eq-Π
             ( λ y g → (λ e → edge-hom-Directed-Graph G H f e) ~ g)
-            ( λ y → is-contr-total-htpy (edge-hom-Directed-Graph G H f))))
+            ( λ y → is-torsorial-htpy (edge-hom-Directed-Graph G H f))))
 
   is-equiv-htpy-eq-hom-Directed-Graph :
     (f g : hom-Directed-Graph G H) → is-equiv (htpy-eq-hom-Directed-Graph f g)
   is-equiv-htpy-eq-hom-Directed-Graph f =
     fundamental-theorem-id
-      ( is-contr-total-htpy-hom-Directed-Graph f)
+      ( is-torsorial-htpy-hom-Directed-Graph f)
       ( htpy-eq-hom-Directed-Graph f)
 
   extensionality-hom-Directed-Graph :

--- a/src/graph-theory/morphisms-undirected-graphs.lagda.md
+++ b/src/graph-theory/morphisms-undirected-graphs.lagda.md
@@ -135,11 +135,11 @@ module _
   htpy-eq-hom-Undirected-Graph f .f refl = refl-htpy-hom-Undirected-Graph f
 
   abstract
-    is-contr-total-htpy-hom-Undirected-Graph :
+    is-torsorial-htpy-hom-Undirected-Graph :
       (f : hom-Undirected-Graph G H) →
       is-contr (Σ (hom-Undirected-Graph G H) (htpy-hom-Undirected-Graph f))
-    is-contr-total-htpy-hom-Undirected-Graph f =
-      is-contr-total-Eq-structure
+    is-torsorial-htpy-hom-Undirected-Graph f =
+      is-torsorial-Eq-structure
         ( λ gV gE α →
           ( p : unordered-pair-vertices-Undirected-Graph G) →
           ( e : edge-Undirected-Graph G p) →
@@ -149,7 +149,7 @@ module _
               ( htpy-unordered-pair α p)
               ( edge-hom-Undirected-Graph G H f p e))
             ( gE p e))
-        ( is-contr-total-htpy (vertex-hom-Undirected-Graph G H f))
+        ( is-torsorial-htpy (vertex-hom-Undirected-Graph G H f))
         ( pair (vertex-hom-Undirected-Graph G H f) refl-htpy)
         ( is-contr-equiv'
           ( Σ ( (p : unordered-pair-vertices-Undirected-Graph G) →
@@ -169,18 +169,18 @@ module _
                       equiv-concat
                         ( pr2 (refl-htpy-hom-Undirected-Graph f) p e)
                         ( gE p e)))))
-          ( is-contr-total-Eq-Π
+          ( is-torsorial-Eq-Π
             ( λ p gE →
               ( e : edge-Undirected-Graph G p) →
               Id (edge-hom-Undirected-Graph G H f p e) (gE e))
-            ( λ p → is-contr-total-htpy (edge-hom-Undirected-Graph G H f p))))
+            ( λ p → is-torsorial-htpy (edge-hom-Undirected-Graph G H f p))))
 
   is-equiv-htpy-eq-hom-Undirected-Graph :
     (f g : hom-Undirected-Graph G H) →
     is-equiv (htpy-eq-hom-Undirected-Graph f g)
   is-equiv-htpy-eq-hom-Undirected-Graph f =
     fundamental-theorem-id
-      ( is-contr-total-htpy-hom-Undirected-Graph f)
+      ( is-torsorial-htpy-hom-Undirected-Graph f)
       ( htpy-eq-hom-Undirected-Graph f)
 
   extensionality-hom-Undirected-Graph :

--- a/src/graph-theory/walks-directed-graphs.lagda.md
+++ b/src/graph-theory/walks-directed-graphs.lagda.md
@@ -400,15 +400,15 @@ module _
   {l1 l2 : Level} (G : Directed-Graph l1 l2) (x : vertex-Directed-Graph G)
   where
 
-  is-contr-total-walk-of-length-zero-Directed-Graph :
+  is-torsorial-walk-of-length-zero-Directed-Graph :
     is-contr
       ( Σ ( vertex-Directed-Graph G)
           ( λ y → walk-of-length-Directed-Graph G 0 x y))
-  is-contr-total-walk-of-length-zero-Directed-Graph =
+  is-torsorial-walk-of-length-zero-Directed-Graph =
     is-contr-equiv'
       ( Σ (vertex-Directed-Graph G) (λ y → y ＝ x))
       ( equiv-tot (λ y → compute-raise l2 (y ＝ x)))
-      ( is-contr-total-path' x)
+      ( is-torsorial-path' x)
 ```
 
 ### `cons-walk e w ≠ refl-walk`

--- a/src/graph-theory/walks-undirected-graphs.lagda.md
+++ b/src/graph-theory/walks-undirected-graphs.lagda.md
@@ -168,7 +168,7 @@ module _
     is-contr
       ( vertex-on-walk-Undirected-Graph G (refl-walk-Undirected-Graph {x = x}))
   is-contr-vertex-on-walk-refl-walk-Undirected-Graph =
-    is-contr-total-path x
+    is-torsorial-path x
 ```
 
 ### The type of vertices on a walk is equivalent to `Fin (n + 1)` where `n` is the length of the walk
@@ -191,7 +191,7 @@ module _
     ( equiv-coprod
       ( compute-vertex-on-walk-Undirected-Graph w)
       ( equiv-is-contr
-        ( is-contr-total-path (other-element-unordered-pair p y))
+        ( is-torsorial-path (other-element-unordered-pair p y))
         ( is-contr-unit))) ∘e
     ( left-distributive-Σ-coprod
       ( vertex-Undirected-Graph G)
@@ -230,7 +230,7 @@ module _
     ( equiv-coprod
       ( compute-edge-on-walk-Undirected-Graph w)
       ( equiv-is-contr
-        ( is-contr-total-path (pair p e))
+        ( is-torsorial-path (pair p e))
         ( is-contr-unit))) ∘e
     ( left-distributive-Σ-coprod
       ( total-edge-Undirected-Graph G)
@@ -476,15 +476,15 @@ module _
   pr1 refl-constant-walk-Undirected-Graph = refl-walk-Undirected-Graph
   pr2 refl-constant-walk-Undirected-Graph = refl
 
-  is-contr-total-constant-walk-Undirected-Graph :
+  is-torsorial-constant-walk-Undirected-Graph :
     is-contr (Σ (vertex-Undirected-Graph G) constant-walk-Undirected-Graph)
-  pr1 (pr1 is-contr-total-constant-walk-Undirected-Graph) = x
-  pr2 (pr1 is-contr-total-constant-walk-Undirected-Graph) =
+  pr1 (pr1 is-torsorial-constant-walk-Undirected-Graph) = x
+  pr2 (pr1 is-torsorial-constant-walk-Undirected-Graph) =
     refl-constant-walk-Undirected-Graph
-  pr2 is-contr-total-constant-walk-Undirected-Graph
+  pr2 is-torsorial-constant-walk-Undirected-Graph
     (v , refl-walk-Undirected-Graph , refl) =
     refl
-  pr2 is-contr-total-constant-walk-Undirected-Graph
+  pr2 is-torsorial-constant-walk-Undirected-Graph
     (.(other-element-unordered-pair p _) ,
       cons-walk-Undirected-Graph p e w , ())
 
@@ -497,7 +497,7 @@ module _
     is-equiv (constant-walk-eq-Undirected-Graph y)
   is-equiv-constant-walk-eq-Undirected-Graph =
     fundamental-theorem-id
-      ( is-contr-total-constant-walk-Undirected-Graph)
+      ( is-torsorial-constant-walk-Undirected-Graph)
       ( constant-walk-eq-Undirected-Graph)
 
   equiv-constant-walk-eq-Undirected-Graph :

--- a/src/group-theory/automorphism-groups.lagda.md
+++ b/src/group-theory/automorphism-groups.lagda.md
@@ -113,14 +113,14 @@ module _
     Eq-classifying-type-Automorphism-∞-Group X X
   refl-Eq-classifying-type-Automorphism-∞-Group X = refl
 
-  is-contr-total-Eq-classifying-type-Automorphism-∞-Group :
+  is-torsorial-Eq-classifying-type-Automorphism-∞-Group :
     (X : classifying-type-Automorphism-∞-Group A a) →
     is-contr
       ( Σ ( classifying-type-Automorphism-∞-Group A a)
           ( Eq-classifying-type-Automorphism-∞-Group X))
-  is-contr-total-Eq-classifying-type-Automorphism-∞-Group X =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-path (pr1 X))
+  is-torsorial-Eq-classifying-type-Automorphism-∞-Group X =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-path (pr1 X))
       ( λ a → is-prop-type-trunc-Prop)
       ( pr1 X)
       ( refl)
@@ -137,7 +137,7 @@ module _
     is-equiv (Eq-eq-classifying-type-Automorphism-∞-Group X Y)
   is-equiv-Eq-eq-classifying-type-Automorphism-∞-Group X =
     fundamental-theorem-id
-      ( is-contr-total-Eq-classifying-type-Automorphism-∞-Group X)
+      ( is-torsorial-Eq-classifying-type-Automorphism-∞-Group X)
       ( Eq-eq-classifying-type-Automorphism-∞-Group X)
 
   extensionality-classifying-type-Automorphism-∞-Group :
@@ -173,13 +173,13 @@ module _
   refl-Eq-classifying-type-Automorphism-Group =
     refl-Eq-classifying-type-Automorphism-∞-Group a
 
-  is-contr-total-Eq-classifying-type-Automorphism-Group :
+  is-torsorial-Eq-classifying-type-Automorphism-Group :
     (X : classifying-type-Automorphism-Group A a) →
     is-contr
       ( Σ ( classifying-type-Automorphism-Group A a)
           ( Eq-classifying-type-Automorphism-Group X))
-  is-contr-total-Eq-classifying-type-Automorphism-Group =
-    is-contr-total-Eq-classifying-type-Automorphism-∞-Group a
+  is-torsorial-Eq-classifying-type-Automorphism-Group =
+    is-torsorial-Eq-classifying-type-Automorphism-∞-Group a
 
   Eq-eq-classifying-type-Automorphism-Group :
     (X Y : classifying-type-Automorphism-Group A a) →
@@ -192,7 +192,7 @@ module _
     is-equiv (Eq-eq-classifying-type-Automorphism-Group X Y)
   is-equiv-Eq-eq-classifying-type-Automorphism-Group X =
     fundamental-theorem-id
-      ( is-contr-total-Eq-classifying-type-Automorphism-Group X)
+      ( is-torsorial-Eq-classifying-type-Automorphism-Group X)
       ( Eq-eq-classifying-type-Automorphism-Group X)
 
   extensionality-classifying-type-Automorphism-Group :

--- a/src/group-theory/category-of-groups.lagda.md
+++ b/src/group-theory/category-of-groups.lagda.md
@@ -29,7 +29,7 @@ is-large-category-Group :
   is-large-category-Large-Precategory Group-Large-Precategory
 is-large-category-Group G =
   fundamental-theorem-id
-    ( is-contr-total-iso-Group G)
+    ( is-torsorial-iso-Group G)
     ( iso-eq-Group G)
 
 eq-iso-Group : {l : Level} (G H : Group l) → iso-Group G H → Id G H

--- a/src/group-theory/category-of-semigroups.lagda.md
+++ b/src/group-theory/category-of-semigroups.lagda.md
@@ -37,7 +37,7 @@ is-large-category-Semigroup :
   is-large-category-Large-Precategory Semigroup-Large-Precategory
 is-large-category-Semigroup G =
   fundamental-theorem-id
-    ( is-contr-total-iso-Semigroup G)
+    ( is-torsorial-iso-Semigroup G)
     ( iso-eq-Semigroup G)
 
 extensionality-Semigroup :

--- a/src/group-theory/congruence-relations-abelian-groups.lagda.md
+++ b/src/group-theory/congruence-relations-abelian-groups.lagda.md
@@ -177,13 +177,13 @@ refl-relate-same-elements-congruence-Ab :
 refl-relate-same-elements-congruence-Ab A =
   refl-relate-same-elements-congruence-Group (group-Ab A)
 
-is-contr-total-relate-same-elements-congruence-Ab :
+is-torsorial-relate-same-elements-congruence-Ab :
   {l1 l2 : Level} (A : Ab l1) (R : congruence-Ab l2 A) →
   is-contr
     ( Σ ( congruence-Ab l2 A)
         ( relate-same-elements-congruence-Ab A R))
-is-contr-total-relate-same-elements-congruence-Ab A =
-  is-contr-total-relate-same-elements-congruence-Group (group-Ab A)
+is-torsorial-relate-same-elements-congruence-Ab A =
+  is-torsorial-relate-same-elements-congruence-Group (group-Ab A)
 
 relate-same-elements-eq-congruence-Ab :
   {l1 l2 : Level} (A : Ab l1) (R S : congruence-Ab l2 A) →

--- a/src/group-theory/congruence-relations-commutative-monoids.lagda.md
+++ b/src/group-theory/congruence-relations-commutative-monoids.lagda.md
@@ -147,14 +147,14 @@ refl-relate-same-elements-congruence-Commutative-Monoid :
 refl-relate-same-elements-congruence-Commutative-Monoid M =
   refl-relate-same-elements-congruence-Monoid (monoid-Commutative-Monoid M)
 
-is-contr-total-relate-same-elements-congruence-Commutative-Monoid :
+is-torsorial-relate-same-elements-congruence-Commutative-Monoid :
   {l1 l2 : Level} (M : Commutative-Monoid l1)
   (R : congruence-Commutative-Monoid l2 M) →
   is-contr
     ( Σ ( congruence-Commutative-Monoid l2 M)
         ( relate-same-elements-congruence-Commutative-Monoid M R))
-is-contr-total-relate-same-elements-congruence-Commutative-Monoid M =
-  is-contr-total-relate-same-elements-congruence-Monoid
+is-torsorial-relate-same-elements-congruence-Commutative-Monoid M =
+  is-torsorial-relate-same-elements-congruence-Monoid
     ( monoid-Commutative-Monoid M)
 
 relate-same-elements-eq-congruence-Commutative-Monoid :

--- a/src/group-theory/congruence-relations-groups.lagda.md
+++ b/src/group-theory/congruence-relations-groups.lagda.md
@@ -230,13 +230,13 @@ refl-relate-same-elements-congruence-Group :
 refl-relate-same-elements-congruence-Group G =
   refl-relate-same-elements-congruence-Semigroup (semigroup-Group G)
 
-is-contr-total-relate-same-elements-congruence-Group :
+is-torsorial-relate-same-elements-congruence-Group :
   {l1 l2 : Level} (G : Group l1) (R : congruence-Group l2 G) →
   is-contr
     ( Σ ( congruence-Group l2 G)
         ( relate-same-elements-congruence-Group G R))
-is-contr-total-relate-same-elements-congruence-Group G =
-  is-contr-total-relate-same-elements-congruence-Semigroup
+is-torsorial-relate-same-elements-congruence-Group G =
+  is-torsorial-relate-same-elements-congruence-Semigroup
     ( semigroup-Group G)
 
 relate-same-elements-eq-congruence-Group :

--- a/src/group-theory/congruence-relations-monoids.lagda.md
+++ b/src/group-theory/congruence-relations-monoids.lagda.md
@@ -125,13 +125,13 @@ refl-relate-same-elements-congruence-Monoid :
 refl-relate-same-elements-congruence-Monoid M =
   refl-relate-same-elements-congruence-Semigroup (semigroup-Monoid M)
 
-is-contr-total-relate-same-elements-congruence-Monoid :
+is-torsorial-relate-same-elements-congruence-Monoid :
   {l1 l2 : Level} (M : Monoid l1) (R : congruence-Monoid l2 M) →
   is-contr
     ( Σ ( congruence-Monoid l2 M)
         ( relate-same-elements-congruence-Monoid M R))
-is-contr-total-relate-same-elements-congruence-Monoid M =
-  is-contr-total-relate-same-elements-congruence-Semigroup (semigroup-Monoid M)
+is-torsorial-relate-same-elements-congruence-Monoid M =
+  is-torsorial-relate-same-elements-congruence-Semigroup (semigroup-Monoid M)
 
 relate-same-elements-eq-congruence-Monoid :
   {l1 l2 : Level} (M : Monoid l1) (R S : congruence-Monoid l2 M) →

--- a/src/group-theory/congruence-relations-semigroups.lagda.md
+++ b/src/group-theory/congruence-relations-semigroups.lagda.md
@@ -137,14 +137,14 @@ refl-relate-same-elements-congruence-Semigroup G R =
   refl-relate-same-elements-Equivalence-Relation
     ( eq-rel-congruence-Semigroup G R)
 
-is-contr-total-relate-same-elements-congruence-Semigroup :
+is-torsorial-relate-same-elements-congruence-Semigroup :
   {l1 l2 : Level} (G : Semigroup l1) (R : congruence-Semigroup l2 G) →
   is-contr
     ( Σ ( congruence-Semigroup l2 G)
         ( relate-same-elements-congruence-Semigroup G R))
-is-contr-total-relate-same-elements-congruence-Semigroup G R =
-  is-contr-total-Eq-subtype
-    ( is-contr-total-relate-same-elements-Equivalence-Relation
+is-torsorial-relate-same-elements-congruence-Semigroup G R =
+  is-torsorial-Eq-subtype
+    ( is-torsorial-relate-same-elements-Equivalence-Relation
       ( eq-rel-congruence-Semigroup G R))
     ( is-prop-is-congruence-Semigroup G)
     ( eq-rel-congruence-Semigroup G R)
@@ -162,7 +162,7 @@ is-equiv-relate-same-elements-eq-congruence-Semigroup :
   is-equiv (relate-same-elements-eq-congruence-Semigroup G R S)
 is-equiv-relate-same-elements-eq-congruence-Semigroup G R =
   fundamental-theorem-id
-    ( is-contr-total-relate-same-elements-congruence-Semigroup G R)
+    ( is-torsorial-relate-same-elements-congruence-Semigroup G R)
     ( relate-same-elements-eq-congruence-Semigroup G R)
 
 extensionality-congruence-Semigroup :

--- a/src/group-theory/equivalences-concrete-group-actions.lagda.md
+++ b/src/group-theory/equivalences-concrete-group-actions.lagda.md
@@ -63,12 +63,12 @@ module _
   eq-equiv-action-Concrete-Group Y =
     map-inv-equiv (extensionality-action-Concrete-Group Y)
 
-  is-contr-total-equiv-action-Concrete-Group :
+  is-torsorial-equiv-action-Concrete-Group :
     is-contr (Σ (action-Concrete-Group l2 G) equiv-action-Concrete-Group)
-  is-contr-total-equiv-action-Concrete-Group =
-    is-contr-total-Eq-Π
+  is-torsorial-equiv-action-Concrete-Group =
+    is-torsorial-Eq-Π
       ( λ u → type-equiv-Set (X u))
-      ( λ u → is-contr-total-equiv-Set (X u))
+      ( λ u → is-torsorial-equiv-Set (X u))
 
 module _
   {l1 l2 l3 : Level} (G : Concrete-Group l1) (X : action-Concrete-Group l2 G)

--- a/src/group-theory/equivalences-concrete-groups.lagda.md
+++ b/src/group-theory/equivalences-concrete-groups.lagda.md
@@ -57,11 +57,11 @@ module _
   {l : Level} (G : Concrete-Group l)
   where
 
-  is-contr-total-equiv-Concrete-Group :
+  is-torsorial-equiv-Concrete-Group :
     is-contr (Σ (Concrete-Group l) (equiv-Concrete-Group G))
-  is-contr-total-equiv-Concrete-Group =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-equiv-∞-Group (∞-group-Concrete-Group G))
+  is-torsorial-equiv-Concrete-Group =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-equiv-∞-Group (∞-group-Concrete-Group G))
       ( λ H → is-prop-is-set (type-∞-Group H))
       ( ∞-group-Concrete-Group G)
       ( id-equiv-∞-Group (∞-group-Concrete-Group G))
@@ -75,7 +75,7 @@ module _
     (H : Concrete-Group l) → is-equiv (equiv-eq-Concrete-Group H)
   is-equiv-equiv-eq-Concrete-Group =
     fundamental-theorem-id
-      is-contr-total-equiv-Concrete-Group
+      is-torsorial-equiv-Concrete-Group
       equiv-eq-Concrete-Group
 
   extensionality-Concrete-Group :

--- a/src/group-theory/equivalences-group-actions.lagda.md
+++ b/src/group-theory/equivalences-group-actions.lagda.md
@@ -126,11 +126,11 @@ module _
   htpy-eq-equiv-Abstract-Group-Action .e refl =
     refl-htpy-equiv-Abstract-Group-Action
 
-  is-contr-total-htpy-equiv-Abstract-Group-Action :
+  is-torsorial-htpy-equiv-Abstract-Group-Action :
     is-contr
       ( Σ ( equiv-Abstract-Group-Action G X Y)
           ( htpy-equiv-Abstract-Group-Action))
-  is-contr-total-htpy-equiv-Abstract-Group-Action =
+  is-torsorial-htpy-equiv-Abstract-Group-Action =
     is-contr-equiv
       ( Σ ( Σ ( hom-Abstract-Group-Action G X Y) (λ f → is-equiv (pr1 f)))
           ( λ f →
@@ -144,8 +144,8 @@ module _
             ( pr1 f))
         ( equiv-right-swap-Σ)
         ( λ ((f , E) , H) → id-equiv))
-      ( is-contr-total-Eq-subtype
-        ( is-contr-total-htpy-hom-Abstract-Group-Action G X Y
+      ( is-torsorial-Eq-subtype
+        ( is-torsorial-htpy-hom-Abstract-Group-Action G X Y
           ( hom-equiv-Abstract-Group-Action G X Y e))
         ( λ f → is-property-is-equiv (pr1 f))
         ( hom-equiv-Abstract-Group-Action G X Y e)
@@ -157,7 +157,7 @@ module _
     is-equiv (htpy-eq-equiv-Abstract-Group-Action f)
   is-equiv-htpy-eq-equiv-Abstract-Group-Action =
     fundamental-theorem-id
-      is-contr-total-htpy-equiv-Abstract-Group-Action
+      is-torsorial-htpy-equiv-Abstract-Group-Action
       htpy-eq-equiv-Abstract-Group-Action
 
   extensionality-equiv-Abstract-Group-Action :
@@ -227,18 +227,18 @@ module _
   equiv-eq-Abstract-Group-Action .X refl = id-equiv-Abstract-Group-Action
 
   abstract
-    is-contr-total-equiv-Abstract-Group-Action :
+    is-torsorial-equiv-Abstract-Group-Action :
       is-contr
         ( Σ ( Abstract-Group-Action G l2)
             ( equiv-Abstract-Group-Action G X))
-    is-contr-total-equiv-Abstract-Group-Action =
-      is-contr-total-Eq-structure
+    is-torsorial-equiv-Abstract-Group-Action =
+      is-torsorial-Eq-structure
         ( λ Y ν e →
           (g : type-Group G) →
           htpy-equiv
             ( e ∘e map-hom-Group G (symmetric-Group (pr1 X)) (pr2 X) g)
             ( map-hom-Group G (symmetric-Group Y) ν g ∘e e))
-        ( is-contr-total-equiv-Set (pr1 X))
+        ( is-torsorial-equiv-Set (pr1 X))
         ( pair (pr1 X) id-equiv)
         ( is-contr-equiv
           ( Σ ( hom-Group G (symmetric-Group (pr1 X)))
@@ -251,7 +251,7 @@ module _
                     ( extensionality-equiv
                       ( map-hom-Group G (symmetric-Group (pr1 X)) (pr2 X) g)
                       ( map-hom-Group G (symmetric-Group (pr1 X)) f g)))))
-          ( is-contr-total-htpy-hom-Group G
+          ( is-torsorial-htpy-hom-Group G
             ( symmetric-Group (pr1 X))
             ( pr2 X)))
 
@@ -261,7 +261,7 @@ module _
       is-equiv (equiv-eq-Abstract-Group-Action Y)
     is-equiv-equiv-eq-Abstract-Group-Action =
       fundamental-theorem-id
-        is-contr-total-equiv-Abstract-Group-Action
+        is-torsorial-equiv-Abstract-Group-Action
         equiv-eq-Abstract-Group-Action
 
   eq-equiv-Abstract-Group-Action :

--- a/src/group-theory/equivalences-semigroups.lagda.md
+++ b/src/group-theory/equivalences-semigroups.lagda.md
@@ -109,26 +109,26 @@ module _
                         ( μ (μ x y) z) (μ x (μ y z))))))
         ( eq-htpy (λ x → eq-htpy (λ y → μ-id x y))))
 
-  is-contr-total-preserves-mul-id-Semigroup :
+  is-torsorial-preserves-mul-id-Semigroup :
     is-contr
       ( Σ ( has-associative-mul (type-Semigroup G))
           ( λ μ → preserves-mul (mul-Semigroup G) (pr1 μ) id))
-  pr1 is-contr-total-preserves-mul-id-Semigroup =
+  pr1 is-torsorial-preserves-mul-id-Semigroup =
     center-total-preserves-mul-id-Semigroup
-  pr2 is-contr-total-preserves-mul-id-Semigroup =
+  pr2 is-torsorial-preserves-mul-id-Semigroup =
     contraction-total-preserves-mul-id-Semigroup
 
-  is-contr-total-equiv-Semigroup :
+  is-torsorial-equiv-Semigroup :
     is-contr (Σ (Semigroup l) (equiv-Semigroup G))
-  is-contr-total-equiv-Semigroup =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-Semigroup =
+    is-torsorial-Eq-structure
       ( λ H μH → preserves-mul-equiv-Semigroup G (pair H μH))
-      ( is-contr-total-Eq-subtype
-        ( is-contr-total-equiv (type-Semigroup G))
+      ( is-torsorial-Eq-subtype
+        ( is-torsorial-equiv (type-Semigroup G))
         ( is-prop-is-set)
         ( type-Semigroup G)
         ( id-equiv)
         ( is-set-type-Semigroup G))
       ( pair (set-Semigroup G) id-equiv)
-      ( is-contr-total-preserves-mul-id-Semigroup)
+      ( is-torsorial-preserves-mul-id-Semigroup)
 ```

--- a/src/group-theory/free-groups-with-one-generator.lagda.md
+++ b/src/group-theory/free-groups-with-one-generator.lagda.md
@@ -100,15 +100,15 @@ module _
             ( ( preserves-mul-hom-Group ℤ-Group G h one-ℤ x) ∙
               ( ap ( mul-Group' G (map-hom-Group ℤ-Group G h x)) p)))))
 
-  is-contr-total-hom-element-Group :
+  is-torsorial-hom-element-Group :
     is-contr
       ( Σ ( hom-Group ℤ-Group G)
           ( λ h → map-hom-Group ℤ-Group G h one-ℤ ＝ g))
-  pr1 (pr1 is-contr-total-hom-element-Group) =
+  pr1 (pr1 is-torsorial-hom-element-Group) =
     hom-element-Group
-  pr2 (pr1 is-contr-total-hom-element-Group) =
+  pr2 (pr1 is-torsorial-hom-element-Group) =
     right-unit-law-mul-Group G g
-  pr2 is-contr-total-hom-element-Group (pair h p) =
+  pr2 is-torsorial-hom-element-Group (pair h p) =
     eq-type-subtype
       ( λ f → Id-Prop (set-Group G) (map-hom-Group ℤ-Group G f one-ℤ) g)
       ( eq-htpy-hom-Group ℤ-Group G
@@ -118,5 +118,5 @@ abstract
   is-free-group-with-one-generator-ℤ :
     is-free-group-with-one-generator ℤ-Group one-ℤ
   is-free-group-with-one-generator-ℤ G =
-    is-equiv-is-contr-map (is-contr-total-hom-element-Group G)
+    is-equiv-is-contr-map (is-torsorial-hom-element-Group G)
 ```

--- a/src/group-theory/homomorphisms-abelian-groups.lagda.md
+++ b/src/group-theory/homomorphisms-abelian-groups.lagda.md
@@ -96,10 +96,10 @@ module _
   htpy-eq-hom-Ab f g = htpy-eq-hom-Group (group-Ab A) (group-Ab B) f g
 
   abstract
-    is-contr-total-htpy-hom-Ab :
+    is-torsorial-htpy-hom-Ab :
       (f : hom-Ab A B) → is-contr (Σ (hom-Ab A B) (htpy-hom-Ab f))
-    is-contr-total-htpy-hom-Ab f =
-      is-contr-total-htpy-hom-Group (group-Ab A) (group-Ab B) f
+    is-torsorial-htpy-hom-Ab f =
+      is-torsorial-htpy-hom-Group (group-Ab A) (group-Ab B) f
 
   abstract
     is-equiv-htpy-eq-hom-Ab :

--- a/src/group-theory/homomorphisms-commutative-monoids.lagda.md
+++ b/src/group-theory/homomorphisms-commutative-monoids.lagda.md
@@ -151,12 +151,12 @@ module _
   (f : hom-Commutative-Monoid M N)
   where
 
-  is-contr-total-htpy-hom-Commutative-Monoid :
+  is-torsorial-htpy-hom-Commutative-Monoid :
     is-contr
       ( Σ ( hom-Commutative-Monoid M N)
           ( htpy-hom-Commutative-Monoid M N f))
-  is-contr-total-htpy-hom-Commutative-Monoid =
-    is-contr-total-htpy-hom-Monoid
+  is-torsorial-htpy-hom-Commutative-Monoid =
+    is-torsorial-htpy-hom-Monoid
       ( monoid-Commutative-Monoid M)
       ( monoid-Commutative-Monoid N)
       ( f)

--- a/src/group-theory/homomorphisms-group-actions.lagda.md
+++ b/src/group-theory/homomorphisms-group-actions.lagda.md
@@ -129,13 +129,13 @@ module _
   htpy-eq-hom-Abstract-Group-Action .f refl =
     refl-htpy-hom-Abstract-Group-Action
 
-  is-contr-total-htpy-hom-Abstract-Group-Action :
+  is-torsorial-htpy-hom-Abstract-Group-Action :
     is-contr
       ( Σ ( hom-Abstract-Group-Action G X Y)
           ( htpy-hom-Abstract-Group-Action))
-  is-contr-total-htpy-hom-Abstract-Group-Action =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-htpy (pr1 f))
+  is-torsorial-htpy-hom-Abstract-Group-Action =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-htpy (pr1 f))
       ( λ g →
         is-prop-Π
           ( λ x →
@@ -154,7 +154,7 @@ module _
     is-equiv (htpy-eq-hom-Abstract-Group-Action g)
   is-equiv-htpy-eq-hom-Abstract-Group-Action =
     fundamental-theorem-id
-      is-contr-total-htpy-hom-Abstract-Group-Action
+      is-torsorial-htpy-hom-Abstract-Group-Action
       htpy-eq-hom-Abstract-Group-Action
 
   extensionality-hom-Abstract-Group-Action :

--- a/src/group-theory/homomorphisms-groups.lagda.md
+++ b/src/group-theory/homomorphisms-groups.lagda.md
@@ -107,11 +107,11 @@ module _
       ( semigroup-Group H)
 
   abstract
-    is-contr-total-htpy-hom-Group :
+    is-torsorial-htpy-hom-Group :
       ( f : hom-Group G H) →
       is-contr (Σ (hom-Group G H) (htpy-hom-Group f))
-    is-contr-total-htpy-hom-Group =
-      is-contr-total-htpy-hom-Semigroup
+    is-torsorial-htpy-hom-Group =
+      is-torsorial-htpy-hom-Semigroup
         ( semigroup-Group G)
         ( semigroup-Group H)
 

--- a/src/group-theory/homomorphisms-monoids.lagda.md
+++ b/src/group-theory/homomorphisms-monoids.lagda.md
@@ -185,11 +185,11 @@ module _
   {l1 l2 : Level} (M : Monoid l1) (N : Monoid l2) (f : hom-Monoid M N)
   where
 
-  is-contr-total-htpy-hom-Monoid :
+  is-torsorial-htpy-hom-Monoid :
     is-contr (Σ (hom-Monoid M N) (htpy-hom-Monoid M N f))
-  is-contr-total-htpy-hom-Monoid =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-htpy-hom-Semigroup
+  is-torsorial-htpy-hom-Monoid =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-htpy-hom-Semigroup
         ( semigroup-Monoid M)
         ( semigroup-Monoid N)
         ( hom-semigroup-hom-Monoid M N f))
@@ -205,7 +205,7 @@ module _
   is-equiv-htpy-eq-hom-Monoid :
     (g : hom-Monoid M N) → is-equiv (htpy-eq-hom-Monoid g)
   is-equiv-htpy-eq-hom-Monoid =
-    fundamental-theorem-id is-contr-total-htpy-hom-Monoid htpy-eq-hom-Monoid
+    fundamental-theorem-id is-torsorial-htpy-hom-Monoid htpy-eq-hom-Monoid
 
   extensionality-hom-Monoid :
     (g : hom-Monoid M N) → (f ＝ g) ≃ htpy-hom-Monoid M N f g

--- a/src/group-theory/homomorphisms-semigroups.lagda.md
+++ b/src/group-theory/homomorphisms-semigroups.lagda.md
@@ -123,12 +123,12 @@ module _
   htpy-eq-hom-Semigroup f .f refl = refl-htpy-hom-Semigroup f
 
   abstract
-    is-contr-total-htpy-hom-Semigroup :
+    is-torsorial-htpy-hom-Semigroup :
       (f : hom-Semigroup) →
       is-contr (Σ hom-Semigroup (htpy-hom-Semigroup f))
-    is-contr-total-htpy-hom-Semigroup f =
-      is-contr-total-Eq-subtype
-        ( is-contr-total-htpy (map-hom-Semigroup f))
+    is-torsorial-htpy-hom-Semigroup f =
+      is-torsorial-Eq-subtype
+        ( is-torsorial-htpy (map-hom-Semigroup f))
         ( is-prop-preserves-mul-Semigroup)
         ( map-hom-Semigroup f)
         ( refl-htpy)
@@ -139,7 +139,7 @@ module _
       (f g : hom-Semigroup) → is-equiv (htpy-eq-hom-Semigroup f g)
     is-equiv-htpy-eq-hom-Semigroup f =
       fundamental-theorem-id
-        ( is-contr-total-htpy-hom-Semigroup f)
+        ( is-torsorial-htpy-hom-Semigroup f)
         ( htpy-eq-hom-Semigroup f)
 
   eq-htpy-hom-Semigroup :

--- a/src/group-theory/isomorphisms-abelian-groups.lagda.md
+++ b/src/group-theory/isomorphisms-abelian-groups.lagda.md
@@ -189,19 +189,19 @@ abstract
     ( equiv-ap-inclusion-subtype is-abelian-group-Prop {A} {B})
 
 abstract
-  is-contr-total-iso-Ab :
+  is-torsorial-iso-Ab :
     {l : Level} (A : Ab l) → is-contr (Σ (Ab l) (iso-Ab A))
-  is-contr-total-iso-Ab {l} A =
+  is-torsorial-iso-Ab {l} A =
     is-contr-equiv'
       ( Σ (Ab l) (Id A))
       ( equiv-tot (equiv-iso-eq-Ab' A))
-      ( is-contr-total-path A)
+      ( is-torsorial-path A)
 
 is-equiv-iso-eq-Ab :
   {l : Level} (A B : Ab l) → is-equiv (iso-eq-Ab A B)
 is-equiv-iso-eq-Ab A =
   fundamental-theorem-id
-    ( is-contr-total-iso-Ab A)
+    ( is-torsorial-iso-Ab A)
     ( iso-eq-Ab A)
 
 eq-iso-Ab :

--- a/src/group-theory/isomorphisms-groups.lagda.md
+++ b/src/group-theory/isomorphisms-groups.lagda.md
@@ -238,12 +238,12 @@ module _
       ( equiv-ap-inclusion-subtype is-group-Prop {s = G} {t = H})
 
   abstract
-    is-contr-total-iso-Group : is-contr (Σ (Group l) (iso-Group G))
-    is-contr-total-iso-Group =
+    is-torsorial-iso-Group : is-contr (Σ (Group l) (iso-Group G))
+    is-torsorial-iso-Group =
       is-contr-equiv'
         ( Σ (Group l) (Id G))
         ( equiv-tot extensionality-Group')
-        ( is-contr-total-path G)
+        ( is-torsorial-path G)
 ```
 
 ### Group isomorphisms are stable by composition

--- a/src/group-theory/isomorphisms-semigroups.lagda.md
+++ b/src/group-theory/isomorphisms-semigroups.lagda.md
@@ -298,13 +298,13 @@ module _
   {l : Level} (G : Semigroup l)
   where
 
-  is-contr-total-iso-Semigroup :
+  is-torsorial-iso-Semigroup :
     is-contr (Σ (Semigroup l) (iso-Semigroup G))
-  is-contr-total-iso-Semigroup =
+  is-torsorial-iso-Semigroup =
     is-contr-equiv'
       ( Σ (Semigroup l) (equiv-Semigroup G))
       ( equiv-tot (equiv-iso-equiv-Semigroup G))
-      ( is-contr-total-equiv-Semigroup G)
+      ( is-torsorial-equiv-Semigroup G)
 
   id-iso-Semigroup : iso-Semigroup G G
   id-iso-Semigroup =

--- a/src/group-theory/orbits-monoid-actions.lagda.md
+++ b/src/group-theory/orbits-monoid-actions.lagda.md
@@ -72,12 +72,12 @@ module _
   htpy-eq-hom-orbit-Monoid-Action f .f refl =
     refl-htpy-hom-orbit-Monoid-Action f
 
-  is-contr-total-htpy-hom-orbit-Monoid-Action :
+  is-torsorial-htpy-hom-orbit-Monoid-Action :
     {x y : type-Monoid-Action M X} (f : hom-orbit-Monoid-Action x y) →
     is-contr (Σ (hom-orbit-Monoid-Action x y) (htpy-hom-orbit-Monoid-Action f))
-  is-contr-total-htpy-hom-orbit-Monoid-Action {x} {y} f =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-path (element-hom-orbit-Monoid-Action f))
+  is-torsorial-htpy-hom-orbit-Monoid-Action {x} {y} f =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-path (element-hom-orbit-Monoid-Action f))
       ( λ u →
         is-set-type-Monoid-Action M X (mul-Monoid-Action M X u x) y)
       ( element-hom-orbit-Monoid-Action f)
@@ -89,7 +89,7 @@ module _
     is-equiv (htpy-eq-hom-orbit-Monoid-Action f g)
   is-equiv-htpy-eq-hom-orbit-Monoid-Action f =
     fundamental-theorem-id
-      ( is-contr-total-htpy-hom-orbit-Monoid-Action f)
+      ( is-torsorial-htpy-hom-orbit-Monoid-Action f)
       ( htpy-eq-hom-orbit-Monoid-Action f)
 
   extensionality-hom-orbit-Monoid-Action :

--- a/src/group-theory/saturated-congruence-relations-commutative-monoids.lagda.md
+++ b/src/group-theory/saturated-congruence-relations-commutative-monoids.lagda.md
@@ -192,16 +192,16 @@ refl-relate-same-elements-saturated-congruence-Commutative-Monoid M R =
   refl-relate-same-elements-congruence-Commutative-Monoid M
     ( congruence-saturated-congruence-Commutative-Monoid M R)
 
-is-contr-total-relate-same-elements-saturated-congruence-Commutative-Monoid :
+is-torsorial-relate-same-elements-saturated-congruence-Commutative-Monoid :
   {l1 l2 : Level} (M : Commutative-Monoid l1)
   (R : saturated-congruence-Commutative-Monoid l2 M) →
   is-contr
     ( Σ ( saturated-congruence-Commutative-Monoid l2 M)
         ( relate-same-elements-saturated-congruence-Commutative-Monoid M R))
-is-contr-total-relate-same-elements-saturated-congruence-Commutative-Monoid
+is-torsorial-relate-same-elements-saturated-congruence-Commutative-Monoid
   M R =
-  is-contr-total-Eq-subtype
-    ( is-contr-total-relate-same-elements-congruence-Commutative-Monoid M
+  is-torsorial-Eq-subtype
+    ( is-torsorial-relate-same-elements-congruence-Commutative-Monoid M
       ( congruence-saturated-congruence-Commutative-Monoid M R))
     ( is-prop-is-saturated-congruence-Commutative-Monoid M)
     ( congruence-saturated-congruence-Commutative-Monoid M R)
@@ -223,7 +223,7 @@ is-equiv-relate-same-elements-eq-saturated-congruence-Commutative-Monoid :
     ( relate-same-elements-eq-saturated-congruence-Commutative-Monoid M R S)
 is-equiv-relate-same-elements-eq-saturated-congruence-Commutative-Monoid M R =
   fundamental-theorem-id
-    ( is-contr-total-relate-same-elements-saturated-congruence-Commutative-Monoid
+    ( is-torsorial-relate-same-elements-saturated-congruence-Commutative-Monoid
       ( M)
       ( R))
     ( relate-same-elements-eq-saturated-congruence-Commutative-Monoid M R)

--- a/src/group-theory/saturated-congruence-relations-monoids.lagda.md
+++ b/src/group-theory/saturated-congruence-relations-monoids.lagda.md
@@ -171,14 +171,14 @@ refl-relate-same-elements-saturated-congruence-Monoid M R =
   refl-relate-same-elements-congruence-Monoid M
     ( congruence-saturated-congruence-Monoid M R)
 
-is-contr-total-relate-same-elements-saturated-congruence-Monoid :
+is-torsorial-relate-same-elements-saturated-congruence-Monoid :
   {l1 l2 : Level} (M : Monoid l1) (R : saturated-congruence-Monoid l2 M) →
   is-contr
     ( Σ ( saturated-congruence-Monoid l2 M)
         ( relate-same-elements-saturated-congruence-Monoid M R))
-is-contr-total-relate-same-elements-saturated-congruence-Monoid M R =
-  is-contr-total-Eq-subtype
-    ( is-contr-total-relate-same-elements-congruence-Monoid M
+is-torsorial-relate-same-elements-saturated-congruence-Monoid M R =
+  is-torsorial-Eq-subtype
+    ( is-torsorial-relate-same-elements-congruence-Monoid M
       ( congruence-saturated-congruence-Monoid M R))
     ( is-prop-is-saturated-congruence-Monoid M)
     ( congruence-saturated-congruence-Monoid M R)
@@ -197,7 +197,7 @@ is-equiv-relate-same-elements-eq-saturated-congruence-Monoid :
   is-equiv (relate-same-elements-eq-saturated-congruence-Monoid M R S)
 is-equiv-relate-same-elements-eq-saturated-congruence-Monoid M R =
   fundamental-theorem-id
-    ( is-contr-total-relate-same-elements-saturated-congruence-Monoid M R)
+    ( is-torsorial-relate-same-elements-saturated-congruence-Monoid M R)
     ( relate-same-elements-eq-saturated-congruence-Monoid M R)
 
 extensionality-saturated-congruence-Monoid :

--- a/src/group-theory/torsors.lagda.md
+++ b/src/group-theory/torsors.lagda.md
@@ -153,11 +153,11 @@ module _
   equiv-eq-Torsor-Abstract-Group .X refl =
     id-equiv-Torsor-Abstract-Group
 
-  is-contr-total-equiv-Torsor-Abstract-Group :
+  is-torsorial-equiv-Torsor-Abstract-Group :
     is-contr (Σ (Torsor-Abstract-Group G l2) (equiv-Torsor-Abstract-Group))
-  is-contr-total-equiv-Torsor-Abstract-Group =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-equiv-Abstract-Group-Action G
+  is-torsorial-equiv-Torsor-Abstract-Group =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-equiv-Abstract-Group-Action G
         ( action-Torsor-Abstract-Group G X))
       ( is-prop-is-torsor-Abstract-Group G)
       ( action-Torsor-Abstract-Group G X)
@@ -169,7 +169,7 @@ module _
     is-equiv (equiv-eq-Torsor-Abstract-Group Y)
   is-equiv-equiv-eq-Torsor-Abstract-Group =
     fundamental-theorem-id
-      is-contr-total-equiv-Torsor-Abstract-Group
+      is-torsorial-equiv-Torsor-Abstract-Group
       equiv-eq-Torsor-Abstract-Group
 
   eq-equiv-Torsor-Abstract-Group :
@@ -214,12 +214,12 @@ module _
   htpy-eq-equiv-Torsor-Abstract-Group .e refl =
     refl-htpy-equiv-Torsor-Abstract-Group
 
-  is-contr-total-htpy-equiv-Torsor-Abstract-Group :
+  is-torsorial-htpy-equiv-Torsor-Abstract-Group :
     is-contr
       ( Σ ( equiv-Torsor-Abstract-Group G X Y)
           ( htpy-equiv-Torsor-Abstract-Group))
-  is-contr-total-htpy-equiv-Torsor-Abstract-Group =
-    is-contr-total-htpy-equiv-Abstract-Group-Action G
+  is-torsorial-htpy-equiv-Torsor-Abstract-Group =
+    is-torsorial-htpy-equiv-Abstract-Group-Action G
       ( action-Torsor-Abstract-Group G X)
       ( action-Torsor-Abstract-Group G Y)
       ( e)
@@ -229,7 +229,7 @@ module _
     is-equiv (htpy-eq-equiv-Torsor-Abstract-Group f)
   is-equiv-htpy-eq-equiv-Torsor-Abstract-Group =
     fundamental-theorem-id
-      is-contr-total-htpy-equiv-Torsor-Abstract-Group
+      is-torsorial-htpy-equiv-Torsor-Abstract-Group
       htpy-eq-equiv-Torsor-Abstract-Group
 
   extensionality-equiv-Torsor-Abstract-Group :

--- a/src/higher-group-theory/equivalences-higher-groups.lagda.md
+++ b/src/higher-group-theory/equivalences-higher-groups.lagda.md
@@ -71,11 +71,11 @@ module _
 ### The total space of equivalences of higher groups is contractible
 
 ```agda
-is-contr-total-equiv-∞-Group :
+is-torsorial-equiv-∞-Group :
   {l1 : Level} (G : ∞-Group l1) → is-contr (Σ (∞-Group l1) (equiv-∞-Group G))
-is-contr-total-equiv-∞-Group G =
-  is-contr-total-Eq-subtype
-    ( is-contr-total-equiv-Pointed-Type (classifying-pointed-type-∞-Group G))
+is-torsorial-equiv-∞-Group G =
+  is-torsorial-Eq-subtype
+    ( is-torsorial-equiv-Pointed-Type (classifying-pointed-type-∞-Group G))
     ( λ X → is-prop-is-0-connected (type-Pointed-Type X))
     ( classifying-pointed-type-∞-Group G)
     ( id-pointed-equiv)
@@ -89,7 +89,7 @@ is-equiv-equiv-eq-∞-Group :
   {l1 : Level} (G H : ∞-Group l1) → is-equiv (equiv-eq-∞-Group G H)
 is-equiv-equiv-eq-∞-Group G =
   fundamental-theorem-id
-    ( is-contr-total-equiv-∞-Group G)
+    ( is-torsorial-equiv-∞-Group G)
     ( equiv-eq-∞-Group G)
 
 extensionality-∞-Group :

--- a/src/lists/lists.lagda.md
+++ b/src/lists/lists.lagda.md
@@ -212,14 +212,14 @@ equiv-Eq-list :
 equiv-Eq-list l l' =
   pair (Eq-eq-list l l') (is-equiv-Eq-eq-list l l')
 
-is-contr-total-Eq-list :
+is-torsorial-Eq-list :
   {l1 : Level} {A : UU l1} (l : list A) →
   is-contr (Σ (list A) (Eq-list l))
-is-contr-total-Eq-list {A = A} l =
+is-torsorial-Eq-list {A = A} l =
   is-contr-equiv'
     ( Σ (list A) (Id l))
     ( equiv-tot (equiv-Eq-list l))
-    ( is-contr-total-path l)
+    ( is-torsorial-path l)
 
 is-trunc-Eq-list :
   (k : 𝕋) {l : Level} {A : UU l} → is-trunc (succ-𝕋 (succ-𝕋 k)) A →

--- a/src/order-theory/order-preserving-maps-posets.lagda.md
+++ b/src/order-theory/order-preserving-maps-posets.lagda.md
@@ -88,11 +88,11 @@ module _
     (f g : hom-Poset P Q) → Id f g → htpy-hom-Poset f g
   htpy-eq-hom-Poset = htpy-eq-hom-Preorder (preorder-Poset P) (preorder-Poset Q)
 
-  is-contr-total-htpy-hom-Poset :
+  is-torsorial-htpy-hom-Poset :
     (f : hom-Poset P Q) →
     is-contr (Σ (hom-Poset P Q) (htpy-hom-Poset f))
-  is-contr-total-htpy-hom-Poset =
-    is-contr-total-htpy-hom-Preorder (preorder-Poset P) (preorder-Poset Q)
+  is-torsorial-htpy-hom-Poset =
+    is-torsorial-htpy-hom-Preorder (preorder-Poset P) (preorder-Poset Q)
 
   is-equiv-htpy-eq-hom-Poset :
     (f g : hom-Poset P Q) → is-equiv (htpy-eq-hom-Poset f g)

--- a/src/order-theory/order-preserving-maps-preorders.lagda.md
+++ b/src/order-theory/order-preserving-maps-preorders.lagda.md
@@ -91,12 +91,12 @@ module _
     (f g : hom-Preorder P Q) → Id f g → htpy-hom-Preorder f g
   htpy-eq-hom-Preorder f .f refl = refl-htpy-hom-Preorder f
 
-  is-contr-total-htpy-hom-Preorder :
+  is-torsorial-htpy-hom-Preorder :
     (f : hom-Preorder P Q) →
     is-contr (Σ (hom-Preorder P Q) (htpy-hom-Preorder f))
-  is-contr-total-htpy-hom-Preorder f =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-htpy (map-hom-Preorder P Q f))
+  is-torsorial-htpy-hom-Preorder f =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-htpy (map-hom-Preorder P Q f))
       ( is-prop-preserves-order-Preorder P Q)
       ( map-hom-Preorder P Q f)
       ( refl-htpy)
@@ -106,7 +106,7 @@ module _
     (f g : hom-Preorder P Q) → is-equiv (htpy-eq-hom-Preorder f g)
   is-equiv-htpy-eq-hom-Preorder f =
     fundamental-theorem-id
-      ( is-contr-total-htpy-hom-Preorder f)
+      ( is-torsorial-htpy-hom-Preorder f)
       ( htpy-eq-hom-Preorder f)
 
   extensionality-hom-Preorder :

--- a/src/order-theory/similarity-of-elements-large-posets.lagda.md
+++ b/src/order-theory/similarity-of-elements-large-posets.lagda.md
@@ -124,10 +124,10 @@ module _
     is-prop-all-elements-equal
       ( all-elements-equal-total-sim-Large-Poset x)
 
-  is-contr-total-sim-Large-Poset :
+  is-torsorial-sim-Large-Poset :
     {l1 : Level} (x : type-Large-Poset P l1) →
     is-contr (Σ (type-Large-Poset P l1) (sim-Large-Poset P x))
-  is-contr-total-sim-Large-Poset x =
+  is-torsorial-sim-Large-Poset x =
     is-proof-irrelevant-is-prop
       ( is-prop-total-sim-Large-Poset x)
       ( x , refl-sim-Large-Poset P x)
@@ -150,7 +150,7 @@ module _
     is-equiv (sim-eq-Large-Poset x y)
   is-equiv-sim-eq-Large-Poset x =
     fundamental-theorem-id
-      ( is-contr-total-sim-Large-Poset P x)
+      ( is-torsorial-sim-Large-Poset P x)
       ( sim-eq-Large-Poset x)
 
   extensionality-Large-Poset :

--- a/src/orthogonal-factorization-systems/closed-modalities.lagda.md
+++ b/src/orthogonal-factorization-systems/closed-modalities.lagda.md
@@ -91,7 +91,7 @@ module _
                         ( center (is-modal-B q))))) ∘e
               ( equiv-up-join A (type-Prop Q) B))
             ( λ _ → id-equiv))
-          ( is-contr-total-path' f))
+          ( is-torsorial-path' f))
 
   reflective-subuniverse-closed-modality :
     reflective-subuniverse (l ⊔ lQ) (l ⊔ lQ)

--- a/src/orthogonal-factorization-systems/extensions-of-maps.lagda.md
+++ b/src/orthogonal-factorization-systems/extensions-of-maps.lagda.md
@@ -258,21 +258,21 @@ module _
     (e e' : extension-dependent-type i P f) → e ＝ e' → htpy-extension e e'
   htpy-eq-extension e .e refl = refl-htpy-extension e
 
-  is-contr-total-htpy-extension :
+  is-torsorial-htpy-extension :
     (e : extension-dependent-type i P f) →
     is-contr (Σ (extension-dependent-type i P f) (htpy-extension e))
-  is-contr-total-htpy-extension e =
-    is-contr-total-Eq-structure
+  is-torsorial-htpy-extension e =
+    is-torsorial-Eq-structure
       ( λ g G → coherence-htpy-extension e (g , G))
-      ( is-contr-total-htpy (map-extension e))
+      ( is-torsorial-htpy (map-extension e))
       ( map-extension e , refl-htpy)
-      ( is-contr-total-htpy (is-extension-map-extension e ∙h refl-htpy))
+      ( is-torsorial-htpy (is-extension-map-extension e ∙h refl-htpy))
 
   is-equiv-htpy-eq-extension :
     (e e' : extension-dependent-type i P f) → is-equiv (htpy-eq-extension e e')
   is-equiv-htpy-eq-extension e =
     fundamental-theorem-id
-      ( is-contr-total-htpy-extension e)
+      ( is-torsorial-htpy-extension e)
       ( htpy-eq-extension e)
 
   extensionality-extension :
@@ -298,7 +298,7 @@ module _
   inv-compute-total-extension-dependent-type :
     {P : B → UU l3} → total-extension-dependent-type i P ≃ ((y : B) → P y)
   inv-compute-total-extension-dependent-type =
-    ( right-unit-law-Σ-is-contr (λ f → is-contr-total-htpy' (f ∘ i))) ∘e
+    ( right-unit-law-Σ-is-contr (λ f → is-torsorial-htpy' (f ∘ i))) ∘e
     ( equiv-left-swap-Σ)
 
   compute-total-extension-dependent-type :

--- a/src/orthogonal-factorization-systems/factorizations-of-maps.lagda.md
+++ b/src/orthogonal-factorization-systems/factorizations-of-maps.lagda.md
@@ -178,26 +178,26 @@ module _
     F ＝ F' → htpy-factorization-through F F'
   htpy-eq-factorization-through F .F refl = refl-htpy-factorization-through F
 
-  is-contr-total-htpy-factorization-through :
+  is-torsorial-htpy-factorization-through :
     (F : factorization-through f X) →
     is-contr (Σ (factorization-through f X) (htpy-factorization-through F))
-  is-contr-total-htpy-factorization-through F =
-    is-contr-total-Eq-structure
+  is-torsorial-htpy-factorization-through F =
+    is-torsorial-Eq-structure
       ( λ g hH R →
         Σ ( left-map-factorization-through F ~
             left-map-factorization-through (g , hH))
           ( coherence-htpy-factorization-through F (g , hH) R))
-      ( is-contr-total-htpy (right-map-factorization-through F))
+      ( is-torsorial-htpy (right-map-factorization-through F))
       ( right-map-factorization-through F , refl-htpy)
-      ( is-contr-total-Eq-structure
+      ( is-torsorial-Eq-structure
         ( λ h H →
           coherence-htpy-factorization-through
             ( F)
             ( right-map-factorization-through F , h , H)
             ( refl-htpy))
-        ( is-contr-total-htpy (left-map-factorization-through F))
+        ( is-torsorial-htpy (left-map-factorization-through F))
         ( left-map-factorization-through F , refl-htpy)
-        ( is-contr-total-htpy
+        ( is-torsorial-htpy
           ( is-factorization-factorization-through F ∙h refl-htpy)))
 
   is-equiv-htpy-eq-factorization-through :
@@ -205,7 +205,7 @@ module _
     is-equiv (htpy-eq-factorization-through F F')
   is-equiv-htpy-eq-factorization-through F =
     fundamental-theorem-id
-      ( is-contr-total-htpy-factorization-through F)
+      ( is-torsorial-htpy-factorization-through F)
       ( htpy-eq-factorization-through F)
 
   extensionality-factorization-through :

--- a/src/orthogonal-factorization-systems/lifts-of-maps.lagda.md
+++ b/src/orthogonal-factorization-systems/lifts-of-maps.lagda.md
@@ -190,19 +190,19 @@ module _
   htpy-eq-lift : (l l' : lift i f) → l ＝ l' → htpy-lift l l'
   htpy-eq-lift l .l refl = refl-htpy-lift l
 
-  is-contr-total-htpy-lift :
+  is-torsorial-htpy-lift :
     (l : lift i f) → is-contr (Σ (lift i f) (htpy-lift l))
-  is-contr-total-htpy-lift l =
-    is-contr-total-Eq-structure
+  is-torsorial-htpy-lift l =
+    is-torsorial-Eq-structure
       (λ g G → coherence-htpy-lift l (g , G))
-      (is-contr-total-htpy (map-lift i l))
+      (is-torsorial-htpy (map-lift i l))
       (map-lift i l , refl-htpy)
-      (is-contr-total-htpy (is-lift-map-lift i l ∙h refl-htpy))
+      (is-torsorial-htpy (is-lift-map-lift i l ∙h refl-htpy))
 
   is-equiv-htpy-eq-lift :
     (l l' : lift i f) → is-equiv (htpy-eq-lift l l')
   is-equiv-htpy-eq-lift l =
-    fundamental-theorem-id (is-contr-total-htpy-lift l) (htpy-eq-lift l)
+    fundamental-theorem-id (is-torsorial-htpy-lift l) (htpy-eq-lift l)
 
   extensionality-lift :
     (l l' : lift i f) → (l ＝ l') ≃ (htpy-lift l l')
@@ -222,7 +222,7 @@ module _
 
   inv-compute-total-lift : total-lift i X ≃ (X → A)
   inv-compute-total-lift =
-    ( right-unit-law-Σ-is-contr ( λ f → is-contr-total-htpy' (i ∘ f))) ∘e
+    ( right-unit-law-Σ-is-contr ( λ f → is-torsorial-htpy' (i ∘ f))) ∘e
     ( equiv-left-swap-Σ)
 
   compute-total-lift : (X → A) ≃ total-lift i X

--- a/src/ring-theory/category-of-cyclic-rings.lagda.md
+++ b/src/ring-theory/category-of-cyclic-rings.lagda.md
@@ -75,8 +75,8 @@ abstract
     is-large-category-Large-Precategory Cyclic-Ring-Large-Precategory
   is-large-category-Cyclic-Ring-Large-Category R =
     fundamental-theorem-id
-      ( is-contr-total-Eq-subtype
-        ( is-contr-total-iso-Ring (ring-Cyclic-Ring R))
+      ( is-torsorial-Eq-subtype
+        ( is-torsorial-iso-Ring (ring-Cyclic-Ring R))
         ( is-prop-is-cyclic-Ring)
         ( ring-Cyclic-Ring R)
         ( id-iso-Ring (ring-Cyclic-Ring R))

--- a/src/ring-theory/congruence-relations-rings.lagda.md
+++ b/src/ring-theory/congruence-relations-rings.lagda.md
@@ -230,13 +230,13 @@ refl-relate-same-elements-congruence-Ring :
 refl-relate-same-elements-congruence-Ring R =
   refl-relate-same-elements-congruence-Semiring (semiring-Ring R)
 
-is-contr-total-relate-same-elements-congruence-Ring :
+is-torsorial-relate-same-elements-congruence-Ring :
   {l1 l2 : Level} (R : Ring l1) (S : congruence-Ring l2 R) →
   is-contr
     ( Σ ( congruence-Ring l2 R)
         ( relate-same-elements-congruence-Ring R S))
-is-contr-total-relate-same-elements-congruence-Ring R =
-  is-contr-total-relate-same-elements-congruence-Semiring
+is-torsorial-relate-same-elements-congruence-Ring R =
+  is-torsorial-relate-same-elements-congruence-Semiring
     ( semiring-Ring R)
 
 relate-same-elements-eq-congruence-Ring :

--- a/src/ring-theory/congruence-relations-semirings.lagda.md
+++ b/src/ring-theory/congruence-relations-semirings.lagda.md
@@ -175,14 +175,14 @@ refl-relate-same-elements-congruence-Semiring R S =
   refl-relate-same-elements-Equivalence-Relation
     ( eq-rel-congruence-Semiring R S)
 
-is-contr-total-relate-same-elements-congruence-Semiring :
+is-torsorial-relate-same-elements-congruence-Semiring :
   {l1 l2 : Level} (R : Semiring l1) (S : congruence-Semiring l2 R) →
   is-contr
     ( Σ ( congruence-Semiring l2 R)
         ( relate-same-elements-congruence-Semiring R S))
-is-contr-total-relate-same-elements-congruence-Semiring R S =
-  is-contr-total-Eq-subtype
-    ( is-contr-total-relate-same-elements-congruence-Monoid
+is-torsorial-relate-same-elements-congruence-Semiring R S =
+  is-torsorial-Eq-subtype
+    ( is-torsorial-relate-same-elements-congruence-Monoid
       ( additive-monoid-Semiring R)
       ( congruence-additive-monoid-congruence-Semiring R S))
     ( is-prop-is-congruence-Semiring R)
@@ -201,7 +201,7 @@ is-equiv-relate-same-elements-eq-congruence-Semiring :
   is-equiv (relate-same-elements-eq-congruence-Semiring R S T)
 is-equiv-relate-same-elements-eq-congruence-Semiring R S =
     fundamental-theorem-id
-      ( is-contr-total-relate-same-elements-congruence-Semiring R S)
+      ( is-torsorial-relate-same-elements-congruence-Semiring R S)
       ( relate-same-elements-eq-congruence-Semiring R S)
 
 extensionality-congruence-Semiring :

--- a/src/ring-theory/homomorphisms-rings.lagda.md
+++ b/src/ring-theory/homomorphisms-rings.lagda.md
@@ -306,11 +306,11 @@ module _
     (g : hom-Ring R S) → (f ＝ g) → htpy-hom-Ring R S f g
   htpy-eq-hom-Ring .f refl = refl-htpy-hom-Ring R S f
 
-  is-contr-total-htpy-hom-Ring :
+  is-torsorial-htpy-hom-Ring :
     is-contr (Σ (hom-Ring R S) (htpy-hom-Ring R S f))
-  is-contr-total-htpy-hom-Ring =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-htpy-hom-Ab
+  is-torsorial-htpy-hom-Ring =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-htpy-hom-Ab
         ( ab-Ring R)
         ( ab-Ring S)
         ( hom-ab-hom-Ring R S f))
@@ -323,7 +323,7 @@ module _
     (g : hom-Ring R S) → is-equiv (htpy-eq-hom-Ring g)
   is-equiv-htpy-eq-hom-Ring =
     fundamental-theorem-id
-      is-contr-total-htpy-hom-Ring
+      is-torsorial-htpy-hom-Ring
       htpy-eq-hom-Ring
 
   extensionality-hom-Ring :

--- a/src/ring-theory/homomorphisms-semirings.lagda.md
+++ b/src/ring-theory/homomorphisms-semirings.lagda.md
@@ -282,11 +282,11 @@ module _
   (f : hom-Semiring R S)
   where
 
-  is-contr-total-htpy-hom-Semiring :
+  is-torsorial-htpy-hom-Semiring :
     is-contr (Σ (hom-Semiring R S) (htpy-hom-Semiring R S f))
-  is-contr-total-htpy-hom-Semiring =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-htpy-hom-Commutative-Monoid
+  is-torsorial-htpy-hom-Semiring =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-htpy-hom-Commutative-Monoid
         ( additive-commutative-monoid-Semiring R)
         ( additive-commutative-monoid-Semiring S)
         ( hom-additive-commutative-monoid-hom-Semiring R S f))
@@ -303,7 +303,7 @@ module _
     (g : hom-Semiring R S) → is-equiv (htpy-eq-hom-Semiring g)
   is-equiv-htpy-eq-hom-Semiring =
     fundamental-theorem-id
-      is-contr-total-htpy-hom-Semiring
+      is-torsorial-htpy-hom-Semiring
       htpy-eq-hom-Semiring
 
   extensionality-hom-Semiring :

--- a/src/ring-theory/ideals-rings.lagda.md
+++ b/src/ring-theory/ideals-rings.lagda.md
@@ -181,11 +181,11 @@ module _
   refl-has-same-elements-ideal-Ring =
     refl-has-same-elements-subtype (subset-ideal-Ring R I)
 
-  is-contr-total-has-same-elements-ideal-Ring :
+  is-torsorial-has-same-elements-ideal-Ring :
     is-contr (Σ (ideal-Ring l2 R) (has-same-elements-ideal-Ring R I))
-  is-contr-total-has-same-elements-ideal-Ring =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-has-same-elements-subtype (subset-ideal-Ring R I))
+  is-torsorial-has-same-elements-ideal-Ring =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-has-same-elements-subtype (subset-ideal-Ring R I))
       ( is-prop-is-ideal-subset-Ring R)
       ( subset-ideal-Ring R I)
       ( refl-has-same-elements-ideal-Ring)
@@ -199,7 +199,7 @@ module _
     (J : ideal-Ring l2 R) → is-equiv (has-same-elements-eq-ideal-Ring J)
   is-equiv-has-same-elements-eq-ideal-Ring =
     fundamental-theorem-id
-      is-contr-total-has-same-elements-ideal-Ring
+      is-torsorial-has-same-elements-ideal-Ring
       has-same-elements-eq-ideal-Ring
 
   extensionality-ideal-Ring :

--- a/src/ring-theory/isomorphisms-rings.lagda.md
+++ b/src/ring-theory/isomorphisms-rings.lagda.md
@@ -472,22 +472,22 @@ module _
   where
 
   abstract
-    is-contr-total-iso-Ring : is-contr (Σ (Ring l) (iso-Ring R))
-    is-contr-total-iso-Ring =
+    is-torsorial-iso-Ring : is-contr (Σ (Ring l) (iso-Ring R))
+    is-torsorial-iso-Ring =
       is-contr-equiv
         ( Σ (Ring l) (iso-ab-Ring R))
         ( equiv-tot (equiv-iso-ab-iso-Ring R))
-        ( is-contr-total-Eq-structure
+        ( is-torsorial-Eq-structure
           ( λ A μ f →
             is-ring-homomorphism-hom-Ab R (A , μ) (hom-iso-Ab (ab-Ring R) A f))
-          ( is-contr-total-iso-Ab (ab-Ring R))
+          ( is-torsorial-iso-Ab (ab-Ring R))
           ( ab-Ring R , id-iso-Ab (ab-Ring R))
-          ( is-contr-total-Eq-structure
+          ( is-torsorial-Eq-structure
             ( λ μ H pres-mul → one-Ring R ＝ pr1 (pr1 H))
-            ( is-contr-total-Eq-subtype
-              ( is-contr-total-Eq-Π
+            ( is-torsorial-Eq-subtype
+              ( is-torsorial-Eq-Π
                 ( λ x m → (y : type-Ring R) → mul-Ring R x y ＝ m y)
-                ( λ x → is-contr-total-htpy (mul-Ring R x)))
+                ( λ x → is-torsorial-htpy (mul-Ring R x)))
               ( λ μ →
                 is-prop-Π
                   ( λ x →
@@ -500,9 +500,9 @@ module _
               ( λ x y → refl)
               ( associative-mul-Ring R))
             ( (mul-Ring R , associative-mul-Ring R) , λ x y → refl)
-            ( is-contr-total-Eq-subtype
-              ( is-contr-total-Eq-subtype
-                ( is-contr-total-path (one-Ring R))
+            ( is-torsorial-Eq-subtype
+              ( is-torsorial-Eq-subtype
+                ( is-torsorial-path (one-Ring R))
                 ( λ x →
                   is-prop-prod
                     ( is-prop-Π (λ y → is-set-type-Ring R (mul-Ring R x y) y))
@@ -543,7 +543,7 @@ module _
     (S : Ring l) → is-equiv (iso-eq-Ring R S)
   is-equiv-iso-eq-Ring =
     fundamental-theorem-id
-      ( is-contr-total-iso-Ring)
+      ( is-torsorial-iso-Ring)
       ( iso-eq-Ring R)
 
   extensionality-Ring : (S : Ring l) → (R ＝ S) ≃ iso-Ring R S

--- a/src/ring-theory/left-ideals-rings.lagda.md
+++ b/src/ring-theory/left-ideals-rings.lagda.md
@@ -153,11 +153,11 @@ module _
   refl-has-same-elements-left-ideal-Ring =
     refl-has-same-elements-subtype (subset-left-ideal-Ring R I)
 
-  is-contr-total-has-same-elements-left-ideal-Ring :
+  is-torsorial-has-same-elements-left-ideal-Ring :
     is-contr (Σ (left-ideal-Ring l2 R) (has-same-elements-left-ideal-Ring R I))
-  is-contr-total-has-same-elements-left-ideal-Ring =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-has-same-elements-subtype (subset-left-ideal-Ring R I))
+  is-torsorial-has-same-elements-left-ideal-Ring =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-has-same-elements-subtype (subset-left-ideal-Ring R I))
       ( is-prop-is-left-ideal-subset-Ring R)
       ( subset-left-ideal-Ring R I)
       ( refl-has-same-elements-left-ideal-Ring)
@@ -174,7 +174,7 @@ module _
     is-equiv (has-same-elements-eq-left-ideal-Ring J)
   is-equiv-has-same-elements-eq-left-ideal-Ring =
     fundamental-theorem-id
-      is-contr-total-has-same-elements-left-ideal-Ring
+      is-torsorial-has-same-elements-left-ideal-Ring
       has-same-elements-eq-left-ideal-Ring
 
   extensionality-left-ideal-Ring :

--- a/src/ring-theory/right-ideals-rings.lagda.md
+++ b/src/ring-theory/right-ideals-rings.lagda.md
@@ -153,12 +153,12 @@ module _
   refl-has-same-elements-right-ideal-Ring =
     refl-has-same-elements-subtype (subset-right-ideal-Ring R I)
 
-  is-contr-total-has-same-elements-right-ideal-Ring :
+  is-torsorial-has-same-elements-right-ideal-Ring :
     is-contr
       ( Σ (right-ideal-Ring l2 R) (has-same-elements-right-ideal-Ring R I))
-  is-contr-total-has-same-elements-right-ideal-Ring =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-has-same-elements-subtype (subset-right-ideal-Ring R I))
+  is-torsorial-has-same-elements-right-ideal-Ring =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-has-same-elements-subtype (subset-right-ideal-Ring R I))
       ( is-prop-is-right-ideal-subset-Ring R)
       ( subset-right-ideal-Ring R I)
       ( refl-has-same-elements-right-ideal-Ring)
@@ -175,7 +175,7 @@ module _
     is-equiv (has-same-elements-eq-right-ideal-Ring J)
   is-equiv-has-same-elements-eq-right-ideal-Ring =
     fundamental-theorem-id
-      is-contr-total-has-same-elements-right-ideal-Ring
+      is-torsorial-has-same-elements-right-ideal-Ring
       has-same-elements-eq-right-ideal-Ring
 
   extensionality-right-ideal-Ring :

--- a/src/species/cauchy-products-species-of-types-in-subuniverses.lagda.md
+++ b/src/species/cauchy-products-species-of-types-in-subuniverses.lagda.md
@@ -315,7 +315,7 @@ module _
     inclusion-subuniverse (subuniverse-global-subuniverse Q l3) (S X)
   equiv-right-unit-law-cauchy-product-species-subuniverse X =
     ( ( left-unit-law-Σ-is-contr
-        ( is-contr-total-equiv-subuniverse P X)
+        ( is-torsorial-equiv-subuniverse P X)
         ( X , id-equiv)) ∘e
       ( ( equiv-Σ-equiv-base
           ( λ p →

--- a/src/species/composition-cauchy-series-species-of-types.lagda.md
+++ b/src/species/composition-cauchy-series-species-of-types.lagda.md
@@ -91,7 +91,7 @@ module _
                 ( ( inv-equiv universal-property-product) ∘e
                   ( equiv-prod id-equiv equiv-ev-pair))) ∘e
               ( left-unit-law-Σ-is-contr
-                ( is-contr-total-equiv' (Σ U V))
+                ( is-torsorial-equiv' (Σ U V))
                 ( Σ U V , id-equiv))))))) ∘e
       ( reassociate)
 ```

--- a/src/species/dirichlet-products-species-of-types-in-subuniverses.lagda.md
+++ b/src/species/dirichlet-products-species-of-types-in-subuniverses.lagda.md
@@ -344,7 +344,7 @@ module _
     inclusion-subuniverse (subuniverse-global-subuniverse Q l3) (S X)
   equiv-right-unit-law-dirichlet-product-species-subuniverse X =
     ( ( left-unit-law-Σ-is-contr
-        ( is-contr-total-equiv-subuniverse P X)
+        ( is-torsorial-equiv-subuniverse P X)
         ( X , id-equiv)) ∘e
       ( ( equiv-Σ-equiv-base
           ( λ p →

--- a/src/species/morphisms-finite-species.lagda.md
+++ b/src/species/morphisms-finite-species.lagda.md
@@ -121,7 +121,7 @@ is-contr-htpy-hom-species-𝔽 :
   (f : hom-species-𝔽 F G) →
   is-contr (Σ (hom-species-𝔽 F G) (htpy-hom-species-𝔽 F G f))
 is-contr-htpy-hom-species-𝔽 F G f =
-  is-contr-total-Eq-Π (λ X h → f X ~ h) (λ X → is-contr-total-htpy (f X))
+  is-torsorial-Eq-Π (λ X h → f X ~ h) (λ X → is-torsorial-htpy (f X))
 
 is-equiv-htpy-eq-hom-species-𝔽 :
   {l1 l2 l3 : Level} (F : species-𝔽 l1 l2) (G : species-𝔽 l1 l3)

--- a/src/species/morphisms-species-of-types.lagda.md
+++ b/src/species/morphisms-species-of-types.lagda.md
@@ -81,7 +81,7 @@ is-contr-htpy-hom-species-types :
   (f : hom-species-types F G) →
   is-contr (Σ (hom-species-types F G) (htpy-hom-species-types f))
 is-contr-htpy-hom-species-types f =
-  is-contr-total-Eq-Π (λ X h → f X ~ h) (λ X → is-contr-total-htpy (f X))
+  is-torsorial-Eq-Π (λ X h → f X ~ h) (λ X → is-torsorial-htpy (f X))
 
 is-equiv-htpy-eq-hom-species-types :
   {l1 l2 l3 : Level} {F : species-types l1 l2} {G : species-types l1 l3}

--- a/src/species/products-cauchy-series-species-of-types.lagda.md
+++ b/src/species/products-cauchy-series-species-of-types.lagda.md
@@ -94,7 +94,7 @@ module _
                 ( id-equiv)
                 ( equiv-universal-property-coprod X)) ∘e
               ( left-unit-law-Σ-is-contr
-                ( is-contr-total-equiv' (A + B))
+                ( is-torsorial-equiv' (A + B))
                 ( A + B , id-equiv))))) ∘e
       ( reassociate))
 ```

--- a/src/species/products-dirichlet-series-species-of-types-in-subuniverses.lagda.md
+++ b/src/species/products-dirichlet-series-species-of-types-in-subuniverses.lagda.md
@@ -161,7 +161,7 @@ module _
                 ( universal-property-product ∘e
                   equiv-postcomp X (C2 A B))) ∘e
               left-unit-law-Σ-is-contr
-                ( is-contr-total-equiv-subuniverse'
+                ( is-torsorial-equiv-subuniverse'
                   ( P)
                   ( inclusion-subuniverse P A ×
                     inclusion-subuniverse P B ,

--- a/src/species/products-dirichlet-series-species-of-types.lagda.md
+++ b/src/species/products-dirichlet-series-species-of-types.lagda.md
@@ -112,7 +112,7 @@ module _
                 ( universal-property-product ∘e
                   equiv-postcomp X (C1 A B))) ∘e
               ( left-unit-law-Σ-is-contr
-                ( is-contr-total-equiv' (A × B))
+                ( is-torsorial-equiv' (A × B))
                 ( A × B , id-equiv))))) ∘e
       ( reassociate))
 ```

--- a/src/structured-types/dependent-types-equipped-with-automorphisms.lagda.md
+++ b/src/structured-types/dependent-types-equipped-with-automorphisms.lagda.md
@@ -147,13 +147,13 @@ module _
   equiv-eq-Dependent-Type-With-Automorphism Q .Q refl =
     id-equiv-Dependent-Type-With-Automorphism Q
 
-  is-contr-total-equiv-Dependent-Type-With-Automorphism :
+  is-torsorial-equiv-Dependent-Type-With-Automorphism :
     ( Q : Dependent-Type-With-Automorphism l2 P) →
     is-contr
       ( Σ ( Dependent-Type-With-Automorphism l2 P)
           ( equiv-Dependent-Type-With-Automorphism P Q))
-  is-contr-total-equiv-Dependent-Type-With-Automorphism Q =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-Dependent-Type-With-Automorphism Q =
+    is-torsorial-Eq-structure
       ( λ R K H →
         ( x : type-Type-With-Automorphism P) →
         coherence-square-maps
@@ -161,15 +161,15 @@ module _
           ( map-Dependent-Type-With-Automorphism P Q)
           ( map-equiv (K x))
           ( map-equiv (H (map-Type-With-Automorphism P x))))
-      ( is-contr-total-equiv-fam (family-Dependent-Type-With-Automorphism P Q))
+      ( is-torsorial-equiv-fam (family-Dependent-Type-With-Automorphism P Q))
       ( family-Dependent-Type-With-Automorphism P Q ,
         id-equiv-fam (family-Dependent-Type-With-Automorphism P Q))
-      ( is-contr-total-Eq-Π
+      ( is-torsorial-Eq-Π
         ( λ x K →
           ( map-Dependent-Type-With-Automorphism P Q) ~
           ( map-equiv K))
         ( λ x →
-          is-contr-total-htpy-equiv
+          is-torsorial-htpy-equiv
             ( dependent-automorphism-Dependent-Type-With-Automorphism P Q x)))
 
   is-equiv-equiv-eq-Dependent-Type-With-Automorphism :
@@ -177,7 +177,7 @@ module _
     is-equiv (equiv-eq-Dependent-Type-With-Automorphism Q T)
   is-equiv-equiv-eq-Dependent-Type-With-Automorphism Q =
     fundamental-theorem-id
-      ( is-contr-total-equiv-Dependent-Type-With-Automorphism Q)
+      ( is-torsorial-equiv-Dependent-Type-With-Automorphism Q)
       ( equiv-eq-Dependent-Type-With-Automorphism Q)
 
   extensionality-Dependent-Type-With-Automorphism :

--- a/src/structured-types/equivalences-types-equipped-with-automorphisms.lagda.md
+++ b/src/structured-types/equivalences-types-equipped-with-automorphisms.lagda.md
@@ -200,13 +200,13 @@ module _
       ( type-with-endomorphism-Type-With-Automorphism X)
       ( type-with-endomorphism-Type-With-Automorphism Y)
 
-  is-contr-total-htpy-equiv-Type-With-Automorphism :
+  is-torsorial-htpy-equiv-Type-With-Automorphism :
     (e : equiv-Type-With-Automorphism X Y) →
     is-contr
       ( Σ ( equiv-Type-With-Automorphism X Y)
           ( htpy-equiv-Type-With-Automorphism e))
-  is-contr-total-htpy-equiv-Type-With-Automorphism =
-    is-contr-total-htpy-equiv-Type-With-Endomorphism
+  is-torsorial-htpy-equiv-Type-With-Automorphism =
+    is-torsorial-htpy-equiv-Type-With-Endomorphism
       ( type-with-endomorphism-Type-With-Automorphism X)
       ( type-with-endomorphism-Type-With-Automorphism Y)
 
@@ -280,26 +280,26 @@ module _
   equiv-eq-Type-With-Automorphism .X refl =
     id-equiv-Type-With-Automorphism X
 
-  is-contr-total-equiv-Type-With-Automorphism :
+  is-torsorial-equiv-Type-With-Automorphism :
     is-contr (Σ (Type-With-Automorphism l1) (equiv-Type-With-Automorphism X))
-  is-contr-total-equiv-Type-With-Automorphism =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-Type-With-Automorphism =
+    is-torsorial-Eq-structure
       ( λ Y e h →
         coherence-square-maps
           ( map-equiv h)
           ( map-Type-With-Automorphism X)
           ( map-equiv e)
           ( map-equiv h))
-      ( is-contr-total-equiv (type-Type-With-Automorphism X))
+      ( is-torsorial-equiv (type-Type-With-Automorphism X))
       ( type-Type-With-Automorphism X , id-equiv)
-      ( is-contr-total-htpy-equiv (automorphism-Type-With-Automorphism X))
+      ( is-torsorial-htpy-equiv (automorphism-Type-With-Automorphism X))
 
   is-equiv-equiv-eq-Type-With-Automorphism :
     ( Y : Type-With-Automorphism l1) →
     is-equiv (equiv-eq-Type-With-Automorphism Y)
   is-equiv-equiv-eq-Type-With-Automorphism =
     fundamental-theorem-id
-      is-contr-total-equiv-Type-With-Automorphism
+      is-torsorial-equiv-Type-With-Automorphism
       equiv-eq-Type-With-Automorphism
 
   extensionality-Type-With-Automorphism :

--- a/src/structured-types/equivalences-types-equipped-with-endomorphisms.lagda.md
+++ b/src/structured-types/equivalences-types-equipped-with-endomorphisms.lagda.md
@@ -194,12 +194,12 @@ module _
   htpy-eq-equiv-Type-With-Endomorphism e .e refl =
     refl-htpy-equiv-Type-With-Endomorphism e
 
-  is-contr-total-htpy-equiv-Type-With-Endomorphism :
+  is-torsorial-htpy-equiv-Type-With-Endomorphism :
     (e : equiv-Type-With-Endomorphism X Y) →
     is-contr
       ( Σ ( equiv-Type-With-Endomorphism X Y)
           ( htpy-equiv-Type-With-Endomorphism e))
-  is-contr-total-htpy-equiv-Type-With-Endomorphism e =
+  is-torsorial-htpy-equiv-Type-With-Endomorphism e =
     is-contr-equiv
       ( Σ ( Σ ( hom-Type-With-Endomorphism X Y)
               ( λ f → is-equiv (map-hom-Type-With-Endomorphism X Y f)))
@@ -214,8 +214,8 @@ module _
             ( pr1 f))
         ( equiv-right-swap-Σ)
         ( λ f → id-equiv))
-      ( is-contr-total-Eq-subtype
-        ( is-contr-total-htpy-hom-Type-With-Endomorphism X Y
+      ( is-torsorial-Eq-subtype
+        ( is-torsorial-htpy-hom-Type-With-Endomorphism X Y
           ( hom-equiv-Type-With-Endomorphism X Y e))
         ( λ f → is-property-is-equiv (pr1 f))
         ( hom-equiv-Type-With-Endomorphism X Y e)
@@ -228,7 +228,7 @@ module _
     is-equiv (htpy-eq-equiv-Type-With-Endomorphism e f)
   is-equiv-htpy-eq-equiv-Type-With-Endomorphism e =
     fundamental-theorem-id
-      ( is-contr-total-htpy-equiv-Type-With-Endomorphism e)
+      ( is-torsorial-htpy-equiv-Type-With-Endomorphism e)
       ( htpy-eq-equiv-Type-With-Endomorphism e)
 
   extensionality-equiv-Type-With-Endomorphism :
@@ -305,22 +305,22 @@ module _
   equiv-eq-Type-With-Endomorphism .X refl =
     id-equiv-Type-With-Endomorphism X
 
-  is-contr-total-equiv-Type-With-Endomorphism :
+  is-torsorial-equiv-Type-With-Endomorphism :
     is-contr (Σ (Type-With-Endomorphism l1) (equiv-Type-With-Endomorphism X))
-  is-contr-total-equiv-Type-With-Endomorphism =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-Type-With-Endomorphism =
+    is-torsorial-Eq-structure
       ( λ Y f e →
         map-equiv e ∘ endomorphism-Type-With-Endomorphism X ~ f ∘ map-equiv e)
-      ( is-contr-total-equiv (type-Type-With-Endomorphism X))
+      ( is-torsorial-equiv (type-Type-With-Endomorphism X))
       ( type-Type-With-Endomorphism X , id-equiv)
-      ( is-contr-total-htpy (endomorphism-Type-With-Endomorphism X))
+      ( is-torsorial-htpy (endomorphism-Type-With-Endomorphism X))
 
   is-equiv-equiv-eq-Type-With-Endomorphism :
     ( Y : Type-With-Endomorphism l1) →
     is-equiv (equiv-eq-Type-With-Endomorphism Y)
   is-equiv-equiv-eq-Type-With-Endomorphism =
     fundamental-theorem-id
-      is-contr-total-equiv-Type-With-Endomorphism
+      is-torsorial-equiv-Type-With-Endomorphism
       equiv-eq-Type-With-Endomorphism
 
   extensionality-Type-With-Endomorphism :

--- a/src/structured-types/involutive-type-of-h-space-structures.lagda.md
+++ b/src/structured-types/involutive-type-of-h-space-structures.lagda.md
@@ -119,15 +119,15 @@ module _
       ( right-unit)) ∙
     ( inv (ap-id (pr2 coh-μ x)))
 
-  is-contr-total-htpy-h-space-Involutive-Type :
+  is-torsorial-htpy-h-space-Involutive-Type :
     ( μ : h-space-Involutive-Type A X) →
     is-contr (Σ (h-space-Involutive-Type A X) (htpy-h-space-Involutive-Type μ))
-  is-contr-total-htpy-h-space-Involutive-Type (μ , ν , ρ) =
-    is-contr-total-Eq-structure
+  is-torsorial-htpy-h-space-Involutive-Type (μ , ν , ρ) =
+    is-torsorial-Eq-structure
       ( λ μ' νρ' H → _)
-      ( is-contr-total-htpy μ)
+      ( is-torsorial-htpy μ)
       ( μ , refl-htpy)
-      ( is-contr-total-Eq-structure
+      ( is-torsorial-Eq-structure
         ( λ ν' ρ' H →
           Eq-symmetric-Id
             ( ( X) , (λ x → ν' (const-Pointed-Type _ A) x refl))
@@ -141,12 +141,12 @@ module _
               ( id-equiv)
               ( X , (λ x → ν' (const-Pointed-Type _ A) x refl))
               ( ρ')))
-        ( is-contr-total-Eq-Π
+        ( is-torsorial-Eq-Π
           ( λ f ν' → (x : type-2-Element-Type X) → ν f x ~ ν' x)
           ( λ f →
-            is-contr-total-Eq-Π
+            is-torsorial-Eq-Π
               ( λ x ν' → ν f x ~ ν')
-              ( λ x → is-contr-total-htpy (ν f x))))
+              ( λ x → is-torsorial-htpy (ν f x))))
         ( ν , (λ f x p → refl))
         ( is-contr-equiv
           ( Σ ( symmetric-Id
@@ -165,7 +165,7 @@ module _
                 ( id-equiv-symmetric-Id
                   ( X , (λ x → ν (const-Pointed-Type _ A) x refl))
                   ( α))))
-          ( is-contr-total-Eq-symmetric-Id
+          ( is-torsorial-Eq-symmetric-Id
             ( X , (λ x → ν (const-Pointed-Type _ A) x refl))
             ( ρ))))
 
@@ -180,7 +180,7 @@ module _
     is-equiv (htpy-eq-h-space-Involutive-Type μ μ')
   is-equiv-htpy-eq-h-space-Involutive-Type μ =
     fundamental-theorem-id
-      ( is-contr-total-htpy-h-space-Involutive-Type μ)
+      ( is-torsorial-htpy-h-space-Involutive-Type μ)
       ( htpy-eq-h-space-Involutive-Type μ)
 
   extensionality-h-space-Involutive-Type :

--- a/src/structured-types/mere-equivalences-types-equipped-with-endomorphisms.lagda.md
+++ b/src/structured-types/mere-equivalences-types-equipped-with-endomorphisms.lagda.md
@@ -126,14 +126,14 @@ module _
   equiv-eq-Component-Type-With-Endomorphism T .T refl =
     id-equiv-Component-Type-With-Endomorphism T
 
-  is-contr-total-equiv-Component-Type-With-Endomorphism :
+  is-torsorial-equiv-Component-Type-With-Endomorphism :
     is-contr
       ( Σ ( Component-Type-With-Endomorphism X)
           ( equiv-Component-Type-With-Endomorphism
               ( canonical-Component-Type-With-Endomorphism X)))
-  is-contr-total-equiv-Component-Type-With-Endomorphism =
-    is-contr-total-Eq-subtype
-      ( is-contr-total-equiv-Type-With-Endomorphism X)
+  is-torsorial-equiv-Component-Type-With-Endomorphism =
+    is-torsorial-Eq-subtype
+      ( is-torsorial-equiv-Type-With-Endomorphism X)
       ( λ Y → is-prop-type-trunc-Prop)
       ( X)
       ( id-equiv-Type-With-Endomorphism X)
@@ -147,7 +147,7 @@ module _
         ( T))
   is-equiv-equiv-eq-Component-Type-With-Endomorphism =
     fundamental-theorem-id
-      ( is-contr-total-equiv-Component-Type-With-Endomorphism)
+      ( is-torsorial-equiv-Component-Type-With-Endomorphism)
       ( equiv-eq-Component-Type-With-Endomorphism
         ( canonical-Component-Type-With-Endomorphism X))
 ```

--- a/src/structured-types/morphisms-types-equipped-with-automorphisms.lagda.md
+++ b/src/structured-types/morphisms-types-equipped-with-automorphisms.lagda.md
@@ -107,12 +107,12 @@ module _
       ( type-with-endomorphism-Type-With-Automorphism X)
       ( type-with-endomorphism-Type-With-Automorphism Y)
 
-  is-contr-total-htpy-hom-Type-With-Automorphism :
+  is-torsorial-htpy-hom-Type-With-Automorphism :
     (f : hom-Type-With-Automorphism X Y) →
     is-contr
       ( Σ (hom-Type-With-Automorphism X Y) (htpy-hom-Type-With-Automorphism f))
-  is-contr-total-htpy-hom-Type-With-Automorphism =
-    is-contr-total-htpy-hom-Type-With-Endomorphism
+  is-torsorial-htpy-hom-Type-With-Automorphism =
+    is-torsorial-htpy-hom-Type-With-Endomorphism
       ( type-with-endomorphism-Type-With-Automorphism X)
       ( type-with-endomorphism-Type-With-Automorphism Y)
 

--- a/src/structured-types/morphisms-types-equipped-with-endomorphisms.lagda.md
+++ b/src/structured-types/morphisms-types-equipped-with-endomorphisms.lagda.md
@@ -110,18 +110,18 @@ module _
   htpy-eq-hom-Type-With-Endomorphism f .f refl =
     refl-htpy-hom-Type-With-Endomorphism f
 
-  is-contr-total-htpy-hom-Type-With-Endomorphism :
+  is-torsorial-htpy-hom-Type-With-Endomorphism :
     (f : hom-Type-With-Endomorphism X Y) →
     is-contr
       ( Σ (hom-Type-With-Endomorphism X Y) (htpy-hom-Type-With-Endomorphism f))
-  is-contr-total-htpy-hom-Type-With-Endomorphism f =
-    is-contr-total-Eq-structure
+  is-torsorial-htpy-hom-Type-With-Endomorphism f =
+    is-torsorial-Eq-structure
       ( λ g G H →
         ( ( H ·r endomorphism-Type-With-Endomorphism X) ∙h
           ( G)) ~
         ( ( coherence-square-hom-Type-With-Endomorphism X Y f) ∙h
           ( endomorphism-Type-With-Endomorphism Y ·l H)))
-      ( is-contr-total-htpy (map-hom-Type-With-Endomorphism X Y f))
+      ( is-torsorial-htpy (map-hom-Type-With-Endomorphism X Y f))
       ( map-hom-Type-With-Endomorphism X Y f , refl-htpy)
       ( is-contr-equiv
         ( Σ ( coherence-square-maps
@@ -131,7 +131,7 @@ module _
               ( map-hom-Type-With-Endomorphism X Y f))
             ( λ H → H ~ coherence-square-hom-Type-With-Endomorphism X Y f))
         ( equiv-tot (λ H → equiv-concat-htpy' H right-unit-htpy))
-        ( is-contr-total-htpy'
+        ( is-torsorial-htpy'
           ( coherence-square-hom-Type-With-Endomorphism X Y f)))
 
   is-equiv-htpy-eq-hom-Type-With-Endomorphism :
@@ -139,7 +139,7 @@ module _
     is-equiv (htpy-eq-hom-Type-With-Endomorphism f g)
   is-equiv-htpy-eq-hom-Type-With-Endomorphism f =
     fundamental-theorem-id
-      ( is-contr-total-htpy-hom-Type-With-Endomorphism f)
+      ( is-torsorial-htpy-hom-Type-With-Endomorphism f)
       ( htpy-eq-hom-Type-With-Endomorphism f)
 
   extensionality-hom-Type-With-Endomorphism :

--- a/src/structured-types/pointed-equivalences.lagda.md
+++ b/src/structured-types/pointed-equivalences.lagda.md
@@ -158,14 +158,14 @@ module _
   {l1 : Level} (A : Pointed-Type l1)
   where
 
-  is-contr-total-equiv-Pointed-Type :
+  is-torsorial-equiv-Pointed-Type :
     is-contr (Σ (Pointed-Type l1) (λ B → A ≃∗ B))
-  is-contr-total-equiv-Pointed-Type =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-Pointed-Type =
+    is-torsorial-Eq-structure
       ( λ X x e → map-equiv e (point-Pointed-Type A) ＝ x)
-      ( is-contr-total-equiv (type-Pointed-Type A))
+      ( is-torsorial-equiv (type-Pointed-Type A))
       ( pair (type-Pointed-Type A) id-equiv)
-      ( is-contr-total-path (point-Pointed-Type A))
+      ( is-torsorial-path (point-Pointed-Type A))
 
   extensionality-Pointed-Type : (B : Pointed-Type l1) → Id A B ≃ (A ≃∗ B)
   extensionality-Pointed-Type =
@@ -190,7 +190,7 @@ module _
   is-contr-section-is-equiv-pointed-map :
     is-equiv-pointed-map f → is-contr (section-pointed-map f)
   is-contr-section-is-equiv-pointed-map H =
-    is-contr-total-Eq-structure
+    is-torsorial-Eq-structure
       ( λ g p (G : (map-pointed-map f ∘ g) ~ id) →
         Id
           { A =
@@ -232,7 +232,7 @@ module _
   is-contr-retraction-is-equiv-pointed-map :
     is-equiv-pointed-map f → is-contr (retraction-pointed-map f)
   is-contr-retraction-is-equiv-pointed-map H =
-    is-contr-total-Eq-structure
+    is-torsorial-Eq-structure
       ( λ g p (G : g ∘ map-pointed-map f ~ id) →
         Id
           ( G (point-Pointed-Type A))

--- a/src/structured-types/pointed-types-equipped-with-automorphisms.lagda.md
+++ b/src/structured-types/pointed-types-equipped-with-automorphisms.lagda.md
@@ -149,14 +149,14 @@ htpy-hom-Pointed-Type-With-Aut-eq :
 htpy-hom-Pointed-Type-With-Aut-eq X Y h1 .h1 refl =
   refl-htpy-hom-Pointed-Type-With-Aut X Y h1
 
-is-contr-total-htpy-hom-Pointed-Type-With-Aut :
+is-torsorial-htpy-hom-Pointed-Type-With-Aut :
   {l1 l2 : Level} (X : Pointed-Type-With-Aut l1)
   (Y : Pointed-Type-With-Aut l2) (h1 : hom-Pointed-Type-With-Aut X Y) →
   is-contr
     ( Σ ( hom-Pointed-Type-With-Aut X Y)
         ( htpy-hom-Pointed-Type-With-Aut X Y h1))
-is-contr-total-htpy-hom-Pointed-Type-With-Aut X Y h1 =
-  is-contr-total-Eq-structure
+is-torsorial-htpy-hom-Pointed-Type-With-Aut X Y h1 =
+  is-torsorial-Eq-structure
     ( λ ( map-h2 : type-Pointed-Type-With-Aut X → type-Pointed-Type-With-Aut Y)
         ( str-h2 :
           ( ( map-h2 (point-Pointed-Type-With-Aut X)) ＝
@@ -173,9 +173,9 @@ is-contr-total-htpy-hom-Pointed-Type-With-Aut X Y h1 =
               ( ap (map-aut-Pointed-Type-With-Aut Y) (H x))) ＝
             ( ( H (map-aut-Pointed-Type-With-Aut X x)) ∙
               ( pr2 str-h2 x)))))
-    ( is-contr-total-htpy (map-hom-Pointed-Type-With-Aut X Y h1))
+    ( is-torsorial-htpy (map-hom-Pointed-Type-With-Aut X Y h1))
     ( pair (map-hom-Pointed-Type-With-Aut X Y h1) refl-htpy)
-    ( is-contr-total-Eq-structure
+    ( is-torsorial-Eq-structure
       ( λ ( point-h2 :
             ( map-hom-Pointed-Type-With-Aut X Y h1
               ( point-Pointed-Type-With-Aut X)) ＝
@@ -192,7 +192,7 @@ is-contr-total-htpy-hom-Pointed-Type-With-Aut X Y h1 =
             ( ( preserves-aut-map-hom-Pointed-Type-With-Aut X Y h1 x) ∙
               ( refl)) ＝
             ( aut-h2 x)))
-      ( is-contr-total-path
+      ( is-torsorial-path
         ( preserves-point-map-hom-Pointed-Type-With-Aut X Y h1))
       ( pair (preserves-point-map-hom-Pointed-Type-With-Aut X Y h1) refl)
       ( is-contr-equiv'
@@ -205,7 +205,7 @@ is-contr-total-htpy-hom-Pointed-Type-With-Aut X Y h1 =
               ( x : type-Pointed-Type-With-Aut X) →
               preserves-aut-map-hom-Pointed-Type-With-Aut X Y h1 x ＝ aut-h2 x))
         ( equiv-tot (equiv-concat-htpy right-unit-htpy))
-        ( is-contr-total-htpy
+        ( is-torsorial-htpy
           ( preserves-aut-map-hom-Pointed-Type-With-Aut X Y h1))))
 
 is-equiv-htpy-hom-Pointed-Type-With-Aut :
@@ -214,7 +214,7 @@ is-equiv-htpy-hom-Pointed-Type-With-Aut :
   is-equiv (htpy-hom-Pointed-Type-With-Aut-eq X Y h1 h2)
 is-equiv-htpy-hom-Pointed-Type-With-Aut X Y h1 =
   fundamental-theorem-id
-    ( is-contr-total-htpy-hom-Pointed-Type-With-Aut X Y h1)
+    ( is-torsorial-htpy-hom-Pointed-Type-With-Aut X Y h1)
     ( htpy-hom-Pointed-Type-With-Aut-eq X Y h1)
 
 eq-htpy-hom-Pointed-Type-With-Aut :

--- a/src/synthetic-homotopy-theory/26-descent.lagda.md
+++ b/src/synthetic-homotopy-theory/26-descent.lagda.md
@@ -559,30 +559,30 @@ equiv-Fam-pushout-eq :
 equiv-Fam-pushout-eq {P = P} {.P} refl =
   reflexive-equiv-Fam-pushout P
 
-is-contr-total-equiv-Fam-pushout :
+is-torsorial-equiv-Fam-pushout :
   {l1 l2 l3 l : Level} {S : UU l1} {A : UU l2} {B : UU l3}
   {f : S → A} {g : S → B} (P : Fam-pushout l f g) →
   is-contr (Σ (Fam-pushout l f g) (equiv-Fam-pushout P))
-is-contr-total-equiv-Fam-pushout {S = S} {A} {B} {f} {g} P =
-  is-contr-total-Eq-structure
+is-torsorial-equiv-Fam-pushout {S = S} {A} {B} {f} {g} P =
+  is-torsorial-Eq-structure
     ( λ PA' t eA →
       Σ ( (b : B) → (pr1 (pr2 P) b) ≃ (pr1 t b))
         ( coherence-equiv-Fam-pushout P (pair PA' t) eA))
-    ( is-contr-total-Eq-Π
+    ( is-torsorial-Eq-Π
       ( λ a X → (pr1 P a) ≃ X)
-      ( λ a → is-contr-total-equiv (pr1 P a)))
+      ( λ a → is-torsorial-equiv (pr1 P a)))
     ( pair (pr1 P) (λ a → id-equiv))
-    ( is-contr-total-Eq-structure
+    ( is-torsorial-Eq-structure
       ( λ PB' PS' eB →
         coherence-equiv-Fam-pushout
           P (pair (pr1 P) (pair PB' PS')) (λ a → id-equiv) eB)
-      ( is-contr-total-Eq-Π
+      ( is-torsorial-Eq-Π
         ( λ b Y → (pr1 (pr2 P) b) ≃ Y)
-        ( λ b → is-contr-total-equiv (pr1 (pr2 P) b)))
+        ( λ b → is-torsorial-equiv (pr1 (pr2 P) b)))
       ( pair (pr1 (pr2 P)) (λ b → id-equiv))
-      ( is-contr-total-Eq-Π
+      ( is-torsorial-Eq-Π
         ( λ s e → (map-equiv (pr2 (pr2 P) s)) ~ (map-equiv e))
-        ( λ s → is-contr-total-htpy-equiv (pr2 (pr2 P) s))))
+        ( λ s → is-torsorial-htpy-equiv (pr2 (pr2 P) s))))
 
 is-equiv-equiv-Fam-pushout-eq :
   {l1 l2 l3 l : Level} {S : UU l1} {A : UU l2} {B : UU l3}
@@ -590,7 +590,7 @@ is-equiv-equiv-Fam-pushout-eq :
   is-equiv (equiv-Fam-pushout-eq {P = P} {Q})
 is-equiv-equiv-Fam-pushout-eq P =
   fundamental-theorem-id
-    ( is-contr-total-equiv-Fam-pushout P)
+    ( is-torsorial-equiv-Fam-pushout P)
     ( λ Q → equiv-Fam-pushout-eq {P = P} {Q})
 
 equiv-equiv-Fam-pushout :

--- a/src/synthetic-homotopy-theory/26-id-pushout.lagda.md
+++ b/src/synthetic-homotopy-theory/26-id-pushout.lagda.md
@@ -98,40 +98,40 @@ module hom-Fam-pushout
   htpy-hom-Fam-pushout-eq h .h refl =
     reflexive-htpy-hom-Fam-pushout h
 
-  is-contr-total-htpy-hom-Fam-pushout :
+  is-torsorial-htpy-hom-Fam-pushout :
     ( h : hom-Fam-pushout) →
     is-contr (Σ (hom-Fam-pushout) (htpy-hom-Fam-pushout h))
-  is-contr-total-htpy-hom-Fam-pushout h =
-    is-contr-total-Eq-structure
+  is-torsorial-htpy-hom-Fam-pushout h =
+    is-torsorial-Eq-structure
       ( λ kA kB-ke (HA : (x : A) → (pr1 h x) ~ (kA x)) →
           Σ ( (y : B) → (pr1 (pr2 h) y) ~ (pr1 kB-ke y)) (λ HB →
             ( s : S) →
               ( ((HB (g s)) ·r (map-equiv (PS s))) ∙h (pr2 kB-ke s)) ~
               ( (pr2 (pr2 h) s) ∙h ((map-equiv (QS s)) ·l (HA (f s))))))
-      ( is-contr-total-Eq-Π
+      ( is-torsorial-Eq-Π
         ( λ x τ → (pr1 h x) ~ τ)
-        ( λ x → is-contr-total-htpy (pr1 h x)))
+        ( λ x → is-torsorial-htpy (pr1 h x)))
       ( pair (pr1 h) (λ x → refl-htpy))
-      ( is-contr-total-Eq-structure
+      ( is-torsorial-Eq-structure
         ( λ kB ke (HB : (y : B) → (pr1 (pr2 h) y) ~ kB y) →
           (s : S) →
             ( ((HB (g s)) ·r (map-equiv (PS s))) ∙h (ke s)) ~
             ( (pr2 (pr2 h) s) ∙h ((map-equiv (QS s)) ·l refl-htpy)))
-        ( is-contr-total-Eq-Π
+        ( is-torsorial-Eq-Π
           ( λ y τ → (pr1 (pr2 h) y) ~ τ)
-          ( λ y → is-contr-total-htpy (pr1 (pr2 h) y)))
+          ( λ y → is-torsorial-htpy (pr1 (pr2 h) y)))
         ( pair (pr1 (pr2 h)) (λ y → refl-htpy))
-        ( is-contr-total-Eq-Π
+        ( is-torsorial-Eq-Π
           ( λ (s : S) he →
             (he ~ (pr2 (pr2 h) s ∙h (map-equiv (QS s) ·l refl-htpy))))
-          ( λ s → is-contr-total-htpy'
+          ( λ s → is-torsorial-htpy'
             ((pr2 (pr2 h) s) ∙h ((map-equiv (QS s)) ·l refl-htpy)))))
 
   is-equiv-htpy-hom-Fam-pushout-eq :
     ( h k : hom-Fam-pushout) → is-equiv (htpy-hom-Fam-pushout-eq h k)
   is-equiv-htpy-hom-Fam-pushout-eq h =
     fundamental-theorem-id
-      ( is-contr-total-htpy-hom-Fam-pushout h)
+      ( is-torsorial-htpy-hom-Fam-pushout h)
       ( htpy-hom-Fam-pushout-eq h)
 
   eq-htpy-hom-Fam-pushout :

--- a/src/synthetic-homotopy-theory/27-sequences.lagda.md
+++ b/src/synthetic-homotopy-theory/27-sequences.lagda.md
@@ -71,26 +71,26 @@ equiv-eq-Seq :
   { l1 : Level} (A B : Sequence l1) → Id A B → equiv-Seq A B
 equiv-eq-Seq A .A refl = id-equiv-Seq A
 
-is-contr-total-equiv-Seq :
+is-torsorial-equiv-Seq :
   { l1 : Level} (A : Sequence l1) →
   is-contr (Σ (Sequence l1) (equiv-Seq A))
-is-contr-total-equiv-Seq A =
-  is-contr-total-Eq-structure
+is-torsorial-equiv-Seq A =
+  is-torsorial-Eq-structure
     ( λ B g (e : (n : ℕ) → (type-seq A n) ≃ B n) →
       (n : ℕ) → naturality-hom-Seq A (pair B g) (λ n → map-equiv (e n)) n)
-    ( is-contr-total-Eq-Π
+    ( is-torsorial-Eq-Π
       ( λ n X → type-seq A n ≃ X)
-      ( λ n → is-contr-total-equiv (type-seq A n)))
+      ( λ n → is-torsorial-equiv (type-seq A n)))
     ( pair (type-seq A) (λ n → id-equiv))
-    ( is-contr-total-Eq-Π
+    ( is-torsorial-Eq-Π
       ( λ n h → h ~ (map-seq A n))
-      ( λ n → is-contr-total-htpy' (map-seq A n)))
+      ( λ n → is-torsorial-htpy' (map-seq A n)))
 
 is-equiv-equiv-eq-Seq :
   { l1 : Level} (A B : Sequence l1) → is-equiv (equiv-eq-Seq A B)
 is-equiv-equiv-eq-Seq A =
   fundamental-theorem-id
-    ( is-contr-total-equiv-Seq A)
+    ( is-torsorial-equiv-Seq A)
     ( equiv-eq-Seq A)
 
 eq-equiv-Seq :
@@ -155,22 +155,22 @@ htpy-cocone-sequence-eq :
 htpy-cocone-sequence-eq A c .c refl =
   reflexive-htpy-cocone-sequence A c
 
-is-contr-total-htpy-cocone-sequence :
+is-torsorial-htpy-cocone-sequence :
   { l1 l2 : Level} (A : Sequence l1) {X : UU l2} (c : cocone-sequence A X) →
   is-contr (Σ (cocone-sequence A X) (htpy-cocone-sequence A c))
-is-contr-total-htpy-cocone-sequence A c =
-  is-contr-total-Eq-structure
+is-torsorial-htpy-cocone-sequence A c =
+  is-torsorial-Eq-structure
     ( λ j t H →
       (n : ℕ) → naturality-htpy-cocone-sequence A c (pair j t) H n)
-    ( is-contr-total-Eq-Π
+    ( is-torsorial-Eq-Π
       ( λ n j → map-cocone-sequence A c n ~ j)
-      ( λ n → is-contr-total-htpy (map-cocone-sequence A c n)))
+      ( λ n → is-torsorial-htpy (map-cocone-sequence A c n)))
     ( pair
       ( map-cocone-sequence A c)
       ( λ n → refl-htpy))
-    ( is-contr-total-Eq-Π
+    ( is-torsorial-Eq-Π
       ( λ n H → H ~ ((triangle-cocone-sequence A c n) ∙h refl-htpy))
-      ( λ n → is-contr-total-htpy'
+      ( λ n → is-torsorial-htpy'
         ( (triangle-cocone-sequence A c n) ∙h refl-htpy)))
 
 is-equiv-htpy-cocone-sequence-eq :
@@ -178,7 +178,7 @@ is-equiv-htpy-cocone-sequence-eq :
   is-equiv (htpy-cocone-sequence-eq A c c')
 is-equiv-htpy-cocone-sequence-eq A c =
   fundamental-theorem-id
-    ( is-contr-total-htpy-cocone-sequence A c)
+    ( is-torsorial-htpy-cocone-sequence A c)
     ( htpy-cocone-sequence-eq A c)
 ```
 

--- a/src/synthetic-homotopy-theory/cocones-under-spans.lagda.md
+++ b/src/synthetic-homotopy-theory/cocones-under-spans.lagda.md
@@ -123,21 +123,21 @@ module _
     (c c' : cocone f g X) → c ＝ c' → htpy-cocone c c'
   htpy-eq-cocone c .c refl = reflexive-htpy-cocone c
 
-  is-contr-total-htpy-cocone :
+  is-torsorial-htpy-cocone :
     (c : cocone f g X) → is-contr (Σ (cocone f g X) (htpy-cocone c))
-  is-contr-total-htpy-cocone c =
-    is-contr-total-Eq-structure
+  is-torsorial-htpy-cocone c =
+    is-torsorial-Eq-structure
       ( λ i' jH' K →
         Σ ( vertical-map-cocone f g c ~ (pr1 jH'))
           ( statement-coherence-htpy-cocone c (i' , jH') K))
-      ( is-contr-total-htpy (horizontal-map-cocone f g c))
+      ( is-torsorial-htpy (horizontal-map-cocone f g c))
       ( horizontal-map-cocone f g c , refl-htpy)
-      ( is-contr-total-Eq-structure
+      ( is-torsorial-Eq-structure
         ( λ j' H' →
           statement-coherence-htpy-cocone c
             ( horizontal-map-cocone f g c , j' , H')
             ( refl-htpy))
-        ( is-contr-total-htpy (vertical-map-cocone f g c))
+        ( is-torsorial-htpy (vertical-map-cocone f g c))
         ( vertical-map-cocone f g c , refl-htpy)
         ( is-contr-is-equiv'
           ( Σ ( ( horizontal-map-cocone f g c ∘ f) ~
@@ -145,13 +145,13 @@ module _
               ( λ H' → coherence-square-cocone f g c ~ H'))
           ( tot (λ H' M → right-unit-htpy ∙h M))
           ( is-equiv-tot-is-fiberwise-equiv (λ H' → is-equiv-concat-htpy _ _))
-          ( is-contr-total-htpy (coherence-square-cocone f g c))))
+          ( is-torsorial-htpy (coherence-square-cocone f g c))))
 
   is-equiv-htpy-eq-cocone :
     (c c' : cocone f g X) → is-equiv (htpy-eq-cocone c c')
   is-equiv-htpy-eq-cocone c =
     fundamental-theorem-id
-      ( is-contr-total-htpy-cocone c)
+      ( is-torsorial-htpy-cocone c)
       ( htpy-eq-cocone c)
 
   extensionality-cocone :

--- a/src/synthetic-homotopy-theory/coforks.lagda.md
+++ b/src/synthetic-homotopy-theory/coforks.lagda.md
@@ -140,12 +140,12 @@ module _
   htpy-cofork-eq e .e refl = reflexive-htpy-cofork e
 
   abstract
-    is-contr-total-htpy-cofork :
+    is-torsorial-htpy-cofork :
       ( e : cofork f g X) → is-contr (Σ (cofork f g X) (htpy-cofork f g e))
-    is-contr-total-htpy-cofork e =
-      is-contr-total-Eq-structure
+    is-torsorial-htpy-cofork e =
+      is-torsorial-Eq-structure
         ( ev-pair (coherence-htpy-cofork f g e))
-        ( is-contr-total-htpy (map-cofork f g e))
+        ( is-torsorial-htpy (map-cofork f g e))
         ( map-cofork f g e , refl-htpy)
         ( is-contr-is-equiv'
           ( Σ ( map-cofork f g e ∘ f ~ map-cofork f g e ∘ g)
@@ -153,12 +153,12 @@ module _
           ( tot (λ K M → right-unit-htpy ∙h M))
           ( is-equiv-tot-is-fiberwise-equiv
             ( is-equiv-concat-htpy right-unit-htpy))
-          ( is-contr-total-htpy (coherence-cofork f g e)))
+          ( is-torsorial-htpy (coherence-cofork f g e)))
 
     is-equiv-htpy-cofork-eq :
       ( e e' : cofork f g X) → is-equiv (htpy-cofork-eq e e')
     is-equiv-htpy-cofork-eq e =
-      fundamental-theorem-id (is-contr-total-htpy-cofork e) (htpy-cofork-eq e)
+      fundamental-theorem-id (is-torsorial-htpy-cofork e) (htpy-cofork-eq e)
 
   eq-htpy-cofork :
     ( e e' : cofork f g X) → htpy-cofork f g e e' → e ＝ e'

--- a/src/synthetic-homotopy-theory/dependent-cocones-under-spans.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-cocones-under-spans.lagda.md
@@ -179,21 +179,21 @@ module _
       pr2 (pr2 (htpy-eq-dependent-cocone d' p))
 
   abstract
-    is-contr-total-htpy-dependent-cocone :
+    is-torsorial-htpy-dependent-cocone :
       is-contr (Σ (dependent-cocone f g c P) htpy-dependent-cocone)
-    is-contr-total-htpy-dependent-cocone =
-      is-contr-total-Eq-structure
+    is-torsorial-htpy-dependent-cocone =
+      is-torsorial-Eq-structure
         ( λ α βγ K →
             Σ ( vertical-map-dependent-cocone f g c P d ~ pr1 βγ)
               ( coherence-htpy-dependent-cocone (α , βγ) K))
-        ( is-contr-total-htpy (horizontal-map-dependent-cocone f g c P d))
+        ( is-torsorial-htpy (horizontal-map-dependent-cocone f g c P d))
         ( horizontal-map-dependent-cocone f g c P d , refl-htpy)
-        ( is-contr-total-Eq-structure
+        ( is-torsorial-Eq-structure
           ( λ β γ →
             coherence-htpy-dependent-cocone
               ( horizontal-map-dependent-cocone f g c P d , β , γ)
               ( refl-htpy))
-          ( is-contr-total-htpy (vertical-map-dependent-cocone f g c P d))
+          ( is-torsorial-htpy (vertical-map-dependent-cocone f g c P d))
           ( vertical-map-dependent-cocone f g c P d , refl-htpy)
           ( is-contr-equiv
             ( Σ ( (s : S) →
@@ -203,7 +203,7 @@ module _
                     ( vertical-map-dependent-cocone f g c P d (g s)))
                 ( λ γ → coherence-square-dependent-cocone f g c P d ~ γ))
             ( equiv-tot (equiv-concat-htpy inv-htpy-right-unit-htpy))
-            ( is-contr-total-htpy
+            ( is-torsorial-htpy
               ( coherence-square-dependent-cocone f g c P d))))
 
   abstract
@@ -211,7 +211,7 @@ module _
       (d' : dependent-cocone f g c P) → is-equiv (htpy-eq-dependent-cocone d')
     is-equiv-htpy-eq-dependent-cocone =
       fundamental-theorem-id
-        ( is-contr-total-htpy-dependent-cocone)
+        ( is-torsorial-htpy-dependent-cocone)
         ( htpy-eq-dependent-cocone)
 
     eq-htpy-dependent-cocone :

--- a/src/synthetic-homotopy-theory/dependent-coforks.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-coforks.lagda.md
@@ -173,13 +173,13 @@ module _
   htpy-dependent-cofork-eq k .k refl = reflexive-htpy-dependent-cofork k
 
   abstract
-    is-contr-total-htpy-dependent-cofork :
+    is-torsorial-htpy-dependent-cofork :
       ( k : dependent-cofork f g e P) →
       is-contr (Σ (dependent-cofork f g e P) (htpy-dependent-cofork f g P k))
-    is-contr-total-htpy-dependent-cofork k =
-      is-contr-total-Eq-structure
+    is-torsorial-htpy-dependent-cofork k =
+      is-torsorial-Eq-structure
         ( ev-pair (coherence-htpy-dependent-cofork f g P k))
-        ( is-contr-total-htpy (map-dependent-cofork f g P k))
+        ( is-torsorial-htpy (map-dependent-cofork f g P k))
         ( map-dependent-cofork f g P k , refl-htpy)
         ( is-contr-is-equiv'
           ( Σ ( (a : A) →
@@ -191,14 +191,14 @@ module _
           ( tot (λ K M → right-unit-htpy ∙h M))
           ( is-equiv-tot-is-fiberwise-equiv
             ( is-equiv-concat-htpy right-unit-htpy))
-          ( is-contr-total-htpy (coherence-dependent-cofork f g P k)))
+          ( is-torsorial-htpy (coherence-dependent-cofork f g P k)))
 
     is-equiv-htpy-dependent-cofork-eq :
       ( k k' : dependent-cofork f g e P) →
       is-equiv (htpy-dependent-cofork-eq k k')
     is-equiv-htpy-dependent-cofork-eq k =
       fundamental-theorem-id
-        ( is-contr-total-htpy-dependent-cofork k)
+        ( is-torsorial-htpy-dependent-cofork k)
         ( htpy-dependent-cofork-eq k)
 
   eq-htpy-dependent-cofork :

--- a/src/synthetic-homotopy-theory/dependent-descent-circle.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-descent-circle.lagda.md
@@ -316,13 +316,13 @@ module _
   equiv-eq-dependent-descent-data-circle =
     equiv-eq-Dependent-Type-With-Automorphism P
 
-  is-contr-total-equiv-dependent-descent-data-circle :
+  is-torsorial-equiv-dependent-descent-data-circle :
     ( Q : dependent-descent-data-circle l2 P) →
     is-contr
       ( Σ ( dependent-descent-data-circle l2 P)
           ( equiv-dependent-descent-data-circle P Q))
-  is-contr-total-equiv-dependent-descent-data-circle =
-    is-contr-total-equiv-Dependent-Type-With-Automorphism P
+  is-torsorial-equiv-dependent-descent-data-circle =
+    is-torsorial-equiv-Dependent-Type-With-Automorphism P
 
   is-equiv-equiv-eq-dependent-descent-data-circle :
     ( Q T : dependent-descent-data-circle l2 P) →

--- a/src/synthetic-homotopy-theory/descent-circle.lagda.md
+++ b/src/synthetic-homotopy-theory/descent-circle.lagda.md
@@ -273,11 +273,11 @@ equiv-eq-descent-data-circle :
 equiv-eq-descent-data-circle =
   equiv-eq-Type-With-Automorphism
 
-is-contr-total-equiv-descent-data-circle :
+is-torsorial-equiv-descent-data-circle :
   { l1 : Level} (P : descent-data-circle l1) →
   is-contr (Σ (descent-data-circle l1) (equiv-descent-data-circle P))
-is-contr-total-equiv-descent-data-circle =
-  is-contr-total-equiv-Type-With-Automorphism
+is-torsorial-equiv-descent-data-circle =
+  is-torsorial-equiv-Type-With-Automorphism
 
 is-equiv-equiv-eq-descent-data-circle :
   { l1 : Level} (P Q : descent-data-circle l1) →

--- a/src/synthetic-homotopy-theory/free-loops.lagda.md
+++ b/src/synthetic-homotopy-theory/free-loops.lagda.md
@@ -89,26 +89,26 @@ module _
   Eq-eq-free-loop α .α refl = refl-Eq-free-loop α
 
   abstract
-    is-contr-total-Eq-free-loop :
+    is-torsorial-Eq-free-loop :
       (α : free-loop X) → is-contr (Σ (free-loop X) (Eq-free-loop α))
-    is-contr-total-Eq-free-loop (pair x α) =
-      is-contr-total-Eq-structure
+    is-torsorial-Eq-free-loop (pair x α) =
+      is-torsorial-Eq-structure
         ( λ x α' p → Id (α ∙ p) (p ∙ α'))
-        ( is-contr-total-path x)
+        ( is-torsorial-path x)
         ( pair x refl)
         ( is-contr-is-equiv'
           ( Σ (Id x x) (λ α' → Id α α'))
           ( tot (λ α' α → right-unit ∙ α))
           ( is-equiv-tot-is-fiberwise-equiv
             ( λ α' → is-equiv-concat right-unit α'))
-          ( is-contr-total-path α))
+          ( is-torsorial-path α))
 
   abstract
     is-equiv-Eq-eq-free-loop :
       (α α' : free-loop X) → is-equiv (Eq-eq-free-loop α α')
     is-equiv-Eq-eq-free-loop α =
       fundamental-theorem-id
-        ( is-contr-total-Eq-free-loop α)
+        ( is-torsorial-Eq-free-loop α)
         ( Eq-eq-free-loop α)
 ```
 
@@ -137,20 +137,20 @@ module _
   Eq-free-dependent-loop-eq p .p refl = refl-Eq-free-dependent-loop p
 
   abstract
-    is-contr-total-Eq-free-dependent-loop :
+    is-torsorial-Eq-free-dependent-loop :
       ( p : free-dependent-loop α P) →
       is-contr (Σ (free-dependent-loop α P) (Eq-free-dependent-loop p))
-    is-contr-total-Eq-free-dependent-loop (pair y p) =
-      is-contr-total-Eq-structure
+    is-torsorial-Eq-free-dependent-loop (pair y p) =
+      is-torsorial-Eq-structure
         ( λ y' p' q → Id (p ∙ q) ((ap (tr P (loop-free-loop α)) q) ∙ p'))
-        ( is-contr-total-path y)
+        ( is-torsorial-path y)
         ( pair y refl)
         ( is-contr-is-equiv'
           ( Σ (Id (tr P (loop-free-loop α) y) y) (λ p' → Id p p'))
           ( tot (λ p' α → right-unit ∙ α))
           ( is-equiv-tot-is-fiberwise-equiv
             ( λ p' → is-equiv-concat right-unit p'))
-          ( is-contr-total-path p))
+          ( is-torsorial-path p))
 
   abstract
     is-equiv-Eq-free-dependent-loop-eq :
@@ -158,7 +158,7 @@ module _
       is-equiv (Eq-free-dependent-loop-eq p p')
     is-equiv-Eq-free-dependent-loop-eq p =
       fundamental-theorem-id
-        ( is-contr-total-Eq-free-dependent-loop p)
+        ( is-torsorial-Eq-free-dependent-loop p)
         ( Eq-free-dependent-loop-eq p)
 
   eq-Eq-free-dependent-loop :

--- a/src/synthetic-homotopy-theory/hatchers-acyclic-type.lagda.md
+++ b/src/synthetic-homotopy-theory/hatchers-acyclic-type.lagda.md
@@ -133,12 +133,12 @@ module _
   pr1 (pr2 (pr2 refl-Eq-structure-Hatcher-Acyclic-Type)) = right-unit
   pr2 (pr2 (pr2 refl-Eq-structure-Hatcher-Acyclic-Type)) = right-unit
 
-  is-contr-total-Eq-structure-Hatcher-Acyclic-Type :
+  is-torsorial-Eq-structure-Hatcher-Acyclic-Type :
     is-contr
       ( Σ ( structure-Hatcher-Acyclic-Type A)
           ( Eq-structure-Hatcher-Acyclic-Type))
-  is-contr-total-Eq-structure-Hatcher-Acyclic-Type =
-    is-contr-total-Eq-structure
+  is-torsorial-Eq-structure-Hatcher-Acyclic-Type =
+    is-torsorial-Eq-structure
       ( λ (ω : type-Ω A) u (p : pr1 s ＝ ω) →
           Σ ( pr1 (pr2 s) ＝ pr1 u)
             ( λ q →
@@ -147,9 +147,9 @@ module _
               ( ( pr2
                   ( pr2 (pr2 s)) ∙ ap (power-nat-Ω 2 A) (ap-binary _∙_ p q)) ＝
                 ( ap (power-nat-Ω 3 A) q ∙ pr2 (pr2 u)))))
-      ( is-contr-total-path (pr1 s))
+      ( is-torsorial-path (pr1 s))
       ( pr1 s , refl)
-      ( is-contr-total-Eq-structure
+      ( is-torsorial-Eq-structure
         ( λ ω u p →
           Σ ( ( pr1 (pr2 (pr2 s)) ∙ ap (power-nat-Ω 3 A) p) ＝
               ( ap (power-nat-Ω 5 A) {pr1 s} refl ∙ pr1 u))
@@ -159,13 +159,13 @@ module _
                   ( power-nat-Ω 2 A)
                   ( ap-binary _∙_ {pr1 s} {pr1 s} refl p))) ＝
               ( ap (power-nat-Ω 3 A) p ∙ pr2 u)))
-        ( is-contr-total-path (pr1 (pr2 s)))
+        ( is-torsorial-path (pr1 (pr2 s)))
         ( pr1 (pr2 s) , refl)
-        ( is-contr-total-Eq-structure
+        ( is-torsorial-Eq-structure
           ( λ u v w → Id (pr2 (pr2 (pr2 s)) ∙ refl) v)
-          ( is-contr-total-path (pr1 (pr2 (pr2 s)) ∙ refl))
+          ( is-torsorial-path (pr1 (pr2 (pr2 s)) ∙ refl))
           ( pr1 (pr2 (pr2 s)) , right-unit)
-          ( is-contr-total-path (pr2 (pr2 (pr2 s)) ∙ refl))))
+          ( is-torsorial-path (pr2 (pr2 (pr2 s)) ∙ refl))))
 
   Eq-eq-structure-Hatcher-Acyclic-Type :
     (t : structure-Hatcher-Acyclic-Type A) →
@@ -178,7 +178,7 @@ module _
     is-equiv (Eq-eq-structure-Hatcher-Acyclic-Type t)
   is-equiv-Eq-eq-structure-Hatcher-Acyclic-Type =
     fundamental-theorem-id
-      is-contr-total-Eq-structure-Hatcher-Acyclic-Type
+      is-torsorial-Eq-structure-Hatcher-Acyclic-Type
       Eq-eq-structure-Hatcher-Acyclic-Type
 
   extensionality-structure-Hatcher-Acyclic-Type :
@@ -220,7 +220,7 @@ module _
               ( ( inv (power-nat-mul-Ω 3 2 (Ω A) a)) ∙
                 ( power-nat-succ-Ω' 5 (Ω A) a)))) ∘e
           ( ( ( left-unit-law-Σ-is-contr
-                ( is-contr-total-path' (a ∙ a))
+                ( is-torsorial-path' (a ∙ a))
                 ( a ∙ a , refl)) ∘e
               ( inv-associative-Σ
                 ( type-Ω (Ω A))
@@ -243,7 +243,7 @@ module _
                     ( equiv-concat'
                       ( power-nat-Ω 3 (Ω A) b)
                       ( interchange-concat-Ω² a b a b)))))))))
-        ( is-contr-total-path refl)
+        ( is-torsorial-path refl)
 ```
 
 ## See also

--- a/src/synthetic-homotopy-theory/infinite-cyclic-types.lagda.md
+++ b/src/synthetic-homotopy-theory/infinite-cyclic-types.lagda.md
@@ -102,10 +102,10 @@ module _
     (Y : Infinite-Cyclic-Type l1) → Id X Y → equiv-Infinite-Cyclic-Type Y
   equiv-eq-Infinite-Cyclic-Type = equiv-eq-Cyclic-Type zero-ℕ X
 
-  is-contr-total-equiv-Infinite-Cyclic-Type :
+  is-torsorial-equiv-Infinite-Cyclic-Type :
     is-contr (Σ (Infinite-Cyclic-Type l1) equiv-Infinite-Cyclic-Type)
-  is-contr-total-equiv-Infinite-Cyclic-Type =
-    is-contr-total-equiv-Cyclic-Type zero-ℕ X
+  is-torsorial-equiv-Infinite-Cyclic-Type =
+    is-torsorial-equiv-Cyclic-Type zero-ℕ X
 
   is-equiv-equiv-eq-Infinite-Cyclic-Type :
     (Y : Infinite-Cyclic-Type l1) → is-equiv (equiv-eq-Infinite-Cyclic-Type Y)

--- a/src/synthetic-homotopy-theory/suspension-structures.lagda.md
+++ b/src/synthetic-homotopy-theory/suspension-structures.lagda.md
@@ -249,7 +249,7 @@ module _
           ( Σ (suspension-structure X Z) (λ c' → c ＝ c'))
           ( inv-equiv
             ( equiv-tot (extensionality-suspension-structure c)))
-          ( is-contr-total-path c))
+          ( is-torsorial-path c))
         ( P))
 ```
 

--- a/src/synthetic-homotopy-theory/universal-cover-circle.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-cover-circle.lagda.md
@@ -480,7 +480,7 @@ contraction-total-fundamental-cover-circle-data
         l dup-circle h p))
     x y
 
-is-contr-total-fundamental-cover-circle-data :
+is-torsorial-fundamental-cover-circle-data :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
   ( dup-circle : {l2 : Level} → dependent-universal-property-circle l2 l) →
   ( h :
@@ -499,9 +499,9 @@ is-contr-total-fundamental-cover-circle-data :
       ( h)
       ( h)) →
   is-contr (Σ X (fundamental-cover-circle l dup-circle))
-pr1 (is-contr-total-fundamental-cover-circle-data l dup-circle h p) =
+pr1 (is-torsorial-fundamental-cover-circle-data l dup-circle h p) =
   center-total-fundamental-cover-circle l dup-circle
-pr2 (is-contr-total-fundamental-cover-circle-data l dup-circle h p) =
+pr2 (is-torsorial-fundamental-cover-circle-data l dup-circle h p) =
   contraction-total-fundamental-cover-circle-data l dup-circle h p
 ```
 
@@ -570,12 +570,12 @@ Contraction-fundamental-cover-circle l dup-circle =
       ( path-total-fundamental-cover-circle l dup-circle k))
 
 abstract
-  is-contr-total-fundamental-cover-circle :
+  is-torsorial-fundamental-cover-circle :
     { l1 : Level} {X : UU l1} (l : free-loop X) →
     ( dup-circle : {l2 : Level} → dependent-universal-property-circle l2 l) →
     is-contr (Σ X (fundamental-cover-circle l dup-circle))
-  is-contr-total-fundamental-cover-circle l dup-circle =
-    is-contr-total-fundamental-cover-circle-data l dup-circle
+  is-torsorial-fundamental-cover-circle l dup-circle =
+    is-torsorial-fundamental-cover-circle-data l dup-circle
       ( pr1 (Contraction-fundamental-cover-circle l dup-circle))
       ( inv-htpy
         ( pr2 (pr2 (Contraction-fundamental-cover-circle l dup-circle))))
@@ -601,7 +601,7 @@ abstract
     ( x : X) → is-equiv (fundamental-cover-circle-eq l dup-circle x)
   is-equiv-fundamental-cover-circle-eq l dup-circle =
     fundamental-theorem-id
-      ( is-contr-total-fundamental-cover-circle l dup-circle)
+      ( is-torsorial-fundamental-cover-circle l dup-circle)
       ( fundamental-cover-circle-eq l dup-circle)
 
 equiv-fundamental-cover-circle :

--- a/src/synthetic-homotopy-theory/universal-property-pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-pushouts.lagda.md
@@ -231,7 +231,7 @@ uniquely-unique-pushout :
   is-contr
     ( Σ (X ≃ Y) (λ e → htpy-cocone f g (cocone-map f g c (map-equiv e)) d))
 uniquely-unique-pushout f g c d up-c up-d =
-  is-contr-total-Eq-subtype
+  is-torsorial-Eq-subtype
     ( uniqueness-map-universal-property-pushout f g c up-c d)
     ( is-property-is-equiv)
     ( map-universal-property-pushout f g c up-c d)

--- a/src/synthetic-homotopy-theory/universal-property-suspensions-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-suspensions-of-pointed-types.lagda.md
@@ -149,7 +149,7 @@ module _
     (suspension-Pointed-Type X →∗ Y) ≃ (X →∗ Ω Y)
   equiv-transpose-suspension-loop-adjunction =
     ( left-unit-law-Σ-is-contr
-      ( is-contr-total-path (point-Pointed-Type Y))
+      ( is-torsorial-path (point-Pointed-Type Y))
       ( point-Pointed-Type Y , refl)) ∘e
     ( inv-associative-Σ
       ( type-Pointed-Type Y)
@@ -165,9 +165,9 @@ module _
         Σ ( point-Pointed-Type Y ＝ pr1 z)
           ( λ x → pr2 z (point-Pointed-Type X) ＝ x))) ∘e
     ( inv-right-unit-law-Σ-is-contr
-      ( λ z → is-contr-total-path (pr2 z (point-Pointed-Type X)))) ∘e
+      ( λ z → is-torsorial-path (pr2 z (point-Pointed-Type X)))) ∘e
     ( left-unit-law-Σ-is-contr
-      ( is-contr-total-path' (point-Pointed-Type Y))
+      ( is-torsorial-path' (point-Pointed-Type Y))
       ( point-Pointed-Type Y , refl)) ∘e
     ( equiv-right-swap-Σ) ∘e
     ( equiv-Σ-equiv-base

--- a/src/trees/equivalences-directed-trees.lagda.md
+++ b/src/trees/equivalences-directed-trees.lagda.md
@@ -333,10 +333,10 @@ module _
   (e : equiv-Directed-Tree S T)
   where
 
-  is-contr-total-htpy-equiv-Directed-Tree :
+  is-torsorial-htpy-equiv-Directed-Tree :
     is-contr (Σ (equiv-Directed-Tree S T) (htpy-equiv-Directed-Tree S T e))
-  is-contr-total-htpy-equiv-Directed-Tree =
-    is-contr-total-htpy-equiv-Directed-Graph
+  is-torsorial-htpy-equiv-Directed-Tree =
+    is-torsorial-htpy-equiv-Directed-Graph
       ( graph-Directed-Tree S)
       ( graph-Directed-Tree T)
       ( e)
@@ -436,13 +436,13 @@ module _
     (S : Directed-Tree l1 l2) → equiv-Directed-Tree T S → (T ＝ S)
   eq-equiv-Directed-Tree S = map-inv-equiv (extensionality-Directed-Tree S)
 
-  is-contr-total-equiv-Directed-Tree :
+  is-torsorial-equiv-Directed-Tree :
     is-contr (Σ (Directed-Tree l1 l2) (equiv-Directed-Tree T))
-  is-contr-total-equiv-Directed-Tree =
+  is-torsorial-equiv-Directed-Tree =
     is-contr-equiv'
       ( Σ (Directed-Tree l1 l2) (λ S → T ＝ S))
       ( equiv-tot extensionality-Directed-Tree)
-      ( is-contr-total-path T)
+      ( is-torsorial-path T)
 ```
 
 ### A morphism of directed trees is an equivalence if it is an equivalence on the nodes

--- a/src/trees/equivalences-enriched-directed-trees.lagda.md
+++ b/src/trees/equivalences-enriched-directed-trees.lagda.md
@@ -499,15 +499,15 @@ module _
   eq-equiv-Enriched-Directed-Tree S =
     map-inv-equiv (extensionality-Enriched-Directed-Tree S)
 
-  is-contr-total-equiv-Enriched-Directed-Tree :
+  is-torsorial-equiv-Enriched-Directed-Tree :
     is-contr
       ( Σ ( Enriched-Directed-Tree l3 l4 A B)
           ( equiv-Enriched-Directed-Tree A B T))
-  is-contr-total-equiv-Enriched-Directed-Tree =
+  is-torsorial-equiv-Enriched-Directed-Tree =
     is-contr-equiv'
       ( Σ (Enriched-Directed-Tree l3 l4 A B) (λ S → T ＝ S))
       ( equiv-tot extensionality-Enriched-Directed-Tree)
-      ( is-contr-total-path T)
+      ( is-torsorial-path T)
 ```
 
 ### A morphism of enriched directed trees is an equivalence if it is an equivalence on the nodes

--- a/src/trees/extensional-w-types.lagda.md
+++ b/src/trees/extensional-w-types.lagda.md
@@ -91,13 +91,13 @@ module _
   refl-Eq-Eq-ext-𝕎 : (x y : 𝕎 A B) (u : Eq-ext-𝕎 x y) → Eq-Eq-ext-𝕎 x y u u
   refl-Eq-Eq-ext-𝕎 x y u z = refl-htpy
 
-  is-contr-total-Eq-Eq-ext-𝕎 :
+  is-torsorial-Eq-Eq-ext-𝕎 :
     (x y : 𝕎 A B) (u : Eq-ext-𝕎 x y) →
     is-contr (Σ (Eq-ext-𝕎 x y) (Eq-Eq-ext-𝕎 x y u))
-  is-contr-total-Eq-Eq-ext-𝕎 x y u =
-    is-contr-total-Eq-Π
+  is-torsorial-Eq-Eq-ext-𝕎 x y u =
+    is-torsorial-Eq-Π
       ( λ z e → map-equiv (u z) ~ map-equiv e)
-      ( λ z → is-contr-total-htpy-equiv (u z))
+      ( λ z → is-torsorial-htpy-equiv (u z))
 
   Eq-Eq-ext-eq-𝕎 :
     (x y : 𝕎 A B) (u v : Eq-ext-𝕎 x y) → u ＝ v → Eq-Eq-ext-𝕎 x y u v
@@ -107,7 +107,7 @@ module _
     (x y : 𝕎 A B) (u v : Eq-ext-𝕎 x y) → is-equiv (Eq-Eq-ext-eq-𝕎 x y u v)
   is-equiv-Eq-Eq-ext-eq-𝕎 x y u =
     fundamental-theorem-id
-      ( is-contr-total-Eq-Eq-ext-𝕎 x y u)
+      ( is-torsorial-Eq-Eq-ext-𝕎 x y u)
       ( Eq-Eq-ext-eq-𝕎 x y u)
 
   eq-Eq-Eq-ext-𝕎 :
@@ -121,7 +121,7 @@ module _
     ( ( equiv-tot
             ( λ x →
               ( ( right-unit-law-Σ-is-contr
-                  ( λ e → is-contr-total-htpy (f ∘ map-inv-equiv e))) ∘e
+                  ( λ e → is-torsorial-htpy (f ∘ map-inv-equiv e))) ∘e
                 ( equiv-tot
                   ( λ e →
                     equiv-tot
@@ -157,9 +157,9 @@ module _
           ( pr2 (map-equiv inv-equiv-structure-𝕎-Alg z)))
     H (tree-𝕎 b g) = id-equiv
 
-  is-contr-total-Eq-ext-is-univalent-𝕎 :
+  is-torsorial-Eq-ext-is-univalent-𝕎 :
     is-univalent B → (x : 𝕎 A B) → is-contr (Σ (𝕎 A B) (Eq-ext-𝕎 x))
-  is-contr-total-Eq-ext-is-univalent-𝕎 H (tree-𝕎 a f) =
+  is-torsorial-Eq-ext-is-univalent-𝕎 H (tree-𝕎 a f) =
     is-contr-equiv
       ( Σ A (λ x → B a ≃ B x))
       ( equiv-total-Eq-ext-𝕎 (tree-𝕎 a f))
@@ -169,7 +169,7 @@ module _
     is-univalent B → is-extensional-𝕎 A B
   is-extensional-is-univalent-𝕎 H x =
     fundamental-theorem-id
-      ( is-contr-total-Eq-ext-is-univalent-𝕎 H x)
+      ( is-torsorial-Eq-ext-is-univalent-𝕎 H x)
       ( λ y → extensional-Eq-eq-𝕎 {y = y})
 
   is-univalent-is-extensional-𝕎 :

--- a/src/trees/fibers-enriched-directed-trees.lagda.md
+++ b/src/trees/fibers-enriched-directed-trees.lagda.md
@@ -99,7 +99,7 @@ module _
     ( interchange-Σ-Σ (λ u e v → v ＝ cons-walk-Directed-Graph e w)) ∘e
     ( ( inv-right-unit-law-Σ-is-contr
         ( λ i →
-          is-contr-total-path' (cons-walk-Directed-Graph (pr2 i) w))) ∘e
+          is-torsorial-path' (cons-walk-Directed-Graph (pr2 i) w))) ∘e
       ( enrichment-Enriched-Directed-Tree A B T y))
 
   fiber-Enriched-Directed-Tree : Enriched-Directed-Tree (l3 ⊔ l4) (l3 ⊔ l4) A B
@@ -157,7 +157,7 @@ module _
     map-enrichment-fiber-Enriched-Directed-Tree y b
   eq-map-enrichment-fiber-Enriched-Directed-Tree y b w p =
     eq-interchange-Σ-Σ-is-contr _
-      ( is-contr-total-path'
+      ( is-torsorial-path'
         ( cons-walk-Directed-Graph
           ( edge-enrichment-Enriched-Directed-Tree A B T
             ( node-inclusion-fiber-Enriched-Directed-Tree y)

--- a/src/trees/morphisms-algebras-polynomial-endofunctors.lagda.md
+++ b/src/trees/morphisms-algebras-polynomial-endofunctors.lagda.md
@@ -130,12 +130,12 @@ module _
   htpy-eq-hom-algebra-polynomial-endofunctor .f refl =
     refl-htpy-hom-algebra-polynomial-endofunctor
 
-  is-contr-total-htpy-hom-algebra-polynomial-endofunctor :
+  is-torsorial-htpy-hom-algebra-polynomial-endofunctor :
     is-contr
       ( Σ ( hom-algebra-polynomial-endofunctor X Y)
           ( htpy-hom-algebra-polynomial-endofunctor))
-  is-contr-total-htpy-hom-algebra-polynomial-endofunctor =
-    is-contr-total-Eq-structure
+  is-torsorial-htpy-hom-algebra-polynomial-endofunctor =
+    is-torsorial-Eq-structure
       ( λ ( g : pr1 X → pr1 Y)
           ( G : (g ∘ pr2 X) ~ ((pr2 Y) ∘ (map-polynomial-endofunctor A B g)))
           ( H : map-hom-algebra-polynomial-endofunctor X Y f ~ g) →
@@ -143,7 +143,7 @@ module _
             ( ( structure-algebra-polynomial-endofunctor Y) ·l
               ( htpy-polynomial-endofunctor A B H))) ~
           ( ( H ·r structure-algebra-polynomial-endofunctor X) ∙h G))
-      ( is-contr-total-htpy (map-hom-algebra-polynomial-endofunctor X Y f))
+      ( is-torsorial-htpy (map-hom-algebra-polynomial-endofunctor X Y f))
       ( pair (map-hom-algebra-polynomial-endofunctor X Y f) refl-htpy)
       ( is-contr-equiv'
         ( Σ ( ( (pr1 f) ∘ pr2 X) ~
@@ -163,14 +163,14 @@ module _
                     ( coh-refl-htpy-polynomial-endofunctor A B (pr1 f) x)))
               ( H)) ∘e
             ( equiv-concat-htpy right-unit-htpy H)))
-        ( is-contr-total-htpy (pr2 f)))
+        ( is-torsorial-htpy (pr2 f)))
 
   is-equiv-htpy-eq-hom-algebra-polynomial-endofunctor :
     (g : hom-algebra-polynomial-endofunctor X Y) →
     is-equiv (htpy-eq-hom-algebra-polynomial-endofunctor g)
   is-equiv-htpy-eq-hom-algebra-polynomial-endofunctor =
     fundamental-theorem-id
-      ( is-contr-total-htpy-hom-algebra-polynomial-endofunctor)
+      ( is-torsorial-htpy-hom-algebra-polynomial-endofunctor)
       ( htpy-eq-hom-algebra-polynomial-endofunctor)
 
   extensionality-hom-algebra-polynomial-endofunctor :

--- a/src/trees/morphisms-coalgebras-polynomial-endofunctors.lagda.md
+++ b/src/trees/morphisms-coalgebras-polynomial-endofunctors.lagda.md
@@ -132,12 +132,12 @@ module _
   htpy-eq-hom-coalgebra-polynomial-endofunctor .f refl =
     refl-htpy-hom-coalgebra-polynomial-endofunctor
 
-  is-contr-total-htpy-hom-coalgebra-polynomial-endofunctor :
+  is-torsorial-htpy-hom-coalgebra-polynomial-endofunctor :
     is-contr
       ( Σ ( hom-coalgebra-polynomial-endofunctor X Y)
           ( htpy-hom-coalgebra-polynomial-endofunctor))
-  is-contr-total-htpy-hom-coalgebra-polynomial-endofunctor =
-    is-contr-total-Eq-structure
+  is-torsorial-htpy-hom-coalgebra-polynomial-endofunctor =
+    is-torsorial-Eq-structure
       ( λ ( g :
             type-coalgebra-polynomial-endofunctor X →
             type-coalgebra-polynomial-endofunctor Y)
@@ -152,7 +152,7 @@ module _
           ( ( ( htpy-polynomial-endofunctor A B H) ·r
               ( structure-coalgebra-polynomial-endofunctor X)) ∙h
             ( G)))
-      ( is-contr-total-htpy (map-hom-coalgebra-polynomial-endofunctor X Y f))
+      ( is-torsorial-htpy (map-hom-coalgebra-polynomial-endofunctor X Y f))
       ( map-hom-coalgebra-polynomial-endofunctor X Y f , refl-htpy)
       ( is-contr-equiv'
         ( Σ ( coherence-square-maps
@@ -181,7 +181,7 @@ module _
                     ( coh-refl-htpy-polynomial-endofunctor A B
                       ( map-hom-coalgebra-polynomial-endofunctor X Y f)
                       ( structure-coalgebra-polynomial-endofunctor X x))))))
-        ( is-contr-total-htpy
+        ( is-torsorial-htpy
           ( ( structure-hom-coalgebra-polynomial-endofunctor X Y f) ∙h
             ( refl-htpy))))
 
@@ -190,7 +190,7 @@ module _
     is-equiv (htpy-eq-hom-coalgebra-polynomial-endofunctor g)
   is-equiv-htpy-eq-hom-coalgebra-polynomial-endofunctor =
     fundamental-theorem-id
-      ( is-contr-total-htpy-hom-coalgebra-polynomial-endofunctor)
+      ( is-torsorial-htpy-hom-coalgebra-polynomial-endofunctor)
       ( htpy-eq-hom-coalgebra-polynomial-endofunctor)
 
   extensionality-hom-coalgebra-polynomial-endofunctor :

--- a/src/trees/morphisms-directed-trees.lagda.md
+++ b/src/trees/morphisms-directed-trees.lagda.md
@@ -227,10 +227,10 @@ module _
   (f : hom-Directed-Tree S T)
   where
 
-  is-contr-total-htpy-hom-Directed-Tree :
+  is-torsorial-htpy-hom-Directed-Tree :
     is-contr (Σ (hom-Directed-Tree S T) (htpy-hom-Directed-Tree S T f))
-  is-contr-total-htpy-hom-Directed-Tree =
-    is-contr-total-htpy-hom-Directed-Graph
+  is-torsorial-htpy-hom-Directed-Tree =
+    is-torsorial-htpy-hom-Directed-Graph
       ( graph-Directed-Tree S)
       ( graph-Directed-Tree T)
       ( f)

--- a/src/trees/polynomial-endofunctors.lagda.md
+++ b/src/trees/polynomial-endofunctors.lagda.md
@@ -64,17 +64,17 @@ module _
     Eq-type-polynomial-endofunctor x x
   refl-Eq-type-polynomial-endofunctor (pair x α) = pair refl refl-htpy
 
-  is-contr-total-Eq-type-polynomial-endofunctor :
+  is-torsorial-Eq-type-polynomial-endofunctor :
     (x : type-polynomial-endofunctor A B X) →
     is-contr
       ( Σ ( type-polynomial-endofunctor A B X)
           ( Eq-type-polynomial-endofunctor x))
-  is-contr-total-Eq-type-polynomial-endofunctor (pair x α) =
-    is-contr-total-Eq-structure
+  is-torsorial-Eq-type-polynomial-endofunctor (pair x α) =
+    is-torsorial-Eq-structure
       ( ( λ (y : A) (β : B y → X) (p : x ＝ y) → α ~ (β ∘ tr B p)))
-      ( is-contr-total-path x)
+      ( is-torsorial-path x)
       ( pair x refl)
-      ( is-contr-total-htpy α)
+      ( is-torsorial-htpy α)
 
   Eq-type-polynomial-endofunctor-eq :
     (x y : type-polynomial-endofunctor A B X) →
@@ -87,7 +87,7 @@ module _
     is-equiv (Eq-type-polynomial-endofunctor-eq x y)
   is-equiv-Eq-type-polynomial-endofunctor-eq x =
     fundamental-theorem-id
-      ( is-contr-total-Eq-type-polynomial-endofunctor x)
+      ( is-torsorial-Eq-type-polynomial-endofunctor x)
       ( Eq-type-polynomial-endofunctor-eq x)
 
   eq-Eq-type-polynomial-endofunctor :

--- a/src/trees/rooted-morphisms-directed-trees.lagda.md
+++ b/src/trees/rooted-morphisms-directed-trees.lagda.md
@@ -249,13 +249,13 @@ module _
   eq-htpy-rooted-hom-Directed-Tree g =
     map-inv-equiv (extensionality-rooted-hom-Directed-Tree g)
 
-  is-contr-total-htpy-rooted-hom-Directed-Tree :
+  is-torsorial-htpy-rooted-hom-Directed-Tree :
     is-contr
       ( Σ ( rooted-hom-Directed-Tree S T)
           ( htpy-rooted-hom-Directed-Tree S T f))
-  is-contr-total-htpy-rooted-hom-Directed-Tree =
+  is-torsorial-htpy-rooted-hom-Directed-Tree =
     is-contr-equiv'
       ( Σ (rooted-hom-Directed-Tree S T) (λ g → f ＝ g))
       ( equiv-tot extensionality-rooted-hom-Directed-Tree)
-      ( is-contr-total-path f)
+      ( is-torsorial-path f)
 ```

--- a/src/trees/underlying-trees-elements-coalgebras-polynomial-endofunctors.lagda.md
+++ b/src/trees/underlying-trees-elements-coalgebras-polynomial-endofunctors.lagda.md
@@ -240,15 +240,15 @@ module _
       ( contraction-total-Eq-node-element-coalgebra _
         ( _ , e))
 
-  is-contr-total-Eq-node-element-coalgebra :
+  is-torsorial-Eq-node-element-coalgebra :
     (w : type-coalgebra-polynomial-endofunctor X)
     (x : node-element-coalgebra X w) →
     is-contr
       ( Σ ( node-element-coalgebra X w)
           ( Eq-node-element-coalgebra w x))
-  pr1 (is-contr-total-Eq-node-element-coalgebra w x) =
+  pr1 (is-torsorial-Eq-node-element-coalgebra w x) =
     center-total-Eq-node-element-coalgebra x
-  pr2 (is-contr-total-Eq-node-element-coalgebra w x) =
+  pr2 (is-torsorial-Eq-node-element-coalgebra w x) =
     contraction-total-Eq-node-element-coalgebra x
 
   Eq-eq-node-element-coalgebra :
@@ -264,7 +264,7 @@ module _
     is-equiv (Eq-eq-node-element-coalgebra w {x} {y})
   is-equiv-Eq-eq-node-element-coalgebra w x =
     fundamental-theorem-id
-      ( is-contr-total-Eq-node-element-coalgebra w x)
+      ( is-torsorial-Eq-node-element-coalgebra w x)
       ( λ y → Eq-eq-node-element-coalgebra w {x} {y})
 
   extensionality-node-element-coalgebra :

--- a/src/trees/underlying-trees-of-elements-of-w-types.lagda.md
+++ b/src/trees/underlying-trees-of-elements-of-w-types.lagda.md
@@ -292,11 +292,11 @@ module _
     Eq-node-element-𝕎 w x x
   refl-Eq-node-element-𝕎 = refl-Eq-node-element-coalgebra (𝕎-Coalg A B)
 
-  is-contr-total-Eq-node-element-𝕎 :
+  is-torsorial-Eq-node-element-𝕎 :
     (w : 𝕎 A B) (x : node-element-𝕎 w) →
     is-contr (Σ (node-element-𝕎 w) (Eq-node-element-𝕎 w x))
-  is-contr-total-Eq-node-element-𝕎 =
-    is-contr-total-Eq-node-element-coalgebra (𝕎-Coalg A B)
+  is-torsorial-Eq-node-element-𝕎 =
+    is-torsorial-Eq-node-element-coalgebra (𝕎-Coalg A B)
 
   Eq-eq-node-element-𝕎 :
     (w : 𝕎 A B) {x y : node-element-𝕎 w} →

--- a/src/trees/w-types.lagda.md
+++ b/src/trees/w-types.lagda.md
@@ -156,8 +156,8 @@ module _
       { y = λ y → pair (β y) (e y)}
       ( eq-htpy (λ y → contraction-total-Eq-𝕎 (α y) (pair (β y) (e y))))
 
-  is-contr-total-Eq-𝕎 : (w : 𝕎 A B) → is-contr (Σ (𝕎 A B) (Eq-𝕎 w))
-  is-contr-total-Eq-𝕎 w =
+  is-torsorial-Eq-𝕎 : (w : 𝕎 A B) → is-contr (Σ (𝕎 A B) (Eq-𝕎 w))
+  is-torsorial-Eq-𝕎 w =
     pair (center-total-Eq-𝕎 w) (contraction-total-Eq-𝕎 w)
 
   Eq-𝕎-eq : (v w : 𝕎 A B) → v ＝ w → Eq-𝕎 v w
@@ -166,7 +166,7 @@ module _
   is-equiv-Eq-𝕎-eq : (v w : 𝕎 A B) → is-equiv (Eq-𝕎-eq v w)
   is-equiv-Eq-𝕎-eq v =
     fundamental-theorem-id
-      ( is-contr-total-Eq-𝕎 v)
+      ( is-torsorial-Eq-𝕎 v)
       ( Eq-𝕎-eq v)
 
   eq-Eq-𝕎 : (v w : 𝕎 A B) → Eq-𝕎 v w → v ＝ w

--- a/src/univalent-combinatorics/2-element-subtypes.lagda.md
+++ b/src/univalent-combinatorics/2-element-subtypes.lagda.md
@@ -130,10 +130,10 @@ module _
     ( equiv-coprod
       ( equiv-is-contr
         ( is-contr-Fin-one-ℕ)
-        ( is-contr-total-path x))
+        ( is-torsorial-path x))
       ( equiv-is-contr
         ( is-contr-unit)
-        ( is-contr-total-path y)))
+        ( is-torsorial-path y)))
 
   has-two-elements-type-standard-2-Element-Subtype :
     has-two-elements type-standard-2-Element-Subtype

--- a/src/univalent-combinatorics/2-element-types.lagda.md
+++ b/src/univalent-combinatorics/2-element-types.lagda.md
@@ -179,11 +179,11 @@ equiv-eq-2-Element-Type :
 equiv-eq-2-Element-Type X Y = equiv-eq-component-UU-Level
 
 abstract
-  is-contr-total-equiv-2-Element-Type :
+  is-torsorial-equiv-2-Element-Type :
     {l1 : Level} (X : 2-Element-Type l1) →
     is-contr (Σ (2-Element-Type l1) (equiv-2-Element-Type X))
-  is-contr-total-equiv-2-Element-Type X =
-    is-contr-total-equiv-component-UU-Level X
+  is-torsorial-equiv-2-Element-Type X =
+    is-torsorial-equiv-component-UU-Level X
 
 abstract
   is-equiv-equiv-eq-2-Element-Type :
@@ -364,7 +364,7 @@ abstract
         ( λ X →
           ( equiv-ev-zero-equiv-Fin-two-ℕ X) ∘e
           ( equiv-precomp-equiv (compute-raise-Fin l 2) (pr1 X))))
-      ( is-contr-total-equiv-subuniverse
+      ( is-torsorial-equiv-subuniverse
         ( has-cardinality-Prop 2)
         ( standard-2-Element-Type l))
 ```
@@ -468,7 +468,7 @@ module _
       is-fiberwise-equiv-is-equiv-tot
         ( is-equiv-is-contr
           ( tot (ev-zero-htpy-equiv-Fin-two-ℕ e))
-          ( is-contr-total-htpy-equiv e)
+          ( is-torsorial-htpy-equiv e)
           ( is-contr-equiv
             ( fiber (ev-zero-equiv-Fin-two-ℕ) (map-equiv e (zero-Fin 1)))
             ( equiv-tot

--- a/src/univalent-combinatorics/binomial-types.lagda.md
+++ b/src/univalent-combinatorics/binomial-types.lagda.md
@@ -255,7 +255,7 @@ abstract
                           ( equiv-is-contr is-contr-raise-unit is-contr-unit))
                         ( Maybe B)))) ∘e
                   ( left-unit-law-Σ-is-contr
-                    ( is-contr-total-true-Prop)
+                    ( is-torsorial-true-Prop)
                     ( pair (raise-unit-Prop _) raise-star)))
                 ( ( equiv-trunc-Prop
                     ( equiv-postcomp-equiv
@@ -265,7 +265,7 @@ abstract
                         ( is-empty-raise-empty))
                       ( Maybe B))) ∘e
                   ( left-unit-law-Σ-is-contr
-                    ( is-contr-total-false-Prop)
+                    ( is-torsorial-false-Prop)
                     ( pair (raise-empty-Prop _) map-inv-raise)))) ∘e
               ( right-distributive-Σ-coprod
                 ( Σ (Prop _) type-Prop)

--- a/src/univalent-combinatorics/cartesian-product-types.lagda.md
+++ b/src/univalent-combinatorics/cartesian-product-types.lagda.md
@@ -85,7 +85,7 @@ equiv-left-factor :
 equiv-left-factor {l1} {l2} {X} {Y} y =
   ( ( right-unit-law-prod) ∘e
     ( equiv-tot
-      ( λ x → equiv-is-contr (is-contr-total-path' y) is-contr-unit))) ∘e
+      ( λ x → equiv-is-contr (is-torsorial-path' y) is-contr-unit))) ∘e
   ( associative-Σ X (λ x → Y) (λ t → Id (pr2 t) y))
 
 count-left-factor :

--- a/src/univalent-combinatorics/counting-dependent-pair-types.lagda.md
+++ b/src/univalent-combinatorics/counting-dependent-pair-types.lagda.md
@@ -149,7 +149,7 @@ count-fiber-map-section-family :
 count-fiber-map-section-family {l1} {l2} {A} {B} b e f (pair y z) =
   count-equiv'
     ( ( ( left-unit-law-Σ-is-contr
-            ( is-contr-total-path' y)
+            ( is-torsorial-path' y)
             ( pair y refl)) ∘e
         ( inv-associative-Σ A
           ( λ x → Id x y)

--- a/src/univalent-combinatorics/cyclic-finite-types.lagda.md
+++ b/src/univalent-combinatorics/cyclic-finite-types.lagda.md
@@ -186,12 +186,12 @@ module _
     (Y : Cyclic-Type l k) → Id X Y → equiv-Cyclic-Type k X Y
   equiv-eq-Cyclic-Type .X refl = id-equiv-Cyclic-Type
 
-is-contr-total-equiv-Cyclic-Type :
+is-torsorial-equiv-Cyclic-Type :
   {l1 : Level} (k : ℕ) (X : Cyclic-Type l1 k) →
   is-contr (Σ (Cyclic-Type l1 k) (equiv-Cyclic-Type k X))
-is-contr-total-equiv-Cyclic-Type k X =
-  is-contr-total-Eq-subtype
-    ( is-contr-total-equiv-Type-With-Endomorphism (endo-Cyclic-Type k X))
+is-torsorial-equiv-Cyclic-Type k X =
+  is-torsorial-Eq-subtype
+    ( is-torsorial-equiv-Type-With-Endomorphism (endo-Cyclic-Type k X))
     ( λ Y → is-prop-type-trunc-Prop)
     ( endo-Cyclic-Type k X)
     ( id-equiv-Type-With-Endomorphism (endo-Cyclic-Type k X))
@@ -205,7 +205,7 @@ module _
     (Y : Cyclic-Type l k) → is-equiv (equiv-eq-Cyclic-Type k X Y)
   is-equiv-equiv-eq-Cyclic-Type =
     fundamental-theorem-id
-      ( is-contr-total-equiv-Cyclic-Type k X)
+      ( is-torsorial-equiv-Cyclic-Type k X)
       ( equiv-eq-Cyclic-Type k X)
 
   extensionality-Cyclic-Type :
@@ -237,10 +237,10 @@ module _
     (e f : equiv-Cyclic-Type k X Y) → Id e f → htpy-equiv-Cyclic-Type e f
   htpy-eq-equiv-Cyclic-Type e .e refl = refl-htpy-equiv-Cyclic-Type e
 
-  is-contr-total-htpy-equiv-Cyclic-Type :
+  is-torsorial-htpy-equiv-Cyclic-Type :
     (e : equiv-Cyclic-Type k X Y) →
     is-contr (Σ (equiv-Cyclic-Type k X Y) (htpy-equiv-Cyclic-Type e))
-  is-contr-total-htpy-equiv-Cyclic-Type e =
+  is-torsorial-htpy-equiv-Cyclic-Type e =
     is-contr-equiv'
       ( Σ ( equiv-Type-With-Endomorphism
             ( endo-Cyclic-Type k X)
@@ -264,7 +264,7 @@ module _
                     ( coherence-square-equiv-Cyclic-Type k X Y f x))
                   ( ( coherence-square-equiv-Cyclic-Type k X Y e x) ∙
                     ( ap (endomorphism-Cyclic-Type k Y) (H x)))))))
-      ( is-contr-total-htpy-equiv-Type-With-Endomorphism
+      ( is-torsorial-htpy-equiv-Type-With-Endomorphism
         ( endo-Cyclic-Type k X)
         ( endo-Cyclic-Type k Y)
         ( e))
@@ -273,7 +273,7 @@ module _
     (e f : equiv-Cyclic-Type k X Y) → is-equiv (htpy-eq-equiv-Cyclic-Type e f)
   is-equiv-htpy-eq-equiv-Cyclic-Type e =
     fundamental-theorem-id
-      ( is-contr-total-htpy-equiv-Cyclic-Type e)
+      ( is-torsorial-htpy-equiv-Cyclic-Type e)
       ( htpy-eq-equiv-Cyclic-Type e)
 
   extensionality-equiv-Cyclic-Type :

--- a/src/univalent-combinatorics/dependent-pair-types.lagda.md
+++ b/src/univalent-combinatorics/dependent-pair-types.lagda.md
@@ -106,7 +106,7 @@ abstract
                       ( λ (x : A) → Id x (pr1 t))
                       ( λ s → Id (tr B (pr2 s) (b (pr1 s))) (pr2 t))) ∘e
                     ( inv-left-unit-law-Σ-is-contr
-                      ( is-contr-total-path' (pr1 t))
+                      ( is-torsorial-path' (pr1 t))
                       ( pair (pr1 t) refl))))))
             ( count-Σ e
               ( λ t →

--- a/src/univalent-combinatorics/equivalences-cubes.lagda.md
+++ b/src/univalent-combinatorics/equivalences-cubes.lagda.md
@@ -66,26 +66,26 @@ equiv-eq-cube :
   (k : ℕ) {X Y : cube k} → Id X Y → equiv-cube k X Y
 equiv-eq-cube k {X} refl = id-equiv-cube k X
 
-is-contr-total-equiv-cube :
+is-torsorial-equiv-cube :
   (k : ℕ) (X : cube k) → is-contr (Σ (cube k) (equiv-cube k X))
-is-contr-total-equiv-cube k X =
-  is-contr-total-Eq-structure
+is-torsorial-equiv-cube k X =
+  is-torsorial-Eq-structure
     ( λ D (A : type-UU-Fin k D → UU-Fin lzero 2)
           (e : equiv-UU-Fin k (dim-cube-UU-Fin k X) D) →
           (i : dim-cube k X) → axis-cube k X i ≃ pr1 (A (map-equiv e i)))
-    ( is-contr-total-equiv-UU-Fin {k = k} (dim-cube-UU-Fin k X))
+    ( is-torsorial-equiv-UU-Fin {k = k} (dim-cube-UU-Fin k X))
     ( pair
       ( dim-cube-UU-Fin k X)
       ( id-equiv-UU-Fin {k = k} (dim-cube-UU-Fin k X)))
-    ( is-contr-total-Eq-Π
+    ( is-torsorial-Eq-Π
       ( λ i (A : UU-Fin lzero 2) → equiv-UU-Fin 2 (axis-cube-UU-2 k X i) A)
-      ( λ i → is-contr-total-equiv-UU-Fin {k = 2} (axis-cube-UU-2 k X i)))
+      ( λ i → is-torsorial-equiv-UU-Fin {k = 2} (axis-cube-UU-2 k X i)))
 
 is-equiv-equiv-eq-cube :
   (k : ℕ) (X Y : cube k) → is-equiv (equiv-eq-cube k {X} {Y})
 is-equiv-equiv-eq-cube k X =
   fundamental-theorem-id
-    ( is-contr-total-equiv-cube k X)
+    ( is-torsorial-equiv-cube k X)
     ( λ Y → equiv-eq-cube k {X = X} {Y})
 
 eq-equiv-cube :
@@ -117,27 +117,27 @@ htpy-eq-equiv-cube :
   Id e f → htpy-equiv-cube k X Y e f
 htpy-eq-equiv-cube k X Y e .e refl = refl-htpy-equiv-cube k X Y e
 
-is-contr-total-htpy-equiv-cube :
+is-torsorial-htpy-equiv-cube :
   (k : ℕ) (X Y : cube k) (e : equiv-cube k X Y) →
   is-contr (Σ (equiv-cube k X Y) (htpy-equiv-cube k X Y e))
-is-contr-total-htpy-equiv-cube k X Y e =
-  is-contr-total-Eq-structure
+is-torsorial-htpy-equiv-cube k X Y e =
+  is-torsorial-Eq-structure
     ( λ α β H →
       ( d : dim-cube k X) →
       ( tr (axis-cube k Y) (H d) ∘ map-axis-equiv-cube k X Y e d) ~
       ( map-equiv (β d)))
-    ( is-contr-total-htpy-equiv (dim-equiv-cube k X Y e))
+    ( is-torsorial-htpy-equiv (dim-equiv-cube k X Y e))
     ( pair (dim-equiv-cube k X Y e) refl-htpy)
-    ( is-contr-total-Eq-Π
+    ( is-torsorial-Eq-Π
       ( λ d β → htpy-equiv (axis-equiv-cube k X Y e d) β)
-      ( λ d → is-contr-total-htpy-equiv (axis-equiv-cube k X Y e d)))
+      ( λ d → is-torsorial-htpy-equiv (axis-equiv-cube k X Y e d)))
 
 is-equiv-htpy-eq-equiv-cube :
   (k : ℕ) (X Y : cube k) (e f : equiv-cube k X Y) →
   is-equiv (htpy-eq-equiv-cube k X Y e f)
 is-equiv-htpy-eq-equiv-cube k X Y e =
   fundamental-theorem-id
-    ( is-contr-total-htpy-equiv-cube k X Y e)
+    ( is-torsorial-htpy-equiv-cube k X Y e)
     ( htpy-eq-equiv-cube k X Y e)
 
 eq-htpy-equiv-cube :

--- a/src/univalent-combinatorics/ferrers-diagrams.lagda.md
+++ b/src/univalent-combinatorics/ferrers-diagrams.lagda.md
@@ -156,17 +156,17 @@ module _
     (E : ferrers-diagram l2 l3 A) → Id D E → equiv-ferrers-diagram E
   equiv-eq-ferrers-diagram .D refl = id-equiv-ferrers-diagram
 
-  is-contr-total-equiv-ferrers-diagram :
+  is-torsorial-equiv-ferrers-diagram :
     is-contr (Σ (ferrers-diagram l2 l3 A) (equiv-ferrers-diagram))
-  is-contr-total-equiv-ferrers-diagram =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-ferrers-diagram =
+    is-torsorial-Eq-structure
       ( λ X Y e →
         (x : row-ferrers-diagram D) →
         dot-ferrers-diagram D x ≃ pr1 Y (map-equiv e x))
-      ( is-contr-total-equiv (row-ferrers-diagram D))
+      ( is-torsorial-equiv (row-ferrers-diagram D))
       ( pair (row-ferrers-diagram D) id-equiv)
-      ( is-contr-total-Eq-subtype
-        ( is-contr-total-equiv-fam (dot-ferrers-diagram D))
+      ( is-torsorial-Eq-subtype
+        ( is-torsorial-equiv-fam (dot-ferrers-diagram D))
         ( λ Y →
           is-prop-prod
             ( is-prop-Π (λ x → is-prop-type-trunc-Prop))
@@ -181,7 +181,7 @@ module _
     (E : ferrers-diagram l2 l3 A) → is-equiv (equiv-eq-ferrers-diagram E)
   is-equiv-equiv-eq-ferrers-diagram =
     fundamental-theorem-id
-      is-contr-total-equiv-ferrers-diagram
+      is-torsorial-equiv-ferrers-diagram
       equiv-eq-ferrers-diagram
 
   eq-equiv-ferrers-diagram :
@@ -212,26 +212,26 @@ module _
     (E : ferrers-diagram-𝔽 l2 l3 A) → Id D E → equiv-ferrers-diagram-𝔽 E
   equiv-eq-ferrers-diagram-𝔽 .D refl = id-equiv-ferrers-diagram-𝔽
 
-  is-contr-total-equiv-ferrers-diagram-𝔽 :
+  is-torsorial-equiv-ferrers-diagram-𝔽 :
     is-contr (Σ (ferrers-diagram-𝔽 l2 l3 A) (equiv-ferrers-diagram-𝔽))
-  is-contr-total-equiv-ferrers-diagram-𝔽 =
-    is-contr-total-Eq-structure
+  is-torsorial-equiv-ferrers-diagram-𝔽 =
+    is-torsorial-Eq-structure
       ( λ X Y e →
         (x : type-row-ferrers-diagram-𝔽 A D) →
         type-dot-ferrers-diagram-𝔽 A D x ≃ type-𝔽 (pr1 Y (map-equiv e x)))
-      ( is-contr-total-Eq-subtype
-        ( is-contr-total-equiv (type-row-ferrers-diagram-𝔽 A D))
+      ( is-torsorial-Eq-subtype
+        ( is-torsorial-equiv (type-row-ferrers-diagram-𝔽 A D))
         ( is-prop-is-finite)
         ( type-row-ferrers-diagram-𝔽 A D)
         ( id-equiv)
         ( is-finite-type-row-ferrers-diagram-𝔽 A D))
       ( pair (row-ferrers-diagram-𝔽 A D) id-equiv)
-      ( is-contr-total-Eq-subtype
-        ( is-contr-total-Eq-Π
+      ( is-torsorial-Eq-subtype
+        ( is-torsorial-Eq-Π
           ( λ x Y → type-dot-ferrers-diagram-𝔽 A D x ≃ type-𝔽 Y)
           ( λ x →
-            is-contr-total-Eq-subtype
-              ( is-contr-total-equiv (type-dot-ferrers-diagram-𝔽 A D x))
+            is-torsorial-Eq-subtype
+              ( is-torsorial-equiv (type-dot-ferrers-diagram-𝔽 A D x))
               ( is-prop-is-finite)
               ( type-dot-ferrers-diagram-𝔽 A D x)
               ( id-equiv)
@@ -250,7 +250,7 @@ module _
     (E : ferrers-diagram-𝔽 l2 l3 A) → is-equiv (equiv-eq-ferrers-diagram-𝔽 E)
   is-equiv-equiv-eq-ferrers-diagram-𝔽 =
     fundamental-theorem-id
-      is-contr-total-equiv-ferrers-diagram-𝔽
+      is-torsorial-equiv-ferrers-diagram-𝔽
       equiv-eq-ferrers-diagram-𝔽
 
   eq-equiv-ferrers-diagram-𝔽 :

--- a/src/univalent-combinatorics/fibers-of-maps.lagda.md
+++ b/src/univalent-combinatorics/fibers-of-maps.lagda.md
@@ -113,7 +113,7 @@ abstract
   is-finite-fiber-map-section-family {l1} {l2} {A} {B} b f g (pair y z) =
     is-finite-equiv'
       ( ( ( left-unit-law-Σ-is-contr
-            ( is-contr-total-path' y)
+            ( is-torsorial-path' y)
             ( pair y refl)) ∘e
           ( inv-associative-Σ A
             ( λ x → Id x y)

--- a/src/univalent-combinatorics/finite-types.lagda.md
+++ b/src/univalent-combinatorics/finite-types.lagda.md
@@ -575,13 +575,13 @@ id-equiv-𝔽 X = id-equiv
 extensionality-𝔽 : {l : Level} → (X Y : 𝔽 l) → Id X Y ≃ equiv-𝔽 X Y
 extensionality-𝔽 = extensionality-subuniverse is-finite-Prop
 
-is-contr-total-equiv-𝔽 :
+is-torsorial-equiv-𝔽 :
   {l : Level} → (X : 𝔽 l) → is-contr (Σ (𝔽 l) (equiv-𝔽 X))
-is-contr-total-equiv-𝔽 {l} X =
+is-torsorial-equiv-𝔽 {l} X =
   is-contr-equiv'
     ( Σ (𝔽 l) (Id X))
     ( equiv-tot (extensionality-𝔽 X))
-    ( is-contr-total-path X)
+    ( is-torsorial-path X)
 
 equiv-eq-𝔽 : {l : Level} → (X Y : 𝔽 l) → Id X Y → equiv-𝔽 X Y
 equiv-eq-𝔽 X Y = map-equiv (extensionality-𝔽 X Y)
@@ -620,11 +620,11 @@ equiv-eq-UU-Fin :
 equiv-eq-UU-Fin k p = equiv-eq-component-UU-Level p
 
 abstract
-  is-contr-total-equiv-UU-Fin :
+  is-torsorial-equiv-UU-Fin :
     {l : Level} {k : ℕ} (X : UU-Fin l k) →
     is-contr (Σ (UU-Fin l k) (equiv-UU-Fin k X))
-  is-contr-total-equiv-UU-Fin {l} {k} X =
-    is-contr-total-equiv-component-UU-Level X
+  is-torsorial-equiv-UU-Fin {l} {k} X =
+    is-torsorial-equiv-component-UU-Level X
 
 abstract
   is-equiv-equiv-eq-UU-Fin :


### PR DESCRIPTION
Since the definition of `is-torsorial` is that the total space is contractible, this pull request proposes to replace the clumsy-looking `is-contr-total` with `is-torsorial`.