### PR TITLE
Improve computational behaviour of `iso-eq`

### DIFF
--- a/src/category-theory/categories.lagda.md
+++ b/src/category-theory/categories.lagda.md
@@ -156,7 +156,21 @@ module _
     is-emb-is-equiv (is-category-Category C x y)
 ```
 
-### Precomposition by a morphism
+### Equalities induce morphisms
+
+```agda
+module _
+  {l1 l2 : Level} (C : Category l1 l2) (x y : obj-Category C)
+  where
+
+  hom-eq-Category : x ＝ y → hom-Category C x y
+  hom-eq-Category = hom-eq-Precategory (precategory-Category C) x y
+
+  hom-inv-eq-Category : x ＝ y → hom-Category C y x
+  hom-inv-eq-Category = hom-inv-eq-Precategory (precategory-Category C) x y
+```
+
+### Pre- and postcomposition by a morphism
 
 ```agda
 precomp-hom-Category :
@@ -164,32 +178,12 @@ precomp-hom-Category :
   (f : hom-Category C x y) (z : obj-Category C) →
   hom-Category C y z → hom-Category C x z
 precomp-hom-Category C = precomp-hom-Precategory (precategory-Category C)
-```
 
-### Postcomposition by a morphism
-
-```agda
 postcomp-hom-Category :
   {l1 l2 : Level} (C : Category l1 l2) {x y : obj-Category C}
   (f : hom-Category C x y) (z : obj-Category C) →
   hom-Category C z x → hom-Category C z y
 postcomp-hom-Category C = postcomp-hom-Precategory (precategory-Category C)
-```
-
-### Equalities induce morphisms
-
-```agda
-module _
-  {l1 l2 : Level} (C : Category l1 l2)
-  where
-
-  hom-eq-Category :
-    (x y : obj-Category C) → x ＝ y → hom-Category C x y
-  hom-eq-Category = hom-eq-Precategory (precategory-Category C)
-
-  hom-inv-eq-Category :
-    (x y : obj-Category C) → x ＝ y → hom-Category C y x
-  hom-inv-eq-Category = hom-inv-eq-Precategory (precategory-Category C)
 ```
 
 ## Properties

--- a/src/category-theory/isomorphisms-in-large-categories.lagda.md
+++ b/src/category-theory/isomorphisms-in-large-categories.lagda.md
@@ -176,7 +176,8 @@ module _
   compute-iso-eq-Large-Category :
     iso-eq-Category (category-Large-Category C l1) X Y ~
     iso-eq-Large-Category
-  compute-iso-eq-Large-Category refl = refl
+  compute-iso-eq-Large-Category =
+    compute-iso-eq-Large-Precategory (large-precategory-Large-Category C) X Y
 
   extensionality-obj-Large-Category :
     (X ＝ Y) ≃ iso-Large-Category C X Y

--- a/src/category-theory/isomorphisms-in-large-precategories.lagda.md
+++ b/src/category-theory/isomorphisms-in-large-precategories.lagda.md
@@ -140,31 +140,6 @@ module _
   pr2 id-iso-Large-Precategory = is-iso-id-hom-Large-Precategory
 ```
 
-### Equalities induce isomorphisms
-
-An equality between objects `X Y : A` gives rise to an isomorphism between them.
-This is because, by the J-rule, it is enough to construct an isomorphism given
-`refl : X ＝ X`, from `X` to itself. We take the identity morphism as such an
-isomorphism.
-
-```agda
-iso-eq-Large-Precategory :
-  {α : Level → Level} {β : Level → Level → Level} →
-  (C : Large-Precategory α β) {l1 : Level}
-  (X : obj-Large-Precategory C l1) (Y : obj-Large-Precategory C l1) →
-  X ＝ Y → iso-Large-Precategory C X Y
-pr1 (iso-eq-Large-Precategory C X Y p) = hom-eq-Large-Precategory C X Y p
-pr2 (iso-eq-Large-Precategory C X .X refl) = is-iso-id-hom-Large-Precategory C
-
-compute-iso-eq-Large-Precategory :
-  {α : Level → Level} {β : Level → Level → Level} →
-  (C : Large-Precategory α β) {l1 : Level}
-  (X : obj-Large-Precategory C l1) (Y : obj-Large-Precategory C l1) →
-  iso-eq-Precategory (precategory-Large-Precategory C l1) X Y ~
-  iso-eq-Large-Precategory C X Y
-compute-iso-eq-Large-Precategory C X .X refl = refl
-```
-
 ## Properties
 
 ### Being an isomorphism is a proposition
