### PR TITLE
Refactor funext

### DIFF
--- a/src/foundation-core/function-extensionality.lagda.md
+++ b/src/foundation-core/function-extensionality.lagda.md
@@ -36,11 +36,24 @@ module _
   {l1 l2 : Level} {A : UU l1} {B : A → UU l2}
   where
 
-  htpy-eq : {f g : (x : A) → B x} → (f ＝ g) → (f ~ g)
+  htpy-eq : {f g : (x : A) → B x} → f ＝ g → f ~ g
   htpy-eq refl = refl-htpy
 
-  function-extensionality : (f : (x : A) → B x) → UU (l1 ⊔ l2)
-  function-extensionality f = (g : (x : A) → B x) → is-equiv (htpy-eq {f} {g})
+  instance-function-extensionality : (f g : (x : A) → B x) → UU (l1 ⊔ l2)
+  instance-function-extensionality f g = is-equiv (htpy-eq {f} {g})
+
+  based-function-extensionality : (f : (x : A) → B x) → UU (l1 ⊔ l2)
+  based-function-extensionality f =
+    (g : (x : A) → B x) → is-equiv (htpy-eq {f} {g})
+
+function-extensionality-Level : (l1 l2 : Level) → UU (lsuc l1 ⊔ lsuc l2)
+function-extensionality-Level l1 l2 =
+  {A : UU l1} {B : A → UU l2}
+  (f g : (x : A) → B x) →
+  instance-function-extensionality f g
+
+function-extensionality : UUω
+function-extensionality = {l1 l2 : Level} → function-extensionality-Level l1 l2
 ```
 
 ## Properties

--- a/src/foundation/function-extensionality.lagda.md
+++ b/src/foundation/function-extensionality.lagda.md
@@ -35,17 +35,17 @@ defined in
 ## Postulate
 
 ```agda
-module _
-  {l1 l2 : Level} {A : UU l1} {B : A → UU l2}
-  where
-
-  postulate
-    funext : (f : (x : A) → B x) → function-extensionality f
+postulate
+  funext : function-extensionality
 ```
 
 ### Components of `funext`
 
 ```agda
+module _
+  {l1 l2 : Level} {A : UU l1} {B : A → UU l2}
+  where
+
   equiv-funext : {f g : (x : A) → B x} → (f ＝ g) ≃ (f ~ g)
   pr1 (equiv-funext) = htpy-eq
   pr2 (equiv-funext {f} {g}) = funext f g

--- a/src/foundation/homotopy-induction.lagda.md
+++ b/src/foundation/homotopy-induction.lagda.md
@@ -82,22 +82,22 @@ module _
 
 ```agda
 abstract
-  induction-principle-homotopies-function-extensionality :
+  induction-principle-homotopies-based-function-extensionality :
     {l1 l2 : Level} {A : UU l1} {B : A → UU l2} (f : (x : A) → B x) →
-    function-extensionality f →
+    based-function-extensionality f →
     induction-principle-homotopies f
-  induction-principle-homotopies-function-extensionality
+  induction-principle-homotopies-based-function-extensionality
     {A = A} {B} f funext-f =
     is-identity-system-is-torsorial f
       ( refl-htpy)
       ( is-torsorial-htpy f)
 
 abstract
-  function-extensionality-induction-principle-homotopies :
+  based-function-extensionality-induction-principle-homotopies :
     {l1 l2 : Level} {A : UU l1} {B : A → UU l2} (f : (x : A) → B x) →
     induction-principle-homotopies f →
-    function-extensionality f
-  function-extensionality-induction-principle-homotopies f ind-htpy-f =
+    based-function-extensionality f
+  based-function-extensionality-induction-principle-homotopies f ind-htpy-f =
     fundamental-theorem-id-is-identity-system f
       ( refl-htpy)
       ( ind-htpy-f)
@@ -115,7 +115,7 @@ module _
     induction-principle-htpy :
       (f : (x : A) → B x) → induction-principle-homotopies f
     induction-principle-htpy f =
-      induction-principle-homotopies-function-extensionality f (funext f)
+      induction-principle-homotopies-based-function-extensionality f (funext f)
 
     ind-htpy :
       {l3 : Level} (f : (x : A) → B x)

--- a/src/foundation/univalence-implies-function-extensionality.lagda.md
+++ b/src/foundation/univalence-implies-function-extensionality.lagda.md
@@ -34,24 +34,19 @@ The [univalence axiom](foundation-core.univalence.md) implies
 
 ```agda
 abstract
-  weak-funext-univalence :
-    {l : Level} {A : UU l} {B : A → UU l} → weak-function-extensionality A B
-  weak-funext-univalence {A = A} {B} is-contr-B =
+  weak-funext-univalence : {l : Level} → weak-function-extensionality-Level l l
+  weak-funext-univalence A B is-contr-B =
     is-contr-retract-of
