### PR TITLE
Implicit function extensionality

### DIFF
--- a/src/foundation-core/contractible-types.lagda.md
+++ b/src/foundation-core/contractible-types.lagda.md
@@ -11,6 +11,7 @@ open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
 open import foundation.equality-cartesian-product-types
 open import foundation.function-extensionality
+open import foundation.implicit-function-types
 open import foundation.universe-levels
 
 open import foundation-core.cartesian-product-types
@@ -283,6 +284,13 @@ abstract
     map-inv-is-equiv
       ( funext (λ x → center (H x)) f)
       ( λ x → contraction (H x) (f x))
+
+abstract
+  is-contr-implicit-Π :
+    {l1 l2 : Level} {A : UU l1} {B : A → UU l2} →
+    ((x : A) → is-contr (B x)) → is-contr ({x : A} → B x)
+  is-contr-implicit-Π H =
+    is-contr-equiv _ equiv-explicit-implicit-Π (is-contr-Π H)
 ```
 
 ### The type of functions into a contractible type is contractible

--- a/src/foundation-core/functoriality-dependent-function-types.lagda.md
+++ b/src/foundation-core/functoriality-dependent-function-types.lagda.md
@@ -11,6 +11,7 @@ open import foundation.action-on-identifications-dependent-functions
 open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
 open import foundation.function-extensionality
+open import foundation.implicit-function-types
 open import foundation.type-theoretic-principle-of-choice
 open import foundation.universe-levels
 
@@ -32,40 +33,6 @@ open import foundation-core.transport-along-identifications
 </details>
 
 ## Properties
-
-### Dependent function types taking implicit arguments are equivalent to dependent function types taking explicit arguments
-
-```agda
-module _
-  {l1 l2 : Level} {A : UU l1} {B : A → UU l2}
-  where
-
-  implicit-explicit-Π : ((x : A) → B x) → {x : A} → B x
-  implicit-explicit-Π f {x} = f x
-
-  explicit-implicit-Π : ({x : A} → B x) → (x : A) → B x
-  explicit-implicit-Π f x = f {x}
-
-  is-equiv-implicit-explicit-Π : is-equiv implicit-explicit-Π
-  pr1 (pr1 is-equiv-implicit-explicit-Π) = explicit-implicit-Π
-  pr2 (pr1 is-equiv-implicit-explicit-Π) = refl-htpy
-  pr1 (pr2 is-equiv-implicit-explicit-Π) = explicit-implicit-Π
-  pr2 (pr2 is-equiv-implicit-explicit-Π) = refl-htpy
-
-  is-equiv-explicit-implicit-Π : is-equiv explicit-implicit-Π
-  pr1 (pr1 is-equiv-explicit-implicit-Π) = implicit-explicit-Π
-  pr2 (pr1 is-equiv-explicit-implicit-Π) = refl-htpy
-  pr1 (pr2 is-equiv-explicit-implicit-Π) = implicit-explicit-Π
-  pr2 (pr2 is-equiv-explicit-implicit-Π) = refl-htpy
-
-  equiv-implicit-explicit-Π : ((x : A) → B x) ≃ ({x : A} → B x)
-  pr1 equiv-implicit-explicit-Π = implicit-explicit-Π
-  pr2 equiv-implicit-explicit-Π = is-equiv-implicit-explicit-Π
-
-  equiv-explicit-implicit-Π : ({x : A} → B x) ≃ ((x : A) → B x)
-  pr1 equiv-explicit-implicit-Π = explicit-implicit-Π
-  pr2 equiv-explicit-implicit-Π = is-equiv-explicit-implicit-Π
-```
 
 ### The operation `map-Π` preserves homotopies
 
@@ -184,7 +151,7 @@ abstract
     is-coherently-invertible f →
     (C : B → UU l3) → is-equiv (precomp-Π f C)
   is-equiv-precomp-Π-is-coherently-invertible f
-    ( pair g (pair is-section-g (pair is-retraction-g coh))) C =
+    ( g , is-section-g , is-retraction-g , coh) C =
     is-equiv-is-invertible
       (λ s y → tr C (is-section-g y) (s (g y)))
       ( λ s → eq-htpy (λ x →

--- a/src/foundation.lagda.md
+++ b/src/foundation.lagda.md
@@ -158,6 +158,7 @@ open import foundation.identity-truncated-types public
 open import foundation.identity-types public
 open import foundation.images public
 open import foundation.images-subtypes public
+open import foundation.implicit-function-types public
 open import foundation.impredicative-encodings public
 open import foundation.impredicative-universes public
 open import foundation.induction-principle-propositional-truncation public

--- a/src/foundation/equality-dependent-function-types.lagda.md
+++ b/src/foundation/equality-dependent-function-types.lagda.md
@@ -9,6 +9,7 @@ module foundation.equality-dependent-function-types where
 ```agda
 open import foundation.dependent-pair-types
 open import foundation.fundamental-theorem-of-identity-types
+open import foundation.implicit-function-types
 open import foundation.type-theoretic-principle-of-choice
 open import foundation.universe-levels
 

--- a/src/foundation/function-extensionality.lagda.md
+++ b/src/foundation/function-extensionality.lagda.md
@@ -10,6 +10,7 @@ module foundation.function-extensionality where
 open import foundation.action-on-identifications-binary-functions
 open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
+open import foundation.implicit-function-types
 open import foundation.universe-levels
 
 open import foundation-core.equivalences
@@ -130,6 +131,30 @@ module _
     equiv-eq-htpy : {f g : (x : A) → B x} → (f ~ g) ≃ (f ＝ g)
     pr1 (equiv-eq-htpy {f} {g}) = eq-htpy
     pr2 (equiv-eq-htpy {f} {g}) = is-equiv-eq-htpy f g