@@ -254,6 +229,35 @@ module _
   iso-set-Large-Precategory : Set (β l1 l1 ⊔ β l1 l2 ⊔ β l2 l1 ⊔ β l2 l2)
   pr1 iso-set-Large-Precategory = iso-Large-Precategory C X Y
   pr2 iso-set-Large-Precategory = is-set-iso-Large-Precategory
+```
+
+### Equalities induce isomorphisms
+
+An equality between objects `X Y : A` gives rise to an isomorphism between them.
+This is because, by the J-rule, it is enough to construct an isomorphism given
+`refl : X ＝ X`, from `X` to itself. We take the identity morphism as such an
+isomorphism.
+
+```agda
+module _
+  {α : Level → Level} {β : Level → Level → Level}
+  (C : Large-Precategory α β) {l1 : Level}
+  where
+
+  iso-eq-Large-Precategory :
+    (X Y : obj-Large-Precategory C l1) → X ＝ Y → iso-Large-Precategory C X Y
+  pr1 (iso-eq-Large-Precategory X Y p) = hom-eq-Large-Precategory C X Y p
+  pr2 (iso-eq-Large-Precategory X .X refl) = is-iso-id-hom-Large-Precategory C
+
+  compute-iso-eq-Large-Precategory :
+    (X Y : obj-Large-Precategory C l1) →
+    iso-eq-Precategory (precategory-Large-Precategory C l1) X Y ~
+    iso-eq-Large-Precategory X Y
+  compute-iso-eq-Large-Precategory X Y p =
+    eq-iso-eq-hom-Large-Precategory C
+      ( iso-eq-Precategory (precategory-Large-Precategory C l1) X Y p)
+      ( iso-eq-Large-Precategory X Y p)
+      ( compute-hom-eq-Large-Precategory C X Y p)
 ```
 
 ### Isomorphisms are closed under composition

--- a/src/category-theory/isomorphisms-in-large-precategories.lagda.md
+++ b/src/category-theory/isomorphisms-in-large-precategories.lagda.md
@@ -153,7 +153,8 @@ iso-eq-Large-Precategory :
   (C : Large-Precategory α β) {l1 : Level}
   (X : obj-Large-Precategory C l1) (Y : obj-Large-Precategory C l1) →
   X ＝ Y → iso-Large-Precategory C X Y
-iso-eq-Large-Precategory C X .X refl = id-iso-Large-Precategory C
+pr1 (iso-eq-Large-Precategory C X Y p) = hom-eq-Large-Precategory C X Y p
+pr2 (iso-eq-Large-Precategory C X .X refl) = is-iso-id-hom-Large-Precategory C
 
 compute-iso-eq-Large-Precategory :
   {α : Level → Level} {β : Level → Level → Level} →

--- a/src/category-theory/isomorphisms-in-precategories.lagda.md
+++ b/src/category-theory/isomorphisms-in-precategories.lagda.md
@@ -164,7 +164,8 @@ module _
   iso-eq-Precategory :
     (x y : obj-Precategory C) →
     x ＝ y → iso-Precategory C x y
-  iso-eq-Precategory x .x refl = id-iso-Precategory C
+  pr1 (iso-eq-Precategory x y p) = hom-eq-Precategory C x y p
+  pr2 (iso-eq-Precategory x .x refl) = is-iso-id-hom-Precategory C
 
   compute-hom-iso-eq-Precategory :
     {x y : obj-Precategory C} →

--- a/src/category-theory/large-categories.lagda.md
+++ b/src/category-theory/large-categories.lagda.md
@@ -15,6 +15,7 @@ open import category-theory.precategories
 open import foundation.action-on-identifications-binary-functions
 open import foundation.dependent-pair-types
 open import foundation.equivalences
+open import foundation.homotopies
 open import foundation.identity-types
 open import foundation.sets
 open import foundation.universe-levels
@@ -36,6 +37,8 @@ proposition.
 
 ## Definition
 
+### The predicate on large precategories of being a large category
+
 ```agda
 is-large-category-Large-Precategory :
   {α : Level → Level} {β : Level → Level → Level} →
