### PR TITLE
Add a mdbook `#concept` macro

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -48,6 +48,8 @@ suppress_processing = [
 [preprocessor.concepts]
 command = "python3 ./scripts/preprocessor_concepts.py"
 output-file = "docs/concept_index.json"
+mage-template = "https://katjabercic.github.io/MaGE/?id={wikidata_id}"
+wikidata-template = "https://www.wikidata.org/entity/{wikidata_id}"
 
 [output.linkcheck]
 follow-web-links = false

--- a/book.toml
+++ b/book.toml
@@ -48,7 +48,7 @@ suppress_processing = [
 [preprocessor.concepts]
 command = "python3 ./scripts/preprocessor_concepts.py"
 output-file = "docs/concept_index.json"
-mage-template = "https://katjabercic.github.io/MaGE/?id={wikidata_id}"
+mathswitch-template = "https://mathswitch.xyz/concept/Wd/{wikidata_id}"
 wikidata-template = "https://www.wikidata.org/entity/{wikidata_id}"
 
 [output.linkcheck]

--- a/book.toml
+++ b/book.toml
@@ -45,6 +45,10 @@ suppress_processing = [
   "ART.md"
 ]
 
+[preprocessor.concepts]
+command = "python3 ./scripts/preprocessor_concepts.py"
+output-file = "docs/concept_index.json"
+
 [output.linkcheck]
 follow-web-links = false
 

--- a/scripts/preprocessor_concepts.py
+++ b/scripts/preprocessor_concepts.py
@@ -11,37 +11,127 @@ import time
 from utils import eprint
 
 CONCEPT_REGEX = re.compile(
-    r'\{\{#concept (?:WD=(\w+) )?"(.*?)"\}\}')
+    r'\{\{#concept "([^"]+)"(.*?)\}\}')
+
+WIKIDATA_ID_REGEX = re.compile(
+    r'WDID=(\S+)')
+
+WIKIDATA_LABEL_REGEX = re.compile(
+    r'WD="([^"]+)"')
+
+AGDA_REGEX = re.compile(
+    r'Agda=(\S+)')
 
 LINK_REGEX = re.compile(
     r'\[(.*?)\]\(.*\)')
+
+EXTERNAL_LINKS_REGEX = re.compile(
+    r'## External links\s+', re.MULTILINE)
+
+def make_definition_regex(definition):
+    return re.compile(
+        r'<a id="(\d+)" href="[^"]+" class="[^"]+">' + definition + r'</a>')
 
 
 def does_support(backend):
     return backend == 'html'
 
+def match_wikidata_id(meta_text):
+    m = WIKIDATA_ID_REGEX.search(meta_text)
+    if m is None:
+        return None
+    return m.group(1)
 
-def sub_match_for_concept(m, mut_index, path):
-    wikidata_id = m.group(1)
-    text = m.group(2)
+def match_wikidata_label(meta_text):
+    m = WIKIDATA_LABEL_REGEX.search(meta_text)
+    if m is None:
+        return None
+    return m.group(1)
+
+def match_agda_name(meta_text):
+    m = AGDA_REGEX.search(meta_text)
+    if m is None:
+        return None
+    return m.group(1)
+
+def get_definition_id(name, content):
+    definition_regex = make_definition_regex(name)
+    m = definition_regex.search(content)
+    if m is None:
+        return None
+
+    return m.group(1)
+
+def sup_link_reference(href, content, brackets = True, new_tab = False):
+    # f-strings can't contain backslashes, so we can't escape the quotes
+    link_target = new_tab * ' target="_blank"'
+    return f'<sup>{brackets * "["}<a href="{href}"{link_target}>{content}</a>{brackets * "]"}</sup>'
+
+def sub_match_for_concept(m, mut_index, config, path, initial_content):
+    text = m.group(1)
+    metadata = m.group(2)
+    wikidata_id = match_wikidata_id(metadata)
+    wikidata_label = match_wikidata_label(metadata)
+    agda_name = match_agda_name(metadata)
     plaintext = LINK_REGEX.sub(r'\1', text)
+    url_path = path[:-2] + 'html'
     index_entry = {
         'name': plaintext,
         'text': text
     }
     anchor = ''
-    if wikidata_id is not None:
+    target = ''
+    target_id = None
+    references = []
+    if wikidata_id is not None and wikidata_id != 'NA':
         index_entry['wikidata'] = wikidata_id
-        index_entry['link'] = f'{path[:-2]}html#{wikidata_id}'
-        anchor = f'<a id="{wikidata_id}" class="wikidata"><span style="display:none">{plaintext}</span></a>'
+        index_entry['link'] = f'{url_path}#{wikidata_id}'
+        target_id = wikidata_id
+        anchor += f'<a id="{target_id}" class="wikidata"><span style="display:none">{plaintext}</span></a>'
+        references.append(sup_link_reference(config.get('mage-template').format(wikidata_id=wikidata_id), 'WD', True, True))
+    if agda_name is not None:
+        target_id = f'concept-{agda_name}'
+        anchor += f'<a id="{target_id}" class="concept"></a>'
+        agda_id = get_definition_id(agda_name, initial_content)
+        if agda_id is not None:
+            destination = f'{url_path}#{agda_id}'
+            index_entry['definition'] = destination
+            references.append(sup_link_reference(destination, 'AG'))
+        else:
+            eprint('Concept definition not found:', plaintext, '; expected', agda_name, 'to exist in', path)
+    if target_id is not None:
+        references.append(f'<sup><a href="#{target_id}"></a></sup>')
+        references.append(sup_link_reference(f'#{target_id}', '¶', False))
+    if wikidata_label is not None:
+        index_entry['__wikidata_label'] = wikidata_label
     mut_index.append(index_entry)
-    return f'{anchor}<b>{text}</b>'
+    return f'{anchor}<b>{text}</b>{"".join(reversed(references))}'
 
 
 def tag_concepts_chapter_rec_mut(chapter, config, mut_index):
+    mut_local_index = []
     chapter['content'] = CONCEPT_REGEX.sub(
-        lambda m: sub_match_for_concept(m, mut_index, chapter['path']),
+        lambda m: sub_match_for_concept(m, mut_local_index, config, chapter['path'], chapter['content']),
         chapter['content'])
+    external_references = []
+    for entry in mut_local_index:
+        wikidata_label = entry.pop('__wikidata_label', None)
+        wikidata_id = entry.get('wikidata', None)
+        if wikidata_label is not None and wikidata_id is not None:
+            mage_link = config.get('mage-template').format(wikidata_id=wikidata_id)
+            external_references.append(f'<a href="{mage_link}">{wikidata_label}</a> at MaGE')
+            wikidata_link = config.get('wikidata-template').format(wikidata_id=wikidata_id)
+            external_references.append(f'<a href="{wikidata_link}">{wikidata_label}</a> at Wikidata')
+            pass
+        mut_index.append(entry)
+    if external_references != []:
+        formatted_references = ''.join(map(lambda a: f'- {a}\n', external_references))
+        external_links_location = EXTERNAL_LINKS_REGEX.search(chapter['content'])
+        if external_links_location is not None:
+            insert_at = external_links_location.end()
+            chapter['content'] = chapter['content'][:insert_at] + formatted_references + chapter['content'][insert_at:]
+        else:
+            chapter['content'] += f'\n## External links\n\n{formatted_references}'
     tag_concepts_sections_rec_mut(chapter['sub_items'], config, mut_index)
 
 

--- a/scripts/preprocessor_concepts.py
+++ b/scripts/preprocessor_concepts.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+# This file is intended to be used as a mdbook preprocessor,
+# and it adheres to the appropriate protocol; see
+# https://rust-lang.github.io/mdBook/for_developers/preprocessors.html#hooking-into-mdbook
+
+import json
+import re
+import sys
+import time
+from utils import eprint
+
+CONCEPT_REGEX = re.compile(
+    r'\{\{#concept (?:WD=(\w+) )?"(.*?)"\}\}')
+
+LINK_REGEX = re.compile(
+    r'\[(.*?)\]\(.*\)')
+
+def does_support(backend):
+    return backend == 'html'
+
+def sub_match_for_concept(m, mut_index, path):
+    wikidata_id = m.group(1)
+    text = m.group(2)
+    plaintext = LINK_REGEX.sub(r'\1', text)
+    index_entry = {
+        'name': plaintext,
+        'text': text
+    }
+    anchor = ''
+    if wikidata_id is not None:
+        index_entry['wikidata'] = wikidata_id
+        index_entry['link'] = f'{path[:-2]}html#{wikidata_id}'
+        anchor = f'<a id="{wikidata_id}" style="display:none;" class="wikidata">{plaintext}</a>'
+    mut_index.append(index_entry)
+    return f'{anchor}<b>{text}</b>'
+
+def tag_concepts_chapter_rec_mut(chapter, config, mut_index):
+    chapter['content'] = CONCEPT_REGEX.sub(
+        lambda m: sub_match_for_concept(m, mut_index, chapter['path']),
+        chapter['content'])
+    tag_concepts_sections_rec_mut(chapter['sub_items'], config, mut_index)
+
+def tag_concepts_sections_rec_mut(sections, config, mut_index):
+    for section in sections:
+        chapter = section.get('Chapter')
+        if chapter is None:
+            continue
+
+        tag_concepts_chapter_rec_mut(chapter, config, mut_index)
+
+def tag_concepts_root_section(section, config, mut_index):
+    chapter = section.get('Chapter')
+    if chapter is not None:
+        tag_concepts_chapter_rec_mut(chapter, config, mut_index)
+
+    return section
+
+if __name__ == '__main__':
+    if len(sys.argv) > 1:
+        arguments = sys.argv[1:]
+        # Indicate with the exit code whether the preprocessor supports the
+        # given backend or not
+        if arguments[0] == 'supports':
+            if not does_support(arguments[1]):
+                sys.exit(1)
+            else:
+                sys.exit(0)
+
+    # Load the book contents from standard input
+    context, book = json.load(sys.stdin)
+    concepts_config = context['config']['preprocessor']['concepts']
+
+    # Thread the index through execution
+    mut_index = []
+    start = time.time()
+    if bool(concepts_config.get('enable', True)) == True:
+        book['sections'] = list(map(
+            lambda s: tag_concepts_root_section(s, concepts_config, mut_index),
+            book['sections']))
+    else:
+        eprint('Skipping concept tagging, enable option was',
+               concepts_config.get('enable'))
+
+    end = time.time()
+    eprint(end - start)
+
+    if mut_index != []:
+        with open(concepts_config.get('output-file', 'concept_index.json'), 'w') as index_f:
+            json.dump(mut_index, index_f)
+
+    # Pass the book back to mdbook
+    json.dump(book, sys.stdout)

--- a/scripts/preprocessor_concepts.py
+++ b/scripts/preprocessor_concepts.py
@@ -31,7 +31,7 @@ def sub_match_for_concept(m, mut_index, path):
     if wikidata_id is not None:
         index_entry['wikidata'] = wikidata_id
         index_entry['link'] = f'{path[:-2]}html#{wikidata_id}'
-        anchor = f'<a id="{wikidata_id}" style="display:none;" class="wikidata">{plaintext}</a>'
+        anchor = f'<a id="{wikidata_id}" class="wikidata"><span style="display:none">{plaintext}</span></a>'
     mut_index.append(index_entry)
     return f'{anchor}<b>{text}</b>'
 

--- a/scripts/preprocessor_concepts.py
+++ b/scripts/preprocessor_concepts.py
@@ -16,8 +16,10 @@ CONCEPT_REGEX = re.compile(
 LINK_REGEX = re.compile(
     r'\[(.*?)\]\(.*\)')
 
+
 def does_support(backend):
     return backend == 'html'
+
 
 def sub_match_for_concept(m, mut_index, path):
     wikidata_id = m.group(1)
@@ -35,11 +37,13 @@ def sub_match_for_concept(m, mut_index, path):
     mut_index.append(index_entry)
     return f'{anchor}<b>{text}</b>'
 
+
 def tag_concepts_chapter_rec_mut(chapter, config, mut_index):
     chapter['content'] = CONCEPT_REGEX.sub(
         lambda m: sub_match_for_concept(m, mut_index, chapter['path']),
         chapter['content'])
     tag_concepts_sections_rec_mut(chapter['sub_items'], config, mut_index)
+
 
 def tag_concepts_sections_rec_mut(sections, config, mut_index):
     for section in sections:
@@ -49,12 +53,14 @@ def tag_concepts_sections_rec_mut(sections, config, mut_index):
 
         tag_concepts_chapter_rec_mut(chapter, config, mut_index)
 
+
 def tag_concepts_root_section(section, config, mut_index):
     chapter = section.get('Chapter')
     if chapter is not None:
         tag_concepts_chapter_rec_mut(chapter, config, mut_index)
 
     return section
+
 
 if __name__ == '__main__':
     if len(sys.argv) > 1:

--- a/scripts/preprocessor_concepts.py
+++ b/scripts/preprocessor_concepts.py
@@ -28,6 +28,7 @@ LINK_REGEX = re.compile(
 EXTERNAL_LINKS_REGEX = re.compile(
     r'## External links\s+', re.MULTILINE)
 
+
 def make_definition_regex(definition):
     return re.compile(
         r'<a id="(\d+)" href="[^"]+" class="[^"]+">' + definition + r'</a>')
@@ -36,11 +37,13 @@ def make_definition_regex(definition):
 def does_support(backend):
     return backend == 'html'
 
+
 def match_wikidata_id(meta_text):
     m = WIKIDATA_ID_REGEX.search(meta_text)
     if m is None:
         return None
     return m.group(1)
+
 
 def match_wikidata_label(meta_text):
     m = WIKIDATA_LABEL_REGEX.search(meta_text)
@@ -48,11 +51,13 @@ def match_wikidata_label(meta_text):
         return None
     return m.group(1)
 
+
 def match_agda_name(meta_text):
     m = AGDA_REGEX.search(meta_text)
     if m is None:
         return None
     return m.group(1)
+
 
 def get_definition_id(name, content):
     definition_regex = make_definition_regex(name)
@@ -62,10 +67,12 @@ def get_definition_id(name, content):
 
     return m.group(1)
 
-def sup_link_reference(href, content, brackets = True, new_tab = False):
+
+def sup_link_reference(href, content, brackets=True, new_tab=False):
     # f-strings can't contain backslashes, so we can't escape the quotes
     link_target = new_tab * ' target="_blank"'
     return f'<sup>{brackets * "["}<a href="{href}"{link_target}>{content}</a>{brackets * "]"}</sup>'
+
 
 def sub_match_for_concept(m, mut_index, config, path, initial_content):
     text = m.group(1)
@@ -88,7 +95,8 @@ def sub_match_for_concept(m, mut_index, config, path, initial_content):
         index_entry['link'] = f'{url_path}#{wikidata_id}'
         target_id = wikidata_id
         anchor += f'<a id="{target_id}" class="wikidata"><span style="display:none">{plaintext}</span></a>'
-        references.append(sup_link_reference(config.get('mage-template').format(wikidata_id=wikidata_id), 'WD', True, True))
+        references.append(sup_link_reference(config.get(
+            'mage-template').format(wikidata_id=wikidata_id), 'WD', True, True))
     if agda_name is not None:
         target_id = f'concept-{agda_name}'
         anchor += f'<a id="{target_id}" class="concept"></a>'
@@ -98,7 +106,8 @@ def sub_match_for_concept(m, mut_index, config, path, initial_content):
             index_entry['definition'] = destination
             references.append(sup_link_reference(destination, 'AG'))
         else:
-            eprint('Concept definition not found:', plaintext, '; expected', agda_name, 'to exist in', path)
+            eprint('Concept definition not found:', plaintext,
+                   '; expected', agda_name, 'to exist in', path)
     if target_id is not None:
         references.append(f'<sup><a href="#{target_id}"></a></sup>')
         references.append(sup_link_reference(f'#{target_id}', '¶', False))
@@ -111,25 +120,33 @@ def sub_match_for_concept(m, mut_index, config, path, initial_content):
 def tag_concepts_chapter_rec_mut(chapter, config, mut_index):
     mut_local_index = []
     chapter['content'] = CONCEPT_REGEX.sub(
-        lambda m: sub_match_for_concept(m, mut_local_index, config, chapter['path'], chapter['content']),
+        lambda m: sub_match_for_concept(
+            m, mut_local_index, config, chapter['path'], chapter['content']),
         chapter['content'])
     external_references = []
     for entry in mut_local_index:
         wikidata_label = entry.pop('__wikidata_label', None)
         wikidata_id = entry.get('wikidata', None)
         if wikidata_label is not None and wikidata_id is not None:
-            mage_link = config.get('mage-template').format(wikidata_id=wikidata_id)
-            external_references.append(f'<a href="{mage_link}">{wikidata_label}</a> at MaGE')
-            wikidata_link = config.get('wikidata-template').format(wikidata_id=wikidata_id)
-            external_references.append(f'<a href="{wikidata_link}">{wikidata_label}</a> at Wikidata')
+            mage_link = config.get(
+                'mage-template').format(wikidata_id=wikidata_id)
+            external_references.append(
+                f'<a href="{mage_link}">{wikidata_label}</a> at MaGE')
+            wikidata_link = config.get(
+                'wikidata-template').format(wikidata_id=wikidata_id)
+            external_references.append(
+                f'<a href="{wikidata_link}">{wikidata_label}</a> at Wikidata')
             pass
         mut_index.append(entry)
     if external_references != []:
-        formatted_references = ''.join(map(lambda a: f'- {a}\n', external_references))
-        external_links_location = EXTERNAL_LINKS_REGEX.search(chapter['content'])
+        formatted_references = ''.join(
+            map(lambda a: f'- {a}\n', external_references))
+        external_links_location = EXTERNAL_LINKS_REGEX.search(
+            chapter['content'])
         if external_links_location is not None:
             insert_at = external_links_location.end()
-            chapter['content'] = chapter['content'][:insert_at] + formatted_references + chapter['content'][insert_at:]
+            chapter['content'] = chapter['content'][:insert_at] + \
+                formatted_references + chapter['content'][insert_at:]
         else:
             chapter['content'] += f'\n## External links\n\n{formatted_references}'
     tag_concepts_sections_rec_mut(chapter['sub_items'], config, mut_index)

--- a/scripts/preprocessor_concepts.py
+++ b/scripts/preprocessor_concepts.py
@@ -108,7 +108,7 @@ def sub_match_for_concept(m, mut_index, config, path, initial_content):
 
         # TODO: decide if we want this
         # references.append(sup_link_reference(config.get(
-        #     'mage-template').format(wikidata_id=wikidata_id), 'WD', True, True))
+        #     'mathswitch-template').format(wikidata_id=wikidata_id), 'WD', True, True))
     if agda_name is not None:
         target_id = f'concept-{agda_name}'
         agda_id = get_definition_id(agda_name, initial_content)
@@ -145,10 +145,10 @@ def tag_concepts_chapter_rec_mut(chapter, config, mut_index):
         wikidata_label = entry.pop('__wikidata_label', None)
         wikidata_id = entry.get('wikidata', None)
         if wikidata_label is not None and wikidata_id is not None:
-            mage_link = config.get(
-                'mage-template').format(wikidata_id=wikidata_id)
+            mathswitch_link = config.get(
+                'mathswitch-template').format(wikidata_id=wikidata_id)
             external_references.append(
-                f'<a href="{mage_link}">{wikidata_label}</a> at Mathswitch')
+                f'<a href="{mathswitch_link}">{wikidata_label}</a> at Mathswitch')
             wikidata_link = config.get(
                 'wikidata-template').format(wikidata_id=wikidata_id)
             # TODO: Decide if we want this

--- a/scripts/preprocessor_concepts.py
+++ b/scripts/preprocessor_concepts.py
@@ -95,8 +95,9 @@ def sub_match_for_concept(m, mut_index, config, path, initial_content):
         index_entry['link'] = f'{url_path}#{wikidata_id}'
         target_id = wikidata_id
         anchor += f'<a id="{target_id}" class="wikidata"><span style="display:none">{plaintext}</span></a>'
-        references.append(sup_link_reference(config.get(
-            'mage-template').format(wikidata_id=wikidata_id), 'WD', True, True))
+        # TODO: decide if we want this
+        # references.append(sup_link_reference(config.get(
+        #     'mage-template').format(wikidata_id=wikidata_id), 'WD', True, True))
     if agda_name is not None:
         target_id = f'concept-{agda_name}'
         anchor += f'<a id="{target_id}" class="concept"></a>'
@@ -104,12 +105,12 @@ def sub_match_for_concept(m, mut_index, config, path, initial_content):
         if agda_id is not None:
             destination = f'{url_path}#{agda_id}'
             index_entry['definition'] = destination
-            references.append(sup_link_reference(destination, 'AG'))
+            # TODO: decide if we want this
+            # references.append(sup_link_reference(destination, 'AG'))
         else:
             eprint('Concept definition not found:', plaintext,
                    '; expected', agda_name, 'to exist in', path)
     if target_id is not None:
-        references.append(f'<sup><a href="#{target_id}"></a></sup>')
         references.append(sup_link_reference(f'#{target_id}', '¶', False))
     if wikidata_label is not None:
         index_entry['__wikidata_label'] = wikidata_label
@@ -134,9 +135,9 @@ def tag_concepts_chapter_rec_mut(chapter, config, mut_index):
                 f'<a href="{mage_link}">{wikidata_label}</a> at MaGE')
             wikidata_link = config.get(
                 'wikidata-template').format(wikidata_id=wikidata_id)
-            external_references.append(
-                f'<a href="{wikidata_link}">{wikidata_label}</a> at Wikidata')
-            pass
+            # TODO: Decide if we want this
+            # external_references.append(
+            #     f'<a href="{wikidata_link}">{wikidata_label}</a> at Wikidata')
         mut_index.append(entry)
     if external_references != []:
         formatted_references = ''.join(

--- a/src/graph-theory/acyclic-undirected-graphs.lagda.md
+++ b/src/graph-theory/acyclic-undirected-graphs.lagda.md
@@ -18,8 +18,8 @@ open import graph-theory.undirected-graphs
 
 ## Idea
 
-An {{#concept "acyclic undirected graph" WDID=Q3115453 WD="Acyclic graph"}} is an
-[undirected graph](graph-theory.undirected-graphs.md) of which the
+An {{#concept "acyclic undirected graph" WDID=Q3115453 WD="Acyclic graph"}} is
+an [undirected graph](graph-theory.undirected-graphs.md) of which the
 [geometric realization](graph-theory.geometric-realizations-undirected-graphs.md)
 is [contractible](foundation-core.contractible-types.md).
 

--- a/src/graph-theory/acyclic-undirected-graphs.lagda.md
+++ b/src/graph-theory/acyclic-undirected-graphs.lagda.md
@@ -18,7 +18,7 @@ open import graph-theory.undirected-graphs
 
 ## Idea
 
-An **acyclic undirected graph** is an
+An {{#concept WD=Q3115453 "acyclic undirected graph"}} is an
 [undirected graph](graph-theory.undirected-graphs.md) of which the
 [geometric realization](graph-theory.geometric-realizations-undirected-graphs.md)
 is [contractible](foundation-core.contractible-types.md).
@@ -69,5 +69,3 @@ is-acyclic-Undirected-Graph l G =
   Wikipedia
 - [Acyclic graphs](https://mathworld.wolfram.com/AcyclicGraph.html) at Wolfram
   Mathworld.
-
-<concept id="https://www.wikidata.org/entity/Q3115453" />

--- a/src/graph-theory/acyclic-undirected-graphs.lagda.md
+++ b/src/graph-theory/acyclic-undirected-graphs.lagda.md
@@ -18,7 +18,7 @@ open import graph-theory.undirected-graphs
 
 ## Idea
 
-An {{#concept WD=Q3115453 "acyclic undirected graph"}} is an
+An {{#concept "acyclic undirected graph" WDID=Q3115453 WD="Acyclic graph"}} is an
 [undirected graph](graph-theory.undirected-graphs.md) of which the
 [geometric realization](graph-theory.geometric-realizations-undirected-graphs.md)
 is [contractible](foundation-core.contractible-types.md).
@@ -64,7 +64,6 @@ is-acyclic-Undirected-Graph l G =
 ## External links
 
 - [Trees](https://ncatlab.org/nlab/show/tree) at nlab
-- [Acyclic graph](https://www.wikidata.org/entity/Q3115453) at Wikidata
 - [Forests](<https://en.wikipedia.org/wiki/Tree_(graph_theory)#Forest>) at
   Wikipedia
 - [Acyclic graphs](https://mathworld.wolfram.com/AcyclicGraph.html) at Wolfram

--- a/src/graph-theory/circuits-undirected-graphs.lagda.md
+++ b/src/graph-theory/circuits-undirected-graphs.lagda.md
@@ -21,7 +21,7 @@ open import graph-theory.undirected-graphs
 
 ## Idea
 
-A {{#concept WD=Q245595 "circuit"}} in an
+A {{#concept "circuit" Agda=circuit-Undirected-Graph WD="Cycle" WDID=Q245595}} in an
 [undirected graph](graph-theory.undirected-graphs.md) `G` consists of a
 [`k`-gon](graph-theory.polygons.md) `H` equipped with a
 [totally faithful](graph-theory.totally-faithful-morphisms-undirected-graphs.md)
@@ -45,7 +45,6 @@ module _
 
 ## External links
 
-- [Cycle](https://www.wikidata.org/entity/Q245595) at Wikidata
 - [Cycle (Graph Theory)](<https://en.wikipedia.org/wiki/Cycle_(graph_theory)>)
   at Wikipedia
 - [Graph Cycle](https://mathworld.wolfram.com/GraphCycle.html) at Wolfram

--- a/src/graph-theory/circuits-undirected-graphs.lagda.md
+++ b/src/graph-theory/circuits-undirected-graphs.lagda.md
@@ -21,8 +21,8 @@ open import graph-theory.undirected-graphs
 
 ## Idea
 
-A {{#concept "circuit" Agda=circuit-Undirected-Graph WD="Cycle" WDID=Q245595}} in an
-[undirected graph](graph-theory.undirected-graphs.md) `G` consists of a
+A {{#concept "circuit" Agda=circuit-Undirected-Graph WD="Cycle" WDID=Q245595}}
+in an [undirected graph](graph-theory.undirected-graphs.md) `G` consists of a
 [`k`-gon](graph-theory.polygons.md) `H` equipped with a
 [totally faithful](graph-theory.totally-faithful-morphisms-undirected-graphs.md)
 [morphism](graph-theory.morphisms-undirected-graphs.md) of undirected graphs

--- a/src/graph-theory/circuits-undirected-graphs.lagda.md
+++ b/src/graph-theory/circuits-undirected-graphs.lagda.md
@@ -21,8 +21,8 @@ open import graph-theory.undirected-graphs
 
 ## Idea
 
-A **circuit** in an [undirected graph](graph-theory.undirected-graphs.md) `G`
-consists of a [`k`-gon](graph-theory.polygons.md) `H` equipped with a
+A {{#concept WD=Q245595 "circuit"}} in an [undirected graph](graph-theory.undirected-graphs.md)
+`G` consists of a [`k`-gon](graph-theory.polygons.md) `H` equipped with a
 [totally faithful](graph-theory.totally-faithful-morphisms-undirected-graphs.md)
 [morphism](graph-theory.morphisms-undirected-graphs.md) of undirected graphs
 from `H` to `G`. In other words, a circuit is a closed walk with no repeated
@@ -49,5 +49,3 @@ module _
   at Wikipedia
 - [Graph Cycle](https://mathworld.wolfram.com/GraphCycle.html) at Wolfram
   Mathworld
-
-<concept id="https://www.wikidata.org/entity/Q245595" />

--- a/src/graph-theory/circuits-undirected-graphs.lagda.md
+++ b/src/graph-theory/circuits-undirected-graphs.lagda.md
@@ -21,8 +21,9 @@ open import graph-theory.undirected-graphs
 
 ## Idea
 
-A {{#concept WD=Q245595 "circuit"}} in an [undirected graph](graph-theory.undirected-graphs.md)
-`G` consists of a [`k`-gon](graph-theory.polygons.md) `H` equipped with a
+A {{#concept WD=Q245595 "circuit"}} in an
+[undirected graph](graph-theory.undirected-graphs.md) `G` consists of a
+[`k`-gon](graph-theory.polygons.md) `H` equipped with a
 [totally faithful](graph-theory.totally-faithful-morphisms-undirected-graphs.md)
 [morphism](graph-theory.morphisms-undirected-graphs.md) of undirected graphs
 from `H` to `G`. In other words, a circuit is a closed walk with no repeated


### PR DESCRIPTION
Usage: `The {{#concept "concept name" Agda=concept-definition WDID=wikidata-id WD="Foobar"}} is a foobar over quxs.`; the Agda, WDID and WD fields are optional.

------
OLD INFORMATION, see https://github.com/UniMath/agda-unimath/pull/884#issuecomment-1783354443 for latest implementation.

Currently it generates an invisible anchor so that we can get a link to that part of the webpage by appending `#wikidata-id` to the URL, and makes the text bold. The text isn't a link to anything and we don't want it to be, because it can itself contain a link (e.g. cocones over _spans_, where _spans_ is a link), and nested links aren't valid HTML.
The anchor is only generated when a wikidata ID is provided.

Scrapers can get all concepts defined on the webpage by querying for the `a.wikidata` selector.

Additionally the preprocessor also generates a `concept_index.json` file, which contains information about all concepts in the library. It's an array of objects which look like this:
```json
{
  "name": "concept name without links",
  "text": "raw markdown from the file",
  "wikidata": "wikidata id",
  "link": "link to the concept, relative to the agda-unimath homepage"
}
```
The `wikidata` and `link` fields are optional, since we want to be able to use this macro also for concepts without a WD id, for consistency.