+```
+
+### Function extensionality for implicit functions
+
+```agda
+module _
+  {l1 l2 : Level} {A : UU l1} {B : A → UU l2} {f g : {x : A} → B x}
+  where
+
+  equiv-funext-implicit :
+    (Id {A = {x : A} → B x} f g) ≃ ((x : A) → f {x} ＝ g {x})
+  equiv-funext-implicit =
+    equiv-funext ∘e equiv-ap equiv-explicit-implicit-Π f g
+
+  htpy-eq-implicit :
+    Id {A = {x : A} → B x} f g → (x : A) → f {x} ＝ g {x}
+  htpy-eq-implicit = map-equiv equiv-funext-implicit
+
+  funext-implicit : is-equiv htpy-eq-implicit
+  funext-implicit = is-equiv-map-equiv equiv-funext-implicit
+
+  eq-htpy-implicit :
+    ((x : A) → f {x} ＝ g {x}) → Id {A = {x : A} → B x} f g
+  eq-htpy-implicit = map-inv-equiv equiv-funext-implicit
 ```
 
 ## Properties

--- a/src/foundation/implicit-function-types.lagda.md
+++ b/src/foundation/implicit-function-types.lagda.md
@@ -53,7 +53,7 @@ module _
   pr2 equiv-explicit-implicit-Π = is-equiv-explicit-implicit-Π
 ```
 
-### Equality if explicit functions is equality of implicit functions
+### Equality of explicit functions is equality of implicit functions
 
 ```agda
 module _

--- a/src/foundation/implicit-function-types.lagda.md
+++ b/src/foundation/implicit-function-types.lagda.md
@@ -1,0 +1,81 @@
+# Implicit function types
+
+```agda
+module foundation.implicit-function-types where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.dependent-pair-types
+open import foundation.universe-levels
+
+open import foundation-core.equivalences
+open import foundation-core.homotopies
+open import foundation-core.identity-types
+```
+
+</details>
+
+## Properties
+
+### Dependent function types taking implicit arguments are equivalent to dependent function types taking explicit arguments
+
+```agda
+module _
+  {l1 l2 : Level} {A : UU l1} {B : A → UU l2}
+  where
+
+  implicit-explicit-Π : ((x : A) → B x) → {x : A} → B x
+  implicit-explicit-Π f {x} = f x
+
+  explicit-implicit-Π : ({x : A} → B x) → (x : A) → B x
+  explicit-implicit-Π f x = f {x}
+
+  is-equiv-implicit-explicit-Π : is-equiv implicit-explicit-Π
+  pr1 (pr1 is-equiv-implicit-explicit-Π) = explicit-implicit-Π
+  pr2 (pr1 is-equiv-implicit-explicit-Π) = refl-htpy
+  pr1 (pr2 is-equiv-implicit-explicit-Π) = explicit-implicit-Π
+  pr2 (pr2 is-equiv-implicit-explicit-Π) = refl-htpy
+
+  is-equiv-explicit-implicit-Π : is-equiv explicit-implicit-Π
+  pr1 (pr1 is-equiv-explicit-implicit-Π) = implicit-explicit-Π
+  pr2 (pr1 is-equiv-explicit-implicit-Π) = refl-htpy
+  pr1 (pr2 is-equiv-explicit-implicit-Π) = implicit-explicit-Π
+  pr2 (pr2 is-equiv-explicit-implicit-Π) = refl-htpy
+
+  equiv-implicit-explicit-Π : ((x : A) → B x) ≃ ({x : A} → B x)
+  pr1 equiv-implicit-explicit-Π = implicit-explicit-Π
+  pr2 equiv-implicit-explicit-Π = is-equiv-implicit-explicit-Π
+
+  equiv-explicit-implicit-Π : ({x : A} → B x) ≃ ((x : A) → B x)
+  pr1 equiv-explicit-implicit-Π = explicit-implicit-Π
+  pr2 equiv-explicit-implicit-Π = is-equiv-explicit-implicit-Π
+```
+
+### Equality if explicit functions is equality of implicit functions
+
+```agda
+module _
+  {l1 l2 : Level} {A : UU l1} {B : A → UU l2}
+  {f g : (x : A) → B x}
+  where
+
+  equiv-eq-implicit-eq-explicit-Π : (f ＝ g) ≃ (Id (λ {x} → f x) (λ {x} → g x))
+  equiv-eq-implicit-eq-explicit-Π = equiv-ap equiv-implicit-explicit-Π f g
+
+  eq-implicit-eq-explicit-Π : (f ＝ g) → (Id (λ {x} → f x) (λ {x} → g x))
+  eq-implicit-eq-explicit-Π = map-equiv equiv-eq-implicit-eq-explicit-Π
+
+  equiv-eq-explicit-eq-implicit-Π : (Id (λ {x} → f x) (λ {x} → g x)) ≃ (f ＝ g)
+  equiv-eq-explicit-eq-implicit-Π =
+    equiv-ap equiv-explicit-implicit-Π (λ {x} → f x) (λ {x} → g x)
+
+  eq-explicit-eq-implicit-Π : (Id (λ {x} → f x) (λ {x} → g x)) → (f ＝ g)
+  eq-explicit-eq-implicit-Π = map-equiv equiv-eq-explicit-eq-implicit-Π
+```
+
+## See also
+
+- Function extensionality for implicit function types is established in
+  [`foundation.function-extensionality`](foundation.function-extensionality.md).

--- a/src/foundation/iterated-dependent-product-types.lagda.md
+++ b/src/foundation/iterated-dependent-product-types.lagda.md
@@ -11,9 +11,12 @@ open import foundation.telescopes public
 ```agda
 open import elementary-number-theory.natural-numbers
 
+open import foundation.implicit-function-types
 open import foundation.universe-levels
 
 open import foundation-core.contractible-types
+open import foundation-core.equivalences
+open import foundation-core.functoriality-dependent-function-types
 open import foundation-core.propositions
 open import foundation-core.truncated-types
 open import foundation-core.truncation-levels
@@ -116,6 +119,39 @@ section-iterated-Π-section-Π-section-codomain P f ._ {{base-telescope A}} H =
   H
 section-iterated-Π-section-Π-section-codomain P f ._ {{cons-telescope A}} H =
   f (λ x → section-iterated-Π-section-Π-section-codomain P f _ {{A x}} (H x))