@@ -43,7 +46,11 @@ is-large-category-Large-Precategory :
 is-large-category-Large-Precategory C =
   {l : Level} (X Y : obj-Large-Precategory C l) →
   is-equiv (iso-eq-Large-Precategory C X Y)
+```
 
+### The large type of large categories
+
+```agda
 record
   Large-Category (α : Level → Level) (β : Level → Level → Level) : UUω
   where
@@ -164,26 +171,6 @@ module _
     hom-Large-Category Y Z →
     hom-Large-Category X Z
   comp-hom-Large-Category' f g = comp-hom-Large-Category g f
-
-  precomp-hom-Large-Category :
-    {l1 l2 l3 : Level}
-    {X : obj-Large-Category l1}
-    {Y : obj-Large-Category l2}
-    (f : hom-Large-Category X Y) →
-    (Z : obj-Large-Category l3) →
-    hom-Large-Category Y Z → hom-Large-Category X Z
-  precomp-hom-Large-Category f Z g =
-    comp-hom-Large-Category g f
-
-  postcomp-hom-Large-Category :
-    {l1 l2 l3 : Level}
-    (X : obj-Large-Category l1)
-    {Y : obj-Large-Category l2}
-    {Z : obj-Large-Category l3}
-    (f : hom-Large-Category Y Z) →
-    hom-Large-Category X Y → hom-Large-Category X Z
-  postcomp-hom-Large-Category X f g =
-    comp-hom-Large-Category f g
 ```
 
 ### Categories obtained from large categories
@@ -222,4 +209,55 @@ module _
   category-Large-Category : (l : Level) → Category (α l) (β l l)
   pr1 (category-Large-Category l) = precategory-Large-Category l
   pr2 (category-Large-Category l) = is-category-Large-Category l
+```
+
+### Equalities induce morphisms
+
+```agda
+module _
+  {α : Level → Level} {β : Level → Level → Level}
+  (C : Large-Category α β)
+  {l1 : Level} (X Y : obj-Large-Category C l1)
+  where
+
+  hom-eq-Large-Category : X ＝ Y → hom-Large-Category C X Y
+  hom-eq-Large-Category =
+    hom-eq-Large-Precategory (large-precategory-Large-Category C) X Y
+
+  hom-inv-eq-Large-Category : X ＝ Y → hom-Large-Category C Y X
+  hom-inv-eq-Large-Category =
+    hom-inv-eq-Large-Precategory (large-precategory-Large-Category C) X Y
+
+  compute-hom-eq-Large-Category :
+    hom-eq-Category (category-Large-Category C l1) X Y ~ hom-eq-Large-Category
+  compute-hom-eq-Large-Category =
+    compute-hom-eq-Large-Precategory (large-precategory-Large-Category C) X Y
+```
+
+### Pre- and postcomposing by a morphism
+
+```agda
+module _
+  {α : Level → Level} {β : Level → Level → Level}
+  (C : Large-Category α β)
+  {l1 l2 l3 : Level}
+  where
+
+  precomp-hom-Large-Category :
+    {X : obj-Large-Category C l1}
+    {Y : obj-Large-Category C l2}
+    (f : hom-Large-Category C X Y) →
+    (Z : obj-Large-Category C l3) →
+    hom-Large-Category C Y Z → hom-Large-Category C X Z
+  precomp-hom-Large-Category f Z g =
+    comp-hom-Large-Category C g f
+
+  postcomp-hom-Large-Category :
+    (X : obj-Large-Category C l1)
+    {Y : obj-Large-Category C l2}
+    {Z : obj-Large-Category C l3}
+    (f : hom-Large-Category C Y Z) →
+    hom-Large-Category C X Y → hom-Large-Category C X Z
+  postcomp-hom-Large-Category X f g =
+    comp-hom-Large-Category C f g
 ```

