### PR TITLE
Refactoring of retractions, sections, and equivalences, and adding the 6-for-2 property of equivalences

### DIFF
--- a/src/foundation-core/commuting-squares-of-maps.lagda.md
+++ b/src/foundation-core/commuting-squares-of-maps.lagda.md
@@ -7,11 +7,13 @@ module foundation-core.commuting-squares-of-maps where
 <details><summary>Imports</summary>
 
 ```agda
+open import foundation.action-on-identifications-functions
 open import foundation.universe-levels
 
 open import foundation-core.commuting-triangles-of-maps
 open import foundation-core.function-types
 open import foundation-core.homotopies
+open import foundation-core.identity-types
 open import foundation-core.whiskering-homotopies
 ```
 
@@ -113,3 +115,110 @@ module _
       ( pasting-vertical-coherence-square-maps sq-top sq-bottom)) ∙h
     ( inv-htpy (K ·r top))
 ```
+
+### Associativity of horizontal pasting
+
+**Proof:** Consider a commuting diagram of the form
+
+```text
+        α₀       β₀       γ₀
+    A -----> X -----> U -----> K
+    |        |        |        |
+  f |   α  g |   β  h |   γ    | i
+    V        V        V        V
+    B -----> Y -----> V -----> L.
+        α₁       β₁       γ₁
+```
+
+Then we can make the following calculation, in which we write `□` for horizontal
+pasting of squares:
+
+```text
+  (α □ β) □ γ
+  ＝ (γ₁ ·l ((β₁ ·l α) ∙h (β ·r α₀))) ∙h (γ ·r (β₀ ∘ α₀))
+  ＝ ((γ₁ ·l (β₁ ·l α)) ∙h (γ₁ ·l (β ·r α₀))) ∙h (γ ·r (β₀ ∘ α₀))
+  ＝ ((γ₁ ∘ β₁) ·l α) ∙h (((γ₁ ·l β) ·r α₀) ∙h ((γ ·r β₀) ·r α₀))
+  ＝ ((γ₁ ∘ β₁) ·l α) ∙h (((γ₁ ·l β) ∙h (γ ·r β₀)) ·r α₀)
+  ＝ α □ (β □ γ)
+```
+
+```agda
+module _
+  {l1 l2 l3 l4 l5 l6 l7 l8 : Level}
+  {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4} {U : UU l5} {V : UU l6}
+  {K : UU l7} {L : UU l8}
+  (α₀ : A → X) (β₀ : X → U) (γ₀ : U → K)
+  (f : A → B) (g : X → Y) (h : U → V) (i : K → L)
+  (α₁ : B → Y) (β₁ : Y → V) (γ₁ : V → L)
+  (α : coherence-square-maps α₀ f g α₁)
+  (β : coherence-square-maps β₀ g h β₁)
+  (γ : coherence-square-maps γ₀ h i γ₁)
+  where
+
+  assoc-pasting-horizontal-coherence-square-maps :
+    pasting-horizontal-coherence-square-maps
+      ( β₀ ∘ α₀)
+      ( γ₀)
+      ( f)
+      ( h)
+      ( i)
+      ( β₁ ∘ α₁)
+      ( γ₁)
+      ( pasting-horizontal-coherence-square-maps α₀ β₀ f g h α₁ β₁ α β)
+      ( γ) ~
+    pasting-horizontal-coherence-square-maps
+      ( α₀)
+      ( γ₀ ∘ β₀)
+      ( f)
+      ( g)
+      ( i)
+      ( α₁)
+      ( γ₁ ∘ β₁)
+      ( α)
+      ( pasting-horizontal-coherence-square-maps β₀ γ₀ g h i β₁ γ₁ β γ)
+  assoc-pasting-horizontal-coherence-square-maps a =
+    ( ap
+      ( _∙ _)
+      ( ( ap-concat γ₁ (ap β₁ (α a)) (β (α₀ a))) ∙
+        ( inv (ap (_∙ _) (ap-comp γ₁ β₁ (α a)))))) ∙
+    ( assoc (ap (γ₁ ∘ β₁) (α a)) (ap γ₁ (β (α₀ a))) (γ (β₀ (α₀ a))))
+```
+
+### The unit laws for horizontal pasting of commuting squares of maps
+
+#### The left unit law
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
+  (i : A → X) (f : A → B) (g : X → Y) (j : B → Y)
+  (α : coherence-square-maps i f g j)
+  where
+
+  left-unit-law-pasting-horizontal-coherence-square-maps :
+    pasting-horizontal-coherence-square-maps id i f f g id j refl-htpy α ~ α
+  left-unit-law-pasting-horizontal-coherence-square-maps = refl-htpy
+```
+
+### The right unit law
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
+  (i : A → X) (f : A → B) (g : X → Y) (j : B → Y)
+  (α : coherence-square-maps i f g j)
+  where
+
+  right-unit-law-pasting-horizontal-coherence-square-maps :
+    pasting-horizontal-coherence-square-maps i id f g g j id α refl-htpy ~ α
+  right-unit-law-pasting-horizontal-coherence-square-maps a =
+    right-unit ∙ ap-id (α a)
+```
+
+## See also
+
+Several structures make essential use of commuting squares of maps:
+
+- [Cones over cospans](foundation.cones-over-cospans.md)
+- [Cocones under spans](synthetic-homotopy-theory.cocones-under-spans.md)
+- [Morphisms of arrows](foundation.morphisms-arrows.md)

--- a/src/foundation-core/commuting-triangles-of-maps.lagda.md
+++ b/src/foundation-core/commuting-triangles-of-maps.lagda.md
@@ -106,7 +106,7 @@ then the triangle
    g\     /f
      \   /
       V V
-       X,
+       X
 ```
 
 commutes.
@@ -138,7 +138,7 @@ then the triangle
    h\     /r
      \   /
       V V
-       B,
+       B
 ```
 
 commutes.

--- a/src/foundation-core/commuting-triangles-of-maps.lagda.md
+++ b/src/foundation-core/commuting-triangles-of-maps.lagda.md
@@ -128,16 +128,16 @@ module _
 
 ### If the right map has a retraction, then the reversed triangle with the retraction on the right commutes
 
-If `r : B → A` is a section of the top map `h`, then the triangle
+If `r : X → B` is a retraction of the right map `g` in a triangle `f ~ g ∘ h`, then the triangle
 
 ```text
-       t
-  B ------> A
+       f
+  A ------> X
    \       /
-   g\     /f
+   h\     /r
      \   /
       V V
-       X,
+       B,
 ```
 
 commutes.

--- a/src/foundation-core/commuting-triangles-of-maps.lagda.md
+++ b/src/foundation-core/commuting-triangles-of-maps.lagda.md
@@ -10,8 +10,9 @@ module foundation-core.commuting-triangles-of-maps where
 open import foundation.universe-levels
 
 open import foundation-core.function-types
-open import foundation-core.functoriality-function-types
 open import foundation-core.homotopies
+open import foundation-core.retractions
+open import foundation-core.sections
 open import foundation-core.whiskering-homotopies
 ```
 
@@ -22,16 +23,16 @@ open import foundation-core.whiskering-homotopies
 A triangle of maps
 
 ```text
-      top
-   A ----> B
-    \     /
-left \   / right
-      V V
-       X
+        top
+     A ----> B
+      \     /
+  left \   / right
+        V V
+         X
 ```
 
-is said to commute if there is a homotopy between the map on the left and the
-composite map
+is said to **commute** if there is a [homotopy](foundation-core.homotopies.md)
+between the map on the left and the composite of the top and right maps:
 
 ```text
   left ~ right ∘ top.
@@ -71,46 +72,87 @@ module _
     H ∙h (K ·r i)
 ```
 
-### Any commuting triangle of maps induces a commuting triangle of function spaces
-
-```agda
-module _
-  { l1 l2 l3 l4 : Level} {X : UU l1} {A : UU l2} {B : UU l3}
-  ( left : A → X) (right : B → X) (top : A → B)
-  where
-
-  precomp-coherence-triangle-maps :
-    coherence-triangle-maps left right top →
-    ( W : UU l4) →
-    coherence-triangle-maps
-      ( precomp left W)
-      ( precomp top W)
-      ( precomp right W)
-  precomp-coherence-triangle-maps H W = htpy-precomp H W
-
-  precomp-coherence-triangle-maps' :
-    coherence-triangle-maps' left right top →
-    ( W : UU l4) →
-    coherence-triangle-maps'
-      ( precomp left W)
-      ( precomp top W)
-      ( precomp right W)
-  precomp-coherence-triangle-maps' H W = htpy-precomp H W
-```
-
 ### Coherences of commuting triangles of maps with fixed vertices
 
 This or its opposite should be the coherence in the characterization of
 identifications of commuting triangles of maps with fixed end vertices.
 
 ```agda
-coherence-htpy-triangle-maps :
+module _
   {l1 l2 l3 : Level} {X : UU l1} {A : UU l2} {B : UU l3}
   (left : A → X) (right : B → X) (top : A → B)
-  (left' : A → X) (right' : B → X) (top' : A → B) →
-  coherence-triangle-maps left right top →
-  coherence-triangle-maps left' right' top' →
-  left ~ left' → right ~ right' → top ~ top' → UU (l1 ⊔ l2)
-coherence-htpy-triangle-maps left right top left' right' top' c c' L R T =
-  c ∙h htpy-comp-horizontal T R ~ L ∙h c'
+  (left' : A → X) (right' : B → X) (top' : A → B)
+  (c : coherence-triangle-maps left right top)
+  (c' : coherence-triangle-maps left' right' top')
+  where
+
+  coherence-htpy-triangle-maps :
+    left ~ left' → right ~ right' → top ~ top' → UU (l1 ⊔ l2)
+  coherence-htpy-triangle-maps L R T =
+    c ∙h htpy-comp-horizontal T R ~ L ∙h c'
+```
+
+## Properties
+
+### If the top map has a section, then the reversed triangle with the section on top commutes
+
+If `t : B → A` is a [section](foundation-core.sections.md) of the top map `h`,
+then the triangle
+
+```text
+       t
+  B ------> A
+   \       /
+   g\     /f
+     \   /
+      V V
+       X,
+```
+
+commutes.
+
+```agda
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
+  (f : A → X) (g : B → X) (h : A → B) (H : coherence-triangle-maps f g h)
+  (t : section h)
+  where
+
+  inv-triangle-section : coherence-triangle-maps' g f (map-section h t)
+  inv-triangle-section =
+    (H ·r map-section h t) ∙h (g ·l is-section-map-section h t)
+
+  triangle-section : coherence-triangle-maps g f (map-section h t)
+  triangle-section = inv-htpy inv-triangle-section
+```
+
+### If the right map has a retraction, then the reversed triangle with the retraction on the right commutes
+
+If `r : B → A` is a section of the top map `h`, then the triangle
+
+```text
+       t
+  B ------> A
+   \       /
+   g\     /f
+     \   /
+      V V
+       X,
+```
+
+commutes.
+
+```agda
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
+  (f : A → X) (g : B → X) (h : A → B) (H : coherence-triangle-maps f g h)
+  (r : retraction g)
+  where
+
+  inv-triangle-retraction : coherence-triangle-maps' h (map-retraction g r) f
+  inv-triangle-retraction =
+    (map-retraction g r ·l H) ∙h (is-retraction-map-retraction g r ·r h)
+
+  triangle-retraction : coherence-triangle-maps h (map-retraction g r) f
+  triangle-retraction = inv-htpy inv-triangle-retraction
 ```

--- a/src/foundation-core/commuting-triangles-of-maps.lagda.md
+++ b/src/foundation-core/commuting-triangles-of-maps.lagda.md
@@ -128,7 +128,8 @@ module _
 
 ### If the right map has a retraction, then the reversed triangle with the retraction on the right commutes
 
-If `r : X → B` is a retraction of the right map `g` in a triangle `f ~ g ∘ h`, then the triangle
+If `r : X → B` is a retraction of the right map `g` in a triangle `f ~ g ∘ h`,
+then the triangle
 
 ```text
        f

--- a/src/foundation-core/contractible-types.lagda.md
+++ b/src/foundation-core/contractible-types.lagda.md
@@ -12,6 +12,7 @@ open import foundation.dependent-pair-types
 open import foundation.equality-cartesian-product-types
 open import foundation.function-extensionality
 open import foundation.implicit-function-types
+open import foundation.retracts-of-types
 open import foundation.universe-levels
 
 open import foundation-core.cartesian-product-types

--- a/src/foundation-core/equivalences.lagda.md
+++ b/src/foundation-core/equivalences.lagda.md
@@ -101,32 +101,36 @@ A ≃ B = equiv A B
 
 ```agda
 module _
-  {l1 l2 : Level} {A : UU l1} {B : UU l2}
+  {l1 l2 : Level} {A : UU l1} {B : UU l2} (e : A ≃ B)
   where
 
-  map-equiv : (A ≃ B) → (A → B)
-  map-equiv e = pr1 e
+  map-equiv : A → B
+  map-equiv = pr1 e
 
-  is-equiv-map-equiv : (e : A ≃ B) → is-equiv (map-equiv e)
-  is-equiv-map-equiv e = pr2 e
+  is-equiv-map-equiv : is-equiv map-equiv
+  is-equiv-map-equiv = pr2 e
 
-  retraction-map-equiv : (e : A ≃ B) → retraction (map-equiv e)
-  retraction-map-equiv = retraction-is-equiv ∘ is-equiv-map-equiv
+  section-map-equiv : section map-equiv
+  section-map-equiv = section-is-equiv is-equiv-map-equiv
 
-  section-map-equiv : (e : A ≃ B) → section (map-equiv e)
-  section-map-equiv = section-is-equiv ∘ is-equiv-map-equiv
+  map-section-map-equiv : B → A
+  map-section-map-equiv = map-section map-equiv section-map-equiv
 
-  is-retraction-map-equiv :
-    (e : A ≃ B) →
-    ( map-equiv e ∘ map-section-is-equiv (is-equiv-map-equiv e)) ~ id
-  is-retraction-map-equiv =
-    is-section-map-section-is-equiv ∘ is-equiv-map-equiv
+  is-section-map-section-map-equiv :
+    is-section map-equiv map-section-map-equiv
+  is-section-map-section-map-equiv =
+    is-section-map-section map-equiv section-map-equiv
 
-  is-section-map-equiv :
-    (e : A ≃ B) →
-    ( map-retraction-is-equiv (is-equiv-map-equiv e) ∘ map-equiv e) ~ id
-  is-section-map-equiv =
-    is-retraction-map-retraction-is-equiv ∘ is-equiv-map-equiv
+  retraction-map-equiv : retraction map-equiv
+  retraction-map-equiv = retraction-is-equiv is-equiv-map-equiv
+
+  map-retraction-map-equiv : B → A
+  map-retraction-map-equiv = map-retraction map-equiv retraction-map-equiv
+
+  is-retraction-map-retraction-map-equiv :
+    is-retraction map-equiv map-retraction-map-equiv
+  is-retraction-map-retraction-map-equiv =
+    is-retraction-map-retraction map-equiv retraction-map-equiv
 ```
 
 ### Families of equivalences

--- a/src/foundation-core/equivalences.lagda.md
+++ b/src/foundation-core/equivalences.lagda.md
@@ -181,14 +181,12 @@ and hence an equivalence.
 For the converse, suppose that `f : A → B` is an equivalence with section
 `g : B → A` equipped with `G : f ∘ g ~ id`, and retraction `h : B → A` equipped
 with `H : h ∘ f ~ id`. We claim that the map `g : B → A` is also a retraction.
-To see this, we concatenate the following identifications
+To see this, we concatenate the following homotopies
 
 ```text