+
+section-iterated-implicit-Π-section-Π-section-codomain :
+  (P : {l : Level} → UU l → UU l) →
+  ( {l1 l2 : Level} {A : UU l1} {B : A → UU l2} →
+    ((x : A) → P (B x)) → P ({x : A} → B x)) →
+  {l : Level} (n : ℕ) {{A : telescope l n}} →
+  apply-codomain-iterated-Π P A → P (iterated-implicit-Π A)
+section-iterated-implicit-Π-section-Π-section-codomain
+  P f ._ {{base-telescope A}} H =
+  H
+section-iterated-implicit-Π-section-Π-section-codomain
+  P f ._ {{cons-telescope A}} H =
+  f ( λ x →
+      section-iterated-implicit-Π-section-Π-section-codomain
+        P f _ {{A x}} (H x))
+```
+
+### Multivariable function types are equivalent to multivariable implicit function types
+
+```agda
+equiv-explicit-implicit-iterated-Π :
+  {l : Level} (n : ℕ) {{A : telescope l n}} →
+  iterated-implicit-Π A ≃ iterated-Π A
+equiv-explicit-implicit-iterated-Π .0 ⦃ base-telescope A ⦄ = id-equiv
+equiv-explicit-implicit-iterated-Π ._ ⦃ cons-telescope A ⦄ =
+  equiv-Π-equiv-family (λ x → equiv-explicit-implicit-iterated-Π _ {{A x}}) ∘e
+  equiv-explicit-implicit-Π
+
+equiv-implicit-explicit-iterated-Π :
+  {l : Level} (n : ℕ) {{A : telescope l n}} →
+  iterated-Π A ≃ iterated-implicit-Π A
+equiv-implicit-explicit-iterated-Π n {{A}} =
+  inv-equiv (equiv-explicit-implicit-iterated-Π n {{A}})
 ```
 
 ### Iterated products of contractible types is contractible
@@ -126,6 +162,14 @@ is-contr-iterated-Π :
   apply-codomain-iterated-Π is-contr A → is-contr (iterated-Π A)
 is-contr-iterated-Π =
   section-iterated-Π-section-Π-section-codomain is-contr is-contr-Π
+
+is-contr-iterated-implicit-Π :
+  {l : Level} (n : ℕ) {{A : telescope l n}} →
+  apply-codomain-iterated-Π is-contr A → is-contr (iterated-implicit-Π A)
+is-contr-iterated-implicit-Π =
+  section-iterated-implicit-Π-section-Π-section-codomain
+    ( is-contr)
+    ( is-contr-implicit-Π)
 ```
 
 ### Iterated products of propositions are propositions
@@ -136,6 +180,12 @@ is-prop-iterated-Π :
   apply-codomain-iterated-Π is-prop A → is-prop (iterated-Π A)
 is-prop-iterated-Π =
   section-iterated-Π-section-Π-section-codomain is-prop is-prop-Π
+
+is-prop-iterated-implicit-Π :
+  {l : Level} (n : ℕ) {{A : telescope l n}} →
+  apply-codomain-iterated-Π is-prop A → is-prop (iterated-implicit-Π A)
+is-prop-iterated-implicit-Π =
+  section-iterated-implicit-Π-section-Π-section-codomain is-prop is-prop-Π'
 ```
 
 ### Iterated products of truncated types are truncated

--- a/src/foundation/multivariable-homotopies.lagda.md
+++ b/src/foundation/multivariable-homotopies.lagda.md
@@ -15,13 +15,9 @@ open import foundation.function-extensionality
 open import foundation.iterated-dependent-product-types
 open import foundation.universe-levels
 
-open import foundation-core.contractible-types
 open import foundation-core.equivalences
 open import foundation-core.functoriality-dependent-function-types
 open import foundation-core.identity-types
-open import foundation-core.propositions
-open import foundation-core.truncated-types
-open import foundation-core.truncation-levels
 ```
 
 </details>
@@ -45,6 +41,16 @@ multivariable-htpy :
 multivariable-htpy {{base-telescope A}} f g = f ＝ g
 multivariable-htpy {{cons-telescope A}} f g =
   (x : _) → multivariable-htpy {{A x}} (f x) (g x)
+```
+
+### Multivariable homotopies between implicit functions
+
+```agda
+multivariable-htpy-implicit :
+  {l : Level} {n : ℕ} {{A : telescope l n}} (f g : iterated-implicit-Π A) → UU l
+multivariable-htpy-implicit {{base-telescope A}} f g = f ＝ g
+multivariable-htpy-implicit {{cons-telescope A}} f g =
+  (x : _) → multivariable-htpy-implicit {{A x}} (f {x}) (g {x})
 ```
 
 ### Iterated function extensionality
@@ -77,6 +83,39 @@ equiv-iterated-funext :
 equiv-iterated-funext .0 {{base-telescope A}} = id-equiv
 equiv-iterated-funext ._ {{cons-telescope A}} =
   equiv-Π-equiv-family (λ x → equiv-iterated-funext _ {{A x}}) ∘e equiv-funext
+```
+
+### Iterated function extensionality for implicit functions
+
+```agda
+refl-multivariable-htpy-implicit :
+  {l : Level} (n : ℕ) {{A : telescope l n}} {f : iterated-implicit-Π A} →
+  multivariable-htpy-implicit {{A}} f f
+refl-multivariable-htpy-implicit .0 {{base-telescope A}} = refl
+refl-multivariable-htpy-implicit ._ {{cons-telescope A}} x =
+  refl-multivariable-htpy-implicit _ {{A x}}
+
+multivariable-htpy-eq-implicit :
+  {l : Level} (n : ℕ) {{A : telescope l n}} {f g : iterated-implicit-Π A} →
+  Id {A = iterated-implicit-Π A} f g → multivariable-htpy-implicit {{A}} f g
+multivariable-htpy-eq-implicit .0 {{base-telescope A}} p = p
+multivariable-htpy-eq-implicit ._ {{cons-telescope A}} p x =
+  multivariable-htpy-eq-implicit _ {{A x}} (htpy-eq-implicit p x)
+
+eq-multivariable-htpy-implicit :
+  {l : Level} (n : ℕ) {{A : telescope l n}} {f g : iterated-implicit-Π A} →
+  multivariable-htpy-implicit {{A}} f g → Id {A = iterated-implicit-Π A} f g
+eq-multivariable-htpy-implicit .0 {{base-telescope A}} H = H
+eq-multivariable-htpy-implicit ._ {{cons-telescope A}} H =
+  eq-htpy-implicit (λ x → eq-multivariable-htpy-implicit _ {{A x}} (H x))
+
+equiv-iterated-funext-implicit :
+  {l : Level} (n : ℕ) {{A : telescope l n}} {f g : iterated-implicit-Π A} →
+  (Id {A = iterated-implicit-Π A} f g) ≃ multivariable-htpy-implicit {{A}} f g
+equiv-iterated-funext-implicit .0 {{base-telescope A}} = id-equiv
+equiv-iterated-funext-implicit ._ {{cons-telescope A}} =
+  ( equiv-Π-equiv-family (λ x → equiv-iterated-funext-implicit _ {{A x}})) ∘e
+  ( equiv-funext-implicit)
 ```
 
 ## See also