--- a/src/category-theory/large-precategories.lagda.md
+++ b/src/category-theory/large-precategories.lagda.md
@@ -11,8 +11,9 @@ open import category-theory.precategories
 
 open import foundation.action-on-identifications-binary-functions
 open import foundation.dependent-pair-types
-open import foundation.identity-types
 open import foundation.function-types
+open import foundation.homotopies
+open import foundation.identity-types
 open import foundation.sets
 open import foundation.universe-levels
 ```
@@ -27,7 +28,7 @@ be done with Σ-types, we must use a record type.)
 
 ## Definition
 
-### Large precategories
+### The large type of large precategories
 
 ```agda
 record
@@ -130,54 +131,6 @@ module _
   comp-hom-Large-Precategory' f g = comp-hom-Large-Precategory C g f
 ```
 
-### Precomposition by a morphism
-
-```agda
-  precomp-hom-Large-Precategory :
-    {l1 l2 l3 : Level}
-    {X : obj-Large-Precategory C l1}
-    {Y : obj-Large-Precategory C l2}
-    (f : hom-Large-Precategory X Y) →
-    (Z : obj-Large-Precategory C l3) →
-    hom-Large-Precategory Y Z → hom-Large-Precategory X Z
-  precomp-hom-Large-Precategory f Z g =
-    comp-hom-Large-Precategory C g f
-```
-
-### Postcomposition by a morphism
-
-```agda
-  postcomp-hom-Large-Precategory :
-    {l1 l2 l3 : Level}
-    (X : obj-Large-Precategory C l1)
-    {Y : obj-Large-Precategory C l2}
-    {Z : obj-Large-Precategory C l3}
-    (f : hom-Large-Precategory Y Z) →
-    hom-Large-Precategory X Y → hom-Large-Precategory X Z
-  postcomp-hom-Large-Precategory X f g =
-    comp-hom-Large-Precategory C f g
-```
-
-### Equalities induce morphisms
-
-```agda
-module _
-  {α : Level → Level} {β : Level → Level → Level}
-  (C : Large-Precategory α β)
-  {l1 : Level}
-  where
-
-  hom-eq-Large-Precategory :
-    (X : obj-Large-Precategory C l1) (Y : obj-Large-Precategory C l1) →
-    X ＝ Y → hom-Large-Precategory C X Y
-  hom-eq-Large-Precategory X .X refl = id-hom-Large-Precategory C
-
-  hom-eq-Large-Precategory' :
-    (X : obj-Large-Precategory C l1) (Y : obj-Large-Precategory C l1) →
-    X ＝ Y → hom-Large-Precategory C Y X
-  hom-eq-Large-Precategory' X Y = hom-eq-Large-Precategory Y X ∘ inv
-```
-
 ### Precategories obtained from large precategories
 
 ```agda
@@ -202,4 +155,57 @@ module _
     left-unit-law-comp-hom-Large-Precategory C
   pr2 (pr2 (pr2 (pr2 (pr2 (precategory-Large-Precategory l))))) =
     right-unit-law-comp-hom-Large-Precategory C