-           H (g (f x))⁻¹                  ap h (G (f x))           H x
-  g (f x) =============== h (f (g (f x)) ================ h (f x) ===== x
+         H⁻¹ ·r g ·r f                  h ·l G ·r f           H
+  g ∘ h ---------------> h ∘ f ∘ g ∘ f -------------> h ∘ f -----> id.
 ```
-
-for any element `x : A`.
 
 ```agda
 module _

--- a/src/foundation-core/equivalences.lagda.md
+++ b/src/foundation-core/equivalences.lagda.md
@@ -34,11 +34,12 @@ also called being **biinvertible**.
 
 The condition of biinvertibility may look odd: Why not say that an equivalence
 is a map that has a [2-sided inverse](foundation-core.invertible-maps.md)? The
-reason is that the condition of invertibility is structure, whereas the
-condition of being biinvertible is a
-[property](foundation-core.propositions.md). To quickly see this: if `f` is an
-equivalence, then it has up to [homotopy](foundation-core.homotopies.md) only
-one section, and it has up to homotopy only one retraction.
+reason is that the condition of invertibility is
+[structure](foundation.structure.md), whereas the condition of being
+biinvertible is a [property](foundation-core.propositions.md). To quickly see
+this: if `f` is an equivalence, then it has up to
+[homotopy](foundation-core.homotopies.md) only one section, and it has up to
+homotopy only one retraction.
 
 ## Definition
 

--- a/src/foundation-core/equivalences.lagda.md
+++ b/src/foundation-core/equivalences.lagda.md
@@ -14,6 +14,7 @@ open import foundation.universe-levels
 
 open import foundation-core.cartesian-product-types
 open import foundation-core.coherently-invertible-maps
+open import foundation-core.commuting-triangles-of-maps
 open import foundation-core.function-types
 open import foundation-core.homotopies
 open import foundation-core.identity-types
@@ -27,17 +28,21 @@ open import foundation-core.whiskering-homotopies
 
 ## Idea
 
-An equivalence is a map that has a section and a (separate) retraction. This is
-also called being biinvertible. This may look odd: Why not say that an
-equivalence is a map that has a 2-sided inverse? The reason is that the latter
-requirement would put nontrivial structure on the map, whereas having the
-section and retraction separate yields a property. To quickly see this: if `f`
-is an equivalence, then it has up to homotopy only one section, and it has up to
-homotopy only one retraction.
+An **equivalence** is a map that has a [section](foundation-core.sections.md)
+and a (separate) [retraction](foundation-core.retractions.md). This condition is
+also called being **biinvertible**.
+
+The condition of biinvertibility may look odd: Why not say that an equivalence
+is a map that has a [2-sided inverse](foundation-core.invertible-maps.md)? The
+reason is that the condition of invertibility is structure, whereas the
+condition of being biinvertible is a
+[property](foundation-core.propositions.md). To quickly see this: if `f` is an
+equivalence, then it has up to [homotopy](foundation-core.homotopies.md) only
+one section, and it has up to homotopy only one retraction.
 
 ## Definition
 
-### Equivalences
+### The predicate of being an equivalence
 
 ```agda
 module _
@@ -46,39 +51,55 @@ module _
 
   is-equiv : (A → B) → UU (l1 ⊔ l2)
   is-equiv f = section f × retraction f
+```
+
+### Components of a proof of equivalence
+
+```agda
+module _
+  {l1 l2 : Level} {A : UU l1} {B : UU l2} {f : A → B} (H : is-equiv f)
+  where
+
+  section-is-equiv : section f
+  section-is-equiv = pr1 H
+
+  retraction-is-equiv : retraction f
+  retraction-is-equiv = pr2 H
+
+  map-section-is-equiv : B → A
+  map-section-is-equiv = map-section f section-is-equiv
+
+  map-retraction-is-equiv : B → A
+  map-retraction-is-equiv = map-retraction f retraction-is-equiv
+
+  is-section-map-section-is-equiv : is-section f map-section-is-equiv
+  is-section-map-section-is-equiv = is-section-map-section f section-is-equiv
+
+  is-retraction-map-retraction-is-equiv :
+    is-retraction f map-retraction-is-equiv
+  is-retraction-map-retraction-is-equiv =
+    is-retraction-map-retraction f retraction-is-equiv
+```
+
+### Equivalences
+
+```agda
+module _
+  {l1 l2 : Level} (A : UU l1) (B : UU l2)
+  where
+
+  equiv : UU (l1 ⊔ l2)
+  equiv = Σ (A → B) is-equiv
 
 infix 6 _≃_
+
 _≃_ : {l1 l2 : Level} (A : UU l1) (B : UU l2) → UU (l1 ⊔ l2)
-A ≃ B = Σ (A → B) is-equiv
+A ≃ B = equiv A B
 ```
 
 ### Components of an equivalence
 
 ```agda
-module _
-  {l1 l2 : Level} {A : UU l1} {B : UU l2} {f : A → B}
-  where
-
-  section-is-equiv : is-equiv f → section f
-  section-is-equiv = pr1
-
-  retraction-is-equiv : is-equiv f → retraction f
-  retraction-is-equiv = pr2
-
-  map-section-is-equiv : is-equiv f → B → A
-  map-section-is-equiv = pr1 ∘ pr1
-
-  map-retraction-is-equiv : is-equiv f → B → A
-  map-retraction-is-equiv = pr1 ∘ pr2
-
-  is-retraction-is-equiv :
-    (is-equiv-f : is-equiv f) → (f ∘ map-section-is-equiv is-equiv-f) ~ id
-  is-retraction-is-equiv is-equiv-f = pr2 (pr1 is-equiv-f)
-
-  is-section-is-equiv :
-    (is-equiv-f : is-equiv f) → (map-retraction-is-equiv is-equiv-f ∘ f) ~ id
-  is-section-is-equiv is-equiv-f = pr2 (pr2 is-equiv-f)
-
 module _
   {l1 l2 : Level} {A : UU l1} {B : UU l2}
   where
@@ -98,12 +119,14 @@ module _
   is-retraction-map-equiv :
     (e : A ≃ B) →
     ( map-equiv e ∘ map-section-is-equiv (is-equiv-map-equiv e)) ~ id
-  is-retraction-map-equiv = is-retraction-is-equiv ∘ is-equiv-map-equiv
+  is-retraction-map-equiv =
+    is-section-map-section-is-equiv ∘ is-equiv-map-equiv
 
   is-section-map-equiv :
     (e : A ≃ B) →
     ( map-retraction-is-equiv (is-equiv-map-equiv e) ∘ map-equiv e) ~ id
-  is-section-map-equiv = is-section-is-equiv ∘ is-equiv-map-equiv
+  is-section-map-equiv =
+    is-retraction-map-retraction-is-equiv ∘ is-equiv-map-equiv
 ```
 
 ### Families of equivalences
@@ -125,7 +148,7 @@ module _
   fam-equiv B C = (x : A) → B x ≃ C x
 ```
 
-### The identity map is an equivalence
+### The identity equivalence
 
 ```agda
 module _
@@ -145,7 +168,23 @@ module _
 
 ## Properties
 
-### A map has an two-sided inverse if and only if it is an equivalence
+### A map is invertible if and only if it is an equivalence
+
+**Proof:** It is clear that if a map is
+[invertible](foundation-core.invertible-maps.md), then it is also biinvertible,
+and hence an equivalence.
+
+For the converse, suppose that `f : A → B` is an equivalence with section
+`g : B → A` equipped with `G : f ∘ g ~ id`, and retraction `h : B → A` equipped
+with `H : h ∘ f ~ id`. We claim that the map `g : B → A` is also a retraction.
+To see this, we concatenate the following identifications
+
+```text
+           H (g (f x))⁻¹                  ap h (G (f x))           H x
+  g (f x) =============== h (f (g (f x)) ================ h (f x) ===== x
+```
+
+for any element `x : A`.
 
 ```agda
 module _
@@ -153,21 +192,30 @@ module _
   where
 
   is-equiv-is-invertible' : is-invertible f → is-equiv f
-  pr1 (pr1 (is-equiv-is-invertible' (pair g (pair H K)))) = g
-  pr2 (pr1 (is-equiv-is-invertible' (pair g (pair H K)))) = H
-  pr1 (pr2 (is-equiv-is-invertible' (pair g (pair H K)))) = g
-  pr2 (pr2 (is-equiv-is-invertible' (pair g (pair H K)))) = K
+  pr1 (pr1 (is-equiv-is-invertible' (g , H , K))) = g
+  pr2 (pr1 (is-equiv-is-invertible' (g , H , K))) = H
+  pr1 (pr2 (is-equiv-is-invertible' (g , H , K))) = g
+  pr2 (pr2 (is-equiv-is-invertible' (g , H , K))) = K
 
   is-equiv-is-invertible :
     (g : B → A) (H : (f ∘ g) ~ id) (K : (g ∘ f) ~ id) → is-equiv f
   is-equiv-is-invertible g H K =
-    is-equiv-is-invertible' (pair g (pair H K))
+    is-equiv-is-invertible' (g , H , K)
+
+  is-retraction-map-section-is-equiv :
+    (H : is-equiv f) → is-retraction f (map-section-is-equiv H)
+  is-retraction-map-section-is-equiv H =
+    ( ( ( inv-htpy
+          ( ( is-retraction-map-retraction-is-equiv H) ·r
+            ( map-section-is-equiv H))) ∙h
+        ( map-retraction-is-equiv H ·l is-section-map-section-is-equiv H)) ·r
+      ( f)) ∙h
+    ( is-retraction-map-retraction-is-equiv H)
 
   is-invertible-is-equiv : is-equiv f → is-invertible f
-  pr1 (is-invertible-is-equiv (pair (pair g G) (pair h H))) = g
-  pr1 (pr2 (is-invertible-is-equiv (pair (pair g G) (pair h H)))) = G
-  pr2 (pr2 (is-invertible-is-equiv (pair (pair g G) (pair h H)))) =
-    (((inv-htpy (H ·r g)) ∙h (h ·l G)) ·r f) ∙h H
+  pr1 (is-invertible-is-equiv H) = map-section-is-equiv H
+  pr1 (pr2 (is-invertible-is-equiv H)) = is-section-map-section-is-equiv H
+  pr2 (pr2 (is-invertible-is-equiv H)) = is-retraction-map-section-is-equiv H
 ```
 
 ### Coherently invertible maps are equivalences
@@ -185,8 +233,8 @@ module _
   abstract
     is-equiv-is-coherently-invertible :
       is-coherently-invertible f → is-equiv f
-    is-equiv-is-coherently-invertible (g , G , H , K) =
-      is-equiv-is-invertible g G H
+    is-equiv-is-coherently-invertible H =
+      is-equiv-is-invertible' (is-invertible-is-coherently-invertible H)
 ```
 
 ### Structure obtained from being coherently invertible
@@ -199,16 +247,19 @@ module _
   map-inv-is-equiv : B → A
   map-inv-is-equiv = pr1 (is-invertible-is-equiv H)
 
-  is-section-map-inv-is-equiv : (f ∘ map-inv-is-equiv) ~ id
+  is-section-map-inv-is-equiv : is-section f map-inv-is-equiv
   is-section-map-inv-is-equiv =
     is-section-map-inv-is-invertible (is-invertible-is-equiv H)
 
-  is-retraction-map-inv-is-equiv : (map-inv-is-equiv ∘ f) ~ id
+  is-retraction-map-inv-is-equiv : is-retraction f map-inv-is-equiv
   is-retraction-map-inv-is-equiv =
     is-retraction-map-inv-is-invertible (is-invertible-is-equiv H)
 
   coherence-map-inv-is-equiv :
-    ( is-section-map-inv-is-equiv ·r f) ~ (f ·l is-retraction-map-inv-is-equiv)
+    coherence-is-coherently-invertible f
+      ( map-inv-is-equiv)
+      ( is-section-map-inv-is-equiv)
+      ( is-retraction-map-inv-is-equiv)
   coherence-map-inv-is-equiv =
     coherence-map-inv-is-invertible (is-invertible-is-equiv H)
 
@@ -229,16 +280,19 @@ module _
   map-inv-equiv : B → A
   map-inv-equiv = map-inv-is-equiv (is-equiv-map-equiv e)
 
-  is-section-map-inv-equiv : ((map-equiv e) ∘ map-inv-equiv) ~ id
+  is-section-map-inv-equiv : is-section (map-equiv e) map-inv-equiv
   is-section-map-inv-equiv = is-section-map-inv-is-equiv (is-equiv-map-equiv e)
 
-  is-retraction-map-inv-equiv : (map-inv-equiv ∘ (map-equiv e)) ~ id
+  is-retraction-map-inv-equiv : is-retraction (map-equiv e) map-inv-equiv
   is-retraction-map-inv-equiv =
     is-retraction-map-inv-is-equiv (is-equiv-map-equiv e)
 
   coherence-map-inv-equiv :
-    ( is-section-map-inv-equiv ·r (map-equiv e)) ~
-    ( (map-equiv e) ·l is-retraction-map-inv-equiv)
+    coherence-is-coherently-invertible
+      ( map-equiv e)
+      ( map-inv-equiv)
+      ( is-section-map-inv-equiv)
+      ( is-retraction-map-inv-equiv)
   coherence-map-inv-equiv =
     coherence-map-inv-is-equiv (is-equiv-map-equiv e)
 
@@ -252,21 +306,114 @@ module _
 
 ### The 3-for-2 property of equivalences
 
-#### Composites of equivalences are equivalences
+The **3-for-2 property** of equivalences asserts that for any
+[commuting triangle](foundation-core.commuting-triangles-of-maps.md) of maps
+
+```text
+       h
+  A ------> B
+   \       /
+   f\     /g
+     \   /
+      V V
+       X,
+```
+
+if two of the three maps are equivalences, then so is the third.
+
+We also record special cases of the 3-for-2 property of equivalences, where we
+only assume maps `g : B → X` and `h : A → B`. In this special case, we set
+`f := g ∘ h` and the triangle commutes by `refl-htpy`.
+
+[André Joyal](https://en.wikipedia.org/wiki/André_Joyal) proposed calling this
+property the 3-for-2 property, despite most mathematicians calling it the
+_2-out-of-3 property_. The story goes that on the produce market is is common to
+advertise a discount as "3-for-2". If you buy two apples, then you get the third
+for free. Similarly, if you prove that two maps in a commuting triangle are
+equivalences, then you get the third for free.
+
+#### The left map in a commuting triangle is an equivalence if the other two maps are equivalences
 
 ```agda
 module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
-  (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
+  (f : A → X) (g : B → X) (h : A → B) (T : f ~ g ∘ h)
   where
 
   abstract
-    is-equiv-comp-htpy : is-equiv h → is-equiv g → is-equiv f
-    pr1 (is-equiv-comp-htpy (sh , rh) (sg , rg)) =
-      section-comp-htpy f g h H sh sg
-    pr2 (is-equiv-comp-htpy (sh , rh) (sg , rg)) =
-      retraction-comp-htpy f g h H rg rh
+    is-equiv-left-map-triangle : is-equiv h → is-equiv g → is-equiv f
+    pr1 (is-equiv-left-map-triangle H G) =
+      section-left-map-triangle f g h T
+        ( section-is-equiv H)
+        ( section-is-equiv G)
+    pr2 (is-equiv-left-map-triangle H G) =
+      retraction-left-map-triangle f g h T
+        ( retraction-is-equiv G)
+        ( retraction-is-equiv H)
+```
 
+#### The right map in a commuting triangle is an equivalence if the other two maps are equivalences
+
+```agda
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
+  (f : A → X) (g : B → X) (h : A → B) (H : f ~ g ∘ h)
+  where
+
+  abstract
+    is-equiv-right-map-triangle :
+      is-equiv f → is-equiv h → is-equiv g
+    is-equiv-right-map-triangle
+      ( section-f , retraction-f)
+      ( (sh , is-section-sh) , retraction-h) =
+        ( pair
+          ( section-right-map-triangle f g h H section-f)
+          ( retraction-left-map-triangle g f sh
+            ( triangle-section f g h H (sh , is-section-sh))
+            ( retraction-f)
+            ( h , is-section-sh)))
+```
+
+#### If the left and right maps in a commuting triangle are equivalences, then the top map is an equivalence
+
+```agda
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
+  (f : A → X) (g : B → X) (h : A → B) (H : f ~ g ∘ h)
+  where
+
+  section-is-equiv-top-map-triangle :
+    is-equiv g → is-equiv f → section h
+  section-is-equiv-top-map-triangle G F =
+    section-left-map-triangle h
+      ( map-retraction-is-equiv G)
+      ( f)
+      ( triangle-retraction f g h H (retraction-is-equiv G))
+      ( section-is-equiv F)
+      ( g , is-retraction-map-retraction-is-equiv G)
+
+  map-section-is-equiv-top-map-triangle :
+    is-equiv g → is-equiv f → B → A
+  map-section-is-equiv-top-map-triangle G F =
+    map-section h (section-is-equiv-top-map-triangle G F)
+
+  abstract
+    is-equiv-top-map-triangle :
+      is-equiv g → is-equiv f → is-equiv h
+    is-equiv-top-map-triangle
+      ( section-g , (rg , is-retraction-rg))
+      ( section-f , retraction-f) =
+      ( pair
+        ( section-left-map-triangle h rg f
+          ( triangle-retraction f g h H (rg , is-retraction-rg))
+          ( section-f)
+          ( g , is-retraction-rg))
+        ( retraction-top-map-triangle f g h H retraction-f))
+```
+
+#### Composites of equivalences are equivalences
+
+```agda
 module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
   where
@@ -295,25 +442,11 @@ module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
   where
 
-  abstract
-    is-equiv-left-factor-htpy :
-      (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
-      is-equiv f → is-equiv h → is-equiv g
-    is-equiv-left-factor-htpy f g h H
-      ( pair section-f retraction-f)
-      ( pair (pair sh is-section-sh) retraction-h) =
-        ( pair
-          ( section-left-factor-htpy f g h H section-f)
-          ( retraction-comp-htpy g f sh
-            ( triangle-section f g h H (pair sh is-section-sh))
-            ( retraction-f)
-            ( pair h is-section-sh)))
-
   is-equiv-left-factor :
     (g : B → X) (h : A → B) →
     is-equiv (g ∘ h) → is-equiv h → is-equiv g
   is-equiv-left-factor g h is-equiv-gh is-equiv-h =
-      is-equiv-left-factor-htpy (g ∘ h) g h refl-htpy is-equiv-gh is-equiv-h
+      is-equiv-right-map-triangle (g ∘ h) g h refl-htpy is-equiv-gh is-equiv-h
 ```
 
 #### If a composite and its left factor are equivalences, then so is its right factor
@@ -323,25 +456,11 @@ module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
   where
 
-  abstract
-    is-equiv-right-factor-htpy :
-      (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
-      is-equiv g → is-equiv f → is-equiv h
-    is-equiv-right-factor-htpy f g h H
-        ( pair section-g (pair rg is-retraction-rg))
-        ( pair section-f retraction-f) =
-          ( pair
-            ( section-comp-htpy h rg f
-              ( triangle-retraction f g h H (pair rg is-retraction-rg))
-              ( section-f)
-              ( pair g is-retraction-rg))
-            ( retraction-right-factor-htpy f g h H retraction-f))
-
   is-equiv-right-factor :
     (g : B → X) (h : A → B) →
     is-equiv g → is-equiv (g ∘ h) → is-equiv h
   is-equiv-right-factor g h is-equiv-g is-equiv-gh =
-    is-equiv-right-factor-htpy (g ∘ h) g h refl-htpy is-equiv-g is-equiv-gh
+    is-equiv-top-map-triangle (g ∘ h) g h refl-htpy is-equiv-g is-equiv-gh
 ```
 
 ### Equivalences are closed under homotopies
@@ -393,7 +512,7 @@ abstract
     {l1 l2 : Level} {A : UU l1} {B : UU l2} {f : A → B} {g : B → A} →
     is-equiv f → (g ∘ f) ~ id → is-equiv g
   is-equiv-is-retraction {A = A} {f = f} {g = g} is-equiv-f H =
-    is-equiv-left-factor-htpy id g f (inv-htpy H) is-equiv-id is-equiv-f
+    is-equiv-right-map-triangle id g f (inv-htpy H) is-equiv-id is-equiv-f
 ```
 
 ### Any section of an equivalence is an equivalence
@@ -404,7 +523,7 @@ abstract
     {l1 l2 : Level} {A : UU l1} {B : UU l2} {f : A → B} {g : B → A} →
     is-equiv f → f ∘ g ~ id → is-equiv g
   is-equiv-is-section {B = B} {f = f} {g = g} is-equiv-f H =
-    is-equiv-right-factor-htpy id f g (inv-htpy H) is-equiv-f is-equiv-id
+    is-equiv-top-map-triangle id f g (inv-htpy H) is-equiv-f is-equiv-id
 ```
 
 ### If a section of `f` is an equivalence, then `f` is an equivalence
@@ -417,7 +536,7 @@ module _
   abstract
     is-equiv-section-is-equiv :
       ( section-f : section f) → is-equiv (pr1 section-f) → is-equiv f
-    is-equiv-section-is-equiv (pair g is-section-g) is-equiv-section-f =
+    is-equiv-section-is-equiv (g , is-section-g) is-equiv-section-f =
       is-equiv-htpy h
         ( ( f ·l (inv-htpy (is-section-map-inv-is-equiv is-equiv-section-f))) ∙h
           ( htpy-right-whisk is-section-g h))
@@ -466,7 +585,7 @@ is-equiv-equiv {f = f} {g} i j H K =
     ( map-equiv j)
     ( f)
     ( is-equiv-map-equiv j)
-    ( is-equiv-comp-htpy
+    ( is-equiv-left-map-triangle
       ( map-equiv j ∘ f)
       ( g)
       ( map-equiv i)
@@ -482,7 +601,7 @@ is-equiv-equiv' {f = f} {g} i j H K =
   is-equiv-left-factor
     ( g)
     ( map-equiv i)
-    ( is-equiv-comp-htpy
+    ( is-equiv-left-map-triangle
       ( g ∘ map-equiv i)
       ( map-equiv j)
       ( f)
@@ -495,13 +614,13 @@ is-equiv-equiv' {f = f} {g} i j H K =
 We will assume a commuting square
 
 ```text
-          h
-    A --------> C
-    |           |
-   f|           |g
-    V           V
-    B --------> D
-          i
+        h
+    A -----> C
+    |        |
+  f |        | g
+    V        V
+    B -----> D
+        i
 ```
 
 ```agda
@@ -514,31 +633,34 @@ module _
     is-equiv-top-is-equiv-left-square :
       is-equiv i → is-equiv f → is-equiv g → is-equiv h
     is-equiv-top-is-equiv-left-square Ei Ef Eg =
-      is-equiv-right-factor-htpy (i ∘ f) g h H Eg (is-equiv-comp i f Ef Ei)
+      is-equiv-top-map-triangle (i ∘ f) g h H Eg (is-equiv-comp i f Ef Ei)
 
   abstract
     is-equiv-top-is-equiv-bottom-square :
       is-equiv f → is-equiv g → is-equiv i → is-equiv h
     is-equiv-top-is-equiv-bottom-square Ef Eg Ei =
-      is-equiv-right-factor-htpy (i ∘ f) g h H Eg (is-equiv-comp i f Ef Ei)
+      is-equiv-top-map-triangle (i ∘ f) g h H Eg (is-equiv-comp i f Ef Ei)
 
   abstract
     is-equiv-bottom-is-equiv-top-square :
       is-equiv f → is-equiv g → is-equiv h → is-equiv i
     is-equiv-bottom-is-equiv-top-square Ef Eg Eh =
-      is-equiv-left-factor i f (is-equiv-comp-htpy (i ∘ f) g h H Eh Eg) Ef
+      is-equiv-left-factor i f
+        ( is-equiv-left-map-triangle (i ∘ f) g h H Eh Eg)
+        ( Ef)
 
   abstract
     is-equiv-left-is-equiv-right-square :
       is-equiv h → is-equiv i → is-equiv g → is-equiv f
     is-equiv-left-is-equiv-right-square Eh Ei Eg =
-      is-equiv-right-factor i f Ei (is-equiv-comp-htpy (i ∘ f) g h H Eh Eg)
+      is-equiv-right-factor i f Ei
+        ( is-equiv-left-map-triangle (i ∘ f) g h H Eh Eg)
 
   abstract
     is-equiv-right-is-equiv-left-square :
       is-equiv h → is-equiv i → is-equiv f → is-equiv g
     is-equiv-right-is-equiv-left-square Eh Ei Ef =
-      is-equiv-left-factor-htpy (i ∘ f) g h H (is-equiv-comp i f Ef Ei) Eh
+      is-equiv-right-map-triangle (i ∘ f) g h H (is-equiv-comp i f Ef Ei) Eh
 ```
 
 ### Equivalences are embeddings

--- a/src/foundation-core/fibers-of-maps.lagda.md
+++ b/src/foundation-core/fibers-of-maps.lagda.md
@@ -111,6 +111,11 @@ module _
   equiv-eq-Eq-fiber : {s t : fiber f b} → Eq-fiber s t ≃ (s ＝ t)
   pr1 equiv-eq-Eq-fiber = eq-Eq-fiber-uncurry
   pr2 equiv-eq-Eq-fiber = is-equiv-eq-Eq-fiber
+
+  compute-ap-inclusion-fiber-eq-Eq-fiber :
+    {s t : fiber f b} (α : pr1 s ＝ pr1 t) (β : ap f α ∙ pr2 t ＝ pr2 s) →
+    ap (inclusion-fiber f) (eq-Eq-fiber α β) ＝ α
+  compute-ap-inclusion-fiber-eq-Eq-fiber refl refl = refl
 ```
 
 #### The case of `fiber'`

--- a/src/foundation-core/functoriality-dependent-pair-types.lagda.md
+++ b/src/foundation-core/functoriality-dependent-pair-types.lagda.md
@@ -333,7 +333,7 @@ module _
       {f : A → B} {g : (x : A) → C x → D (f x)} →
       is-equiv f → is-fiberwise-equiv g → is-equiv (map-Σ D f g)
     is-equiv-map-Σ {f} {g} is-equiv-f is-fiberwise-equiv-g =
-      is-equiv-comp-htpy
+      is-equiv-left-map-triangle
         ( map-Σ D f g)
         ( map-Σ-map-base f D)
         ( tot g)
@@ -355,7 +355,7 @@ module _
       is-equiv f → is-equiv (map-Σ D f g) → is-fiberwise-equiv g
     is-fiberwise-equiv-is-equiv-map-Σ f g H K =
       is-fiberwise-equiv-is-equiv-tot
-        ( is-equiv-right-factor-htpy
+        ( is-equiv-top-map-triangle
           ( map-Σ D f g)
           ( map-Σ-map-base f D)
           ( tot g)

--- a/src/foundation-core/functoriality-function-types.lagda.md
+++ b/src/foundation-core/functoriality-function-types.lagda.md
@@ -13,6 +13,7 @@ open import foundation.function-extensionality
 open import foundation.type-theoretic-principle-of-choice
 open import foundation.universe-levels
 
+open import foundation-core.commuting-triangles-of-maps
 open import foundation-core.contractible-maps
 open import foundation-core.contractible-types
 open import foundation-core.equivalences
@@ -311,6 +312,33 @@ is-equiv-is-equiv-precomp-Truncated-Type :
 is-equiv-is-equiv-precomp-Truncated-Type k A B f H =
     is-equiv-is-equiv-precomp-subuniverse (λ l → l) (λ l → is-trunc k) A B f
       ( λ l → H {l})
+```
+
+### Any commuting triangle of maps induces a commuting triangle of function spaces
+
+```agda
+module _
+  { l1 l2 l3 l4 : Level} {X : UU l1} {A : UU l2} {B : UU l3}
+  ( left : A → X) (right : B → X) (top : A → B)
+  where
+
+  precomp-coherence-triangle-maps :
+    coherence-triangle-maps left right top →
+    ( W : UU l4) →
+    coherence-triangle-maps
+      ( precomp left W)
+      ( precomp top W)
+      ( precomp right W)
+  precomp-coherence-triangle-maps H W = htpy-precomp H W
+
+  precomp-coherence-triangle-maps' :
+    coherence-triangle-maps' left right top →
+    ( W : UU l4) →
+    coherence-triangle-maps'
+      ( precomp left W)
+      ( precomp top W)
+      ( precomp right W)
+  precomp-coherence-triangle-maps' H W = htpy-precomp H W
 ```
 
 ## See also

--- a/src/foundation-core/identity-types.lagda.md
+++ b/src/foundation-core/identity-types.lagda.md
@@ -157,18 +157,29 @@ module _
 
 ```agda
 module _
-  {l : Level} {A : UU l} {x y : A}
+  {l : Level} {A : UU l}
   where
 
   left-transpose-eq-concat :
-    (p : x ＝ y) {z : A} (q : y ＝ z) (r : x ＝ z) →
+    {x y : A} (p : x ＝ y) {z : A} (q : y ＝ z) (r : x ＝ z) →
     p ∙ q ＝ r → q ＝ inv p ∙ r
   left-transpose-eq-concat refl q r s = s
 
   right-transpose-eq-concat :
-    (p : x ＝ y) {z : A} (q : y ＝ z) (r : x ＝ z) →
+    {x y : A} (p : x ＝ y) {z : A} (q : y ＝ z) (r : x ＝ z) →
     p ∙ q ＝ r → p ＝ r ∙ inv q
   right-transpose-eq-concat p refl r s = (inv right-unit ∙ s) ∙ inv right-unit
+
+  double-transpose-eq-concat :
+    {x y u v : A} (r : x ＝ u) (p : x ＝ y) (s : u ＝ v) (q : y ＝ v) →
+    p ∙ q ＝ r ∙ s → (inv r) ∙ p ＝ s ∙ (inv q)
+  double-transpose-eq-concat refl p s refl α =
+    (inv right-unit ∙ α) ∙ inv right-unit
+
+  double-transpose-eq-concat' :
+    {x y u v : A} (r : x ＝ u) (p : x ＝ y) (s : u ＝ v) (q : y ＝ v) →
+    p ∙ q ＝ r ∙ s → q ∙ inv s ＝ inv p ∙ r
+  double-transpose-eq-concat' r refl refl q α = right-unit ∙ (α ∙ right-unit)
 ```
 
 The fact that `left-transpose-eq-concat` and `right-transpose-eq-concat` are

--- a/src/foundation-core/injective-maps.lagda.md
+++ b/src/foundation-core/injective-maps.lagda.md
@@ -73,10 +73,10 @@ module _
     is-injective (g ∘ h) → is-injective h
   is-injective-right-factor g h is-inj-gh p = is-inj-gh (ap g p)
 
-  is-injective-right-factor-htpy :
+  is-injective-top-map-triangle :
     (f : A → C) (g : B → C) (h : A → B) (H : f ~ (g ∘ h)) →
     is-injective f → is-injective h
-  is-injective-right-factor-htpy f g h H is-inj-f {x} {x'} p =
+  is-injective-top-map-triangle f g h H is-inj-f {x} {x'} p =
     is-inj-f {x} {x'} ((H x) ∙ ((ap g p) ∙ (inv (H x'))))
 ```
 
@@ -92,10 +92,10 @@ module _
     is-injective h → is-injective g → is-injective (g ∘ h)
   is-injective-comp is-inj-h is-inj-g = is-inj-h ∘ is-inj-g
 
-  is-injective-comp-htpy :
+  is-injective-left-map-triangle :
     (f : A → C) (g : B → C) (h : A → B) → f ~ (g ∘ h) →
     is-injective h → is-injective g → is-injective f
-  is-injective-comp-htpy f g h H is-inj-h is-inj-g {x} {x'} p =
+  is-injective-left-map-triangle f g h H is-inj-h is-inj-g {x} {x'} p =
     is-inj-h (is-inj-g ((inv (H x)) ∙ (p ∙ (H x'))))
 ```
 

--- a/src/foundation-core/pullbacks.lagda.md
+++ b/src/foundation-core/pullbacks.lagda.md
@@ -334,7 +334,7 @@ abstract
     (f : A → X) (g : B → X) (c : cone f g C) →
     is-pullback f g c → is-pullback g f (swap-cone f g c)
   is-pullback-swap-cone f g c is-pb-c =
-    is-equiv-comp-htpy
+    is-equiv-left-map-triangle
       ( gap g f (swap-cone f g c))
       ( map-commutative-standard-pullback f g)
       ( gap f g c)
@@ -348,7 +348,7 @@ abstract
     (f : A → X) (g : B → X) (c : cone f g C) →
     is-pullback g f (swap-cone f g c) → is-pullback f g c
   is-pullback-swap-cone' f g c is-pb-c' =
-    is-equiv-right-factor-htpy
+    is-equiv-top-map-triangle
       ( gap g f (swap-cone f g c))
       ( map-commutative-standard-pullback f g)
       ( gap f g c)
@@ -400,7 +400,7 @@ abstract
       ( ap pr2 α)
       ( ( inv (is-section-pair-eq α)) ∙
         ( ap
-          ( λ t → (eq-pair t (ap pr2 α)))
+          ( λ t → eq-pair t (ap pr2 α))
           ( ( inv right-unit) ∙
             ( inv (ap (concat (ap pr1 α) x) (left-inv (ap pr2 α)))) ∙
             ( inv (assoc (ap pr1 α) (inv (ap pr2 α)) (ap pr2 α))))) ∙
@@ -458,7 +458,7 @@ abstract
     is-pullback f g c →
     is-pullback (map-prod f g) (diagonal X) (fold-cone f g c)
   is-pullback-fold-cone-is-pullback {X = X} f g c is-pb-c =
-    is-equiv-comp-htpy
+    is-equiv-left-map-triangle
       ( gap (map-prod f g) (diagonal X) (fold-cone f g c))
       ( map-fold-cone f g)
       ( gap f g c)
@@ -473,7 +473,7 @@ abstract
     is-pullback (map-prod f g) (diagonal X) (fold-cone f g c) →
     is-pullback f g c
   is-pullback-is-pullback-fold-cone {X = X} f g c is-pb-fold =
-    is-equiv-right-factor-htpy
+    is-equiv-top-map-triangle
       ( gap (map-prod f g) (diagonal X) (fold-cone f g c))
       ( map-fold-cone f g)
       ( gap f g c)
@@ -547,13 +547,14 @@ abstract
               ( λ y p y' → f' (pr2 t) ＝ g' y'))
             ( is-equiv-map-interchange-Σ-Σ _)
             ( is-equiv-tot-is-fiberwise-equiv
-              ( λ s → is-equiv-comp
-                ( eq-pair')
-                ( id)
-                ( is-equiv-id)
-                ( is-equiv-eq-pair
-                  ( map-prod f f' t)
-                  ( map-prod g g' s))))))
+              ( λ s →
+                is-equiv-comp
+                  ( eq-pair')
+                  ( id)
+                  ( is-equiv-id)
+                  ( is-equiv-eq-pair
+                    ( map-prod f f' t)
+                    ( map-prod g g' s))))))
 
 abstract
   is-pullback-prod-is-pullback-pair :
@@ -566,7 +567,7 @@ abstract
     is-pullback
       ( map-prod f f') (map-prod g g') (prod-cone f g f' g' c c')
   is-pullback-prod-is-pullback-pair f g c f' g' c' is-pb-c is-pb-c' =
-    is-equiv-comp-htpy
+    is-equiv-left-map-triangle
       ( gap (map-prod f f') (map-prod g g') (prod-cone f g f' g' c c'))
       ( map-prod-cone f g f' g')
       ( map-prod (gap f g c) (gap f' g' c'))
@@ -588,7 +589,7 @@ abstract
     standard-pullback f' g' → is-pullback f g c
   is-pullback-left-factor-is-pullback-prod f g c f' g' c' is-pb-cc' t =
     is-equiv-left-factor-is-equiv-map-prod (gap f g c) (gap f' g' c') t
-      ( is-equiv-right-factor-htpy
+      ( is-equiv-top-map-triangle
         ( gap
           ( map-prod f f')
           ( map-prod g g')
@@ -613,7 +614,7 @@ abstract
     standard-pullback f g → is-pullback f' g' c'
   is-pullback-right-factor-is-pullback-prod f g c f' g' c' is-pb-cc' t =
     is-equiv-right-factor-is-equiv-map-prod (gap f g c) (gap f' g' c') t
-      ( is-equiv-right-factor-htpy
+      ( is-equiv-top-map-triangle
         ( gap
           ( map-prod f f')
           ( map-prod g g')
@@ -705,8 +706,9 @@ module _
           ( square-tot-map-fiber-cone)
           ( is-equiv-map-equiv-total-fiber (vertical-map-cone f g c))
           ( is-equiv-tot-is-fiberwise-equiv
-            ( λ x → is-equiv-tot-is-fiberwise-equiv
-              ( λ y → is-equiv-inv (g y) (f x))))
+            ( λ x →
+              is-equiv-tot-is-fiberwise-equiv
+                ( λ y → is-equiv-inv (g y) (f x))))
           ( pb))
 
   abstract
@@ -721,8 +723,9 @@ module _
         ( square-tot-map-fiber-cone)
         ( is-equiv-map-equiv-total-fiber (vertical-map-cone f g c))
         ( is-equiv-tot-is-fiberwise-equiv
-          ( λ x → is-equiv-tot-is-fiberwise-equiv
-            ( λ y → is-equiv-inv (g y) (f x))))
+          ( λ x →
+            is-equiv-tot-is-fiberwise-equiv
+              ( λ y → is-equiv-inv (g y) (f x))))
         ( is-equiv-tot-is-fiberwise-equiv is-equiv-fsq)
 ```
 
@@ -743,17 +746,19 @@ module _
     is-pullback-rectangle-is-pullback-left-square c d is-pb-c is-pb-d =
       is-pullback-is-fiberwise-equiv-map-fiber-cone (j ∘ i) h
         ( pasting-horizontal-cone i j h c d)
-        ( λ x → is-equiv-comp-htpy
-          ( map-fiber-cone (j ∘ i) h (pasting-horizontal-cone i j h c d) x)
-          ( map-fiber-cone j h c (i x))
-          ( map-fiber-cone i (vertical-map-cone j h c) d x)
-          ( map-fiber-pasting-horizontal-cone i j h c d x)
-          ( is-fiberwise-equiv-map-fiber-cone-is-pullback i
-            ( vertical-map-cone j h c)
-            ( d)
-            ( is-pb-d)
-            ( x))
-          ( is-fiberwise-equiv-map-fiber-cone-is-pullback j h c is-pb-c (i x)))
+        ( λ x →
+          is-equiv-left-map-triangle
+            ( map-fiber-cone (j ∘ i) h (pasting-horizontal-cone i j h c d) x)
+            ( map-fiber-cone j h c (i x))
+            ( map-fiber-cone i (vertical-map-cone j h c) d x)
+            ( map-fiber-pasting-horizontal-cone i j h c d x)
+            ( is-fiberwise-equiv-map-fiber-cone-is-pullback i
+              ( vertical-map-cone j h c)
+              ( d)
+              ( is-pb-d)
+              ( x))
+            ( is-fiberwise-equiv-map-fiber-cone-is-pullback j h c is-pb-c
+              ( i x)))
 
   abstract
     is-pullback-left-square-is-pullback-rectangle :
@@ -765,14 +770,17 @@ module _
       is-pullback-is-fiberwise-equiv-map-fiber-cone i
         ( vertical-map-cone j h c)
         ( d)
-        ( λ x → is-equiv-right-factor-htpy
-          ( map-fiber-cone (j ∘ i) h (pasting-horizontal-cone i j h c d) x)
-          ( map-fiber-cone j h c (i x))
-          ( map-fiber-cone i (vertical-map-cone j h c) d x)
-          ( map-fiber-pasting-horizontal-cone i j h c d x)
-          ( is-fiberwise-equiv-map-fiber-cone-is-pullback j h c is-pb-c (i x))
-          ( is-fiberwise-equiv-map-fiber-cone-is-pullback (j ∘ i) h
-            ( pasting-horizontal-cone i j h c d) is-pb-rect x))
+        ( λ x →
+          is-equiv-top-map-triangle
+            ( map-fiber-cone (j ∘ i) h (pasting-horizontal-cone i j h c d) x)
+            ( map-fiber-cone j h c (i x))
+            ( map-fiber-cone i (vertical-map-cone j h c) d x)
+            ( map-fiber-pasting-horizontal-cone i j h c d x)
+            ( is-fiberwise-equiv-map-fiber-cone-is-pullback j h c is-pb-c (i x))
+            ( is-fiberwise-equiv-map-fiber-cone-is-pullback
+              ( j ∘ i)
+              ( h)
+              ( pasting-horizontal-cone i j h c d) is-pb-rect x))
 ```
 
 ### The vertical pullback pasting property
@@ -840,28 +848,34 @@ module _
     is-pullback-rectangle-is-pullback-top c d is-pb-c is-pb-d =
       is-pullback-is-fiberwise-equiv-map-fiber-cone f (g ∘ h)
         ( pasting-vertical-cone f g h c d)
-        ( λ x → is-equiv-bottom-is-equiv-top-square
-          ( inv-map-compute-fiber-comp
-            ( vertical-map-cone f g c)
-            ( vertical-map-cone (horizontal-map-cone f g c) h d)
-            ( x))
-          ( inv-map-compute-fiber-comp g h (f x))
-          ( map-Σ
-            ( λ t → fiber h (pr1 t))
-            ( map-fiber-cone f g c x)
-            ( λ t → map-fiber-cone (horizontal-map-cone f g c) h d (pr1 t)))
-          ( map-fiber-cone f (g ∘ h) (pasting-vertical-cone f g h c d) x)
-          ( map-fiber-pasting-vertical-cone f g h c d x)
-          ( is-equiv-inv-map-compute-fiber-comp
-            ( vertical-map-cone f g c)
-            ( vertical-map-cone (horizontal-map-cone f g c) h d)
-            ( x))
-          ( is-equiv-inv-map-compute-fiber-comp g h (f x))
-          ( is-equiv-map-Σ
-            ( λ t → fiber h (pr1 t))
-            ( is-fiberwise-equiv-map-fiber-cone-is-pullback f g c is-pb-c x)
-            ( λ t → is-fiberwise-equiv-map-fiber-cone-is-pullback
-              (horizontal-map-cone f g c) h d is-pb-d (pr1 t))))
+        ( λ x →
+          is-equiv-bottom-is-equiv-top-square
+            ( inv-map-compute-fiber-comp
+              ( vertical-map-cone f g c)
+              ( vertical-map-cone (horizontal-map-cone f g c) h d)
+              ( x))
+            ( inv-map-compute-fiber-comp g h (f x))
+            ( map-Σ
+              ( λ t → fiber h (pr1 t))
+              ( map-fiber-cone f g c x)
+              ( λ t → map-fiber-cone (horizontal-map-cone f g c) h d (pr1 t)))
+            ( map-fiber-cone f (g ∘ h) (pasting-vertical-cone f g h c d) x)
+            ( map-fiber-pasting-vertical-cone f g h c d x)
+            ( is-equiv-inv-map-compute-fiber-comp
+              ( vertical-map-cone f g c)
+              ( vertical-map-cone (horizontal-map-cone f g c) h d)
+              ( x))
+            ( is-equiv-inv-map-compute-fiber-comp g h (f x))
+            ( is-equiv-map-Σ
+              ( λ t → fiber h (pr1 t))
+              ( is-fiberwise-equiv-map-fiber-cone-is-pullback f g c is-pb-c x)
+              ( λ t →
+                is-fiberwise-equiv-map-fiber-cone-is-pullback
+                  ( horizontal-map-cone f g c)
+                  ( h)
+                  ( d)
+                  ( is-pb-d)
+                  ( pr1 t))))
 ```
 
 ## Table of files about pullbacks

--- a/src/foundation-core/pullbacks.lagda.md
+++ b/src/foundation-core/pullbacks.lagda.md
@@ -780,7 +780,9 @@ module _
             ( is-fiberwise-equiv-map-fiber-cone-is-pullback
               ( j ∘ i)
               ( h)
-              ( pasting-horizontal-cone i j h c d) is-pb-rect x))
+              ( pasting-horizontal-cone i j h c d)
+              ( is-pb-rect)
+              ( x)))
 ```
 
 ### The vertical pullback pasting property

--- a/src/foundation-core/pullbacks.lagda.md
+++ b/src/foundation-core/pullbacks.lagda.md
@@ -751,7 +751,7 @@ module _
             ( map-fiber-cone (j ∘ i) h (pasting-horizontal-cone i j h c d) x)
             ( map-fiber-cone j h c (i x))
             ( map-fiber-cone i (vertical-map-cone j h c) d x)
-            ( map-fiber-pasting-horizontal-cone i j h c d x)
+            ( preserves-pasting-horizontal-map-fiber-cone i j h c d x)
             ( is-fiberwise-equiv-map-fiber-cone-is-pullback i
               ( vertical-map-cone j h c)
               ( d)
@@ -775,7 +775,7 @@ module _
             ( map-fiber-cone (j ∘ i) h (pasting-horizontal-cone i j h c d) x)
             ( map-fiber-cone j h c (i x))
             ( map-fiber-cone i (vertical-map-cone j h c) d x)
-            ( map-fiber-pasting-horizontal-cone i j h c d x)
+            ( preserves-pasting-horizontal-map-fiber-cone i j h c d x)
             ( is-fiberwise-equiv-map-fiber-cone-is-pullback j h c is-pb-c (i x))
             ( is-fiberwise-equiv-map-fiber-cone-is-pullback
               ( j ∘ i)
@@ -824,7 +824,7 @@ module _
                 ( g ∘ h)
                 ( pasting-vertical-cone f g h c d)
                 ( vertical-map-cone f g c x))
-              ( map-fiber-pasting-vertical-cone f g h c d
+              ( preserves-pasting-vertical-map-fiber-cone f g h c d
                 ( vertical-map-cone f g c x))
               ( is-equiv-inv-map-compute-fiber-comp
                 ( vertical-map-cone f g c)
@@ -860,7 +860,7 @@ module _
               ( map-fiber-cone f g c x)
               ( λ t → map-fiber-cone (horizontal-map-cone f g c) h d (pr1 t)))
             ( map-fiber-cone f (g ∘ h) (pasting-vertical-cone f g h c d) x)
-            ( map-fiber-pasting-vertical-cone f g h c d x)
+            ( preserves-pasting-vertical-map-fiber-cone f g h c d x)
             ( is-equiv-inv-map-compute-fiber-comp
               ( vertical-map-cone f g c)
               ( vertical-map-cone (horizontal-map-cone f g c) h d)

--- a/src/foundation-core/retractions.lagda.md
+++ b/src/foundation-core/retractions.lagda.md
@@ -196,8 +196,8 @@ In a commuting triangle of the form
 ```
 
 if `r : X → A` is a retraction of the map `g` on the right and `s : B → A` is a
-retraction of the map `h` on top, then `s ∘ r` is a retraction of the map `f` on the
-left.
+retraction of the map `h` on top, then `s ∘ r` is a retraction of the map `f` on
+the left.
 
 ```agda
 module _

--- a/src/foundation-core/retractions.lagda.md
+++ b/src/foundation-core/retractions.lagda.md
@@ -21,10 +21,9 @@ open import foundation-core.whiskering-homotopies
 
 ## Idea
 
-A **retraction** is a map that has a right inverse, i.e. a section. Thus,
-`r : B → A` is a retraction of `f : A → B` if the composition `r ∘ f` is
-homotopic to the identity at `A`. Moreover, in this case we say that `A` _is a
-retract of_ `B`.
+A **retraction** of a map `f : A → B` consists of a map `r : B → A` equipped
+with a homotopy `r ∘ f ~ id`. In other words, a retraction of a map `f` is a
+left inverse of `f`.
 
 ## Definition
 
@@ -33,8 +32,11 @@ module _
   {l1 l2 : Level} {A : UU l1} {B : UU l2}
   where
 
+  is-retraction : (f : A → B) (g : B → A) → UU l1
+  is-retraction f g = g ∘ f ~ id
+
   retraction : (f : A → B) → UU (l1 ⊔ l2)
-  retraction f = Σ (B → A) (λ r → (r ∘ f) ~ id)
+  retraction f = Σ (B → A) (is-retraction f)
 
   map-retraction : (f : A → B) → retraction f → B → A
   map-retraction f = pr1
@@ -42,34 +44,32 @@ module _
   is-retraction-map-retraction :
     (f : A → B) (r : retraction f) → (map-retraction f r ∘ f) ~ id
   is-retraction-map-retraction f = pr2
-
-_retract-of_ :
-  {l1 l2 : Level} → UU l1 → UU l2 → UU (l1 ⊔ l2)
-A retract-of B = Σ (A → B) retraction
-
-module _
-  {l1 l2 : Level} {A : UU l1} {B : UU l2}
-  where
-
-  section-retract-of : A retract-of B → A → B
-  section-retract-of = pr1
-
-  retraction-section-retract-of :
-    (R : A retract-of B) → retraction (section-retract-of R)
-  retraction-section-retract-of = pr2
-
-  retraction-retract-of : (A retract-of B) → B → A
-  retraction-retract-of R = pr1 (retraction-section-retract-of R)
-
-  is-retraction-retraction-retract-of :
-    (R : A retract-of B) →
-    (retraction-retract-of R ∘ section-retract-of R) ~ id
-  is-retraction-retraction-retract-of R = pr2 (retraction-section-retract-of R)
 ```
 
 ## Properties
 
-### If `A` is a retraction of `B`, then the identity types of `A` are retractions of the identity types of `B`
+### For any map `i : A → B`, a retraction of `i` induces a retraction of the action on identifications of `i`
+
+**Proof:** Suppose that `H : r ∘ i ~ id` and `p : i x ＝ i y` is an
+identification in `B`. Then we get the identification
+
+```text
+     (H x)⁻¹           ap r p           H y
+  x ========= r (i x) ======== r (i y) ===== y
+```
+
+This defines a map `s : (i x ＝ i y) → x ＝ y`. To see that `s ∘ ap i ~ id`,
+i.e., that the concatenation
+
+```text
+     (H x)⁻¹           ap r (ap i p)           H y
+  x ========= r (i x) =============== r (i y) ===== y
+```
+
+is identical to `p : x ＝ y` for all `p : x ＝ y`, we simply proceed by
+identification elimination. Then it suffices to show that `(H x)⁻¹ ∙ (H x)` is
+identical by `refl`, which is indeed the case by the left inverse law of
+concatenation of identifications.
 
 ```agda
 module _
@@ -77,13 +77,13 @@ module _
   where
 
   ap-retraction :
-    (i : A → B) (r : B → A) (H : (r ∘ i) ~ id)
+    (i : A → B) (r : B → A) (H : r ∘ i ~ id)
     (x y : A) → i x ＝ i y → x ＝ y
   ap-retraction i r H x y p =
       ( inv (H x)) ∙ ((ap r p) ∙ (H y))
 
   is-retraction-ap-retraction :
-    (i : A → B) (r : B → A) (H : (r ∘ i) ~ id)
+    (i : A → B) (r : B → A) (H : r ∘ i ~ id)
     (x y : A) → ((ap-retraction i r H x y) ∘ (ap i {x} {y})) ~ id
   is-retraction-ap-retraction i r H x .x refl = left-inv (H x)
 
@@ -91,11 +91,27 @@ module _
     (i : A → B) → retraction i → (x y : A) → retraction (ap i {x} {y})
   pr1 (retraction-ap i (pair r H) x y) = ap-retraction i r H x y
   pr2 (retraction-ap i (pair r H) x y) = is-retraction-ap-retraction i r H x y
+```
 
-  retract-eq :
-    (R : A retract-of B) → (x y : A) → (x ＝ y) retract-of (pr1 R x ＝ pr1 R y)
-  pr1 (retract-eq (pair i (pair r H)) x y) = ap i
-  pr2 (retract-eq (pair i (pair r H)) x y) = retraction-ap i (pair r H) x y
+### Composites of retractions are retractions
+
+```agda
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
+  (g : B → X) (h : A → B) (r : retraction g) (s : retraction h)
+  where
+
+  map-retraction-comp : X → A
+  map-retraction-comp = map-retraction h s ∘ map-retraction g r
+
+  is-retraction-map-retraction-comp : is-retraction (g ∘ h) map-retraction-comp
+  is-retraction-map-retraction-comp =
+    ( map-retraction h s ·l (is-retraction-map-retraction g r ·r h)) ∙h
+    ( is-retraction-map-retraction h s)
+
+  retraction-comp : retraction (g ∘ h)
+  pr1 retraction-comp = map-retraction-comp
+  pr2 retraction-comp = is-retraction-map-retraction-comp
 ```
 
 ### If `g ∘ f` has a retraction then `f` has a retraction
@@ -103,50 +119,110 @@ module _
 ```agda
 module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
+  (g : B → X) (h : A → B) (r : retraction (g ∘ h))
   where
 
-  retraction-right-factor :
-    (g : B → X) (h : A → B) → retraction (g ∘ h) → retraction h
-  pr1 (retraction-right-factor g h retraction-gh) = pr1 retraction-gh ∘ g
-  pr2 (retraction-right-factor g h retraction-gh) = pr2 retraction-gh
+  map-retraction-right-factor : B → A
+  map-retraction-right-factor = map-retraction (g ∘ h) r ∘ g
 
-  retraction-right-factor-htpy :
-    (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
-    retraction f → retraction h
-  pr1 (retraction-right-factor-htpy f g h H retraction-f) =
-    pr1 retraction-f ∘ g
-  pr2 (retraction-right-factor-htpy f g h H retraction-f) =
-    (inv-htpy ((pr1 retraction-f) ·l H)) ∙h (pr2 retraction-f)
+  is-retraction-map-retraction-right-factor :
+    is-retraction h map-retraction-right-factor
+  is-retraction-map-retraction-right-factor =
+    is-retraction-map-retraction (g ∘ h) r
+
+  retraction-right-factor : retraction h
+  pr1 retraction-right-factor = map-retraction-right-factor
+  pr2 retraction-right-factor = is-retraction-map-retraction-right-factor
 ```
 
-### Composites of retractions are retractions
+### In a commuting triangle `f ~ g ∘ h`, any retraction of the left map `f` induces a retraction of the top map `h`
+
+In a commuting triangle of the form
+
+```text
+       h
+  A ------> B
+   \       /
+   f\     /g
+     \   /
+      V V
+       X,
+```
+
+if `r : X → A` is a retraction of the map `f` on the left, then `r ∘ g` is a
+retraction of the top map `h`.
+
+Note: In this file we are unable to use the definition of
+[commuting triangles](foundation-core.commuting-triangles-of-maps.md), because
+that would result in a cyclic module dependency.
 
 ```agda
-  retraction-comp :
-    (g : B → X) (h : A → B) → retraction g → retraction h → retraction (g ∘ h)
-  pr1 (retraction-comp g h retraction-g retraction-h) =
-    pr1 retraction-h ∘ pr1 retraction-g
-  pr2 (retraction-comp g h retraction-g retraction-h) =
-    ((pr1 retraction-h) ·l (pr2 retraction-g ·r h)) ∙h (pr2 retraction-h)
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
+  (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
+  (r : retraction f)
+  where
 
-  retraction-comp-htpy :
-    (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
-    retraction g → retraction h → retraction f
-  pr1 (retraction-comp-htpy f g h H retraction-g retraction-h) =
-    pr1 (retraction-comp g h retraction-g retraction-h)
-  pr2 (retraction-comp-htpy f g h H retraction-g retraction-h) =
-    ( pr1 (retraction-comp g h retraction-g retraction-h) ·l H) ∙h
-    pr2 (retraction-comp g h retraction-g retraction-h)
+  map-retraction-top-map-triangle : B → A
+  map-retraction-top-map-triangle = map-retraction f r ∘ g
 
-  inv-triangle-retraction :
-    (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
-    (retraction-g : retraction g) → ((pr1 retraction-g) ∘ f) ~ h
-  inv-triangle-retraction f g h H retraction-g =
-    (pr1 retraction-g ·l H) ∙h (pr2 retraction-g ·r h)
+  is-retraction-map-retraction-top-map-triangle :
+    is-retraction h map-retraction-top-map-triangle
+  is-retraction-map-retraction-top-map-triangle =
+    ( inv-htpy (map-retraction f r ·l H)) ∙h
+    ( is-retraction-map-retraction f r)
 
-  triangle-retraction :
-    (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
-    (retraction-g : retraction g) → h ~ ((pr1 retraction-g) ∘ f)
-  triangle-retraction f g h H retraction-g =
-    inv-htpy (inv-triangle-retraction f g h H retraction-g)
+  retraction-top-map-triangle : retraction h
+  pr1 retraction-top-map-triangle =
+    map-retraction-top-map-triangle
+  pr2 retraction-top-map-triangle =
+    is-retraction-map-retraction-top-map-triangle
 ```
+
+### In a commuting triangle `f ~ g ∘ h`, retractions of `g` and `h` compose to a retraction of `f`
+
+In a commuting triangle of the form
+
+```text
+       h
+  A ------> B
+   \       /
+   f\     /g
+     \   /
+      V V
+       X,
+```
+
+if `r : X → A` is a section of the map `g` on the right and `t : B → A` is a
+section of the map `h` on top, then `t ∘ s` is a section of the map `f` on the
+left.
+
+```agda
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
+  (f : A → X) (g : B → X) (h : A → B) (H : f ~ g ∘ h)
+  (r : retraction g) (s : retraction h)
+  where
+
+  map-retraction-left-map-triangle : X → A
+  map-retraction-left-map-triangle = map-retraction-comp g h r s
+
+  is-retraction-map-retraction-left-map-triangle :
+    is-retraction f map-retraction-left-map-triangle
+  is-retraction-map-retraction-left-map-triangle =
+    ( map-retraction-comp g h r s ·l H) ∙h
+    ( is-retraction-map-retraction-comp g h r s)
+
+  retraction-left-map-triangle : retraction f
+  pr1 retraction-left-map-triangle =
+    map-retraction-left-map-triangle
+  pr2 retraction-left-map-triangle =
+    is-retraction-map-retraction-left-map-triangle
+```
+
+## See also
+
+- Retracts of types are defined in
+  [`foundation.retracts-of-types`](foundation.retracts-of-types.md).
+- Retracts of maps are defined in
+  [`foundation.retracts-of-maps`](foundation.retracts-of-maps.md).

--- a/src/foundation-core/retractions.lagda.md
+++ b/src/foundation-core/retractions.lagda.md
@@ -22,8 +22,8 @@ open import foundation-core.whiskering-homotopies
 ## Idea
 
 A **retraction** of a map `f : A → B` consists of a map `r : B → A` equipped
-with a homotopy `r ∘ f ~ id`. In other words, a retraction of a map `f` is a
-left inverse of `f`.
+with a [homotopy](foundation-core.homotopies.md) `r ∘ f ~ id`. In other words, a
+retraction of a map `f` is a left inverse of `f`.
 
 ## Definitions
 
@@ -70,7 +70,7 @@ i.e., that the concatenation
 
 is identical to `p : x ＝ y` for all `p : x ＝ y`, we simply proceed by
 identification elimination. Then it suffices to show that `(H x)⁻¹ ∙ (H x)` is
-identical by `refl`, which is indeed the case by the left inverse law of
+identical to `refl`, which is indeed the case by the left inverse law of
 concatenation of identifications.
 
 ```agda
@@ -161,7 +161,7 @@ that would result in a cyclic module dependency.
 ```agda
 module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
-  (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
+  (f : A → X) (g : B → X) (h : A → B) (H : f ~ g ∘ h)
   (r : retraction f)
   where
 
@@ -195,8 +195,8 @@ In a commuting triangle of the form
        X,
 ```
 
-if `r : X → A` is a section of the map `g` on the right and `t : B → A` is a
-section of the map `h` on top, then `t ∘ s` is a section of the map `f` on the
+if `r : X → A` is a retraction of the map `g` on the right and `s : B → A` is a
+retraction of the map `h` on top, then `s ∘ r` is a retraction of the map `f` on the
 left.
 
 ```agda

--- a/src/foundation-core/sections.lagda.md
+++ b/src/foundation-core/sections.lagda.md
@@ -19,13 +19,33 @@ open import foundation-core.whiskering-homotopies
 
 ## Idea
 
-A **section** is a map that has a left inverse, i.e. a retraction. Thus,
-`s : B → A` is a section of `f : A → B` if the composition `f ∘ s` is homotopic
-to the identity at `B`.
+A **section** of a map `f : A → B` consists of a map `s : B → A` equipped with a
+homotopy `f ∘ s ~ id`. In other words, a section of a map `f` is a right inverse
+of `f`. For example, every dependent function induces a section of the
+projection map.
 
-For example, every dependent function induces a section of the projection map.
+Note that unlike retractions, sections don't induce sections on identity types.
+A map `f` equipped with a section such that all
+[actions on identifications](foundation.action-on-identifications-functions.md)
+`ap f : (x ＝ y) → (f x ＝ f y)` come equipped with sections is called a
+[path split](foundation-core.path-split-maps.md) map. The condition of being
+path split is equivalent to being an
+[equivalence](foundation-core.equivalences.md).
 
 ## Definition
+
+### The predicate of being a section of a map
+
+```agda
+module _
+  {l1 l2 : Level} {A : UU l1} {B : UU l2} (f : A → B)
+  where
+
+  is-section : (B → A) → UU l2
+  is-section g = f ∘ g ~ id
+```
+
+### The type of sections of a map
 
 ```agda
 module _
@@ -33,71 +53,165 @@ module _
   where
 
   section : UU (l1 ⊔ l2)
-  section = Σ (B → A) (λ s → (f ∘ s) ~ id)
+  section = Σ (B → A) (is-section f)
 
   map-section : section → B → A
   map-section = pr1
 
-  is-section-map-section : (s : section) → (f ∘ map-section s) ~ id
+  is-section-map-section : (s : section) → is-section f (map-section s)
   is-section-map-section = pr2
 ```
 
 ## Properties
 
-### If `g ∘ f` has a section then `g` has a section
+### If `g ∘ h` has a section then `g` has a section
 
 ```agda
 module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
+  (g : B → X) (h : A → B) (s : section (g ∘ h))
   where
 
-  section-left-factor :
-    (g : B → X) (h : A → B) → section (g ∘ h) → section g
-  pr1 (section-left-factor g h section-gh) = h ∘ (pr1 section-gh)
-  pr2 (section-left-factor g h section-gh) = pr2 section-gh
+  map-section-left-factor : X → B
+  map-section-left-factor = h ∘ map-section (g ∘ h) s
 
-  section-left-factor-htpy' :
-    (f : A → X) (g : B → X) (h : A → B) (H' : (g ∘ h) ~ f) →
-    section f → section g
-  pr1 (section-left-factor-htpy' f g h H' section-f) =
-    h ∘ (pr1 section-f)
-  pr2 (section-left-factor-htpy' f g h H' section-f) =
-    (H' ·r pr1 section-f) ∙h (pr2 section-f)
+  is-section-map-section-left-factor : is-section g map-section-left-factor
+  is-section-map-section-left-factor = pr2 s
 
-  section-left-factor-htpy :
-    (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
-    section f → section g
-  section-left-factor-htpy f g h H section-f =
-    section-left-factor-htpy' f g h (inv-htpy H) section-f
+  section-left-factor : section g
+  pr1 section-left-factor = map-section-left-factor
+  pr2 section-left-factor = is-section-map-section-left-factor
 ```
 
-### Composites of sections are sections
+### Composites of sections are sections of composites
 
 ```agda
-  section-comp :
-    (g : B → X) (h : A → B) → section h → section g → section (g ∘ h)
-  pr1 (section-comp g h section-h section-g) = pr1 section-h ∘ pr1 section-g
-  pr2 (section-comp g h section-h section-g) =
-    (g ·l (pr2 section-h ·r (pr1 section-g))) ∙h (pr2 section-g)
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
+  (g : B → X) (h : A → B) (t : section h) (s : section g)
+  where
 
-  section-comp-htpy :
-    (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
-    section h → section g → section f
-  pr1 (section-comp-htpy f g h H section-h section-g) =
-    pr1 (section-comp g h section-h section-g)
-  pr2 (section-comp-htpy f g h H section-h section-g) =
-    (H ·r pr1 (section-comp g h section-h section-g)) ∙h
-    (pr2 (section-comp g h section-h section-g))
+  map-section-comp : X → A
+  map-section-comp = map-section h t ∘ map-section g s
 
-  inv-triangle-section :
-    (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
-    (section-h : section h) → (f ∘ (pr1 section-h)) ~ g
-  inv-triangle-section h g f H section-h =
-    (H ·r (pr1 section-h)) ∙h (g ·l (pr2 section-h))
+  is-section-map-section-comp :
+    is-section (g ∘ h) map-section-comp
+  is-section-map-section-comp =
+    ( g ·l (is-section-map-section h t ·r map-section g s)) ∙h
+    ( is-section-map-section g s)
 
-  triangle-section :
-    (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
-    (section-h : section h) → g ~ (f ∘ (pr1 section-h))
-  triangle-section h g f H section-h =
-    inv-htpy (inv-triangle-section h g f H section-h)
+  section-comp : section (g ∘ h)
+  pr1 section-comp = map-section-comp
+  pr2 section-comp = is-section-map-section-comp
+```
+
+### In a commuting triangle `g ∘ h ~ f`, any section of `f` induces a section of `g`
+
+In a commuting triangle of the form
+
+```text
+       h
+  A ------> B
+   \       /
+   f\     /g
+     \   /
+      V V
+       X,
+```
+
+if `s : X → A` is a section of the map `f` on the left, then `h ∘ s` is a
+section of the map `g` on the right.
+
+Note: In this file we are unable to use the definition of
+[commuting triangles](foundation-core.commuting-triangles-of-maps.md), because
+that would result in a cyclic module dependency.
+
+We state two versions: one with a homotopy `g ∘ h ~ f`, and the other with a
+homotopy `f ~ g ∘ h`. Our convention for commuting triangles of maps is that the
+homotopy is specified in the second way, i.e., as `f ~ g ∘ h`.
+
+#### First version, with the commutativity of the triangle opposite to our convention
+
+```agda
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
+  (f : A → X) (g : B → X) (h : A → B) (H' : g ∘ h ~ f) (s : section f)
+  where
+
+  map-section-right-map-triangle' : X → B
+  map-section-right-map-triangle' = h ∘ map-section f s
+
+  is-section-map-section-right-map-triangle' :
+    is-section g map-section-right-map-triangle'
+  is-section-map-section-right-map-triangle' =
+    (H' ·r map-section f s) ∙h is-section-map-section f s
+
+  section-right-map-triangle' : section g
+  pr1 section-right-map-triangle' =
+    map-section-right-map-triangle'
+  pr2 section-right-map-triangle' =
+    is-section-map-section-right-map-triangle'
+```
+
+#### Second version, with the commutativity of the triangle accoring to our convention
+
+We state the same result as the previous result, only with the homotopy
+witnessing the commutativity of the triangle inverted.
+
+```agda
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
+  (f : A → X) (g : B → X) (h : A → B) (H : f ~ g ∘ h) (s : section f)
+  where
+
+  map-section-right-map-triangle : X → B
+  map-section-right-map-triangle =
+    map-section-right-map-triangle' f g h (inv-htpy H) s
+
+  is-section-map-section-right-map-triangle :
+    is-section g map-section-right-map-triangle
+  is-section-map-section-right-map-triangle =
+    is-section-map-section-right-map-triangle' f g h (inv-htpy H) s
+
+  section-right-map-triangle : section g
+  section-right-map-triangle =
+    section-right-map-triangle' f g h (inv-htpy H) s
+```
+
+### Composites of sections in commuting triangles are sections
+
+In a commuting triangle of the form
+
+```text
+       h
+  A ------> B
+   \       /
+   f\     /g
+     \   /
+      V V
+       X,
+```
+
+if `s : X → B` is a section of the map `g` on the right and `t : B → A` is a
+section of the map `h` on top, then `t ∘ s` is a section of the map `f` on the
+left.
+
+```agda
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
+  (f : A → X) (g : B → X) (h : A → B) (H : f ~ g ∘ h) (t : section h)
+  where
+
+  map-section-left-map-triangle : section g → X → A
+  map-section-left-map-triangle s = map-section-comp g h t s
+
+  is-section-map-section-left-map-triangle :
+    (s : section g) → is-section f (map-section-left-map-triangle s)
+  is-section-map-section-left-map-triangle s =
+    ( H ·r map-section-comp g h t s) ∙h
+    ( is-section-map-section-comp g h t s)
+
+  section-left-map-triangle : section g → section f
+  pr1 (section-left-map-triangle s) = map-section-left-map-triangle s
+  pr2 (section-left-map-triangle s) = is-section-map-section-left-map-triangle s
 ```

--- a/src/foundation-core/truncated-maps.lagda.md
+++ b/src/foundation-core/truncated-maps.lagda.md
@@ -227,11 +227,11 @@ module _
   is-prop-map-comp = is-trunc-map-comp neg-one-𝕋 g h
 
 abstract
-  is-trunc-map-comp-htpy :
+  is-trunc-map-left-map-triangle :
     {l1 l2 l3 : Level} (k : 𝕋) {A : UU l1} {B : UU l2}
     {X : UU l3} (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
     is-trunc-map k g → is-trunc-map k h → is-trunc-map k f
-  is-trunc-map-comp-htpy k f g h H is-trunc-g is-trunc-h =
+  is-trunc-map-left-map-triangle k f g h H is-trunc-g is-trunc-h =
     is-trunc-map-htpy k H
       ( is-trunc-map-comp k g h is-trunc-g is-trunc-h)
 
@@ -240,24 +240,26 @@ module _
   (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
   where
 
-  is-contr-map-comp-htpy :
+  is-contr-map-left-map-triangle :
     is-contr-map g → is-contr-map h → is-contr-map f
-  is-contr-map-comp-htpy = is-trunc-map-comp-htpy neg-two-𝕋 f g h H
+  is-contr-map-left-map-triangle =
+    is-trunc-map-left-map-triangle neg-two-𝕋 f g h H
 
-  is-prop-map-comp-htpy :
+  is-prop-map-left-map-triangle :
     is-prop-map g → is-prop-map h → is-prop-map f
-  is-prop-map-comp-htpy = is-trunc-map-comp-htpy neg-one-𝕋 f g h H
+  is-prop-map-left-map-triangle =
+    is-trunc-map-left-map-triangle neg-one-𝕋 f g h H
 ```
 
 ### If a composite is truncated, then its right factor is truncated
 
 ```agda
 abstract
-  is-trunc-map-right-factor-htpy :
+  is-trunc-map-top-map-triangle :
     {l1 l2 l3 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} {X : UU l3}
     (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
     is-trunc-map k g → is-trunc-map k f → is-trunc-map k h
-  is-trunc-map-right-factor-htpy k {A} f g h H is-trunc-g is-trunc-f b =
+  is-trunc-map-top-map-triangle k {A} f g h H is-trunc-g is-trunc-f b =
     is-trunc-fam-is-trunc-Σ k
       ( is-trunc-g (g b))
       ( is-trunc-is-equiv' k
@@ -272,22 +274,22 @@ module _
   (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h))
   where
 
-  is-contr-map-right-factor-htpy :
+  is-contr-map-top-map-triangle :
     is-contr-map g → is-contr-map f → is-contr-map h
-  is-contr-map-right-factor-htpy =
-    is-trunc-map-right-factor-htpy neg-two-𝕋 f g h H
+  is-contr-map-top-map-triangle =
+    is-trunc-map-top-map-triangle neg-two-𝕋 f g h H
 
-  is-prop-map-right-factor-htpy :
+  is-prop-map-top-map-triangle :
     is-prop-map g → is-prop-map f → is-prop-map h
-  is-prop-map-right-factor-htpy =
-    is-trunc-map-right-factor-htpy neg-one-𝕋 f g h H
+  is-prop-map-top-map-triangle =
+    is-trunc-map-top-map-triangle neg-one-𝕋 f g h H
 
 is-trunc-map-right-factor :
   {l1 l2 l3 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} {X : UU l3}
   (g : B → X) (h : A → B) →
   is-trunc-map k g → is-trunc-map k (g ∘ h) → is-trunc-map k h
 is-trunc-map-right-factor k {A} g h =
-  is-trunc-map-right-factor-htpy k (g ∘ h) g h refl-htpy
+  is-trunc-map-top-map-triangle k (g ∘ h) g h refl-htpy
 
 module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
@@ -317,7 +319,7 @@ module _
   is-trunc-map-top-is-trunc-map-bottom-is-equiv :
     is-equiv g → is-equiv h → is-trunc-map k i → is-trunc-map k f
   is-trunc-map-top-is-trunc-map-bottom-is-equiv K L M =
-    is-trunc-map-right-factor-htpy k (i ∘ g) h f H
+    is-trunc-map-top-map-triangle k (i ∘ g) h f H
       ( is-trunc-map-is-equiv k L)
       ( is-trunc-map-comp k i g M
         ( is-trunc-map-is-equiv k K))
@@ -395,7 +397,7 @@ module _
     is-trunc-map k f → ((x : A) → is-trunc-map k (g x)) →
     is-trunc-map k (map-Σ D f g)
   is-trunc-map-map-Σ k D {f} {g} H K =
-    is-trunc-map-comp-htpy k
+    is-trunc-map-left-map-triangle k
       ( map-Σ D f g)
       ( map-Σ-map-base f D)
       ( tot g)

--- a/src/foundation-core/truncated-types.lagda.md
+++ b/src/foundation-core/truncated-types.lagda.md
@@ -11,6 +11,7 @@ open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
 open import foundation.equality-cartesian-product-types
 open import foundation.function-extensionality
+open import foundation.retracts-of-types
 open import foundation.universe-levels
 
 open import foundation-core.cartesian-product-types

--- a/src/foundation-core/universal-property-pullbacks.lagda.md
+++ b/src/foundation-core/universal-property-pullbacks.lagda.md
@@ -91,7 +91,7 @@ module _
     is-equiv-up-pullback-up-pullback up up' =
       is-equiv-is-equiv-postcomp h
         ( λ D →
-          is-equiv-right-factor-htpy
+          is-equiv-top-map-triangle
             ( cone-map f g c')
             ( cone-map f g c)
             ( postcomp D h)
@@ -105,7 +105,7 @@ module _
       ({l : Level} → universal-property-pullback l f g c) →
       ({l : Level} → universal-property-pullback l f g c')
     up-pullback-up-pullback-is-equiv is-equiv-h up D =
-      is-equiv-comp-htpy
+      is-equiv-left-map-triangle
         ( cone-map f g c')
         ( cone-map f g c)
         ( postcomp D h)
@@ -119,7 +119,7 @@ module _
       is-equiv h →
       ({l : Level} → universal-property-pullback l f g c)
     up-pullback-is-equiv-up-pullback up' is-equiv-h D =
-      is-equiv-left-factor-htpy
+      is-equiv-right-map-triangle
         ( cone-map f g c')
         ( cone-map f g c)
         ( postcomp D h)

--- a/src/foundation.lagda.md
+++ b/src/foundation.lagda.md
@@ -247,6 +247,7 @@ open import foundation.repetitions-of-values public
 open import foundation.repetitions-sequences public
 open import foundation.replacement public
 open import foundation.retractions public
+open import foundation.retracts-of-types public
 open import foundation.russells-paradox public
 open import foundation.sections public
 open import foundation.separated-types public

--- a/src/foundation.lagda.md
+++ b/src/foundation.lagda.md
@@ -195,6 +195,7 @@ open import foundation.mere-embeddings public
 open import foundation.mere-equality public
 open import foundation.mere-equivalences public
 open import foundation.monomorphisms public
+open import foundation.morphisms-arrows public
 open import foundation.morphisms-binary-relations public
 open import foundation.morphisms-cospans public
 open import foundation.morphisms-towers public

--- a/src/foundation.lagda.md
+++ b/src/foundation.lagda.md
@@ -199,6 +199,7 @@ open import foundation.morphisms-arrows public
 open import foundation.morphisms-binary-relations public
 open import foundation.morphisms-cospans public
 open import foundation.morphisms-towers public
+open import foundation.morphisms-twisted-arrows public
 open import foundation.multisubsets public
 open import foundation.multivariable-correspondences public
 open import foundation.multivariable-decidable-relations public

--- a/src/foundation/0-maps.lagda.md
+++ b/src/foundation/0-maps.lagda.md
@@ -92,10 +92,10 @@ module _
     is-0-map g → is-0-map h → is-0-map (g ∘ h)
   is-0-map-comp = is-trunc-map-comp zero-𝕋
 
-  is-0-map-comp-htpy :
+  is-0-map-left-map-triangle :
     (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
     is-0-map g → is-0-map h → is-0-map f
-  is-0-map-comp-htpy = is-trunc-map-comp-htpy zero-𝕋
+  is-0-map-left-map-triangle = is-trunc-map-left-map-triangle zero-𝕋
 ```
 
 ### If a composite is a 0-map, then so is its right factor
@@ -110,10 +110,10 @@ module _
     is-0-map g → is-0-map (g ∘ h) → is-0-map h
   is-0-map-right-factor = is-trunc-map-right-factor zero-𝕋
 
-  is-0-map-right-factor-htpy :
+  is-0-map-top-map-triangle :
     (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
     is-0-map g → is-0-map f → is-0-map h
-  is-0-map-right-factor-htpy = is-trunc-map-right-factor-htpy zero-𝕋
+  is-0-map-top-map-triangle = is-trunc-map-top-map-triangle zero-𝕋
 ```
 
 ### A family of `0`-maps induces a `0`-map on total spaces

--- a/src/foundation/binary-embeddings.lagda.md
+++ b/src/foundation/binary-embeddings.lagda.md
@@ -60,7 +60,7 @@ is-binary-emb-is-binary-equiv :
 is-binary-emb-is-binary-equiv {f = f} H {x} {x'} {y} {y'} =
   pair
     ( λ q →
-      is-equiv-comp-htpy
+      is-equiv-left-map-triangle
         ( λ p → ap-binary f p q)
         ( concat' (f x y) (ap (fix-left f x') q))
         ( λ p → ap (fix-right f y) p)
@@ -68,7 +68,7 @@ is-binary-emb-is-binary-equiv {f = f} H {x} {x'} {y} {y'} =
         ( is-emb-fix-right-is-binary-equiv f H x x')
         ( is-equiv-concat' (f x y) (ap (fix-left f x') q)))
     ( λ p →
-      is-equiv-comp-htpy
+      is-equiv-left-map-triangle
         ( λ q → ap-binary f p q)
         ( concat (ap (fix-right f y) p) (f x' y'))
         ( λ q → ap (fix-left f x') q)

--- a/src/foundation/commuting-cubes-of-maps.lagda.md
+++ b/src/foundation/commuting-cubes-of-maps.lagda.md
@@ -453,7 +453,7 @@ module _
           ( W)
         by
         inv-htpy
-          ( distributive-precomp-coherence-square-comp-htpy-coherence-triangle-maps
+          ( distributive-precomp-coherence-square-left-map-triangle-coherence-triangle-maps
             ( W)
             ( hA)
             ( h' ∘ f')
@@ -498,7 +498,7 @@ module _
         ( ( precomp-front-right-inv-whisk-g') ∙h
           ( precomp-k-whisk-back-right-inv))
         by
-        distributive-precomp-coherence-square-comp-htpy-coherence-triangle-maps'
+        distributive-precomp-coherence-square-left-map-triangle-coherence-triangle-maps'
           ( W)
           ( hA)
           ( h' ∘ f')

--- a/src/foundation/commuting-squares-of-maps.lagda.md
+++ b/src/foundation/commuting-squares-of-maps.lagda.md
@@ -457,7 +457,7 @@ module _
   ( top : A → X) (left : A → B) (right : X → Y) (bottom : B → Y)
   where
 
-  distributive-precomp-coherence-square-comp-htpy-coherence-triangle-maps :
+  distributive-precomp-coherence-square-left-map-triangle-coherence-triangle-maps :
     { diagonal-left diagonal-right : A → Y} →
     ( L : diagonal-left ~ diagonal-right) →
     ( H : coherence-triangle-maps' diagonal-left bottom left) →
@@ -484,7 +484,7 @@ module _
       ( htpy-precomp L W)
       ( precomp-coherence-triangle-maps' diagonal-left bottom left H W)
       ( precomp-coherence-triangle-maps diagonal-right right top K W))
-  distributive-precomp-coherence-square-comp-htpy-coherence-triangle-maps
+  distributive-precomp-coherence-square-left-map-triangle-coherence-triangle-maps
     { diagonal-right = diagonal-right}
     ( L)
     ( H)
@@ -495,7 +495,7 @@ module _
       ( _∙ precomp-coherence-triangle-maps diagonal-right right top K W h)
       ( compute-concat-htpy-precomp H L W h))
 
-  distributive-precomp-coherence-square-comp-htpy-coherence-triangle-maps' :
+  distributive-precomp-coherence-square-left-map-triangle-coherence-triangle-maps' :
     { diagonal-left diagonal-right : A → Y} →
     ( L : diagonal-left ~ diagonal-right) →
     ( H : coherence-triangle-maps' diagonal-left bottom left) →
@@ -522,7 +522,7 @@ module _
       ( htpy-precomp L W)
       ( precomp-coherence-triangle-maps' diagonal-left bottom left H W)
       ( precomp-coherence-triangle-maps diagonal-right right top K W))
-  distributive-precomp-coherence-square-comp-htpy-coherence-triangle-maps'
+  distributive-precomp-coherence-square-left-map-triangle-coherence-triangle-maps'
     { diagonal-left = diagonal-left}
     ( L)
     ( H)

--- a/src/foundation/cones-over-cospans.lagda.md
+++ b/src/foundation/cones-over-cospans.lagda.md
@@ -10,6 +10,7 @@ module foundation.cones-over-cospans where
 open import foundation.dependent-pair-types
 open import foundation.fundamental-theorem-of-identity-types
 open import foundation.homotopy-induction
+open import foundation.morphisms-arrows
 open import foundation.structure-identity-principle
 open import foundation.universe-levels
 
@@ -71,6 +72,14 @@ module _
   coherence-square-cone :
     coherence-square-maps horizontal-map-cone vertical-map-cone g f
   coherence-square-cone = pr2 (pr2 c)
+
+  hom-arrow-cone : hom-arrow vertical-map-cone g
+  pr1 hom-arrow-cone = horizontal-map-cone
+  pr1 (pr2 hom-arrow-cone) = f
+  pr2 (pr2 hom-arrow-cone) = coherence-square-cone
+
+  hom-arrow-cone' : hom-arrow horizontal-map-cone f
+  hom-arrow-cone' = transpose-hom-arrow vertical-map-cone g hom-arrow-cone
 ```
 
 ### Dependent cones over cospans

--- a/src/foundation/decidable-equality.lagda.md
+++ b/src/foundation/decidable-equality.lagda.md
@@ -13,6 +13,7 @@ open import foundation.decidable-types
 open import foundation.dependent-pair-types
 open import foundation.double-negation
 open import foundation.negation
+open import foundation.retracts-of-types
 open import foundation.sections
 open import foundation.type-arithmetic-dependent-pair-types
 open import foundation.unit-type

--- a/src/foundation/decidable-types.lagda.md
+++ b/src/foundation/decidable-types.lagda.md
@@ -15,6 +15,7 @@ open import foundation.hilberts-epsilon-operators
 open import foundation.negation
 open import foundation.propositional-truncations
 open import foundation.raising-universe-levels
+open import foundation.retracts-of-types
 open import foundation.type-arithmetic-empty-type
 open import foundation.unit-type
 open import foundation.universe-levels

--- a/src/foundation/descent-coproduct-types.lagda.md
+++ b/src/foundation/descent-coproduct-types.lagda.md
@@ -112,7 +112,7 @@ module _
             ( i)
             ( cone-descent-coprod (triple h f' H) (triple k g' K)))
       α (inl x) =
-        is-equiv-left-factor-htpy
+        is-equiv-right-map-triangle
           ( map-fiber-cone f i (triple h f' H) x)
           ( map-fiber-cone (ind-coprod _ f g) i
             ( cone-descent-coprod (triple h f' H) (triple k g' K))
@@ -124,7 +124,7 @@ module _
             ( triple h f' H) is-pb-cone-A' x)
           ( is-equiv-fiber-map-coprod-inl-fiber h k x)
       α (inr y) =
-        is-equiv-left-factor-htpy
+        is-equiv-right-map-triangle
           ( map-fiber-cone g i (triple k g' K) y)
           ( map-fiber-cone
             ( ind-coprod _ f g) i
@@ -144,7 +144,7 @@ module _
       is-pullback f i cone-A'
     descent-coprod-inl (pair h (pair f' H)) (pair k (pair g' K)) is-pb-dsq =
         is-pullback-is-fiberwise-equiv-map-fiber-cone f i (triple h f' H)
-          ( λ a → is-equiv-comp-htpy
+          ( λ a → is-equiv-left-map-triangle
             ( map-fiber-cone f i (triple h f' H) a)
             ( map-fiber-cone (ind-coprod _ f g) i
               ( cone-descent-coprod (triple h f' H) (triple k g' K))
@@ -165,7 +165,7 @@ module _
       is-pullback g i cone-B'
     descent-coprod-inr (pair h (pair f' H)) (pair k (pair g' K)) is-pb-dsq =
         is-pullback-is-fiberwise-equiv-map-fiber-cone g i (triple k g' K)
-          ( λ b → is-equiv-comp-htpy
+          ( λ b → is-equiv-left-map-triangle
             ( map-fiber-cone g i (triple k g' K) b)
             ( map-fiber-cone (ind-coprod _ f g) i
               ( cone-descent-coprod (triple h f' H) (triple k g' K))

--- a/src/foundation/descent-coproduct-types.lagda.md
+++ b/src/foundation/descent-coproduct-types.lagda.md
@@ -144,7 +144,8 @@ module _
       is-pullback f i cone-A'
     descent-coprod-inl (pair h (pair f' H)) (pair k (pair g' K)) is-pb-dsq =
         is-pullback-is-fiberwise-equiv-map-fiber-cone f i (triple h f' H)
-          ( λ a → is-equiv-left-map-triangle
+          ( λ a →
+            is-equiv-left-map-triangle
             ( map-fiber-cone f i (triple h f' H) a)
             ( map-fiber-cone (ind-coprod _ f g) i
               ( cone-descent-coprod (triple h f' H) (triple k g' K))
@@ -165,7 +166,8 @@ module _
       is-pullback g i cone-B'
     descent-coprod-inr (pair h (pair f' H)) (pair k (pair g' K)) is-pb-dsq =
         is-pullback-is-fiberwise-equiv-map-fiber-cone g i (triple k g' K)
-          ( λ b → is-equiv-left-map-triangle
+          ( λ b →
+            is-equiv-left-map-triangle
             ( map-fiber-cone g i (triple k g' K) b)
             ( map-fiber-cone (ind-coprod _ f g) i
               ( cone-descent-coprod (triple h f' H) (triple k g' K))

--- a/src/foundation/descent-dependent-pair-types.lagda.md
+++ b/src/foundation/descent-dependent-pair-types.lagda.md
@@ -56,7 +56,8 @@ module _
         ( h)
         ( cone-descent-Σ)
         ( ind-Σ
-          ( λ i a → is-equiv-right-map-triangle
+          ( λ i a →
+            is-equiv-right-map-triangle
             ( map-fiber-cone (f i) h (c i) a)
             ( map-fiber-cone (ind-Σ f) h cone-descent-Σ (pair i a))
             ( map-inv-compute-fiber-tot (λ i → pr1 (c i)) (pair i a))
@@ -71,7 +72,8 @@ module _
       ((i : I) → is-pullback (f i) h (c i))
     descent-Σ' is-pb-dsq i =
       is-pullback-is-fiberwise-equiv-map-fiber-cone (f i) h (c i)
-        ( λ a → is-equiv-left-map-triangle
+        ( λ a →
+          is-equiv-left-map-triangle
           ( map-fiber-cone (f i) h (c i) a)
           ( map-fiber-cone (ind-Σ f) h cone-descent-Σ (pair i a))
           ( map-inv-compute-fiber-tot (λ i → pr1 (c i)) (pair i a))

--- a/src/foundation/descent-dependent-pair-types.lagda.md
+++ b/src/foundation/descent-dependent-pair-types.lagda.md
@@ -56,7 +56,7 @@ module _
         ( h)
         ( cone-descent-Σ)
         ( ind-Σ
-          ( λ i a → is-equiv-left-factor-htpy
+          ( λ i a → is-equiv-right-map-triangle
             ( map-fiber-cone (f i) h (c i) a)
             ( map-fiber-cone (ind-Σ f) h cone-descent-Σ (pair i a))
             ( map-inv-compute-fiber-tot (λ i → pr1 (c i)) (pair i a))
@@ -71,7 +71,7 @@ module _
       ((i : I) → is-pullback (f i) h (c i))
     descent-Σ' is-pb-dsq i =
       is-pullback-is-fiberwise-equiv-map-fiber-cone (f i) h (c i)
-        ( λ a → is-equiv-comp-htpy
+        ( λ a → is-equiv-left-map-triangle
           ( map-fiber-cone (f i) h (c i) a)
           ( map-fiber-cone (ind-Σ f) h cone-descent-Σ (pair i a))
           ( map-inv-compute-fiber-tot (λ i → pr1 (c i)) (pair i a))

--- a/src/foundation/descent-equivalences.lagda.md
+++ b/src/foundation/descent-equivalences.lagda.md
@@ -57,7 +57,7 @@ module _
       ( map-inv-is-equiv-precomp-Π-is-equiv
         ( is-equiv-i)
         ( λ y → is-equiv (map-fiber-cone j h c y))
-        ( λ x → is-equiv-left-factor-htpy
+        ( λ x → is-equiv-right-map-triangle
           ( map-fiber-cone (j ∘ i) h
             ( pasting-horizontal-cone i j h c d) x)
           ( map-fiber-cone j h c (i x))

--- a/src/foundation/descent-equivalences.lagda.md
+++ b/src/foundation/descent-equivalences.lagda.md
@@ -62,7 +62,7 @@ module _
             ( pasting-horizontal-cone i j h c d) x)
           ( map-fiber-cone j h c (i x))
           ( map-fiber-cone i (vertical-map-cone j h c) d x)
-          ( map-fiber-pasting-horizontal-cone i j h c d x)
+          ( preserves-pasting-horizontal-map-fiber-cone i j h c d x)
           ( is-fiberwise-equiv-map-fiber-cone-is-pullback (j ∘ i) h
             ( pasting-horizontal-cone i j h c d)
             ( is-pb-rectangle)

--- a/src/foundation/descent-equivalences.lagda.md
+++ b/src/foundation/descent-equivalences.lagda.md
@@ -57,7 +57,8 @@ module _
       ( map-inv-is-equiv-precomp-Π-is-equiv
         ( is-equiv-i)
         ( λ y → is-equiv (map-fiber-cone j h c y))
-        ( λ x → is-equiv-right-map-triangle
+        ( λ x →
+          is-equiv-right-map-triangle
           ( map-fiber-cone (j ∘ i) h
             ( pasting-horizontal-cone i j h c d) x)
           ( map-fiber-cone j h c (i x))

--- a/src/foundation/embeddings.lagda.md
+++ b/src/foundation/embeddings.lagda.md
@@ -22,6 +22,7 @@ open import foundation.truncated-maps
 open import foundation.universe-levels
 
 open import foundation-core.cartesian-product-types
+open import foundation-core.commuting-triangles-of-maps
 open import foundation-core.contractible-types
 open import foundation-core.function-types
 open import foundation-core.functoriality-dependent-pair-types
@@ -108,15 +109,19 @@ module _
   is-emb-comp :
     (g : B → C) (h : A → B) → is-emb g → is-emb h → is-emb (g ∘ h)
   is-emb-comp g h is-emb-g is-emb-h x y =
-    is-equiv-comp-htpy (ap (g ∘ h)) (ap g) (ap h) (ap-comp g h)
+    is-equiv-left-map-triangle
+      ( ap (g ∘ h))
+      ( ap g)
+      ( ap h)
+      ( ap-comp g h)
       ( is-emb-h x y)
       ( is-emb-g (h x) (h y))
 
   abstract
-    is-emb-comp-htpy :
-      (f : A → C) (g : B → C) (h : A → B) (H : f ~ g ∘ h) → is-emb g →
-      is-emb h → is-emb f
-    is-emb-comp-htpy f g h H is-emb-g is-emb-h =
+    is-emb-left-map-triangle :
+      (f : A → C) (g : B → C) (h : A → B) (H : coherence-triangle-maps f g h) →
+      is-emb g → is-emb h → is-emb f
+    is-emb-left-map-triangle f g h H is-emb-g is-emb-h =
       is-emb-htpy H (is-emb-comp g h is-emb-g is-emb-h)
 
   comp-emb :
@@ -136,7 +141,7 @@ module _
     (g : B → C) (h : A → B) →
     is-emb g → is-emb (g ∘ h) → is-emb h
   is-emb-right-factor g h is-emb-g is-emb-gh x y =
-    is-equiv-right-factor-htpy
+    is-equiv-top-map-triangle
       ( ap (g ∘ h))
       ( ap g)
       ( ap h)
@@ -145,11 +150,11 @@ module _
       ( is-emb-gh x y)
 
   abstract
-    is-emb-right-factor-htpy :
-      (f : A → C) (g : B → C) (h : A → B) (H : f ~ (g ∘ h)) →
+    is-emb-top-map-triangle :
+      (f : A → C) (g : B → C) (h : A → B) (H : coherence-triangle-maps f g h) →
       is-emb g → is-emb f → is-emb h
-    is-emb-right-factor-htpy f g h H is-emb-g is-emb-f x y =
-      is-equiv-right-factor-htpy
+    is-emb-top-map-triangle f g h H is-emb-g is-emb-f x y =
+      is-equiv-top-map-triangle
         ( ap (g ∘ h))
         ( ap g)
         ( ap h)
@@ -159,10 +164,10 @@ module _
 
   abstract
     is-emb-triangle-is-equiv :
-      (f : A → C) (g : B → C) (e : A → B) (H : f ~ (g ∘ e)) →
+      (f : A → C) (g : B → C) (e : A → B) (H : coherence-triangle-maps f g e) →
       is-equiv e → is-emb g → is-emb f
     is-emb-triangle-is-equiv f g e H is-equiv-e is-emb-g =
-      is-emb-comp-htpy f g e H is-emb-g (is-emb-is-equiv is-equiv-e)
+      is-emb-left-map-triangle f g e H is-emb-g (is-emb-is-equiv is-equiv-e)
 
 module _
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
@@ -170,7 +175,7 @@ module _
 
   abstract
     is-emb-triangle-is-equiv' :
-      (f : A → C) (g : B → C) (e : A → B) (H : f ~ (g ∘ e)) →
+      (f : A → C) (g : B → C) (e : A → B) (H : coherence-triangle-maps f g e) →
       is-equiv e → is-emb f → is-emb g
     is-emb-triangle-is-equiv' f g e H is-equiv-e is-emb-f =
       is-emb-triangle-is-equiv g f

--- a/src/foundation/equality-coproduct-types.lagda.md
+++ b/src/foundation/equality-coproduct-types.lagda.md
@@ -268,7 +268,7 @@ module _
     is-emb f → is-emb g → ((a : A) (b : B) → f a ≠ g b) →
     is-emb (ind-coprod (λ x → C) f g)
   is-emb-coprod H K L (inl a) (inl a') =
-    is-equiv-left-factor-htpy
+    is-equiv-right-map-triangle
       ( ap f)
       ( ap (ind-coprod (λ x → C) f g))
       ( ap inl)
@@ -280,7 +280,7 @@ module _
   is-emb-coprod H K L (inr b) (inl a') =
     is-equiv-is-empty (ap (ind-coprod (λ x → C) f g)) (L a' b ∘ inv)
   is-emb-coprod H K L (inr b) (inr b') =
-    is-equiv-left-factor-htpy
+    is-equiv-right-map-triangle
       ( ap g)
       ( ap (ind-coprod (λ x → C) f g))
       ( ap inr)

--- a/src/foundation/equality-fibers-of-maps.lagda.md
+++ b/src/foundation/equality-fibers-of-maps.lagda.md
@@ -83,7 +83,7 @@ module _
     is-equiv-fiber-ap-eq-fiber :
       (s t : fiber f b) → is-equiv (fiber-ap-eq-fiber s t)
     is-equiv-fiber-ap-eq-fiber s t =
-      is-equiv-comp-htpy
+      is-equiv-left-map-triangle
         ( fiber-ap-eq-fiber s t)
         ( tot (fiber-ap-eq-fiber-fiberwise s t))
         ( pair-eq-Σ {s = s} {t})

--- a/src/foundation/equivalences.lagda.md
+++ b/src/foundation/equivalences.lagda.md
@@ -323,7 +323,7 @@ Consider a commuting diagram of maps
 ```
 
 The **6-for-2 property of equivalences** asserts that if `i` and `j` are
-equivalences, then all maps are equivalences.
+equivalences, then so are `h`, `f`, `g`, and the triple composite `g ∘ h ∘ f`.
 
 **First proof:** Since `i` is an equivalence, it follows that `i` is surjective.
 This implies that `h` is surjective. Furthermore, since `j` is an equivalence it
@@ -411,6 +411,16 @@ module _
   is-equiv-right-is-equiv-top-is-equiv-bottom-square H K =
     is-equiv-right-map-triangle j g h v K
       ( is-equiv-diagonal-filler-is-equiv-top-is-equiv-bottom-square H K)
+
+  is-equiv-triple-comp :
+    is-equiv i → is-equiv j → is-equiv (g ∘ h ∘ f)
+  is-equiv-triple-comp H K =
+    is-equiv-comp g
+      ( h ∘ f)
+      ( is-equiv-comp h f
+        ( is-equiv-left-is-equiv-top-is-equiv-bottom-square H K)
+        ( is-equiv-diagonal-filler-is-equiv-top-is-equiv-bottom-square H K))
+      ( is-equiv-right-is-equiv-top-is-equiv-bottom-square H K)
 ```
 
 ### Being an equivalence is closed under homotopies

--- a/src/foundation/equivalences.lagda.md
+++ b/src/foundation/equivalences.lagda.md
@@ -345,9 +345,9 @@ along equivalences. Similarly, the map `j⁻¹ ∘ g` is a retraction of `h`, si
 we have `(g ∘ h ~ j) → (j⁻¹ ∘ g ∘ h ~ id)` by transposing along equivalences.
 Since `h` therefore has a section and a retraction, it is an equivalence.
 
-In fact, the above argument shows that if the top map has a section and the
-bottom map has a retraction, then the diagonal filler, and hence all other maps
-are equivalences.
+In fact, the above argument shows that if the top map `i` has a section and the
+bottom map `j` has a retraction, then the diagonal filler, and hence all other
+maps are equivalences.
 
 ```agda
 module _
@@ -691,4 +691,4 @@ equiv-fiberwise-equiv-fam-equiv B C = distributive-Π-Σ
 
 - The
   [2-out-of-6 property](https://ncatlab.org/nlab/show/two-out-of-six+property)
-  at the nLab.
+  at nlab

--- a/src/foundation/equivalences.lagda.md
+++ b/src/foundation/equivalences.lagda.md
@@ -345,6 +345,10 @@ along equivalences. Similarly, the map `j⁻¹ ∘ g` is a retraction of `h`, si
 we have `(g ∘ h ~ j) → (j⁻¹ ∘ g ∘ h ~ id)` by transposing along equivalences.
 Since `h` therefore has a section and a retraction, it is an equivalence.
 
+In fact, the above argument shows that if the top map has a section and the
+bottom map has a retraction, then the diagonal filler, and hence all other maps
+are equivalences.
+
 ```agda
 module _
   {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
@@ -352,53 +356,68 @@ module _
   (u : coherence-triangle-maps i h f) (v : coherence-triangle-maps j g h)
   where
 
-  map-section-diagonal-filler-is-equiv-top-is-equiv-bottom-square :
-    is-equiv i → X → B
-  map-section-diagonal-filler-is-equiv-top-is-equiv-bottom-square H =
-    f ∘ map-inv-is-equiv H
-
-  is-section-section-diagonal-filler-is-equiv-top-is-equiv-bottom-square :
-    (H : is-equiv i) →
-    h ∘ map-section-diagonal-filler-is-equiv-top-is-equiv-bottom-square H ~ id
-  is-section-section-diagonal-filler-is-equiv-top-is-equiv-bottom-square H x =
-    ( inv (u (map-inv-is-equiv H x))) ∙
-    ( is-section-map-inv-is-equiv H x)
+  section-diagonal-filler-section-top-square :
+    section i → section h
+  section-diagonal-filler-section-top-square =
+    section-right-map-triangle i h f u
 
   section-diagonal-filler-is-equiv-top-is-equiv-bottom-square :
     is-equiv i → section h
-  pr1 (section-diagonal-filler-is-equiv-top-is-equiv-bottom-square H) =
-    map-section-diagonal-filler-is-equiv-top-is-equiv-bottom-square H
-  pr2 (section-diagonal-filler-is-equiv-top-is-equiv-bottom-square H) =
-    is-section-section-diagonal-filler-is-equiv-top-is-equiv-bottom-square H
+  section-diagonal-filler-is-equiv-top-is-equiv-bottom-square H =
+    section-diagonal-filler-section-top-square (section-is-equiv H)
+
+  map-section-diagonal-filler-is-equiv-top-is-equiv-bottom-square :
+    is-equiv i → X → B
+  map-section-diagonal-filler-is-equiv-top-is-equiv-bottom-square H =
+    map-section h
+      ( section-diagonal-filler-is-equiv-top-is-equiv-bottom-square H)
+
+  is-section-section-diagonal-filler-is-equiv-top-is-equiv-bottom-square :
+    (H : is-equiv i) →
+    is-section h
+      ( map-section-diagonal-filler-is-equiv-top-is-equiv-bottom-square H)
+  is-section-section-diagonal-filler-is-equiv-top-is-equiv-bottom-square H =
+    is-section-map-section h
+      ( section-diagonal-filler-is-equiv-top-is-equiv-bottom-square H)
+
+  retraction-diagonal-filler-retraction-bottom-square :
+    retraction j → retraction h
+  retraction-diagonal-filler-retraction-bottom-square =
+    retraction-top-map-triangle j g h v
+
+  retraction-diagonal-filler-is-equiv-top-is-equiv-bottom-square :
+    is-equiv j → retraction h
+  retraction-diagonal-filler-is-equiv-top-is-equiv-bottom-square K =
+    retraction-diagonal-filler-retraction-bottom-square (retraction-is-equiv K)
 
   map-retraction-diagonal-filler-is-equiv-top-is-equiv-bottom-square :
     is-equiv j → X → B
   map-retraction-diagonal-filler-is-equiv-top-is-equiv-bottom-square K =
-    map-inv-is-equiv K ∘ g
+    map-retraction h
+      ( retraction-diagonal-filler-is-equiv-top-is-equiv-bottom-square K)
 
   is-retraction-retraction-diagonal-fller-is-equiv-top-is-equiv-bottom-square :
     (K : is-equiv j) →
-    map-retraction-diagonal-filler-is-equiv-top-is-equiv-bottom-square K ∘ h ~
-    id
+    is-retraction h
+      ( map-retraction-diagonal-filler-is-equiv-top-is-equiv-bottom-square K)
   is-retraction-retraction-diagonal-fller-is-equiv-top-is-equiv-bottom-square
-    K b =
-    ( inv (ap (map-inv-is-equiv K) (v b))) ∙
-    ( is-retraction-map-inv-is-equiv K b)
+    K =
+    is-retraction-map-retraction h
+      ( retraction-diagonal-filler-is-equiv-top-is-equiv-bottom-square K)
 
-  retraction-diagonal-filler-is-equiv-top-is-equiv-bottom-square :
-    (K : is-equiv j) → retraction h
-  pr1 (retraction-diagonal-filler-is-equiv-top-is-equiv-bottom-square K) =
-    map-retraction-diagonal-filler-is-equiv-top-is-equiv-bottom-square K
-  pr2 (retraction-diagonal-filler-is-equiv-top-is-equiv-bottom-square K) =
-    is-retraction-retraction-diagonal-fller-is-equiv-top-is-equiv-bottom-square
-      K
+  is-equiv-diagonal-filler-section-top-retraction-bottom-square :
+    section i → retraction j → is-equiv h
+  pr1 (is-equiv-diagonal-filler-section-top-retraction-bottom-square H K) =
+    section-diagonal-filler-section-top-square H
+  pr2 (is-equiv-diagonal-filler-section-top-retraction-bottom-square H K) =
+    retraction-diagonal-filler-retraction-bottom-square K
 
   is-equiv-diagonal-filler-is-equiv-top-is-equiv-bottom-square :
     is-equiv i → is-equiv j → is-equiv h
-  pr1 (is-equiv-diagonal-filler-is-equiv-top-is-equiv-bottom-square H K) =
-    section-diagonal-filler-is-equiv-top-is-equiv-bottom-square H
-  pr2 (is-equiv-diagonal-filler-is-equiv-top-is-equiv-bottom-square H K) =
-    retraction-diagonal-filler-is-equiv-top-is-equiv-bottom-square K
+  is-equiv-diagonal-filler-is-equiv-top-is-equiv-bottom-square H K =
+    is-equiv-diagonal-filler-section-top-retraction-bottom-square
+      ( section-is-equiv H)
+      ( retraction-is-equiv K)
 
   is-equiv-left-is-equiv-top-is-equiv-bottom-square :
     is-equiv i → is-equiv j → is-equiv f

--- a/src/foundation/equivalences.lagda.md
+++ b/src/foundation/equivalences.lagda.md
@@ -324,6 +324,7 @@ Consider a commuting diagram of maps
 
 The **6-for-2 property of equivalences** asserts that if `i` and `j` are
 equivalences, then so are `h`, `f`, `g`, and the triple composite `g ∘ h ∘ f`.
+The 6-for-2 property is also commonly known as the **2-out-of-6 property**.
 
 **First proof:** Since `i` is an equivalence, it follows that `i` is surjective.
 This implies that `h` is surjective. Furthermore, since `j` is an equivalence it
@@ -666,3 +667,9 @@ equiv-fiberwise-equiv-fam-equiv B C = distributive-Π-Σ
   [`foundation.contractible-maps`](foundation.contractible-maps.md).
 - For the notion of path-split maps see
   [`foundation.path-split-maps`](foundation.path-split-maps.md).
+
+## External links
+
+- The
+  [2-out-of-6 property](https://ncatlab.org/nlab/show/two-out-of-six+property)
+  at the nLab.

--- a/src/foundation/faithful-maps.lagda.md
+++ b/src/foundation/faithful-maps.lagda.md
@@ -166,12 +166,12 @@ module _
           ( is-0-map-is-faithful is-faithful-h))
 
   abstract
-    is-faithful-comp-htpy :
+    is-faithful-left-map-triangle :
       (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
       is-faithful g → is-faithful h → is-faithful f
-    is-faithful-comp-htpy f g h H is-faithful-g is-faithful-h =
+    is-faithful-left-map-triangle f g h H is-faithful-g is-faithful-h =
       is-faithful-is-0-map
-        ( is-0-map-comp-htpy f g h H
+        ( is-0-map-left-map-triangle f g h H
           ( is-0-map-is-faithful is-faithful-g)
           ( is-0-map-is-faithful is-faithful-h))
 ```
@@ -192,12 +192,12 @@ module _
         ( is-0-map-is-faithful is-faithful-g)
         ( is-0-map-is-faithful is-faithful-gh))
 
-  is-faithful-right-factor-htpy :
+  is-faithful-top-map-triangle :
     (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
     is-faithful g → is-faithful f → is-faithful h
-  is-faithful-right-factor-htpy f g h H is-faithful-g is-faithful-f =
+  is-faithful-top-map-triangle f g h H is-faithful-g is-faithful-f =
     is-faithful-is-0-map
-      ( is-0-map-right-factor-htpy f g h H
+      ( is-0-map-top-map-triangle f g h H
         ( is-0-map-is-faithful is-faithful-g)
         ( is-0-map-is-faithful is-faithful-f))
 ```

--- a/src/foundation/functoriality-dependent-function-types.lagda.md
+++ b/src/foundation/functoriality-dependent-function-types.lagda.md
@@ -129,23 +129,23 @@ module _
   { l1 l2 l3 : Level} {A : UU l1}
   where
 
-  equiv-htpy-Π-precomp-htpy :
+  equiv-htpy-Π-preleft-map-triangle :
     { B : UU l2} {C : B → UU l3} →
     ( f g : (b : B) → C b) (e : A ≃ B) →
     ( (f ∘ map-equiv e) ~ (g ∘ map-equiv e)) ≃
     ( f ~ g)
-  equiv-htpy-Π-precomp-htpy f g e =
+  equiv-htpy-Π-preleft-map-triangle f g e =
     equiv-Π
       ( eq-value f g)
       ( e)
       ( λ a → id-equiv)
 
-  equiv-htpy-Π-postcomp-htpy :
+  equiv-htpy-Π-postleft-map-triangle :
     { B : A → UU l2} { C : UU l3} →
     ( e : (a : A) → B a ≃ C) (f g : (a : A) → B a) →
     ( f ~ g) ≃
     ( (a : A) → ( map-equiv (e a) (f a) ＝ map-equiv (e a) (g a)))
-  equiv-htpy-Π-postcomp-htpy e f g =
+  equiv-htpy-Π-postleft-map-triangle e f g =
     equiv-Π-equiv-family
       ( λ a → equiv-ap (e a) (f a) (g a))
 ```

--- a/src/foundation/functoriality-dependent-function-types.lagda.md
+++ b/src/foundation/functoriality-dependent-function-types.lagda.md
@@ -129,12 +129,12 @@ module _
   { l1 l2 l3 : Level} {A : UU l1}
   where
 
-  equiv-htpy-Π-preleft-map-triangle :
+  equiv-htpy-Π-precomp-htpy :
     { B : UU l2} {C : B → UU l3} →
     ( f g : (b : B) → C b) (e : A ≃ B) →
     ( (f ∘ map-equiv e) ~ (g ∘ map-equiv e)) ≃
     ( f ~ g)
-  equiv-htpy-Π-preleft-map-triangle f g e =
+  equiv-htpy-Π-precomp-htpy f g e =
     equiv-Π
       ( eq-value f g)
       ( e)

--- a/src/foundation/functoriality-dependent-function-types.lagda.md
+++ b/src/foundation/functoriality-dependent-function-types.lagda.md
@@ -140,12 +140,12 @@ module _
       ( e)
       ( λ a → id-equiv)
 
-  equiv-htpy-Π-postleft-map-triangle :
+  equiv-htpy-Π-postcomp-htpy :
     { B : A → UU l2} { C : UU l3} →
     ( e : (a : A) → B a ≃ C) (f g : (a : A) → B a) →
     ( f ~ g) ≃
     ( (a : A) → ( map-equiv (e a) (f a) ＝ map-equiv (e a) (g a)))
-  equiv-htpy-Π-postleft-map-triangle e f g =
+  equiv-htpy-Π-postcomp-htpy e f g =
     equiv-Π-equiv-family
       ( λ a → equiv-ap (e a) (f a) (g a))
 ```

--- a/src/foundation/functoriality-dependent-pair-types.lagda.md
+++ b/src/foundation/functoriality-dependent-pair-types.lagda.md
@@ -160,7 +160,7 @@ module _
         ( g' (pr1 (pr2 c) x))
         ( c' x))
       ( is-pb-c)
-      ( is-equiv-right-factor-htpy
+      ( is-equiv-top-map-triangle
         ( gap (map-Σ PX f f') (map-Σ PX g g') tot-cone-cone-family)
         ( map-standard-pullback-tot-cone-cone-family)
         ( map-Σ _
@@ -183,7 +183,7 @@ module _
     is-pullback
       (map-Σ PX f f') (map-Σ PX g g') tot-cone-cone-family
   is-pullback-tot-is-pullback-family is-pb-c is-pb-c' =
-    is-equiv-comp-htpy
+    is-equiv-left-map-triangle
       ( gap (map-Σ PX f f') (map-Σ PX g g') tot-cone-cone-family)
       ( map-standard-pullback-tot-cone-cone-family)
       ( map-Σ _

--- a/src/foundation/functoriality-fibers-of-maps.lagda.md
+++ b/src/foundation/functoriality-fibers-of-maps.lagda.md
@@ -325,7 +325,7 @@ constructed as a family of identifications of the form
   eq-Eq-fiber g (γ₀ a) _,
 ```
 
-it follows that when we left-whisker this homotopy with `inclusion-fiber g`, we
+it follows that when we left whisker this homotopy with `inclusion-fiber g`, we
 recover the homotopy `γ₀ ·r inclusion-fiber f`.
 
 Now it remains to fill a coherence for the square of homotopies
@@ -343,13 +343,6 @@ Now it remains to fill a coherence for the square of homotopies
 
 where `H` is the homotopy that we just constructed, witnessing that the upper
 triangle commutes, and where we have written `i` for all fiber inclusions.
-
-coherence-square-homotopies (pr1 (pr2 htpy-hom-arrow-fiber) ·r inclusion-fiber
-f) (coh-hom-arrow (inclusion-fiber f) (inclusion-fiber g) (comp-hom-arrow
-(inclusion-fiber f) (inclusion-fiber g) (inclusion-fiber g)
-(tr-hom-arrow-inclusion-fiber g (htpy-codomain-htpy-hom-arrow f g α β γ b))
-(hom-arrow-fiber f g α b))) (coh-hom-arrow (inclusion-fiber f) (inclusion-fiber
-g) (hom-arrow-fiber f g β b)) (inclusion-fiber g ·l pr1 htpy-hom-arrow-fiber)
 
 ```agda
 module _

--- a/src/foundation/functoriality-fibers-of-maps.lagda.md
+++ b/src/foundation/functoriality-fibers-of-maps.lagda.md
@@ -21,6 +21,7 @@ open import foundation-core.function-types
 open import foundation-core.functoriality-dependent-pair-types
 open import foundation-core.homotopies
 open import foundation-core.identity-types
+open import foundation-core.transport-along-identifications
 open import foundation-core.whiskering-homotopies
 ```
 
@@ -28,7 +29,8 @@ open import foundation-core.whiskering-homotopies
 
 ## Idea
 
-Any [morphism of arrows](foundation.morphisms-arrows.md) `(i , j , H)` from `f` to `g`
+Any [morphism of arrows](foundation.morphisms-arrows.md) `(i , j , H)` from `f`
+to `g`
 
 ```text
         i
@@ -40,7 +42,9 @@ Any [morphism of arrows](foundation.morphisms-arrows.md) `(i , j , H)` from `f` 
         j
 ```
 
-induces a morphism of arrows between the [fiber inclusions](foundation-core.fibers-of-maps.md) of `f` and `g`, i.e., a [commuting square](foundation-core.commuting-squares-of-maps.md)
+induces a morphism of arrows between the
+[fiber inclusions](foundation-core.fibers-of-maps.md) of `f` and `g`, i.e., a
+[commuting square](foundation-core.commuting-squares-of-maps.md)
 
 ```text
   fiber f b -----> fiber g (j b)
@@ -50,11 +54,17 @@ induces a morphism of arrows between the [fiber inclusions](foundation-core.fibe
       A ---------------> X.
 ```
 
-This operation from morphisms of arrows from `f` to `g` to morphisms of arrows between their fiber inclusions is the **functorial action of fibers**. The functorial action obeys the functor laws, i.e., it preserves identity morphisms and composition.
+This operation from morphisms of arrows from `f` to `g` to morphisms of arrows
+between their fiber inclusions is the **functorial action of fibers**. The
+functorial action obeys the functor laws, i.e., it preserves identity morphisms
+and composition.
 
 ## Definitions
 
 ### Any commuting square induces a family of maps between the fibers of the vertical maps
+
+Our definition of `map-domain-hom-arrow-fiber` is given in such a way that it
+always computes nicely.
 
 ```agda
 module _
@@ -64,9 +74,11 @@ module _
 
   map-domain-hom-arrow-fiber :
     fiber f b → fiber g (map-codomain-hom-arrow f g α b)
-  pr1 (map-domain-hom-arrow-fiber (y , p)) = map-domain-hom-arrow f g α y
-  pr2 (map-domain-hom-arrow-fiber (y , p)) =
-    inv (coh-hom-arrow f g α y) ∙ ap (map-codomain-hom-arrow f g α) p
+  map-domain-hom-arrow-fiber =
+    map-Σ _
+      ( map-domain-hom-arrow f g α)
+      ( λ a p →
+        inv (coh-hom-arrow f g α a) ∙ ap (map-codomain-hom-arrow f g α) p)
 
   map-fiber :
     fiber f b → fiber g (map-codomain-hom-arrow f g α b)
@@ -109,6 +121,21 @@ module _
       ( a)
 ```
 
+### For any `f : A → B` and any identification `p : b ＝ b'` in `B`, we obtain a morphism of arrows between the fiber inclusion at `b` to the fiber inclusion at `b'`
+
+```agda
+module _
+  {l1 l2 : Level} {A : UU l1} {B : UU l2} (f : A → B)
+  where
+
+  tr-hom-arrow-inclusion-fiber :
+    {b b' : B} (p : b ＝ b') →
+    hom-arrow (inclusion-fiber f {b}) (inclusion-fiber f {b'})
+  pr1 (tr-hom-arrow-inclusion-fiber p) = tot (λ a → concat' (f a) p)
+  pr1 (pr2 (tr-hom-arrow-inclusion-fiber p)) = id
+  pr2 (pr2 (tr-hom-arrow-inclusion-fiber p)) = refl-htpy
+```
+
 ## Properties
 
 ### The functorial action of `fiber` preserves the identity function
@@ -117,7 +144,7 @@ module _
 module _
   {l1 l2 : Level} {A : UU l1} {B : UU l2} (f : A → B) (b : B)
   where
-  
+
   preserves-id-map-fiber :
     map-domain-hom-arrow-fiber f f id-hom-arrow b ~ id
   preserves-id-map-fiber (a , refl) = refl
@@ -128,7 +155,7 @@ module _
       ( refl-htpy)
       ( coh-hom-arrow-fiber f f id-hom-arrow b)
       ( inclusion-fiber f ·l preserves-id-map-fiber)
-  coh-preserves-id-hom-arrow-fiber (a , refl) = refl 
+  coh-preserves-id-hom-arrow-fiber (a , refl) = refl
 
   preserves-id-hom-arrow-fiber :
     htpy-hom-arrow
@@ -196,7 +223,7 @@ module _
     ap
       ( concat _ _)
       ( compute-left-whisker-inclusion-fiber-preserves-comp-map-fiber p)
-  
+
   preserves-comp-hom-arrow-fiber :
     htpy-hom-arrow
       ( inclusion-fiber f)
@@ -213,6 +240,191 @@ module _
   pr2 (pr2 preserves-comp-hom-arrow-fiber) = coh-preserves-comp-hom-arrow-fiber
 ```
 
+### The functorial action of `fiber` preserves homotopies of morphisms of fibers
+
+Given two morphisms of arrows
+
+```text
+        α₀
+      ------>
+    A ------> X
+    |   β₀    |
+    |         |
+  f |  α  β   | g
+    |         |
+    V   α₁    V
+    B ------> Y
+      ------>
+        β₁
+```
+
+with a homotopy `γ : α ~ β` of morphisms of arrows, we obtain a commuting
+diagram of the form
+
+```text
+           fiber g (α₁ b)
+            ∧     |   \
+           /      |    \ (x , q) ↦ (x , q ∙ γ₁ b)
+          /       |     \
+         /        |      V
+  fiber f b --------> fiber g (β₁ b)
+        |         |     /
+        |         |    /
+        |         |   /
+        |         |  /
+        V         V V
+        A -------> X
+```
+
+To show that we have such a commuting diagram, we have to show that the top
+triangle commutes, and that there is a homotopy filling the diagram:
+
+We first show that the top triangle commutes. To see this, let
+`(a , refl) : fiber f (f a)`. Then we have to show that
+
+```text
+  ((x , q) ↦ (x , q ∙ γ₁ b)) (map-fiber f g α (a , refl)) ＝
+  map-fiber f g β (a , refl)
+```
+
+Simply computing the left-hand side and the right-hand side, we're tasked with
+constructing an identification
+
+```text
+  (α₀ a , ((α a)⁻¹ ∙ refl) ∙ γ₁ (f a)) ＝ (β₀ a , (β a)⁻¹ ∙ refl)
+```
+
+By the characterization of equality in fibers, it suffices to construct
+identifications
+
+```text
+  p : α₀ a ＝ β₀ a
+  q : ap g p ∙ ((β a)⁻¹ ∙ refl) ＝ ((α a)⁻¹ ∙ refl) ∙ γ₁ (f a)
+```
+
+The first identification is simply `γ₀ a`. To obtain the second identification,
+we first simplify using the right unit law. I.e., it suffices to construct an
+identification
+
+```text
+  ap g p ∙ (β a)⁻¹ ＝ (α a)⁻¹ ∙ γ₁ (f a).
+```
+
+Now we proceed by transposing equality on both sides, i.e., it suffices to
+costruct an identification
+
+```text
+  α a ∙ ap g p ＝ γ₁ (f a) ∙ β a.
+```
+
+The identification `γ a` has exactly this type. This completes the construction
+of the homotopy witnessing that the upper triangle commutes. Since it is
+constructed as a family of identifications of the form
+
+```text
+  eq-Eq-fiber g (γ₀ a) _,
+```
+
+it follows that when we left-whisker this homotopy with `inclusion-fiber g`, we
+recover the homotopy `γ₀ ·r inclusion-fiber f`.
+
+Now it remains to fill a coherence for the square of homotopies
+
+```text
+                   γ₀ ·r i
+                · ---------> ·
+                |            |
+ coh (tr ∘ α b) |            | coh-hom-arrow-fiber f g β b
+    ≐ refl-htpy |            | ≐ refl-htpy
+                V            V
+                · ---------> ·
+                   i ·r H
+```
+
+where `H` is the homotopy that we just constructed, witnessing that the upper
+triangle commutes, and where we have written `i` for all fiber inclusions.
+
+coherence-square-homotopies (pr1 (pr2 htpy-hom-arrow-fiber) ·r inclusion-fiber
+f) (coh-hom-arrow (inclusion-fiber f) (inclusion-fiber g) (comp-hom-arrow
+(inclusion-fiber f) (inclusion-fiber g) (inclusion-fiber g)
+(tr-hom-arrow-inclusion-fiber g (htpy-codomain-htpy-hom-arrow f g α β γ b))
+(hom-arrow-fiber f g α b))) (coh-hom-arrow (inclusion-fiber f) (inclusion-fiber
+g) (hom-arrow-fiber f g β b)) (inclusion-fiber g ·l pr1 htpy-hom-arrow-fiber)
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
+  (f : A → B) (g : X → Y) (α β : hom-arrow f g) (γ : htpy-hom-arrow f g α β)
+  (b : B)
+  where
+
+  htpy-fiber :
+    ( tot (λ x → concat' (g x) (htpy-codomain-htpy-hom-arrow f g α β γ b)) ∘
+      map-fiber f g α b) ~
+    ( map-fiber f g β b)
+  htpy-fiber (a , refl) =
+    eq-Eq-fiber g
+      ( map-codomain-hom-arrow f g β (f a))
+      ( htpy-domain-htpy-hom-arrow f g α β γ a)
+      ( ( ap
+          ( concat
+            ( ap g (htpy-domain-htpy-hom-arrow f g α β γ a))
+            ( map-codomain-hom-arrow f g β (f a)))
+          ( right-unit)) ∙
+        ( double-transpose-eq-concat'
+          ( htpy-codomain-htpy-hom-arrow f g α β γ (f a))
+          ( coh-hom-arrow f g α a)
+          ( coh-hom-arrow f g β a)
+          ( ap g (htpy-domain-htpy-hom-arrow f g α β γ a))
+          ( coh-htpy-hom-arrow f g α β γ a)) ∙
+        ( inv
+          ( ap
+            ( concat'
+              ( g (map-domain-hom-arrow f g α a))
+              ( htpy-codomain-htpy-hom-arrow f g α β γ (f a)))
+            ( right-unit))))
+
+  compute-left-whisker-inclusion-fiber-htpy-fiber :
+    inclusion-fiber g ·l htpy-fiber ~
+    htpy-domain-htpy-hom-arrow f g α β γ ·r inclusion-fiber f
+  compute-left-whisker-inclusion-fiber-htpy-fiber (a , refl) =
+    compute-ap-inclusion-fiber-eq-Eq-fiber g
+      ( map-codomain-hom-arrow f g β (f a))
+      ( htpy-domain-htpy-hom-arrow f g α β γ a)
+      ( _)
+
+  htpy-codomain-htpy-hom-arrow-fiber :
+    map-codomain-hom-arrow-fiber f g α b ~
+    map-codomain-hom-arrow-fiber f g β b
+  htpy-codomain-htpy-hom-arrow-fiber =
+    htpy-domain-htpy-hom-arrow f g α β γ
+
+  coh-htpy-hom-arrow-fiber :
+    coherence-square-homotopies
+      ( htpy-domain-htpy-hom-arrow f g α β γ ·r inclusion-fiber f)
+      ( refl-htpy)
+      ( refl-htpy)
+      ( inclusion-fiber g ·l htpy-fiber)
+  coh-htpy-hom-arrow-fiber =
+    compute-left-whisker-inclusion-fiber-htpy-fiber ∙h inv-htpy right-unit-htpy
+
+  htpy-hom-arrow-fiber :
+    htpy-hom-arrow
+      ( inclusion-fiber f)
+      ( inclusion-fiber g)
+      ( comp-hom-arrow
+        ( inclusion-fiber f)
+        ( inclusion-fiber g)
+        ( inclusion-fiber g)
+        ( tr-hom-arrow-inclusion-fiber g
+          ( htpy-codomain-htpy-hom-arrow f g α β γ b))
+        ( hom-arrow-fiber f g α b))
+      ( hom-arrow-fiber f g β b)
+  pr1 htpy-hom-arrow-fiber = htpy-fiber
+  pr1 (pr2 htpy-hom-arrow-fiber) = htpy-codomain-htpy-hom-arrow-fiber
+  pr2 (pr2 htpy-hom-arrow-fiber) = coh-htpy-hom-arrow-fiber
+```
+
 ### Computing `map-fiber-cone` of a horizontal pasting of cones
 
 ```agda
@@ -222,25 +434,24 @@ module _
   (i : X → Y) (j : Y → Z) (h : C → Z)
   where
 
-  map-fiber-pasting-horizontal-cone :
+  preserves-pasting-horizontal-map-fiber-cone :
     (c : cone j h B) (d : cone i (vertical-map-cone j h c) A) (x : X) →
     ( map-fiber-cone (j ∘ i) h (pasting-horizontal-cone i j h c d) x) ~
     ( map-fiber-cone j h c (i x) ∘
       map-fiber-cone i (vertical-map-cone j h c) d x)
-  map-fiber-pasting-horizontal-cone
-    (g , q , K) (f , p , H) .(f a) (a , refl) =
-    eq-pair-eq-pr2
-      ( ( ap
-          ( concat' (h (q (p a))) refl)
-          ( distributive-inv-concat (ap j (H a)) (K (p a)))) ∙
-        ( assoc (inv (K (p a))) (inv (ap j (H a))) refl) ∙
-        ( ap
-          ( concat (inv (K (p a))) (j (i (f a))))
-          ( ( ap (concat' (j (g (p a))) refl) (inv (ap-inv j (H a)))) ∙
-            ( inv (ap-concat j (inv (H a)) refl)))))
+  preserves-pasting-horizontal-map-fiber-cone c d =
+    preserves-comp-map-fiber
+      ( vertical-map-cone i (vertical-map-cone j h c) d)
+      ( vertical-map-cone j h c)
+      ( h)
+      ( hom-arrow-cone j h c)
+      ( hom-arrow-cone i (vertical-map-cone j h c) d)
 ```
 
 ### Computing `map-fiber-cone` of a horizontal pasting of cones
+
+Note: There should be a definition of vertical composition of morphisms of
+arrows, and a proof that `hom-arrow-fiber` preserves vertical composition.
 
 ```agda
 module _
@@ -249,7 +460,7 @@ module _
   (f : C → Z) (g : Y → Z) (h : X → Y)
   where
 
-  map-fiber-pasting-vertical-cone :
+  preserves-pasting-vertical-map-fiber-cone :
     (c : cone f g B) (d : cone (pr1 (pr2 c)) h A) (x : C) →
     ( ( map-fiber-cone f (g ∘ h) (pasting-vertical-cone f g h c d) x) ∘
       ( inv-map-compute-fiber-comp (pr1 c) (pr1 d) x)) ~
@@ -258,7 +469,7 @@ module _
         ( λ t → fiber h (pr1 t))
         ( map-fiber-cone f g c x)
         ( λ t → map-fiber-cone (pr1 (pr2 c)) h d (pr1 t))))
-  map-fiber-pasting-vertical-cone
+  preserves-pasting-vertical-map-fiber-cone
     (p , q , H) (p' , q' , H') .(p (p' a))
     ((.(p' a) , refl) , (a , refl)) =
     eq-pair-eq-pr2

--- a/src/foundation/functoriality-fibers-of-maps.lagda.md
+++ b/src/foundation/functoriality-fibers-of-maps.lagda.md
@@ -167,9 +167,8 @@ module _
 
 ## See also
 
-- In [retracts of maps](foundation.retracts-of-maps.md),
-  we show that if `g` is a retract of `g'`, then the fibers of `g` are retracts
-  of the fibers of `g'`.
+- In [retracts of maps](foundation.retracts-of-maps.md), we show that if `g` is
+  a retract of `g'`, then the fibers of `g` are retracts of the fibers of `g'`.
 
 ## Table of files about fibers of maps
 

--- a/src/foundation/functoriality-fibers-of-maps.lagda.md
+++ b/src/foundation/functoriality-fibers-of-maps.lagda.md
@@ -8,8 +8,10 @@ module foundation.functoriality-fibers-of-maps where
 
 ```agda
 open import foundation.action-on-identifications-functions
+open import foundation.commuting-squares-of-homotopies
 open import foundation.cones-over-cospans
 open import foundation.dependent-pair-types
+open import foundation.morphisms-arrows
 open import foundation.universe-levels
 
 open import foundation-core.commuting-squares-of-maps
@@ -19,13 +21,14 @@ open import foundation-core.function-types
 open import foundation-core.functoriality-dependent-pair-types
 open import foundation-core.homotopies
 open import foundation-core.identity-types
+open import foundation-core.whiskering-homotopies
 ```
 
 </details>
 
 ## Idea
 
-Any [commuting square](foundation-core.commuting-squares-of-maps.md)
+Any [morphism of arrows](foundation.morphisms-arrows.md) `(i , j , H)` from `f` to `g`
 
 ```text
         i
@@ -37,16 +40,17 @@ Any [commuting square](foundation-core.commuting-squares-of-maps.md)
         j
 ```
 
-induces a map between the [fibers](foundation-core.fibers-of-maps.md) of the
-vertical maps, which fits in a commuting square
+induces a morphism of arrows between the [fiber inclusions](foundation-core.fibers-of-maps.md) of `f` and `g`, i.e., a [commuting square](foundation-core.commuting-squares-of-maps.md)
 
 ```text
   fiber f b -----> fiber g (j b)
       |                  |
       |                  |
       V                  V
-      A ---------------> X
+      A ---------------> X.
 ```
+
+This operation from morphisms of arrows from `f` to `g` to morphisms of arrows between their fiber inclusions is the **functorial action of fibers**. The functorial action obeys the functor laws, i.e., it preserves identity morphisms and composition.
 
 ## Definitions
 
@@ -54,43 +58,38 @@ vertical maps, which fits in a commuting square
 
 ```agda
 module _
-  {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4}
-  (top : C → B) (left : C → A) (right : B → X) (bottom : A → X)
-  (H : coherence-square-maps' top left right bottom)
+  {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
+  (f : A → B) (g : X → Y) (α : hom-arrow f g) (b : B)
   where
 
-  map-fiber-square' :
-    (x : A) → fiber left x → fiber right (bottom x)
-  pr1 (map-fiber-square' x (y , p)) = top y
-  pr2 (map-fiber-square' x (y , p)) = H y ∙ ap bottom p
+  map-domain-hom-arrow-fiber :
+    fiber f b → fiber g (map-codomain-hom-arrow f g α b)
+  pr1 (map-domain-hom-arrow-fiber (y , p)) = map-domain-hom-arrow f g α y
+  pr2 (map-domain-hom-arrow-fiber (y , p)) =
+    inv (coh-hom-arrow f g α y) ∙ ap (map-codomain-hom-arrow f g α) p
 
-  coherence-fiber-square' :
-    (x : A) →
-    coherence-square-maps'
-      ( map-fiber-square' x)
-      ( inclusion-fiber left)
-      ( inclusion-fiber right)
-      ( top)
-  coherence-fiber-square' x p = refl
+  map-fiber :
+    fiber f b → fiber g (map-codomain-hom-arrow f g α b)
+  map-fiber = map-domain-hom-arrow-fiber
 
-module _
-  {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4}
-  (top : C → B) (left : C → A) (right : B → X) (bottom : A → X)
-  (H : coherence-square-maps top left right bottom)
-  where
+  map-codomain-hom-arrow-fiber : A → X
+  map-codomain-hom-arrow-fiber = map-domain-hom-arrow f g α
 
-  map-fiber-square :
-    (x : A) → fiber left x → fiber right (bottom x)
-  map-fiber-square = map-fiber-square' top left right bottom (inv-htpy H)
-
-  coherence-fiber-square :
-    (x : A) →
+  coh-hom-arrow-fiber :
     coherence-square-maps
-      ( map-fiber-square x)
-      ( inclusion-fiber left)
-      ( inclusion-fiber right)
-      ( top)
-  coherence-fiber-square x p = refl
+      ( map-domain-hom-arrow-fiber)
+      ( inclusion-fiber f)
+      ( inclusion-fiber g)
+      ( map-domain-hom-arrow f g α)
+  coh-hom-arrow-fiber = refl-htpy
+
+  hom-arrow-fiber :
+    hom-arrow
+      ( inclusion-fiber f {b})
+      ( inclusion-fiber g {map-codomain-hom-arrow f g α b})
+  pr1 hom-arrow-fiber = map-domain-hom-arrow-fiber
+  pr1 (pr2 hom-arrow-fiber) = map-codomain-hom-arrow-fiber
+  pr2 (pr2 hom-arrow-fiber) = coh-hom-arrow-fiber
 ```
 
 ### Any cone induces a family of maps between the fibers of the vertical maps
@@ -98,17 +97,16 @@ module _
 ```agda
 module _
   {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4}
-  (f : A → X) (g : B → X) (c : cone f g C)
+  (f : A → X) (g : B → X) (c : cone f g C) (a : A)
   where
 
-  map-fiber-cone : (x : A) → fiber (pr1 c) x → fiber g (f x)
+  map-fiber-cone : fiber (vertical-map-cone f g c) a → fiber g (f a)
   map-fiber-cone =
-    map-fiber-square
-      ( horizontal-map-cone f g c)
+    map-domain-hom-arrow-fiber
       ( vertical-map-cone f g c)
       ( g)
-      ( f)
-      ( coherence-square-cone f g c)
+      ( hom-arrow-cone f g c)
+      ( a)
 ```
 
 ## Properties
@@ -116,10 +114,103 @@ module _
 ### The functorial action of `fiber` preserves the identity function
 
 ```agda
-map-fiber-square-id :
-  {l1 l2 : Level} {B : UU l1} {X : UU l2} (g : B → X) (x : X) →
-  map-fiber-square id g g id refl-htpy x ~ id
-map-fiber-square-id g .(g b) (b , refl) = refl
+module _
+  {l1 l2 : Level} {A : UU l1} {B : UU l2} (f : A → B) (b : B)
+  where
+  
+  preserves-id-map-fiber :
+    map-domain-hom-arrow-fiber f f id-hom-arrow b ~ id
+  preserves-id-map-fiber (a , refl) = refl
+
+  coh-preserves-id-hom-arrow-fiber :
+    coherence-square-homotopies
+      ( refl-htpy)
+      ( refl-htpy)
+      ( coh-hom-arrow-fiber f f id-hom-arrow b)
+      ( inclusion-fiber f ·l preserves-id-map-fiber)
+  coh-preserves-id-hom-arrow-fiber (a , refl) = refl 
+
+  preserves-id-hom-arrow-fiber :
+    htpy-hom-arrow
+      ( inclusion-fiber f)
+      ( inclusion-fiber f)
+      ( hom-arrow-fiber f f id-hom-arrow b)
+      ( id-hom-arrow)
+  pr1 preserves-id-hom-arrow-fiber = preserves-id-map-fiber
+  pr1 (pr2 preserves-id-hom-arrow-fiber) = refl-htpy
+  pr2 (pr2 preserves-id-hom-arrow-fiber) = coh-preserves-id-hom-arrow-fiber
+```
+
+### The functorial action of `fiber` preserves composition of morphisms of arrows
+
+```agda
+module _
+  {l1 l2 l3 l4 l5 l6 : Level}
+  {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4} {U : UU l5} {V : UU l6}
+  (f : A → B) (g : X → Y) (h : U → V) (β : hom-arrow g h) (α : hom-arrow f g)
+  (b : B)
+  where
+
+  preserves-comp-map-fiber :
+    map-fiber f h (comp-hom-arrow f g h β α) b ~
+    map-fiber g h β (map-codomain-hom-arrow f g α b) ∘ map-fiber f g α b
+  preserves-comp-map-fiber (a , refl) =
+    ap
+      ( pair _)
+      ( ( right-unit) ∙
+        ( distributive-inv-concat
+          ( ap (map-codomain-hom-arrow g h β) (coh-hom-arrow f g α a))
+          ( coh-hom-arrow g h β (map-domain-hom-arrow f g α a))) ∙
+        ( ap
+          ( concat (inv (coh-hom-arrow g h β (pr1 α a))) _)
+          ( inv
+            ( ( ap (ap (map-codomain-hom-arrow g h β)) right-unit) ∙
+              ( ap-inv
+                ( map-codomain-hom-arrow g h β)
+                ( coh-hom-arrow f g α a))))))
+
+  compute-left-whisker-inclusion-fiber-preserves-comp-map-fiber :
+    inclusion-fiber h ·l preserves-comp-map-fiber ~ refl-htpy
+  compute-left-whisker-inclusion-fiber-preserves-comp-map-fiber (a , refl) =
+    ( inv (ap-comp (inclusion-fiber h) (pair _) _)) ∙
+    ( ap-const _ _)
+
+  coh-preserves-comp-hom-arrow-fiber :
+    coherence-square-homotopies
+      ( refl-htpy)
+      ( coh-hom-arrow
+        ( inclusion-fiber f)
+        ( inclusion-fiber h)
+        ( hom-arrow-fiber f h (comp-hom-arrow f g h β α) b))
+      ( coh-hom-arrow
+        ( inclusion-fiber f)
+        ( inclusion-fiber h)
+        ( comp-hom-arrow
+          ( inclusion-fiber f)
+          ( inclusion-fiber g)
+          ( inclusion-fiber h)
+          ( hom-arrow-fiber g h β (map-codomain-hom-arrow f g α b))
+          ( hom-arrow-fiber f g α b)))
+      ( inclusion-fiber h ·l preserves-comp-map-fiber)
+  coh-preserves-comp-hom-arrow-fiber p =
+    ap
+      ( concat _ _)
+      ( compute-left-whisker-inclusion-fiber-preserves-comp-map-fiber p)
+  
+  preserves-comp-hom-arrow-fiber :
+    htpy-hom-arrow
+      ( inclusion-fiber f)
+      ( inclusion-fiber h)
+      ( hom-arrow-fiber f h (comp-hom-arrow f g h β α) b)
+      ( comp-hom-arrow
+        ( inclusion-fiber f)
+        ( inclusion-fiber g)
+        ( inclusion-fiber h)
+        ( hom-arrow-fiber g h β (map-codomain-hom-arrow f g α b))
+        ( hom-arrow-fiber f g α b))
+  pr1 preserves-comp-hom-arrow-fiber = preserves-comp-map-fiber
+  pr1 (pr2 preserves-comp-hom-arrow-fiber) = refl-htpy
+  pr2 (pr2 preserves-comp-hom-arrow-fiber) = coh-preserves-comp-hom-arrow-fiber
 ```
 
 ### Computing `map-fiber-cone` of a horizontal pasting of cones
@@ -132,9 +223,10 @@ module _
   where
 
   map-fiber-pasting-horizontal-cone :
-    (c : cone j h B) (d : cone i (pr1 c) A) → (x : X) →
+    (c : cone j h B) (d : cone i (vertical-map-cone j h c) A) (x : X) →
     ( map-fiber-cone (j ∘ i) h (pasting-horizontal-cone i j h c d) x) ~
-    ( map-fiber-cone j h c (i x) ∘ map-fiber-cone i (pr1 c) d x)
+    ( map-fiber-cone j h c (i x) ∘
+      map-fiber-cone i (vertical-map-cone j h c) d x)
   map-fiber-pasting-horizontal-cone
     (g , q , K) (f , p , H) .(f a) (a , refl) =
     eq-pair-eq-pr2

--- a/src/foundation/functoriality-fibers-of-maps.lagda.md
+++ b/src/foundation/functoriality-fibers-of-maps.lagda.md
@@ -28,20 +28,24 @@ open import foundation-core.identity-types
 Any [commuting square](foundation-core.commuting-squares-of-maps.md)
 
 ```text
-        f'
-    C -----> B
-    |        |
-  g'|        | g
-    v        v
+        i
     A -----> X
-        f
+    |        |
+  f |        | g
+    v        v
+    B -----> Y
+        j
 ```
 
 induces a map between the [fibers](foundation-core.fibers-of-maps.md) of the
-vertical maps
+vertical maps, which fits in a commuting square
 
 ```text
-  fiber g' x → fiber g (f x).
+  fiber f b -----> fiber g (j b)
+      |                  |
+      |                  |
+      V                  V
+      A ---------------> X
 ```
 
 ## Definitions
@@ -52,33 +56,41 @@ vertical maps
 module _
   {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4}
   (top : C → B) (left : C → A) (right : B → X) (bottom : A → X)
+  (H : coherence-square-maps' top left right bottom)
   where
 
   map-fiber-square' :
-    (H : coherence-square-maps' top left right bottom)
     (x : A) → fiber left x → fiber right (bottom x)
-  pr1 (map-fiber-square' H x (y , p)) = top y
-  pr2 (map-fiber-square' H x (y , p)) = H y ∙ ap bottom p
+  pr1 (map-fiber-square' x (y , p)) = top y
+  pr2 (map-fiber-square' x (y , p)) = H y ∙ ap bottom p
 
   coherence-fiber-square' :
-    (H : coherence-square-maps' top left right bottom)
-    (x : A) → coherence-square-maps' (map-fiber-square' H x) pr1 pr1 top
-  coherence-fiber-square' H x p = refl
+    (x : A) →
+    coherence-square-maps'
+      ( map-fiber-square' x)
+      ( inclusion-fiber left)
+      ( inclusion-fiber right)
+      ( top)
+  coherence-fiber-square' x p = refl
+
+module _
+  {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4}
+  (top : C → B) (left : C → A) (right : B → X) (bottom : A → X)
+  (H : coherence-square-maps top left right bottom)
+  where
 
   map-fiber-square :
-    (H : coherence-square-maps top left right bottom)
     (x : A) → fiber left x → fiber right (bottom x)
-  map-fiber-square H = map-fiber-square' (inv-htpy H)
+  map-fiber-square = map-fiber-square' top left right bottom (inv-htpy H)
 
   coherence-fiber-square :
-    (H : coherence-square-maps top left right bottom)
-    (x : A) → coherence-square-maps (map-fiber-square H x) pr1 pr1 top
-  coherence-fiber-square H x p = refl
-
-map-fiber-square-id :
-  {l1 l2 : Level} {B : UU l1} {X : UU l2} (g : B → X) (x : X) →
-  map-fiber-square id g g id refl-htpy x ~ id
-map-fiber-square-id g .(g b) (b , refl) = refl
+    (x : A) →
+    coherence-square-maps
+      ( map-fiber-square x)
+      ( inclusion-fiber left)
+      ( inclusion-fiber right)
+      ( top)
+  coherence-fiber-square x p = refl
 ```
 
 ### Any cone induces a family of maps between the fibers of the vertical maps
@@ -100,6 +112,15 @@ module _
 ```
 
 ## Properties
+
+### The functorial action of `fiber` preserves the identity function
+
+```agda
+map-fiber-square-id :
+  {l1 l2 : Level} {B : UU l1} {X : UU l2} (g : B → X) (x : X) →
+  map-fiber-square id g g id refl-htpy x ~ id
+map-fiber-square-id g .(g b) (b , refl) = refl
+```
 
 ### Computing `map-fiber-cone` of a horizontal pasting of cones
 

--- a/src/foundation/functoriality-fibers-of-maps.lagda.md
+++ b/src/foundation/functoriality-fibers-of-maps.lagda.md
@@ -167,7 +167,7 @@ module _
 
 ## See also
 
-- In [retracts of maps](orthogonal-factorization-systems.retracts-of-maps.md),
+- In [retracts of maps](foundation.retracts-of-maps.md),
   we show that if `g` is a retract of `g'`, then the fibers of `g` are retracts
   of the fibers of `g'`.
 

--- a/src/foundation/functoriality-function-types.lagda.md
+++ b/src/foundation/functoriality-function-types.lagda.md
@@ -74,11 +74,11 @@ module _
   { l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
   where
 
-  equiv-htpy-preleft-map-triangle :
+  equiv-htpy-precomp-htpy :
     ( f g : B → C) (e : A ≃ B) →
     ( (f ∘ map-equiv e) ~ (g ∘ map-equiv e)) ≃
     ( f ~ g)
-  equiv-htpy-preleft-map-triangle f g e =
+  equiv-htpy-precomp-htpy f g e =
     equiv-Π
       ( eq-value f g)
       ( e)

--- a/src/foundation/functoriality-function-types.lagda.md
+++ b/src/foundation/functoriality-function-types.lagda.md
@@ -74,21 +74,21 @@ module _
   { l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
   where
 
-  equiv-htpy-precomp-htpy :
+  equiv-htpy-preleft-map-triangle :
     ( f g : B → C) (e : A ≃ B) →
     ( (f ∘ map-equiv e) ~ (g ∘ map-equiv e)) ≃
     ( f ~ g)
-  equiv-htpy-precomp-htpy f g e =
+  equiv-htpy-preleft-map-triangle f g e =
     equiv-Π
       ( eq-value f g)
       ( e)
       ( λ a → id-equiv)
 
-  equiv-htpy-postcomp-htpy :
+  equiv-htpy-postleft-map-triangle :
     ( e : B ≃ C) (f g : A → B) →
     ( f ~ g) ≃
     ( (map-equiv e ∘ f) ~ (map-equiv e ∘ g))
-  equiv-htpy-postcomp-htpy e f g =
+  equiv-htpy-postleft-map-triangle e f g =
     equiv-Π-equiv-family
       ( λ a → equiv-ap e (f a) (g a))
 ```

--- a/src/foundation/functoriality-function-types.lagda.md
+++ b/src/foundation/functoriality-function-types.lagda.md
@@ -84,11 +84,11 @@ module _
       ( e)
       ( λ a → id-equiv)
 
-  equiv-htpy-postleft-map-triangle :
+  equiv-htpy-postcomp-htpy :
     ( e : B ≃ C) (f g : A → B) →
     ( f ~ g) ≃
     ( (map-equiv e ∘ f) ~ (map-equiv e ∘ g))
-  equiv-htpy-postleft-map-triangle e f g =
+  equiv-htpy-postcomp-htpy e f g =
     equiv-Π-equiv-family
       ( λ a → equiv-ap e (f a) (g a))
 ```

--- a/src/foundation/invertible-maps.lagda.md
+++ b/src/foundation/invertible-maps.lagda.md
@@ -373,7 +373,7 @@ module _
             ( map-section-is-equiv (is-equiv-map-equiv f) ∘ map-equiv f)
             ( id))) ∘e
         ( equiv-concat-htpy
-          ( is-retraction-map-equiv f ·r map-equiv f)
+          ( is-section-map-section-map-equiv f ·r map-equiv f)
           ( map-equiv f)))) ∘e
     ( equiv-tot (λ f → extensionality-equiv f f))
 ```

--- a/src/foundation/invertible-maps.lagda.md
+++ b/src/foundation/invertible-maps.lagda.md
@@ -368,7 +368,7 @@ module _
           ( is-contr-section-is-equiv (is-equiv-map-equiv f))
           ( section-is-equiv (is-equiv-map-equiv f))) ∘e
         ( inv-equiv
-          ( equiv-htpy-postleft-map-triangle
+          ( equiv-htpy-postcomp-htpy
             ( f)
             ( map-section-is-equiv (is-equiv-map-equiv f) ∘ map-equiv f)
             ( id))) ∘e

--- a/src/foundation/invertible-maps.lagda.md
+++ b/src/foundation/invertible-maps.lagda.md
@@ -284,7 +284,7 @@ abstract
   is-equiv-is-invertible-id-htpy-id-id :
     {l : Level} (A : UU l) → is-equiv (is-invertible-id-htpy-id-id A)
   is-equiv-is-invertible-id-htpy-id-id A =
-    is-equiv-comp-htpy
+    is-equiv-left-map-triangle
       ( is-invertible-id-htpy-id-id A)
       ( map-associative-Σ
         ( A → A)
@@ -368,7 +368,7 @@ module _
           ( is-contr-section-is-equiv (is-equiv-map-equiv f))
           ( section-is-equiv (is-equiv-map-equiv f))) ∘e
         ( inv-equiv
-          ( equiv-htpy-postcomp-htpy
+          ( equiv-htpy-postleft-map-triangle
             ( f)
             ( map-section-is-equiv (is-equiv-map-equiv f) ∘ map-equiv f)
             ( id))) ∘e

--- a/src/foundation/morphisms-arrows.lagda.md
+++ b/src/foundation/morphisms-arrows.lagda.md
@@ -118,7 +118,7 @@ Consider a commuting diagram of the form
         α₁       β₁
 ```
 
-Then the outer rectangle commutes by horizontal pasing of commuting squares of
+Then the outer rectangle commutes by horizontal pasting of commuting squares of
 maps.
 
 ```agda
@@ -165,7 +165,7 @@ module _
 
 ### Homotopies of morphsims of arrows
 
-A \*\*homotopy of morphisms of arrows from `(i , j , H)` to `(i' , j' , H')` is
+A **homotopy of morphisms of arrows** from `(i , j , H)` to `(i' , j' , H')` is
 a triple `(I , J , K)` consisting of homotopies `I : i ~ i'` and `J : j ~ j'`
 and a homotopy `K` witnessing that the
 [square of homotopies](foundation.commuting-squares-of-homotopies.md)

--- a/src/foundation/morphisms-arrows.lagda.md
+++ b/src/foundation/morphisms-arrows.lagda.md
@@ -74,6 +74,21 @@ module _
   coh-hom-arrow = pr2 ∘ pr2
 ```
 
+### Transposing morphisms of arrows
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
+  (f : A → B) (g : X → Y) (α : hom-arrow f g)
+  where
+
+  transpose-hom-arrow :
+    hom-arrow (map-domain-hom-arrow f g α) (map-codomain-hom-arrow f g α)
+  pr1 transpose-hom-arrow = f
+  pr1 (pr2 transpose-hom-arrow) = g
+  pr2 (pr2 transpose-hom-arrow) = inv-htpy (coh-hom-arrow f g α)
+```
+
 ### The identity morphism of arrows
 
 ```agda
@@ -242,7 +257,7 @@ module _
 
 ### Associativity of composition of morphisms of arrows
 
-**Proof:** Consider a commuting diagram of the form
+Consider a commuting diagram of the form
 
 ```text
         α₀       β₀       γ₀
@@ -253,6 +268,9 @@ module _
     B -----> Y -----> V -----> L
         α₁       β₁       γ₁
 ```
+
+Then associativity of composition of morphisms of arrows follows directly from
+associativity of horizontal pasting of commutative squares of maps.
 
 ```agda
 module _
@@ -268,5 +286,66 @@ module _
       ( comp-hom-arrow f h i γ (comp-hom-arrow f g h β α))
   pr1 assoc-comp-hom-arrow = refl-htpy
   pr1 (pr2 assoc-comp-hom-arrow) = refl-htpy
-  pr2 (pr2 assoc-comp-hom-arrow) = {!!}
+  pr2 (pr2 assoc-comp-hom-arrow) =
+    ( right-unit-htpy) ∙h
+    ( inv-htpy
+      ( assoc-pasting-horizontal-coherence-square-maps
+        ( map-domain-hom-arrow f g α)
+        ( map-domain-hom-arrow g h β)
+        ( map-domain-hom-arrow h i γ)
+        ( f)
+        ( g)
+        ( h)
+        ( i)
+        ( map-codomain-hom-arrow f g α)
+        ( map-codomain-hom-arrow g h β)
+        ( map-codomain-hom-arrow h i γ)
+        ( coh-hom-arrow f g α)
+        ( coh-hom-arrow g h β)
+        ( coh-hom-arrow h i γ)))
 ```
+
+### The left unit law for composition of morphisms of arrows
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
+  (f : A → B) (g : X → Y) (α : hom-arrow f g)
+  where
+
+  left-unit-law-comp-hom-arrow :
+    htpy-hom-arrow f g
+      ( comp-hom-arrow f g g id-hom-arrow α)
+      ( α)
+  pr1 left-unit-law-comp-hom-arrow = refl-htpy
+  pr1 (pr2 left-unit-law-comp-hom-arrow) = refl-htpy
+  pr2 (pr2 left-unit-law-comp-hom-arrow) =
+    ( right-unit-htpy) ∙h
+    ( right-unit-law-pasting-horizontal-coherence-square-maps
+      ( map-domain-hom-arrow f g α)
+      ( f)
+      ( g)
+      ( map-codomain-hom-arrow f g α)
+      ( coh-hom-arrow f g α))
+```
+
+### The right unit law for composition of morphisms of arrows
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
+  (f : A → B) (g : X → Y) (α : hom-arrow f g)
+  where
+
+  right-unit-law-comp-hom-arrow :
+    htpy-hom-arrow f g
+      ( comp-hom-arrow f f g α id-hom-arrow)
+      ( α)
+  pr1 right-unit-law-comp-hom-arrow = refl-htpy
+  pr1 (pr2 right-unit-law-comp-hom-arrow) = refl-htpy
+  pr2 (pr2 right-unit-law-comp-hom-arrow) = right-unit-htpy
+```
+
+## See also
+
+- [Morphisms of twisted arrows](foundation.morphisms-twisted-arrows.md).

--- a/src/foundation/morphisms-arrows.lagda.md
+++ b/src/foundation/morphisms-arrows.lagda.md
@@ -1,0 +1,272 @@
+# Morphisms of arrows
+
+```agda
+module foundation.morphisms-arrows where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.commuting-squares-of-homotopies
+open import foundation.dependent-pair-types
+open import foundation.fundamental-theorem-of-identity-types
+open import foundation.homotopy-induction
+open import foundation.structure-identity-principle
+open import foundation.universe-levels
+
+open import foundation-core.commuting-squares-of-maps
+open import foundation-core.equivalences
+open import foundation-core.function-types
+open import foundation-core.homotopies
+open import foundation-core.identity-types
+open import foundation-core.torsorial-type-families
+open import foundation-core.whiskering-homotopies
+```
+
+</details>
+
+## Idea
+
+A **morphism of arrows** from a function `f : A → B` to a function `g : X → Y`
+is a triple `(i , j , H)` consisting of maps `i : A → X` and `j : B → Y` and a
+[homotopy](foundation-core.homotopies.md) `H : j ∘ f ~ g ∘ i` witnessing that
+the square
+
+```text
+        i
+    A -----> X
+    |        |
+  f |        | g
+    V        V
+    B -----> Y
+        j
+```
+
+[commutes](foundation-core.commuting-squares-of-maps.md). Morphisms of arrows
+can be composed horizontally or vertically by pasting of squares.
+
+## Definitions
+
+### Morphisms of arrows
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
+  (f : A → B) (g : X → Y)
+  where
+
+  hom-arrow : UU (l1 ⊔ l2 ⊔ l3 ⊔ l4)
+  hom-arrow = Σ (A → X) (λ i → Σ (B → Y) (coherence-square-maps i f g))
+
+  map-domain-hom-arrow : hom-arrow → A → X
+  map-domain-hom-arrow = pr1
+
+  map-codomain-hom-arrow : hom-arrow → B → Y
+  map-codomain-hom-arrow = pr1 ∘ pr2
+
+  coh-hom-arrow :
+    (h : hom-arrow) →
+    coherence-square-maps
+      ( map-domain-hom-arrow h)
+      ( f)
+      ( g)
+      ( map-codomain-hom-arrow h)
+  coh-hom-arrow = pr2 ∘ pr2
+```
+
+### The identity morphism of arrows
+
+```agda
+module _
+  {l1 l2 : Level} {A : UU l1} {B : UU l2} {f : A → B}
+  where
+
+  id-hom-arrow : hom-arrow f f
+  pr1 id-hom-arrow = id
+  pr1 (pr2 id-hom-arrow) = id
+  pr2 (pr2 id-hom-arrow) = refl-htpy
+```
+
+### Composition of morphisms of arrows
+
+Consider a commuting diagram of the form
+
+```text
+        α₀       β₀
+    A -----> X -----> U
+    |        |        |
+  f |   α  g |   β    | h
+    V        V        V
+    B -----> Y -----> V.
+        α₁       β₁
+```
+
+Then the outer rectangle commutes by horizontal pasing of commuting squares of
+maps.
+
+```agda
+module _
+  {l1 l2 l3 l4 l5 l6 : Level}
+  {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4} {U : UU l5} {V : UU l6}
+  (f : A → B) (g : X → Y) (h : U → V) (b : hom-arrow g h) (a : hom-arrow f g)
+  where
+
+  map-domain-comp-hom-arrow : A → U
+  map-domain-comp-hom-arrow =
+    map-domain-hom-arrow g h b ∘ map-domain-hom-arrow f g a
+
+  map-codomain-comp-hom-arrow : B → V
+  map-codomain-comp-hom-arrow =
+    map-codomain-hom-arrow g h b ∘ map-codomain-hom-arrow f g a
+
+  coh-comp-hom-arrow :
+    coherence-square-maps
+      ( map-domain-comp-hom-arrow)
+      ( f)
+      ( h)
+      ( map-codomain-comp-hom-arrow)
+  coh-comp-hom-arrow =
+    pasting-horizontal-coherence-square-maps
+      ( map-domain-hom-arrow f g a)
+      ( map-domain-hom-arrow g h b)
+      ( f)
+      ( g)
+      ( h)
+      ( map-codomain-hom-arrow f g a)
+      ( map-codomain-hom-arrow g h b)
+      ( coh-hom-arrow f g a)
+      ( coh-hom-arrow g h b)
+
+  comp-hom-arrow : hom-arrow f h
+  pr1 comp-hom-arrow =
+    map-domain-comp-hom-arrow
+  pr1 (pr2 comp-hom-arrow) =
+    map-codomain-comp-hom-arrow
+  pr2 (pr2 comp-hom-arrow) =
+    coh-comp-hom-arrow
+```
+
+### Homotopies of morphsims of arrows
+
+A \*\*homotopy of morphisms of arrows from `(i , j , H)` to `(i' , j' , H')` is
+a triple `(I , J , K)` consisting of homotopies `I : i ~ i'` and `J : j ~ j'`
+and a homotopy `K` witnessing that the
+[square of homotopies](foundation.commuting-squares-of-homotopies.md)
+
+```text
+           J ·r f
+  (j ∘ f) --------> (j' ∘ f)
+     |                 |
+   H |                 | H'
+     V                 V
+  (g ∘ i) --------> (g ∘ i')
+           g ·l I
+```
+
+commutes.
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
+  (f : A → B) (g : X → Y) (α : hom-arrow f g)
+  where
+
+  htpy-hom-arrow :
+    (β : hom-arrow f g) → UU (l1 ⊔ l2 ⊔ l3 ⊔ l4)
+  htpy-hom-arrow β =
+    Σ ( map-domain-hom-arrow f g α ~ map-domain-hom-arrow f g β)
+      ( λ I →
+        Σ ( map-codomain-hom-arrow f g α ~ map-codomain-hom-arrow f g β)
+          ( λ J →
+            coherence-square-homotopies
+              ( J ·r f)
+              ( coh-hom-arrow f g α)
+              ( coh-hom-arrow f g β)
+              ( g ·l I)))
+
+  module _
+    (β : hom-arrow f g) (η : htpy-hom-arrow β)
+    where
+
+    htpy-domain-htpy-hom-arrow :
+      map-domain-hom-arrow f g α ~ map-domain-hom-arrow f g β
+    htpy-domain-htpy-hom-arrow = pr1 η
+
+    htpy-codomain-htpy-hom-arrow :
+      map-codomain-hom-arrow f g α ~ map-codomain-hom-arrow f g β
+    htpy-codomain-htpy-hom-arrow = pr1 (pr2 η)
+
+    coh-htpy-hom-arrow :
+      coherence-square-homotopies
+        ( htpy-codomain-htpy-hom-arrow ·r f)
+        ( coh-hom-arrow f g α)
+        ( coh-hom-arrow f g β)
+        ( g ·l htpy-domain-htpy-hom-arrow)
+    coh-htpy-hom-arrow = pr2 (pr2 η)
+
+  refl-htpy-hom-arrow : htpy-hom-arrow α
+  pr1 refl-htpy-hom-arrow = refl-htpy
+  pr1 (pr2 refl-htpy-hom-arrow) = refl-htpy
+  pr2 (pr2 refl-htpy-hom-arrow) = right-unit-htpy
+
+  is-torsorial-htpy-hom-arrow :
+    is-torsorial htpy-hom-arrow
+  is-torsorial-htpy-hom-arrow =
+    is-torsorial-Eq-structure
+      ( λ i jH I → Σ _ _)
+      ( is-torsorial-htpy (map-domain-hom-arrow f g α))
+      ( map-domain-hom-arrow f g α , refl-htpy)
+      ( is-torsorial-Eq-structure
+        ( λ j H J → _)
+        ( is-torsorial-htpy (map-codomain-hom-arrow f g α))
+        ( map-codomain-hom-arrow f g α , refl-htpy)
+        ( is-torsorial-htpy (coh-hom-arrow f g α ∙h refl-htpy)))
+
+  htpy-eq-hom-arrow : (β : hom-arrow f g) → (α ＝ β) → htpy-hom-arrow β
+  htpy-eq-hom-arrow β refl = refl-htpy-hom-arrow
+
+  is-equiv-htpy-eq-hom-arrow :
+    (β : hom-arrow f g) → is-equiv (htpy-eq-hom-arrow β)
+  is-equiv-htpy-eq-hom-arrow =
+    fundamental-theorem-id is-torsorial-htpy-hom-arrow htpy-eq-hom-arrow
+
+  extensionality-hom-arrow :
+    (β : hom-arrow f g) → (α ＝ β) ≃ htpy-hom-arrow β
+  pr1 (extensionality-hom-arrow β) = htpy-eq-hom-arrow β
+  pr2 (extensionality-hom-arrow β) = is-equiv-htpy-eq-hom-arrow β
+
+  eq-htpy-hom-arrow :
+    (β : hom-arrow f g) → htpy-hom-arrow β → α ＝ β
+  eq-htpy-hom-arrow β = map-inv-equiv (extensionality-hom-arrow β)
+```
+
+### Associativity of composition of morphisms of arrows
+
+**Proof:** Consider a commuting diagram of the form
+
+```text
+        α₀       β₀       γ₀
+    A -----> X -----> U -----> K
+    |        |        |        |
+  f |   α  g |   β  h |   γ    | i
+    V        V        V        V
+    B -----> Y -----> V -----> L
+        α₁       β₁       γ₁
+```
+
+```agda
+module _
+  {l1 l2 l3 l4 l5 l6 l7 l8 : Level}
+  {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4} {U : UU l5} {V : UU l6}
+  {K : UU l7} {L : UU l8} (f : A → B) (g : X → Y) (h : U → V) (i : K → L)
+  (γ : hom-arrow h i) (β : hom-arrow g h) (α : hom-arrow f g)
+  where
+
+  assoc-comp-hom-arrow :
+    htpy-hom-arrow f i
+      ( comp-hom-arrow f g i (comp-hom-arrow g h i γ β) α)
+      ( comp-hom-arrow f h i γ (comp-hom-arrow f g h β α))
+  pr1 assoc-comp-hom-arrow = refl-htpy
+  pr1 (pr2 assoc-comp-hom-arrow) = refl-htpy
+  pr2 (pr2 assoc-comp-hom-arrow) = {!!}
+```

--- a/src/foundation/morphisms-twisted-arrows.lagda.md
+++ b/src/foundation/morphisms-twisted-arrows.lagda.md
@@ -38,6 +38,9 @@ A **morphism of twisted arrows** from `f : A → B` to `g : X → Y` is a triple
 
   commutes.
 
+Thus, a morphism of twisted arrows can also be understood as _a factorization of
+`g` through `f`_.
+
 ## Definitions
 
 ```agda

--- a/src/foundation/morphisms-twisted-arrows.lagda.md
+++ b/src/foundation/morphisms-twisted-arrows.lagda.md
@@ -1,0 +1,70 @@
+# Morphisms of twisted arrows
+
+```agda
+module foundation.morphisms-twisted-arrows where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.dependent-pair-types
+open import foundation.universe-levels
+
+open import foundation-core.function-types
+open import foundation-core.homotopies
+```
+
+</details>
+
+## Idea
+
+A **morphism of twisted arrows** from `f : A → B` to `g : X → Y` is a triple
+`(i , j , H)` consisting of
+
+- a map `i : X → A`
+- a map `j : B → Y`, and
+- a [homotopy](foundation-core.homotopies.md) `H : j ∘ f ∘ i ~ g` witnessing
+  that the square
+
+  ```text
+           i
+      A <----- X
+      |        |
+    f |        | g
+      V        V
+      B -----> Y
+          j
+  ```
+
+  commutes.
+
+## Definitions
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
+  (f : A → B) (g : X → Y)
+  where
+
+  hom-twisted-arrow : UU (l1 ⊔ l2 ⊔ l3 ⊔ l4)
+  hom-twisted-arrow =
+    Σ (X → A) (λ i → Σ (B → Y) (λ j → j ∘ f ∘ i ~ g))
+
+  module _
+    (α : hom-twisted-arrow)
+    where
+
+    map-domain-hom-twisted-arrow : X → A
+    map-domain-hom-twisted-arrow = pr1 α
+
+    map-codomain-hom-twisted-arrow : B → Y
+    map-codomain-hom-twisted-arrow = pr1 (pr2 α)
+
+    coh-hom-twisted-arrow :
+      map-codomain-hom-twisted-arrow ∘ f ∘ map-domain-hom-twisted-arrow ~ g
+    coh-hom-twisted-arrow = pr2 (pr2 α)
+```
+
+## See also
+
+- [Morphisms of arrows](foundation.morphisms-arrows.md).

--- a/src/foundation/propositions.lagda.md
+++ b/src/foundation/propositions.lagda.md
@@ -12,6 +12,7 @@ open import foundation-core.propositions public
 open import foundation.contractible-types
 open import foundation.dependent-pair-types
 open import foundation.embeddings
+open import foundation.retracts-of-types
 open import foundation.universe-levels
 
 open import foundation-core.retractions

--- a/src/foundation/pullbacks.lagda.md
+++ b/src/foundation/pullbacks.lagda.md
@@ -113,7 +113,7 @@ abstract
       ( postcomp T g)
       ( exponent-cone T f g c)
   is-pullback-exponent-is-pullback f g c is-pb-c T =
-    is-equiv-right-factor-htpy
+    is-equiv-top-map-triangle
       ( cone-map f g c)
       ( map-standard-pullback-exponent f g T)
       ( gap (f ∘_) (g ∘_) (exponent-cone T f g c))
@@ -132,7 +132,7 @@ abstract
     is-pullback f g c
   is-pullback-is-pullback-exponent f g c is-pb-exp =
     is-pullback-universal-property-pullback f g c
-      ( λ T → is-equiv-comp-htpy
+      ( λ T → is-equiv-left-map-triangle
         ( cone-map f g c)
         ( map-standard-pullback-exponent f g T)
         ( gap (f ∘_) (g ∘_) (exponent-cone T f g c))
@@ -286,7 +286,7 @@ module _
       (Hc : htpy-parallel-cone Hf Hg c c') →
       is-pullback f' g' c' → is-pullback f g c
     is-pullback-htpy {c = p , q , H} (p' , q' , H') (Hp , Hq , HH) is-pb-c' =
-      is-equiv-comp-htpy
+      is-equiv-left-map-triangle
         ( gap f g (p , q , H))
         ( map-equiv-standard-pullback-htpy Hf Hg)
         ( gap f' g' (p' , q' , H'))
@@ -301,7 +301,7 @@ module _
       (Hc : htpy-parallel-cone Hf Hg c c') →
       is-pullback f g c → is-pullback f' g' c'
     is-pullback-htpy' (p , q , H) {p' , q' , H'} (Hp , Hq , HH) is-pb-c =
-      is-equiv-right-factor-htpy
+      is-equiv-top-map-triangle
         ( gap f g (p , q , H))
         ( map-equiv-standard-pullback-htpy Hf Hg)
         ( gap f' g' (p' , q' , H'))
@@ -442,13 +442,13 @@ htpy-eq-square-refl-htpy f g c c' =
     ( λ p → htpy-parallel-cone (refl-htpy' f) (refl-htpy' g) c c')
     ( htpy-eq-square f g c c')
 
-comp-htpy-eq-square-refl-htpy :
+left-map-triangle-eq-square-refl-htpy :
   {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {C : UU l4}
   (f : A → X) (g : B → X) (c c' : cone f g C) →
   ( htpy-eq-square-refl-htpy f g c c' ∘
     concat (tr-tr-refl-htpy-cone f g c) c') ~
   ( htpy-eq-square f g c c')
-comp-htpy-eq-square-refl-htpy f g c c' =
+left-map-triangle-eq-square-refl-htpy f g c c' =
   is-section-map-inv-is-equiv-precomp-Π-is-equiv
     ( is-equiv-concat (tr-tr-refl-htpy-cone f g c) c')
     ( λ p → htpy-parallel-cone (refl-htpy' f) (refl-htpy' g) c c')
@@ -477,13 +477,13 @@ abstract
         htpy-parallel-cone refl-htpy Hg' c c')
       ( htpy-eq-square-refl-htpy f g)
 
-  comp-htpy-parallel-cone-eq' :
+  left-map-triangle-parallel-cone-eq' :
     {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {C : UU l4}
     (f : A → X) (g : B → X) (c c' : cone f g C) →
     ( ( htpy-parallel-cone-eq' f refl-htpy c c') ∘
       ( concat (tr-tr-refl-htpy-cone f g c) c')) ~
     ( htpy-eq-square f g c c')
-  comp-htpy-parallel-cone-eq' {A = A} {B} {X} {C} f g c c' =
+  left-map-triangle-parallel-cone-eq' {A = A} {B} {X} {C} f g c c' =
     htpy-right-whisk
       ( htpy-eq (htpy-eq (htpy-eq (compute-ind-htpy g
         ( λ g'' Hg' →
@@ -494,7 +494,7 @@ abstract
           htpy-parallel-cone refl-htpy Hg' c c')
       ( htpy-eq-square-refl-htpy f g)) c) c'))
       ( concat (tr-tr-refl-htpy-cone f g c) c') ∙h
-    ( comp-htpy-eq-square-refl-htpy f g c c')
+    ( left-map-triangle-eq-square-refl-htpy f g c c')
 
 abstract
   htpy-parallel-cone-eq :
@@ -517,13 +517,13 @@ abstract
     ( λ g g' → htpy-parallel-cone-eq' f {g = g} {g' = g'})
     Hf g g' Hg c c' p
 
-  comp-htpy-parallel-cone-eq :
+  left-map-triangle-parallel-cone-eq :
     {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {C : UU l4}
     (f : A → X) (g : B → X) (c c' : cone f g C) →
     ( ( htpy-parallel-cone-eq refl-htpy refl-htpy c c') ∘
       ( concat (tr-tr-refl-htpy-cone f g c) c')) ~
     ( htpy-eq-square f g c c')
-  comp-htpy-parallel-cone-eq {A = A} {B} {X} {C} f g c c' =
+  left-map-triangle-parallel-cone-eq {A = A} {B} {X} {C} f g c c' =
     htpy-right-whisk
       ( htpy-eq (htpy-eq (htpy-eq (htpy-eq (htpy-eq (htpy-eq (compute-ind-htpy f
         ( λ f'' Hf' →
@@ -538,7 +538,7 @@ abstract
         ( λ g g' → htpy-parallel-cone-eq' f {g = g} {g' = g'})) g) g)
         refl-htpy) c) c'))
       ( concat (tr-tr-refl-htpy-cone f g c) c') ∙h
-      ( comp-htpy-parallel-cone-eq' f g c c')
+      ( left-map-triangle-parallel-cone-eq' f g c c')
 
 abstract
   is-fiberwise-equiv-htpy-parallel-cone-eq :
@@ -558,11 +558,11 @@ abstract
             ( c : cone f g C) (c' : cone f g' C) →
               is-equiv (htpy-parallel-cone-eq refl-htpy Hg c c'))
           ( λ c c' →
-            is-equiv-left-factor-htpy
+            is-equiv-right-map-triangle
               ( htpy-eq-square f g c c')
               ( htpy-parallel-cone-eq refl-htpy refl-htpy c c')
               ( concat (tr-tr-refl-htpy-cone f g c) c')
-              ( inv-htpy (comp-htpy-parallel-cone-eq f g c c'))
+              ( inv-htpy (left-map-triangle-parallel-cone-eq f g c c'))
               ( fundamental-theorem-id
                 ( is-torsorial-htpy-parallel-cone
                   ( refl-htpy' f)
@@ -684,7 +684,7 @@ abstract
     ((i : I) → is-pullback (f i) (g i) (c i)) →
     is-pullback (map-Π f) (map-Π g) (cone-Π f g c)
   is-pullback-cone-Π f g c is-pb-c =
-    is-equiv-right-factor-htpy
+    is-equiv-top-map-triangle
       ( map-Π (λ i → gap (f i) (g i) (c i)))
       ( map-standard-pullback-Π f g)
       ( gap (map-Π f) (map-Π g) (cone-Π f g c))

--- a/src/foundation/retractions.lagda.md
+++ b/src/foundation/retractions.lagda.md
@@ -12,6 +12,7 @@ open import foundation-core.retractions public
 open import foundation.action-on-identifications-functions
 open import foundation.coslice
 open import foundation.dependent-pair-types
+open import foundation.retracts-of-types
 open import foundation.universe-levels
 
 open import foundation-core.equivalences
@@ -57,16 +58,16 @@ module _
 ### If the left factor of a composite has a retraction, then the type of retractions of the right factor is a retract of the type of retractions of the composite
 
 ```agda
-is-retraction-retraction-comp-htpy :
+is-retraction-retraction-left-map-triangle :
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
   (f : A → X) (g : B → X) (h : A → B)
   (H : f ~ (g ∘ h)) (rg : retraction g) →
-  ( ( retraction-right-factor-htpy f g h H) ∘
-    ( retraction-comp-htpy f g h H rg)) ~ id
-is-retraction-retraction-comp-htpy f g h H (l , L) (k , K) =
+  ( ( retraction-top-map-triangle f g h H) ∘
+    ( retraction-left-map-triangle f g h H rg)) ~ id
+is-retraction-retraction-left-map-triangle f g h H (l , L) (k , K) =
   eq-htpy-retraction
-    ( ( retraction-right-factor-htpy f g h H
-        ( retraction-comp-htpy f g h H (l , L) (k , K)
+    ( ( retraction-top-map-triangle f g h H
+        ( retraction-left-map-triangle f g h H (l , L) (k , K)
           )))
     ( k , K)
     ( k ·l L)
@@ -85,15 +86,15 @@ retraction-right-factor-retract-of-retraction-left-factor :
   (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
   retraction g → (retraction h) retract-of (retraction f)
 pr1 (retraction-right-factor-retract-of-retraction-left-factor f g h H rg) =
-  retraction-comp-htpy f g h H rg
+  retraction-left-map-triangle f g h H rg
 pr1
   ( pr2
     ( retraction-right-factor-retract-of-retraction-left-factor f g h H rg)) =
-  retraction-right-factor-htpy f g h H
+  retraction-top-map-triangle f g h H
 pr2
   ( pr2
     ( retraction-right-factor-retract-of-retraction-left-factor f g h H rg)) =
-  is-retraction-retraction-comp-htpy f g h H rg
+  is-retraction-retraction-left-map-triangle f g h H rg
 ```
 
 ### If `f` has a retraction, then `f` is injective

--- a/src/foundation/retracts-of-maps.lagda.md
+++ b/src/foundation/retracts-of-maps.lagda.md
@@ -657,8 +657,9 @@ module _
           ( preserves-id-hom-arrow-fiber f b)))
 
   retract-map-inclusion-fiber-retract-map :
-    ( inclusion-fiber f {b}) retract-of-map
-    ( inclusion-fiber g {map-codomain-inclusion-retract-map f g R b})
+    retract-map
+      ( inclusion-fiber g {map-codomain-inclusion-retract-map f g R b})
+      ( inclusion-fiber f {b})
   pr1 retract-map-inclusion-fiber-retract-map =
     inclusion-retract-map-inclusion-fiber-retract-map
   pr1 (pr2 retract-map-inclusion-fiber-retract-map) =
@@ -676,8 +677,9 @@ module _
   where
 
   retract-fiber-retract-map :
-    ( fiber f b) retract-of
-    ( fiber g (map-codomain-inclusion-retract-map f g R b))
+    retract
+      ( fiber g (map-codomain-inclusion-retract-map f g R b))
+      ( fiber f b)
   retract-fiber-retract-map =
     retract-domain-retract-map
       ( inclusion-fiber f)

--- a/src/foundation/retracts-of-maps.lagda.md
+++ b/src/foundation/retracts-of-maps.lagda.md
@@ -31,25 +31,26 @@ open import foundation.whiskering-homotopies
 
 ## Idea
 
-A **retract** of a map `f : X → Y` is a map `g : A → B` that is a retract in the
-arrow category of types. Hence, it consists of
+A map `g : A → B` is said to be a **retract** of a map `f : X → Y` if it is a retract in the arrow category of types. In other words, `g` is a retract of `f` if there are [morphisms of arrows] `i : g → f` and `r : f → g` equipped with a homotopy of morphisms of arrows `r ∘ i ~ id`.
+
+More explicitly, it consists of
 [retracts](foundation-core.retractions.md) `A` of `X` and `B` of `Y` that fit
 into a commutative diagram
 
 ```text
-         i         r
+         i₀        r₀
     A ------> X ------> A
     |         |         |
-  g |    I    | f   R   | g
+  g |    i    | f   r   | g
     v         v         v
     B ------> Y ------> B
-         i'        r'
+         i₁        r₁
 ```
 
 with coherences
 
 ```text
-  I : i' ∘ g ~ f ∘ i  and   R : r' ∘ f ~ g ∘ r
+  i : i₁ ∘ g ~ f ∘ i₀  and   r : r₁ ∘ f ~ g ∘ r₀
 ```
 
 witnessing that the left and right
@@ -57,15 +58,15 @@ witnessing that the left and right
 coherence
 
 ```text
-                   R ·r i
-       r' ∘ f ∘ i --------> g ∘ r ∘ i
-            |                |
-            |                |
-  r' ·l I⁻¹ |        L       | g ·l H
-            |                |
-            V                V
-      r' ∘ i' ∘ g ---------> g
-                   H' ·r g
+                    r₀ ·r i₀
+       r₁ ∘ f ∘ i₀ ----------> g ∘ r₀ ∘ i₀
+            |                      |
+            |                      |
+  r₁ ·l i⁻¹ |          L           | g ·l H
+            |                      |
+            V                      V
+      r₁ ∘ i₁ ∘ g ---------------> g
+                       H' ·r g
 ```
 
 witnessing that the
@@ -465,12 +466,10 @@ module _
   inclusion-fiber-retract-map :
     (y : B) → fiber g y → fiber f (inclusion-codomain-retract-map f g k y)
   inclusion-fiber-retract-map =
-    map-fiber-square
-      ( inclusion-domain-retract-map f g k)
-      ( g)
-      ( f)
-      ( inclusion-codomain-retract-map f g k)
-      ( coh-inclusion-retract-map f g k)
+    map-fiber-square g f
+      ( inclusion-domain-retract-map f g k ,
+        inclusion-codomain-retract-map f g k ,
+        coh-inclusion-retract-map f g k)
 
   map-retraction-fiber-retract-map' :
     (y : Y) →

--- a/src/foundation/retracts-of-maps.lagda.md
+++ b/src/foundation/retracts-of-maps.lagda.md
@@ -262,7 +262,7 @@ module _
 
 ```text
            i''                 r''
-  fib g x -----> fib f (s' x) -----> fib g x
+  fib g x -----> fib f (i' x) -----> fib g x
      |               |                  |
      |       I'      |          R'      |
      v               v                  v

--- a/src/foundation/retracts-of-maps.lagda.md
+++ b/src/foundation/retracts-of-maps.lagda.md
@@ -417,7 +417,7 @@ In fact, we only need the following data to show this:
           f |    R    | g
             v         v
   B ------> Y ------> B.
-       s'   H'   r'
+       i'   H'   r'
 ```
 
 ```agda

--- a/src/foundation/retracts-of-maps.lagda.md
+++ b/src/foundation/retracts-of-maps.lagda.md
@@ -464,13 +464,13 @@ module _
 In fact, we only need the following data to show this:
 
 ```text
-       s    H    r
+       i    H    r
   A ------> X ------> A
   |         |
-  g    S    f
+  g    I    f
   v         v
   B ------> Y.
-       s'
+       i'
 ```
 
 ```agda

--- a/src/foundation/retracts-of-maps.lagda.md
+++ b/src/foundation/retracts-of-maps.lagda.md
@@ -261,154 +261,6 @@ module _
 
 ## Properties
 
-### If `g` is a retract of `f`, then the fibers of `g` are retracts of the fibers of `f`
-
-```text
-           i''                 r''
-  fib g x -----> fib f (i' x) -----> fib g x
-     |               |                  |
-     |       I'      |        R'        |
-     v               v                  v
-     A ----- i ----> X ------ r ------> A
-     |               |                  |
-   g |       I       f        R         | g
-     v               v                  v
-     B ------------> Y ---------------> B
-             i'               r'
-```
-
-```agda
-module _
-  {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
-  (f : X → Y) (g : A → B) (k : g retract-of-map f)
-  where
-
-  inclusion-fiber-retract-map :
-    (y : B) → fiber g y → fiber f (inclusion-codomain-retract-map f g k y)
-  inclusion-fiber-retract-map =
-    map-fiber-square
-      ( inclusion-domain-retract-map f g k)
-      ( g)
-      ( f)
-      ( inclusion-codomain-retract-map f g k)
-      ( coh-inclusion-retract-map f g k)
-
-  map-retraction-fiber-retract-map' :
-    (y : Y) →
-    fiber f y → fiber g (map-retraction-codomain-retract-map f g k y)
-  map-retraction-fiber-retract-map' =
-    map-fiber-square
-      ( map-retraction-domain-retract-map f g k)
-      ( f)
-      ( g)
-      ( map-retraction-codomain-retract-map f g k)
-      ( coh-map-retraction-retract-map f g k)
-
-  map-retraction-fiber-retract-map :
-    (y : B) → fiber f (inclusion-codomain-retract-map f g k y) → fiber g y
-  pr1 (map-retraction-fiber-retract-map y (x , p)) =
-    map-retraction-domain-retract-map f g k x
-  pr2 (map-retraction-fiber-retract-map y (x , p)) =
-    ( inv (coh-map-retraction-retract-map f g k x)) ∙
-    ( ap (map-retraction-codomain-retract-map f g k) p) ∙
-    ( is-retraction-map-retraction-codomain-retract-map f g k y)
-
-  coherence-is-retraction-fiber-retract-map :
-    (y : B) (z : fiber g y) →
-    ( g ·l is-retraction-map-retraction-domain-retract-map f g k)
-      ( inclusion-fiber g z) ＝
-    ( inv
-      ( coh-map-retraction-retract-map f g k
-        ( inclusion-fiber f (inclusion-fiber-retract-map y z)))) ∙
-    ( ap
-      ( map-retraction-codomain-retract-map f g k)
-      ( compute-value-inclusion-fiber f (inclusion-fiber-retract-map y z))) ∙
-    ( is-retraction-map-retraction-codomain-retract-map f g k y) ∙
-    ( inv (compute-value-inclusion-fiber g z))
-  coherence-is-retraction-fiber-retract-map y (x , refl) =
-    ( ( ( left-transpose-htpy-concat
-          ( coh-map-retraction-retract-map f g k ·r
-            inclusion-domain-retract-map f g k)
-          ( g ·l is-retraction-map-retraction-domain-retract-map f g k)
-          ( ( map-retraction-codomain-retract-map f g k ·l
-              inv-htpy (coh-inclusion-retract-map f g k)) ∙h
-            ( is-retraction-map-retraction-codomain-retract-map f g k ·r g))
-          ( inv-htpy (coh-retract-map f g k))) ∙h
-        ( inv-htpy-assoc-htpy
-          ( inv-htpy
-            ( coh-map-retraction-retract-map f g k ·r
-              inclusion-domain-retract-map f g k))
-          ( map-retraction-codomain-retract-map f g k ·l
-            inv-htpy (coh-inclusion-retract-map f g k))
-          ( is-retraction-map-retraction-codomain-retract-map f g k ·r g)))
-      ( x)) ∙
-    ( ap
-      ( λ p →
-        ( inv
-          ( coh-map-retraction-retract-map f g k
-            ( inclusion-domain-retract-map f g k x))) ∙
-        ( ap (map-retraction-codomain-retract-map f g k) p) ∙
-        ( is-retraction-map-retraction-codomain-retract-map f g k y))
-      ( inv right-unit)) ∙
-    ( inv right-unit)
-
-  is-retraction-fiber-retract-map :
-    (y : B) →
-    is-retraction
-      ( inclusion-fiber-retract-map y)
-      ( map-retraction-fiber-retract-map y)
-  is-retraction-fiber-retract-map y z =
-    map-inv-fiber-ap-eq-fiber g
-      ( map-retraction-fiber-retract-map y
-        ( inclusion-fiber-retract-map y z))
-      ( z)
-      ( ( is-retraction-map-retraction-domain-retract-map f g k
-          ( inclusion-fiber g z)) ,
-        ( coherence-is-retraction-fiber-retract-map y z))
-
-  retract-fiber-retract-map :
-    (y : B) →
-    ( fiber g y) retract-of
-    ( fiber f (inclusion-codomain-retract-map f g k y))
-  pr1 (retract-fiber-retract-map y) =
-    inclusion-fiber-retract-map y
-  pr1 (pr2 (retract-fiber-retract-map y)) =
-    map-retraction-fiber-retract-map y
-  pr2 (pr2 (retract-fiber-retract-map y)) =
-    is-retraction-fiber-retract-map y
-```
-
-### If `g` is a retract of `f`, then the fiber inclusions of `g` are retracts of the fiber inclusions of `f`
-
-```agda
-module _
-  {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
-  (f : X → Y) (g : A → B) (k : g retract-of-map f) (y : B)
-  where
-
-  is-retract-map-fiber-retract-map :
-    is-retract-of-map
-      ( inclusion-fiber f)
-      ( inclusion-fiber g)
-      ( retract-fiber-retract-map f g k y)
-      ( retract-domain-retract-map f g k)
-  pr1 is-retract-map-fiber-retract-map =
-    refl-htpy
-  pr1 (pr2 is-retract-map-fiber-retract-map) =
-    refl-htpy
-  pr2 (pr2 is-retract-map-fiber-retract-map) z =
-    inv (ap-pr1-map-inv-fiber-ap-eq-fiber g _ z _)
-
-  retract-map-fiber-retract-map :
-    (inclusion-fiber g) retract-of-map (inclusion-fiber f)
-  pr1 retract-map-fiber-retract-map =
-    retract-fiber-retract-map f g k y
-  pr1 (pr2 retract-map-fiber-retract-map) =
-    retract-domain-retract-map f g k
-  pr2 (pr2 retract-map-fiber-retract-map) =
-    is-retract-map-fiber-retract-map
-```
-
 ### Retracts of maps with sections have sections
 
 In fact, we only need the following data to show this:
@@ -577,6 +429,163 @@ module _
   is-equiv-retract-map-is-equiv : is-equiv g
   pr1 is-equiv-retract-map-is-equiv = section-retract-map-is-equiv
   pr2 is-equiv-retract-map-is-equiv = retraction-retract-map-is-equiv
+```
+
+### If `g` is a retract of `f`, then the fibers of `g` are retracts of the fibers of `f`
+
+Consider a retract `g : A → B` of a map `f : X → Y`, as indicated in the bottom
+row of squares in the diagram below.
+
+```text
+           i''                 r''
+  fib g x -----> fib f (i' x) -----> fib g x
+     |               |                  |
+     |       I'      |        R'        |
+     v               v                  v
+     A ----- i ----> X ------ r ------> A
+     |               |                  |
+   g |       I       | f      R         | g
+     v               v                  v
+     B ------------> Y ---------------> B
+             i'               r'
+```
+
+Then we claim that the [fiber inclusion](foundation-core.fibers-of-maps.md)
+`fib g x → A` is a retract of the fiber inclusion `fib f (i' x) → X`.
+
+**Proof:** The proof is immediate by
+[functoriality of fibers of maps](foundation.functoriality-fibers-of-maps.md).
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
+  (f : X → Y) (g : A → B) (k : g retract-of-map f)
+  where
+
+  inclusion-fiber-retract-map :
+    (y : B) → fiber g y → fiber f (inclusion-codomain-retract-map f g k y)
+  inclusion-fiber-retract-map =
+    map-fiber-square
+      ( inclusion-domain-retract-map f g k)
+      ( g)
+      ( f)
+      ( inclusion-codomain-retract-map f g k)
+      ( coh-inclusion-retract-map f g k)
+
+  map-retraction-fiber-retract-map' :
+    (y : Y) →
+    fiber f y → fiber g (map-retraction-codomain-retract-map f g k y)
+  map-retraction-fiber-retract-map' =
+    map-fiber-square
+      ( map-retraction-domain-retract-map f g k)
+      ( f)
+      ( g)
+      ( map-retraction-codomain-retract-map f g k)
+      ( coh-map-retraction-retract-map f g k)
+
+  map-retraction-fiber-retract-map :
+    (y : B) → fiber f (inclusion-codomain-retract-map f g k y) → fiber g y
+  pr1 (map-retraction-fiber-retract-map y (x , p)) =
+    map-retraction-domain-retract-map f g k x
+  pr2 (map-retraction-fiber-retract-map y (x , p)) =
+    ( inv (coh-map-retraction-retract-map f g k x)) ∙
+    ( ap (map-retraction-codomain-retract-map f g k) p) ∙
+    ( is-retraction-map-retraction-codomain-retract-map f g k y)
+
+  coherence-is-retraction-fiber-retract-map :
+    (y : B) (z : fiber g y) →
+    ( g ·l is-retraction-map-retraction-domain-retract-map f g k)
+      ( inclusion-fiber g z) ＝
+    ( inv
+      ( coh-map-retraction-retract-map f g k
+        ( inclusion-fiber f (inclusion-fiber-retract-map y z)))) ∙
+    ( ap
+      ( map-retraction-codomain-retract-map f g k)
+      ( compute-value-inclusion-fiber f (inclusion-fiber-retract-map y z))) ∙
+    ( is-retraction-map-retraction-codomain-retract-map f g k y) ∙
+    ( inv (compute-value-inclusion-fiber g z))
+  coherence-is-retraction-fiber-retract-map y (x , refl) =
+    ( ( ( left-transpose-htpy-concat
+          ( coh-map-retraction-retract-map f g k ·r
+            inclusion-domain-retract-map f g k)
+          ( g ·l is-retraction-map-retraction-domain-retract-map f g k)
+          ( ( map-retraction-codomain-retract-map f g k ·l
+              inv-htpy (coh-inclusion-retract-map f g k)) ∙h
+            ( is-retraction-map-retraction-codomain-retract-map f g k ·r g))
+          ( inv-htpy (coh-retract-map f g k))) ∙h
+        ( inv-htpy-assoc-htpy
+          ( inv-htpy
+            ( coh-map-retraction-retract-map f g k ·r
+              inclusion-domain-retract-map f g k))
+          ( map-retraction-codomain-retract-map f g k ·l
+            inv-htpy (coh-inclusion-retract-map f g k))
+          ( is-retraction-map-retraction-codomain-retract-map f g k ·r g)))
+      ( x)) ∙
+    ( ap
+      ( λ p →
+        ( inv
+          ( coh-map-retraction-retract-map f g k
+            ( inclusion-domain-retract-map f g k x))) ∙
+        ( ap (map-retraction-codomain-retract-map f g k) p) ∙
+        ( is-retraction-map-retraction-codomain-retract-map f g k y))
+      ( inv right-unit)) ∙
+    ( inv right-unit)
+
+  is-retraction-fiber-retract-map :
+    (y : B) →
+    is-retraction
+      ( inclusion-fiber-retract-map y)
+      ( map-retraction-fiber-retract-map y)
+  is-retraction-fiber-retract-map y z =
+    map-inv-fiber-ap-eq-fiber g
+      ( map-retraction-fiber-retract-map y
+        ( inclusion-fiber-retract-map y z))
+      ( z)
+      ( ( is-retraction-map-retraction-domain-retract-map f g k
+          ( inclusion-fiber g z)) ,
+        ( coherence-is-retraction-fiber-retract-map y z))
+
+  retract-fiber-retract-map :
+    (y : B) →
+    ( fiber g y) retract-of
+    ( fiber f (inclusion-codomain-retract-map f g k y))
+  pr1 (retract-fiber-retract-map y) =
+    inclusion-fiber-retract-map y
+  pr1 (pr2 (retract-fiber-retract-map y)) =
+    map-retraction-fiber-retract-map y
+  pr2 (pr2 (retract-fiber-retract-map y)) =
+    is-retraction-fiber-retract-map y
+```
+
+### If `g` is a retract of `f`, then the fiber inclusions of `g` are retracts of the fiber inclusions of `f`
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
+  (f : X → Y) (g : A → B) (k : g retract-of-map f) (y : B)
+  where
+
+  is-retract-map-fiber-retract-map :
+    is-retract-of-map
+      ( inclusion-fiber f)
+      ( inclusion-fiber g)
+      ( retract-fiber-retract-map f g k y)
+      ( retract-domain-retract-map f g k)
+  pr1 is-retract-map-fiber-retract-map =
+    refl-htpy
+  pr1 (pr2 is-retract-map-fiber-retract-map) =
+    refl-htpy
+  pr2 (pr2 is-retract-map-fiber-retract-map) z =
+    inv (ap-pr1-map-inv-fiber-ap-eq-fiber g _ z _)
+
+  retract-map-fiber-retract-map :
+    (inclusion-fiber g) retract-of-map (inclusion-fiber f)
+  pr1 retract-map-fiber-retract-map =
+    retract-fiber-retract-map f g k y
+  pr1 (pr2 retract-map-fiber-retract-map) =
+    retract-domain-retract-map f g k
+  pr2 (pr2 retract-map-fiber-retract-map) =
+    is-retract-map-fiber-retract-map
 ```
 
 ## References

--- a/src/foundation/retracts-of-maps.lagda.md
+++ b/src/foundation/retracts-of-maps.lagda.md
@@ -107,13 +107,13 @@ module _
   is-retract-of-map : UU (l1 ⊔ l2 ⊔ l3 ⊔ l4)
   is-retract-of-map =
     Σ ( coherence-square-maps (inclusion-retract r) g f (inclusion-retract r'))
-      ( λ S →
+      ( λ I →
         Σ ( coherence-square-maps
             ( map-retraction-retract r)
             ( f)
             ( g)
             ( map-retraction-retract r'))
-          ( coherence-retract-of-map f g r r' S))
+          ( coherence-retract-of-map f g r r' I))
 
 module _
   {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}

--- a/src/foundation/retracts-of-maps.lagda.md
+++ b/src/foundation/retracts-of-maps.lagda.md
@@ -461,8 +461,8 @@ module _
   (f : X → Y) (g : A → B) (k : g retract-of-map f)
   where
 
-  section-retract-section : section f → section g
-  section-retract-section =
+  section-retract-map-section : section f → section g
+  section-retract-map-section =
     section-retract-map-section' f g
       ( map-retraction-domain-retract-map f g k)
       ( retract-codomain-retract-map f g k)
@@ -568,7 +568,7 @@ module _
 
   section-retract-map-is-equiv : section g
   section-retract-map-is-equiv =
-    section-retract-section f g k (section-is-equiv H)
+    section-retract-map-section f g k (section-is-equiv H)
 
   retraction-retract-map-is-equiv : retraction g
   retraction-retract-map-is-equiv =

--- a/src/foundation/retracts-of-maps.lagda.md
+++ b/src/foundation/retracts-of-maps.lagda.md
@@ -32,10 +32,10 @@ open import foundation.whiskering-homotopies
 
 ## Idea
 
-A map `g : A → B` is said to be a **retract** of a map `f : X → Y` if it is a
-retract in the arrow category of types. In other words, `g` is a retract of `f`
-if there are [morphisms of arrows](foundation.morphisms-arrows.md) `i : g → f`
-and `r : f → g` equipped with a homotopy of morphisms of arrows `r ∘ i ~ id`.
+A map `f : A → B` is said to be a **retract** of a map `g : X → Y` if it is a
+retract in the arrow category of types. In other words, `f` is a retract of `g`
+if there are [morphisms of arrows](foundation.morphisms-arrows.md) `i : f → g`
+and `r : g → f` equipped with a homotopy of morphisms of arrows `r ∘ i ~ id`.
 
 More explicitly, it consists of [retracts](foundation-core.retractions.md) `A`
 of `X` and `B` of `Y` that fit into a commutative diagram

--- a/src/foundation/retracts-of-maps.lagda.md
+++ b/src/foundation/retracts-of-maps.lagda.md
@@ -264,11 +264,11 @@ module _
            i''                 r''
   fib g x -----> fib f (i' x) -----> fib g x
      |               |                  |
-     |       I'      |          R'      |
+     |       I'      |        R'        |
      v               v                  v
      A ----- i ----> X ------ r ------> A
      |               |                  |
-   g |       I       f          R       | g
+   g |       I       f        R         | g
      v               v                  v
      B ------------> Y ---------------> B
              i'               r'

--- a/src/foundation/retracts-of-maps.lagda.md
+++ b/src/foundation/retracts-of-maps.lagda.md
@@ -34,8 +34,8 @@ open import foundation.whiskering-homotopies
 
 A map `g : A → B` is said to be a **retract** of a map `f : X → Y` if it is a
 retract in the arrow category of types. In other words, `g` is a retract of `f`
-if there are [morphisms of arrows] `i : g → f` and `r : f → g` equipped with a
-homotopy of morphisms of arrows `r ∘ i ~ id`.
+if there are [morphisms of arrows](foundation.morphisms-arrows.md) `i : g → f`
+and `r : f → g` equipped with a homotopy of morphisms of arrows `r ∘ i ~ id`.
 
 More explicitly, it consists of [retracts](foundation-core.retractions.md) `A`
 of `X` and `B` of `Y` that fit into a commutative diagram

--- a/src/foundation/retracts-of-maps.lagda.md
+++ b/src/foundation/retracts-of-maps.lagda.md
@@ -435,7 +435,9 @@ In fact, we only need the following data to show this:
             B.
 ```
 
-Since both `r'` and `f` are assumed to have [sections](foundation-core.sections.md), it follows that the composite `r' ∘ f` has a section, and therefore `g` has a section.
+Since both `r'` and `f` are assumed to have
+[sections](foundation-core.sections.md), it follows that the composite `r' ∘ f`
+has a section, and therefore `g` has a section.
 
 ```agda
 module _
@@ -493,7 +495,8 @@ In fact, we only need the following data to show this:
            Y.
 ```
 
-Since both `f` and `i` are assumed to have retractions, it follows that `f ∘ i` has a retraction, and hence that `g` has a retraction.
+Since both `f` and `i` are assumed to have retractions, it follows that `f ∘ i`
+has a retraction, and hence that `g` has a retraction.
 
 ```agda
 module _

--- a/src/foundation/retracts-of-maps.lagda.md
+++ b/src/foundation/retracts-of-maps.lagda.md
@@ -137,7 +137,19 @@ module _
   coh-is-retract-of-map = pr2 (pr2 k)
 ```
 
-### The type of retracts of maps
+### The predicate that a map is a retract of a map `f`
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
+  where
+
+  retract-map : (X → Y) → (A → B) → UU (l1 ⊔ l2 ⊔ l3 ⊔ l4)
+  retract-map f g =
+    Σ (retract X A) (λ r → Σ (retract Y B) (is-retract-of-map f g r))
+```
+
+### The binary relation `g f ↦ g retract-of-map f` asserting that `g` is a retract of the map `f`
 
 ```agda
 module _
@@ -145,12 +157,10 @@ module _
   (g : A → B) (f : X → Y)
   where
 
-  retract-map : UU (l1 ⊔ l2 ⊔ l3 ⊔ l4)
-  retract-map =
-    Σ (retract X A) (λ r → Σ (retract Y B) (is-retract-of-map f g r))
+  infix 6 _retract-of-map_
 
   _retract-of-map_ : UU (l1 ⊔ l2 ⊔ l3 ⊔ l4)
-  _retract-of-map_ = retract-map
+  _retract-of-map_ = retract-map f g
 
 module _
   {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
@@ -353,19 +363,19 @@ module _
           ( inclusion-fiber g z)) ,
         ( coherence-is-retraction-fiber-retract-map y z))
 
-  retract-of-fiber-retract-map :
+  retract-fiber-retract-map :
     (y : B) →
     ( fiber g y) retract-of
     ( fiber f (inclusion-codomain-retract-map f g k y))
-  pr1 (retract-of-fiber-retract-map y) =
+  pr1 (retract-fiber-retract-map y) =
     inclusion-fiber-retract-map y
-  pr1 (pr2 (retract-of-fiber-retract-map y)) =
+  pr1 (pr2 (retract-fiber-retract-map y)) =
     map-retraction-fiber-retract-map y
-  pr2 (pr2 (retract-of-fiber-retract-map y)) =
+  pr2 (pr2 (retract-fiber-retract-map y)) =
     is-retraction-fiber-retract-map y
 ```
 
-### If `g` is a retract of `f`, then the fiber projections of `g` are retracts of the fiber projections of `f`
+### If `g` is a retract of `f`, then the fiber inclusions of `g` are retracts of the fiber inclusions of `f`
 
 ```agda
 module _
@@ -375,18 +385,21 @@ module _
 
   is-retract-map-fiber-retract-map :
     is-retract-of-map
-      ( pr1)
-      ( pr1)
-      ( retract-of-fiber-retract-map f g k y)
+      ( inclusion-fiber f)
+      ( inclusion-fiber g)
+      ( retract-fiber-retract-map f g k y)
       ( retract-domain-retract-map f g k)
-  pr1 is-retract-map-fiber-retract-map = refl-htpy
-  pr1 (pr2 is-retract-map-fiber-retract-map) = refl-htpy
-  pr2 (pr2 is-retract-map-fiber-retract-map) (x , p) =
-    inv (ap-pr1-map-inv-fiber-ap-eq-fiber g _ (x , p) _)
+  pr1 is-retract-map-fiber-retract-map =
+    refl-htpy
+  pr1 (pr2 is-retract-map-fiber-retract-map) =
+    refl-htpy
+  pr2 (pr2 is-retract-map-fiber-retract-map) z =
+    inv (ap-pr1-map-inv-fiber-ap-eq-fiber g _ z _)
 
-  retract-map-fiber-retract-map : pr1 retract-of-map pr1
+  retract-map-fiber-retract-map :
+    (inclusion-fiber g) retract-of-map (inclusion-fiber f)
   pr1 retract-map-fiber-retract-map =
-    retract-of-fiber-retract-map f g k y
+    retract-fiber-retract-map f g k y
   pr1 (pr2 retract-map-fiber-retract-map) =
     retract-domain-retract-map f g k
   pr2 (pr2 retract-map-fiber-retract-map) =
@@ -401,7 +414,7 @@ In fact, we only need the following data to show this:
                  r
             X ------> A
             |         |
-            f    R    g
+          f |    R    | g
             v         v
   B ------> Y ------> B.
        s'   H'   r'
@@ -420,7 +433,7 @@ module _
     r ∘ map-section f section-f ∘ inclusion-retract r'
 
   is-section-map-section-is-retract-of-section' :
-    g ∘ map-section-is-retract-of-section' ~ id
+    is-section g map-section-is-retract-of-section'
   is-section-map-section-is-retract-of-section' =
     ( inv-htpy R ·r (map-section f section-f ∘ inclusion-retract r')) ∙h
     ( ( map-retraction-retract r') ·l
@@ -510,8 +523,11 @@ module _
   (S : coherence-square-maps (inclusion-retract r) g f (inclusion-retract r'))
   (R :
     coherence-square-maps
-      ( map-retraction-retract r) f g (map-retraction-retract r'))
-  (is-equiv-f : is-equiv f)
+      ( map-retraction-retract r)
+      ( f)
+      ( g)
+      ( map-retraction-retract r'))
+  (H : is-equiv f)
   where
 
   is-equiv-is-retract-of-is-equiv' : is-equiv g
@@ -520,27 +536,26 @@ module _
       ( map-retraction-retract r)
       ( r')
       ( R)
-      ( section-is-equiv is-equiv-f)
+      ( section-is-equiv H)
   pr2 is-equiv-is-retract-of-is-equiv' =
     has-retraction-is-retract-of-has-retraction' f g
       ( r)
       ( inclusion-retract r')
       ( S)
-      ( retraction-is-equiv is-equiv-f)
+      ( retraction-is-equiv H)
 
 module _
   {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
-  (f : X → Y) (g : A → B) (k : g retract-of-map f) (is-equiv-f : is-equiv f)
+  (f : X → Y) (g : A → B) (k : g retract-of-map f) (H : is-equiv f)
   where
 
   section-retract-of-is-equiv : section g
   section-retract-of-is-equiv =
-    section-retract-section f g k (section-is-equiv is-equiv-f)
+    section-retract-section f g k (section-is-equiv H)
 
   retraction-retract-of-is-equiv : retraction g
   retraction-retract-of-is-equiv =
-    has-map-retraction-retract-has-retraction f g k
-      ( retraction-is-equiv is-equiv-f)
+    has-map-retraction-retract-has-retraction f g k (retraction-is-equiv H)
 
   is-equiv-retract-of-is-equiv : is-equiv g
   pr1 is-equiv-retract-of-is-equiv = section-retract-of-is-equiv

--- a/src/foundation/retracts-of-maps.lagda.md
+++ b/src/foundation/retracts-of-maps.lagda.md
@@ -86,12 +86,15 @@ module _
   coherence-retract-of-map :
     coherence-square-maps (inclusion-retract r) g f (inclusion-retract r') →
     coherence-square-maps
-      ( map-retraction-retract r) f g (map-retraction-retract r') →
+      ( map-retraction-retract r)
+      ( f)
+      ( g)
+      ( map-retraction-retract r') →
     UU (l1 ⊔ l2)
-  coherence-retract-of-map S R =
+  coherence-retract-of-map I R =
     coherence-square-homotopies
       ( R ·r inclusion-retract r)
-      ( map-retraction-retract r' ·l inv-htpy S)
+      ( map-retraction-retract r' ·l inv-htpy I)
       ( g ·l is-retraction-map-retraction-retract r)
       ( is-retraction-map-retraction-retract r' ·r g)
 ```
@@ -406,7 +409,7 @@ module _
     is-retract-map-fiber-retract-map
 ```
 
-### If `f` has a section, then retracts of `f` have a section
+### Retracts of maps with sections have sections
 
 In fact, we only need the following data to show this:
 
@@ -420,31 +423,36 @@ In fact, we only need the following data to show this:
        i'   H'   r'
 ```
 
+**Proof:** Note that `g` is the right map of a triangle
+
+```text
+            r
+       X ------> A
+        \       /
+  r' ∘ f \     / g
+          \   /
+           V V
+            B.
+```
+
+Since both `r'` and `f` are assumed to have [sections](foundation-core.sections.md), it follows that the composite `r' ∘ f` has a section, and therefore `g` has a section.
+
 ```agda
 module _
   {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
   (f : X → Y) (g : A → B) (r : X → A) (r' : B retract-of Y)
   (R : coherence-square-maps r f g (map-retraction-retract r'))
-  (section-f : section f)
+  (s : section f)
   where
 
-  map-section-is-retract-of-section' : B → A
-  map-section-is-retract-of-section' =
-    r ∘ map-section f section-f ∘ inclusion-retract r'
-
-  is-section-map-section-is-retract-of-section' :
-    is-section g map-section-is-retract-of-section'
-  is-section-map-section-is-retract-of-section' =
-    ( inv-htpy R ·r (map-section f section-f ∘ inclusion-retract r')) ∙h
-    ( ( map-retraction-retract r') ·l
-      ( is-section-map-section f section-f ·r inclusion-retract r')) ∙h
-    ( is-retraction-map-retraction-retract r')
-
-  section-is-retract-of-section' : section g
-  pr1 section-is-retract-of-section' =
-    map-section-is-retract-of-section'
-  pr2 section-is-retract-of-section' =
-    is-section-map-section-is-retract-of-section'
+  section-retract-map-section' : section g
+  section-retract-map-section' =
+    section-right-map-triangle
+      ( map-retraction-retract r' ∘ f)
+      ( g)
+      ( r)
+      ( R)
+      ( section-comp (map-retraction-retract r') f s (section-retract r'))
 
 module _
   {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
@@ -453,60 +461,66 @@ module _
 
   section-retract-section : section f → section g
   section-retract-section =
-    section-is-retract-of-section' f g
+    section-retract-map-section' f g
       ( map-retraction-domain-retract-map f g k)
       ( retract-codomain-retract-map f g k)
       ( coh-map-retraction-retract-map f g k)
 ```
 
-### If `f` has a retraction, then retracts of `f` have a retraction
+### Retracts of maps with retractions have retractions
 
 In fact, we only need the following data to show this:
 
 ```text
-       i    H    r
-  A ------> X ------> A
-  |         |
-  g    I    f
-  v         v
-  B ------> Y.
-       i'
+         i    H    r
+    A ------> X ------> A
+    |         |
+  g |    I    | f
+    v         v
+    B ------> Y.
+         i'
 ```
+
+**Proof:** Note that `g` is the top map in the triangle
+
+```text
+           g
+      A ------> B
+       \       /
+  f ∘ i \     / i'
+         \   /
+          V V
+           Y.
+```
+
+Since both `f` and `i` are assumed to have retractions, it follows that `f ∘ i` has a retraction, and hence that `g` has a retraction.
 
 ```agda
 module _
-  {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
-  (f : X → Y) (g : A → B) (r : A retract-of X) (s' : B → Y)
-  (S : coherence-square-maps (inclusion-retract r) g f s')
-  (retraction-f : retraction f)
+  {l1 l2 l3 l4 : Level}
+  {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4} (f : X → Y) (g : A → B)
+  (r : A retract-of X) (i' : B → Y)
+  (I : coherence-square-maps (inclusion-retract r) g f i')
+  (s : retraction f)
   where
 
-  map-has-retraction-is-retract-of-has-retraction' : B → A
-  map-has-retraction-is-retract-of-has-retraction' =
-    map-retraction-retract r ∘ map-retraction f retraction-f ∘ s'
-
-  is-retraction-map-has-retraction-is-retract-of-has-retraction' :
-    map-has-retraction-is-retract-of-has-retraction' ∘ g ~ id
-  is-retraction-map-has-retraction-is-retract-of-has-retraction' =
-    ( ( map-retraction-retract r ∘ map-retraction f retraction-f) ·l S) ∙h
-    ( ( map-retraction-retract r) ·l
-      ( is-retraction-map-retraction f retraction-f ·r inclusion-retract r)) ∙h
-    ( is-retraction-map-retraction-retract r)
-
-  has-retraction-is-retract-of-has-retraction' : retraction g
-  pr1 has-retraction-is-retract-of-has-retraction' =
-    map-has-retraction-is-retract-of-has-retraction'
-  pr2 has-retraction-is-retract-of-has-retraction' =
-    is-retraction-map-has-retraction-is-retract-of-has-retraction'
+  retraction-retract-map-retraction' : retraction g
+  retraction-retract-map-retraction' =
+    retraction-top-map-triangle
+      ( f ∘ inclusion-retract r)
+      ( i')
+      ( g)
+      ( inv-htpy I)
+      ( retraction-comp f (inclusion-retract r) s (retraction-retract r))
 
 module _
   {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
   (f : X → Y) (g : A → B) (k : g retract-of-map f)
   where
 
-  has-map-retraction-retract-has-retraction : retraction f → retraction g
-  has-map-retraction-retract-has-retraction =
-    has-retraction-is-retract-of-has-retraction' f g
+  retraction-retract-map-retraction : retraction f → retraction g
+  retraction-retract-map-retraction =
+    retraction-retract-map-retraction' f g
       ( retract-domain-retract-map f g k)
       ( inclusion-codomain-retract-map f g k)
       ( coh-inclusion-retract-map f g k)
@@ -520,7 +534,7 @@ Note that the higher coherence of a retract of maps is not needed.
 module _
   {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
   (f : X → Y) (g : A → B) (r : A retract-of X) (r' : B retract-of Y)
-  (S : coherence-square-maps (inclusion-retract r) g f (inclusion-retract r'))
+  (I : coherence-square-maps (inclusion-retract r) g f (inclusion-retract r'))
   (R :
     coherence-square-maps
       ( map-retraction-retract r)
@@ -530,18 +544,18 @@ module _
   (H : is-equiv f)
   where
 
-  is-equiv-is-retract-of-is-equiv' : is-equiv g
-  pr1 is-equiv-is-retract-of-is-equiv' =
-    section-is-retract-of-section' f g
+  is-equiv-retract-map-is-equiv' : is-equiv g
+  pr1 is-equiv-retract-map-is-equiv' =
+    section-retract-map-section' f g
       ( map-retraction-retract r)
       ( r')
       ( R)
       ( section-is-equiv H)
-  pr2 is-equiv-is-retract-of-is-equiv' =
-    has-retraction-is-retract-of-has-retraction' f g
+  pr2 is-equiv-retract-map-is-equiv' =
+    retraction-retract-map-retraction' f g
       ( r)
       ( inclusion-retract r')
-      ( S)
+      ( I)
       ( retraction-is-equiv H)
 
 module _
@@ -549,17 +563,17 @@ module _
   (f : X → Y) (g : A → B) (k : g retract-of-map f) (H : is-equiv f)
   where
 
-  section-retract-of-is-equiv : section g
-  section-retract-of-is-equiv =
+  section-retract-map-is-equiv : section g
+  section-retract-map-is-equiv =
     section-retract-section f g k (section-is-equiv H)
 
-  retraction-retract-of-is-equiv : retraction g
-  retraction-retract-of-is-equiv =
-    has-map-retraction-retract-has-retraction f g k (retraction-is-equiv H)
+  retraction-retract-map-is-equiv : retraction g
+  retraction-retract-map-is-equiv =
+    retraction-retract-map-retraction f g k (retraction-is-equiv H)
 
-  is-equiv-retract-of-is-equiv : is-equiv g
-  pr1 is-equiv-retract-of-is-equiv = section-retract-of-is-equiv
-  pr2 is-equiv-retract-of-is-equiv = retraction-retract-of-is-equiv
+  is-equiv-retract-map-is-equiv : is-equiv g
+  pr1 is-equiv-retract-map-is-equiv = section-retract-map-is-equiv
+  pr2 is-equiv-retract-map-is-equiv = retraction-retract-map-is-equiv
 ```
 
 ## References

--- a/src/foundation/retracts-of-types.lagda.md
+++ b/src/foundation/retracts-of-types.lagda.md
@@ -15,6 +15,7 @@ open import foundation-core.function-types
 open import foundation-core.homotopies
 open import foundation-core.identity-types
 open import foundation-core.retractions
+open import foundation-core.sections
 ```
 
 </details>
@@ -29,9 +30,9 @@ come equipped with **retract data**, i.e., with maps
   A -----> B -----> A
 ```
 
-and a homotopy `r ∘ i ~ id`. The map `i` is called the **inclusion** of the
-retract data, and the map `r` is called the **(underlying map of the) retract
-data**.
+and a [homotopy](foundation-core.homotopies.md) `r ∘ i ~ id`. The map `i` is called the **inclusion** of the
+retract data, and the map `r` is called the **underlying map of the
+retraction**.
 
 ## Definitions
 
@@ -55,23 +56,26 @@ _retract-of_ :
 A retract-of B = retract B A
 
 module _
-  {l1 l2 : Level} {A : UU l1} {B : UU l2}
+  {l1 l2 : Level} {A : UU l1} {B : UU l2} (R : retract B A)
   where
 
-  inclusion-retract : retract B A → A → B
-  inclusion-retract = pr1
+  inclusion-retract : A → B
+  inclusion-retract = pr1 R
 
-  retraction-retract :
-    (R : retract B A) → retraction (inclusion-retract R)
-  retraction-retract = pr2
+  retraction-retract : retraction inclusion-retract
+  retraction-retract = pr2 R
 
-  map-retraction-retract : retract B A → B → A
-  map-retraction-retract R = pr1 (retraction-retract R)
+  map-retraction-retract : B → A
+  map-retraction-retract = map-retraction inclusion-retract retraction-retract
 
   is-retraction-map-retraction-retract :
-    (R : retract B A) →
-    map-retraction-retract R ∘ inclusion-retract R ~ id
-  is-retraction-map-retraction-retract R = pr2 (retraction-retract R)
+    is-section map-retraction-retract inclusion-retract
+  is-retraction-map-retraction-retract =
+    is-retraction-map-retraction inclusion-retract retraction-retract
+
+  section-retract : section map-retraction-retract
+  pr1 section-retract = inclusion-retract
+  pr2 section-retract = is-retraction-map-retraction-retract
 ```
 
 ## Properties
@@ -90,3 +94,7 @@ module _
   pr2 retract-eq =
     retraction-ap (inclusion-retract R) (retraction-retract R) x y
 ```
+
+## See also
+
+- [Retracts of maps](foundation.retracts-of-maps.md)

--- a/src/foundation/retracts-of-types.lagda.md
+++ b/src/foundation/retracts-of-types.lagda.md
@@ -1,0 +1,83 @@
+# Retracts of types
+
+```agda
+module foundation.retracts-of-types where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.action-on-identifications-functions
+open import foundation.dependent-pair-types
+open import foundation.universe-levels
+
+open import foundation-core.function-types
+open import foundation-core.homotopies
+open import foundation-core.identity-types
+open import foundation-core.retractions
+```
+
+</details>
+
+## Idea
+
+We say that a type `A` is a **retract of** a type `B` if the types `A` and `B`
+come equipped with **retract data**, i.e., with maps
+
+```text
+      i        r
+  A -----> B -----> A
+```
+
+and a homotopy `r ∘ i ~ id`. The map `i` is called the **inclusion of the
+retract data, and the map `r` is called the **(underlying map of the) retract
+data\*\*.
+
+## Definitions
+
+### The type of witnesses that `A` is a retract of `B`
+
+```agda
+retract : {l1 l2 : Level} → UU l1 → UU l2 → UU (l1 ⊔ l2)
+retract A B = Σ (A → B) retraction
+
+_retract-of_ :
+  {l1 l2 : Level} → UU l1 → UU l2 → UU (l1 ⊔ l2)
+A retract-of B = retract A B
+
+module _
+  {l1 l2 : Level} {A : UU l1} {B : UU l2}
+  where
+
+  inclusion-retract : retract A B → A → B
+  inclusion-retract = pr1
+
+  retraction-retract :
+    (R : retract A B) → retraction (inclusion-retract R)
+  retraction-retract = pr2
+
+  map-retraction-retract : retract A B → B → A
+  map-retraction-retract R = pr1 (retraction-retract R)
+
+  is-retraction-retraction-retract :
+    (R : retract A B) →
+    map-retraction-retract R ∘ inclusion-retract R ~ id
+  is-retraction-retraction-retract R = pr2 (retraction-retract R)
+```
+
+## Properties
+
+### If `A` is a retract of `B` with inclusion `i : A → B`, then `x ＝ y` is a retract of `i x ＝ i y` for any two elements `x y : A`
+
+```agda
+module _
+  {l1 l2 : Level} {A : UU l1} {B : UU l2} (R : retract A B) (x y : A)
+  where
+
+  retract-eq :
+    (x ＝ y) retract-of (inclusion-retract R x ＝ inclusion-retract R y)
+  pr1 retract-eq =
+    ap (inclusion-retract R)
+  pr2 retract-eq =
+    retraction-ap (inclusion-retract R) (retraction-retract R) x y
+```

--- a/src/foundation/retracts-of-types.lagda.md
+++ b/src/foundation/retracts-of-types.lagda.md
@@ -30,9 +30,9 @@ come equipped with **retract data**, i.e., with maps
   A -----> B -----> A
 ```
 
-and a [homotopy](foundation-core.homotopies.md) `r ∘ i ~ id`. The map `i` is called the **inclusion** of the
-retract data, and the map `r` is called the **underlying map of the
-retraction**.
+and a [homotopy](foundation-core.homotopies.md) `r ∘ i ~ id`. The map `i` is
+called the **inclusion** of the retract data, and the map `r` is called the
+**underlying map of the retraction**.
 
 ## Definitions
 

--- a/src/foundation/sections.lagda.md
+++ b/src/foundation/sections.lagda.md
@@ -13,6 +13,7 @@ open import foundation.action-on-identifications-functions
 open import foundation.commuting-triangles-of-homotopies
 open import foundation.dependent-pair-types
 open import foundation.function-extensionality
+open import foundation.retracts-of-types
 open import foundation.structure-identity-principle
 open import foundation.type-arithmetic-dependent-pair-types
 open import foundation.type-theoretic-principle-of-choice
@@ -95,15 +96,15 @@ module _
 ### If the right factor of a composite has a section, then the type of sections of the left factor is a retract of the type of sections of the composite
 
 ```agda
-is-retraction-section-comp-htpy :
+is-retraction-section-left-map-triangle :
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}
   (f : A → X) (g : B → X) (h : A → B)
   (H : f ~ (g ∘ h)) (s : section h) →
-  (section-left-factor-htpy f g h H ∘ section-comp-htpy f g h H s) ~ id
-is-retraction-section-comp-htpy f g h H (k , K) (l , L) =
+  section-right-map-triangle f g h H ∘ section-left-map-triangle f g h H s ~ id
+is-retraction-section-left-map-triangle f g h H (k , K) (l , L) =
   eq-htpy-section
-    ( ( section-left-factor-htpy f g h H ∘
-        section-comp-htpy f g h H (k , K))
+    ( ( section-right-map-triangle f g h H ∘
+        section-left-map-triangle f g h H (k , K))
       ( l , L))
     ( l , L)
     ( K ·r l)
@@ -122,12 +123,12 @@ section-left-factor-retract-of-section-composition :
   (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
   section h → (section g) retract-of (section f)
 pr1 (section-left-factor-retract-of-section-composition f g h H s) =
-  section-comp-htpy f g h H s
+  section-left-map-triangle f g h H s
 pr1 (pr2 (section-left-factor-retract-of-section-composition f g h H s)) =
-  section-left-factor-htpy f g h H
+  section-right-map-triangle f g h H
 
 pr2 (pr2 (section-left-factor-retract-of-section-composition f g h H s)) =
-  is-retraction-section-comp-htpy f g h H s
+  is-retraction-section-left-map-triangle f g h H s
 ```
 
 ### The equivalence of sections of the projection map and sections of the type family
@@ -159,7 +160,7 @@ module _
   is-equiv-map-section-family :
     ((x : A) → is-contr (B x)) → is-equiv (map-section-family b)
   is-equiv-map-section-family C =
-    is-equiv-right-factor-htpy
+    is-equiv-top-map-triangle
       ( id)
       ( pr1)
       ( map-section-family b)
@@ -176,7 +177,7 @@ module _
     is-equiv (map-section-family b) → ((x : A) → is-contr (B x))
   is-contr-fam-is-equiv-map-section-family H =
     is-contr-is-equiv-pr1
-      ( is-equiv-left-factor-htpy id pr1
+      ( is-equiv-right-map-triangle id pr1
         ( map-section-family b)
         ( htpy-map-section-family b)
         ( is-equiv-id)

--- a/src/foundation/surjective-maps.lagda.md
+++ b/src/foundation/surjective-maps.lagda.md
@@ -409,10 +409,10 @@ module _
   where
 
   abstract
-    is-surjective-comp-htpy :
+    is-surjective-left-map-triangle :
       (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
       is-surjective g → is-surjective h → is-surjective f
-    is-surjective-comp-htpy f g h H is-surj-g is-surj-h x =
+    is-surjective-left-map-triangle f g h H is-surj-g is-surj-h x =
       apply-universal-property-trunc-Prop
         ( is-surj-g x)
         ( trunc-Prop (fiber f x))
@@ -427,7 +427,7 @@ module _
     {g : B → X} {h : A → B} →
     is-surjective g → is-surjective h → is-surjective (g ∘ h)
   is-surjective-comp {g} {h} =
-    is-surjective-comp-htpy (g ∘ h) g h refl-htpy
+    is-surjective-left-map-triangle (g ∘ h) g h refl-htpy
 ```
 
 ### Functoriality of products preserves being surjective
@@ -477,10 +477,10 @@ module _
   where
 
   abstract
-    is-surjective-left-factor-htpy :
+    is-surjective-right-map-triangle :
       (f : A → X) (g : B → X) (h : A → B) (H : f ~ (g ∘ h)) →
       is-surjective f → is-surjective g
-    is-surjective-left-factor-htpy f g h H is-surj-f x =
+    is-surjective-right-map-triangle f g h H is-surj-f x =
       apply-universal-property-trunc-Prop
         ( is-surj-f x)
         ( trunc-Prop (fiber g x))
@@ -489,7 +489,7 @@ module _
   is-surjective-left-factor :
     {g : B → X} (h : A → B) → is-surjective (g ∘ h) → is-surjective g
   is-surjective-left-factor {g} h =
-    is-surjective-left-factor-htpy (g ∘ h) g h refl-htpy
+    is-surjective-right-map-triangle (g ∘ h) g h refl-htpy
 ```
 
 ### Surjective maps are `-1`-connected

--- a/src/foundation/uniqueness-image.lagda.md
+++ b/src/foundation/uniqueness-image.lagda.md
@@ -15,6 +15,7 @@ open import foundation.type-arithmetic-dependent-pair-types
 open import foundation.universal-property-image
 open import foundation.universe-levels
 
+open import foundation-core.commuting-triangles-of-maps
 open import foundation-core.contractible-types
 open import foundation-core.embeddings
 open import foundation-core.function-types

--- a/src/foundation/uniqueness-set-quotients.lagda.md
+++ b/src/foundation/uniqueness-set-quotients.lagda.md
@@ -137,7 +137,7 @@ module _
     is-equiv h → ({l : Level} → is-set-quotient l R B f) →
     {l : Level} → is-set-quotient l R C g
   is-set-quotient-is-set-quotient-is-equiv E Uf {l} X =
-    is-equiv-comp-htpy
+    is-equiv-left-map-triangle
       ( precomp-Set-Quotient R C g X)
       ( precomp-Set-Quotient R B f X)
       ( precomp h (type-Set X))
@@ -153,7 +153,7 @@ module _
     ({l : Level} → is-set-quotient l R C g) → is-equiv h →
     {l : Level} → is-set-quotient l R B f
   is-set-quotient-is-equiv-is-set-quotient Ug E {l} X =
-    is-equiv-left-factor-htpy
+    is-equiv-right-map-triangle
       ( precomp-Set-Quotient R C g X)
       ( precomp-Set-Quotient R B f X)
       ( precomp h (type-Set X))

--- a/src/foundation/universal-property-sequential-limits.lagda.md
+++ b/src/foundation/universal-property-sequential-limits.lagda.md
@@ -115,7 +115,7 @@ module _
       up up' =
       is-equiv-is-equiv-postcomp h
         ( λ D →
-          is-equiv-right-factor-htpy
+          is-equiv-top-map-triangle
             ( cone-map-tower A c')
             ( cone-map-tower A c)
             ( postcomp D h)
@@ -130,7 +130,7 @@ module _
       ({l : Level} → universal-property-sequential-limit l A c')
     universal-property-sequential-limit-universal-property-sequential-limit-is-equiv
       is-equiv-h up D =
-      is-equiv-comp-htpy
+      is-equiv-left-map-triangle
         ( cone-map-tower A c')
         ( cone-map-tower A c)
         ( postcomp D h)
@@ -145,7 +145,7 @@ module _
       ({l : Level} → universal-property-sequential-limit l A c)
     universal-property-sequential-limit-is-equiv-universal-property-sequential-limit
       up' is-equiv-h D =
-      is-equiv-left-factor-htpy
+      is-equiv-right-map-triangle
         ( cone-map-tower A c')
         ( cone-map-tower A c)
         ( postcomp D h)

--- a/src/foundation/unordered-pairs.lagda.md
+++ b/src/foundation/unordered-pairs.lagda.md
@@ -258,7 +258,7 @@ module _
   abstract
     is-equiv-ev-refl-Eq-unordered-pair : is-equiv ev-refl-Eq-unordered-pair
     is-equiv-ev-refl-Eq-unordered-pair =
-      is-equiv-left-factor-htpy
+      is-equiv-right-map-triangle
         ( ev-point (p , refl-Eq-unordered-pair p))
         ( ev-refl-Eq-unordered-pair)
         ( ev-pair)

--- a/src/group-theory/normal-submonoids-commutative-monoids.lagda.md
+++ b/src/group-theory/normal-submonoids-commutative-monoids.lagda.md
@@ -15,7 +15,7 @@ open import foundation.function-types
 open import foundation.identity-types
 open import foundation.logical-equivalences
 open import foundation.propositions
-open import foundation.retractions
+open import foundation.retracts-of-types
 open import foundation.sets
 open import foundation.subtype-identity-principle
 open import foundation.subtypes

--- a/src/group-theory/normal-submonoids.lagda.md
+++ b/src/group-theory/normal-submonoids.lagda.md
@@ -16,7 +16,7 @@ open import foundation.function-types
 open import foundation.identity-types
 open import foundation.logical-equivalences
 open import foundation.propositions
-open import foundation.retractions
+open import foundation.retracts-of-types
 open import foundation.sets
 open import foundation.subtype-identity-principle
 open import foundation.subtypes

--- a/src/group-theory/quotient-groups.lagda.md
+++ b/src/group-theory/quotient-groups.lagda.md
@@ -542,7 +542,7 @@ module _
         ( quotient-Group G N)
         ( nullifying-quotient-hom-Group G N)
     is-quotient-group-quotient-Group H =
-      is-equiv-comp-htpy
+      is-equiv-left-map-triangle
         ( precomp-nullifying-hom-Group G N
           ( quotient-Group G N)
           ( nullifying-quotient-hom-Group G N)

--- a/src/synthetic-homotopy-theory/26-descent.lagda.md
+++ b/src/synthetic-homotopy-theory/26-descent.lagda.md
@@ -690,7 +690,7 @@ is-equiv-desc-fam :
   ((l' : Level) → universal-property-pushout l' f g c) →
   is-equiv (desc-fam {l = l} {f = f} {g} c)
 is-equiv-desc-fam {l = l} {f = f} {g} c up-c =
-  is-equiv-comp-htpy
+  is-equiv-left-map-triangle
     ( desc-fam c)
     ( Fam-pushout-cocone-UU l)
     ( cocone-map f g c)

--- a/src/synthetic-homotopy-theory/26-id-pushout.lagda.md
+++ b/src/synthetic-homotopy-theory/26-id-pushout.lagda.md
@@ -262,7 +262,7 @@ is-equiv-hom-Fam-pushout-map :
   ( P : X → UU l5) (Q : X → UU l6) →
   is-equiv (hom-Fam-pushout-map c P Q)
 is-equiv-hom-Fam-pushout-map {l5 = l5} {l6} {f = f} {g} c up-X P Q =
-  is-equiv-comp-htpy
+  is-equiv-left-map-triangle
     ( hom-Fam-pushout-map c P Q)
     ( hom-Fam-pushout-dependent-cocone c P Q)
     ( dependent-cocone-map f g c (λ x → P x → Q x))
@@ -327,7 +327,7 @@ is-universal-id-Fam-pushout' :
       ( desc-fam c Q)
       ( refl))
 is-universal-id-Fam-pushout' c up-X a Q =
-  is-equiv-left-factor-htpy
+  is-equiv-right-map-triangle
     ( ev-refl (pr1 c a) {B = λ x p → Q x})
     ( ev-point-hom-Fam-pushout
       ( desc-fam c (Id (pr1 c a)))

--- a/src/synthetic-homotopy-theory/acyclic-types.lagda.md
+++ b/src/synthetic-homotopy-theory/acyclic-types.lagda.md
@@ -10,7 +10,7 @@ module synthetic-homotopy-theory.acyclic-types where
 open import foundation.contractible-types
 open import foundation.equivalences
 open import foundation.propositions
-open import foundation.retractions
+open import foundation.retracts-of-types
 open import foundation.universe-levels
 
 open import synthetic-homotopy-theory.functoriality-suspensions

--- a/src/synthetic-homotopy-theory/dependent-universal-property-coequalizers.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-universal-property-coequalizers.lagda.md
@@ -136,7 +136,7 @@ module _
   dependent-universal-property-coequalizer-dependent-universal-property-pushout
     ( dup-pushout)
     ( P) =
-    is-equiv-comp-htpy
+    is-equiv-left-map-triangle
       ( dependent-cofork-map f g e)
       ( dependent-cofork-dependent-cocone-codiagonal f g e P)
       ( dependent-cocone-map
@@ -159,7 +159,7 @@ module _
   dependent-universal-property-pushout-dependent-universal-property-coequalizer
     ( dup-coequalizer)
     ( P) =
-    is-equiv-right-factor-htpy
+    is-equiv-top-map-triangle
       ( dependent-cofork-map f g e)
       ( dependent-cofork-dependent-cocone-codiagonal f g e P)
       ( dependent-cocone-map
@@ -186,7 +186,7 @@ module _
   universal-property-dependent-universal-property-coequalizer
     ( dup-coequalizer)
     ( Y) =
-    is-equiv-comp-htpy
+    is-equiv-left-map-triangle
       ( cofork-map f g e)
       ( map-compute-dependent-cofork-constant-family f g e Y)
       ( dependent-cofork-map f g e)

--- a/src/synthetic-homotopy-theory/dependent-universal-property-pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-universal-property-pushouts.lagda.md
@@ -188,7 +188,7 @@ dependent-pullback-property-dependent-universal-property-pushout :
 dependent-pullback-property-dependent-universal-property-pushout
   f g (pair i (pair j H)) I l P =
   let c = (pair i (pair j H)) in
-  is-equiv-right-factor-htpy
+  is-equiv-top-map-triangle
     ( dependent-cocone-map f g c P)
     ( tot (λ h → tot (λ h' → htpy-eq)))
     ( gap
@@ -213,7 +213,7 @@ dependent-universal-property-dependent-pullback-property-pushout :
 dependent-universal-property-dependent-pullback-property-pushout
   f g (pair i (pair j H)) dpullback-c l P =
   let c = (pair i (pair j H)) in
-  is-equiv-comp-htpy
+  is-equiv-left-map-triangle
     ( dependent-cocone-map f g c P)
     ( tot (λ h → tot (λ h' → htpy-eq)))
     ( gap

--- a/src/synthetic-homotopy-theory/dependent-universal-property-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-universal-property-sequential-colimits.lagda.md
@@ -145,7 +145,7 @@ module _
   dependent-universal-property-sequential-colimit-dependent-universal-property-coequalizer
     ( dup-coequalizer)
     ( P) =
-    is-equiv-comp-htpy
+    is-equiv-left-map-triangle
       ( dependent-cocone-map-sequential-diagram A c P)
       ( dependent-cocone-sequential-diagram-dependent-cofork A c P)
       ( dependent-cofork-map
@@ -167,7 +167,7 @@ module _
   dependent-universal-property-coequalizer-dependent-universal-property-sequential-colimit
     ( dup-sequential-colimit)
     ( P) =
-    is-equiv-right-factor-htpy
+    is-equiv-top-map-triangle
       ( dependent-cocone-map-sequential-diagram A c P)
       ( dependent-cocone-sequential-diagram-dependent-cofork A c P)
       ( dependent-cofork-map
@@ -193,7 +193,7 @@ module _
   universal-property-dependent-universal-property-sequential-colimit
     ( dup-sequential-colimit)
     ( Y) =
-    is-equiv-comp-htpy
+    is-equiv-left-map-triangle
       ( cocone-map-sequential-diagram A c)
       ( map-compute-dependent-cocone-sequential-diagram-constant-family A c Y)
       ( dependent-cocone-map-sequential-diagram A c (λ _ → Y))

--- a/src/synthetic-homotopy-theory/descent-circle.lagda.md
+++ b/src/synthetic-homotopy-theory/descent-circle.lagda.md
@@ -344,7 +344,7 @@ module _
     ( up-circle : universal-property-circle (lsuc l2) l) →
     is-equiv (descent-data-family-circle l)
   is-equiv-descent-data-family-circle-universal-property-circle up-circle =
-    is-equiv-comp-htpy
+    is-equiv-left-map-triangle
       ( descent-data-family-circle l)
       ( comparison-descent-data-circle l2)
       ( ev-free-loop l (UU l2))

--- a/src/synthetic-homotopy-theory/flattening-lemma-pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/flattening-lemma-pushouts.lagda.md
@@ -284,7 +284,7 @@ module _
         ( map-equiv equiv-ev-pair³)
         ( cocone-map-flattening-pushout Y ∘ ind-Σ)
         ( is-equiv-map-equiv equiv-ev-pair³)
-        ( is-equiv-right-factor-htpy
+        ( is-equiv-top-map-triangle
           ( dependent-cocone-map f g c (λ x → P x → Y))
           ( map-equiv (comparison-dependent-cocone-ind-Σ-cocone Y))
           ( map-equiv equiv-ev-pair³ ∘ cocone-map-flattening-pushout Y ∘ ind-Σ)

--- a/src/synthetic-homotopy-theory/functoriality-suspensions.lagda.md
+++ b/src/synthetic-homotopy-theory/functoriality-suspensions.lagda.md
@@ -16,6 +16,7 @@ open import foundation.function-types
 open import foundation.homotopies
 open import foundation.identity-types
 open import foundation.retractions
+open import foundation.retracts-of-types
 open import foundation.sections
 open import foundation.universe-levels
 
@@ -233,11 +234,11 @@ module _
   retract-of-suspension-retract-of :
     A retract-of B → (suspension A) retract-of (suspension B)
   pr1 (retract-of-suspension-retract-of R) =
-    map-suspension (section-retract-of R)
+    map-suspension (inclusion-retract R)
   pr2 (retract-of-suspension-retract-of R) =
     retraction-map-suspension-retraction
-      ( section-retract-of R)
-      ( retraction-section-retract-of R)
+      ( inclusion-retract R)
+      ( retraction-retract R)
 ```
 
 ### Equivalent types have equivalent suspensions

--- a/src/synthetic-homotopy-theory/sections-descent-circle.lagda.md
+++ b/src/synthetic-homotopy-theory/sections-descent-circle.lagda.md
@@ -235,7 +235,7 @@ module _
     ( dependent-universal-property-circle l2 l) →
     is-equiv ev-fixpoint-descent-data-circle
   is-equiv-ev-fixpoint-descent-data-circle dup-circle =
-    is-equiv-right-factor-htpy
+    is-equiv-top-map-triangle
       ( ev-free-loop-Π l (family-family-with-descent-data-circle A))
       ( comparison-fixpoint-descent-data-circle)
       ( ev-fixpoint-descent-data-circle)

--- a/src/synthetic-homotopy-theory/universal-property-circle.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-circle.lagda.md
@@ -226,7 +226,7 @@ module _
       ({l : Level} → dependent-universal-property-circle l α) →
       ({l : Level} → universal-property-circle l α)
     universal-property-dependent-universal-property-circle dup-circle Y =
-      is-equiv-right-factor-htpy
+      is-equiv-top-map-triangle
         ( ev-free-loop-Π α (λ x → Y))
         ( map-compute-free-dependent-loop-const α Y)
         ( ev-free-loop α Y)

--- a/src/synthetic-homotopy-theory/universal-property-coequalizers.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-coequalizers.lagda.md
@@ -118,7 +118,7 @@ module _
     ( {l : Level} →
       universal-property-coequalizer l f g e)
   universal-property-coequalizer-universal-property-pushout up-pushout Y =
-    is-equiv-comp-htpy
+    is-equiv-left-map-triangle
       ( cofork-map f g e)
       ( cofork-cocone-codiagonal f g)
       ( cocone-map
@@ -138,7 +138,7 @@ module _
         ( horizontal-map-span-cocone-cofork f g)
         ( cocone-codiagonal-cofork f g e))
   universal-property-pushout-universal-property-coequalizer up-coequalizer Y =
-    is-equiv-right-factor-htpy
+    is-equiv-top-map-triangle
       ( cofork-map f g e)
       ( cofork-cocone-codiagonal f g)
       ( cocone-map

--- a/src/synthetic-homotopy-theory/universal-property-pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-pushouts.lagda.md
@@ -184,7 +184,7 @@ module _
   is-equiv-up-pushout-up-pushout up-c up-d =
     is-equiv-is-equiv-precomp h
       ( λ l Z →
-        is-equiv-right-factor-htpy
+        is-equiv-top-map-triangle
           ( cocone-map f g d)
           ( cocone-map f g c)
           ( precomp h Z)
@@ -197,7 +197,7 @@ module _
     ( up-c : {l : Level} → universal-property-pushout l f g c) →
     {l : Level} → universal-property-pushout l f g d
   up-pushout-up-pushout-is-equiv is-equiv-h up-c Z =
-    is-equiv-comp-htpy
+    is-equiv-left-map-triangle
       ( cocone-map f g d)
       ( cocone-map f g c)
       ( precomp h Z)
@@ -210,7 +210,7 @@ module _
     is-equiv h →
     {l : Level} → universal-property-pushout l f g c
   up-pushout-is-equiv-up-pushout up-d is-equiv-h Z =
-    is-equiv-left-factor-htpy
+    is-equiv-right-map-triangle
       ( cocone-map f g d)
       ( cocone-map f g c)
       ( precomp h Z)
@@ -268,7 +268,7 @@ pullback-property-pushout-universal-property-pushout :
   {B : UU l3} (f : S → A) (g : S → B) {X : UU l4} (c : cocone f g X) →
   universal-property-pushout l f g c → pullback-property-pushout l f g c
 pullback-property-pushout-universal-property-pushout l f g c up-c Y =
-  is-equiv-right-factor-htpy
+  is-equiv-top-map-triangle
     ( cocone-map f g c)
     ( tot (λ i' → tot (λ j' → htpy-eq)))
     ( gap (_∘ f) (_∘ g) (cone-pullback-property-pushout f g c Y))
@@ -283,7 +283,7 @@ universal-property-pushout-pullback-property-pushout :
   {B : UU l3} (f : S → A) (g : S → B) {X : UU l4} (c : cocone f g X) →
   pullback-property-pushout l f g c → universal-property-pushout l f g c
 universal-property-pushout-pullback-property-pushout l f g c pb-c Y =
-  is-equiv-comp-htpy
+  is-equiv-left-map-triangle
     ( cocone-map f g c)
     ( tot (λ i' → tot (λ j' → htpy-eq)))
     ( gap (_∘ f) (_∘ g) (cone-pullback-property-pushout f g c Y))

--- a/src/synthetic-homotopy-theory/universal-property-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-sequential-colimits.lagda.md
@@ -157,7 +157,7 @@ module _
   universal-property-sequential-colimit-universal-property-coequalizer
     ( up-cofork)
     ( Y) =
-    is-equiv-comp-htpy
+    is-equiv-left-map-triangle
       ( cocone-map-sequential-diagram A c)
       ( cocone-sequential-diagram-cofork A)
       ( cofork-map
@@ -179,7 +179,7 @@ module _
   universal-property-coequalizer-universal-property-sequential-colimit
     ( up-sequential-colimit)
     ( Y) =
-    is-equiv-right-factor-htpy
+    is-equiv-top-map-triangle
       ( cocone-map-sequential-diagram A c)
       ( cocone-sequential-diagram-cofork A)
       ( cofork-map
@@ -242,7 +242,7 @@ module _
       ( up-sequential-colimit') =
       is-equiv-is-equiv-precomp h
         ( λ l Z →
-          is-equiv-right-factor-htpy
+          is-equiv-top-map-triangle
             ( cocone-map-sequential-diagram A c')
             ( cocone-map-sequential-diagram A c)
             ( precomp h Z)
@@ -258,7 +258,7 @@ module _
       ( up-sequential-colimit)
       ( is-equiv-h)
       ( Z) =
-      is-equiv-comp-htpy
+      is-equiv-left-map-triangle
         ( cocone-map-sequential-diagram A c')
         ( cocone-map-sequential-diagram A c)
         ( precomp h Z)
@@ -274,7 +274,7 @@ module _
       ( is-equiv-h)
       ( up-sequential-colimit)
       ( Z) =
-      is-equiv-left-factor-htpy
+      is-equiv-right-map-triangle
         ( cocone-map-sequential-diagram A c')
         ( cocone-map-sequential-diagram A c)
         ( precomp h Z)

--- a/src/synthetic-homotopy-theory/universal-property-suspensions.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-suspensions.lagda.md
@@ -93,7 +93,7 @@ is-equiv-ev-suspension :
   ( up-Y : universal-property-suspension' l3 X Y s) →
   ( Z : UU l3) → is-equiv (ev-suspension s Z)
 is-equiv-ev-suspension {X = X} s up-Y Z =
-  is-equiv-comp-htpy
+  is-equiv-left-map-triangle
     ( ev-suspension s Z)
     ( map-equiv-suspension-structure-suspension-cocone X Z)
     ( cocone-map

--- a/src/univalent-combinatorics/pi-finite-types.lagda.md
+++ b/src/univalent-combinatorics/pi-finite-types.lagda.md
@@ -874,7 +874,7 @@ abstract
           ( is-surjective-map-unit-im (f ∘ inl))
       is-emb-i : is-emb i
       is-emb-i =
-        is-emb-right-factor-htpy
+        is-emb-top-map-triangle
           ( (unit-trunc-Set ∘ f) ∘ inl)
           ( inclusion-trunc-im-Set (f ∘ inl))
           ( i)

--- a/src/univalent-combinatorics/retracts-of-finite-types.lagda.md
+++ b/src/univalent-combinatorics/retracts-of-finite-types.lagda.md
@@ -17,6 +17,7 @@ open import foundation.fibers-of-maps
 open import foundation.functoriality-propositional-truncation
 open import foundation.injective-maps
 open import foundation.retractions
+open import foundation.retracts-of-types
 open import foundation.universe-levels
 
 open import univalent-combinatorics.counting


### PR DESCRIPTION
- Some cleanup of the `commuting-triangles-of-maps` file. I moved the commuting triangles induced by sections and retractions here, and moved the action of precomposition on commuting traingles to `functoriality-of-function-types`
- A total cleanup of `foundation-core.equivalences`. One of the ways I cleaned up was by writing a bit more infrastructure for sections and retractions. This made the long names obsolete, because now the projections are named. This is also a general case I would like to make against long variable names: If you write proper infrastructure then you don't need long variable names, plus it will be a lot easier to maintain your naming scheme and not float off course with it.
- The `foundation-core.equivalences` file now contains much more explanations.
- I introduced a new naming scheme for proving that certain maps in commuting triangles have certain properties. Previously we had parts of names like `left-factor-htpy`, which was supposed to mean the left factor up to homotopy. However, I think it is clearer if we mention `triangle` in such names, and name the map in the triangle that is the subject of the assertion. Note that diagrammatic ordering is usually the opposite of the compositional ordering, so `left-factor-htpy` got replaced by `right-map-triangle`. Similarly, I replaced `comp-htpy` by `left-map-triangle` and `right-factor-htpy` by `top-map-triangle`. This change triggered a lot of changes throughout the library.
- I added names for the projections out of the fiber of a map. We failed to do so previously, and it lead to clumsy formalization in some places. There are probably other places in the library where we could use those names, but I didn't go look for them as it would trigger another lot of changes throughout many files.
- In `retractions` I added a predicate for `is-retraction`, for obvious reasons
- In `sections` I added a predicate for `is-section`. In both cases I could have gone through the library and implement this predicate throughout. I didn't do so, but I could potentially do that in a subsequent pull request (not this one).
- I factored out `retracts-of-types` from `retractions`, because it is a separate concept from the concept of a retraction of a map, even though it is of course closely related. One thing I did in this file was introduce a non-infix notation for retracts of types. We usually have some non-infix notation for infix operators that indicate how to use statements involving that operator in a naming scheme. Writing `retract-of` in names quickly looks very awkward, so I improved that to `retract` using this setup.
- I moved the file `retracts-of-maps` from `orthogonal-factorization-systems` to `foundation`, so that it can be next to `retracts-of-types`
- I worked the new infrastructure into the file `retracts-of-maps`, but that triggered lots of changes throughout that file. I ended up renaming quite a lot of things, and I hope that is ok. One of the thing I fixed was that the word `section` was used in names, but no element of `section _` was constructed or involved. I also replaced `retract-of-map` with `retract-map` to not have to write `of` so often. Prepositions are not very common in our naming scheme, and I think our naming scheme is better when we use them very sparingly.