--- a/src/foundation/type-theoretic-principle-of-choice.lagda.md
+++ b/src/foundation/type-theoretic-principle-of-choice.lagda.md
@@ -30,26 +30,26 @@ distributivity of Π over Σ, is also known as the type theoretic principle of
 choice. Indeed, it is the Curry-Howard interpretation of (one formulation of)
 the axiom of choice.
 
-## Definitions
+## Distributivity of Π over Σ
 
-### Distributivity of Π over Σ
+### Definitions
 
 ```agda
-Π-total-fam :
+module _
   {l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2}
-  (C : (x : A) → B x → UU l3) → UU (l1 ⊔ l2 ⊔ l3)
-Π-total-fam {A = A} {B} C = (x : A) → Σ (B x) (C x)
+  (C : (x : A) → B x → UU l3)
+  where
 
-universally-structured-Π :
-  {l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2}
-  (C : (x : A) → B x → UU l3) → UU (l1 ⊔ l2 ⊔ l3)
-universally-structured-Π {A = A} {B} C =
-  Σ ((x : A) → B x) (λ f → (x : A) → C x (f x))
+  Π-total-fam : UU (l1 ⊔ l2 ⊔ l3)
+  Π-total-fam = (x : A) → Σ (B x) (C x)
+
+  universally-structured-Π : UU (l1 ⊔ l2 ⊔ l3)
+  universally-structured-Π = Σ ((x : A) → B x) (λ f → (x : A) → C x (f x))
 ```
 
-## Properties
+### Properties
 
-### Characterizing the identity type of `universally-structured-Π`
+#### Characterizing the identity type of `universally-structured-Π`
 
 ```agda
 module _
@@ -81,113 +81,210 @@ module _
     map-inv-equiv (extensionality-universally-structured-Π t t')
 ```
 
-### The distributivity of Π over Σ
+#### The distributivity of Π over Σ
 
 ```agda
-map-distributive-Π-Σ :
-  {l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2} {C : (x : A) → B x → UU l3} →
-  Π-total-fam C → universally-structured-Π C
-pr1 (map-distributive-Π-Σ φ) x = pr1 (φ x)
-pr2 (map-distributive-Π-Σ φ) x = pr2 (φ x)
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2} {C : (x : A) → B x → UU l3}
+  where
 
-map-inv-distributive-Π-Σ :
-  {l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2} {C : (x : A) → B x → UU l3} →
-  universally-structured-Π C → Π-total-fam C
-pr1 (map-inv-distributive-Π-Σ ψ x) = (pr1 ψ) x
-pr2 (map-inv-distributive-Π-Σ ψ x) = (pr2 ψ) x
+  map-distributive-Π-Σ : Π-total-fam C → universally-structured-Π C
+  pr1 (map-distributive-Π-Σ φ) x = pr1 (φ x)
+  pr2 (map-distributive-Π-Σ φ) x = pr2 (φ x)
 
-is-section-map-inv-distributive-Π-Σ :
-  {l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2} {C : (x : A) → B x → UU l3} →
-  ( ( map-distributive-Π-Σ {A = A} {B = B} {C = C}) ∘
-    ( map-inv-distributive-Π-Σ {A = A} {B = B} {C = C})) ~ id
-is-section-map-inv-distributive-Π-Σ {A = A} {C = C} (pair ψ ψ') =
-  eq-htpy-universally-structured-Π C (pair refl-htpy refl-htpy)
+  map-inv-distributive-Π-Σ : universally-structured-Π C → Π-total-fam C
+  pr1 (map-inv-distributive-Π-Σ ψ x) = (pr1 ψ) x
+  pr2 (map-inv-distributive-Π-Σ ψ x) = (pr2 ψ) x
 
-is-retraction-map-inv-distributive-Π-Σ :
-  {l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2} {C : (x : A) → B x → UU l3} →
-  ( ( map-inv-distributive-Π-Σ {A = A} {B = B} {C = C}) ∘
-    ( map-distributive-Π-Σ {A = A} {B = B} {C = C})) ~ id
-is-retraction-map-inv-distributive-Π-Σ φ =
-  eq-htpy (λ x → eq-pair-Σ refl refl)
+  is-section-map-inv-distributive-Π-Σ :
+    map-distributive-Π-Σ ∘ map-inv-distributive-Π-Σ ~ id
+  is-section-map-inv-distributive-Π-Σ (pair ψ ψ') =
+    eq-htpy-universally-structured-Π C (pair refl-htpy refl-htpy)
 
-abstract
-  is-equiv-map-distributive-Π-Σ :
-    {l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2} {C : (x : A) → B x → UU l3} →
-    is-equiv (map-distributive-Π-Σ {A = A} {B = B} {C = C})
-  is-equiv-map-distributive-Π-Σ {A = A} {B = B} {C = C} =
-    is-equiv-is-invertible
-      ( map-inv-distributive-Π-Σ {A = A} {B = B} {C = C})
-      ( is-section-map-inv-distributive-Π-Σ {A = A} {B = B} {C = C})
-      ( is-retraction-map-inv-distributive-Π-Σ {A = A} {B = B} {C = C})
+  is-retraction-map-inv-distributive-Π-Σ :
+    map-inv-distributive-Π-Σ ∘ map-distributive-Π-Σ ~ id
+  is-retraction-map-inv-distributive-Π-Σ φ =
+    eq-htpy (λ x → eq-pair-Σ refl refl)
 
-distributive-Π-Σ :
-  { l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2} {C : (x : A) → B x → UU l3} →
-  Π-total-fam C ≃ universally-structured-Π C
-pr1 distributive-Π-Σ = map-distributive-Π-Σ
-pr2 distributive-Π-Σ = is-equiv-map-distributive-Π-Σ
+  abstract
+    is-equiv-map-distributive-Π-Σ : is-equiv (map-distributive-Π-Σ)
+    is-equiv-map-distributive-Π-Σ =
+      is-equiv-is-invertible
+        ( map-inv-distributive-Π-Σ)
+        ( is-section-map-inv-distributive-Π-Σ)
+        ( is-retraction-map-inv-distributive-Π-Σ)
 
-abstract
-  is-equiv-map-inv-distributive-Π-Σ :
-    {l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2} {C : (x : A) → B x → UU l3} →
-    is-equiv (map-inv-distributive-Π-Σ {A = A} {B = B} {C = C})
-  is-equiv-map-inv-distributive-Π-Σ {A = A} {B = B} {C = C} =
-    is-equiv-is-invertible
-      ( map-distributive-Π-Σ {A = A} {B = B} {C = C})
-      ( is-retraction-map-inv-distributive-Π-Σ {A = A} {B = B} {C = C})
-      ( is-section-map-inv-distributive-Π-Σ {A = A} {B = B} {C = C})
+  distributive-Π-Σ : Π-total-fam C ≃ universally-structured-Π C
+  pr1 distributive-Π-Σ = map-distributive-Π-Σ
+  pr2 distributive-Π-Σ = is-equiv-map-distributive-Π-Σ
 
-inv-distributive-Π-Σ :
-  {l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2} {C : (x : A) → B x → UU l3} →
-  (universally-structured-Π C) ≃ (Π-total-fam C)
-pr1 inv-distributive-Π-Σ = map-inv-distributive-Π-Σ
-pr2 inv-distributive-Π-Σ = is-equiv-map-inv-distributive-Π-Σ
+  abstract
+    is-equiv-map-inv-distributive-Π-Σ : is-equiv (map-inv-distributive-Π-Σ)
+    is-equiv-map-inv-distributive-Π-Σ =
+      is-equiv-is-invertible
+        ( map-distributive-Π-Σ)
+        ( is-retraction-map-inv-distributive-Π-Σ)
+        ( is-section-map-inv-distributive-Π-Σ)
+
+  inv-distributive-Π-Σ : universally-structured-Π C ≃ Π-total-fam C
+  pr1 inv-distributive-Π-Σ = map-inv-distributive-Π-Σ
+  pr2 inv-distributive-Π-Σ = is-equiv-map-inv-distributive-Π-Σ
 ```
 