+```
+
+### Equalities induce morphisms
+
+```agda
+module _
+  {α : Level → Level} {β : Level → Level → Level}
+  (C : Large-Precategory α β)
+  {l1 : Level}
+  where
+
+  hom-eq-Large-Precategory :
+    (X Y : obj-Large-Precategory C l1) → X ＝ Y → hom-Large-Precategory C X Y
+  hom-eq-Large-Precategory X .X refl = id-hom-Large-Precategory C
+
+  hom-inv-eq-Large-Precategory :
+    (X Y : obj-Large-Precategory C l1) → X ＝ Y → hom-Large-Precategory C Y X
+  hom-inv-eq-Large-Precategory X Y = hom-eq-Large-Precategory Y X ∘ inv
+
+  compute-hom-eq-Large-Precategory :
+    (X Y : obj-Large-Precategory C l1) →
+    hom-eq-Precategory (precategory-Large-Precategory C l1) X Y ~
+    hom-eq-Large-Precategory X Y
+  compute-hom-eq-Large-Precategory X .X refl = refl
+```
+
+### Pre- and postcomposition by a morphism
+
+```agda
+module _
+  {α : Level → Level} {β : Level → Level → Level}
+  (C : Large-Precategory α β)
+  where
+
+  precomp-hom-Large-Precategory :
+    {l1 l2 l3 : Level}
+    {X : obj-Large-Precategory C l1}
+    {Y : obj-Large-Precategory C l2}
+    (f : hom-Large-Precategory C X Y) →
+    (Z : obj-Large-Precategory C l3) →
+    hom-Large-Precategory C Y Z → hom-Large-Precategory C X Z
+  precomp-hom-Large-Precategory f Z g =
+    comp-hom-Large-Precategory C g f
+
+  postcomp-hom-Large-Precategory :
+    {l1 l2 l3 : Level}
+    (X : obj-Large-Precategory C l1)
+    {Y : obj-Large-Precategory C l2}
+    {Z : obj-Large-Precategory C l3}
+    (f : hom-Large-Precategory C Y Z) →
+    hom-Large-Precategory C X Y → hom-Large-Precategory C X Z
+  postcomp-hom-Large-Precategory X f g =
+    comp-hom-Large-Precategory C f g
 ```

--- a/src/category-theory/large-precategories.lagda.md
+++ b/src/category-theory/large-precategories.lagda.md
@@ -12,6 +12,7 @@ open import category-theory.precategories
 open import foundation.action-on-identifications-binary-functions
 open import foundation.dependent-pair-types
 open import foundation.identity-types
+open import foundation.function-types
 open import foundation.sets
 open import foundation.universe-levels
 ```
@@ -155,6 +156,26 @@ module _
     hom-Large-Precategory X Y → hom-Large-Precategory X Z
   postcomp-hom-Large-Precategory X f g =
     comp-hom-Large-Precategory C f g
+```
+
+### Equalities induce morphisms
+
+```agda
+module _
+  {α : Level → Level} {β : Level → Level → Level}
+  (C : Large-Precategory α β)
+  {l1 : Level}
+  where
+
+  hom-eq-Large-Precategory :
+    (X : obj-Large-Precategory C l1) (Y : obj-Large-Precategory C l1) →
+    X ＝ Y → hom-Large-Precategory C X Y
+  hom-eq-Large-Precategory X .X refl = id-hom-Large-Precategory C
+
+  hom-eq-Large-Precategory' :
+    (X : obj-Large-Precategory C l1) (Y : obj-Large-Precategory C l1) →
+    X ＝ Y → hom-Large-Precategory C Y X
+  hom-eq-Large-Precategory' X Y = hom-eq-Large-Precategory Y X ∘ inv
 ```
 
 ### Precategories obtained from large precategories

--- a/src/category-theory/precategories.lagda.md
+++ b/src/category-theory/precategories.lagda.md
@@ -167,41 +167,6 @@ module _
     associative-comp-hom-Precategory C
 ```
 
