### PR TITLE
Miscellaneous Agda configuration maintenance

### DIFF
--- a/src/elementary-number-theory/addition-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/addition-natural-numbers.lagda.md
@@ -32,8 +32,6 @@ add-ℕ : ℕ → ℕ → ℕ
 add-ℕ x 0 = x
 add-ℕ x (succ-ℕ y) = succ-ℕ (add-ℕ x y)
 
-{-# BUILTIN NATPLUS add-ℕ #-}
-
 infixl 35 _+ℕ_
 _+ℕ_ = add-ℕ
 

--- a/src/elementary-number-theory/addition-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/addition-natural-numbers.lagda.md
@@ -32,11 +32,13 @@ add-ℕ : ℕ → ℕ → ℕ
 add-ℕ x 0 = x
 add-ℕ x (succ-ℕ y) = succ-ℕ (add-ℕ x y)
 
-add-ℕ' : ℕ → ℕ → ℕ
-add-ℕ' m n = add-ℕ n m
+{-# BUILTIN NATPLUS add-ℕ #-}
 
 infixl 35 _+ℕ_
 _+ℕ_ = add-ℕ
+
+add-ℕ' : ℕ → ℕ → ℕ
+add-ℕ' m n = add-ℕ n m
 
 ap-add-ℕ :
   {m n m' n' : ℕ} → m ＝ m' → n ＝ n' → m +ℕ n ＝ m' +ℕ n'

--- a/src/elementary-number-theory/integers.lagda.md
+++ b/src/elementary-number-theory/integers.lagda.md
@@ -44,6 +44,8 @@ negative whole numbers.
 ```agda
 ℤ : UU lzero
 ℤ = ℕ + (unit + ℕ)
+
+{-# BUILTIN INTEGER ℤ #-}
 ```
 
 ### Inclusion of the negative integers

--- a/src/elementary-number-theory/multiplication-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/multiplication-natural-numbers.lagda.md
@@ -32,8 +32,6 @@ mul-ℕ : ℕ → ℕ → ℕ
 mul-ℕ 0 n = 0
 mul-ℕ (succ-ℕ m) n = (mul-ℕ m n) +ℕ n
 
-{-# BUILTIN NATTIMES mul-ℕ #-}
-
 infixl 40 _*ℕ_
 _*ℕ_ = mul-ℕ
 

--- a/src/elementary-number-theory/multiplication-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/multiplication-natural-numbers.lagda.md
@@ -32,6 +32,8 @@ mul-ℕ : ℕ → ℕ → ℕ
 mul-ℕ 0 n = 0
 mul-ℕ (succ-ℕ m) n = (mul-ℕ m n) +ℕ n
 
+{-# BUILTIN NATTIMES mul-ℕ #-}
+
 infixl 40 _*ℕ_
 _*ℕ_ = mul-ℕ
 

--- a/src/foundation-core/identity-types.lagda.md
+++ b/src/foundation-core/identity-types.lagda.md
@@ -59,7 +59,7 @@ module _
   where
 
   data Id (x : A) : A → UU l where
-    refl : Id x x
+    instance refl : Id x x
 
   infix 6 _＝_
   _＝_ : A → A → UU l

--- a/src/foundation/maybe.lagda.md
+++ b/src/foundation/maybe.lagda.md
@@ -42,6 +42,7 @@ Maybe X = X + unit
 data Maybe' {l} (X : UU l) : UU l where
   unit-Maybe' : X → Maybe' X
   exception-Maybe' : Maybe' X
+
 {-# BUILTIN MAYBE Maybe' #-}
 
 unit-Maybe : {l : Level} {X : UU l} → X → Maybe X

--- a/src/foundation/telescopes.lagda.md
+++ b/src/foundation/telescopes.lagda.md
@@ -90,11 +90,6 @@ only define instances for fixed length telescopes. We have defined instances of
 telescopes up to length 18, so although Agda cannot infer a telescope of a
 general length using this approach, it can infer them up to this given length.
 
-In the case of telescopes, this has the unfortunate disadvantage that we can
-only define instances for fixed length telescopes. We have defined instances of
-telescopes up to length 18, so although Agda cannot infer a telescope of a
-general length using this approach, it can infer them up to this given length.
-
 ```agda
 instance-telescope : {l : Level} {n : ℕ} → {{telescope l n}} → telescope l n
 instance-telescope {{x}} = x


### PR DESCRIPTION
### Summary
- ~Adds built-in binding to `add-ℕ` and `mul-ℕ`~ This leads to the library [not type-checking](https://github.com/UniMath/agda-unimath/actions/runs/6841375267/job/18601660143) for some reason.
- Adds built-in binding to `ℤ`
- Defines `refl` as an instance
- Removes a duplicate paragraph in `foundation.telescopes`