-## Consequences
+### Consequences
 
-### Characterizing the identity type of `Π-total-fam`
+#### Characterizing the identity type of `Π-total-fam`
 
 ```agda
-Eq-Π-total-fam :
+module _
   {l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2} (C : (x : A) → B x → UU l3)
-  (t t' : (a : A) → Σ (B a) (C a)) → UU (l1 ⊔ l2 ⊔ l3)
-Eq-Π-total-fam {A = A} C t t' =
-  Π-total-fam (λ x (p : pr1 (t x) ＝ pr1 (t' x)) →
-    tr (C x) p (pr2 (t x)) ＝ pr2 (t' x))
+  (f g : (a : A) → Σ (B a) (C a))
+  where
 
-extensionality-Π-total-fam :
-  {l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2} (C : (x : A) → B x → UU l3)
-  (f g : (a : A) → Σ (B a) (C a)) → (f ＝ g) ≃ Eq-Π-total-fam C f g
-extensionality-Π-total-fam C f g =
-  ( inv-distributive-Π-Σ ∘e
+  Eq-Π-total-fam : UU (l1 ⊔ l2 ⊔ l3)
+  Eq-Π-total-fam =
+    Π-total-fam (λ x (p : pr1 (f x) ＝ pr1 (g x)) →
+      tr (C x) p (pr2 (f x)) ＝ pr2 (g x))
+
+  extensionality-Π-total-fam : (f ＝ g) ≃ Eq-Π-total-fam
+  extensionality-Π-total-fam =
+    ( inv-distributive-Π-Σ) ∘e
     ( extensionality-universally-structured-Π C
       ( map-distributive-Π-Σ f)
-      ( map-distributive-Π-Σ g))) ∘e
-  ( equiv-ap distributive-Π-Σ f g)
+      ( map-distributive-Π-Σ g)) ∘e
+    ( equiv-ap distributive-Π-Σ f g)
 
-eq-Eq-Π-total-fam :
-  {l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2} (C : (x : A) → B x → UU l3)
-  (f g : (a : A) → Σ (B a) (C a)) → Eq-Π-total-fam C f g → f ＝ g
-eq-Eq-Π-total-fam C f g = map-inv-equiv (extensionality-Π-total-fam C f g)
+  eq-Eq-Π-total-fam : Eq-Π-total-fam → f ＝ g
+  eq-Eq-Π-total-fam = map-inv-equiv extensionality-Π-total-fam
 ```
 