-### The total hom-type of a precategory
-
-```agda
-total-hom-Precategory :
-  {l1 l2 : Level} (C : Precategory l1 l2) → UU (l1 ⊔ l2)
-total-hom-Precategory C =
-  total-hom-Nonunital-Precategory (nonunital-precategory-Precategory C)
-
-obj-total-hom-Precategory :
-  {l1 l2 : Level} (C : Precategory l1 l2) →
-  total-hom-Precategory C → obj-Precategory C × obj-Precategory C
-obj-total-hom-Precategory C =
-  obj-total-hom-Nonunital-Precategory (nonunital-precategory-Precategory C)
-```
-
-### Precomposition by a morphism
-
-```agda
-precomp-hom-Precategory :
-  {l1 l2 : Level} (C : Precategory l1 l2) {x y : obj-Precategory C}
-  (f : hom-Precategory C x y) (z : obj-Precategory C) →
-  hom-Precategory C y z → hom-Precategory C x z
-precomp-hom-Precategory C f z g = comp-hom-Precategory C g f
-```
-
-### Postcomposition by a morphism
-
-```agda
-postcomp-hom-Precategory :
-  {l1 l2 : Level} (C : Precategory l1 l2) {x y : obj-Precategory C}
-  (f : hom-Precategory C x y) (z : obj-Precategory C) →
-  hom-Precategory C z x → hom-Precategory C z y
-postcomp-hom-Precategory C f z = comp-hom-Precategory C f
-```
-
 ### Equalities induce morphisms
 
 ```agda
@@ -217,4 +182,35 @@ module _
   hom-inv-eq-Precategory :
     (x y : obj-Precategory C) → x ＝ y → hom-Precategory C y x
   hom-inv-eq-Precategory x y = hom-eq-Precategory y x ∘ inv
+```
+
+### The total hom-type of a precategory
+
+```agda
+total-hom-Precategory :
+  {l1 l2 : Level} (C : Precategory l1 l2) → UU (l1 ⊔ l2)
+total-hom-Precategory C =
+  total-hom-Nonunital-Precategory (nonunital-precategory-Precategory C)
+
+obj-total-hom-Precategory :
+  {l1 l2 : Level} (C : Precategory l1 l2) →
+  total-hom-Precategory C → obj-Precategory C × obj-Precategory C
+obj-total-hom-Precategory C =
+  obj-total-hom-Nonunital-Precategory (nonunital-precategory-Precategory C)
+```
+
+### Pre- and postcomposition by a morphism
+
+```agda
+precomp-hom-Precategory :
+  {l1 l2 : Level} (C : Precategory l1 l2) {x y : obj-Precategory C}
+  (f : hom-Precategory C x y) (z : obj-Precategory C) →
+  hom-Precategory C y z → hom-Precategory C x z
+precomp-hom-Precategory C f z g = comp-hom-Precategory C g f
+
+postcomp-hom-Precategory :
+  {l1 l2 : Level} (C : Precategory l1 l2) {x y : obj-Precategory C}
+  (f : hom-Precategory C x y) (z : obj-Precategory C) →
+  hom-Precategory C z x → hom-Precategory C z y
+postcomp-hom-Precategory C f z = comp-hom-Precategory C f
 ```

--- a/src/category-theory/preunivalent-categories.lagda.md
+++ b/src/category-theory/preunivalent-categories.lagda.md
@@ -30,16 +30,24 @@ objects [embed](foundation-core.embeddings.md) into the
 [isomorphisms](category-theory.isomorphisms-in-precategories.md). More
 specifically, an equality between objects gives rise to an isomorphism between
 them, by the J-rule. A precategory is a preunivalent category if this function,
-called `iso-eq`, is an embedding. In particular, being preunivalent is a
-[proposition](foundation-core.propositions.md) since `is-emb` is a proposition.
+called `iso-eq`, is an embedding.
 
-The idea of preunivalence is that it is a common generalization of univalent
-mathematics and mathematics with Axiom K. Hence preunivalent categories
-generalize both [categories](category-theory.categories.md) in the sense we have
-defined them (as univalent categories), and strict categories, which are
+The idea of [preunivalence](foundation.preunivalence.md) is that it is a common
+generalization of univalent mathematics and mathematics with Axiom K. Hence
+preunivalent categories generalize both
+[(univalent) categories](category-theory.categories.md) and
+[strict categories](category-theory.strict-categories.md), which are
 precategories whose objects form a [set](foundation-core.sets.md).
 
+Summarized, the preunivalence condition on precategories states that the type of
+objects is a subgroupoid of the [groupoid](category-theory.groupoids.md) of
+isomorphisms. For univalent categories the groupoid of objects is equivalent to
+the groupoid of isomorphisms, while for strict categories the groupoid of
+objects is discrete.
+
 ## Definitions
+
+### The predicate on precategories of being a preunivalent category
 
 ```agda
 module _
@@ -57,7 +65,11 @@ module _
 
   is-preunivalent-Precategory : UU (l1 ⊔ l2)
   is-preunivalent-Precategory = type-Prop is-preunivalent-prop-Precategory
+```
 
