### PR TITLE
Acyclic types are closed under equivalences

### DIFF
--- a/src/synthetic-homotopy-theory/acyclic-types.lagda.md
+++ b/src/synthetic-homotopy-theory/acyclic-types.lagda.md
@@ -8,9 +8,11 @@ module synthetic-homotopy-theory.acyclic-types where
 
 ```agda
 open import foundation.contractible-types
+open import foundation.equivalences
 open import foundation.propositions
 open import foundation.universe-levels
 
+open import synthetic-homotopy-theory.functoriality-suspensions
 open import synthetic-homotopy-theory.suspensions-of-types
 ```
 
@@ -33,6 +35,23 @@ is-acyclic A = type-Prop (is-acyclic-Prop A)
 
 is-prop-is-acyclic : {l : Level} (A : UU l) → is-prop (is-acyclic A)
 is-prop-is-acyclic A = is-prop-type-Prop (is-acyclic-Prop A)
+```
+
+## Properties
+
+### Being acyclic is invariant under equivalence
+
+```agda
+is-acyclic-equiv :
+  {l1 l2 : Level} {A : UU l1} {B : UU l2} →
+  A ≃ B → is-acyclic B → is-acyclic A
+is-acyclic-equiv {B = B} e ac =
+  is-contr-equiv (suspension B) (equiv-suspension e) ac
+
+is-acyclic-equiv' :
+  {l1 l2 : Level} {A : UU l1} {B : UU l2} →
+  A ≃ B → is-acyclic A → is-acyclic B
+is-acyclic-equiv' e = is-acyclic-equiv (inv-equiv e)
 ```
 
 ## See also

--- a/src/synthetic-homotopy-theory/functoriality-suspensions.lagda.md
+++ b/src/synthetic-homotopy-theory/functoriality-suspensions.lagda.md
@@ -10,9 +10,13 @@ module synthetic-homotopy-theory.functoriality-suspensions where
 open import foundation.action-on-identifications-functions
 open import foundation.commuting-squares-of-identifications
 open import foundation.dependent-pair-types
+open import foundation.equivalences
+open import foundation.function-extensionality
 open import foundation.function-types
 open import foundation.homotopies
 open import foundation.identity-types
+open import foundation.retractions
+open import foundation.sections
 open import foundation.universe-levels
 
 open import synthetic-homotopy-theory.suspension-structures
@@ -189,4 +193,66 @@ module _
   preserves-comp-map-suspension :
     map-suspension (g ∘ f) ~ map-suspension g ∘ map-suspension f
   preserves-comp-map-suspension = inv-htpy inv-preserves-comp-map-suspension
+```
+
+### Suspensions preserve retracts
+
+```agda
+module _
+  {l1 l2 : Level} {A : UU l1} {B : UU l2}
+  where
+
+  section-map-suspension-section :
+    (f : A → B) → section f → section (map-suspension f)
+  pr1 (section-map-suspension-section f S) =
+    map-suspension (map-section f S)
+  pr2 (section-map-suspension-section f (s , h)) =
+    homotopy-reasoning
+      map-suspension f ∘ map-suspension s
+      ~ map-suspension (f ∘ s)
+        by inv-preserves-comp-map-suspension s f
+      ~ map-suspension id
+        by htpy-eq (ap map-suspension (eq-htpy h))
+      ~ id
+        by id-map-suspension B
+
+  retraction-map-suspension-retraction :
+    (f : A → B) → retraction f → retraction (map-suspension f)
+  pr1 (retraction-map-suspension-retraction f S) =
+    map-suspension (map-retraction f S)
+  pr2 (retraction-map-suspension-retraction f (r , h)) =
+    homotopy-reasoning
+      map-suspension r ∘ map-suspension f
+      ~ map-suspension (r ∘ f)
+        by inv-preserves-comp-map-suspension f r
+      ~ map-suspension id
+        by htpy-eq (ap map-suspension (eq-htpy h))
+      ~ id
+        by id-map-suspension A
+
+  suspension-retract-of-suspension-retract-of :
+    A retract-of B → (suspension A) retract-of (suspension B)
+  pr1 (suspension-retract-of-suspension-retract-of R) =
+    map-suspension (section-retract-of R)
+  pr2 (suspension-retract-of-suspension-retract-of R) =
+    retraction-map-suspension-retraction
+      ( section-retract-of R)
+      ( retraction-section-retract-of R)
+```
+
+### Equivalent types have equivalent suspensions
+
+```agda
+  is-equiv-map-suspension-is-equiv :
+    (f : A → B) → is-equiv f → is-equiv (map-suspension f)
+  pr1 (is-equiv-map-suspension-is-equiv f e) =
+    section-map-suspension-section f (section-is-equiv e)
+  pr2 (is-equiv-map-suspension-is-equiv f e) =
+    retraction-map-suspension-retraction f (retraction-is-equiv e)
+
+  equiv-suspension : A ≃ B → suspension A ≃ suspension B
+  pr1 (equiv-suspension e) =
+    map-suspension (map-equiv e)
+  pr2 (equiv-suspension e) =
+    is-equiv-map-suspension-is-equiv (map-equiv e) (is-equiv-map-equiv e)
 ```