-### Ordinary functions into a Σ-type
+#### Ordinary functions into a Σ-type
 
 ```agda
-mapping-into-Σ :
-  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : B → UU l3} →
-  (A → Σ B C) → Σ (A → B) (λ f → (x : A) → C (f x))
-mapping-into-Σ {B = B} = map-distributive-Π-Σ {B = λ _ → B}
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : B → UU l3}
+  where
 
-abstract
-  is-equiv-mapping-into-Σ :
-    {l1 l2 l3 : Level} {A : UU l1} {B : UU l2}
-    {C : B → UU l3} → is-equiv (mapping-into-Σ {A = A} {C = C})
-  is-equiv-mapping-into-Σ = is-equiv-map-distributive-Π-Σ
+  mapping-into-Σ :
+    (A → Σ B C) → Σ (A → B) (λ f → (x : A) → C (f x))
+  mapping-into-Σ = map-distributive-Π-Σ {B = λ _ → B}
 
-equiv-mapping-into-Σ :
-  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : B → UU l3} →
-  (A → Σ B C) ≃ Σ (A → B) (λ f → (x : A) → C (f x))
-pr1 equiv-mapping-into-Σ = mapping-into-Σ
-pr2 equiv-mapping-into-Σ = is-equiv-mapping-into-Σ
+  abstract
+    is-equiv-mapping-into-Σ : is-equiv mapping-into-Σ
+    is-equiv-mapping-into-Σ = is-equiv-map-distributive-Π-Σ
+
+  equiv-mapping-into-Σ :
+    (A → Σ B C) ≃ Σ (A → B) (λ f → (x : A) → C (f x))
+  pr1 equiv-mapping-into-Σ = mapping-into-Σ
+  pr2 equiv-mapping-into-Σ = is-equiv-mapping-into-Σ
+```
+
+## Distributivity of implicit Π over Σ
+
+### Definitions
+
+```agda
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2}
+  (C : (x : A) → B x → UU l3)
+  where
+
+  implicit-Π-total-fam : UU (l1 ⊔ l2 ⊔ l3)
+  implicit-Π-total-fam = {x : A} → Σ (B x) (C x)
+
+  universally-structured-implicit-Π : UU (l1 ⊔ l2 ⊔ l3)
+  universally-structured-implicit-Π =
+    Σ ({x : A} → B x) (λ f → {x : A} → C x (f {x}))
+```
+
+### Properties
+
+#### Characterizing the identity type of `universally-structured-implicit-Π`
+
+```agda
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2} (C : (x : A) → B x → UU l3)
+  where
+
+  htpy-universally-structured-implicit-Π :
+    (t t' : universally-structured-implicit-Π C) → UU (l1 ⊔ l2 ⊔ l3)
+  htpy-universally-structured-implicit-Π t t' =
+    universally-structured-Π
+      ( λ (x : A) (p : (pr1 t) {x} ＝ (pr1 t') {x}) →
+        tr (C x) p ((pr2 t) {x}) ＝ (pr2 t') {x})
+
+  extensionality-universally-structured-implicit-Π :
+    (t t' : universally-structured-implicit-Π C) →
+    (t ＝ t') ≃ htpy-universally-structured-implicit-Π t t'
+  extensionality-universally-structured-implicit-Π (pair f g) =
+    extensionality-Σ
+      ( λ {f'} g' H → (x : A) → tr (C x) (H x) (g {x}) ＝ g' {x})
+      ( refl-htpy)
+      ( refl-htpy)
+      ( λ f' → equiv-funext-implicit)
+      ( λ g' → equiv-funext-implicit)
+
+  eq-htpy-universally-structured-implicit-Π :
+    {t t' : universally-structured-implicit-Π C} →
+    htpy-universally-structured-implicit-Π t t' → t ＝ t'
+  eq-htpy-universally-structured-implicit-Π {t} {t'} =
+    map-inv-equiv (extensionality-universally-structured-implicit-Π t t')
+```
+
+#### The distributivity of implicit Π over Σ
+
+```agda
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2} {C : (x : A) → B x → UU l3}
+  where
+
+  map-distributive-implicit-Π-Σ :
+    implicit-Π-total-fam C → universally-structured-implicit-Π C
+  pr1 (map-distributive-implicit-Π-Σ φ) {x} = pr1 (φ {x})
+  pr2 (map-distributive-implicit-Π-Σ φ) {x} = pr2 (φ {x})
+
+  map-inv-distributive-implicit-Π-Σ :
+    universally-structured-implicit-Π C → implicit-Π-total-fam C
+  pr1 (map-inv-distributive-implicit-Π-Σ ψ {x}) = (pr1 ψ) {x}
+  pr2 (map-inv-distributive-implicit-Π-Σ ψ {x}) = (pr2 ψ) {x}
+
+  is-section-map-inv-distributive-implicit-Π-Σ :
+    ( ( map-distributive-implicit-Π-Σ) ∘
+      ( map-inv-distributive-implicit-Π-Σ)) ~ id
+  is-section-map-inv-distributive-implicit-Π-Σ (pair ψ ψ') =
+    eq-htpy-universally-structured-implicit-Π C (pair refl-htpy refl-htpy)
+
+  is-retraction-map-inv-distributive-implicit-Π-Σ :
+    ( ( map-inv-distributive-implicit-Π-Σ) ∘
+      ( map-distributive-implicit-Π-Σ)) ~ id
+  is-retraction-map-inv-distributive-implicit-Π-Σ φ =
+    eq-htpy-implicit (λ x → eq-pair-Σ refl refl)
+
+  abstract
+    is-equiv-map-distributive-implicit-Π-Σ :
+      is-equiv (map-distributive-implicit-Π-Σ)
+    is-equiv-map-distributive-implicit-Π-Σ =
+      is-equiv-is-invertible
+        ( map-inv-distributive-implicit-Π-Σ)
+        ( is-section-map-inv-distributive-implicit-Π-Σ)
+        ( is-retraction-map-inv-distributive-implicit-Π-Σ)
+
+  distributive-implicit-Π-Σ :
+    implicit-Π-total-fam C ≃ universally-structured-implicit-Π C
+  pr1 distributive-implicit-Π-Σ = map-distributive-implicit-Π-Σ
+  pr2 distributive-implicit-Π-Σ = is-equiv-map-distributive-implicit-Π-Σ
+
+  abstract
+    is-equiv-map-inv-distributive-implicit-Π-Σ :
+      is-equiv (map-inv-distributive-implicit-Π-Σ)
+    is-equiv-map-inv-distributive-implicit-Π-Σ =
+      is-equiv-is-invertible
+        ( map-distributive-implicit-Π-Σ)
+        ( is-retraction-map-inv-distributive-implicit-Π-Σ)
+        ( is-section-map-inv-distributive-implicit-Π-Σ)
+
+  inv-distributive-implicit-Π-Σ :
+    (universally-structured-implicit-Π C) ≃ (implicit-Π-total-fam C)
+  pr1 inv-distributive-implicit-Π-Σ = map-inv-distributive-implicit-Π-Σ
+  pr2 inv-distributive-implicit-Π-Σ = is-equiv-map-inv-distributive-implicit-Π-Σ
 ```