+### The type of preunivalent categories
+
+```agda
 Preunivalent-Category : (l1 l2 : Level) → UU (lsuc l1 ⊔ lsuc l2)
 Preunivalent-Category l1 l2 =
   Σ (Precategory l1 l2) (is-preunivalent-Precategory)
@@ -141,34 +153,6 @@ module _
   is-preunivalent-Preunivalent-Category = pr2 C
 ```
 
-### Precomposition by a morphism
-
-```agda
-precomp-hom-Preunivalent-Category :
-  {l1 l2 : Level} (C : Preunivalent-Category l1 l2)
-  {x y : obj-Preunivalent-Category C}
-  (f : hom-Preunivalent-Category C x y)
-  (z : obj-Preunivalent-Category C) →
-  hom-Preunivalent-Category C y z →
-  hom-Preunivalent-Category C x z
-precomp-hom-Preunivalent-Category C =
-  precomp-hom-Precategory (precategory-Preunivalent-Category C)
-```
-
-### Postcomposition by a morphism
-
-```agda
-postcomp-hom-Preunivalent-Category :
-  {l1 l2 : Level} (C : Preunivalent-Category l1 l2)
-  {x y : obj-Preunivalent-Category C}
-  (f : hom-Preunivalent-Category C x y)
-  (z : obj-Preunivalent-Category C) →
-  hom-Preunivalent-Category C z x →
-  hom-Preunivalent-Category C z y
-postcomp-hom-Preunivalent-Category C =
-  postcomp-hom-Precategory (precategory-Preunivalent-Category C)
-```
-
 ### Equalities induce morphisms
 
 ```agda
@@ -188,6 +172,30 @@ module _
     x ＝ y → hom-Preunivalent-Category C y x
   hom-inv-eq-Preunivalent-Category =
     hom-inv-eq-Precategory (precategory-Preunivalent-Category C)
+```
+
+### Pre- and postcomposition by a morphism
+
+```agda
+precomp-hom-Preunivalent-Category :
+  {l1 l2 : Level} (C : Preunivalent-Category l1 l2)
+  {x y : obj-Preunivalent-Category C}
+  (f : hom-Preunivalent-Category C x y)
+  (z : obj-Preunivalent-Category C) →
+  hom-Preunivalent-Category C y z →
+  hom-Preunivalent-Category C x z
+precomp-hom-Preunivalent-Category C =
+  precomp-hom-Precategory (precategory-Preunivalent-Category C)
+
+postcomp-hom-Preunivalent-Category :
+  {l1 l2 : Level} (C : Preunivalent-Category l1 l2)
+  {x y : obj-Preunivalent-Category C}
+  (f : hom-Preunivalent-Category C x y)
+  (z : obj-Preunivalent-Category C) →
+  hom-Preunivalent-Category C z x →
+  hom-Preunivalent-Category C z y
+postcomp-hom-Preunivalent-Category C =
+  postcomp-hom-Precategory (precategory-Preunivalent-Category C)
 ```
 
 ## Properties

--- a/src/category-theory/strict-categories.lagda.md
+++ b/src/category-theory/strict-categories.lagda.md
@@ -155,35 +155,11 @@ module _
         ( is-set-type-subtype
           ( is-iso-prop-Precategory (precategory-Strict-Category C))
           ( is-set-hom-Strict-Category C x y))
-        ( λ where
-          {refl} {q} _ →
-            axiom-K-is-set (is-set-obj-Strict-Category C) x q)
+        ( λ _ → eq-is-prop (is-set-obj-Strict-Category C x y))
 
   preunivalent-category-Strict-Category : Preunivalent-Category l1 l2
   pr1 preunivalent-category-Strict-Category = precategory-Strict-Category C
   pr2 preunivalent-category-Strict-Category = is-preunivalent-Strict-Category