--- a/src/synthetic-homotopy-theory/functoriality-suspensions.lagda.md
+++ b/src/synthetic-homotopy-theory/functoriality-suspensions.lagda.md
@@ -243,6 +243,10 @@ module _
 ### Equivalent types have equivalent suspensions
 
 ```agda
+module _
+  {l1 l2 : Level} {A : UU l1} {B : UU l2}
+  where
+
   is-equiv-map-suspension-is-equiv :
     (f : A → B) → is-equiv f → is-equiv (map-suspension f)
   pr1 (is-equiv-map-suspension-is-equiv f e) =

--- a/src/synthetic-homotopy-theory/functoriality-suspensions.lagda.md
+++ b/src/synthetic-homotopy-theory/functoriality-suspensions.lagda.md
@@ -202,11 +202,11 @@ module _
   {l1 l2 : Level} {A : UU l1} {B : UU l2}
   where
 
-  section-map-suspension-section :
+  has-section-map-suspension-has-section :
     (f : A → B) → section f → section (map-suspension f)
-  pr1 (section-map-suspension-section f S) =
+  pr1 (has-section-map-suspension-has-section f S) =
     map-suspension (map-section f S)
-  pr2 (section-map-suspension-section f (s , h)) =
+  pr2 (has-section-map-suspension-has-section f (s , h)) =
     homotopy-reasoning
       map-suspension f ∘ map-suspension s
       ~ map-suspension (f ∘ s)
@@ -216,11 +216,11 @@ module _
       ~ id
         by id-map-suspension B
 
-  retraction-map-suspension-retraction :
+  has-retraction-map-suspension-has-retraction :
     (f : A → B) → retraction f → retraction (map-suspension f)
-  pr1 (retraction-map-suspension-retraction f S) =
+  pr1 (has-retraction-map-suspension-has-retraction f S) =
     map-suspension (map-retraction f S)
-  pr2 (retraction-map-suspension-retraction f (r , h)) =
+  pr2 (has-retraction-map-suspension-has-retraction f (r , h)) =
     homotopy-reasoning
       map-suspension r ∘ map-suspension f
       ~ map-suspension (r ∘ f)
@@ -230,12 +230,12 @@ module _
       ~ id
         by id-map-suspension A
 
-  suspension-retract-of-suspension-retract-of :
+  retract-of-suspension-retract-of :
     A retract-of B → (suspension A) retract-of (suspension B)
-  pr1 (suspension-retract-of-suspension-retract-of R) =
+  pr1 (retract-of-suspension-retract-of R) =
     map-suspension (section-retract-of R)
-  pr2 (suspension-retract-of-suspension-retract-of R) =
-    retraction-map-suspension-retraction
+  pr2 (retract-of-suspension-retract-of R) =
+    has-retraction-map-suspension-has-retraction
       ( section-retract-of R)
       ( retraction-section-retract-of R)
 ```
@@ -250,9 +250,9 @@ module _
   is-equiv-map-suspension-is-equiv :
     (f : A → B) → is-equiv f → is-equiv (map-suspension f)
   pr1 (is-equiv-map-suspension-is-equiv f e) =
-    section-map-suspension-section f (section-is-equiv e)
+    has-section-map-suspension-has-section f (section-is-equiv e)
   pr2 (is-equiv-map-suspension-is-equiv f e) =
-    retraction-map-suspension-retraction f (retraction-is-equiv e)
+    has-retraction-map-suspension-has-retraction f (retraction-is-equiv e)
 
   equiv-suspension : A ≃ B → suspension A ≃ suspension B
   pr1 (equiv-suspension e) =

--- a/src/synthetic-homotopy-theory/functoriality-suspensions.lagda.md
+++ b/src/synthetic-homotopy-theory/functoriality-suspensions.lagda.md
@@ -202,11 +202,11 @@ module _
   {l1 l2 : Level} {A : UU l1} {B : UU l2}
   where
 
-  has-section-map-suspension-has-section :
+  section-map-suspension-section :
     (f : A → B) → section f → section (map-suspension f)
-  pr1 (has-section-map-suspension-has-section f S) =
+  pr1 (section-map-suspension-section f S) =
     map-suspension (map-section f S)
-  pr2 (has-section-map-suspension-has-section f (s , h)) =
+  pr2 (section-map-suspension-section f (s , h)) =
     homotopy-reasoning
       map-suspension f ∘ map-suspension s
       ~ map-suspension (f ∘ s)
@@ -216,11 +216,11 @@ module _
       ~ id
         by id-map-suspension B
 
-  has-retraction-map-suspension-has-retraction :
+  retraction-map-suspension-retraction :
     (f : A → B) → retraction f → retraction (map-suspension f)
-  pr1 (has-retraction-map-suspension-has-retraction f S) =
+  pr1 (retraction-map-suspension-retraction f S) =
     map-suspension (map-retraction f S)
-  pr2 (has-retraction-map-suspension-has-retraction f (r , h)) =
+  pr2 (retraction-map-suspension-retraction f (r , h)) =
     homotopy-reasoning
       map-suspension r ∘ map-suspension f
       ~ map-suspension (r ∘ f)
@@ -235,7 +235,7 @@ module _
   pr1 (retract-of-suspension-retract-of R) =
     map-suspension (section-retract-of R)
   pr2 (retract-of-suspension-retract-of R) =
-    has-retraction-map-suspension-has-retraction
+    retraction-map-suspension-retraction
       ( section-retract-of R)
       ( retraction-section-retract-of R)
 ```
@@ -250,9 +250,9 @@ module _
   is-equiv-map-suspension-is-equiv :
     (f : A → B) → is-equiv f → is-equiv (map-suspension f)
   pr1 (is-equiv-map-suspension-is-equiv f e) =
-    has-section-map-suspension-has-section f (section-is-equiv e)
+    section-map-suspension-section f (section-is-equiv e)
   pr2 (is-equiv-map-suspension-is-equiv f e) =
-    has-retraction-map-suspension-has-retraction f (retraction-is-equiv e)
+    retraction-map-suspension-retraction f (retraction-is-equiv e)
 
   equiv-suspension : A ≃ B → suspension A ≃ suspension B
   pr1 (equiv-suspension e) =


### PR DESCRIPTION
Relies on suspensions preserving equivalences (and retracts)