--- a/src/foundation/type-theoretic-principle-of-choice.lagda.md
+++ b/src/foundation/type-theoretic-principle-of-choice.lagda.md
@@ -9,6 +9,7 @@ module foundation.type-theoretic-principle-of-choice where
 ```agda
 open import foundation.dependent-pair-types
 open import foundation.function-extensionality
+open import foundation.implicit-function-types
 open import foundation.structure-identity-principle
 open import foundation.universe-levels
 
@@ -30,9 +31,9 @@ distributivity of Π over Σ, is also known as the type theoretic principle of
 choice. Indeed, it is the Curry-Howard interpretation of (one formulation of)
 the axiom of choice.
 
-## Distributivity of Π over Σ
+We establish this equivalence both for explicit and implicit function types.
 
-### Definitions
+## Definitions
 
 ```agda
 module _
@@ -45,11 +46,18 @@ module _
 
   universally-structured-Π : UU (l1 ⊔ l2 ⊔ l3)
   universally-structured-Π = Σ ((x : A) → B x) (λ f → (x : A) → C x (f x))
+
+  implicit-Π-total-fam : UU (l1 ⊔ l2 ⊔ l3)
+  implicit-Π-total-fam = {x : A} → Σ (B x) (C x)
+
+  universally-structured-implicit-Π : UU (l1 ⊔ l2 ⊔ l3)
+  universally-structured-implicit-Π =
+    Σ ({x : A} → B x) (λ f → {x : A} → C x (f {x}))
 ```
 
-### Properties
+## Lemma
 
-#### Characterizing the identity type of `universally-structured-Π`
+### Characterizing the identity type of `universally-structured-Π`
 
 ```agda
 module _
