### PR TITLE
Fix Elisabeth's GitHub link

### DIFF
--- a/CONTRIBUTORS.toml
+++ b/CONTRIBUTORS.toml
@@ -36,7 +36,7 @@ displayName = "Elisabeth Stenholm"
 maintainer = true
 usernames = [ "Elisabeth Stenholm", "Elisabeth Bonnevier" ]
 homepage = "https://elisabeth.bonnevier.one"
-github = "elisabethbonnevier"
+github = "elisabethstenholm"
 bio = '''
 Elisabeth is a PhD student at the University of Bergen. Her research is on
 homotopy type theory.


### PR DESCRIPTION
This one slipped through #904; we're now getting a 404 when linking to Elisabeth's github profile.