-      ( fiber (postcomp A (pr1 {B = B})) id)
-      ( pair
-        ( λ f → pair (λ x → pair x (f x)) refl)
-        ( pair
-          ( λ h x → tr B (htpy-eq (pr2 h) x) (pr2 (pr1 h x)))
-          ( refl-htpy)))
+      ( fiber (postcomp A pr1) id)
+      ( ( λ f → ((λ x → (x , f x)) , refl)) ,
+        ( λ h x → tr B (htpy-eq (pr2 h) x) (pr2 (pr1 h x))) ,
+        ( refl-htpy))
       ( is-contr-map-is-equiv
         ( is-equiv-postcomp-univalence A (equiv-pr1 is-contr-B))
         ( id))
 
 abstract
   funext-univalence :
-    {l : Level} {A : UU l} {B : A → UU l} (f : (x : A) → B x) →
-    function-extensionality f
-  funext-univalence {A = A} {B} f =
-    funext-weak-funext (λ A B → weak-funext-univalence) A B f
+    {l : Level} → function-extensionality-Level l l
+  funext-univalence f = funext-weak-funext weak-funext-univalence f
 ```

--- a/src/foundation/weak-function-extensionality.lagda.md
+++ b/src/foundation/weak-function-extensionality.lagda.md
@@ -39,19 +39,35 @@ This principle is [equivalent](foundation-core.equivalences.md) to
 ### Weak function extensionality
 
 ```agda
-weak-function-extensionality :
+instance-weak-function-extensionality :
   {l1 l2 : Level} (A : UU l1) (B : A → UU l2) → UU (l1 ⊔ l2)
-weak-function-extensionality A B =
+instance-weak-function-extensionality A B =
   ((x : A) → is-contr (B x)) → is-contr ((x : A) → B x)
+
+weak-function-extensionality-Level : (l1 l2 : Level) → UU (lsuc l1 ⊔ lsuc l2)
+weak-function-extensionality-Level l1 l2 =
+  (A : UU l1) (B : A → UU l2) → instance-weak-function-extensionality A B
+
+weak-function-extensionality : UUω
+weak-function-extensionality =
+  {l1 l2 : Level} → weak-function-extensionality-Level l1 l2
 ```
 
 ### Weaker function extensionality
 
 ```agda
-weaker-function-extensionality :
+instance-weaker-function-extensionality :
   {l1 l2 : Level} (A : UU l1) (B : A → UU l2) → UU (l1 ⊔ l2)
-weaker-function-extensionality A B =
+instance-weaker-function-extensionality A B =
   ((x : A) → is-prop (B x)) → is-prop ((x : A) → B x)
+
+weaker-function-extensionality-Level : (l1 l2 : Level) → UU (lsuc l1 ⊔ lsuc l2)
+weaker-function-extensionality-Level l1 l2 =
+  (A : UU l1) (B : A → UU l2) → instance-weaker-function-extensionality A B
+
+weaker-function-extensionality : UUω
+weaker-function-extensionality =
+  {l1 l2 : Level} → weaker-function-extensionality-Level l1 l2
 ```
 
 ## Properties
@@ -61,23 +77,22 @@ weaker-function-extensionality A B =
 ```agda
 abstract
   weak-funext-funext :
-    { l1 l2 : Level} →
-    ( (A : UU l1) (B : A → UU l2) (f : (x : A) → B x) →
-      function-extensionality f) →
-    ( (A : UU l1) (B : A → UU l2) → weak-function-extensionality A B)
+    {l1 l2 : Level} →
+    function-extensionality-Level l1 l2 →
+    weak-function-extensionality-Level l1 l2
   pr1 (weak-funext-funext funext A B is-contr-B) x =
     center (is-contr-B x)
   pr2 (weak-funext-funext funext A B is-contr-B) f =
     map-inv-is-equiv
-      ( funext A B (λ x → center (is-contr-B x)) f)
+      ( funext (λ x → center (is-contr-B x)) f)
       ( λ x → contraction (is-contr-B x) (f x))
 
 abstract
   funext-weak-funext :
-    { l1 l2 : Level} →
-    ( (A : UU l1) (B : A → UU l2) → weak-function-extensionality A B) →
-    ( A : UU l1) (B : A → UU l2) (f : (x : A) → B x) → function-extensionality f
-  funext-weak-funext weak-funext A B f =
+    {l1 l2 : Level} →
+    weak-function-extensionality-Level l1 l2 →
+    function-extensionality-Level l1 l2
+  funext-weak-funext weak-funext {A = A} {B} f =
     fundamental-theorem-id
       ( is-contr-retract-of
         ( (x : A) → Σ (B x) (λ b → f x ＝ b))
@@ -142,7 +157,8 @@ module _
 ```agda
 weak-funext-weaker-funext :
   {l1 l2 : Level} {A : UU l1} {B : A → UU l2} →
-  weaker-function-extensionality A B → weak-function-extensionality A B
+  instance-weaker-function-extensionality A B →
+  instance-weak-function-extensionality A B
 weak-funext-weaker-funext H C =
   is-proof-irrelevant-is-prop
     ( H (λ x → is-prop-is-contr (C x)))


### PR DESCRIPTION
Minor refactor of funext to follow the new naming scheme.
There are still some things that could be improved:
- The file on homotopy induction
- Refine the connection between weak funext and funext
- A more detailed treatment of the connection between univalence and funext. Currently, it is not clear where exactly univalence is even needed in the argument, and that `A` and `B` are assumed to live in the same universe is not commented on.