@@ -81,7 +89,41 @@ module _
     map-inv-equiv (extensionality-universally-structured-Π t t')
 ```
 
-#### The distributivity of Π over Σ
+### Characterizing the identity type of `universally-structured-implicit-Π`
+
+```agda
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2} (C : (x : A) → B x → UU l3)
+  where
+
+  htpy-universally-structured-implicit-Π :
+    (t t' : universally-structured-implicit-Π C) → UU (l1 ⊔ l2 ⊔ l3)
+  htpy-universally-structured-implicit-Π t t' =
+    universally-structured-Π
+      ( λ (x : A) (p : (pr1 t) {x} ＝ (pr1 t') {x}) →
+        tr (C x) p ((pr2 t) {x}) ＝ (pr2 t') {x})
+
+  extensionality-universally-structured-implicit-Π :
+    (t t' : universally-structured-implicit-Π C) →
+    (t ＝ t') ≃ htpy-universally-structured-implicit-Π t t'
+  extensionality-universally-structured-implicit-Π (f , g) =
+    extensionality-Σ
+      ( λ {f'} g' H → (x : A) → tr (C x) (H x) (g {x}) ＝ g' {x})
+      ( refl-htpy)
+      ( refl-htpy)
+      ( λ f' → equiv-funext-implicit)
+      ( λ g' → equiv-funext-implicit)
+
+  eq-htpy-universally-structured-implicit-Π :
+    {t t' : universally-structured-implicit-Π C} →
+    htpy-universally-structured-implicit-Π t t' → t ＝ t'
+  eq-htpy-universally-structured-implicit-Π {t} {t'} =
+    map-inv-equiv (extensionality-universally-structured-implicit-Π t t')
+```
+
+## Theorem
+
+### The distributivity of Π over Σ
 
 ```agda
 module _
@@ -131,107 +173,7 @@ module _
   pr2 inv-distributive-Π-Σ = is-equiv-map-inv-distributive-Π-Σ
 ```
 
-### Consequences
-
-#### Characterizing the identity type of `Π-total-fam`
-
-```agda
-module _
-  {l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2} (C : (x : A) → B x → UU l3)
-  (f g : (a : A) → Σ (B a) (C a))
-  where
-
-  Eq-Π-total-fam : UU (l1 ⊔ l2 ⊔ l3)
-  Eq-Π-total-fam =
-    Π-total-fam (λ x (p : pr1 (f x) ＝ pr1 (g x)) →
-      tr (C x) p (pr2 (f x)) ＝ pr2 (g x))
-
-  extensionality-Π-total-fam : (f ＝ g) ≃ Eq-Π-total-fam
-  extensionality-Π-total-fam =
-    ( inv-distributive-Π-Σ) ∘e
-    ( extensionality-universally-structured-Π C
-      ( map-distributive-Π-Σ f)
-      ( map-distributive-Π-Σ g)) ∘e
-    ( equiv-ap distributive-Π-Σ f g)
-
-  eq-Eq-Π-total-fam : Eq-Π-total-fam → f ＝ g
-  eq-Eq-Π-total-fam = map-inv-equiv extensionality-Π-total-fam
-```
-
-#### Ordinary functions into a Σ-type
-
-```agda
-module _
-  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : B → UU l3}
-  where
-
-  mapping-into-Σ :
-    (A → Σ B C) → Σ (A → B) (λ f → (x : A) → C (f x))
-  mapping-into-Σ = map-distributive-Π-Σ {B = λ _ → B}
-
-  abstract
-    is-equiv-mapping-into-Σ : is-equiv mapping-into-Σ
-    is-equiv-mapping-into-Σ = is-equiv-map-distributive-Π-Σ
-
-  equiv-mapping-into-Σ :
-    (A → Σ B C) ≃ Σ (A → B) (λ f → (x : A) → C (f x))
-  pr1 equiv-mapping-into-Σ = mapping-into-Σ
-  pr2 equiv-mapping-into-Σ = is-equiv-mapping-into-Σ
-```
-
-## Distributivity of implicit Π over Σ
-
-### Definitions
-
-```agda
-module _
-  {l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2}
-  (C : (x : A) → B x → UU l3)
-  where
-
-  implicit-Π-total-fam : UU (l1 ⊔ l2 ⊔ l3)
-  implicit-Π-total-fam = {x : A} → Σ (B x) (C x)
-
-  universally-structured-implicit-Π : UU (l1 ⊔ l2 ⊔ l3)
-  universally-structured-implicit-Π =
-    Σ ({x : A} → B x) (λ f → {x : A} → C x (f {x}))
-```
-
-### Properties
-
-#### Characterizing the identity type of `universally-structured-implicit-Π`
-
-```agda
-module _
-  {l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2} (C : (x : A) → B x → UU l3)
-  where
-
-  htpy-universally-structured-implicit-Π :
-    (t t' : universally-structured-implicit-Π C) → UU (l1 ⊔ l2 ⊔ l3)
-  htpy-universally-structured-implicit-Π t t' =
-    universally-structured-Π
-      ( λ (x : A) (p : (pr1 t) {x} ＝ (pr1 t') {x}) →
-        tr (C x) p ((pr2 t) {x}) ＝ (pr2 t') {x})
-
-  extensionality-universally-structured-implicit-Π :
-    (t t' : universally-structured-implicit-Π C) →
-    (t ＝ t') ≃ htpy-universally-structured-implicit-Π t t'
-  extensionality-universally-structured-implicit-Π (pair f g) =
-    extensionality-Σ
-      ( λ {f'} g' H → (x : A) → tr (C x) (H x) (g {x}) ＝ g' {x})
-      ( refl-htpy)
-      ( refl-htpy)
-      ( λ f' → equiv-funext-implicit)
-      ( λ g' → equiv-funext-implicit)
-
-  eq-htpy-universally-structured-implicit-Π :
-    {t t' : universally-structured-implicit-Π C} →
-    htpy-universally-structured-implicit-Π t t' → t ＝ t'
-  eq-htpy-universally-structured-implicit-Π {t} {t'} =
-    map-inv-equiv (extensionality-universally-structured-implicit-Π t t')
-```
-
-#### The distributivity of implicit Π over Σ
+### The distributivity of implicit Π over Σ
 
 ```agda
 module _
@@ -287,4 +229,72 @@ module _
     (universally-structured-implicit-Π C) ≃ (implicit-Π-total-fam C)
   pr1 inv-distributive-implicit-Π-Σ = map-inv-distributive-implicit-Π-Σ
   pr2 inv-distributive-implicit-Π-Σ = is-equiv-map-inv-distributive-implicit-Π-Σ
+```
+
+## Corollaries
+
+### Characterizing the identity type of `Π-total-fam`
+
+```agda
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2} (C : (x : A) → B x → UU l3)
+  (f g : (a : A) → Σ (B a) (C a))
+  where
+
+  Eq-Π-total-fam : UU (l1 ⊔ l2 ⊔ l3)
+  Eq-Π-total-fam =
+    Π-total-fam (λ x (p : pr1 (f x) ＝ pr1 (g x)) →
+      tr (C x) p (pr2 (f x)) ＝ pr2 (g x))
+
+  extensionality-Π-total-fam : (f ＝ g) ≃ Eq-Π-total-fam
+  extensionality-Π-total-fam =
+    ( inv-distributive-Π-Σ) ∘e
+    ( extensionality-universally-structured-Π C
+      ( map-distributive-Π-Σ f)
+      ( map-distributive-Π-Σ g)) ∘e
+    ( equiv-ap distributive-Π-Σ f g)
+
+  eq-Eq-Π-total-fam : Eq-Π-total-fam → f ＝ g
+  eq-Eq-Π-total-fam = map-inv-equiv extensionality-Π-total-fam
+```
+
+### Characterizing the identity type of `implicit-Π-total-fam`
+
+```agda
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : A → UU l2} (C : (x : A) → B x → UU l3)
+  (f g : {a : A} → Σ (B a) (C a))
+  where
+
+  extensionality-implicit-Π-total-fam :
+    (Id {A = {a : A} → Σ (B a) (C a)} f g) ≃
+    Eq-Π-total-fam C (λ x → f {x}) (λ x → g {x})
+  extensionality-implicit-Π-total-fam =
+    ( extensionality-Π-total-fam C (λ x → f {x}) (λ x → g {x})) ∘e
+    ( equiv-ap equiv-explicit-implicit-Π f g)
+
+  eq-Eq-implicit-Π-total-fam :
+    Eq-Π-total-fam C (λ x → f {x}) (λ x → g {x}) →
+    (Id {A = {a : A} → Σ (B a) (C a)} f g)
+  eq-Eq-implicit-Π-total-fam = map-inv-equiv extensionality-implicit-Π-total-fam
+```
+
+### Ordinary functions into a Σ-type
+
+```agda
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : B → UU l3}
+  where
+
+  mapping-into-Σ : (A → Σ B C) → Σ (A → B) (λ f → (x : A) → C (f x))
+  mapping-into-Σ = map-distributive-Π-Σ {B = λ _ → B}
+
+  abstract
+    is-equiv-mapping-into-Σ : is-equiv mapping-into-Σ
+    is-equiv-mapping-into-Σ = is-equiv-map-distributive-Π-Σ
+
+  equiv-mapping-into-Σ :
+    (A → Σ B C) ≃ Σ (A → B) (λ f → (x : A) → C (f x))
+  pr1 equiv-mapping-into-Σ = mapping-into-Σ
+  pr2 equiv-mapping-into-Σ = is-equiv-mapping-into-Σ
 ```


### PR DESCRIPTION
Adds a series of basic lemmas for implicit functions related to function extensionality. Also adds type-theoretic principle of choice for them for better computation.

This is factored out from my other PRs, as I need it for all of them, so they all now depend on this one to be merged first. If I don't get any objections quickly, I will probably just merge this one without review.