-```
-
-### Precomposition by a morphism
-
-```agda
-precomp-hom-Strict-Category :
-  {l1 l2 : Level} (C : Strict-Category l1 l2) {x y : obj-Strict-Category C}
-  (f : hom-Strict-Category C x y) (z : obj-Strict-Category C) →
-  hom-Strict-Category C y z → hom-Strict-Category C x z
-precomp-hom-Strict-Category C =
-  precomp-hom-Precategory (precategory-Strict-Category C)
-```
-
-### Postcomposition by a morphism
-
-```agda
-postcomp-hom-Strict-Category :
-  {l1 l2 : Level} (C : Strict-Category l1 l2) {x y : obj-Strict-Category C}
-  (f : hom-Strict-Category C x y) (z : obj-Strict-Category C) →
-  hom-Strict-Category C z x → hom-Strict-Category C z y
-postcomp-hom-Strict-Category C =
-  postcomp-hom-Precategory (precategory-Strict-Category C)
 ```
 
 ### Equalities induce morphisms
@@ -201,6 +177,24 @@ module _
     (x y : obj-Strict-Category C) → x ＝ y → hom-Strict-Category C y x
   hom-inv-eq-Strict-Category =
     hom-inv-eq-Precategory (precategory-Strict-Category C)
+```
+
+### Pre- and postcomposition by a morphism
+
+```agda
+precomp-hom-Strict-Category :
+  {l1 l2 : Level} (C : Strict-Category l1 l2) {x y : obj-Strict-Category C}
+  (f : hom-Strict-Category C x y) (z : obj-Strict-Category C) →
+  hom-Strict-Category C y z → hom-Strict-Category C x z
+precomp-hom-Strict-Category C =
+  precomp-hom-Precategory (precategory-Strict-Category C)
+
+postcomp-hom-Strict-Category :
+  {l1 l2 : Level} (C : Strict-Category l1 l2) {x y : obj-Strict-Category C}
+  (f : hom-Strict-Category C x y) (z : obj-Strict-Category C) →
+  hom-Strict-Category C z x → hom-Strict-Category C z y
+postcomp-hom-Strict-Category C =
+  postcomp-hom-Precategory (precategory-Strict-Category C)
 ```
 
 ## See also

--- a/src/group-theory/isomorphisms-abelian-groups.lagda.md
+++ b/src/group-theory/isomorphisms-abelian-groups.lagda.md
@@ -11,6 +11,7 @@ open import foundation.contractible-types
 open import foundation.dependent-pair-types
 open import foundation.equivalences
 open import foundation.function-types
+open import foundation.action-on-identifications-functions
 open import foundation.functoriality-dependent-pair-types
 open import foundation.fundamental-theorem-of-identity-types
 open import foundation.homotopies
@@ -167,8 +168,7 @@ module _
 ### The identity isomorphism of abelian groups
 
 ```agda
-id-iso-Ab :
-  {l : Level} (A : Ab l) → iso-Ab A A
+id-iso-Ab : {l : Level} (A : Ab l) → iso-Ab A A
 id-iso-Ab A = id-iso-Group (group-Ab A)
 ```
 
@@ -179,7 +179,7 @@ id-iso-Ab A = id-iso-Group (group-Ab A)
 ```agda
 iso-eq-Ab :
   {l : Level} (A B : Ab l) → Id A B → iso-Ab A B
-iso-eq-Ab A .A refl = id-iso-Ab A
+iso-eq-Ab A B p = iso-eq-Group (group-Ab A) (group-Ab B) (ap pr1 p)
 
 abstract
   equiv-iso-eq-Ab' :

--- a/src/group-theory/isomorphisms-abelian-groups.lagda.md
+++ b/src/group-theory/isomorphisms-abelian-groups.lagda.md
@@ -7,11 +7,11 @@ module group-theory.isomorphisms-abelian-groups where
 <details><summary>Imports</summary>
 
 ```agda
+open import foundation.action-on-identifications-functions
 open import foundation.contractible-types
 open import foundation.dependent-pair-types
 open import foundation.equivalences
 open import foundation.function-types
-open import foundation.action-on-identifications-functions
 open import foundation.functoriality-dependent-pair-types
 open import foundation.fundamental-theorem-of-identity-types
 open import foundation.homotopies


### PR DESCRIPTION
Changes the definition of `iso-eq` to compute definitionally to `hom-eq` on the first component for every identification. This way, we can use lemmas about `hom-eq` more easily, if they were to exist. After all, `is-iso` is a proposition.