### PR TITLE
Functoriality of sequential colimits

### DIFF
--- a/src/foundation-core.lagda.md
+++ b/src/foundation-core.lagda.md
@@ -8,6 +8,7 @@ module foundation-core where
 open import foundation-core.1-types public
 open import foundation-core.cartesian-product-types public
 open import foundation-core.coherently-invertible-maps public
+open import foundation-core.commuting-prisms-of-maps public
 open import foundation-core.commuting-squares-of-maps public
 open import foundation-core.commuting-triangles-of-maps public
 open import foundation-core.constant-maps public

--- a/src/foundation-core/commuting-prisms-of-maps.lagda.md
+++ b/src/foundation-core/commuting-prisms-of-maps.lagda.md
@@ -7,12 +7,12 @@ module foundation-core.commuting-prisms-of-maps where
 <details><summary>Imports</summary>
 
 ```agda
+open import foundation.universe-levels
+
 open import foundation-core.commuting-squares-of-maps
 open import foundation-core.commuting-triangles-of-maps
 open import foundation-core.homotopies
 open import foundation-core.whiskering-homotopies
-
-open import foundation.universe-levels
 ```
 
 </details>

--- a/src/foundation-core/commuting-prisms-of-maps.lagda.md
+++ b/src/foundation-core/commuting-prisms-of-maps.lagda.md
@@ -1,0 +1,76 @@
+# Commuting prisms of maps
+
+```agda
+module foundation-core.commuting-prisms-of-maps where
+```
+
+```agda
+open import foundation-core.commuting-squares-of-maps
+open import foundation-core.commuting-triangles-of-maps
+open import foundation-core.homotopies
+open import foundation-core.whiskering-homotopies
+
+open import foundation.universe-levels
+```
+
+```agda
+module _
+  { l1 l2 l3 l4 l5 l6 : Level}
+  { A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4} {Y : UU l5} {Z : UU l6}
+  ( top : A → X) (left-front : A → C) (left-back : A → B)
+  ( right-front : X → Z) (right-back : X → Y)
+  ( back-bottom : B → Y) (left-bottom : B → C) (right-bottom : Y → Z)
+  ( front-bottom : C → Z)
+  ( back : coherence-square-maps top left-back right-back back-bottom)
+  ( left : coherence-triangle-maps' left-front left-bottom left-back)
+  ( right : coherence-triangle-maps' right-front right-bottom right-back)
+  ( front : coherence-square-maps top left-front right-front front-bottom)
+  ( bottom :
+    coherence-square-maps back-bottom left-bottom right-bottom front-bottom)
+  where
+
+  horizontal-coherence-prism-maps : UU (l1 ⊔ l6)
+  horizontal-coherence-prism-maps =
+    ( ( front-bottom ·l left) ∙h front) ~
+    ( ( pasting-vertical-coherence-square-maps
+        ( top)
+        ( left-back)
+        ( right-back)
+        ( back-bottom)
+        ( left-bottom)
+        ( right-bottom)
+        ( front-bottom)
+        ( back)
+        ( bottom)) ∙h
+      ( right ·r top))
+```
+
+```agda
+module _
+  { l1 l2 l3 l4 l5 l6 : Level}
+  { A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4} {Y : UU l5} {Z : UU l6}
+  ( top-left : A → B) (top-right : B → C) (top-front : A → C)
+  ( front-left : A → X) (back : B → Y) (front-right : C → Z)
+  ( bottom-left : X → Y) (bottom-right : Y → Z) (bottom-front : X → Z)
+  ( top : coherence-triangle-maps top-front top-right top-left)
+  ( left : coherence-square-maps top-left front-left back bottom-left)
+  ( right : coherence-square-maps top-right back front-right bottom-right)
+  ( front : coherence-square-maps top-front front-left front-right bottom-front)
+  ( bottom : coherence-triangle-maps bottom-front bottom-right bottom-left)
+  where
+
+  vertical-coherence-prism-maps : UU (l1 ⊔ l6)
+  vertical-coherence-prism-maps =
+    ( ( bottom ·r front-left) ∙h
+      ( pasting-horizontal-coherence-square-maps
+        ( top-left)
+        ( top-right)
+        ( front-left)
+        ( back)
+        ( front-right)
+        ( bottom-left)
+        ( bottom-right)
+        ( left)
+        ( right))) ~
+    ( front ∙h (front-right ·l top))
+```

--- a/src/foundation-core/commuting-prisms-of-maps.lagda.md
+++ b/src/foundation-core/commuting-prisms-of-maps.lagda.md
@@ -13,6 +13,10 @@ open import foundation-core.whiskering-homotopies
 open import foundation.universe-levels
 ```
 
+## Definitions
+
+### Horizontal commuting prisms of maps
+
 ```agda
 module _
   { l1 l2 l3 l4 l5 l6 : Level}
@@ -45,32 +49,28 @@ module _
       ( right ·r top))
 ```
 
+### Vertical commuting prisms of maps
+
 ```agda
 module _
-  { l1 l2 l3 l4 l5 l6 : Level}
-  { A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4} {Y : UU l5} {Z : UU l6}
-  ( top-left : A → B) (top-right : B → C) (top-front : A → C)
-  ( front-left : A → X) (back : B → Y) (front-right : C → Z)
-  ( bottom-left : X → Y) (bottom-right : Y → Z) (bottom-front : X → Z)
-  ( top : coherence-triangle-maps top-front top-right top-left)
-  ( left : coherence-square-maps top-left front-left back bottom-left)
-  ( right : coherence-square-maps top-right back front-right bottom-right)
-  ( front : coherence-square-maps top-front front-left front-right bottom-front)
-  ( bottom : coherence-triangle-maps bottom-front bottom-right bottom-left)
+  { l1 l2 l3 l1' l2' l3' : Level}
+  { A : UU l1} {B : UU l2} {C : UU l3}
+  ( f : A → C) (g : B → C) (h : A → B)
+  { A' : UU l1'} {B' : UU l2'} {C' : UU l3'}
+  ( f' : A' → C') (g' : B' → C') (h' : A' → B')
+  ( hA : A → A') (hB : B → B') (hC : C → C')
+  ( top : coherence-triangle-maps f g h)
+  ( front : coherence-square-maps f hA hC f')
+  ( right : coherence-square-maps g hB hC g')
+  ( left : coherence-square-maps h hA hB h')
+  ( bottom : coherence-triangle-maps f' g' h')
   where
 
-  vertical-coherence-prism-maps : UU (l1 ⊔ l6)
+  vertical-coherence-prism-maps : UU (l1 ⊔ l3')
   vertical-coherence-prism-maps =
-    ( ( bottom ·r front-left) ∙h
-      ( pasting-horizontal-coherence-square-maps
-        ( top-left)
-        ( top-right)
-        ( front-left)
-        ( back)
-        ( front-right)
-        ( bottom-left)
-        ( bottom-right)
+    ( ( bottom ·r hA) ∙h
+      ( pasting-horizontal-coherence-square-maps h g hA hB hC h' g'
         ( left)
         ( right))) ~
-    ( front ∙h (front-right ·l top))
+    ( front ∙h (hC ·l top))
 ```

--- a/src/foundation-core/commuting-prisms-of-maps.lagda.md
+++ b/src/foundation-core/commuting-prisms-of-maps.lagda.md
@@ -25,13 +25,13 @@ Consider an arrangment of maps composable into a diagram as follows:
          hA
    A ---------> A'
    |\           |\
-   | \ h   ⇗   | \ h'
+   | \ h   ⇗    | \ h'
    |  \      f' |  \
    |   V        |   V
  f | ⇐ B ------ | -> B'
    |   /   hB   | ⇐ /
    |  / g       |  / g'
-   | /     ⇗   | /
+   | /     ⇗    | /
    VV           VV
    C ---------> C' ,
          hC
@@ -58,13 +58,13 @@ We may also arrange the maps into a more vertical shape, like so:
      /  f | ⇑   V
     A ---------> C
     |     | hB   |
-    | ⇗  V   ⇗  |
+    | ⇗   V   ⇗  |
  hA |     B'     | hC
     | h' ^  \ g' |
     |  /  ⇑   \  |
-    |/          V|
+    V/          VV
     A' --------> C' .
-        f'
+          f'
 ```
 
 Then, given homotopies for the faces, we call a homotopy filling this shape a

--- a/src/foundation-core/commuting-prisms-of-maps.lagda.md
+++ b/src/foundation-core/commuting-prisms-of-maps.lagda.md
@@ -51,6 +51,11 @@ module _
 
 ### Vertical commuting prisms of maps
 
+Because triangular prisms are less symmetric than, say, cubes, we have more than
+one natural formulations for where to draw the "seems" for the filler. We
+present two choices, and show that they are equivalent in
+[`foundation.commuting-prisms-of-maps`](foundation.commuting-prisms-of-maps.md).
+
 ```agda
 module _
   { l1 l2 l3 l1' l2' l3' : Level}
@@ -59,18 +64,34 @@ module _
   { A' : UU l1'} {B' : UU l2'} {C' : UU l3'}
   ( f' : A' → C') (g' : B' → C') (h' : A' → B')
   ( hA : A → A') (hB : B → B') (hC : C → C')
-  ( top : coherence-triangle-maps f g h)
-  ( front : coherence-square-maps f hA hC f')
-  ( right : coherence-square-maps g hB hC g')
-  ( left : coherence-square-maps h hA hB h')
-  ( bottom : coherence-triangle-maps f' g' h')
   where
 
-  vertical-coherence-prism-maps : UU (l1 ⊔ l3')
-  vertical-coherence-prism-maps =
-    ( ( bottom ·r hA) ∙h
-      ( pasting-horizontal-coherence-square-maps h g hA hB hC h' g'
-        ( left)
-        ( right))) ~
-    ( front ∙h (hC ·l top))
+  module _
+    ( top : coherence-triangle-maps f g h)
+    ( front : coherence-square-maps f hA hC f')
+    ( right : coherence-square-maps g hB hC g')
+    ( left : coherence-square-maps h hA hB h')
+    ( bottom : coherence-triangle-maps f' g' h')
+    where
+
+    vertical-coherence-prism-maps : UU (l1 ⊔ l3')
+    vertical-coherence-prism-maps =
+      ( ( bottom ·r hA) ∙h
+        ( pasting-horizontal-coherence-square-maps h g hA hB hC h' g'
+          ( left)
+          ( right))) ~
+      ( front ∙h (hC ·l top))
+
+  module _
+    ( top : coherence-triangle-maps f g h)
+    ( inv-front : coherence-square-maps hA f f' hC)
+    ( inv-right : coherence-square-maps hB g g' hC)
+    ( left : coherence-square-maps h hA hB h')
+    ( bottom : coherence-triangle-maps f' g' h')
+    where
+
+    vertical-coherence-prism-maps' : UU (l1 ⊔ l3')
+    vertical-coherence-prism-maps' =
+      ( inv-front ∙h ((bottom ·r hA) ∙h (g' ·l left))) ~
+      ( (hC ·l top) ∙h (inv-right ·r h))
 ```

--- a/src/foundation-core/commuting-prisms-of-maps.lagda.md
+++ b/src/foundation-core/commuting-prisms-of-maps.lagda.md
@@ -45,7 +45,7 @@ from the composition `hC ∘ g ∘ h` to `f' ∘ hA`, namely 1) following the le
 [square](foundation-core.commuting-squares-of-maps.md), or 2) the two back
 squares and then the right triangle; the prism is then a homotopy between these
 two homotopies. In this way, a commuting prism may be viewed as a homotopy
-between a pasting of squares and their composite --- that is the motivation for
+between a pasting of squares and their composite — that is the motivation for
 having the triangles go the unconventional way, from the composition to the
 composite.
 

--- a/src/foundation-core/commuting-prisms-of-maps.lagda.md
+++ b/src/foundation-core/commuting-prisms-of-maps.lagda.md
@@ -19,34 +19,25 @@ open import foundation.universe-levels
 
 ```agda
 module _
-  { l1 l2 l3 l4 l5 l6 : Level}
-  { A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4} {Y : UU l5} {Z : UU l6}
-  ( top : A → X) (left-front : A → C) (left-back : A → B)
-  ( right-front : X → Z) (right-back : X → Y)
-  ( back-bottom : B → Y) (left-bottom : B → C) (right-bottom : Y → Z)
-  ( front-bottom : C → Z)
-  ( back : coherence-square-maps top left-back right-back back-bottom)
-  ( left : coherence-triangle-maps' left-front left-bottom left-back)
-  ( right : coherence-triangle-maps' right-front right-bottom right-back)
-  ( front : coherence-square-maps top left-front right-front front-bottom)
-  ( bottom :
-    coherence-square-maps back-bottom left-bottom right-bottom front-bottom)
+  { l1 l2 l3 l1' l2' l3' : Level}
+  { A : UU l1} {B : UU l2} {C : UU l3} {A' : UU l1'} {B' : UU l2'} {C' : UU l3'}
+  ( hA : A → A') (h : A → B) (h' : A' → B')
+  ( hB : B → B') (g : B → C) (g' : B' → C')
+  ( hC : C → C') (f : A → C) (f' : A' → C')
+  ( left : coherence-triangle-maps' f g h)
+  ( sq-top : coherence-square-maps hA h h' hB)
+  ( sq-bottom : coherence-square-maps hB g g' hC)
+  ( sq-front : coherence-square-maps hA f f' hC)
+  ( right : coherence-triangle-maps' f' g' h')
   where
 
-  horizontal-coherence-prism-maps : UU (l1 ⊔ l6)
+  horizontal-coherence-prism-maps : UU (l1 ⊔ l3')
   horizontal-coherence-prism-maps =
-    ( ( front-bottom ·l left) ∙h front) ~
-    ( ( pasting-vertical-coherence-square-maps
-        ( top)
-        ( left-back)
-        ( right-back)
-        ( back-bottom)
-        ( left-bottom)
-        ( right-bottom)
-        ( front-bottom)
-        ( back)
-        ( bottom)) ∙h
-      ( right ·r top))
+    ( ( hC ·l left) ∙h sq-front) ~
+    ( ( pasting-vertical-coherence-square-maps hA h h' hB g g' hC
+        ( sq-top)
+        ( sq-bottom)) ∙h
+      ( right ·r hA))
 ```
 
 ### Vertical commuting prisms of maps

--- a/src/foundation-core/commuting-prisms-of-maps.lagda.md
+++ b/src/foundation-core/commuting-prisms-of-maps.lagda.md
@@ -40,7 +40,7 @@ Consider an arrangment of maps composable into a diagram as follows:
 and [homotopies](foundation-core.homotopies.md) filling its faces. Then a
 {{#concept "horizontal commuting prism of maps" Agda=horizontal-coherence-prism-maps}}
 is a homotopy filling the shape. In other words, we may choose two homotopies
-from the composition `hC ∘ g ∘ h` to `f' ∘ hA`, namely 1) following the left
+from the composition `hC ∘ g ∘ h` to `f' ∘ hA`, namely following 1) the left
 [triangle](foundation-core.commuting-triangles-of-maps.md) and then the front
 [square](foundation-core.commuting-squares-of-maps.md), or 2) the two back
 squares and then the right triangle; the prism is then a homotopy between these
@@ -72,8 +72,8 @@ Then, given homotopies for the faces, we call a homotopy filling this shape a
 This rotation of a prism may be viewed as a homotopy between two triangles with
 different but related sides.
 
-It remains to be formalized that the type of vertical prisms is equivalent to
-the type of horizontal prisms.
+It remains to be formalized that the type of vertical prisms is
+[equivalent](foundation-core.equivalences.md) to the type of horizontal prisms.
 
 ## Definitions
 
@@ -105,7 +105,7 @@ module _
 ### Vertical commuting prisms of maps
 
 Because triangular prisms are less symmetric than, say, cubes, we have more than
-one natural formulations for where to draw the "seems" for the filler. Here, we
+one natural formulation for where to draw the "seams" for the filler. Here, we
 present two choices, and show that they are equivalent in
 [`foundation.commuting-prisms-of-maps`](foundation.commuting-prisms-of-maps.md).
 

--- a/src/foundation-core/commuting-prisms-of-maps.lagda.md
+++ b/src/foundation-core/commuting-prisms-of-maps.lagda.md
@@ -4,6 +4,8 @@
 module foundation-core.commuting-prisms-of-maps where
 ```
 
+<details><summary>Imports</summary>
+
 ```agda
 open import foundation-core.commuting-squares-of-maps
 open import foundation-core.commuting-triangles-of-maps
@@ -12,6 +14,66 @@ open import foundation-core.whiskering-homotopies
 
 open import foundation.universe-levels
 ```
+
+</details>
+
+## Idea
+
+Consider an arrangment of maps composable into a diagram as follows:
+
+```text
+         hA
+   A ---------> A'
+   |\           |\
+   | \ h   ⇗   | \ h'
+   |  \      f' |  \
+   |   V        |   V
+ f | ⇐ B ------ | -> B'
+   |   /   hB   | ⇐ /
+   |  / g       |  / g'
+   | /     ⇗   | /
+   VV           VV
+   C ---------> C' ,
+         hC
+```
+
+and [homotopies](foundation-core.homotopies.md) filling its faces. Then a
+{{#concept "horizontal commuting prism of maps" Agda=horizontal-coherence-prism-maps}}
+is a homotopy filling the shape. In other words, we may choose two homotopies
+from the composition `hC ∘ g ∘ h` to `f' ∘ hA`, namely 1) following the left
+[triangle](foundation-core.commuting-triangles-of-maps.md) and then the front
+[square](foundation-core.commuting-squares-of-maps.md), or 2) the two back
+squares and then the right triangle; the prism is then a homotopy between these
+two homotopies. In this way, a commuting prism may be viewed as a homotopy
+between a pasting of squares and their composite --- that is the motivation for
+having the triangles go the unconventional way, from the composition to the
+composite.
+
+We may also arrange the maps into a more vertical shape, like so:
+
+```text
+          B
+      h  ^| \  g
+       /  |   \
+     /  f | ⇑   V
+    A ---------> C
+    |     | hB   |
+    | ⇗  V   ⇗  |
+ hA |     B'     | hC
+    | h' ^  \ g' |
+    |  /  ⇑   \  |
+    |/          V|
+    A' --------> C' .
+        f'
+```
+
+Then, given homotopies for the faces, we call a homotopy filling this shape a
+{{#concept "vertical commuting prism of maps" Agda=vertical-coherence-prism-maps Agda=vertical-coherence-prism-maps'}}.
+This rotation of a prism may be viewed as a homotopy between two triangles with
+different but related sides.
+
+It remains to be formalized that the type of vertical prisms is equivalent to
+the type of horizontal prisms.
 
 ## Definitions
 
@@ -43,7 +105,7 @@ module _
 ### Vertical commuting prisms of maps
 
 Because triangular prisms are less symmetric than, say, cubes, we have more than
-one natural formulations for where to draw the "seems" for the filler. We
+one natural formulations for where to draw the "seems" for the filler. Here, we
 present two choices, and show that they are equivalent in
 [`foundation.commuting-prisms-of-maps`](foundation.commuting-prisms-of-maps.md).
 

--- a/src/foundation-core/commuting-squares-of-maps.lagda.md
+++ b/src/foundation-core/commuting-squares-of-maps.lagda.md
@@ -8,11 +8,11 @@ module foundation-core.commuting-squares-of-maps where
 
 ```agda
 open import foundation.action-on-identifications-functions
+open import foundation.homotopies
 open import foundation.universe-levels
 
 open import foundation-core.commuting-triangles-of-maps
 open import foundation-core.function-types
-open import foundation-core.homotopies
 open import foundation-core.identity-types
 open import foundation-core.whiskering-homotopies
 ```
@@ -213,6 +213,155 @@ module _
     pasting-horizontal-coherence-square-maps i id f g g j id α refl-htpy ~ α
   right-unit-law-pasting-horizontal-coherence-square-maps a =
     right-unit ∙ ap-id (α a)
+```
+
+### Commutativity of horizontal and vertical pasting
+
+```agda
+[i] :
+  { l1 l2 : Level} {A : UU l1} {B : UU l2} {f g h k l : A → B} →
+  ( H : f ~ g) (K : g ~ h) (L : h ~ k) (M : k ~ l) →
+  ( H ∙h K) ∙h (L ∙h M) ~ H ∙h (K ∙h L) ∙h M
+[i] H K L M =
+  ( inv-htpy-assoc-htpy (H ∙h K) L M) ∙h
+  ( ap-concat-htpy' _ _ M (assoc-htpy H K L))
+
+[ii] :
+  { l1 l2 : Level} {A : UU l1} {B : UU l2} {f g h h' k l : A → B} →
+  ( H : f ~ g) (K : g ~ h) (K' : g ~ h') (L : h ~ k) (L' : h' ~ k) (M : k ~ l) →
+  ( α : K ∙h L ~ K' ∙h L') →
+  (H ∙h K) ∙h (L ∙h M) ~ (H ∙h K') ∙h (L' ∙h M)
+[ii] H K K' L L' M α =
+  ( [i] H K L M) ∙h
+  ( ap-concat-htpy' _ _ M (ap-concat-htpy H _ _ α)) ∙h
+  ( inv-htpy ([i] H K' L' M))
+
+[iii] :
+  { l1 l2 l3 l4 l5 l6 l7 : Level} →
+  { A : UU l1} {B : UU l2} {C : UU l3} {D : UU l4}
+  { X : UU l5} {Y : UU l6} {Z : UU l7} →
+  ( top : A → B) (left : A → C) (mid-top : B → D) (mid-left : C → D)
+  ( mid-right : D → X) (mid-bottom : D → Y) (right : X → Z) (bottom : Y → Z)
+  ( H : coherence-square-maps top left mid-top mid-left)
+  ( K : coherence-square-maps mid-right mid-bottom right bottom) →
+  ( ( K ·r mid-left ·r left) ∙h (right ·l mid-right ·l H)) ~
+  ( bottom ·l mid-bottom ·l H) ∙h (K ·r mid-top ·r top)
+[iii] top left mid-top mid-left mid-right mid-bottom right bottom H K =
+  ( ap-concat-htpy
+    ( K ·r mid-left ·r left)
+    ( _)
+    ( _)
+    ( associative-left-whisk-comp right mid-right H)) ∙h
+  ( htpy-swap-nat-right-htpy K H) ∙h
+  ( ap-concat-htpy' _ _
+    ( K ·r mid-top ·r top)
+    ( inv-htpy (associative-left-whisk-comp  bottom mid-bottom H)))
+
+module _
+  { l1 l2 l3 l4 l5 l6 l7 l8 l9 : Level}
+  { A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4} {Y : UU l5} {Z : UU l6}
+  { M : UU l7} {N : UU l8} {O : UU l9}
+  ( top-left : A → B) (top-right : B → C)
+  ( left-top : A → X) (mid-top : B → Y) (right-top : C → Z)
+  ( mid-left : X → Y) (mid-right : Y → Z)
+  ( left-bottom : X → M) (mid-bottom : Y → N) (right-bottom : Z → O)
+  ( bottom-left : M → N) (bottom-right : N → O)
+  ( sq-left-top : coherence-square-maps top-left left-top mid-top mid-left)
+  ( sq-right-top : coherence-square-maps top-right mid-top right-top mid-right)
+  ( sq-left-bottom :
+      coherence-square-maps mid-left left-bottom mid-bottom bottom-left)
+  ( sq-right-bottom :
+      coherence-square-maps mid-right mid-bottom right-bottom bottom-right)
+  where
+
+  commutative-pasting-vertical-pasting-horizontal-coherence-square-maps :
+    ( pasting-horizontal-coherence-square-maps
+      ( top-left)
+      ( top-right)
+      ( left-bottom ∘ left-top)
+      ( mid-bottom ∘ mid-top)
+      ( right-bottom ∘ right-top)
+      ( bottom-left)
+      ( bottom-right)
+      ( pasting-vertical-coherence-square-maps
+        ( top-left)
+        ( left-top)
+        ( mid-top)
+        ( mid-left)
+        ( left-bottom)
+        ( mid-bottom)
+        ( bottom-left)
+        ( sq-left-top)
+        ( sq-left-bottom))
+      ( pasting-vertical-coherence-square-maps
+        ( top-right)
+        ( mid-top)
+        ( right-top)
+        ( mid-right)
+        ( mid-bottom)
+        ( right-bottom)
+        ( bottom-right)
+        ( sq-right-top)
+        ( sq-right-bottom))) ~
+    ( pasting-vertical-coherence-square-maps
+      ( top-right ∘ top-left)
+      ( left-top)
+      ( right-top)
+      ( mid-right ∘ mid-left)
+      ( left-bottom)
+      ( right-bottom)
+      ( bottom-right ∘ bottom-left)
+      ( pasting-horizontal-coherence-square-maps
+        ( top-left)
+        ( top-right)
+        ( left-top)
+        ( mid-top)
+        ( right-top)
+        ( mid-left)
+        ( mid-right)
+        ( sq-left-top)
+        ( sq-right-top))
+      ( pasting-horizontal-coherence-square-maps
+        ( mid-left)
+        ( mid-right)
+        ( left-bottom)
+        ( mid-bottom)
+        ( right-bottom)
+        ( bottom-left)
+        ( bottom-right)
+        ( sq-left-bottom)
+        ( sq-right-bottom)))
+  commutative-pasting-vertical-pasting-horizontal-coherence-square-maps =
+    ( ap-concat-htpy' _ _ _
+      ( distributive-left-whisk-concat-htpy
+        ( bottom-right)
+        ( sq-left-bottom ·r left-top)
+        ( mid-bottom ·l sq-left-top)) ∙h
+      ( [ii]
+        ( bottom-right ·l (sq-left-bottom ·r left-top))
+        ( bottom-right ·l mid-bottom ·l sq-left-top)
+        ( sq-right-bottom ·r mid-left ·r left-top)
+        ( sq-right-bottom ·r mid-top ·r top-left)
+        ( right-bottom ·l mid-right ·l sq-left-top)
+        ( right-bottom ·l (sq-right-top ·r top-left))
+        ( inv-htpy
+          ( [iii]
+            ( top-left)
+            ( left-top)
+            ( mid-top)
+            ( mid-left)
+            ( mid-right)
+            ( mid-bottom)
+            ( right-bottom)
+            ( bottom-right)
+            ( sq-left-top)
+            ( sq-right-bottom))))) ∙h
+      ( ap-concat-htpy _ _ _
+        ( inv-htpy
+          ( distributive-left-whisk-concat-htpy
+            ( right-bottom)
+            ( mid-right ·l sq-left-top)
+            ( sq-right-top ·r top-left))))
 ```
 
 ## See also

--- a/src/foundation-core/commuting-squares-of-maps.lagda.md
+++ b/src/foundation-core/commuting-squares-of-maps.lagda.md
@@ -8,6 +8,8 @@ module foundation-core.commuting-squares-of-maps where
 
 ```agda
 open import foundation.action-on-identifications-functions
+open import foundation.commuting-squares-of-homotopies
+open import foundation.commuting-squares-of-identifications
 open import foundation.homotopies
 open import foundation.universe-levels
 open import foundation.whiskering-homotopies
@@ -215,28 +217,47 @@ module _
     right-unit ∙ ap-id (α a)
 ```
 
-### Commutativity of horizontal and vertical pasting
+### Naturality of commuting squares of maps with respect to identifications
 
 ```agda
-[iii] :
-  { l1 l2 l3 l4 l5 l6 l7 : Level} →
+module _
+  { l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {C : UU l3} {D : UU l4}
+  ( top : A → B) (left : A → C) (right : B → D) (bottom : C → D)
+  ( H : coherence-square-maps top left right bottom)
+  where
+
+  nat-coherence-square-maps :
+    { x y : A} (p : x ＝ y) →
+    coherence-square-identifications
+      ( ap bottom (ap left p))
+      ( H x)
+      ( H y)
+      ( ap right (ap top p))
+  nat-coherence-square-maps refl = right-unit
+
+module _
+  { l1 l2 l3 l4 l5 l6 l7 : Level}
   { A : UU l1} {B : UU l2} {C : UU l3} {D : UU l4}
-  { X : UU l5} {Y : UU l6} {Z : UU l7} →
+  { X : UU l5} {Y : UU l6} {Z : UU l7}
   ( top : A → B) (left : A → C) (mid-top : B → D) (mid-left : C → D)
   ( mid-right : D → X) (mid-bottom : D → Y) (right : X → Z) (bottom : Y → Z)
   ( H : coherence-square-maps top left mid-top mid-left)
-  ( K : coherence-square-maps mid-right mid-bottom right bottom) →
-  ( ( K ·r mid-left ·r left) ∙h (right ·l mid-right ·l H)) ~
-  ( bottom ·l mid-bottom ·l H) ∙h (K ·r mid-top ·r top)
-[iii] top left mid-top mid-left mid-right mid-bottom right bottom H K =
-  ( ap-concat-htpy
-    ( K ·r mid-left ·r left)
-    ( associative-left-whisk-comp right mid-right H)) ∙h
-  ( htpy-swap-nat-right-htpy K H) ∙h
-  ( ap-concat-htpy'
-    ( K ·r mid-top ·r top)
-    ( inv-htpy (associative-left-whisk-comp bottom mid-bottom H)))
+  ( K : coherence-square-maps mid-right mid-bottom right bottom)
+  where
 
+  swap-nat-coherence-square-maps :
+    coherence-square-homotopies
+      ( bottom ·l mid-bottom ·l H)
+      ( K ·r mid-left ·r left)
+      ( K ·r mid-top ·r top)
+      ( right ·l mid-right ·l H)
+  swap-nat-coherence-square-maps x =
+    nat-coherence-square-maps mid-right mid-bottom right bottom K (H x)
+```
+
+### Commutativity of horizontal and vertical pasting
+
+```agda
 module _
   { l1 l2 l3 l4 l5 l6 l7 l8 l9 : Level}
   { A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4} {Y : UU l5} {Z : UU l6}
@@ -321,7 +342,7 @@ module _
         ( bottom-right ·l (sq-left-bottom ·r left-top))
         ( right-bottom ·l (sq-right-top ·r top-left))
         ( inv-htpy
-          ( [iii]
+          ( swap-nat-coherence-square-maps
             ( top-left)
             ( left-top)
             ( mid-top)

--- a/src/foundation-core/commuting-squares-of-maps.lagda.md
+++ b/src/foundation-core/commuting-squares-of-maps.lagda.md
@@ -10,11 +10,11 @@ module foundation-core.commuting-squares-of-maps where
 open import foundation.action-on-identifications-functions
 open import foundation.homotopies
 open import foundation.universe-levels
+open import foundation.whiskering-homotopies
 
 open import foundation-core.commuting-triangles-of-maps
 open import foundation-core.function-types
 open import foundation-core.identity-types
-open import foundation-core.whiskering-homotopies
 ```
 
 </details>
@@ -218,24 +218,6 @@ module _
 ### Commutativity of horizontal and vertical pasting
 
 ```agda
-[i] :
-  { l1 l2 : Level} {A : UU l1} {B : UU l2} {f g h k l : A → B} →
-  ( H : f ~ g) (K : g ~ h) (L : h ~ k) (M : k ~ l) →
-  ( H ∙h K) ∙h (L ∙h M) ~ H ∙h (K ∙h L) ∙h M
-[i] H K L M =
-  ( inv-htpy-assoc-htpy (H ∙h K) L M) ∙h
-  ( ap-concat-htpy' M (assoc-htpy H K L))
-
-[ii] :
-  { l1 l2 : Level} {A : UU l1} {B : UU l2} {f g h h' k l : A → B} →
-  ( H : f ~ g) (K : g ~ h) (K' : g ~ h') (L : h ~ k) (L' : h' ~ k) (M : k ~ l) →
-  ( α : K ∙h L ~ K' ∙h L') →
-  (H ∙h K) ∙h (L ∙h M) ~ (H ∙h K') ∙h (L' ∙h M)
-[ii] H K K' L L' M α =
-  ( [i] H K L M) ∙h
-  ( ap-concat-htpy' M (ap-concat-htpy H α)) ∙h
-  ( inv-htpy ([i] H K' L' M))
-
 [iii] :
   { l1 l2 l3 l4 l5 l6 l7 : Level} →
   { A : UU l1} {B : UU l2} {C : UU l3} {D : UU l4}
@@ -335,12 +317,8 @@ module _
         ( bottom-right)
         ( sq-left-bottom ·r left-top)
         ( mid-bottom ·l sq-left-top)) ∙h
-      ( [ii]
+      ( both-whisk-square-htpy
         ( bottom-right ·l (sq-left-bottom ·r left-top))
-        ( bottom-right ·l mid-bottom ·l sq-left-top)
-        ( sq-right-bottom ·r mid-left ·r left-top)
-        ( sq-right-bottom ·r mid-top ·r top-left)
-        ( right-bottom ·l mid-right ·l sq-left-top)
         ( right-bottom ·l (sq-right-top ·r top-left))
         ( inv-htpy
           ( [iii]

--- a/src/foundation-core/commuting-squares-of-maps.lagda.md
+++ b/src/foundation-core/commuting-squares-of-maps.lagda.md
@@ -8,15 +8,13 @@ module foundation-core.commuting-squares-of-maps where
 
 ```agda
 open import foundation.action-on-identifications-functions
-open import foundation.commuting-squares-of-homotopies
-open import foundation.commuting-squares-of-identifications
-open import foundation.homotopies
 open import foundation.universe-levels
-open import foundation.whiskering-homotopies
 
 open import foundation-core.commuting-triangles-of-maps
 open import foundation-core.function-types
+open import foundation-core.homotopies
 open import foundation-core.identity-types
+open import foundation-core.whiskering-homotopies
 ```
 
 </details>
@@ -215,150 +213,6 @@ module _
     pasting-horizontal-coherence-square-maps i id f g g j id α refl-htpy ~ α
   right-unit-law-pasting-horizontal-coherence-square-maps a =
     right-unit ∙ ap-id (α a)
-```
-
-### Naturality of commuting squares of maps with respect to identifications
-
-```agda
-module _
-  { l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {C : UU l3} {D : UU l4}
-  ( top : A → B) (left : A → C) (right : B → D) (bottom : C → D)
-  ( H : coherence-square-maps top left right bottom)
-  where
-
-  nat-coherence-square-maps :
-    { x y : A} (p : x ＝ y) →
-    coherence-square-identifications
-      ( ap bottom (ap left p))
-      ( H x)
-      ( H y)
-      ( ap right (ap top p))
-  nat-coherence-square-maps refl = right-unit
-
-module _
-  { l1 l2 l3 l4 l5 l6 l7 : Level}
-  { A : UU l1} {B : UU l2} {C : UU l3} {D : UU l4}
-  { X : UU l5} {Y : UU l6} {Z : UU l7}
-  ( top : A → B) (left : A → C) (mid-top : B → D) (mid-left : C → D)
-  ( mid-right : D → X) (mid-bottom : D → Y) (right : X → Z) (bottom : Y → Z)
-  ( H : coherence-square-maps top left mid-top mid-left)
-  ( K : coherence-square-maps mid-right mid-bottom right bottom)
-  where
-
-  swap-nat-coherence-square-maps :
-    coherence-square-homotopies
-      ( bottom ·l mid-bottom ·l H)
-      ( K ·r mid-left ·r left)
-      ( K ·r mid-top ·r top)
-      ( right ·l mid-right ·l H)
-  swap-nat-coherence-square-maps x =
-    nat-coherence-square-maps mid-right mid-bottom right bottom K (H x)
-```
-
-### Commutativity of horizontal and vertical pasting
-
-```agda
-module _
-  { l1 l2 l3 l4 l5 l6 l7 l8 l9 : Level}
-  { A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4} {Y : UU l5} {Z : UU l6}
-  { M : UU l7} {N : UU l8} {O : UU l9}
-  ( top-left : A → B) (top-right : B → C)
-  ( left-top : A → X) (mid-top : B → Y) (right-top : C → Z)
-  ( mid-left : X → Y) (mid-right : Y → Z)
-  ( left-bottom : X → M) (mid-bottom : Y → N) (right-bottom : Z → O)
-  ( bottom-left : M → N) (bottom-right : N → O)
-  ( sq-left-top : coherence-square-maps top-left left-top mid-top mid-left)
-  ( sq-right-top : coherence-square-maps top-right mid-top right-top mid-right)
-  ( sq-left-bottom :
-      coherence-square-maps mid-left left-bottom mid-bottom bottom-left)
-  ( sq-right-bottom :
-      coherence-square-maps mid-right mid-bottom right-bottom bottom-right)
-  where
-
-  commutative-pasting-vertical-pasting-horizontal-coherence-square-maps :
-    ( pasting-horizontal-coherence-square-maps
-      ( top-left)
-      ( top-right)
-      ( left-bottom ∘ left-top)
-      ( mid-bottom ∘ mid-top)
-      ( right-bottom ∘ right-top)
-      ( bottom-left)
-      ( bottom-right)
-      ( pasting-vertical-coherence-square-maps
-        ( top-left)
-        ( left-top)
-        ( mid-top)
-        ( mid-left)
-        ( left-bottom)
-        ( mid-bottom)
-        ( bottom-left)
-        ( sq-left-top)
-        ( sq-left-bottom))
-      ( pasting-vertical-coherence-square-maps
-        ( top-right)
-        ( mid-top)
-        ( right-top)
-        ( mid-right)
-        ( mid-bottom)
-        ( right-bottom)
-        ( bottom-right)
-        ( sq-right-top)
-        ( sq-right-bottom))) ~
-    ( pasting-vertical-coherence-square-maps
-      ( top-right ∘ top-left)
-      ( left-top)
-      ( right-top)
-      ( mid-right ∘ mid-left)
-      ( left-bottom)
-      ( right-bottom)
-      ( bottom-right ∘ bottom-left)
-      ( pasting-horizontal-coherence-square-maps
-        ( top-left)
-        ( top-right)
-        ( left-top)
-        ( mid-top)
-        ( right-top)
-        ( mid-left)
-        ( mid-right)
-        ( sq-left-top)
-        ( sq-right-top))
-      ( pasting-horizontal-coherence-square-maps
-        ( mid-left)
-        ( mid-right)
-        ( left-bottom)
-        ( mid-bottom)
-        ( right-bottom)
-        ( bottom-left)
-        ( bottom-right)
-        ( sq-left-bottom)
-        ( sq-right-bottom)))
-  commutative-pasting-vertical-pasting-horizontal-coherence-square-maps =
-    ( ap-concat-htpy' _
-      ( distributive-left-whisk-concat-htpy
-        ( bottom-right)
-        ( sq-left-bottom ·r left-top)
-        ( mid-bottom ·l sq-left-top)) ∙h
-      ( both-whisk-square-htpy
-        ( bottom-right ·l (sq-left-bottom ·r left-top))
-        ( right-bottom ·l (sq-right-top ·r top-left))
-        ( inv-htpy
-          ( swap-nat-coherence-square-maps
-            ( top-left)
-            ( left-top)
-            ( mid-top)
-            ( mid-left)
-            ( mid-right)
-            ( mid-bottom)
-            ( right-bottom)
-            ( bottom-right)
-            ( sq-left-top)
-            ( sq-right-bottom))))) ∙h
-      ( ap-concat-htpy _
-        ( inv-htpy
-          ( distributive-left-whisk-concat-htpy
-            ( right-bottom)
-            ( mid-right ·l sq-left-top)
-            ( sq-right-top ·r top-left))))
 ```
 
 ## See also

--- a/src/foundation-core/commuting-squares-of-maps.lagda.md
+++ b/src/foundation-core/commuting-squares-of-maps.lagda.md
@@ -224,7 +224,7 @@ module _
   ( H ∙h K) ∙h (L ∙h M) ~ H ∙h (K ∙h L) ∙h M
 [i] H K L M =
   ( inv-htpy-assoc-htpy (H ∙h K) L M) ∙h
-  ( ap-concat-htpy' _ _ M (assoc-htpy H K L))
+  ( ap-concat-htpy' M (assoc-htpy H K L))
 
 [ii] :
   { l1 l2 : Level} {A : UU l1} {B : UU l2} {f g h h' k l : A → B} →
@@ -233,7 +233,7 @@ module _
   (H ∙h K) ∙h (L ∙h M) ~ (H ∙h K') ∙h (L' ∙h M)
 [ii] H K K' L L' M α =
   ( [i] H K L M) ∙h
-  ( ap-concat-htpy' _ _ M (ap-concat-htpy H _ _ α)) ∙h
+  ( ap-concat-htpy' M (ap-concat-htpy H α)) ∙h
   ( inv-htpy ([i] H K' L' M))
 
 [iii] :
@@ -249,13 +249,11 @@ module _
 [iii] top left mid-top mid-left mid-right mid-bottom right bottom H K =
   ( ap-concat-htpy
     ( K ·r mid-left ·r left)
-    ( _)
-    ( _)
     ( associative-left-whisk-comp right mid-right H)) ∙h
   ( htpy-swap-nat-right-htpy K H) ∙h
-  ( ap-concat-htpy' _ _
+  ( ap-concat-htpy'
     ( K ·r mid-top ·r top)
-    ( inv-htpy (associative-left-whisk-comp  bottom mid-bottom H)))
+    ( inv-htpy (associative-left-whisk-comp bottom mid-bottom H)))
 
 module _
   { l1 l2 l3 l4 l5 l6 l7 l8 l9 : Level}
@@ -332,7 +330,7 @@ module _
         ( sq-left-bottom)
         ( sq-right-bottom)))
   commutative-pasting-vertical-pasting-horizontal-coherence-square-maps =
-    ( ap-concat-htpy' _ _ _
+    ( ap-concat-htpy' _
       ( distributive-left-whisk-concat-htpy
         ( bottom-right)
         ( sq-left-bottom ·r left-top)
@@ -356,7 +354,7 @@ module _
             ( bottom-right)
             ( sq-left-top)
             ( sq-right-bottom))))) ∙h
-      ( ap-concat-htpy _ _ _
+      ( ap-concat-htpy _
         ( inv-htpy
           ( distributive-left-whisk-concat-htpy
             ( right-bottom)

--- a/src/foundation-core/homotopies.lagda.md
+++ b/src/foundation-core/homotopies.lagda.md
@@ -281,13 +281,13 @@ module _
   where
 
   ap-concat-htpy :
-    (H : f ~ g) (K K' : g ~ h) → K ~ K' → (H ∙h K) ~ (H ∙h K')
-  ap-concat-htpy H K K' L x = ap (concat (H x) (h x)) (L x)
+    (H : f ~ g) {K K' : g ~ h} → K ~ K' → (H ∙h K) ~ (H ∙h K')
+  ap-concat-htpy H L x = ap (concat (H x) (h x)) (L x)
 
   ap-concat-htpy' :
-    (H H' : f ~ g) (K : g ~ h) → H ~ H' → (H ∙h K) ~ (H' ∙h K)
-  ap-concat-htpy' H H' K L x =
-    ap (concat' _ (K x)) (L x)
+    {H H' : f ~ g} (K : g ~ h) → H ~ H' → (H ∙h K) ~ (H' ∙h K)
+  ap-concat-htpy' K L x =
+    ap (concat' (f x) (K x)) (L x)
 
 module _
   {l1 l2 : Level} {A : UU l1} {B : A → UU l2} {f g : (x : A) → B x}

--- a/src/foundation-core/whiskering-homotopies.lagda.md
+++ b/src/foundation-core/whiskering-homotopies.lagda.md
@@ -90,6 +90,10 @@ module _
 
 ### Unit laws for whiskering homotopies
 
+The identity map is the identity element for whiskerings from the function side,
+and the reflexivity homotopy is the identity element for whiskerings from the
+homotopy side.
+
 ```agda
 module _
   { l1 l2 : Level} {A : UU l1} {B : UU l2}

--- a/src/foundation-core/whiskering-homotopies.lagda.md
+++ b/src/foundation-core/whiskering-homotopies.lagda.md
@@ -88,6 +88,30 @@ module _
 
 ## Properties
 
+### Unit laws for whiskering homotopies
+
+```agda
+module _
+  { l1 l2 : Level} {A : UU l1} {B : UU l2}
+  where
+
+  left-unit-law-left-whisk-htpy : {f f' : A → B} → (H : f ~ f') → id ·l H ~ H
+  left-unit-law-left-whisk-htpy H x = ap-id (H x)
+
+  right-unit-law-left-whisk-htpy :
+    { l3 : Level} {C : UU l3} {f : A → B} (g : B → C) →
+    g ·l refl-htpy {f = f} ~ refl-htpy
+  right-unit-law-left-whisk-htpy g = refl-htpy
+
+  left-unit-law-right-whisk-htpy :
+    {l3 : Level} {C : UU l3} {g : B → C} (f : A → B) →
+    refl-htpy {f = g} ·r f ~ refl-htpy
+  left-unit-law-right-whisk-htpy f = refl-htpy
+
+  right-unit-law-right-whisk-htpy : {f f' : A → B} → (H : f ~ f') → H ·r id ~ H
+  right-unit-law-right-whisk-htpy H = refl-htpy
+```
+
 ### Laws for whiskering an inverted homotopy
 
 ```agda
@@ -171,4 +195,21 @@ module _
 
   inv-htpy-coh-htpy-id : (f ·l H) ~ (H ·r f)
   inv-htpy-coh-htpy-id = inv-htpy coh-htpy-id
+```
+
+### Whiskering whiskerings
+
+```agda
+module _
+  { l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
+  { f g : A → B}
+  where
+
+  ap-left-whisk-htpy :
+    ( h : B → C) {H H' : f ~ g} (α : H ~ H') → h ·l H ~ h ·l H'
+  ap-left-whisk-htpy h α x = ap (ap h) (α x)
+
+  ap-right-whisk-htpy :
+    { H H' : f ~ g} (α : H ~ H') (h : C → A) → H ·r h ~ H' ·r h
+  ap-right-whisk-htpy α h = α ·r h
 ```

--- a/src/foundation.lagda.md
+++ b/src/foundation.lagda.md
@@ -47,6 +47,7 @@ open import foundation.commuting-3-simplices-of-maps public
 open import foundation.commuting-cubes-of-maps public
 open import foundation.commuting-hexagons-of-identifications public
 open import foundation.commuting-pentagons-of-identifications public
+open import foundation.commuting-prisms-of-maps public
 open import foundation.commuting-squares-of-homotopies public
 open import foundation.commuting-squares-of-identifications public
 open import foundation.commuting-squares-of-maps public

--- a/src/foundation/action-on-identifications-functions.lagda.md
+++ b/src/foundation/action-on-identifications-functions.lagda.md
@@ -52,6 +52,12 @@ ap-comp :
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3} (g : B → C)
   (f : A → B) {x y : A} (p : x ＝ y) → (ap (g ∘ f) p) ＝ ((ap g ∘ ap f) p)
 ap-comp g f refl = refl
+
+ap-comp-assoc :
+  {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {C : UU l3} {D : UU l4}
+  (h : C → D) (g : B → C) (f : A → B) {x y : A} (p : x ＝ y) →
+  ap (h ∘ g) (ap f p) ＝ ap h (ap (g ∘ f) p)
+ap-comp-assoc h g f refl = refl
 ```
 
 ### The action on identifications of any map preserves `refl`

--- a/src/foundation/commuting-cubes-of-maps.lagda.md
+++ b/src/foundation/commuting-cubes-of-maps.lagda.md
@@ -360,8 +360,6 @@ module _
       ( bottom ·r hA)
       ( (k ·l back-right) ∙h (refl-htpy' (k ∘ (hC ∘ g'))))) ∙h
     ( ( ap-concat-htpy'
-        ( h ·l (inv-htpy back-left))
-        ( inv-htpy (h ·l back-left))
         ( _)
         ( left-whisk-inv-htpy h back-left)) ∙h
       ( inv-htpy-left-transpose-htpy-concat (h ·l back-left) _ _
@@ -372,7 +370,7 @@ module _
                 ( (inv-htpy front-right) ·r g')) ∙h
               ( inv-htpy-right-transpose-htpy-concat _ (front-right ·r g') _
                 ( (assoc-htpy (bottom ·r hA) _ _) ∙h (inv-htpy c))))) ∙h
-          ( ap-concat-htpy (bottom ·r hA) _ _ inv-htpy-right-unit-htpy))))
+          ( ap-concat-htpy (bottom ·r hA) inv-htpy-right-unit-htpy))))
 ```
 
 ### Any commuting cube of maps induces a commuting cube of function spaces

--- a/src/foundation/commuting-cubes-of-maps.lagda.md
+++ b/src/foundation/commuting-cubes-of-maps.lagda.md
@@ -38,7 +38,7 @@ that the cube is presented as a lattice
        |\ /   \ /|
        | \     / |
        |/ \   / \|
-       B    D'   C'
+       B    D'   C
         \   |   /
          \  |  /
           \ | /

--- a/src/foundation/commuting-prisms-of-maps.lagda.md
+++ b/src/foundation/commuting-prisms-of-maps.lagda.md
@@ -190,8 +190,6 @@ module _
   pasting-vertical-coherence-prism-maps prism-top prism-bottom =
     ( ap-concat-htpy
       ( bottom ·r front-left-bottom ·r front-left-top)
-      ( _)
-      ( _)
       ( commutative-pasting-vertical-pasting-horizontal-coherence-square-maps
         ( top-left)
         ( top-right)
@@ -217,8 +215,6 @@ module _
       ( prism-bottom ·r front-left-top)) ∙h
     ( ap-concat-htpy
       ( front-bottom ·r front-left-top)
-      ( _)
-      ( _)
       ( ( inv-htpy
           ( distributive-left-whisk-concat-htpy
             ( front-right-bottom)
@@ -240,8 +236,6 @@ module _
           ( front-right-top ·l top)) ∙h
         ap-concat-htpy
           ( front-right-bottom ·l front-top)
-          ( _)
-          ( _)
           ( associative-left-whisk-comp
             ( front-right-bottom)
             ( front-right-top)

--- a/src/foundation/commuting-prisms-of-maps.lagda.md
+++ b/src/foundation/commuting-prisms-of-maps.lagda.md
@@ -1,0 +1,337 @@
+# Commuting prisms of maps
+
+```agda
+module foundation.commuting-prisms-of-maps where
+```
+
+```agda
+open import foundation-core.commuting-squares-of-maps
+
+open import foundation.action-on-identifications-functions
+open import foundation.commuting-triangles-of-maps
+open import foundation.homotopies
+open import foundation.equivalences
+open import foundation.function-types
+open import foundation.identity-types
+open import foundation.whiskering-homotopies
+open import foundation.universe-levels
+```
+
+```agda
+module _
+  { l1 l2 l3 l4 l5 l6 : Level}
+  { A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4} {Y : UU l5} {Z : UU l6}
+  ( top : A → X) (left-front : A → C) (left-back : A → B)
+  ( right-front : X → Z) (right-back : X → Y)
+  ( back-bottom : B → Y) (left-bottom : B → C) (right-bottom : Y → Z)
+  ( front-bottom : C → Z)
+  ( back : coherence-square-maps top left-back right-back back-bottom)
+  ( left : coherence-triangle-maps' left-front left-bottom left-back)
+  ( right : coherence-triangle-maps' right-front right-bottom right-back)
+  ( front : coherence-square-maps top left-front right-front front-bottom)
+  ( bottom :
+    coherence-square-maps back-bottom left-bottom right-bottom front-bottom)
+  where
+
+  horizontal-coherence-prism-maps : UU (l1 ⊔ l6)
+  horizontal-coherence-prism-maps =
+    ( ( front-bottom ·l left) ∙h front) ~
+    ( ( pasting-vertical-coherence-square-maps
+        ( top)
+        ( left-back)
+        ( right-back)
+        ( back-bottom)
+        ( left-bottom)
+        ( right-bottom)
+        ( front-bottom)
+        ( back)
+        ( bottom) ) ∙h
+      ( right ·r top))
+```
+
+```agda
+module _
+  { l1 l2 l3 l4 l5 l6 : Level}
+  { A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4} {Y : UU l5} {Z : UU l6}
+  ( top-left : A → B) (top-right : B → C) (top-front : A → C)
+  ( front-left : A → X) (back : B → Y) (front-right : C → Z)
+  ( bottom-left : X → Y) (bottom-right : Y → Z) (bottom-front : X → Z)
+  ( top : coherence-triangle-maps top-front top-right top-left)
+  ( left : coherence-square-maps top-left front-left back bottom-left)
+  ( right : coherence-square-maps top-right back front-right bottom-right)
+  ( front : coherence-square-maps top-front front-left front-right bottom-front)
+  ( bottom : coherence-triangle-maps bottom-front bottom-right bottom-left)
+  where
+
+  vertical-coherence-prism-maps : UU (l1 ⊔ l6)
+  vertical-coherence-prism-maps =
+    ( ( bottom ·r front-left) ∙h
+      ( pasting-horizontal-coherence-square-maps
+        ( top-left)
+        ( top-right)
+        ( front-left)
+        ( back)
+        ( front-right)
+        ( bottom-left)
+        ( bottom-right)
+        ( left)
+        ( right))) ~
+    ( front ∙h (front-right ·l top))
+```
+
+```agda
+[iv] :
+  { l1 l2 : Level} {A : UU l1} {B : UU l2}
+  { f g g' h k : A → B} (H : f ~ g) (H' : f ~ g') (K : g ~ h) (K' : g' ~ h)
+  ( L : h ~ k) → ( α : H ∙h K ~ H' ∙h K') →
+  H ∙h (K ∙h L) ~ H' ∙h (K' ∙h L)
+[iv] H H' K K' L α =
+  ( inv-htpy-assoc-htpy H K L) ∙h
+  ( ap-concat-htpy' (H ∙h K) (H' ∙h K') L α) ∙h
+  ( assoc-htpy H' K' L)
+
+module _
+  { l1 l2 l3 l4 l5 l6 l7 l8 l9 : Level}
+  { A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4} {Y : UU l5} {Z : UU l6}
+  { M : UU l7} {N : UU l8} {O : UU l9}
+  ( top-left : A → B) (top-right : B → C) (top-front : A → C)
+  ( front-left-top : A → X) (back-top : B → Y) (front-right-top : C → Z)
+  ( mid-left : X → Y) (mid-right : Y → Z) (mid-front : X → Z)
+  ( front-left-bottom : X → M) (back-bottom : Y → N)
+  ( front-right-bottom : Z → O)
+  ( bottom-left : M → N) (bottom-right : N → O) (bottom-front : M → O)
+  ( top : coherence-triangle-maps top-front top-right top-left)
+  ( left-top : coherence-square-maps top-left front-left-top back-top mid-left)
+  ( right-top :
+      coherence-square-maps top-right back-top front-right-top mid-right)
+  ( front-top :
+      coherence-square-maps top-front front-left-top front-right-top mid-front)
+  ( mid : coherence-triangle-maps mid-front mid-right mid-left)
+  ( left-bottom :
+      coherence-square-maps mid-left front-left-bottom back-bottom bottom-left)
+  ( right-bottom :
+      coherence-square-maps
+        ( mid-right)
+        ( back-bottom)
+        ( front-right-bottom)
+        ( bottom-right))
+  ( front-bottom :
+      coherence-square-maps
+        ( mid-front)
+        ( front-left-bottom)
+        ( front-right-bottom)
+        ( bottom-front))
+  ( bottom : coherence-triangle-maps bottom-front bottom-right bottom-left)
+  where
+
+  pasting-vertical-coherence-prism-maps :
+    vertical-coherence-prism-maps
+      ( top-left)
+      ( top-right)
+      ( top-front)
+      ( front-left-top)
+      ( back-top)
+      ( front-right-top)
+      ( mid-left)
+      ( mid-right)
+      ( mid-front)
+      ( top)
+      ( left-top)
+      ( right-top)
+      ( front-top)
+      ( mid) →
+    vertical-coherence-prism-maps
+      ( mid-left)
+      ( mid-right)
+      ( mid-front)
+      ( front-left-bottom)
+      ( back-bottom)
+      ( front-right-bottom)
+      ( bottom-left)
+      ( bottom-right)
+      ( bottom-front)
+      ( mid)
+      ( left-bottom)
+      ( right-bottom)
+      ( front-bottom)
+      ( bottom) →
+    vertical-coherence-prism-maps
+      ( top-left)
+      ( top-right)
+      ( top-front)
+      ( front-left-bottom ∘ front-left-top)
+      ( back-bottom ∘ back-top)
+      ( front-right-bottom ∘ front-right-top)
+      ( bottom-left)
+      ( bottom-right)
+      ( bottom-front)
+      ( top)
+      ( pasting-vertical-coherence-square-maps
+        ( top-left)
+        ( front-left-top)
+        ( back-top)
+        ( mid-left)
+        ( front-left-bottom)
+        ( back-bottom)
+        ( bottom-left)
+        ( left-top)
+        ( left-bottom))
+      ( pasting-vertical-coherence-square-maps
+        ( top-right)
+        ( back-top)
+        ( front-right-top)
+        ( mid-right)
+        ( back-bottom)
+        ( front-right-bottom)
+        ( bottom-right)
+        ( right-top)
+        ( right-bottom))
+      ( pasting-vertical-coherence-square-maps
+        ( top-front)
+        ( front-left-top)
+        ( front-right-top)
+        ( mid-front)
+        ( front-left-bottom)
+        ( front-right-bottom)
+        ( bottom-front)
+        ( front-top)
+        ( front-bottom))
+      ( bottom)
+  pasting-vertical-coherence-prism-maps prism-top prism-bottom =
+    ( ap-concat-htpy
+      ( bottom ·r front-left-bottom ·r front-left-top)
+      ( _)
+      ( _)
+      ( commutative-pasting-vertical-pasting-horizontal-coherence-square-maps
+        ( top-left)
+        ( top-right)
+        ( front-left-top)
+        ( back-top)
+        ( front-right-top)
+        ( mid-left)
+        ( mid-right)
+        ( front-left-bottom)
+        ( back-bottom)
+        ( front-right-bottom)
+        ( bottom-left)
+        ( bottom-right)
+        ( left-top)
+        ( right-top)
+        ( left-bottom)
+        ( right-bottom))) ∙h
+    ( [iv]
+      ( bottom ·r front-left-bottom ·r front-left-top)
+      ( front-bottom ·r front-left-top)
+      ( ( pasting-horizontal-coherence-square-maps
+          ( mid-left)
+          ( mid-right)
+          ( front-left-bottom)
+          ( back-bottom)
+          ( front-right-bottom)
+          ( bottom-left)
+          ( bottom-right)
+          ( left-bottom)
+          ( right-bottom)) ·r
+        ( front-left-top))
+      ( ( front-right-bottom ·l mid) ·r front-left-top)
+      ( front-right-bottom ·l _)
+      ( prism-bottom ·r front-left-top)) ∙h
+    ( ap-concat-htpy
+      ( front-bottom ·r front-left-top)
+      ( _)
+      ( _)
+      ( ( inv-htpy
+          ( distributive-left-whisk-concat-htpy
+            ( front-right-bottom)
+            ( mid ·r front-left-top)
+            ( pasting-horizontal-coherence-square-maps
+              ( top-left)
+              ( top-right)
+              ( front-left-top)
+              ( back-top)
+              ( front-right-top)
+              ( mid-left)
+              ( mid-right)
+              ( left-top)
+              ( right-top)))) ∙h
+        ( ap-left-whisk-htpy front-right-bottom prism-top) ∙h
+        ( distributive-left-whisk-concat-htpy
+          ( front-right-bottom)
+          ( front-top)
+          ( front-right-top ·l top)) ∙h
+        ap-concat-htpy
+          ( front-right-bottom ·l front-top)
+          ( _)
+          ( _)
+          ( associative-left-whisk-comp
+            ( front-right-bottom)
+            ( front-right-top)
+            ( top)))) ∙h
+    ( inv-htpy-assoc-htpy
+      ( front-bottom ·r front-left-top)
+      ( front-right-bottom ·l front-top)
+      ( ( front-right-bottom ∘ front-right-top) ·l top))
+```
+
+```agda
+module _
+  { l1 l2 l3 l4 l5 l6 : Level}
+  { A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4} {Y : UU l5} {Z : UU l6}
+  ( top-left : A → B) (top-right : B → C) (top-front : A → C)
+  ( front-left : A → X) (back : B → Y) (front-right : C → Z)
+  ( bottom-left : X → Y) (bottom-right : Y → Z) (bottom-front : X → Z)
+  where
+
+  [v] :
+    ( top : coherence-triangle-maps top-front top-right top-left)
+    ( left : coherence-square-maps top-left front-left back bottom-left)
+    ( inv-right : coherence-square-maps back top-right bottom-right front-right)
+    ( inv-front : coherence-square-maps front-left top-front bottom-front front-right)
+    ( bottom : coherence-triangle-maps bottom-front bottom-right bottom-left) →
+    ( ( inv-front ∙h ((bottom ·r front-left) ∙h (bottom-right ·l left))) ~
+      ( (front-right ·l top) ∙h (inv-right ·r top-left))) →
+    vertical-coherence-prism-maps top-left top-right top-front front-left back front-right
+    bottom-left bottom-right bottom-front top left (inv-htpy inv-right) (inv-htpy inv-front) bottom
+  [v] top left inv-right inv-front bottom α a =
+    ( inv
+      ( assoc
+        ( bottom (front-left a))
+        ( ap bottom-right (left a))
+        ( inv (inv-right (top-left a))))) ∙
+    ( inv
+      ( right-transpose-eq-concat
+        ( inv (inv-front a) ∙ ap front-right (top a))
+        ( inv-right (top-left a))
+        ( _)
+        ( inv
+          ( ( left-transpose-eq-concat
+              ( inv-front a)
+              ( bottom (front-left a) ∙ ap bottom-right (left a))
+              ( _)
+              ( α a)) ∙
+            ( inv
+              ( assoc
+                ( inv (inv-front a))
+                ( ap front-right (top a))
+                ( inv-right (top-left a))))))))
+```
+
+```agda
+module _
+  { l1 l2 l3 l4 l5 l6 : Level}
+  { A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4} {Y : UU l5} {Z : UU l6}
+  ( top-left : A → B) (top-right : B → C) (top-front : A → C)
+  ( front-left : A → X) (back : B → Y) (front-right : C → Z)
+  ( bottom-left : X → Y) (bottom-right : Y → Z) (bottom-front : X → Z)
+  ( top : coherence-triangle-maps top-front top-right top-left)
+  ( left : coherence-square-maps top-left front-left back bottom-left)
+  ( right : coherence-square-maps top-right back front-right bottom-right)
+  ( front : coherence-square-maps top-front front-left front-right bottom-front)
+  ( bottom : coherence-triangle-maps bottom-front bottom-right bottom-left)
+  where
+
+  -- equiv-coherence-prism-maps :
+  --   vertical-coherence-prism-maps top-left top-right top-front front-left back front-right bottom-left bottom-right bottom-front top left right front bottom ≃
+  --   horizontal-coherence-prism-maps front-left top-front top-left bottom-front bottom-left back top-right bottom-right front-right (inv-htpy left) (inv-htpy top) (inv-htpy bottom) (inv-htpy front) (inv-htpy right)
+  -- equiv-coherence-prism-maps = {!!}
+```

--- a/src/foundation/commuting-prisms-of-maps.lagda.md
+++ b/src/foundation/commuting-prisms-of-maps.lagda.md
@@ -20,226 +20,136 @@ open import foundation-core.identity-types
 
 ```agda
 module _
-  { l1 l2 l3 l4 l5 l6 l7 l8 l9 : Level}
-  { A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4} {Y : UU l5} {Z : UU l6}
-  { M : UU l7} {N : UU l8} {O : UU l9}
-  ( top-left : A → B) (top-right : B → C) (top-front : A → C)
-  ( front-left-top : A → X) (back-top : B → Y) (front-right-top : C → Z)
-  ( mid-left : X → Y) (mid-right : Y → Z) (mid-front : X → Z)
-  ( front-left-bottom : X → M) (back-bottom : Y → N)
-  ( front-right-bottom : Z → O)
-  ( bottom-left : M → N) (bottom-right : N → O) (bottom-front : M → O)
-  ( top : coherence-triangle-maps top-front top-right top-left)
-  ( left-top : coherence-square-maps top-left front-left-top back-top mid-left)
-  ( right-top :
-      coherence-square-maps top-right back-top front-right-top mid-right)
-  ( front-top :
-      coherence-square-maps top-front front-left-top front-right-top mid-front)
-  ( mid : coherence-triangle-maps mid-front mid-right mid-left)
-  ( left-bottom :
-      coherence-square-maps mid-left front-left-bottom back-bottom bottom-left)
-  ( right-bottom :
-      coherence-square-maps
-        ( mid-right)
-        ( back-bottom)
-        ( front-right-bottom)
-        ( bottom-right))
-  ( front-bottom :
-      coherence-square-maps
-        ( mid-front)
-        ( front-left-bottom)
-        ( front-right-bottom)
-        ( bottom-front))
-  ( bottom : coherence-triangle-maps bottom-front bottom-right bottom-left)
+  { l1 l2 l3 l1' l2' l3' l1'' l2'' l3'' : Level}
+  { A : UU l1} {B : UU l2} {C : UU l3}
+  ( f : A → C) (g : B → C) (h : A → B)
+  { A' : UU l1'} {B' : UU l2'} {C' : UU l3'}
+  ( f' : A' → C') (g' : B' → C') (h' : A' → B')
+  ( hA : A → A') (hB : B → B') (hC : C → C')
+  { A'' : UU l1''} {B'' : UU l2''} {C'' : UU l3''}
+  ( f'' : A'' → C'') (g'' : B'' → C'') (h'' : A'' → B'')
+  ( hA' : A' → A'') (hB' : B' → B'') (hC' : C' → C'')
+  ( top : coherence-triangle-maps f g h)
+  ( front-top : coherence-square-maps f hA hC f')
+  ( right-top : coherence-square-maps g hB hC g')
+  ( left-top : coherence-square-maps h hA hB h')
+  ( mid : coherence-triangle-maps f' g' h')
+  ( front-bottom : coherence-square-maps f' hA' hC' f'')
+  ( right-bottom : coherence-square-maps g' hB' hC' g'')
+  ( left-bottom : coherence-square-maps h' hA' hB' h'')
+  ( bottom : coherence-triangle-maps f'' g'' h'')
   where
 
   pasting-vertical-coherence-prism-maps :
-    vertical-coherence-prism-maps
-      ( top-left)
-      ( top-right)
-      ( top-front)
-      ( front-left-top)
-      ( back-top)
-      ( front-right-top)
-      ( mid-left)
-      ( mid-right)
-      ( mid-front)
+    vertical-coherence-prism-maps f g h f' g' h' hA hB hC
       ( top)
-      ( left-top)
-      ( right-top)
       ( front-top)
+      ( right-top)
+      ( left-top)
       ( mid) →
-    vertical-coherence-prism-maps
-      ( mid-left)
-      ( mid-right)
-      ( mid-front)
-      ( front-left-bottom)
-      ( back-bottom)
-      ( front-right-bottom)
-      ( bottom-left)
-      ( bottom-right)
-      ( bottom-front)
+    vertical-coherence-prism-maps f' g' h' f'' g'' h'' hA' hB' hC'
       ( mid)
-      ( left-bottom)
-      ( right-bottom)
       ( front-bottom)
+      ( right-bottom)
+      ( left-bottom)
       ( bottom) →
-    vertical-coherence-prism-maps
-      ( top-left)
-      ( top-right)
-      ( top-front)
-      ( front-left-bottom ∘ front-left-top)
-      ( back-bottom ∘ back-top)
-      ( front-right-bottom ∘ front-right-top)
-      ( bottom-left)
-      ( bottom-right)
-      ( bottom-front)
+    vertical-coherence-prism-maps f g h f'' g'' h''
+      ( hA' ∘ hA)
+      ( hB' ∘ hB)
+      ( hC' ∘ hC)
       ( top)
-      ( pasting-vertical-coherence-square-maps
-        ( top-left)
-        ( front-left-top)
-        ( back-top)
-        ( mid-left)
-        ( front-left-bottom)
-        ( back-bottom)
-        ( bottom-left)
-        ( left-top)
-        ( left-bottom))
-      ( pasting-vertical-coherence-square-maps
-        ( top-right)
-        ( back-top)
-        ( front-right-top)
-        ( mid-right)
-        ( back-bottom)
-        ( front-right-bottom)
-        ( bottom-right)
-        ( right-top)
-        ( right-bottom))
-      ( pasting-vertical-coherence-square-maps
-        ( top-front)
-        ( front-left-top)
-        ( front-right-top)
-        ( mid-front)
-        ( front-left-bottom)
-        ( front-right-bottom)
-        ( bottom-front)
+      ( pasting-vertical-coherence-square-maps f hA hC f' hA' hC' f''
         ( front-top)
         ( front-bottom))
+      ( pasting-vertical-coherence-square-maps g hB hC g' hB' hC' g''
+        ( right-top)
+        ( right-bottom))
+      ( pasting-vertical-coherence-square-maps h hA hB h' hA' hB' h''
+        ( left-top)
+        ( left-bottom))
       ( bottom)
   pasting-vertical-coherence-prism-maps prism-top prism-bottom =
     ( ap-concat-htpy
-      ( bottom ·r front-left-bottom ·r front-left-top)
+      ( bottom ·r hA' ·r hA)
       ( commutative-pasting-vertical-pasting-horizontal-coherence-square-maps
-        ( top-left)
-        ( top-right)
-        ( front-left-top)
-        ( back-top)
-        ( front-right-top)
-        ( mid-left)
-        ( mid-right)
-        ( front-left-bottom)
-        ( back-bottom)
-        ( front-right-bottom)
-        ( bottom-left)
-        ( bottom-right)
+        h g hA hB hC h' g' hA' hB' hC' h'' g''
         ( left-top)
         ( right-top)
         ( left-bottom)
         ( right-bottom))) ∙h
     ( right-whisk-square-htpy
-      ( front-bottom ·r front-left-top)
-      ( bottom ·r front-left-bottom ·r front-left-top)
-      ( ( front-right-bottom) ·l
-        ( (mid-right ·l left-top) ∙h (right-top ·r top-left)))
-      ( prism-bottom ·r front-left-top)) ∙h
+      ( front-bottom ·r hA)
+      ( bottom ·r hA' ·r hA)
+      ( hC' ·l ((g' ·l left-top) ∙h (right-top ·r h)))
+      ( prism-bottom ·r hA)) ∙h
     ( ap-concat-htpy
-      ( front-bottom ·r front-left-top)
+      ( front-bottom ·r hA)
       ( ( inv-htpy
-          ( distributive-left-whisk-concat-htpy
-            ( front-right-bottom)
-            ( mid ·r front-left-top)
-            ( pasting-horizontal-coherence-square-maps
-              ( top-left)
-              ( top-right)
-              ( front-left-top)
-              ( back-top)
-              ( front-right-top)
-              ( mid-left)
-              ( mid-right)
+          ( distributive-left-whisk-concat-htpy hC'
+            ( mid ·r hA)
+            ( pasting-horizontal-coherence-square-maps h g hA hB hC h' g'
               ( left-top)
               ( right-top)))) ∙h
-        ( ap-left-whisk-htpy front-right-bottom prism-top) ∙h
-        ( distributive-left-whisk-concat-htpy
-          ( front-right-bottom)
-          ( front-top)
-          ( front-right-top ·l top)) ∙h
-        ap-concat-htpy
-          ( front-right-bottom ·l front-top)
+        ( ap-left-whisk-htpy hC' prism-top) ∙h
+        ( distributive-left-whisk-concat-htpy hC' front-top (hC ·l top)) ∙h
+        ( ap-concat-htpy
+          ( hC' ·l front-top)
           ( associative-left-whisk-comp
-            ( front-right-bottom)
-            ( front-right-top)
-            ( top)))) ∙h
+            ( hC')
+            ( hC)
+            ( top))))) ∙h
     ( inv-htpy-assoc-htpy
-      ( front-bottom ·r front-left-top)
-      ( front-right-bottom ·l front-top)
-      ( ( front-right-bottom ∘ front-right-top) ·l top))
+      ( front-bottom ·r hA)
+      ( hC' ·l front-top)
+      ( ( hC' ∘ hC) ·l top))
 ```
 
 ```agda
 module _
-  { l1 l2 l3 l4 l5 l6 : Level}
-  { A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4} {Y : UU l5} {Z : UU l6}
-  ( top-left : A → B) (top-right : B → C) (top-front : A → C)
-  ( front-left : A → X) (back : B → Y) (front-right : C → Z)
-  ( bottom-left : X → Y) (bottom-right : Y → Z) (bottom-front : X → Z)
+  { l1 l2 l3 l1' l2' l3' : Level}
+  { A : UU l1} {B : UU l2} {C : UU l3}
+  ( f : A → C) (g : B → C) (h : A → B)
+  { A' : UU l1'} {B' : UU l2'} {C' : UU l3'}
+  ( f' : A' → C') (g' : B' → C') (h' : A' → B')
+  ( hA : A → A') (hB : B → B') (hC : C → C')
   where
 
   [v] :
-    ( top : coherence-triangle-maps top-front top-right top-left)
-    ( left : coherence-square-maps top-left front-left back bottom-left)
-    ( inv-right : coherence-square-maps back top-right bottom-right front-right)
-    ( inv-front :
-        coherence-square-maps front-left top-front bottom-front front-right)
-    ( bottom : coherence-triangle-maps bottom-front bottom-right bottom-left) →
-    ( ( inv-front ∙h ((bottom ·r front-left) ∙h (bottom-right ·l left))) ~
-      ( (front-right ·l top) ∙h (inv-right ·r top-left))) →
-    vertical-coherence-prism-maps
-      ( top-left)
-      ( top-right)
-      ( top-front)
-      ( front-left)
-      ( back)
-      ( front-right)
-      ( bottom-left)
-      ( bottom-right)
-      ( bottom-front)
+    ( top : coherence-triangle-maps f g h)
+    ( inv-front : coherence-square-maps hA f f' hC)
+    ( inv-right : coherence-square-maps hB g g' hC)
+    ( left : coherence-square-maps h hA hB h')
+    ( bottom : coherence-triangle-maps f' g' h') →
+    ( ( inv-front ∙h ((bottom ·r hA) ∙h (g' ·l left))) ~
+      ( (hC ·l top) ∙h (inv-right ·r h))) →
+    vertical-coherence-prism-maps f g h f' g' h' hA hB hC
       ( top)
-      ( left)
-      ( inv-htpy inv-right)
       ( inv-htpy inv-front)
+      ( inv-htpy inv-right)
+      ( left)
       ( bottom)
-  [v] top left inv-right inv-front bottom α a =
+  [v] top inv-front inv-right left bottom α a =
     ( inv
       ( assoc
-        ( bottom (front-left a))
-        ( ap bottom-right (left a))
-        ( inv (inv-right (top-left a))))) ∙
+        ( bottom (hA a))
+        ( ap g' (left a))
+        ( inv (inv-right (h a))))) ∙
     ( inv
       ( right-transpose-eq-concat
-        ( inv (inv-front a) ∙ ap front-right (top a))
-        ( inv-right (top-left a))
+        ( inv (inv-front a) ∙ ap hC (top a))
+        ( inv-right (h a))
         ( _)
         ( inv
           ( ( left-transpose-eq-concat
               ( inv-front a)
-              ( bottom (front-left a) ∙ ap bottom-right (left a))
+              ( bottom (hA a) ∙ ap g' (left a))
               ( _)
               ( α a)) ∙
             ( inv
               ( assoc
                 ( inv (inv-front a))
-                ( ap front-right (top a))
-                ( inv-right (top-left a))))))))
+                ( ap hC (top a))
+                ( inv-right (h a))))))))
 ```
 
 ```agda

--- a/src/foundation/commuting-prisms-of-maps.lagda.md
+++ b/src/foundation/commuting-prisms-of-maps.lagda.md
@@ -6,6 +6,8 @@ module foundation.commuting-prisms-of-maps where
 open import foundation-core.commuting-prisms-of-maps public
 ```
 
+<details><summary>Imports</summary>
+
 ```agda
 open import foundation.action-on-identifications-functions
 open import foundation.commuting-squares-of-maps
@@ -20,6 +22,12 @@ open import foundation-core.equivalences
 open import foundation-core.function-types
 open import foundation-core.functoriality-dependent-function-types
 ```
+
+</details>
+
+## Definitions
+
+### Vertical pasting of vertical prisms of maps
 
 ```agda
 module _
@@ -106,6 +114,10 @@ module _
       ( hC' ·l front-top)
       ( ( hC' ∘ hC) ·l top))
 ```
+
+## Properties
+
+### The two definitions of vertical prisms are equivalent
 
 ```agda
 module _

--- a/src/foundation/commuting-prisms-of-maps.lagda.md
+++ b/src/foundation/commuting-prisms-of-maps.lagda.md
@@ -171,23 +171,3 @@ module _
   rotate-vertical-coherence-prism-maps =
     map-equiv equiv-rotate-vertical-coherence-prism-maps
 ```
-
-```agda
-module _
-  { l1 l2 l3 l4 l5 l6 : Level}
-  { A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4} {Y : UU l5} {Z : UU l6}
-  ( top-left : A → B) (top-right : B → C) (top-front : A → C)
-  ( front-left : A → X) (back : B → Y) (front-right : C → Z)
-  ( bottom-left : X → Y) (bottom-right : Y → Z) (bottom-front : X → Z)
-  ( top : coherence-triangle-maps top-front top-right top-left)
-  ( left : coherence-square-maps top-left front-left back bottom-left)
-  ( right : coherence-square-maps top-right back front-right bottom-right)
-  ( front : coherence-square-maps top-front front-left front-right bottom-front)
-  ( bottom : coherence-triangle-maps bottom-front bottom-right bottom-left)
-  where
-
-  -- equiv-coherence-prism-maps :
-  --   vertical-coherence-prism-maps top-left top-right top-front front-left back front-right bottom-left bottom-right bottom-front top left right front bottom ≃
-  --   horizontal-coherence-prism-maps front-left top-front top-left bottom-front bottom-left back top-right bottom-right front-right (inv-htpy left) (inv-htpy top) (inv-htpy bottom) (inv-htpy front) (inv-htpy right)
-  -- equiv-coherence-prism-maps = {!!}
-```

--- a/src/foundation/commuting-prisms-of-maps.lagda.md
+++ b/src/foundation/commuting-prisms-of-maps.lagda.md
@@ -9,13 +9,16 @@ open import foundation-core.commuting-prisms-of-maps public
 ```agda
 open import foundation.action-on-identifications-functions
 open import foundation.commuting-squares-of-maps
+open import foundation.homotopies
+open import foundation.identity-types
+open import foundation.path-algebra
 open import foundation.whiskering-homotopies
 open import foundation.universe-levels
 
 open import foundation-core.commuting-triangles-of-maps
-open import foundation-core.homotopies
+open import foundation-core.equivalences
 open import foundation-core.function-types
-open import foundation-core.identity-types
+open import foundation-core.functoriality-dependent-function-types
 ```
 
 ```agda
@@ -112,44 +115,61 @@ module _
   { A' : UU l1'} {B' : UU l2'} {C' : UU l3'}
   ( f' : A' → C') (g' : B' → C') (h' : A' → B')
   ( hA : A → A') (hB : B → B') (hC : C → C')
+  ( top : coherence-triangle-maps f g h)
+  ( inv-front : coherence-square-maps hA f f' hC)
+  ( inv-right : coherence-square-maps hB g g' hC)
+  ( left : coherence-square-maps h hA hB h')
+  ( bottom : coherence-triangle-maps f' g' h')
   where
 
-  [v] :
-    ( top : coherence-triangle-maps f g h)
-    ( inv-front : coherence-square-maps hA f f' hC)
-    ( inv-right : coherence-square-maps hB g g' hC)
-    ( left : coherence-square-maps h hA hB h')
-    ( bottom : coherence-triangle-maps f' g' h') →
-    ( ( inv-front ∙h ((bottom ·r hA) ∙h (g' ·l left))) ~
-      ( (hC ·l top) ∙h (inv-right ·r h))) →
+  equiv-rotate-vertical-coherence-prism-maps :
+    vertical-coherence-prism-maps' f g h f' g' h' hA hB hC
+      ( top)
+      ( inv-front)
+      ( inv-right)
+      ( left)
+      ( bottom) ≃
     vertical-coherence-prism-maps f g h f' g' h' hA hB hC
       ( top)
       ( inv-htpy inv-front)
       ( inv-htpy inv-right)
       ( left)
       ( bottom)
-  [v] top inv-front inv-right left bottom α a =
-    ( inv
-      ( assoc
-        ( bottom (hA a))
-        ( ap g' (left a))
-        ( inv (inv-right (h a))))) ∙
-    ( inv
-      ( right-transpose-eq-concat
-        ( inv (inv-front a) ∙ ap hC (top a))
-        ( inv-right (h a))
-        ( _)
-        ( inv
-          ( ( left-transpose-eq-concat
-              ( inv-front a)
-              ( bottom (hA a) ∙ ap g' (left a))
-              ( _)
-              ( α a)) ∙
-            ( inv
-              ( assoc
-                ( inv (inv-front a))
-                ( ap hC (top a))
-                ( inv-right (h a))))))))
+  equiv-rotate-vertical-coherence-prism-maps =
+    equiv-Π-equiv-family
+      ( λ a →
+        ( equiv-concat-assoc
+          ( bottom (hA a))
+          ( ap g' (left a))
+          ( inv (inv-right (h a))) _) ∘e
+        ( equiv-right-transpose-eq-concat' _
+          ( inv (inv-front a) ∙ ap hC (top a))
+          ( inv-right (h a))) ∘e
+        ( inv-equiv
+          ( equiv-concat-assoc' _
+            ( inv (inv-front a))
+            ( ap hC (top a))
+            ( inv-right (h a)))) ∘e
+        ( equiv-left-transpose-eq-concat
+          ( inv-front a)
+          ( bottom (hA a) ∙ ap g' (left a))
+          ( _)))
+
+  rotate-vertical-coherence-prism-maps :
+    vertical-coherence-prism-maps' f g h f' g' h' hA hB hC
+      ( top)
+      ( inv-front)
+      ( inv-right)
+      ( left)
+      ( bottom) →
+    vertical-coherence-prism-maps f g h f' g' h' hA hB hC
+      ( top)
+      ( inv-htpy inv-front)
+      ( inv-htpy inv-right)
+      ( left)
+      ( bottom)
+  rotate-vertical-coherence-prism-maps =
+    map-equiv equiv-rotate-vertical-coherence-prism-maps
 ```
 
 ```agda

--- a/src/foundation/commuting-prisms-of-maps.lagda.md
+++ b/src/foundation/commuting-prisms-of-maps.lagda.md
@@ -11,16 +11,16 @@ open import foundation-core.commuting-prisms-of-maps public
 ```agda
 open import foundation.action-on-identifications-functions
 open import foundation.commuting-squares-of-maps
-open import foundation.homotopies
 open import foundation.identity-types
 open import foundation.path-algebra
-open import foundation.whiskering-homotopies
 open import foundation.universe-levels
+open import foundation.whiskering-homotopies
 
 open import foundation-core.commuting-triangles-of-maps
 open import foundation-core.equivalences
 open import foundation-core.function-types
 open import foundation-core.functoriality-dependent-function-types
+open import foundation-core.homotopies
 ```
 
 </details>
@@ -95,14 +95,10 @@ module _
       ( prism-bottom ·r hA)) ∙h
     ( ap-concat-htpy
       ( front-bottom ·r hA)
-      ( ( inv-htpy
-          ( distributive-left-whisk-concat-htpy hC'
-            ( mid ·r hA)
-            ( pasting-horizontal-coherence-square-maps h g hA hB hC h' g'
-              ( left-top)
-              ( right-top)))) ∙h
-        ( ap-left-whisk-htpy hC' prism-top) ∙h
-        ( distributive-left-whisk-concat-htpy hC' front-top (hC ·l top)) ∙h
+      ( ( ap-left-whisk-coherence-square-homotopies hC'
+          ( front-top)
+          ( mid ·r hA)
+          ( prism-top)) ∙h
         ( ap-concat-htpy
           ( hC' ·l front-top)
           ( associative-left-whisk-comp

--- a/src/foundation/commuting-prisms-of-maps.lagda.md
+++ b/src/foundation/commuting-prisms-of-maps.lagda.md
@@ -2,81 +2,20 @@
 
 ```agda
 module foundation.commuting-prisms-of-maps where
+
+open import foundation-core.commuting-prisms-of-maps public
 ```
 
 ```agda
-open import foundation-core.commuting-squares-of-maps
-
 open import foundation.action-on-identifications-functions
-open import foundation.commuting-triangles-of-maps
-open import foundation.homotopies
-open import foundation.equivalences
-open import foundation.function-types
-open import foundation.identity-types
+open import foundation.commuting-squares-of-maps
 open import foundation.whiskering-homotopies
 open import foundation.universe-levels
-```
 
-```agda
-module _
-  { l1 l2 l3 l4 l5 l6 : Level}
-  { A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4} {Y : UU l5} {Z : UU l6}
-  ( top : A → X) (left-front : A → C) (left-back : A → B)
-  ( right-front : X → Z) (right-back : X → Y)
-  ( back-bottom : B → Y) (left-bottom : B → C) (right-bottom : Y → Z)
-  ( front-bottom : C → Z)
-  ( back : coherence-square-maps top left-back right-back back-bottom)
-  ( left : coherence-triangle-maps' left-front left-bottom left-back)
-  ( right : coherence-triangle-maps' right-front right-bottom right-back)
-  ( front : coherence-square-maps top left-front right-front front-bottom)
-  ( bottom :
-    coherence-square-maps back-bottom left-bottom right-bottom front-bottom)
-  where
-
-  horizontal-coherence-prism-maps : UU (l1 ⊔ l6)
-  horizontal-coherence-prism-maps =
-    ( ( front-bottom ·l left) ∙h front) ~
-    ( ( pasting-vertical-coherence-square-maps
-        ( top)
-        ( left-back)
-        ( right-back)
-        ( back-bottom)
-        ( left-bottom)
-        ( right-bottom)
-        ( front-bottom)
-        ( back)
-        ( bottom)) ∙h
-      ( right ·r top))
-```
-
-```agda
-module _
-  { l1 l2 l3 l4 l5 l6 : Level}
-  { A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4} {Y : UU l5} {Z : UU l6}
-  ( top-left : A → B) (top-right : B → C) (top-front : A → C)
-  ( front-left : A → X) (back : B → Y) (front-right : C → Z)
-  ( bottom-left : X → Y) (bottom-right : Y → Z) (bottom-front : X → Z)
-  ( top : coherence-triangle-maps top-front top-right top-left)
-  ( left : coherence-square-maps top-left front-left back bottom-left)
-  ( right : coherence-square-maps top-right back front-right bottom-right)
-  ( front : coherence-square-maps top-front front-left front-right bottom-front)
-  ( bottom : coherence-triangle-maps bottom-front bottom-right bottom-left)
-  where
-
-  vertical-coherence-prism-maps : UU (l1 ⊔ l6)
-  vertical-coherence-prism-maps =
-    ( ( bottom ·r front-left) ∙h
-      ( pasting-horizontal-coherence-square-maps
-        ( top-left)
-        ( top-right)
-        ( front-left)
-        ( back)
-        ( front-right)
-        ( bottom-left)
-        ( bottom-right)
-        ( left)
-        ( right))) ~
-    ( front ∙h (front-right ·l top))
+open import foundation-core.commuting-triangles-of-maps
+open import foundation-core.homotopies
+open import foundation-core.function-types
+open import foundation-core.identity-types
 ```
 
 ```agda

--- a/src/foundation/commuting-prisms-of-maps.lagda.md
+++ b/src/foundation/commuting-prisms-of-maps.lagda.md
@@ -45,7 +45,7 @@ module _
         ( right-bottom)
         ( front-bottom)
         ( back)
-        ( bottom) ) ∙h
+        ( bottom)) ∙h
       ( right ·r top))
 ```
 
@@ -265,12 +265,26 @@ module _
     ( top : coherence-triangle-maps top-front top-right top-left)
     ( left : coherence-square-maps top-left front-left back bottom-left)
     ( inv-right : coherence-square-maps back top-right bottom-right front-right)
-    ( inv-front : coherence-square-maps front-left top-front bottom-front front-right)
+    ( inv-front :
+        coherence-square-maps front-left top-front bottom-front front-right)
     ( bottom : coherence-triangle-maps bottom-front bottom-right bottom-left) →
     ( ( inv-front ∙h ((bottom ·r front-left) ∙h (bottom-right ·l left))) ~
       ( (front-right ·l top) ∙h (inv-right ·r top-left))) →
-    vertical-coherence-prism-maps top-left top-right top-front front-left back front-right
-    bottom-left bottom-right bottom-front top left (inv-htpy inv-right) (inv-htpy inv-front) bottom
+    vertical-coherence-prism-maps
+      ( top-left)
+      ( top-right)
+      ( top-front)
+      ( front-left)
+      ( back)
+      ( front-right)
+      ( bottom-left)
+      ( bottom-right)
+      ( bottom-front)
+      ( top)
+      ( left)
+      ( inv-htpy inv-right)
+      ( inv-htpy inv-front)
+      ( bottom)
   [v] top left inv-right inv-front bottom α a =
     ( inv
       ( assoc

--- a/src/foundation/commuting-prisms-of-maps.lagda.md
+++ b/src/foundation/commuting-prisms-of-maps.lagda.md
@@ -80,16 +80,6 @@ module _
 ```
 
 ```agda
-[iv] :
-  { l1 l2 : Level} {A : UU l1} {B : UU l2}
-  { f g g' h k : A → B} (H : f ~ g) (H' : f ~ g') (K : g ~ h) (K' : g' ~ h)
-  ( L : h ~ k) → ( α : H ∙h K ~ H' ∙h K') →
-  H ∙h (K ∙h L) ~ H' ∙h (K' ∙h L)
-[iv] H H' K K' L α =
-  ( inv-htpy-assoc-htpy H K L) ∙h
-  ( ap-concat-htpy' (H ∙h K) (H' ∙h K') L α) ∙h
-  ( assoc-htpy H' K' L)
-
 module _
   { l1 l2 l3 l4 l5 l6 l7 l8 l9 : Level}
   { A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4} {Y : UU l5} {Z : UU l6}
@@ -219,22 +209,11 @@ module _
         ( right-top)
         ( left-bottom)
         ( right-bottom))) ∙h
-    ( [iv]
-      ( bottom ·r front-left-bottom ·r front-left-top)
+    ( right-whisk-square-htpy
       ( front-bottom ·r front-left-top)
-      ( ( pasting-horizontal-coherence-square-maps
-          ( mid-left)
-          ( mid-right)
-          ( front-left-bottom)
-          ( back-bottom)
-          ( front-right-bottom)
-          ( bottom-left)
-          ( bottom-right)
-          ( left-bottom)
-          ( right-bottom)) ·r
-        ( front-left-top))
-      ( ( front-right-bottom ·l mid) ·r front-left-top)
-      ( front-right-bottom ·l _)
+      ( bottom ·r front-left-bottom ·r front-left-top)
+      ( ( front-right-bottom) ·l
+        ( (mid-right ·l left-top) ∙h (right-top ·r top-left)))
       ( prism-bottom ·r front-left-top)) ∙h
     ( ap-concat-htpy
       ( front-bottom ·r front-left-top)

--- a/src/foundation/commuting-squares-of-maps.lagda.md
+++ b/src/foundation/commuting-squares-of-maps.lagda.md
@@ -1,6 +1,7 @@
 # Commuting squares of maps
 
 ```agda
+{-# OPTIONS --allow-unsolved-metas #-}
 module foundation.commuting-squares-of-maps where
 
 open import foundation-core.commuting-squares-of-maps public
@@ -11,8 +12,11 @@ open import foundation-core.commuting-squares-of-maps public
 ```agda
 open import foundation.action-on-identifications-binary-functions
 open import foundation.action-on-identifications-functions
+open import foundation.commuting-prisms-of-maps
 open import foundation.equivalences
 open import foundation.function-extensionality
+open import foundation.homotopies
+open import foundation.path-algebra
 open import foundation.precomposition-functions
 open import foundation.universe-levels
 open import foundation.whiskering-homotopies
@@ -20,7 +24,6 @@ open import foundation.whiskering-homotopies
 open import foundation-core.commuting-triangles-of-maps
 open import foundation-core.function-types
 open import foundation-core.functoriality-function-types
-open import foundation-core.homotopies
 open import foundation-core.identity-types
 ```
 
@@ -161,6 +164,157 @@ precomp-coherence-square-maps top left right bottom H X =
 ```
 
 ## Properties
+
+### Taking inversions of squares is an inverse operation
+
+In other words, vertical (horizontal) composition of a square with the square
+obtained by inverting the vertical (horizontal) maps fits into a
+[prism](foundation.commuting-prisms-of-maps.md) with the reflexivity square.
+
+```agda
+module _
+  { l1 l2 l3 l4 : Level}
+  { A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
+  ( top : A → X) (left : A ≃ B) (right : X ≃ Y) (bottom : B → Y)
+  where
+
+  left-inverse-law-pasting-vertical-coherence-square-maps :
+    ( H : coherence-square-maps top (map-equiv left) (map-equiv right) bottom) →
+    horizontal-coherence-prism-maps
+      ( top)
+      ( id)
+      ( map-equiv left)
+      ( id)
+      ( map-equiv right)
+      ( bottom)
+      ( map-inv-equiv left)
+      ( map-inv-equiv right)
+      ( top)
+      ( H)
+      ( is-retraction-map-inv-equiv left)
+      ( is-retraction-map-inv-equiv right)
+      ( refl-htpy)
+      ( coherence-square-inv-vertical top left right bottom H)
+  left-inverse-law-pasting-vertical-coherence-square-maps H a =
+    ( right-unit) ∙
+    ( inv
+      {!!})
+
+  right-inverse-law-pasting-vertical-coherence-square-maps :
+    ( H : coherence-square-maps top (map-equiv left) (map-equiv right) bottom) →
+    horizontal-coherence-prism-maps
+      ( bottom)
+      ( id)
+      ( map-inv-equiv left)
+      ( id)
+      ( map-inv-equiv right)
+      ( top)
+      ( map-equiv left)
+      ( map-equiv right)
+      ( bottom)
+      ( coherence-square-inv-vertical top left right bottom H)
+      ( is-section-map-inv-equiv left)
+      ( is-section-map-inv-equiv right)
+      ( refl-htpy)
+      ( H)
+  right-inverse-law-pasting-vertical-coherence-square-maps H a =
+    ( right-unit) ∙
+    ( inv
+      ( ( assoc
+          ( H (map-inv-equiv left a))
+          ( ap
+            ( map-equiv right)
+            ( coherence-square-inv-vertical top left right bottom H a))
+          ( is-section-map-inv-equiv right (bottom a))) ∙
+        ( ap
+          ( H (map-inv-equiv left a) ∙_)
+          ( triangle-eq-transpose-equiv
+            ( right)
+            ( ( inv (H (map-inv-equiv left a))) ∙
+              ( ap bottom (is-section-map-inv-equiv left a))))) ∙
+        ( is-retraction-left-concat-inv
+          ( H (map-inv-equiv left a))
+          ( ap bottom (is-section-map-inv-equiv left a)))))
+```
+
+### Associativity of vertical pasting
+
+The proof of associativity of horizontal pasting may be found in
+[`foundation-core.commuting-squares-of-maps`](foundation-core.commuting-squares-of-maps.md).
+
+```agda
+module _
+  { l1 l2 l3 l4 l5 l6 l7 l8 : Level}
+  { A : UU l1} {B : UU l2} {C : UU l3} {D : UU l4}
+  { X : UU l5} {Y : UU l6} {Z : UU l7} {W : UU l8}
+  ( top : A → X) (top-left : A → B) (top-right : X → Y)
+  ( mid-top : B → Y) (mid-left : B → C) (mid-right : Y → Z) (mid-bottom : C → Z)
+  ( bottom-left : C → D) (bottom-right : Z → W) (bottom : D → W)
+  ( sq-top : coherence-square-maps top top-left top-right mid-top)
+  ( sq-mid : coherence-square-maps mid-top mid-left mid-right mid-bottom)
+  ( sq-bottom :
+      coherence-square-maps mid-bottom bottom-left bottom-right bottom)
+  where
+
+  assoc-pasting-vertical-coherence-square-maps :
+    pasting-vertical-coherence-square-maps
+      ( top)
+      ( mid-left ∘ top-left)
+      ( mid-right ∘ top-right)
+      ( mid-bottom)
+      ( bottom-left)
+      ( bottom-right)
+      ( bottom)
+      ( pasting-vertical-coherence-square-maps
+        ( top)
+        ( top-left)
+        ( top-right)
+        ( mid-top)
+        ( mid-left)
+        ( mid-right)
+        ( mid-bottom)
+        ( sq-top)
+        ( sq-mid))
+      ( sq-bottom) ~
+    pasting-vertical-coherence-square-maps
+      ( top)
+      ( top-left)
+      ( top-right)
+      ( mid-top)
+      ( bottom-left ∘ mid-left)
+      ( bottom-right ∘ mid-right)
+      ( bottom)
+      ( sq-top)
+      ( pasting-vertical-coherence-square-maps
+        ( mid-top)
+        ( mid-left)
+        ( mid-right)
+        ( mid-bottom)
+        ( bottom-left)
+        ( bottom-right)
+        ( bottom)
+        ( sq-mid)
+        ( sq-bottom))
+  assoc-pasting-vertical-coherence-square-maps =
+    ( ap-concat-htpy
+      ( sq-bottom ·r mid-left ·r top-left)
+      ( bottom-right ·l (sq-mid ·r top-left ∙h (mid-right ·l sq-top)))
+      ( ( bottom-right ·l (sq-mid ·r top-left)) ∙h
+        ( ( bottom-right ∘ mid-right) ·l sq-top))
+      ( ( distributive-left-whisk-concat-htpy
+          ( bottom-right)
+          ( sq-mid ·r top-left)
+          ( mid-right ·l sq-top)) ∙h
+        ( ap-concat-htpy
+          ( bottom-right ·l (sq-mid ·r top-left))
+          ( bottom-right ·l mid-right ·l sq-top)
+          ( ( bottom-right ∘ mid-right) ·l sq-top)
+          ( associative-left-whisk-comp bottom-right mid-right sq-top)))) ∙h
+    ( inv-htpy-assoc-htpy
+      ( sq-bottom ·r mid-left ·r top-left)
+      ( bottom-right ·l (sq-mid ·r top-left))
+      ( ( bottom-right ∘ mid-right) ·l sq-top))
+```
 
 ### Distributivity of pasting squares and transposing by precomposition
 

--- a/src/foundation/commuting-squares-of-maps.lagda.md
+++ b/src/foundation/commuting-squares-of-maps.lagda.md
@@ -1,7 +1,6 @@
 # Commuting squares of maps
 
 ```agda
-{-# OPTIONS --allow-unsolved-metas #-}
 module foundation.commuting-squares-of-maps where
 
 open import foundation-core.commuting-squares-of-maps public
@@ -200,7 +199,83 @@ module _
   left-inverse-law-pasting-vertical-coherence-square-maps H a =
     ( right-unit) ∙
     ( inv
-      {!!})
+      ( ( ap
+          ( λ q →
+            ( q ∙ ap (map-inv-equiv right) (H a)) ∙
+            ( is-retraction-map-inv-equiv right (top a)))
+          ( triangle-eq-transpose-equiv-concat
+            ( right)
+            ( inv (H (map-inv-equiv left (map-equiv left a))))
+            ( ap bottom (is-section-map-inv-equiv left (map-equiv left a))))) ∙
+        ( assoc
+          ( ( map-eq-transpose-equiv
+              ( right)
+              ( inv (H (map-inv-equiv left (map-equiv left a)))) ∙
+            ( ap
+              ( map-inv-equiv right)
+              ( ap bottom (is-section-map-inv-equiv left (map-equiv left a))))))
+          ( ap (map-inv-equiv right) (H a))
+          ( is-retraction-map-inv-equiv right (top a))) ∙
+        ( left-whisk-square-identification
+          ( map-eq-transpose-equiv
+            ( right)
+            ( inv (H (map-inv-equiv left (map-equiv left a)))))
+          ( inv
+            ( coherence-square-identifications-comp-vertical
+              { p-left =
+                  ap
+                    ( map-inv-equiv right)
+                    ( H (map-inv-equiv left (map-equiv left a)))}
+              { p-top =
+                  ap
+                    ( map-inv-equiv right)
+                    ( ap
+                      ( bottom)
+                      ( is-section-map-inv-equiv left (map-equiv left a)))}
+              { q-bottom = ap top (is-retraction-map-inv-equiv left a)}
+              ( coherence-square-identifications-top-paste
+                ( ap
+                  ( map-inv-equiv right)
+                  ( H (map-inv-equiv left (map-equiv left a))))
+                ( _)
+                ( _)
+                ( _)
+                ( inv
+                  ( ap
+                    ( ap (map-inv-equiv right))
+                    ( ( ap (ap bottom) (coherence-map-inv-equiv left a)) ∙
+                      ( inv
+                        ( ap-comp
+                          ( bottom)
+                          ( map-equiv left)
+                          ( is-retraction-map-inv-equiv left a))))))
+                ( coherence-square-identifications-ap
+                  ( map-inv-equiv right)
+                  ( ap
+                    ( bottom ∘ map-equiv left)
+                    ( is-retraction-map-inv-equiv left a))
+                  ( H (map-inv-equiv left (map-equiv left a)))
+                  ( H a)
+                  ( ap
+                    ( map-equiv right ∘ top)
+                    ( is-retraction-map-inv-equiv left a))
+                  ( nat-htpy H (is-retraction-map-inv-equiv left a))))
+              ( coherence-square-identifications-top-paste _
+                ( ap top (is-retraction-map-inv-equiv left a))
+                ( _)
+                ( _)
+                ( ap-comp
+                  ( map-inv-equiv right)
+                  ( map-equiv right ∘ top)
+                  ( is-retraction-map-inv-equiv left a))
+                ( nat-htpy
+                  ( is-retraction-map-inv-equiv right ·r top)
+                  ( is-retraction-map-inv-equiv left a)))))) ∙
+        ( ap
+          ( _∙ ap top (is-retraction-map-inv-equiv left a))
+          ( triangle-eq-transpose-equiv-retr''
+            ( right)
+            ( H (map-inv-equiv left (map-equiv left a)))))))
 
   right-inverse-law-pasting-vertical-coherence-square-maps :
     ( H : coherence-square-maps top (map-equiv left) (map-equiv right) bottom) →

--- a/src/foundation/commuting-squares-of-maps.lagda.md
+++ b/src/foundation/commuting-squares-of-maps.lagda.md
@@ -166,16 +166,17 @@ precomp-coherence-square-maps top left right bottom H X =
 
 ## Properties
 
-### Taking inversions of squares is an inverse operation
+### Taking vertical inversions of squares is an inverse operation
 
-In other words, vertical (horizontal) composition of a square with the square
-obtained by inverting the vertical (horizontal) maps fits into a
-[prism](foundation.commuting-prisms-of-maps.md) with the reflexivity square.
+Vertical composition of a square with the square obtained by inverting the
+vertical maps fits into a [prism](foundation.commuting-prisms-of-maps.md) with
+the reflexivity square.
+
+The analogous result for horizontal composition remains to be formalized.
 
 ```agda
 module _
-  { l1 l2 l3 l4 : Level}
-  { A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
+  { l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
   ( top : A → X) (left : A ≃ B) (right : X ≃ Y) (bottom : B → Y)
   where
 
@@ -210,10 +211,10 @@ module _
         ( assoc
           ( ( map-eq-transpose-equiv
               ( right)
-              ( inv (H (map-inv-equiv left (map-equiv left a)))) ∙
+              ( inv (H (map-inv-equiv left (map-equiv left a))))) ∙
             ( ap
               ( map-inv-equiv right)
-              ( ap bottom (is-section-map-inv-equiv left (map-equiv left a))))))
+              ( ap bottom (is-section-map-inv-equiv left (map-equiv left a)))))
           ( ap (map-inv-equiv right) (H a))
           ( is-retraction-map-inv-equiv right (top a))) ∙
         ( left-whisk-square-identification
@@ -390,6 +391,19 @@ module _
 
 ### Naturality of commuting squares of maps with respect to identifications
 
+Similarly to the naturality square of homotopies and identifications, we have
+a naturality square of coherence squares of maps and identifications:
+
+```text
+           ap f (ap g p)
+  f (g x) =============== f (g y)
+     ‖                       ‖
+ H x ‖                       ‖ H y
+     ‖                       ‖
+  h (k x) =============== h (k y)
+           ap h (ap k p)           .
+```
+
 ```agda
 module _
   { l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {C : UU l3} {D : UU l4}
@@ -405,7 +419,26 @@ module _
       ( H y)
       ( ap right (ap top p))
   nat-coherence-square-maps refl = right-unit
+```
 
+As a corollary, whenever we have two coherence squares touching at a vertex:
+
+```text
+  A -----> B
+  |        |
+  |  H ⇗  |
+  V        V
+  C -----> D -----> X
+           |        |
+           |  K ⇗  |
+           V        V
+           Y -----> Z ,
+```
+
+there is a homotopy between first applying `H`, then `K`, and first applying
+`K`, then `H`.
+
+```agda
 module _
   { l1 l2 l3 l4 l5 l6 l7 : Level}
   { A : UU l1} {B : UU l2} {C : UU l3} {D : UU l4}
@@ -427,6 +460,34 @@ module _
 ```
 
 ### Commutativity of horizontal and vertical pasting
+
+Given a square of commuting squares, like so:
+
+```text
+  A -----> B -----> C
+  |        |        |
+  |   ⇗   |   ⇗   |
+  V        V        V
+  X -----> Y -----> Z
+  |        |        |
+  |   ⇗   |   ⇗   |
+  V        V        V
+  M -----> N -----> O ,
+```
+
+we have two choices for obtaining the outer commuting square --- either by first
+vertically composing the smaller squares, and then horizontally composing the
+newly created rectangles, or by first horizontally composing the squares, and
+then vertically composing the rectangles.
+
+The following lemma states that the big squares obtained by these two
+compositions are again homotopic. Diagramatically, we have
+
+```text
+ H | K   H | K
+ ----- ~ --|--
+ L | T   L | T .
+```
 
 ```agda
 module _

--- a/src/foundation/commuting-squares-of-maps.lagda.md
+++ b/src/foundation/commuting-squares-of-maps.lagda.md
@@ -477,7 +477,7 @@ Given a square of commuting squares, like so:
   M -----> N -----> O ,
 ```
 
-we have two choices for obtaining the outer commuting square --- either by first
+we have two choices for obtaining the outer commuting square — either by first
 vertically composing the smaller squares, and then horizontally composing the
 newly created rectangles, or by first horizontally composing the squares, and
 then vertically composing the rectangles.

--- a/src/foundation/commuting-squares-of-maps.lagda.md
+++ b/src/foundation/commuting-squares-of-maps.lagda.md
@@ -34,7 +34,7 @@ open import foundation-core.identity-types
 
 ### Pasting commuting triangles into commuting squares along homotopic diagonals
 
-Two commuting triangles
+Two [commuting triangles](foundation-core.commuting-triangles-of-maps.md)
 
 ```text
    A         A --> X
@@ -45,7 +45,8 @@ Two commuting triangles
   B --> Y         Y
 ```
 
-with a homotopic diagonal may be pasted into a commuting square
+with a [homotopic](foundation-core.homotopies.md) diagonal may be pasted into a
+commuting square
 
 ```text
   A -----> X
@@ -96,7 +97,8 @@ module _
 
 ### Inverting squares horizontally and vertically
 
-If the horizontal/vertical maps in a commuting square are both equivalences,
+If the horizontal/vertical maps in a commuting square are both
+[equivalences](foundation-core.equivalences.md),
 then the square remains commuting if we invert those equivalences.
 
 ```agda
@@ -393,8 +395,9 @@ module _
 
 ### Naturality of commuting squares of maps with respect to identifications
 
-Similarly to the naturality square of homotopies and identifications, we have a
-naturality square of coherence squares of maps and identifications:
+Similarly to the naturality square of homotopies and
+[identifications](foundation-core.identity-types.md), we have a naturality
+square of coherence squares of maps and identifications:
 
 ```text
            ap f (ap g p)
@@ -598,8 +601,9 @@ module _
 ### Distributivity of pasting squares and transposing by precomposition
 
 Given two commuting squares which can be composed horizontally (vertically), we
-know that composing them and then transposing them by precomposition gives the
-same homotopies as first transposing the squares and then composing them.
+know that composing them and then transposing them by precomposition gives a
+homotopy that is homotopic to first transposing the squares and then composing
+them.
 
 ```text
       tl       tr                tr ∘ tl

--- a/src/foundation/commuting-squares-of-maps.lagda.md
+++ b/src/foundation/commuting-squares-of-maps.lagda.md
@@ -106,7 +106,8 @@ coherence-square-inv-horizontal :
   coherence-square-maps (map-equiv top) left right (map-equiv bottom) →
   coherence-square-maps (map-inv-equiv top) right left (map-inv-equiv bottom)
 coherence-square-inv-horizontal top left right bottom H b =
-  map-eq-transpose-equiv' bottom
+  map-eq-transpose-equiv-inv
+    ( bottom)
     ( ( ap right (inv (is-section-map-inv-equiv top b))) ∙
       ( inv (H (map-inv-equiv top b))))
 
@@ -116,7 +117,8 @@ coherence-square-inv-vertical :
   coherence-square-maps top (map-equiv left) (map-equiv right) bottom →
   coherence-square-maps bottom (map-inv-equiv left) (map-inv-equiv right) top
 coherence-square-inv-vertical top left right bottom H x =
-  map-eq-transpose-equiv right
+  map-eq-transpose-equiv
+    ( right)
     ( ( inv (H (map-inv-equiv left x))) ∙
       ( ap bottom (is-section-map-inv-equiv left x)))
 
@@ -274,7 +276,7 @@ module _
                   ( is-retraction-map-inv-equiv left a)))))) ∙
         ( ap
           ( _∙ ap top (is-retraction-map-inv-equiv left a))
-          ( triangle-eq-transpose-equiv-retr''
+          ( right-inverse-eq-transpose-equiv
             ( right)
             ( H (map-inv-equiv left (map-equiv left a)))))))
 
@@ -391,8 +393,8 @@ module _
 
 ### Naturality of commuting squares of maps with respect to identifications
 
-Similarly to the naturality square of homotopies and identifications, we have
-a naturality square of coherence squares of maps and identifications:
+Similarly to the naturality square of homotopies and identifications, we have a
+naturality square of coherence squares of maps and identifications:
 
 ```text
            ap f (ap g p)

--- a/src/foundation/commuting-squares-of-maps.lagda.md
+++ b/src/foundation/commuting-squares-of-maps.lagda.md
@@ -12,18 +12,20 @@ open import foundation-core.commuting-squares-of-maps public
 ```agda
 open import foundation.action-on-identifications-binary-functions
 open import foundation.action-on-identifications-functions
-open import foundation.commuting-prisms-of-maps
+open import foundation.commuting-squares-of-homotopies
+open import foundation.commuting-squares-of-identifications
 open import foundation.equivalences
 open import foundation.function-extensionality
-open import foundation.homotopies
 open import foundation.path-algebra
 open import foundation.precomposition-functions
 open import foundation.universe-levels
 open import foundation.whiskering-homotopies
 
+open import foundation-core.commuting-prisms-of-maps
 open import foundation-core.commuting-triangles-of-maps
 open import foundation-core.function-types
 open import foundation-core.functoriality-function-types
+open import foundation-core.homotopies
 open import foundation-core.identity-types
 ```
 
@@ -309,6 +311,150 @@ module _
       ( sq-bottom ·r mid-left ·r top-left)
       ( bottom-right ·l (sq-mid ·r top-left))
       ( ( bottom-right ∘ mid-right) ·l sq-top))
+```
+
+### Naturality of commuting squares of maps with respect to identifications
+
+```agda
+module _
+  { l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {C : UU l3} {D : UU l4}
+  ( top : A → B) (left : A → C) (right : B → D) (bottom : C → D)
+  ( H : coherence-square-maps top left right bottom)
+  where
+
+  nat-coherence-square-maps :
+    { x y : A} (p : x ＝ y) →
+    coherence-square-identifications
+      ( ap bottom (ap left p))
+      ( H x)
+      ( H y)
+      ( ap right (ap top p))
+  nat-coherence-square-maps refl = right-unit
+
+module _
+  { l1 l2 l3 l4 l5 l6 l7 : Level}
+  { A : UU l1} {B : UU l2} {C : UU l3} {D : UU l4}
+  { X : UU l5} {Y : UU l6} {Z : UU l7}
+  ( top : A → B) (left : A → C) (mid-top : B → D) (mid-left : C → D)
+  ( mid-right : D → X) (mid-bottom : D → Y) (right : X → Z) (bottom : Y → Z)
+  ( H : coherence-square-maps top left mid-top mid-left)
+  ( K : coherence-square-maps mid-right mid-bottom right bottom)
+  where
+
+  swap-nat-coherence-square-maps :
+    coherence-square-homotopies
+      ( bottom ·l mid-bottom ·l H)
+      ( K ·r mid-left ·r left)
+      ( K ·r mid-top ·r top)
+      ( right ·l mid-right ·l H)
+  swap-nat-coherence-square-maps x =
+    nat-coherence-square-maps mid-right mid-bottom right bottom K (H x)
+```
+
+### Commutativity of horizontal and vertical pasting
+
+```agda
+module _
+  { l1 l2 l3 l4 l5 l6 l7 l8 l9 : Level}
+  { A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4} {Y : UU l5} {Z : UU l6}
+  { M : UU l7} {N : UU l8} {O : UU l9}
+  ( top-left : A → B) (top-right : B → C)
+  ( left-top : A → X) (mid-top : B → Y) (right-top : C → Z)
+  ( mid-left : X → Y) (mid-right : Y → Z)
+  ( left-bottom : X → M) (mid-bottom : Y → N) (right-bottom : Z → O)
+  ( bottom-left : M → N) (bottom-right : N → O)
+  ( sq-left-top : coherence-square-maps top-left left-top mid-top mid-left)
+  ( sq-right-top : coherence-square-maps top-right mid-top right-top mid-right)
+  ( sq-left-bottom :
+      coherence-square-maps mid-left left-bottom mid-bottom bottom-left)
+  ( sq-right-bottom :
+      coherence-square-maps mid-right mid-bottom right-bottom bottom-right)
+  where
+
+  commutative-pasting-vertical-pasting-horizontal-coherence-square-maps :
+    ( pasting-horizontal-coherence-square-maps
+      ( top-left)
+      ( top-right)
+      ( left-bottom ∘ left-top)
+      ( mid-bottom ∘ mid-top)
+      ( right-bottom ∘ right-top)
+      ( bottom-left)
+      ( bottom-right)
+      ( pasting-vertical-coherence-square-maps
+        ( top-left)
+        ( left-top)
+        ( mid-top)
+        ( mid-left)
+        ( left-bottom)
+        ( mid-bottom)
+        ( bottom-left)
+        ( sq-left-top)
+        ( sq-left-bottom))
+      ( pasting-vertical-coherence-square-maps
+        ( top-right)
+        ( mid-top)
+        ( right-top)
+        ( mid-right)
+        ( mid-bottom)
+        ( right-bottom)
+        ( bottom-right)
+        ( sq-right-top)
+        ( sq-right-bottom))) ~
+    ( pasting-vertical-coherence-square-maps
+      ( top-right ∘ top-left)
+      ( left-top)
+      ( right-top)
+      ( mid-right ∘ mid-left)
+      ( left-bottom)
+      ( right-bottom)
+      ( bottom-right ∘ bottom-left)
+      ( pasting-horizontal-coherence-square-maps
+        ( top-left)
+        ( top-right)
+        ( left-top)
+        ( mid-top)
+        ( right-top)
+        ( mid-left)
+        ( mid-right)
+        ( sq-left-top)
+        ( sq-right-top))
+      ( pasting-horizontal-coherence-square-maps
+        ( mid-left)
+        ( mid-right)
+        ( left-bottom)
+        ( mid-bottom)
+        ( right-bottom)
+        ( bottom-left)
+        ( bottom-right)
+        ( sq-left-bottom)
+        ( sq-right-bottom)))
+  commutative-pasting-vertical-pasting-horizontal-coherence-square-maps =
+    ( ap-concat-htpy' _
+      ( distributive-left-whisk-concat-htpy
+        ( bottom-right)
+        ( sq-left-bottom ·r left-top)
+        ( mid-bottom ·l sq-left-top)) ∙h
+      ( both-whisk-square-htpy
+        ( bottom-right ·l (sq-left-bottom ·r left-top))
+        ( right-bottom ·l (sq-right-top ·r top-left))
+        ( inv-htpy
+          ( swap-nat-coherence-square-maps
+            ( top-left)
+            ( left-top)
+            ( mid-top)
+            ( mid-left)
+            ( mid-right)
+            ( mid-bottom)
+            ( right-bottom)
+            ( bottom-right)
+            ( sq-left-top)
+            ( sq-right-bottom))))) ∙h
+      ( ap-concat-htpy _
+        ( inv-htpy
+          ( distributive-left-whisk-concat-htpy
+            ( right-bottom)
+            ( mid-right ·l sq-left-top)
+            ( sq-right-top ·r top-left))))
 ```
 
 ### Distributivity of pasting squares and transposing by precomposition

--- a/src/foundation/commuting-squares-of-maps.lagda.md
+++ b/src/foundation/commuting-squares-of-maps.lagda.md
@@ -98,8 +98,8 @@ module _
 ### Inverting squares horizontally and vertically
 
 If the horizontal/vertical maps in a commuting square are both
-[equivalences](foundation-core.equivalences.md),
-then the square remains commuting if we invert those equivalences.
+[equivalences](foundation-core.equivalences.md), then the square remains
+commuting if we invert those equivalences.
 
 ```agda
 coherence-square-inv-horizontal :

--- a/src/foundation/commuting-squares-of-maps.lagda.md
+++ b/src/foundation/commuting-squares-of-maps.lagda.md
@@ -183,19 +183,19 @@ module _
     ( H : coherence-square-maps top (map-equiv left) (map-equiv right) bottom) →
     horizontal-coherence-prism-maps
       ( top)
-      ( id)
       ( map-equiv left)
-      ( id)
       ( map-equiv right)
       ( bottom)
       ( map-inv-equiv left)
       ( map-inv-equiv right)
       ( top)
-      ( H)
+      ( id)
+      ( id)
       ( is-retraction-map-inv-equiv left)
-      ( is-retraction-map-inv-equiv right)
-      ( refl-htpy)
+      ( H)
       ( coherence-square-inv-vertical top left right bottom H)
+      ( refl-htpy)
+      ( is-retraction-map-inv-equiv right)
   left-inverse-law-pasting-vertical-coherence-square-maps H a =
     ( right-unit) ∙
     ( inv
@@ -281,19 +281,19 @@ module _
     ( H : coherence-square-maps top (map-equiv left) (map-equiv right) bottom) →
     horizontal-coherence-prism-maps
       ( bottom)
-      ( id)
       ( map-inv-equiv left)
-      ( id)
       ( map-inv-equiv right)
       ( top)
       ( map-equiv left)
       ( map-equiv right)
       ( bottom)
-      ( coherence-square-inv-vertical top left right bottom H)
+      ( id)
+      ( id)
       ( is-section-map-inv-equiv left)
-      ( is-section-map-inv-equiv right)
-      ( refl-htpy)
+      ( coherence-square-inv-vertical top left right bottom H)
       ( H)
+      ( refl-htpy)
+      ( is-section-map-inv-equiv right)
   right-inverse-law-pasting-vertical-coherence-square-maps H a =
     ( right-unit) ∙
     ( inv

--- a/src/foundation/commuting-squares-of-maps.lagda.md
+++ b/src/foundation/commuting-squares-of-maps.lagda.md
@@ -428,11 +428,11 @@ As a corollary, whenever we have two coherence squares touching at a vertex:
 ```text
   A -----> B
   |        |
-  |  H ⇗  |
+  |   H ⇗  |
   V        V
   C -----> D -----> X
            |        |
-           |  K ⇗  |
+           |   K ⇗  |
            V        V
            Y -----> Z ,
 ```
@@ -468,11 +468,11 @@ Given a square of commuting squares, like so:
 ```text
   A -----> B -----> C
   |        |        |
-  |   ⇗   |   ⇗   |
+  |    ⇗   |    ⇗   |
   V        V        V
   X -----> Y -----> Z
   |        |        |
-  |   ⇗   |   ⇗   |
+  |    ⇗   |    ⇗   |
   V        V        V
   M -----> N -----> O ,
 ```

--- a/src/foundation/commuting-squares-of-maps.lagda.md
+++ b/src/foundation/commuting-squares-of-maps.lagda.md
@@ -298,17 +298,12 @@ module _
   assoc-pasting-vertical-coherence-square-maps =
     ( ap-concat-htpy
       ( sq-bottom ·r mid-left ·r top-left)
-      ( bottom-right ·l (sq-mid ·r top-left ∙h (mid-right ·l sq-top)))
-      ( ( bottom-right ·l (sq-mid ·r top-left)) ∙h
-        ( ( bottom-right ∘ mid-right) ·l sq-top))
       ( ( distributive-left-whisk-concat-htpy
           ( bottom-right)
           ( sq-mid ·r top-left)
           ( mid-right ·l sq-top)) ∙h
         ( ap-concat-htpy
           ( bottom-right ·l (sq-mid ·r top-left))
-          ( bottom-right ·l mid-right ·l sq-top)
-          ( ( bottom-right ∘ mid-right) ·l sq-top)
           ( associative-left-whisk-comp bottom-right mid-right sq-top)))) ∙h
     ( inv-htpy-assoc-htpy
       ( sq-bottom ·r mid-left ·r top-left)

--- a/src/foundation/equivalences.lagda.md
+++ b/src/foundation/equivalences.lagda.md
@@ -66,7 +66,7 @@ embeddings.
 
 We have two ways of showing that an application of an equivalence may be
 transposed to the other side of a path, i.e. that the type `e x ＝ y` is
-equivalent to the type `x ＝ e⁻¹ y` --- one uses the fact that `e⁻¹` is a
+equivalent to the type `x ＝ e⁻¹ y` — one uses the fact that `e⁻¹` is a
 section of `e`, from which it follows that
 
 ```text

--- a/src/foundation/equivalences.lagda.md
+++ b/src/foundation/equivalences.lagda.md
@@ -64,6 +64,24 @@ The fact that equivalences are embeddings has many important consequences, we
 will use some of these consequences in order to derive basic properties of
 embeddings.
 
+We have two ways of showing that an application of an equivalence may be
+transposed to the other side of a path, i.e. that the type `e x ＝ y` is
+equivalent to the type `x ＝ e⁻¹ y` --- one uses the fact that `e⁻¹` is a
+section of `e`, from which it follows that
+
+```text
+ (e x ＝ y) ≃ (e x ＝ e e⁻¹ y) ≃ (x ＝ e⁻¹ y) ,
+```
+
+and the other using the fact that `e⁻¹` is a retraction of `e`, resulting in the
+equivalence
+
+```text
+ ( e x ＝ y) ≃ ( e⁻¹ e x ＝ e⁻¹ y) ≃ (x ＝ e⁻¹ y) .
+```
+
+These two equivalences are homotopic, as is shown below.
+
 ```agda
 module _
   {l1 l2 : Level} {A : UU l1} {B : UU l2} (e : A ≃ B)
@@ -77,14 +95,6 @@ module _
       ( map-equiv e x)
       ( inv (is-section-map-inv-equiv e y)))
 
-  eq-transpose-equiv' :
-    (x : A) (y : B) → (map-equiv e x ＝ y) ≃ (x ＝ map-inv-equiv e y)
-  eq-transpose-equiv' x y =
-    ( equiv-concat
-      ( inv (is-retraction-map-inv-equiv e x))
-      ( map-inv-equiv e y)) ∘e
-    ( equiv-ap (inv-equiv e) (map-equiv e x) y)
-
   map-eq-transpose-equiv :
     {x : A} {y : B} → map-equiv e x ＝ y → x ＝ map-inv-equiv e y
   map-eq-transpose-equiv {x} {y} = map-equiv (eq-transpose-equiv x y)
@@ -93,9 +103,77 @@ module _
     {x : A} {y : B} → x ＝ map-inv-equiv e y → map-equiv e x ＝ y
   inv-map-eq-transpose-equiv {x} {y} = map-inv-equiv (eq-transpose-equiv x y)
 
+  eq-transpose-equiv' :
+    (x : A) (y : B) → (map-equiv e x ＝ y) ≃ (x ＝ map-inv-equiv e y)
+  eq-transpose-equiv' x y =
+    ( equiv-concat
+      ( inv (is-retraction-map-inv-equiv e x))
+      ( map-inv-equiv e y)) ∘e
+    ( equiv-ap (inv-equiv e) (map-equiv e x) y)
+
+  map-eq-transpose-equiv' :
+    {x : A} {y : B} → map-equiv e x ＝ y → x ＝ map-inv-equiv e y
+  map-eq-transpose-equiv' {x} {y} = map-equiv (eq-transpose-equiv' x y)
+```
+
+It is sometimes useful to consider paths `y ＝ e x` instead of `e x ＝ y`, so we
+include an inverted equivalence for that as well.
+
+```agda
+  eq-transpose-equiv-inv :
+    (x : A) (y : B) → (y ＝ map-equiv e x) ≃ (map-inv-equiv e y ＝ x)
+  eq-transpose-equiv-inv x y =
+    ( equiv-inv x (map-inv-equiv e y)) ∘e
+    ( eq-transpose-equiv x y) ∘e
+    ( equiv-inv y (map-equiv e x))
+
+  map-eq-transpose-equiv-inv :
+    {a : A} {b : B} → b ＝ map-equiv e a → map-inv-equiv e b ＝ a
+  map-eq-transpose-equiv-inv {a} {b} = map-equiv (eq-transpose-equiv-inv a b)
+
+  inv-map-eq-transpose-equiv-inv :
+    {a : A} {b : B} → map-inv-equiv e b ＝ a → b ＝ map-equiv e a
+  inv-map-eq-transpose-equiv-inv {a} {b} =
+    map-inv-equiv (eq-transpose-equiv-inv a b)
+```
+
+#### Computation rules for transposing equivalences
+
+We begin by showing that the two equivalences stated above are homotopic.
+
+```agda
+module _
+  {l1 l2 : Level} {A : UU l1} {B : UU l2} (e : A ≃ B)
+  where
+
+  htpy-map-eq-transpose-equiv :
+    {x : A} {y : B} →
+    map-eq-transpose-equiv e {x} {y} ~ map-eq-transpose-equiv' e
+  htpy-map-eq-transpose-equiv {x} refl =
+    ( map-eq-transpose-equiv-inv
+      ( equiv-ap e x _)
+      ( ( ap inv (coherence-map-inv-equiv e x)) ∙
+        ( inv (ap-inv (map-equiv e) (is-retraction-map-inv-equiv e x))))) ∙
+    ( inv right-unit)
+```
+
+Transposing a composition of paths fits into a triangle with a transpose of the
+left factor.
+
+```agda
+  triangle-eq-transpose-equiv-concat :
+    {x : A} {y z : B} (p : map-equiv e x ＝ y) (q : y ＝ z) →
+    ( map-eq-transpose-equiv e (p ∙ q)) ＝
+    ( map-eq-transpose-equiv e p ∙ ap (map-inv-equiv e) q)
+  triangle-eq-transpose-equiv-concat refl refl = inv right-unit
+```
+
+Transposed paths fit in commuting triangles with the original paths.
+
+```agda
   triangle-eq-transpose-equiv :
     {x : A} {y : B} (p : map-equiv e x ＝ y) →
-    ( ( ap (map-equiv e) (map-eq-transpose-equiv p)) ∙
+    ( ( ap (map-equiv e) (map-eq-transpose-equiv e p)) ∙
       ( is-section-map-inv-equiv e y)) ＝
     ( p)
   triangle-eq-transpose-equiv {x} {y} p =
@@ -111,35 +189,20 @@ module _
       ( ( ap (concat p y) (left-inv (is-section-map-inv-equiv e y))) ∙
         ( right-unit)))
 
-  triangle-eq-transpose-equiv-concat :
-    {x : A} {y z : B} (p : map-equiv e x ＝ y) (q : y ＝ z) →
-    ( map-eq-transpose-equiv (p ∙ q)) ＝
-    ( map-eq-transpose-equiv p ∙ ap (map-inv-equiv e) q)
-  triangle-eq-transpose-equiv-concat refl refl = inv right-unit
-
-  map-eq-transpose-equiv' :
-    {a : A} {b : B} → b ＝ map-equiv e a → map-inv-equiv e b ＝ a
-  map-eq-transpose-equiv' p = inv (map-eq-transpose-equiv (inv p))
-
-  inv-map-eq-transpose-equiv' :
-    {a : A} {b : B} → map-inv-equiv e b ＝ a → b ＝ map-equiv e a
-  inv-map-eq-transpose-equiv' p =
-    inv (inv-map-eq-transpose-equiv (inv p))
-
-  triangle-eq-transpose-equiv' :
+  triangle-eq-transpose-equiv-inv :
     {x : A} {y : B} (p : y ＝ map-equiv e x) →
     ( (is-section-map-inv-equiv e y) ∙ p) ＝
-    ( ap (map-equiv e) (map-eq-transpose-equiv' p))
-  triangle-eq-transpose-equiv' {x} {y} p =
+    ( ap (map-equiv e) (map-eq-transpose-equiv-inv e p))
+  triangle-eq-transpose-equiv-inv {x} {y} p =
     map-inv-equiv
       ( equiv-ap
         ( equiv-inv (map-equiv e (map-inv-equiv e y)) (map-equiv e x))
         ( (is-section-map-inv-equiv e y) ∙ p)
-        ( ap (map-equiv e) (map-eq-transpose-equiv' p)))
+        ( ap (map-equiv e) (map-eq-transpose-equiv-inv e p)))
       ( ( distributive-inv-concat (is-section-map-inv-equiv e y) p) ∙
         ( ( inv
             ( right-transpose-eq-concat
-              ( ap (map-equiv e) (inv (map-eq-transpose-equiv' p)))
+              ( ap (map-equiv e) (inv (map-eq-transpose-equiv-inv e p)))
               ( is-section-map-inv-equiv e y)
               ( inv p)
               ( ( ap
@@ -152,58 +215,43 @@ module _
                         ( ( inv p) ∙
                           ( inv (is-section-map-inv-equiv e y))))))) ∙
                 ( triangle-eq-transpose-equiv (inv p))))) ∙
-          ( ap-inv (map-equiv e) (map-eq-transpose-equiv' p))))
+          ( ap-inv (map-equiv e) (map-eq-transpose-equiv-inv e p))))
 
-module _
-  {l1 l2 : Level} {A : UU l1} {B : UU l2} (e : A ≃ B)
-  where
-
-  htpy-map-eq-transpose-equiv :
-    {x : A} {y : B} →
-    map-eq-transpose-equiv e ~ map-equiv (eq-transpose-equiv' e x y)
-  htpy-map-eq-transpose-equiv {x} refl =
-    ( map-eq-transpose-equiv'
-      ( equiv-ap e x _)
-      ( ( ap inv (coherence-map-inv-equiv e x)) ∙
-        ( inv (ap-inv (map-equiv e) (is-retraction-map-inv-equiv e x))))) ∙
-    ( inv right-unit)
-
-  triangle-eq-transpose-equiv-retr :
+  triangle-eq-transpose-equiv' :
     {x : A} {y : B} (p : map-equiv e x ＝ y) →
     ( is-retraction-map-inv-equiv e x ∙ map-eq-transpose-equiv e p) ＝
     ( ap (map-inv-equiv e) p)
-  triangle-eq-transpose-equiv-retr {x} refl =
+  triangle-eq-transpose-equiv' {x} refl =
     ( ap
       ( is-retraction-map-inv-equiv e x ∙_)
       ( htpy-map-eq-transpose-equiv refl)) ∙
     ( is-retraction-left-concat-inv (is-retraction-map-inv-equiv e x) refl)
 
-  triangle-eq-transpose-equiv-retr' :
+  triangle-eq-transpose-equiv-inv' :
     {x : A} {y : B} (p : y ＝ map-equiv e x) →
-    ( map-eq-transpose-equiv' e p ∙ inv (is-retraction-map-inv-equiv e x)) ＝
-    ( ap (map-inv-equiv e) p)
-  triangle-eq-transpose-equiv-retr' {x} refl =
-    ( inv
-      ( distributive-inv-concat
+    ( map-eq-transpose-equiv-inv e p) ＝
+    ( ap (map-inv-equiv e) p ∙ is-retraction-map-inv-equiv e x)
+  triangle-eq-transpose-equiv-inv' {x} refl =
+    inv
+      ( right-transpose-eq-concat
         ( is-retraction-map-inv-equiv e x)
-        ( map-eq-transpose-equiv e refl))) ∙
-    ( ap inv (triangle-eq-transpose-equiv-retr refl))
+        ( map-eq-transpose-equiv e refl)
+        ( refl)
+        ( triangle-eq-transpose-equiv' refl))
 
-  triangle-eq-transpose-equiv-retr'' :
+  right-inverse-eq-transpose-equiv :
     {x : A} {y : B} (p : y ＝ map-equiv e x) →
     ( ( map-eq-transpose-equiv e (inv p)) ∙
       ( ap (map-inv-equiv e) p ∙ is-retraction-map-inv-equiv e x)) ＝
-    refl
-  triangle-eq-transpose-equiv-retr'' {x} p =
-    ap
-      ( map-eq-transpose-equiv e (inv p) ∙_)
-      ( ap
-        ( _∙ is-retraction-map-inv-equiv e x)
-        ( inv (triangle-eq-transpose-equiv-retr' p)) ∙
-        is-section-right-concat-inv
-          ( map-eq-transpose-equiv' e p)
-          ( is-retraction-map-inv-equiv e x)) ∙
-    ( right-inv (map-eq-transpose-equiv e (inv p)))
+    ( refl)
+  right-inverse-eq-transpose-equiv {x} p =
+    inv
+      ( map-inv-equiv
+        ( equiv-left-transpose-eq-concat'
+          ( refl)
+          ( map-eq-transpose-equiv e (inv p))
+          ( ap (map-inv-equiv e) p ∙ is-retraction-map-inv-equiv e x))
+        ( right-unit ∙ triangle-eq-transpose-equiv-inv' p))
 ```
 
 ### Equivalences have a contractible type of sections
@@ -617,7 +665,7 @@ module _
   distributive-inv-comp-equiv e f =
     eq-htpy-equiv
       ( λ x →
-        map-eq-transpose-equiv'
+        map-eq-transpose-equiv-inv
           ( f ∘e e)
           ( ( ap (λ g → map-equiv g x) (inv (right-inverse-law-equiv f))) ∙
             ( ap

--- a/src/foundation/equivalences.lagda.md
+++ b/src/foundation/equivalences.lagda.md
@@ -60,10 +60,6 @@ module _
 
 ### Transposing equalities along equivalences
 
-The fact that equivalences are embeddings has many important consequences, we
-will use some of these consequences in order to derive basic properties of
-equivalences.
-
 We have two ways of showing that an application of an equivalence may be
 transposed to the other side of an
 [identification](foundation-core.identity-types.md), i.e. that the type

--- a/src/foundation/equivalences.lagda.md
+++ b/src/foundation/equivalences.lagda.md
@@ -62,25 +62,28 @@ module _
 
 The fact that equivalences are embeddings has many important consequences, we
 will use some of these consequences in order to derive basic properties of
-embeddings.
+equivalences.
 
 We have two ways of showing that an application of an equivalence may be
-transposed to the other side of a path, i.e. that the type `e x ＝ y` is
-equivalent to the type `x ＝ e⁻¹ y` — one uses the fact that `e⁻¹` is a
-section of `e`, from which it follows that
+transposed to the other side of an
+[identification](foundation-core.identity-types.md), i.e. that the type
+`e x ＝ y` is equivalent to the type `x ＝ e⁻¹ y` — one uses the fact that `e⁻¹`
+is a [section](foundation-core.sections.md) of `e`, from which it follows that
 
 ```text
  (e x ＝ y) ≃ (e x ＝ e e⁻¹ y) ≃ (x ＝ e⁻¹ y) ,
 ```
 
-and the other using the fact that `e⁻¹` is a retraction of `e`, resulting in the
+and the other using the fact that `e⁻¹` is a
+[retraction](foundation-core.retractions.md) of `e`, resulting in the
 equivalence
 
 ```text
- ( e x ＝ y) ≃ ( e⁻¹ e x ＝ e⁻¹ y) ≃ (x ＝ e⁻¹ y) .
+ (e x ＝ y) ≃ (e⁻¹ e x ＝ e⁻¹ y) ≃ (x ＝ e⁻¹ y) .
 ```
 
-These two equivalences are homotopic, as is shown below.
+These two equivalences are [homotopic](foundation-core.homotopies.md), as is
+shown below.
 
 ```agda
 module _
@@ -116,8 +119,8 @@ module _
   map-eq-transpose-equiv' {x} {y} = map-equiv (eq-transpose-equiv' x y)
 ```
 
-It is sometimes useful to consider paths `y ＝ e x` instead of `e x ＝ y`, so we
-include an inverted equivalence for that as well.
+It is sometimes useful to consider identifications `y ＝ e x` instead of
+`e x ＝ y`, so we include an inverted equivalence for that as well.
 
 ```agda
   eq-transpose-equiv-inv :
@@ -168,7 +171,9 @@ left factor.
   triangle-eq-transpose-equiv-concat refl refl = inv right-unit
 ```
 
-Transposed paths fit in commuting triangles with the original paths.
+Transposed identifications fit in
+[commuting triangles](foundation.commuting-triangles-of-identifications.md) with
+the original identifications.
 
 ```agda
   triangle-eq-transpose-equiv :

--- a/src/foundation/equivalences.lagda.md
+++ b/src/foundation/equivalences.lagda.md
@@ -16,6 +16,7 @@ open import foundation.equivalence-extensionality
 open import foundation.function-extensionality
 open import foundation.functoriality-fibers-of-maps
 open import foundation.identity-types
+open import foundation.path-algebra
 open import foundation.truncated-maps
 open import foundation.universal-property-equivalences
 open import foundation.universe-levels
@@ -76,6 +77,14 @@ module _
       ( map-equiv e x)
       ( inv (is-section-map-inv-equiv e y)))
 
+  eq-transpose-equiv' :
+    (x : A) (y : B) → (map-equiv e x ＝ y) ≃ (x ＝ map-inv-equiv e y)
+  eq-transpose-equiv' x y =
+    ( equiv-concat
+      ( inv (is-retraction-map-inv-equiv e x))
+      ( map-inv-equiv e y)) ∘e
+    ( equiv-ap (inv-equiv e) (map-equiv e x) y)
+
   map-eq-transpose-equiv :
     {x : A} {y : B} → map-equiv e x ＝ y → x ＝ map-inv-equiv e y
   map-eq-transpose-equiv {x} {y} = map-equiv (eq-transpose-equiv x y)
@@ -101,6 +110,12 @@ module _
         ( is-section-map-inv-equiv e y)) ∙
       ( ( ap (concat p y) (left-inv (is-section-map-inv-equiv e y))) ∙
         ( right-unit)))
+
+  triangle-eq-transpose-equiv-concat :
+    {x : A} {y z : B} (p : map-equiv e x ＝ y) (q : y ＝ z) →
+    ( map-eq-transpose-equiv (p ∙ q)) ＝
+    ( map-eq-transpose-equiv p ∙ ap (map-inv-equiv e) q)
+  triangle-eq-transpose-equiv-concat refl refl = inv right-unit
 
   map-eq-transpose-equiv' :
     {a : A} {b : B} → b ＝ map-equiv e a → map-inv-equiv e b ＝ a
@@ -138,6 +153,57 @@ module _
                           ( inv (is-section-map-inv-equiv e y))))))) ∙
                 ( triangle-eq-transpose-equiv (inv p))))) ∙
           ( ap-inv (map-equiv e) (map-eq-transpose-equiv' p))))
+
+module _
+  {l1 l2 : Level} {A : UU l1} {B : UU l2} (e : A ≃ B)
+  where
+
+  htpy-map-eq-transpose-equiv :
+    {x : A} {y : B} →
+    map-eq-transpose-equiv e ~ map-equiv (eq-transpose-equiv' e x y)
+  htpy-map-eq-transpose-equiv {x} refl =
+    ( map-eq-transpose-equiv'
+      ( equiv-ap e x _)
+      ( ( ap inv (coherence-map-inv-equiv e x)) ∙
+        ( inv (ap-inv (map-equiv e) (is-retraction-map-inv-equiv e x))))) ∙
+    ( inv right-unit)
+
+  triangle-eq-transpose-equiv-retr :
+    {x : A} {y : B} (p : map-equiv e x ＝ y) →
+    ( is-retraction-map-inv-equiv e x ∙ map-eq-transpose-equiv e p) ＝
+    ( ap (map-inv-equiv e) p)
+  triangle-eq-transpose-equiv-retr {x} refl =
+    ( ap
+      ( is-retraction-map-inv-equiv e x ∙_)
+      ( htpy-map-eq-transpose-equiv refl)) ∙
+    ( is-retraction-left-concat-inv (is-retraction-map-inv-equiv e x) refl)
+
+  triangle-eq-transpose-equiv-retr' :
+    {x : A} {y : B} (p : y ＝ map-equiv e x) →
+    ( map-eq-transpose-equiv' e p ∙ inv (is-retraction-map-inv-equiv e x)) ＝
+    ( ap (map-inv-equiv e) p)
+  triangle-eq-transpose-equiv-retr' {x} refl =
+    ( inv
+      ( distributive-inv-concat
+        ( is-retraction-map-inv-equiv e x)
+        ( map-eq-transpose-equiv e refl))) ∙
+    ( ap inv (triangle-eq-transpose-equiv-retr refl))
+
+  triangle-eq-transpose-equiv-retr'' :
+    {x : A} {y : B} (p : y ＝ map-equiv e x) →
+    ( ( map-eq-transpose-equiv e (inv p)) ∙
+      ( ap (map-inv-equiv e) p ∙ is-retraction-map-inv-equiv e x)) ＝
+    refl
+  triangle-eq-transpose-equiv-retr'' {x} p =
+    ap
+      ( map-eq-transpose-equiv e (inv p) ∙_)
+      ( ap
+        ( _∙ is-retraction-map-inv-equiv e x)
+        ( inv (triangle-eq-transpose-equiv-retr' p)) ∙
+        is-section-right-concat-inv
+          ( map-eq-transpose-equiv' e p)
+          ( is-retraction-map-inv-equiv e x)) ∙
+    ( right-inv (map-eq-transpose-equiv e (inv p)))
 ```
 
 ### Equivalences have a contractible type of sections

--- a/src/foundation/identity-types.lagda.md
+++ b/src/foundation/identity-types.lagda.md
@@ -239,6 +239,12 @@ module _
   equiv-left-transpose-eq-concat' p q r =
     equiv-inv _ _ ∘e equiv-left-transpose-eq-concat q r p ∘e equiv-inv _ _
 
+  left-transpose-eq-concat' :
+    (p : x ＝ z) (q : x ＝ y) (r : y ＝ z) →
+    (p ＝ q ∙ r) → (inv q ∙ p ＝ r)
+  left-transpose-eq-concat' p q r =
+    map-equiv (equiv-left-transpose-eq-concat' p q r)
+
   abstract
     is-equiv-right-transpose-eq-concat :
       (p : x ＝ y) (q : y ＝ z) (r : x ＝ z) →
@@ -262,6 +268,12 @@ module _
     (p ＝ q ∙ r) ≃ (p ∙ inv r ＝ q)
   equiv-right-transpose-eq-concat' p q r =
     equiv-inv _ _ ∘e equiv-right-transpose-eq-concat q r p ∘e equiv-inv _ _
+
+  right-transpose-eq-concat' :
+    (p : x ＝ z) (q : x ＝ y) (r : y ＝ z) →
+    (p ＝ q ∙ r) → (p ∙ inv r ＝ q)
+  right-transpose-eq-concat' p q r =
+    map-equiv (equiv-right-transpose-eq-concat' p q r)
 ```
 
 ### Computation of fibers of families of maps out of the identity type

--- a/src/foundation/identity-types.lagda.md
+++ b/src/foundation/identity-types.lagda.md
@@ -233,6 +233,12 @@ module _
   pr2 (equiv-left-transpose-eq-concat p q r) =
     is-equiv-left-transpose-eq-concat p q r
 
+  equiv-left-transpose-eq-concat' :
+    (p : x ＝ z) (q : x ＝ y) (r : y ＝ z) →
+    (p ＝ q ∙ r) ≃ (inv q ∙ p ＝ r)
+  equiv-left-transpose-eq-concat' p q r =
+    equiv-inv _ _ ∘e equiv-left-transpose-eq-concat q r p ∘e equiv-inv _ _
+
   abstract
     is-equiv-right-transpose-eq-concat :
       (p : x ＝ y) (q : y ＝ z) (r : x ＝ z) →
@@ -250,6 +256,12 @@ module _
   pr1 (equiv-right-transpose-eq-concat p q r) = right-transpose-eq-concat p q r
   pr2 (equiv-right-transpose-eq-concat p q r) =
     is-equiv-right-transpose-eq-concat p q r
+
+  equiv-right-transpose-eq-concat' :
+    (p : x ＝ z) (q : x ＝ y) (r : y ＝ z) →
+    (p ＝ q ∙ r) ≃ (p ∙ inv r ＝ q)
+  equiv-right-transpose-eq-concat' p q r =
+    equiv-inv _ _ ∘e equiv-right-transpose-eq-concat q r p ∘e equiv-inv _ _
 ```
 
 ### Computation of fibers of families of maps out of the identity type

--- a/src/foundation/path-algebra.lagda.md
+++ b/src/foundation/path-algebra.lagda.md
@@ -294,14 +294,12 @@ module _
   equiv-concat-assoc :
     (p : x ＝ y) (q : y ＝ z) (r : z ＝ u) (s : x ＝ u) →
     ((p ∙ q) ∙ r ＝ s) ≃ (p ∙ (q ∙ r) ＝ s)
-  pr1 (equiv-concat-assoc p q r s) = concat (inv (assoc p q r)) s
-  pr2 (equiv-concat-assoc p q r s) = is-equiv-concat (inv (assoc p q r)) s
+  equiv-concat-assoc p q r = equiv-concat (inv (assoc p q r))
 
   equiv-concat-assoc' :
     (s : x ＝ u) (p : x ＝ y) (q : y ＝ z) (r : z ＝ u) →
     (s ＝ (p ∙ q) ∙ r) ≃ (s ＝ p ∙ (q ∙ r))
-  pr1 (equiv-concat-assoc' s p q r) = concat' s (assoc p q r)
-  pr2 (equiv-concat-assoc' s p q r) = is-equiv-concat' s (assoc p q r)
+  equiv-concat-assoc' s p q r = equiv-concat' s (assoc p q r)
 ```
 
 ### Whiskering of squares of identifications

--- a/src/foundation/path-algebra.lagda.md
+++ b/src/foundation/path-algebra.lagda.md
@@ -12,10 +12,12 @@ open import foundation.action-on-identifications-functions
 open import foundation.binary-embeddings
 open import foundation.binary-equivalences
 open import foundation.commuting-squares-of-identifications
+open import foundation.dependent-pair-types
 open import foundation.identity-types
 open import foundation.universe-levels
 
 open import foundation-core.constant-maps
+open import foundation-core.equivalences
 open import foundation-core.function-types
 open import foundation-core.homotopies
 ```
@@ -247,6 +249,85 @@ module _
   htpy-identification-left-whisk :
     {q q' : y ＝ z} → q ＝ q' → (_∙ q) ~ (_∙ q')
   htpy-identification-left-whisk β p = identification-left-whisk p β
+```
+
+### Whiskerings of identifications are equivalences
+
+```agda
+module _
+  {l : Level} {A : UU l} {x y z : A}
+  where
+
+  is-equiv-identification-left-whisk :
+    (p : x ＝ y) {q q' : y ＝ z} →
+    is-equiv (identification-left-whisk p {q} {q'})
+  is-equiv-identification-left-whisk p {q} {q'} =
+    is-emb-is-equiv (is-equiv-concat p z) q q'
+
+  equiv-identification-left-whisk :
+    (p : x ＝ y) {q q' : y ＝ z} →
+    (q ＝ q') ≃ (p ∙ q ＝ p ∙ q')
+  pr1 (equiv-identification-left-whisk p) = identification-left-whisk p
+  pr2 (equiv-identification-left-whisk p) = is-equiv-identification-left-whisk p
+
+  is-equiv-identification-right-whisk :
+    {p p' : x ＝ y} → (q : y ＝ z) →
+    is-equiv (λ (α : p ＝ p') → identification-right-whisk α q)
+  is-equiv-identification-right-whisk {p} {p'} q =
+    is-emb-is-equiv (is-equiv-concat' x q) p p'
+
+  equiv-identification-right-whisk :
+    {p p' : x ＝ y} → (q : y ＝ z) →
+    (p ＝ p') ≃ (p ∙ q ＝ p' ∙ q)
+  pr1 (equiv-identification-right-whisk q) α = identification-right-whisk α q
+  pr2 (equiv-identification-right-whisk q) =
+    is-equiv-identification-right-whisk q
+```
+
+### Reassociating one side of a higher identification is an equivalence
+
+```agda
+module _
+  {l : Level} {A : UU l} {x y z u : A}
+  where
+
+  equiv-concat-assoc :
+    (p : x ＝ y) (q : y ＝ z) (r : z ＝ u) (s : x ＝ u) →
+    ((p ∙ q) ∙ r ＝ s) ≃ (p ∙ (q ∙ r) ＝ s)
+  pr1 (equiv-concat-assoc p q r s) = concat (inv (assoc p q r)) s
+  pr2 (equiv-concat-assoc p q r s) = is-equiv-concat (inv (assoc p q r)) s
+
+  equiv-concat-assoc' :
+    (s : x ＝ u) (p : x ＝ y) (q : y ＝ z) (r : z ＝ u) →
+    (s ＝ (p ∙ q) ∙ r) ≃ (s ＝ p ∙ (q ∙ r))
+  pr1 (equiv-concat-assoc' s p q r) = concat' s (assoc p q r)
+  pr2 (equiv-concat-assoc' s p q r) = is-equiv-concat' s (assoc p q r)
+```
+
+### Whiskering of squares of identifications
+
+```agda
+module _
+  {l : Level} {A : UU l} {x y z u w : A}
+  where
+
+  equiv-right-whisk-square-identification :
+    (p : x ＝ y) (p' : x ＝ z) {q : y ＝ u} {q' : z ＝ u} (r : u ＝ w) →
+    ( coherence-square-identifications p p' q q') ≃
+    ( coherence-square-identifications p p' (q ∙ r) (q' ∙ r))
+  equiv-right-whisk-square-identification p p' {q} {q'} r =
+    ( equiv-concat-assoc' (p' ∙ (q' ∙ r)) p q r) ∘e
+    ( equiv-concat-assoc p' q' r (p ∙ q ∙ r)) ∘e
+    ( equiv-identification-right-whisk r)
+
+  equiv-left-whisk-square-identification :
+    (p : w ＝ x) {q : x ＝ y} {q' : x ＝ z} {r : y ＝ u} {r' : z ＝ u} →
+    ( coherence-square-identifications q q' r r') ≃
+    ( coherence-square-identifications (p ∙ q) (p ∙ q') r r')
+  equiv-left-whisk-square-identification p {q} {q'} {r} {r'} =
+    ( inv-equiv (equiv-concat-assoc p q' r' (p ∙ q ∙ r))) ∘e
+    ( inv-equiv (equiv-concat-assoc' (p ∙ (q' ∙ r')) p q r)) ∘e
+    ( equiv-identification-left-whisk p)
 ```
 
 ### Both horizontal and vertical concatenation of 2-paths are binary equivalences

--- a/src/foundation/path-algebra.lagda.md
+++ b/src/foundation/path-algebra.lagda.md
@@ -308,11 +308,11 @@ module _
 
 ```agda
 module _
-  {l : Level} {A : UU l} {x y z u w : A}
+  {l : Level} {A : UU l} {x y z u v : A}
   where
 
   equiv-right-whisk-square-identification :
-    (p : x ＝ y) (p' : x ＝ z) {q : y ＝ u} {q' : z ＝ u} (r : u ＝ w) →
+    (p : x ＝ y) (p' : x ＝ z) {q : y ＝ u} {q' : z ＝ u} (r : u ＝ v) →
     ( coherence-square-identifications p p' q q') ≃
     ( coherence-square-identifications p p' (q ∙ r) (q' ∙ r))
   equiv-right-whisk-square-identification p p' {q} {q'} r =
@@ -321,13 +321,26 @@ module _
     ( equiv-identification-right-whisk r)
 
   equiv-left-whisk-square-identification :
-    (p : w ＝ x) {q : x ＝ y} {q' : x ＝ z} {r : y ＝ u} {r' : z ＝ u} →
+    (p : v ＝ x) {q : x ＝ y} {q' : x ＝ z} {r : y ＝ u} {r' : z ＝ u} →
     ( coherence-square-identifications q q' r r') ≃
     ( coherence-square-identifications (p ∙ q) (p ∙ q') r r')
   equiv-left-whisk-square-identification p {q} {q'} {r} {r'} =
     ( inv-equiv (equiv-concat-assoc p q' r' (p ∙ q ∙ r))) ∘e
     ( inv-equiv (equiv-concat-assoc' (p ∙ (q' ∙ r')) p q r)) ∘e
     ( equiv-identification-left-whisk p)
+
+module _
+  {l : Level} {A : UU l} {x y z u v w : A}
+  where
+
+  equiv-both-whisk-square-identifications :
+    (p : x ＝ y) {q : y ＝ z} {q' : y ＝ u} {r : z ＝ v} {r' : u ＝ v} →
+    (s : v ＝ w) →
+    ( coherence-square-identifications q q' r r') ≃
+    ( coherence-square-identifications (p ∙ q) (p ∙ q') (r ∙ s) (r' ∙ s))
+  equiv-both-whisk-square-identifications p {q} {q'} s =
+    ( equiv-left-whisk-square-identification p) ∘e
+    ( equiv-right-whisk-square-identification q q' s)
 ```
 
 ### Both horizontal and vertical concatenation of 2-paths are binary equivalences

--- a/src/foundation/path-algebra.lagda.md
+++ b/src/foundation/path-algebra.lagda.md
@@ -309,25 +309,53 @@ module _
 ```agda
 module _
   {l : Level} {A : UU l} {x y z u v : A}
+  (p : x ＝ y) (p' : x ＝ z) {q : y ＝ u} {q' : z ＝ u} (r : u ＝ v)
   where
 
   equiv-right-whisk-square-identification :
-    (p : x ＝ y) (p' : x ＝ z) {q : y ＝ u} {q' : z ＝ u} (r : u ＝ v) →
     ( coherence-square-identifications p p' q q') ≃
     ( coherence-square-identifications p p' (q ∙ r) (q' ∙ r))
-  equiv-right-whisk-square-identification p p' {q} {q'} r =
+  equiv-right-whisk-square-identification =
     ( equiv-concat-assoc' (p' ∙ (q' ∙ r)) p q r) ∘e
     ( equiv-concat-assoc p' q' r (p ∙ q ∙ r)) ∘e
     ( equiv-identification-right-whisk r)
 
+  right-whisk-square-identification :
+    coherence-square-identifications p p' q q' →
+    coherence-square-identifications p p' (q ∙ r) (q' ∙ r)
+  right-whisk-square-identification =
+    map-equiv equiv-right-whisk-square-identification
+
+  right-unwhisk-square-identifications :
+    coherence-square-identifications p p' (q ∙ r) (q' ∙ r) →
+    coherence-square-identifications p p' q q'
+  right-unwhisk-square-identifications =
+    map-inv-equiv equiv-right-whisk-square-identification
+
+module _
+  {l : Level} {A : UU l} {x y z u v : A}
+  (p : v ＝ x) {q : x ＝ y} {q' : x ＝ z} {r : y ＝ u} {r' : z ＝ u}
+  where
+
   equiv-left-whisk-square-identification :
-    (p : v ＝ x) {q : x ＝ y} {q' : x ＝ z} {r : y ＝ u} {r' : z ＝ u} →
     ( coherence-square-identifications q q' r r') ≃
     ( coherence-square-identifications (p ∙ q) (p ∙ q') r r')
-  equiv-left-whisk-square-identification p {q} {q'} {r} {r'} =
+  equiv-left-whisk-square-identification =
     ( inv-equiv (equiv-concat-assoc p q' r' (p ∙ q ∙ r))) ∘e
     ( inv-equiv (equiv-concat-assoc' (p ∙ (q' ∙ r')) p q r)) ∘e
     ( equiv-identification-left-whisk p)
+
+  left-whisk-square-identification :
+    coherence-square-identifications q q' r r' →
+    coherence-square-identifications (p ∙ q) (p ∙ q') r r'
+  left-whisk-square-identification =
+    map-equiv equiv-left-whisk-square-identification
+
+  left-unwhisk-square-identification :
+    coherence-square-identifications (p ∙ q) (p ∙ q') r r' →
+    coherence-square-identifications q q' r r'
+  left-unwhisk-square-identification =
+    map-inv-equiv equiv-left-whisk-square-identification
 
 module _
   {l : Level} {A : UU l} {x y z u v w : A}

--- a/src/foundation/pullbacks.lagda.md
+++ b/src/foundation/pullbacks.lagda.md
@@ -341,8 +341,8 @@ htpy-parallel-cone-refl-htpy-htpy-cone f g (p , q , H) (p' , q' , H') =
   tot
     ( λ K → tot
       ( λ L M →
-        ( ap-concat-htpy H _ _ right-unit-htpy) ∙h
-        ( M ∙h ap-concat-htpy' _ _ H' inv-htpy-right-unit-htpy)))
+        ( ap-concat-htpy H right-unit-htpy) ∙h
+        ( M ∙h ap-concat-htpy' H' inv-htpy-right-unit-htpy)))
 
 abstract
   is-equiv-htpy-parallel-cone-refl-htpy-htpy-cone :
@@ -356,11 +356,11 @@ abstract
       ( λ K → is-equiv-tot-is-fiberwise-equiv
         ( λ L → is-equiv-comp
           ( concat-htpy
-            ( ap-concat-htpy H _ _ right-unit-htpy)
+            ( ap-concat-htpy H right-unit-htpy)
             ( (f ·l K) ∙h refl-htpy ∙h H'))
           ( concat-htpy'
             ( H ∙h (g ·l L))
-            ( ap-concat-htpy' _ _ H' inv-htpy-right-unit-htpy))
+            ( ap-concat-htpy' H' inv-htpy-right-unit-htpy))
           ( is-equiv-concat-htpy'
             ( H ∙h (g ·l L))
             ( λ x → ap (λ z → z ∙ H' x) (inv right-unit)))
@@ -897,10 +897,8 @@ is-pullback-top-is-pullback-bottom-cube-is-equiv
           ( inv-htpy c) ∙h
           ( assoc-htpy (h ·l back-left) (front-left ·r f') (hD ·l top)) ∙h
           ( ap-concat-htpy'
-            ( h ·l back-left)
-            ( (h ·l back-left) ∙h refl-htpy)
             ( (front-left ·r f') ∙h (hD ·l top))
-            ( inv-htpy-right-unit-htpy))))
+            ( inv-htpy-right-unit-htpy {H = h ·l back-left}))))
       ( is-pullback-rectangle-is-pullback-top h k hC
         ( f , g , bottom)
         ( hA , g' , back-right)

--- a/src/foundation/retractions.lagda.md
+++ b/src/foundation/retractions.lagda.md
@@ -74,11 +74,7 @@ is-retraction-retraction-left-map-triangle f g h H (l , L) (k , K) =
         ( inv-htpy ((k ∘ l) ·l H))
         ( (k ∘ l) ·l H)
         ( (k ·l (L ·r h)) ∙h K)) ∙h
-      ( ap-concat-htpy'
-        ( (inv-htpy ((k ∘ l) ·l H)) ∙h ((k ∘ l) ·l H))
-        ( refl-htpy)
-        ( (k ·l (L ·r h)) ∙h K)
-        ( left-inv-htpy ((k ∘ l) ·l H))))
+      ( ap-concat-htpy' ((k ·l (L ·r h)) ∙h K) (left-inv-htpy ((k ∘ l) ·l H))))
 
 retraction-right-factor-retract-of-retraction-left-factor :
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}

--- a/src/foundation/sections.lagda.md
+++ b/src/foundation/sections.lagda.md
@@ -111,11 +111,7 @@ is-retraction-section-left-map-triangle f g h H (k , K) (l , L) =
         ( inv-htpy (H ·r (k ∘ l)))
         ( H ·r (k ∘ l))
         ( (g ·l (K ·r l)) ∙h L)) ∙h
-      ( ap-concat-htpy'
-        ( (inv-htpy (H ·r (k ∘ l))) ∙h (H ·r (k ∘ l)))
-        ( refl-htpy)
-        ( (g ·l (K ·r l)) ∙h L)
-        ( left-inv-htpy (H ·r (k ∘ l)))))
+      ( ap-concat-htpy' ((g ·l (K ·r l)) ∙h L) (left-inv-htpy (H ·r (k ∘ l)))))
 
 section-left-factor-retract-of-section-composition :
   {l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3}

--- a/src/foundation/symmetric-cores-binary-relations.lagda.md
+++ b/src/foundation/symmetric-cores-binary-relations.lagda.md
@@ -1,8 +1,6 @@
 # Symmetric cores of binary relations
 
 ```agda
-{-# OPTIONS --allow-unsolved-metas #-}
-
 module foundation.symmetric-cores-binary-relations where
 ```
 

--- a/src/foundation/whiskering-homotopies.lagda.md
+++ b/src/foundation/whiskering-homotopies.lagda.md
@@ -111,8 +111,8 @@ module _
 A
 [commuting square of homotopies](foundation.commuting-squares-of-homotopies.md)
 may be whiskered by a homotopy `L` on the left or right, which results in a
-commuting square of homotopies with `L` appended or prepended to the two paths
-aong the square.
+commuting square of homotopies with `L` appended or prepended to the two ways of
+going around the square.
 
 Diagramatically, we may turn the pasting diagram
 

--- a/src/foundation/whiskering-homotopies.lagda.md
+++ b/src/foundation/whiskering-homotopies.lagda.md
@@ -10,11 +10,15 @@ open import foundation-core.whiskering-homotopies public
 
 ```agda
 open import foundation.action-on-identifications-functions
+open import foundation.commuting-squares-of-homotopies
 open import foundation.function-extensionality
+open import foundation.path-algebra
 open import foundation.postcomposition-functions
 open import foundation.universe-levels
 
+open import foundation-core.equivalences
 open import foundation-core.function-types
+open import foundation-core.functoriality-dependent-function-types
 open import foundation-core.homotopies
 open import foundation-core.identity-types
 open import foundation-core.precomposition-functions
@@ -99,4 +103,55 @@ module _
       ( λ K → eq-htpy (h ·l K))
       ( inv (is-section-eq-htpy H))) ∙
     ( compute-eq-htpy-htpy-eq-left-whisk (eq-htpy H))
+```
+
+### Whiskerings of higher homotopies are equivalences
+
+```agda
+module _
+  { l1 l2 : Level} {A : UU l1} {B : UU l2}
+  { f g g' h k : A → B}
+  where
+
+  module _
+    ( H : f ~ g) (H' : f ~ g') {K : g ~ h} {K' : g' ~ h} (L : h ~ k)
+    where
+
+    equiv-right-whisk-square-htpy :
+      ( coherence-square-homotopies H H' K K') ≃
+      ( coherence-square-homotopies H H' (K ∙h L) (K' ∙h L))
+    equiv-right-whisk-square-htpy =
+      equiv-Π-equiv-family
+        ( λ a → equiv-right-whisk-square-identification (H a) (H' a) (L a))
+
+    right-whisk-square-htpy :
+      coherence-square-homotopies H H' K K' →
+      coherence-square-homotopies H H' (K ∙h L) (K' ∙h L)
+    right-whisk-square-htpy = map-equiv equiv-right-whisk-square-htpy
+
+    right-unwhisk-square-htpy :
+      coherence-square-homotopies H H' (K ∙h L) (K' ∙h L) →
+      coherence-square-homotopies H H' K K'
+    right-unwhisk-square-htpy = map-inv-equiv equiv-right-whisk-square-htpy
+
+  module _
+    ( H : k ~ f) {K : f ~ g} {K' : f ~ g'} {L : g ~ h} {L' : g' ~ h}
+    where
+
+    equiv-left-whisk-square-htpy :
+      ( coherence-square-homotopies K K' L L') ≃
+      ( coherence-square-homotopies (H ∙h K) (H ∙h K') L L')
+    equiv-left-whisk-square-htpy =
+      equiv-Π-equiv-family
+        ( λ a → equiv-left-whisk-square-identification (H a))
+
+    left-whisk-square-htpy :
+      coherence-square-homotopies K K' L L' →
+      coherence-square-homotopies (H ∙h K) (H ∙h K') L L'
+    left-whisk-square-htpy = map-equiv equiv-left-whisk-square-htpy
+
+    left-unwhisk-square-htpy :
+      coherence-square-homotopies (H ∙h K) (H ∙h K') L L' →
+      coherence-square-homotopies K K' L L'
+    left-unwhisk-square-htpy = map-inv-equiv equiv-left-whisk-square-htpy
 ```

--- a/src/foundation/whiskering-homotopies.lagda.md
+++ b/src/foundation/whiskering-homotopies.lagda.md
@@ -120,7 +120,7 @@ Diagramatically, we may turn the pasting diagram
         H
     f ~~~~~ g
     ︴      ︴
- H' ︴ ⇗   ︴ K
+ H' ︴  ⇗   ︴ K
     ︴      ︴
    g' ~~~~~ h ~~~~~ k
        K'       L
@@ -132,7 +132,7 @@ into a commmuting square
         H
     f ~~~~~ g
     ︴      ︴
- H' ︴ ⇗   ︴K ∙h L
+ H' ︴  ⇗   ︴K ∙h L
     ︴      ︴
    g' ~~~~~ k
      K' ∙h L   ,
@@ -220,7 +220,7 @@ Given a square of homotopies
         H
     g ~~~~~ h
     ︴      ︴
- H' ︴ ⇗   ︴ K
+ H' ︴  ⇗   ︴ K
     ︴      ︴
    h' ~~~~~ k
        K'
@@ -233,7 +233,7 @@ homotopies
            f ·l H
          fg ~~~~~ fh
          ︴        ︴
- f ·l H' ︴  ⇗    ︴f ·l K
+ f ·l H' ︴   ⇗    ︴f ·l K
          ︴        ︴
         fh' ~~~~~ fk
            f ·l K' ,

--- a/src/foundation/whiskering-homotopies.lagda.md
+++ b/src/foundation/whiskering-homotopies.lagda.md
@@ -106,7 +106,39 @@ module _
     ( compute-eq-htpy-htpy-eq-left-whisk (eq-htpy H))
 ```
 
-### Whiskerings of higher homotopies are equivalences
+### Whiskering a square of homotopies by a homotopy is an equivalence
+
+A
+[commuting square of homotopies](foundation.commuting-squares-of-homotopies.md)
+may be whiskered by a homotopy `L` on the left or right, which results in a
+commuting square of homotopies with `L` appended or prepended to the two paths
+aong the square.
+
+Diagramatically, we may turn the pasting diagram
+
+```text
+        H
+    f ~~~~~ g
+    ︴      ︴
+ H' ︴ ⇗   ︴ K
+    ︴      ︴
+   g' ~~~~~ h ~~~~~ k
+       K'       L
+```
+
+into a commmuting square
+
+```text
+        H
+    f ~~~~~ g
+    ︴      ︴
+ H' ︴ ⇗   ︴K ∙h L
+    ︴      ︴
+   g' ~~~~~ k
+     K' ∙h L   ,
+```
+
+and similarly for the other side.
 
 ```agda
 module _
@@ -136,24 +168,24 @@ module _
     right-unwhisk-square-htpy = map-inv-equiv equiv-right-whisk-square-htpy
 
   module _
-    ( H : k ~ f) {K : f ~ g} {K' : f ~ g'} {L : g ~ h} {L' : g' ~ h}
+    ( L : k ~ f) {H : f ~ g} {H' : f ~ g'} {K : g ~ h} {K' : g' ~ h}
     where
 
     equiv-left-whisk-square-htpy :
-      ( coherence-square-homotopies K K' L L') ≃
-      ( coherence-square-homotopies (H ∙h K) (H ∙h K') L L')
+      ( coherence-square-homotopies H H' K K') ≃
+      ( coherence-square-homotopies (L ∙h H) (L ∙h H') K K')
     equiv-left-whisk-square-htpy =
       equiv-Π-equiv-family
-        ( λ a → equiv-left-whisk-square-identification (H a))
+        ( λ a → equiv-left-whisk-square-identification (L a))
 
     left-whisk-square-htpy :
-      coherence-square-homotopies K K' L L' →
-      coherence-square-homotopies (H ∙h K) (H ∙h K') L L'
+      coherence-square-homotopies H H' K K' →
+      coherence-square-homotopies (L ∙h H) (L ∙h H') K K'
     left-whisk-square-htpy = map-equiv equiv-left-whisk-square-htpy
 
     left-unwhisk-square-htpy :
-      coherence-square-homotopies (H ∙h K) (H ∙h K') L L' →
-      coherence-square-homotopies K K' L L'
+      coherence-square-homotopies (L ∙h H) (L ∙h H') K K' →
+      coherence-square-homotopies H H' K K'
     left-unwhisk-square-htpy = map-inv-equiv equiv-left-whisk-square-htpy
 
 module _
@@ -180,6 +212,35 @@ module _
   both-unwhisk-square-htpy = map-inv-equiv equiv-both-whisk-square-htpy
 ```
 
+### Whiskering a square of homotopies by a map
+
+Given a square of homotopies
+
+```text
+        H
+    g ~~~~~ h
+    ︴      ︴
+ H' ︴ ⇗   ︴ K
+    ︴      ︴
+   h' ~~~~~ k
+       K'
+```
+
+and a map `f`, we may whisker it by a map on the left into a square of
+homotopies
+
+```text
+           f ·l H
+         fg ~~~~~ fh
+         ︴        ︴
+ f ·l H' ︴  ⇗    ︴f ·l K
+         ︴        ︴
+        fh' ~~~~~ fk
+           f ·l K' ,
+```
+
+and similarly we may whisker it on the right.
+
 ```agda
 module _
   { l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
@@ -192,4 +253,15 @@ module _
     coherence-square-homotopies (f ·l H) (f ·l H') (f ·l K) (f ·l K')
   ap-left-whisk-coherence-square-homotopies α a =
     coherence-square-identifications-ap f (H a) (H' a) (K a) (K' a) (α a)
+
+module _
+  { l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
+  { g h h' k : B → C} (H : g ~ h) (H' : g ~ h') {K : h ~ k} {K' : h' ~ k}
+  ( f : A → B)
+  where
+
+  ap-right-whisk-coherence-square-homotopies :
+    coherence-square-homotopies H H' K K' →
+    coherence-square-homotopies (H ·r f) (H' ·r f) (K ·r f) (K' ·r f)
+  ap-right-whisk-coherence-square-homotopies α = α ·r f
 ```

--- a/src/foundation/whiskering-homotopies.lagda.md
+++ b/src/foundation/whiskering-homotopies.lagda.md
@@ -11,6 +11,7 @@ open import foundation-core.whiskering-homotopies public
 ```agda
 open import foundation.action-on-identifications-functions
 open import foundation.commuting-squares-of-homotopies
+open import foundation.commuting-squares-of-identifications
 open import foundation.function-extensionality
 open import foundation.path-algebra
 open import foundation.postcomposition-functions
@@ -177,4 +178,18 @@ module _
     ( coherence-square-homotopies (H ∙h K) (H ∙h K') (L ∙h M) (L' ∙h M)) →
     ( coherence-square-homotopies K K' L L')
   both-unwhisk-square-htpy = map-inv-equiv equiv-both-whisk-square-htpy
+```
+
+```agda
+module _
+  { l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {C : UU l3}
+  ( f : B → C) {g h h' k : A → B}
+  ( H : g ~ h) (H' : g ~ h') {K : h ~ k} {K' : h' ~ k}
+  where
+
+  ap-left-whisk-coherence-square-homotopies :
+    coherence-square-homotopies H H' K K' →
+    coherence-square-homotopies (f ·l H) (f ·l H') (f ·l K) (f ·l K')
+  ap-left-whisk-coherence-square-homotopies α a =
+    coherence-square-identifications-ap f (H a) (H' a) (K a) (K' a) (α a)
 ```

--- a/src/foundation/whiskering-homotopies.lagda.md
+++ b/src/foundation/whiskering-homotopies.lagda.md
@@ -154,4 +154,27 @@ module _
       coherence-square-homotopies (H ∙h K) (H ∙h K') L L' →
       coherence-square-homotopies K K' L L'
     left-unwhisk-square-htpy = map-inv-equiv equiv-left-whisk-square-htpy
+
+module _
+  { l1 l2 : Level} {A : UU l1} {B : UU l2}
+  { f g h h' k m : A → B}
+  ( H : f ~ g) {K : g ~ h} {K' : g ~ h'} {L : h ~ k} {L' : h' ~ k} (M : k ~ m)
+  where
+
+  equiv-both-whisk-square-htpy :
+    ( coherence-square-homotopies K K' L L') ≃
+    ( coherence-square-homotopies (H ∙h K) (H ∙h K') (L ∙h M) (L' ∙h M))
+  equiv-both-whisk-square-htpy =
+    equiv-Π-equiv-family
+      ( λ a → equiv-both-whisk-square-identifications (H a) (M a))
+
+  both-whisk-square-htpy :
+    ( coherence-square-homotopies K K' L L') →
+    ( coherence-square-homotopies (H ∙h K) (H ∙h K') (L ∙h M) (L' ∙h M))
+  both-whisk-square-htpy = map-equiv equiv-both-whisk-square-htpy
+
+  both-unwhisk-square-htpy :
+    ( coherence-square-homotopies (H ∙h K) (H ∙h K') (L ∙h M) (L' ∙h M)) →
+    ( coherence-square-homotopies K K' L L')
+  both-unwhisk-square-htpy = map-inv-equiv equiv-both-whisk-square-htpy
 ```

--- a/src/graph-theory/equivalences-directed-graphs.lagda.md
+++ b/src/graph-theory/equivalences-directed-graphs.lagda.md
@@ -492,7 +492,7 @@ module _
       ( edge-Directed-Graph G)
       ( vertex-is-retraction-inv-equiv-Directed-Graph x)
       ( vertex-is-retraction-inv-equiv-Directed-Graph y)
-      ( map-eq-transpose-equiv'
+      ( map-eq-transpose-equiv-inv
         ( equiv-edge-equiv-Directed-Graph G H f
           ( vertex-inv-equiv-Directed-Graph
             ( vertex-equiv-Directed-Graph G H f x))

--- a/src/structured-types/initial-pointed-type-equipped-with-automorphism.lagda.md
+++ b/src/structured-types/initial-pointed-type-equipped-with-automorphism.lagda.md
@@ -90,7 +90,7 @@ htpy-map-ℤ-Pointed-Type-With-Aut :
   map-ℤ-Pointed-Type-With-Aut X ~
   map-hom-Pointed-Type-With-Aut ℤ-Pointed-Type-With-Aut X h
 htpy-map-ℤ-Pointed-Type-With-Aut X h (inl zero-ℕ) =
-  map-eq-transpose-equiv'
+  map-eq-transpose-equiv-inv
     ( aut-Pointed-Type-With-Aut X)
     ( ( inv
         ( preserves-point-map-hom-Pointed-Type-With-Aut ℤ-Pointed-Type-With-Aut
@@ -98,7 +98,7 @@ htpy-map-ℤ-Pointed-Type-With-Aut X h (inl zero-ℕ) =
       ( preserves-aut-map-hom-Pointed-Type-With-Aut ℤ-Pointed-Type-With-Aut
         X h neg-one-ℤ))
 htpy-map-ℤ-Pointed-Type-With-Aut X h (inl (succ-ℕ k)) =
-  map-eq-transpose-equiv'
+  map-eq-transpose-equiv-inv
     ( aut-Pointed-Type-With-Aut X)
     ( ( htpy-map-ℤ-Pointed-Type-With-Aut X h (inl k)) ∙
       ( preserves-aut-map-hom-Pointed-Type-With-Aut ℤ-Pointed-Type-With-Aut
@@ -157,7 +157,7 @@ coh-aut-htpy-map-ℤ-Pointed-Type-With-Aut X h (inl zero-ℕ) =
       ( ap
         ( map-equiv (aut-Pointed-Type-With-Aut X))
         ( htpy-map-ℤ-Pointed-Type-With-Aut X h neg-one-ℤ))
-      ( triangle-eq-transpose-equiv'
+      ( triangle-eq-transpose-equiv-inv
         ( aut-Pointed-Type-With-Aut X)
         ( ( inv
             ( preserves-point-map-hom-Pointed-Type-With-Aut
@@ -176,7 +176,7 @@ coh-aut-htpy-map-ℤ-Pointed-Type-With-Aut X h (inl (succ-ℕ k)) =
       ( ap
         ( map-equiv (aut-Pointed-Type-With-Aut X))
         ( htpy-map-ℤ-Pointed-Type-With-Aut X h (inl (succ-ℕ k))))
-      ( triangle-eq-transpose-equiv'
+      ( triangle-eq-transpose-equiv-inv
         ( aut-Pointed-Type-With-Aut X)
         ( ( htpy-map-ℤ-Pointed-Type-With-Aut X h (inl k)) ∙
           ( preserves-aut-map-hom-Pointed-Type-With-Aut

--- a/src/synthetic-homotopy-theory.lagda.md
+++ b/src/synthetic-homotopy-theory.lagda.md
@@ -50,6 +50,7 @@ open import synthetic-homotopy-theory.flattening-lemma-coequalizers public
 open import synthetic-homotopy-theory.flattening-lemma-pushouts public
 open import synthetic-homotopy-theory.free-loops public
 open import synthetic-homotopy-theory.functoriality-loop-spaces public
+open import synthetic-homotopy-theory.functoriality-sequential-colimits public
 open import synthetic-homotopy-theory.functoriality-suspensions public
 open import synthetic-homotopy-theory.groups-of-loops-in-1-types public
 open import synthetic-homotopy-theory.hatchers-acyclic-type public
@@ -77,6 +78,7 @@ open import synthetic-homotopy-theory.pushout-products public
 open import synthetic-homotopy-theory.pushouts public
 open import synthetic-homotopy-theory.pushouts-of-pointed-types public
 open import synthetic-homotopy-theory.sections-descent-circle public
+open import synthetic-homotopy-theory.sequential-colimits public
 open import synthetic-homotopy-theory.sequential-diagrams public
 open import synthetic-homotopy-theory.sequentially-compact-types public
 open import synthetic-homotopy-theory.smash-products-of-pointed-types public

--- a/src/synthetic-homotopy-theory/26-descent.lagda.md
+++ b/src/synthetic-homotopy-theory/26-descent.lagda.md
@@ -255,8 +255,6 @@ coherence-triangle-precompose-lifts-refl-htpy P f h =
   ( ( ( inv-htpy-right-unit-htpy) ∙h
       ( ap-concat-htpy
         ( λ h' → tr-eq-htpy-fam-lifts-refl-htpy P h f (λ a → h' (f a)))
-        ( refl-htpy)
-        ( triangle-precompose-lifts' P refl-htpy h)
         ( inv-htpy (compute-triangle-precompose-lifts' P f h)))) ∙h
     ( htpy-eq
       ( ap
@@ -380,15 +378,11 @@ coherence-inv-htpy-distributive-Π-Σ-refl-htpy :
 coherence-inv-htpy-distributive-Π-Σ-refl-htpy {X = X} P f =
   ( ap-concat-htpy
     ( coherence-square-map-inv-distributive-Π-Σ P f)
-    ( map-inv-distributive-Π-Σ ·l ( htpy-precompose-total-lifts P refl-htpy))
-    ( refl-htpy)
     ( λ h →
       ap
         ( ap map-inv-distributive-Π-Σ)
         ( compute-htpy-precompose-total-lifts P f h))) ∙h
   ( ap-concat-htpy'
-    ( refl-htpy)
-    ( ( htpy-precomp refl-htpy (Σ X P)) ·r map-inv-distributive-Π-Σ)
     ( refl-htpy)
     ( inv-htpy
       ( λ h →

--- a/src/synthetic-homotopy-theory/cocones-under-sequential-diagrams.lagda.md
+++ b/src/synthetic-homotopy-theory/cocones-under-sequential-diagrams.lagda.md
@@ -137,7 +137,7 @@ module _
 ```agda
 module _
   { l1 l2 : Level} (A : sequential-diagram l1) {X : UU l2}
-  ( c c' : cocone-sequential-diagram A X)
+  { c c' : cocone-sequential-diagram A X}
   ( H : htpy-cocone-sequential-diagram A c c')
   where
 

--- a/src/synthetic-homotopy-theory/cocones-under-sequential-diagrams.lagda.md
+++ b/src/synthetic-homotopy-theory/cocones-under-sequential-diagrams.lagda.md
@@ -101,7 +101,7 @@ filling the "pinched cylinder" with the faces `Kₙ`, `Hₙ`, `Lₙ` and `Kₙ�
 
 The coherence datum may be better understood by viewing a cocone as a
 [morphism](synthetic-homotopy-theory.morphisms-sequential-diagrams.md) from
-`(A, a)` to the constant cocone `(n ↦ X, n ↦ id)` --- the two types are
+`(A, a)` to the constant cocone `(n ↦ X, n ↦ id)` — the two types are
 definitionally equal. Then a homotopy of cocones is a regular homotopy of
 morphisms of sequential diagrams.
 

--- a/src/synthetic-homotopy-theory/cocones-under-sequential-diagrams.lagda.md
+++ b/src/synthetic-homotopy-theory/cocones-under-sequential-diagrams.lagda.md
@@ -101,8 +101,9 @@ filling the "pinched cylinder" with the faces `Kₙ`, `Hₙ`, `Lₙ` and `Kₙ�
 
 The coherence datum may be better understood by viewing a cocone as a
 [morphism](synthetic-homotopy-theory.morphisms-sequential-diagrams.md) from
-`(A, a)` to the constant cocone `(n ↦ X, n ↦ id)`. Then a homotopy of cocones is
-a regular homotopy of morphisms of sequential diagrams.
+`(A, a)` to the constant cocone `(n ↦ X, n ↦ id)` --- the two types are
+definitionally equal. Then a homotopy of cocones is a regular homotopy of
+morphisms of sequential diagrams.
 
 ```agda
 module _

--- a/src/synthetic-homotopy-theory/dependent-universal-property-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-universal-property-sequential-colimits.lagda.md
@@ -50,14 +50,10 @@ module _
   ( c : cocone-sequential-diagram A X)
   where
 
-  dependent-universal-property-sequential-colimit-Level :
-    ( l : Level) → UU (l1 ⊔ l2 ⊔ lsuc l)
-  dependent-universal-property-sequential-colimit-Level l =
-    ( P : X → UU l) → is-equiv (dependent-cocone-map-sequential-diagram A c P)
-
   dependent-universal-property-sequential-colimit : UUω
   dependent-universal-property-sequential-colimit =
-    { l : Level} → dependent-universal-property-sequential-colimit-Level l
+    { l : Level} → (P : X → UU l) →
+    is-equiv (dependent-cocone-map-sequential-diagram A c P)
 ```
 
 ### The map induced by the dependent universal property of sequential colimits

--- a/src/synthetic-homotopy-theory/dependent-universal-property-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-universal-property-sequential-colimits.lagda.md
@@ -46,13 +46,18 @@ is an [equivalence](foundation.equivalences.md).
 
 ```agda
 module _
-  { l1 l2 : Level} (l : Level) (A : sequential-diagram l1) {X : UU l2}
+  { l1 l2 : Level} (A : sequential-diagram l1) {X : UU l2}
   ( c : cocone-sequential-diagram A X)
   where
 
-  dependent-universal-property-sequential-colimit : UU (l1 ⊔ l2 ⊔ lsuc l)
-  dependent-universal-property-sequential-colimit =
+  dependent-universal-property-sequential-colimit-Level :
+    ( l : Level) → UU (l1 ⊔ l2 ⊔ lsuc l)
+  dependent-universal-property-sequential-colimit-Level l =
     ( P : X → UU l) → is-equiv (dependent-cocone-map-sequential-diagram A c P)
+
+  dependent-universal-property-sequential-colimit : UUω
+  dependent-universal-property-sequential-colimit =
+    { l : Level} → dependent-universal-property-sequential-colimit-Level l
 ```
 
 ### The map induced by the dependent universal property of sequential colimits
@@ -62,7 +67,7 @@ module _
   { l1 l2 l3 : Level} (A : sequential-diagram l1) {X : UU l2}
   ( c : cocone-sequential-diagram A X) {P : X → UU l3}
   ( dup-sequential-colimit :
-    dependent-universal-property-sequential-colimit l3 A c)
+    dependent-universal-property-sequential-colimit A c)
   where
 
   map-dependent-universal-property-sequential-colimit :
@@ -81,7 +86,7 @@ module _
   { l1 l2 l3 : Level} (A : sequential-diagram l1) {X : UU l2}
   ( c : cocone-sequential-diagram A X) {P : X → UU l3}
   ( dup-sequential-colimit :
-    dependent-universal-property-sequential-colimit l3 A c)
+    dependent-universal-property-sequential-colimit A c)
   ( d : dependent-cocone-sequential-diagram A c P)
   where
 
@@ -138,8 +143,7 @@ module _
         ( bottom-map-cofork-cocone-sequential-diagram A)
         ( top-map-cofork-cocone-sequential-diagram A)
         ( cofork-cocone-sequential-diagram A c)) →
-    ( {l : Level} →
-      dependent-universal-property-sequential-colimit l A c)
+    dependent-universal-property-sequential-colimit A c
   dependent-universal-property-sequential-colimit-dependent-universal-property-coequalizer
     ( dup-coequalizer)
     ( P) =
@@ -155,8 +159,7 @@ module _
       ( is-equiv-dependent-cocone-sequential-diagram-dependent-cofork A c P)
 
   dependent-universal-property-coequalizer-dependent-universal-property-sequential-colimit :
-    ( {l : Level} →
-      dependent-universal-property-sequential-colimit l A c) →
+    dependent-universal-property-sequential-colimit A c →
     ( {l : Level} →
       dependent-universal-property-coequalizer l
         ( bottom-map-cofork-cocone-sequential-diagram A)
@@ -186,8 +189,8 @@ module _
   where
 
   universal-property-dependent-universal-property-sequential-colimit :
-    ( {l : Level} → dependent-universal-property-sequential-colimit l A c) →
-    ( {l : Level} → universal-property-sequential-colimit l A c)
+    dependent-universal-property-sequential-colimit A c →
+    universal-property-sequential-colimit A c
   universal-property-dependent-universal-property-sequential-colimit
     ( dup-sequential-colimit)
     ( Y) =
@@ -202,8 +205,8 @@ module _
         ( compute-dependent-cocone-sequential-diagram-constant-family A c Y))
 
   dependent-universal-property-universal-property-sequential-colimit :
-    ( {l : Level} → universal-property-sequential-colimit l A c) →
-    ( {l : Level} → dependent-universal-property-sequential-colimit l A c)
+    universal-property-sequential-colimit A c →
+    dependent-universal-property-sequential-colimit A c
   dependent-universal-property-universal-property-sequential-colimit
     ( up-sequential-diagram) =
     dependent-universal-property-sequential-colimit-dependent-universal-property-coequalizer

--- a/src/synthetic-homotopy-theory/equivalences-sequential-diagrams.lagda.md
+++ b/src/synthetic-homotopy-theory/equivalences-sequential-diagrams.lagda.md
@@ -9,6 +9,7 @@ module synthetic-homotopy-theory.equivalences-sequential-diagrams where
 ```agda
 open import elementary-number-theory.natural-numbers
 
+open import foundation.commuting-squares-of-maps
 open import foundation.dependent-pair-types
 open import foundation.equality-dependent-function-types
 open import foundation.equivalences
@@ -67,15 +68,18 @@ module _
     family-sequential-diagram A n ≃ family-sequential-diagram B n
   equiv-equiv-sequential-diagram = pr1 e
 
-  hom-equiv-sequential-diagram : hom-sequential-diagram A B
-  pr1 hom-equiv-sequential-diagram n =
-    map-equiv (equiv-equiv-sequential-diagram n)
-  pr2 hom-equiv-sequential-diagram = pr2 e
-
   map-equiv-sequential-diagram :
     ( n : ℕ) →
     family-sequential-diagram A n → family-sequential-diagram B n
   map-equiv-sequential-diagram n = map-equiv (equiv-equiv-sequential-diagram n)
+
+  naturality-equiv-sequential-diagram :
+    naturality-hom-sequential-diagram A B map-equiv-sequential-diagram
+  naturality-equiv-sequential-diagram = pr2 e
+
+  hom-equiv-sequential-diagram : hom-sequential-diagram A B
+  pr1 hom-equiv-sequential-diagram = map-equiv-sequential-diagram
+  pr2 hom-equiv-sequential-diagram = naturality-equiv-sequential-diagram
 
   is-equiv-map-equiv-sequential-diagram :
     ( n : ℕ) →
@@ -116,6 +120,38 @@ module _
       ( comp-hom-sequential-diagram A B C
         ( hom-equiv-sequential-diagram C e)
         ( hom-equiv-sequential-diagram B e'))
+```
+
+### Inverses of equivalences of sequential diagrams
+
+```agda
+module _
+  { l1 l2 : Level} {A : sequential-diagram l1} (B : sequential-diagram l2)
+  ( e : equiv-sequential-diagram A B)
+  where
+
+  inv-equiv-sequential-diagram : equiv-sequential-diagram B A
+  pr1 inv-equiv-sequential-diagram n =
+    inv-equiv (equiv-equiv-sequential-diagram B e n)
+  pr2 inv-equiv-sequential-diagram n =
+    coherence-square-inv-vertical
+      ( map-sequential-diagram A n)
+      ( equiv-equiv-sequential-diagram B e n)
+      ( equiv-equiv-sequential-diagram B e (succ-ℕ n))
+      ( map-sequential-diagram B n)
+      ( naturality-map-hom-sequential-diagram B
+        ( hom-equiv-sequential-diagram B e)
+        ( n))
+
+  map-inv-equiv-sequential-diagram :
+    ( n : ℕ) →
+    family-sequential-diagram B n → family-sequential-diagram A n
+  map-inv-equiv-sequential-diagram =
+    map-equiv-sequential-diagram A inv-equiv-sequential-diagram
+
+  hom-inv-equiv-sequential-diagram : hom-sequential-diagram B A
+  hom-inv-equiv-sequential-diagram =
+    hom-equiv-sequential-diagram A inv-equiv-sequential-diagram
 ```
 
 ## Properties

--- a/src/synthetic-homotopy-theory/equivalences-sequential-diagrams.lagda.md
+++ b/src/synthetic-homotopy-theory/equivalences-sequential-diagrams.lagda.md
@@ -57,6 +57,11 @@ module _
 
 ### Components of equivalences of sequential diagrams
 
+_Implementation note:_ As mentioned in
+[`morphisms-sequential-diagrams`](synthetic-homotopy-theory.morphisms-sequential-diagrams.md),
+Agda can't infer both the domain and the codomain when we use accessors for the
+equivalences, and the codomain needs to be provided explicitly.
+
 ```agda
 module _
   { l1 l2 : Level} {A : sequential-diagram l1} (B : sequential-diagram l2)

--- a/src/synthetic-homotopy-theory/equivalences-sequential-diagrams.lagda.md
+++ b/src/synthetic-homotopy-theory/equivalences-sequential-diagrams.lagda.md
@@ -202,3 +202,46 @@ eq-equiv-sequential-diagram :
 eq-equiv-sequential-diagram A B =
   map-inv-equiv (extensionality-sequential-diagram A B)
 ```
+
+### Inverses of equivalences are inverses with respect to composition of morphisms of sequential diagrams
+
+```agda
+module _
+  { l1 l2 : Level} {A : sequential-diagram l1} (B : sequential-diagram l2)
+  ( e : equiv-sequential-diagram A B)
+  where
+
+  is-section-inv-equiv-sequential-diagram :
+    htpy-hom-sequential-diagram B
+      ( comp-hom-sequential-diagram B A B
+        ( hom-equiv-sequential-diagram B e)
+        ( hom-inv-equiv-sequential-diagram B e))
+      ( id-hom-sequential-diagram B)
+  pr1 is-section-inv-equiv-sequential-diagram n =
+    is-section-map-inv-equiv (equiv-equiv-sequential-diagram B e n)
+  pr2 is-section-inv-equiv-sequential-diagram n =
+    inv-htpy
+      ( right-inverse-law-pasting-vertical-coherence-square-maps
+        ( map-sequential-diagram A n)
+        ( equiv-equiv-sequential-diagram B e n)
+        ( equiv-equiv-sequential-diagram B e (succ-ℕ n))
+        ( map-sequential-diagram B n)
+        ( naturality-equiv-sequential-diagram B e n))
+
+  is-retraction-inv-equiv-sequential-diagram :
+    htpy-hom-sequential-diagram A
+      ( comp-hom-sequential-diagram A B A
+        ( hom-inv-equiv-sequential-diagram B e)
+        ( hom-equiv-sequential-diagram B e))
+      ( id-hom-sequential-diagram A)
+  pr1 is-retraction-inv-equiv-sequential-diagram n =
+    is-retraction-map-inv-equiv (equiv-equiv-sequential-diagram B e n)
+  pr2 is-retraction-inv-equiv-sequential-diagram n =
+    inv-htpy
+      ( left-inverse-law-pasting-vertical-coherence-square-maps
+        ( map-sequential-diagram A n)
+        ( equiv-equiv-sequential-diagram B e n)
+        ( equiv-equiv-sequential-diagram B e (succ-ℕ n))
+        ( map-sequential-diagram B n)
+        ( naturality-equiv-sequential-diagram B e n))
+```

--- a/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
@@ -376,7 +376,7 @@ module _
 
 ### An equivalence of sequential diagrams induces an equivalence of cocones
 
-Additionally, the underlying map of the inverse equivalence if definitionally
+Additionally, the underlying map of the inverse equivalence is definitionally
 equal to the map induced by the inverse of the equivalence of sequential
 diagrams, i.e. `(e∞)⁻¹ = (e⁻¹)∞`.
 

--- a/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
@@ -124,20 +124,20 @@ module _
   prism-htpy-cocone-map-hom-standard-sequential-colimit :
     ( n : ℕ) →
     vertical-coherence-prism-maps
-      ( map-sequential-diagram A n)
-      ( map-cocone-standard-sequential-colimit A (succ-ℕ n))
       ( map-cocone-standard-sequential-colimit A n)
+      ( map-cocone-standard-sequential-colimit A (succ-ℕ n))
+      ( map-sequential-diagram A n)
+      ( map-cocone-standard-sequential-colimit B n)
+      ( map-cocone-standard-sequential-colimit B (succ-ℕ n))
+      ( map-sequential-diagram B n)
       ( map-hom-sequential-diagram B f n)
       ( map-hom-sequential-diagram B f (succ-ℕ n))
       ( map-hom-standard-sequential-colimit)
-      ( map-sequential-diagram B n)
-      ( map-cocone-standard-sequential-colimit B (succ-ℕ n))
-      ( map-cocone-standard-sequential-colimit B n)
       ( coherence-triangle-cocone-standard-sequential-colimit A n)
-      ( naturality-map-hom-sequential-diagram B f n)
+      ( inv-htpy (htpy-htpy-cocone-map-hom-standard-sequential-colimit n))
       ( inv-htpy
         ( htpy-htpy-cocone-map-hom-standard-sequential-colimit (succ-ℕ n)))
-      ( inv-htpy (htpy-htpy-cocone-map-hom-standard-sequential-colimit n))
+      ( naturality-map-hom-sequential-diagram B f n)
       ( coherence-triangle-cocone-standard-sequential-colimit B n)
   prism-htpy-cocone-map-hom-standard-sequential-colimit n =
     [v]
@@ -333,35 +333,35 @@ module _
                 ( map-cocone-standard-sequential-colimit C (succ-ℕ n) ·l _)
                 ( _)) ∙h
               ( pasting-vertical-coherence-prism-maps
-                ( map-sequential-diagram A n)
-                ( map-cocone-standard-sequential-colimit A (succ-ℕ n))
                 ( map-cocone-standard-sequential-colimit A n)
+                ( map-cocone-standard-sequential-colimit A (succ-ℕ n))
+                ( map-sequential-diagram A n)
+                ( map-cocone-standard-sequential-colimit B n)
+                ( map-cocone-standard-sequential-colimit B (succ-ℕ n))
+                ( map-sequential-diagram B n)
                 ( map-hom-sequential-diagram B f n)
                 ( map-hom-sequential-diagram B f (succ-ℕ n))
                 ( map-hom-standard-sequential-colimit B f)
-                ( map-sequential-diagram B n)
-                ( map-cocone-standard-sequential-colimit B (succ-ℕ n))
-                ( map-cocone-standard-sequential-colimit B n)
+                ( map-cocone-standard-sequential-colimit C n)
+                ( map-cocone-standard-sequential-colimit C (succ-ℕ n))
+                ( map-sequential-diagram C n)
                 ( map-hom-sequential-diagram C g n)
                 ( map-hom-sequential-diagram C g (succ-ℕ n))
                 ( map-hom-standard-sequential-colimit C g)
-                ( map-sequential-diagram C n)
-                ( map-cocone-standard-sequential-colimit C (succ-ℕ n))
-                ( map-cocone-standard-sequential-colimit C n)
                 ( coherence-triangle-cocone-standard-sequential-colimit A n)
-                ( naturality-map-hom-sequential-diagram B f n)
+                ( inv-htpy
+                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f n))
                 ( inv-htpy
                   ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f
                     ( succ-ℕ n)))
-                ( inv-htpy
-                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f n))
+                ( naturality-map-hom-sequential-diagram B f n)
                 ( coherence-triangle-cocone-standard-sequential-colimit B n)
-                ( naturality-map-hom-sequential-diagram C g n)
+                ( inv-htpy
+                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g n))
                 ( inv-htpy
                   ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g
                     ( succ-ℕ n)))
-                ( inv-htpy
-                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g n))
+                ( naturality-map-hom-sequential-diagram C g n)
                 ( coherence-triangle-cocone-standard-sequential-colimit C n)
                 ( prism-htpy-cocone-map-hom-standard-sequential-colimit B f n)
                 ( prism-htpy-cocone-map-hom-standard-sequential-colimit C g

--- a/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
@@ -279,21 +279,6 @@ module _
                     ( succ-ℕ n)))) ·r
               ( map-sequential-diagram A n))) ∙h
           ( ap-concat-htpy'
-            ( ( ( map-hom-standard-sequential-colimit C
-                  ( comp-hom-sequential-diagram A B C g f)) ·l
-                ( coherence-triangle-cocone-standard-sequential-colimit A n)) ∙h
-              ( ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C
-                  ( comp-hom-sequential-diagram A B C g f)
-                  ( succ-ℕ n)) ·r
-                ( map-sequential-diagram A n)))
-            ( ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C
-                ( comp-hom-sequential-diagram A B C g f)
-                ( n)) ∙h
-              ( coherence-triangle-cocone-sequential-diagram A
-                ( map-hom-cocone-sequential-colimit
-                  ( comp-hom-sequential-diagram A B C g f)
-                  ( cocone-standard-sequential-colimit C))
-                ( n)))
             ( ( pasting-vertical-coherence-square-maps
                 ( map-cocone-standard-sequential-colimit A (succ-ℕ n))
                 ( map-hom-sequential-diagram B f (succ-ℕ n))
@@ -340,43 +325,6 @@ module _
             ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C
               ( comp-hom-sequential-diagram A B C g f)
               ( n))
-            ( ( coherence-triangle-cocone-sequential-diagram A
-                ( map-hom-cocone-sequential-colimit
-                  ( comp-hom-sequential-diagram A B C g f)
-                  ( cocone-standard-sequential-colimit C))
-                ( n)) ∙h
-              ( ( pasting-vertical-coherence-square-maps
-                  ( map-cocone-standard-sequential-colimit A (succ-ℕ n))
-                  ( map-hom-sequential-diagram B f (succ-ℕ n))
-                  ( map-hom-standard-sequential-colimit B f)
-                  ( map-cocone-standard-sequential-colimit B (succ-ℕ n))
-                  ( map-hom-sequential-diagram C g (succ-ℕ n))
-                  ( map-hom-standard-sequential-colimit C g)
-                  ( map-cocone-standard-sequential-colimit C (succ-ℕ n))
-                  ( inv-htpy
-                    ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f
-                      ( succ-ℕ n)))
-                  ( inv-htpy
-                    ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g
-                      ( succ-ℕ n)))) ·r
-                ( map-sequential-diagram A n)))
-            ( ( pasting-vertical-coherence-square-maps
-                ( map-cocone-standard-sequential-colimit A n)
-                ( map-hom-sequential-diagram B f n)
-                ( map-hom-standard-sequential-colimit B f)
-                ( map-cocone-standard-sequential-colimit B n)
-                ( map-hom-sequential-diagram C g n)
-                ( map-hom-standard-sequential-colimit C g)
-                ( map-cocone-standard-sequential-colimit C n)
-                ( inv-htpy
-                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f
-                    ( n)))
-                ( inv-htpy
-                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g
-                    ( n)))) ∙h
-              ( ( ( map-hom-standard-sequential-colimit C g) ∘
-                  ( map-hom-standard-sequential-colimit B f)) ·l
-                ( coherence-triangle-cocone-standard-sequential-colimit A n)))
             ( ( assoc-htpy
                 ( ( coherence-triangle-cocone-standard-sequential-colimit C
                     ( n)) ·r

--- a/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
@@ -36,8 +36,8 @@ open import synthetic-homotopy-theory.universal-property-sequential-colimits
 ## Idea
 
 Taking a [sequential colimit](synthetic-homotopy-theory.sequential-colimits.md)
-of a [sequential diagram](synthetic-homotopy-theory.sequential-diagrams.md)
-is a functorial action `(A, a) ↦ A∞`. In particular, a
+of a [sequential diagram](synthetic-homotopy-theory.sequential-diagrams.md) is a
+functorial action `(A, a) ↦ A∞`. In particular, a
 [morphism of sequential diagrams](synthetic-homotopy-theory.morphisms-sequential-diagrams.md)
 `f : (A, a) → (B, b)` induces a map `f∞ : A∞ → B∞` between the
 [standard sequential colimits](synthetic-homotopy-theory.sequential-colimits.md)

--- a/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
@@ -14,14 +14,13 @@ open import foundation.commuting-prisms-of-maps
 open import foundation.commuting-squares-of-homotopies
 open import foundation.commuting-squares-of-maps
 open import foundation.dependent-pair-types
+open import foundation.equivalences
 open import foundation.function-extensionality
+open import foundation.function-types
+open import foundation.functoriality-dependent-pair-types
 open import foundation.homotopies
 open import foundation.universe-levels
-
-open import foundation-core.equivalences
-open import foundation-core.function-types
-open import foundation-core.functoriality-dependent-pair-types
-open import foundation-core.whiskering-homotopies
+open import foundation.whiskering-homotopies
 
 open import synthetic-homotopy-theory.cocones-under-sequential-diagrams
 open import synthetic-homotopy-theory.equivalences-sequential-diagrams

--- a/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
@@ -1,0 +1,603 @@
+# Functoriality of sequential colimits
+
+```agda
+module synthetic-homotopy-theory.functoriality-sequential-colimits where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import elementary-number-theory.natural-numbers
+
+open import foundation.action-on-identifications-binary-functions
+open import foundation.action-on-identifications-functions
+open import foundation.commuting-squares-of-homotopies
+open import foundation.commuting-squares-of-maps
+open import foundation.commuting-triangles-of-maps
+open import foundation.commuting-prisms-of-maps
+open import foundation.dependent-pair-types
+open import foundation.equivalences
+open import foundation.function-extensionality
+open import foundation.function-types
+open import foundation.homotopies
+open import foundation.identity-types
+open import foundation.universe-levels
+open import foundation.whiskering-homotopies
+
+open import synthetic-homotopy-theory.cocones-under-sequential-diagrams
+open import synthetic-homotopy-theory.dependent-universal-property-sequential-colimits
+open import synthetic-homotopy-theory.equivalences-sequential-diagrams
+open import synthetic-homotopy-theory.morphisms-sequential-diagrams
+open import synthetic-homotopy-theory.sequential-diagrams
+open import synthetic-homotopy-theory.sequential-colimits
+open import synthetic-homotopy-theory.universal-property-sequential-colimits
+```
+
+</details>
+
+## Idea
+
+A
+[morphism of sequential diagrams](synthetic-homotopy-theory.morphisms-sequential-diagrams.md)
+`f : (A, a) → (B, b)` induces a map `f∞ : A∞ → B∞` between the
+[standard sequential colimits](synthetic-homotopy-theory.standard-sequential-colimit.md)
+of the diagrams.
+
+```text
+```
+
+## Properties
+
+### A morphism of sequential diagrams induces a map of cocones
+
+```agda
+module _
+  { l1 l2 l3 : Level} {A : sequential-diagram l1} {B : sequential-diagram l2}
+  ( f : hom-sequential-diagram A B) {X : UU l3}
+  where
+
+  map-hom-cocone-sequential-colimit :
+    cocone-sequential-diagram B X → cocone-sequential-diagram A X
+  map-hom-cocone-sequential-colimit c =
+    comp-hom-sequential-diagram A B
+      ( constant-sequential-diagram X)
+      ( c)
+      ( f)
+```
+
+### A morphism of sequential diagrams induces a map of sequential colimits
+
+```agda
+module _
+  { l1 l2 : Level} {A : sequential-diagram l1} (B : sequential-diagram l2)
+  ( f : hom-sequential-diagram A B)
+  where
+
+  map-hom-standard-sequential-colimit :
+    standard-sequential-colimit A → standard-sequential-colimit B
+  map-hom-standard-sequential-colimit =
+    map-universal-property-sequential-colimit A
+      ( cocone-standard-sequential-colimit A)
+      ( up-standard-sequential-colimit A)
+      ( map-hom-cocone-sequential-colimit f
+        ( cocone-standard-sequential-colimit B))
+
+  htpy-cocone-map-hom-standard-sequential-colimit :
+    htpy-cocone-sequential-diagram A
+      ( cocone-map-sequential-diagram A
+        ( cocone-standard-sequential-colimit A)
+        ( map-hom-standard-sequential-colimit))
+      ( map-hom-cocone-sequential-colimit f
+        ( cocone-standard-sequential-colimit B))
+  htpy-cocone-map-hom-standard-sequential-colimit =
+    htpy-cocone-universal-property-sequential-colimit A
+      ( cocone-standard-sequential-colimit A)
+      ( up-standard-sequential-colimit A)
+      ( map-hom-cocone-sequential-colimit f
+        ( cocone-standard-sequential-colimit B))
+
+  htpy-htpy-cocone-map-hom-standard-sequential-colimit :
+    ( n : ℕ) →
+    coherence-square-maps
+      ( map-hom-sequential-diagram B f n)
+      ( map-cocone-standard-sequential-colimit A n)
+      ( map-cocone-standard-sequential-colimit B n)
+      ( map-hom-standard-sequential-colimit)
+  htpy-htpy-cocone-map-hom-standard-sequential-colimit =
+    htpy-htpy-cocone-sequential-diagram A
+      ( htpy-cocone-map-hom-standard-sequential-colimit)
+
+  coherence-htpy-cocone-map-hom-standard-sequential-colimit :
+    ( n : ℕ) →
+    coherence-square-homotopies
+      ( htpy-htpy-cocone-map-hom-standard-sequential-colimit n)
+      ( map-hom-standard-sequential-colimit ·l
+        ( coherence-triangle-cocone-standard-sequential-colimit A n))
+      ( (
+          pr2
+          (map-hom-cocone-sequential-colimit f
+          (cocone-standard-sequential-colimit B))
+          n) )
+      ( htpy-htpy-cocone-map-hom-standard-sequential-colimit (succ-ℕ n)
+        ·r pr2 A n)
+  coherence-htpy-cocone-map-hom-standard-sequential-colimit =
+    coherence-htpy-htpy-cocone-sequential-diagram A
+      ( htpy-cocone-map-hom-standard-sequential-colimit)
+
+  prism-htpy-cocone-map-hom-standard-sequential-colimit :
+    ( n : ℕ) →
+    vertical-coherence-prism-maps
+      ( map-sequential-diagram A n)
+      ( map-cocone-standard-sequential-colimit A (succ-ℕ n))
+      ( map-cocone-standard-sequential-colimit A n)
+      ( map-hom-sequential-diagram B f n)
+      ( map-hom-sequential-diagram B f (succ-ℕ n))
+      ( map-hom-standard-sequential-colimit)
+      ( map-sequential-diagram B n)
+      ( map-cocone-standard-sequential-colimit B (succ-ℕ n))
+      ( map-cocone-standard-sequential-colimit B n)
+      ( coherence-triangle-cocone-standard-sequential-colimit A n)
+      ( naturality-map-hom-sequential-diagram B f n)
+      ( inv-htpy (htpy-htpy-cocone-map-hom-standard-sequential-colimit (succ-ℕ n)))
+      ( inv-htpy (htpy-htpy-cocone-map-hom-standard-sequential-colimit n))
+      ( coherence-triangle-cocone-standard-sequential-colimit B n)
+  prism-htpy-cocone-map-hom-standard-sequential-colimit n =
+    [v]
+      ( map-sequential-diagram A n)
+      ( map-cocone-standard-sequential-colimit A (succ-ℕ n))
+      ( map-cocone-standard-sequential-colimit A n)
+      ( map-hom-sequential-diagram B f n)
+      ( map-hom-sequential-diagram B f (succ-ℕ n))
+      ( map-hom-standard-sequential-colimit)
+      ( map-sequential-diagram B n)
+      ( map-cocone-standard-sequential-colimit B (succ-ℕ n))
+      ( map-cocone-standard-sequential-colimit B n)
+      ( coherence-triangle-cocone-standard-sequential-colimit A n)
+      ( naturality-map-hom-sequential-diagram B f n)
+      ( htpy-htpy-cocone-map-hom-standard-sequential-colimit (succ-ℕ n))
+      ( htpy-htpy-cocone-map-hom-standard-sequential-colimit n)
+      ( coherence-triangle-cocone-standard-sequential-colimit B n)
+      ( inv-htpy (coherence-htpy-cocone-map-hom-standard-sequential-colimit n))
+
+```
+
+### Homotopies between morphisms of sequential diagrams induce homotopies of maps of sequential colimits
+
+```agda
+module _
+  { l1 l2 : Level} (A : sequential-diagram l1) {X : UU l2}
+  { f g : standard-sequential-colimit A → X}
+  ( H : htpy-standard-sequential-colimit A f g)
+  where
+
+  htpy-htpy-standard-sequential-colimit : f ~ g
+  htpy-htpy-standard-sequential-colimit =
+    map-dependent-universal-property-sequential-colimit A
+      ( cocone-standard-sequential-colimit A)
+      ( dup-standard-sequential-colimit A)
+      ( pr1 H ,
+        λ n a →
+        map-compute-dependent-identification-eq-value-function f g
+          ( coherence-triangle-cocone-standard-sequential-colimit A n a)
+          ( pr1 H n a)
+          ( (pr1 H (succ-ℕ n) ∘ pr2 A n) a)
+          ( pr2 H n a))
+```
+
+```agda
+module _
+  { l1 l2 : Level} {A : sequential-diagram l1} {B : sequential-diagram l2}
+  { f g : hom-sequential-diagram A B} (H : htpy-hom-sequential-diagram B f g)
+  where
+
+  htpy-map-hom-standard-sequential-colimit-htpy-hom-sequential-diagram :
+    map-hom-standard-sequential-colimit B f ~
+    map-hom-standard-sequential-colimit B g
+  htpy-map-hom-standard-sequential-colimit-htpy-hom-sequential-diagram =
+    htpy-eq
+      ( ap
+        ( map-hom-standard-sequential-colimit B)
+        ( eq-htpy-sequential-diagram A B f g H))
+```
+
+### The identity morphism induces the identity map
+
+```agda
+module _
+  { l1 : Level} (A : sequential-diagram l1)
+  where
+
+  preserves-id-map-hom-standard-sequential-colimit :
+    map-hom-standard-sequential-colimit A
+      ( id-hom-sequential-diagram A) ~
+    id
+  preserves-id-map-hom-standard-sequential-colimit =
+    htpy-htpy-standard-sequential-colimit A
+      ( ( htpy-htpy-cocone-map-hom-standard-sequential-colimit A
+          ( id-hom-sequential-diagram A)) ,
+        ( λ n →
+          ( coherence-htpy-cocone-map-hom-standard-sequential-colimit A
+            ( id-hom-sequential-diagram A) n) ∙h
+          ( horizontal-concat-htpy² refl-htpy
+            ( ( right-unit-htpy) ∙h
+              ( inv-htpy
+                ( left-unit-law-left-whisk-htpy
+                  ( coherence-triangle-cocone-standard-sequential-colimit A
+                    ( n))))))))
+```
+
+### Composition preservation
+
+```agda
+module _
+  { l1 l2 l3 : Level} (A : sequential-diagram l1) (B : sequential-diagram l2)
+  ( C : sequential-diagram l3)
+  ( g : hom-sequential-diagram B C) (f : hom-sequential-diagram A B)
+  where
+
+  preserves-comp-map-hom-standard-sequential-colimit :
+    map-hom-standard-sequential-colimit C
+      ( comp-hom-sequential-diagram A B C g f) ~
+    ( map-hom-standard-sequential-colimit C g ∘
+      map-hom-standard-sequential-colimit B f)
+  preserves-comp-map-hom-standard-sequential-colimit =
+    htpy-htpy-standard-sequential-colimit A
+      ( ( λ n →
+          ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C
+            ( comp-hom-sequential-diagram A B C g f) n) ∙h
+          ( pasting-vertical-coherence-square-maps
+            ( map-cocone-standard-sequential-colimit A n)
+            ( map-hom-sequential-diagram B f n)
+            ( map-hom-standard-sequential-colimit B f)
+            ( map-cocone-standard-sequential-colimit B n)
+            ( map-hom-sequential-diagram C g n)
+            ( map-hom-standard-sequential-colimit C g)
+            ( map-cocone-standard-sequential-colimit C n)
+            ( inv-htpy
+              ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f n))
+            ( inv-htpy
+              ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g n)))) ,
+        ( λ n →
+          ( inv-htpy-assoc-htpy
+            ( ( map-hom-standard-sequential-colimit C
+                ( comp-hom-sequential-diagram A B C g f)) ·l
+              ( coherence-triangle-cocone-standard-sequential-colimit A n))
+            ( ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C
+                ( comp-hom-sequential-diagram A B C g f)
+                ( succ-ℕ n)) ·r
+              ( map-sequential-diagram A n))
+            ( ( pasting-vertical-coherence-square-maps
+                ( map-cocone-standard-sequential-colimit A (succ-ℕ n))
+                ( map-hom-sequential-diagram B f (succ-ℕ n))
+                ( map-hom-standard-sequential-colimit B f)
+                ( map-cocone-standard-sequential-colimit B (succ-ℕ n))
+                ( map-hom-sequential-diagram C g (succ-ℕ n))
+                ( map-hom-standard-sequential-colimit C g)
+                ( map-cocone-standard-sequential-colimit C (succ-ℕ n))
+                ( inv-htpy
+                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f
+                    ( succ-ℕ n)))
+                ( inv-htpy
+                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g
+                    ( succ-ℕ n)))) ·r
+              ( map-sequential-diagram A n))) ∙h
+          ( ap-concat-htpy'
+            ( ( ( map-hom-standard-sequential-colimit C
+                  ( comp-hom-sequential-diagram A B C g f)) ·l
+                ( coherence-triangle-cocone-standard-sequential-colimit A n)) ∙h
+              ( ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C
+                  ( comp-hom-sequential-diagram A B C g f)
+                  ( succ-ℕ n)) ·r
+                ( map-sequential-diagram A n)))
+            ( ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C
+                ( comp-hom-sequential-diagram A B C g f)
+                ( n)) ∙h
+              ( coherence-triangle-cocone-sequential-diagram A
+                ( map-hom-cocone-sequential-colimit
+                  ( comp-hom-sequential-diagram A B C g f)
+                  ( cocone-standard-sequential-colimit C))
+                ( n)))
+            ( ( pasting-vertical-coherence-square-maps
+                ( map-cocone-standard-sequential-colimit A (succ-ℕ n))
+                ( map-hom-sequential-diagram B f (succ-ℕ n))
+                ( map-hom-standard-sequential-colimit B f)
+                ( map-cocone-standard-sequential-colimit B (succ-ℕ n))
+                ( map-hom-sequential-diagram C g (succ-ℕ n))
+                ( map-hom-standard-sequential-colimit C g)
+                ( map-cocone-standard-sequential-colimit C (succ-ℕ n))
+                ( inv-htpy
+                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f
+                    ( succ-ℕ n)))
+                ( inv-htpy
+                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g
+                    ( succ-ℕ n)))) ·r
+              ( map-sequential-diagram A n))
+            ( coherence-htpy-cocone-map-hom-standard-sequential-colimit C
+              ( comp-hom-sequential-diagram A B C g f)
+              ( n)) ∙h
+          ( assoc-htpy
+            ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C
+              ( comp-hom-sequential-diagram A B C g f)
+              ( n))
+            ( coherence-triangle-cocone-sequential-diagram A
+              ( map-hom-cocone-sequential-colimit
+                ( comp-hom-sequential-diagram A B C g f)
+                ( cocone-standard-sequential-colimit C))
+              ( n))
+            ( ( pasting-vertical-coherence-square-maps
+                ( map-cocone-standard-sequential-colimit A (succ-ℕ n))
+                ( map-hom-sequential-diagram B f (succ-ℕ n))
+                ( map-hom-standard-sequential-colimit B f)
+                ( map-cocone-standard-sequential-colimit B (succ-ℕ n))
+                ( map-hom-sequential-diagram C g (succ-ℕ n))
+                ( map-hom-standard-sequential-colimit C g)
+                ( map-cocone-standard-sequential-colimit C (succ-ℕ n))
+                ( inv-htpy
+                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f
+                    ( succ-ℕ n)))
+                ( inv-htpy
+                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g
+                    ( succ-ℕ n)))) ·r
+              ( map-sequential-diagram A n))) ∙h
+          ( ap-concat-htpy
+            ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C
+              ( comp-hom-sequential-diagram A B C g f)
+              ( n))
+            ( ( coherence-triangle-cocone-sequential-diagram A
+                ( map-hom-cocone-sequential-colimit
+                  ( comp-hom-sequential-diagram A B C g f)
+                  ( cocone-standard-sequential-colimit C))
+                ( n)) ∙h
+              ( ( pasting-vertical-coherence-square-maps
+                  ( map-cocone-standard-sequential-colimit A (succ-ℕ n))
+                  ( map-hom-sequential-diagram B f (succ-ℕ n))
+                  ( map-hom-standard-sequential-colimit B f)
+                  ( map-cocone-standard-sequential-colimit B (succ-ℕ n))
+                  ( map-hom-sequential-diagram C g (succ-ℕ n))
+                  ( map-hom-standard-sequential-colimit C g)
+                  ( map-cocone-standard-sequential-colimit C (succ-ℕ n))
+                  ( inv-htpy
+                    ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f
+                      ( succ-ℕ n)))
+                  ( inv-htpy
+                    ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g
+                      ( succ-ℕ n)))) ·r
+                ( map-sequential-diagram A n)))
+            ( ( pasting-vertical-coherence-square-maps
+                ( map-cocone-standard-sequential-colimit A n)
+                ( map-hom-sequential-diagram B f n)
+                ( map-hom-standard-sequential-colimit B f)
+                ( map-cocone-standard-sequential-colimit B n)
+                ( map-hom-sequential-diagram C g n)
+                ( map-hom-standard-sequential-colimit C g)
+                ( map-cocone-standard-sequential-colimit C n)
+                ( inv-htpy
+                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f
+                    ( n)))
+                ( inv-htpy
+                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g
+                    ( n)))) ∙h
+              ( ( ( map-hom-standard-sequential-colimit C g) ∘
+                  ( map-hom-standard-sequential-colimit B f)) ·l
+                ( coherence-triangle-cocone-standard-sequential-colimit A n)))
+            ( ( assoc-htpy
+                ( ( coherence-triangle-cocone-standard-sequential-colimit C n) ·r
+                  ( map-hom-sequential-diagram C g n ∘ map-hom-sequential-diagram B f n))
+                ( map-cocone-standard-sequential-colimit C (succ-ℕ n) ·l _)
+                ( _)) ∙h
+              ( pasting-vertical-coherence-prism-maps
+                ( map-sequential-diagram A n)
+                ( map-cocone-standard-sequential-colimit A (succ-ℕ n))
+                ( map-cocone-standard-sequential-colimit A n)
+                ( map-hom-sequential-diagram B f n)
+                ( map-hom-sequential-diagram B f (succ-ℕ n))
+                ( map-hom-standard-sequential-colimit B f)
+                ( map-sequential-diagram B n)
+                ( map-cocone-standard-sequential-colimit B (succ-ℕ n))
+                ( map-cocone-standard-sequential-colimit B n)
+                ( map-hom-sequential-diagram C g n)
+                ( map-hom-sequential-diagram C g (succ-ℕ n))
+                ( map-hom-standard-sequential-colimit C g)
+                ( map-sequential-diagram C n)
+                ( map-cocone-standard-sequential-colimit C (succ-ℕ n))
+                ( map-cocone-standard-sequential-colimit C n)
+                ( coherence-triangle-cocone-standard-sequential-colimit A n)
+                ( naturality-map-hom-sequential-diagram B f n)
+                ( inv-htpy
+                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f (succ-ℕ n)))
+                ( inv-htpy
+                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f n))
+                ( coherence-triangle-cocone-standard-sequential-colimit B n)
+                ( naturality-map-hom-sequential-diagram C g n)
+                ( inv-htpy
+                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g (succ-ℕ n)))
+                ( inv-htpy
+                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g n))
+                ( coherence-triangle-cocone-standard-sequential-colimit C n)
+                ( prism-htpy-cocone-map-hom-standard-sequential-colimit B f n)
+                ( prism-htpy-cocone-map-hom-standard-sequential-colimit C g n)))) ∙h
+          ( inv-htpy-assoc-htpy
+            ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C
+              ( comp-hom-sequential-diagram A B C g f)
+              ( n))
+            ( pasting-vertical-coherence-square-maps
+              ( map-cocone-standard-sequential-colimit A n)
+              ( map-hom-sequential-diagram B f n)
+              ( map-hom-standard-sequential-colimit B f)
+              ( map-cocone-standard-sequential-colimit B n)
+              ( map-hom-sequential-diagram C g n)
+              ( map-hom-standard-sequential-colimit C g)
+              ( map-cocone-standard-sequential-colimit C n)
+              ( inv-htpy
+                ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f
+                  ( n)))
+              ( inv-htpy
+                ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g
+                  ( n))))
+            ( ( ( map-hom-standard-sequential-colimit C g) ∘
+                  ( map-hom-standard-sequential-colimit B f)) ·l
+                ( coherence-triangle-cocone-standard-sequential-colimit A n))))))
+```
+
+### An equivalence of sequential diagrams induces an equivalence of cocones
+
+```agda
+module _
+  { l1 l2 : Level} {A : sequential-diagram l1} {B : sequential-diagram l2}
+  ( e : equiv-sequential-diagram A B)
+  where
+
+  map-equiv-standard-sequential-colimit :
+    standard-sequential-colimit A → standard-sequential-colimit B
+  map-equiv-standard-sequential-colimit =
+    map-hom-standard-sequential-colimit B
+      ( hom-equiv-sequential-diagram B e)
+
+  inv-map-equiv-standard-sequential-colimit :
+    standard-sequential-colimit B → standard-sequential-colimit A
+  inv-map-equiv-standard-sequential-colimit =
+    map-hom-standard-sequential-colimit A
+      ( hom-inv-equiv-sequential-diagram B e)
+
+  abstract
+    is-section-inv-map-equiv-standard-sequential-colimit :
+      ( map-equiv-standard-sequential-colimit) ∘
+      ( inv-map-equiv-standard-sequential-colimit) ~
+      id
+    is-section-inv-map-equiv-standard-sequential-colimit =
+      ( inv-htpy
+        ( preserves-comp-map-hom-standard-sequential-colimit B A B
+          ( hom-equiv-sequential-diagram B e)
+          ( hom-inv-equiv-sequential-diagram B e))) ∙h
+      ( htpy-map-hom-standard-sequential-colimit-htpy-hom-sequential-diagram
+        ( ( λ n →
+            is-section-map-inv-equiv (equiv-equiv-sequential-diagram B e n)) ,
+          ( λ n →
+            inv-htpy
+              ( right-inverse-law-pasting-vertical-coherence-square-maps
+                ( map-sequential-diagram A n)
+                ( equiv-equiv-sequential-diagram B e n)
+                ( equiv-equiv-sequential-diagram B e (succ-ℕ n))
+                ( map-sequential-diagram B n)
+                ( naturality-equiv-sequential-diagram B e n))))) ∙h
+      ( preserves-id-map-hom-standard-sequential-colimit B)
+
+    is-retraction-inv-map-equiv-standard-sequential-colimit :
+      ( inv-map-equiv-standard-sequential-colimit) ∘
+      ( map-equiv-standard-sequential-colimit) ~
+      id
+    is-retraction-inv-map-equiv-standard-sequential-colimit =
+      ( inv-htpy
+        ( preserves-comp-map-hom-standard-sequential-colimit A B A
+          ( hom-inv-equiv-sequential-diagram B e)
+          ( hom-equiv-sequential-diagram B e))) ∙h
+      ( htpy-map-hom-standard-sequential-colimit-htpy-hom-sequential-diagram
+        ( ( λ n →
+            is-retraction-map-inv-equiv
+              ( equiv-equiv-sequential-diagram B e n)) ,
+          ( λ n →
+            inv-htpy
+              ( left-inverse-law-pasting-vertical-coherence-square-maps
+                ( map-sequential-diagram A n)
+                ( equiv-equiv-sequential-diagram B e n)
+                ( equiv-equiv-sequential-diagram B e (succ-ℕ n))
+                ( map-sequential-diagram B n)
+                ( naturality-equiv-sequential-diagram B e n))))) ∙h
+      ( preserves-id-map-hom-standard-sequential-colimit A)
+
+  -- equiv-cocone-equiv-sequential-diagram :
+  --   { l3 : Level} {X : UU l3} →
+  --   cocone-sequential-diagram B X ≃ cocone-sequential-diagram A X
+  -- equiv-cocone-equiv-sequential-diagram {X = X} =
+  --   equiv-precomp-equiv-hom-sequential-diagram A B
+  --     ( constant-sequential-diagram X)
+  --     ( e)
+
+  -- triangle-equiv-cocone-equiv-sequential-diagram :
+  --   { l3 : Level} {X : UU l3} →
+  --   coherence-triangle-maps
+  --     ( cocone-map-sequential-diagram A
+  --       ( map-hom-cocone-sequential-colimit
+  --         ( hom-equiv-sequential-diagram B e)
+  --         ( cocone-standard-sequential-colimit B))
+  --       { Y = X})
+  --     ( map-equiv equiv-cocone-equiv-sequential-diagram)
+  --     ( cocone-map-sequential-diagram B (cocone-standard-sequential-colimit B))
+  -- triangle-equiv-cocone-equiv-sequential-diagram h =
+  --   eq-htpy-cocone-sequential-diagram A _ _
+  --     ( ( λ n → refl-htpy) ,
+  --       ( λ n →
+  --         ( right-unit-htpy) ∙h
+  --         ( λ a →
+  --           ( distributive-left-whisk-concat-htpy h
+  --             ( ( coherence-triangle-cocone-sequential-diagram B
+  --                 ( cocone-standard-sequential-colimit B)
+  --                 ( n)) ·r
+  --               ( map-equiv-sequential-diagram B e n))
+  --             ( ( map-cocone-sequential-diagram B
+  --                 ( cocone-standard-sequential-colimit B)
+  --                 ( succ-ℕ n) ·l
+  --               ( naturality-map-hom-sequential-diagram B
+  --                 ( hom-equiv-sequential-diagram B e) n)))
+  --             ( a)) ∙
+  --           ( ap
+  --             ( ap h
+  --               ( coherence-triangle-cocone-sequential-diagram B
+  --                 ( cocone-standard-sequential-colimit B)
+  --                 ( n)
+  --                 ( map-equiv-sequential-diagram B e n a)) ∙_)
+  --             ( associative-left-whisk-comp h
+  --               ( map-cocone-standard-sequential-colimit B (succ-ℕ n))
+  --               ( naturality-equiv-sequential-diagram B e n)
+  --               ( a))))))
+
+  -- map-up-cocone-equiv-sequential-diagram :
+  --   ( {l : Level} →
+  --     universal-property-sequential-colimit l A
+  --       ( map-hom-cocone-sequential-colimit
+  --         ( hom-equiv-sequential-diagram B e)
+  --         ( cocone-standard-sequential-colimit B)))
+  -- map-up-cocone-equiv-sequential-diagram Y =
+  --   is-equiv-left-map-triangle
+  --     ( cocone-map-sequential-diagram A
+  --       ( map-hom-cocone-sequential-colimit
+  --         ( hom-equiv-sequential-diagram B e)
+  --         ( cocone-standard-sequential-colimit B)))
+  --     ( map-equiv equiv-cocone-equiv-sequential-diagram)
+  --     ( cocone-map-sequential-diagram B (cocone-standard-sequential-colimit B))
+  --     ( triangle-equiv-cocone-equiv-sequential-diagram)
+  --     ( up-standard-sequential-colimit B Y)
+  --     ( is-equiv-map-equiv equiv-cocone-equiv-sequential-diagram)
+
+  -- is-equiv-map-hom-standard-sequential-colimit :
+  --   is-equiv map-equiv-standard-sequential-colimit
+  -- is-equiv-map-hom-standard-sequential-colimit =
+  --   is-equiv-universal-property-sequential-colimit-universal-property-sequential-colimit
+  --     ( A)
+  --     ( cocone-standard-sequential-colimit A)
+  --     ( map-hom-cocone-sequential-colimit
+  --       ( hom-equiv-sequential-diagram B e)
+  --       ( cocone-standard-sequential-colimit B))
+  --     ( map-hom-standard-sequential-colimit B
+  --       ( hom-equiv-sequential-diagram B e))
+  --     ( htpy-cocone-map-hom-standard-sequential-colimit B
+  --       ( hom-equiv-sequential-diagram B e))
+  --     ( up-standard-sequential-colimit A)
+  --     ( map-up-cocone-equiv-sequential-diagram)
+
+  is-equiv-map-hom-standard-sequential-colimit' :
+    is-equiv map-equiv-standard-sequential-colimit
+  is-equiv-map-hom-standard-sequential-colimit' =
+    is-equiv-is-invertible
+      ( inv-map-equiv-standard-sequential-colimit)
+      ( is-section-inv-map-equiv-standard-sequential-colimit)
+      ( is-retraction-inv-map-equiv-standard-sequential-colimit)
+
+  equiv-equiv-standard-sequential-colimit :
+    standard-sequential-colimit A ≃ standard-sequential-colimit B
+  pr1 equiv-equiv-standard-sequential-colimit =
+    map-hom-standard-sequential-colimit B
+      ( hom-equiv-sequential-diagram B e)
+  pr2 equiv-equiv-standard-sequential-colimit =
+    is-equiv-map-hom-standard-sequential-colimit'
+```

--- a/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
@@ -83,17 +83,17 @@ This homotopy provides
 
 ```text
           Aₙ₊₁
-         ^| \
-       /  |   \
-     /    |fₙ₊₁ V
+         ^ | \
+       /   |   \
+     /     |fₙ₊₁ V
     Aₙ ---------> A∞
-    |     |      |
-    |     V      |
- fₙ |     Bₙ₊₁   | f∞
-    |    ^  \    |
-    |  /      \  |
-    |/          V|
-    Bₙ --------> B∞ ,
+    |      |      |
+    |      V      |
+ fₙ |     Bₙ₊₁    | f∞
+    |    ^   \    |
+    |  /       \  |
+    V/           VV
+    Bₙ ---------> B∞ ,
 ```
 
 where the triangles are coherences of the cocones of the standard sequential

--- a/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
@@ -35,11 +35,14 @@ open import synthetic-homotopy-theory.universal-property-sequential-colimits
 
 ## Idea
 
-A
+Taking a [sequential colimit](synthetic-homotopy-theory.sequential-colimits.md)
+of a [sequential diagram](synthetic-homotopy-theory.sequential-diagrams.md)
+is a functorial action `(A, a) ↦ A∞`. In particular, a
 [morphism of sequential diagrams](synthetic-homotopy-theory.morphisms-sequential-diagrams.md)
 `f : (A, a) → (B, b)` induces a map `f∞ : A∞ → B∞` between the
 [standard sequential colimits](synthetic-homotopy-theory.sequential-colimits.md)
-of the diagrams.
+of the diagrams, and this action preserves the identity morphism and morphism
+composition.
 
 Furthermore, an
 [equivalence of sequential diagrams](synthetic-homotopy-theory.equivalences-sequential-diagrams.md)
@@ -75,10 +78,12 @@ The induced map
         b₀      b₁      b₂
 ```
 
-then induces a cocone under `(A, a)` with codomain `B∞`, which is homotopic to
-the standard cocone under `(B, b)` precomposed by `f`.
+then induces a
+[cocone](synthetic-homotopy-theory.cocones-under-sequential-diagrams.md) under
+`(A, a)` with codomain `B∞`, which is homotopic to the standard cocone under
+`(B, b)` precomposed by `f`.
 
-This homotopy provides
+This homotopy of cocones provides
 [vertical commuting prisms of maps](foundation.commuting-prisms-of-maps.md),
 
 ```text
@@ -96,9 +101,10 @@ This homotopy provides
     Bₙ ---------> B∞ ,
 ```
 
-where the triangles are coherences of the cocones of the standard sequential
-colimits, the back left square is coherence of `f`, and the front and back right
-squares are provided by uniqueness of `f∞`.
+where the [triangles](foundation-core.commuting-triangles-of-maps.md) are
+coherences of the cocones of the standard sequential colimits, the back left
+[square](foundation-core.commuting-triangles-of-maps.md) is coherence of `f`,
+and the front and back right squares are provided by uniqueness of `f∞`.
 
 ```agda
 module _
@@ -211,6 +217,8 @@ module _
 
 ### The identity morphism induces the identity map
 
+We have `id∞ ~ id : A∞ → A∞`.
+
 ```agda
 module _
   { l1 : Level} {A : sequential-diagram l1}
@@ -242,7 +250,9 @@ module _
       ( htpy-preserves-id-map-hom-standard-sequential-colimit)
 ```
 
-### Composition of morphisms of sequential diagrams induces a composition of maps between sequential colimits
+### Forming sequential colimits preserves composition of morphisms of sequential diagrams
+
+We have `(f ∘ g)∞ ~ (f∞ ∘ g∞) : A∞ → C∞`.
 
 ```agda
 module _
@@ -361,8 +371,9 @@ module _
 
 ### An equivalence of sequential diagrams induces an equivalence of cocones
 
-Additionally, the inverse of the induced equivalence is the map induced by the
-inverse equivalence of sequential diagrams, i.e. `(e∞)⁻¹ ≐ (e⁻¹)∞`.
+Additionally, the underlying map of the inverse equivalence if definitionally
+equal to the map induced by the inverse of the equivalence of sequential
+diagrams, i.e. `(e∞)⁻¹ = (e⁻¹)∞`.
 
 ```agda
 module _

--- a/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
@@ -11,10 +11,10 @@ open import elementary-number-theory.natural-numbers
 
 open import foundation.action-on-identifications-binary-functions
 open import foundation.action-on-identifications-functions
+open import foundation.commuting-prisms-of-maps
 open import foundation.commuting-squares-of-homotopies
 open import foundation.commuting-squares-of-maps
 open import foundation.commuting-triangles-of-maps
-open import foundation.commuting-prisms-of-maps
 open import foundation.dependent-pair-types
 open import foundation.equivalences
 open import foundation.function-extensionality
@@ -28,8 +28,8 @@ open import synthetic-homotopy-theory.cocones-under-sequential-diagrams
 open import synthetic-homotopy-theory.dependent-universal-property-sequential-colimits
 open import synthetic-homotopy-theory.equivalences-sequential-diagrams
 open import synthetic-homotopy-theory.morphisms-sequential-diagrams
-open import synthetic-homotopy-theory.sequential-diagrams
 open import synthetic-homotopy-theory.sequential-colimits
+open import synthetic-homotopy-theory.sequential-diagrams
 open import synthetic-homotopy-theory.universal-property-sequential-colimits
 ```
 
@@ -40,11 +40,8 @@ open import synthetic-homotopy-theory.universal-property-sequential-colimits
 A
 [morphism of sequential diagrams](synthetic-homotopy-theory.morphisms-sequential-diagrams.md)
 `f : (A, a) → (B, b)` induces a map `f∞ : A∞ → B∞` between the
-[standard sequential colimits](synthetic-homotopy-theory.standard-sequential-colimit.md)
+[standard sequential colimits](synthetic-homotopy-theory.sequential-colimits.md)
 of the diagrams.
-
-```text
-```
 
 ## Properties
 
@@ -117,7 +114,7 @@ module _
           pr2
           (map-hom-cocone-sequential-colimit f
           (cocone-standard-sequential-colimit B))
-          n) )
+          n))
       ( htpy-htpy-cocone-map-hom-standard-sequential-colimit (succ-ℕ n)
         ·r pr2 A n)
   coherence-htpy-cocone-map-hom-standard-sequential-colimit =
@@ -138,7 +135,8 @@ module _
       ( map-cocone-standard-sequential-colimit B n)
       ( coherence-triangle-cocone-standard-sequential-colimit A n)
       ( naturality-map-hom-sequential-diagram B f n)
-      ( inv-htpy (htpy-htpy-cocone-map-hom-standard-sequential-colimit (succ-ℕ n)))
+      ( inv-htpy
+        ( htpy-htpy-cocone-map-hom-standard-sequential-colimit (succ-ℕ n)))
       ( inv-htpy (htpy-htpy-cocone-map-hom-standard-sequential-colimit n))
       ( coherence-triangle-cocone-standard-sequential-colimit B n)
   prism-htpy-cocone-map-hom-standard-sequential-colimit n =
@@ -158,7 +156,6 @@ module _
       ( htpy-htpy-cocone-map-hom-standard-sequential-colimit n)
       ( coherence-triangle-cocone-standard-sequential-colimit B n)
       ( inv-htpy (coherence-htpy-cocone-map-hom-standard-sequential-colimit n))
-
 ```
 
 ### Homotopies between morphisms of sequential diagrams induce homotopies of maps of sequential colimits
@@ -381,8 +378,10 @@ module _
                   ( map-hom-standard-sequential-colimit B f)) ·l
                 ( coherence-triangle-cocone-standard-sequential-colimit A n)))
             ( ( assoc-htpy
-                ( ( coherence-triangle-cocone-standard-sequential-colimit C n) ·r
-                  ( map-hom-sequential-diagram C g n ∘ map-hom-sequential-diagram B f n))
+                ( ( coherence-triangle-cocone-standard-sequential-colimit C
+                    ( n)) ·r
+                  ( ( map-hom-sequential-diagram C g n) ∘
+                    ( map-hom-sequential-diagram B f n)))
                 ( map-cocone-standard-sequential-colimit C (succ-ℕ n) ·l _)
                 ( _)) ∙h
               ( pasting-vertical-coherence-prism-maps
@@ -404,18 +403,21 @@ module _
                 ( coherence-triangle-cocone-standard-sequential-colimit A n)
                 ( naturality-map-hom-sequential-diagram B f n)
                 ( inv-htpy
-                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f (succ-ℕ n)))
+                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f
+                    ( succ-ℕ n)))
                 ( inv-htpy
                   ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f n))
                 ( coherence-triangle-cocone-standard-sequential-colimit B n)
                 ( naturality-map-hom-sequential-diagram C g n)
                 ( inv-htpy
-                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g (succ-ℕ n)))
+                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g
+                    ( succ-ℕ n)))
                 ( inv-htpy
                   ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g n))
                 ( coherence-triangle-cocone-standard-sequential-colimit C n)
                 ( prism-htpy-cocone-map-hom-standard-sequential-colimit B f n)
-                ( prism-htpy-cocone-map-hom-standard-sequential-colimit C g n)))) ∙h
+                ( prism-htpy-cocone-map-hom-standard-sequential-colimit C g
+                  ( n))))) ∙h
           ( inv-htpy-assoc-htpy
             ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C
               ( comp-hom-sequential-diagram A B C g f)
@@ -436,7 +438,8 @@ module _
                   ( n))))
             ( ( ( map-hom-standard-sequential-colimit C g) ∘
                   ( map-hom-standard-sequential-colimit B f)) ·l
-                ( coherence-triangle-cocone-standard-sequential-colimit A n))))))
+                ( coherence-triangle-cocone-standard-sequential-colimit A
+                  ( n)))))))
 ```
 
 ### An equivalence of sequential diagrams induces an equivalence of cocones

--- a/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
@@ -48,6 +48,9 @@ Furthermore, an
 [equivalence of sequential diagrams](synthetic-homotopy-theory.equivalences-sequential-diagrams.md)
 `e : (A, a) ≃ (B, b)` induces an equivalence `e∞ : A∞ ≃ B∞`.
 
+The development in this file is a formalization of Lemma 3.5 in Sequential
+Colimits in Homotopy Type Theory.
+
 ## Properties
 
 ### A morphism of sequential diagrams induces a map of cocones
@@ -435,3 +438,11 @@ module _
   pr2 equiv-equiv-standard-sequential-colimit =
     is-equiv-map-hom-standard-sequential-colimit
 ```
+
+## References
+
+1. Kristina Sojakova, Floris van Doorn, and Egbert Rijke. 2020. Sequential
+   Colimits in Homotopy Type Theory. In Proceedings of the 35th Annual ACM/IEEE
+   Symposium on Logic in Computer Science (LICS '20). Association for Computing
+   Machinery, New York, NY, USA, 845–858,
+   [DOI:10.1145](https://doi.org/10.1145/3373718.3394801)

--- a/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
@@ -58,10 +58,7 @@ module _
   map-cocone-hom-sequential-diagram :
     cocone-sequential-diagram B X → cocone-sequential-diagram A X
   map-cocone-hom-sequential-diagram c =
-    comp-hom-sequential-diagram A B
-      ( constant-sequential-diagram X)
-      ( c)
-      ( f)
+    comp-hom-sequential-diagram A B (constant-sequential-diagram X) c f
 ```
 
 ### A morphism of sequential diagrams induces a map of sequential colimits
@@ -112,7 +109,7 @@ module _
   map-hom-standard-sequential-colimit :
     standard-sequential-colimit A → standard-sequential-colimit B
   map-hom-standard-sequential-colimit =
-    cogap-standard-sequential-colimit A
+    cogap-standard-sequential-colimit
       ( map-cocone-hom-sequential-diagram f
         ( cocone-standard-sequential-colimit B))
 
@@ -126,7 +123,7 @@ module _
   htpy-cocone-map-hom-standard-sequential-colimit =
     htpy-cocone-universal-property-sequential-colimit A
       ( cocone-standard-sequential-colimit A)
-      ( up-standard-sequential-colimit A)
+      ( up-standard-sequential-colimit)
       ( map-cocone-hom-sequential-diagram f
         ( cocone-standard-sequential-colimit B))
 
@@ -134,8 +131,8 @@ module _
     ( n : ℕ) →
     coherence-square-maps
       ( map-hom-sequential-diagram B f n)
-      ( map-cocone-standard-sequential-colimit A n)
-      ( map-cocone-standard-sequential-colimit B n)
+      ( map-cocone-standard-sequential-colimit n)
+      ( map-cocone-standard-sequential-colimit n)
       ( map-hom-standard-sequential-colimit)
   htpy-htpy-cocone-map-hom-standard-sequential-colimit =
     htpy-htpy-cocone-sequential-diagram A
@@ -146,7 +143,7 @@ module _
     coherence-square-homotopies
       ( htpy-htpy-cocone-map-hom-standard-sequential-colimit n)
       ( ( map-hom-standard-sequential-colimit) ·l
-        ( coherence-triangle-cocone-standard-sequential-colimit A n))
+        ( coherence-triangle-cocone-standard-sequential-colimit n))
       ( coherence-triangle-cocone-sequential-diagram A
           ( map-cocone-hom-sequential-diagram f
             ( cocone-standard-sequential-colimit B))
@@ -160,37 +157,37 @@ module _
   prism-htpy-cocone-map-hom-standard-sequential-colimit :
     ( n : ℕ) →
     vertical-coherence-prism-maps
-      ( map-cocone-standard-sequential-colimit A n)
-      ( map-cocone-standard-sequential-colimit A (succ-ℕ n))
+      ( map-cocone-standard-sequential-colimit n)
+      ( map-cocone-standard-sequential-colimit (succ-ℕ n))
       ( map-sequential-diagram A n)
-      ( map-cocone-standard-sequential-colimit B n)
-      ( map-cocone-standard-sequential-colimit B (succ-ℕ n))
+      ( map-cocone-standard-sequential-colimit n)
+      ( map-cocone-standard-sequential-colimit (succ-ℕ n))
       ( map-sequential-diagram B n)
       ( map-hom-sequential-diagram B f n)
       ( map-hom-sequential-diagram B f (succ-ℕ n))
       ( map-hom-standard-sequential-colimit)
-      ( coherence-triangle-cocone-standard-sequential-colimit A n)
+      ( coherence-triangle-cocone-standard-sequential-colimit n)
       ( inv-htpy (htpy-htpy-cocone-map-hom-standard-sequential-colimit n))
       ( inv-htpy
         ( htpy-htpy-cocone-map-hom-standard-sequential-colimit (succ-ℕ n)))
       ( naturality-map-hom-sequential-diagram B f n)
-      ( coherence-triangle-cocone-standard-sequential-colimit B n)
+      ( coherence-triangle-cocone-standard-sequential-colimit n)
   prism-htpy-cocone-map-hom-standard-sequential-colimit n =
     rotate-vertical-coherence-prism-maps
-      ( map-cocone-standard-sequential-colimit A n)
-      ( map-cocone-standard-sequential-colimit A (succ-ℕ n))
+      ( map-cocone-standard-sequential-colimit n)
+      ( map-cocone-standard-sequential-colimit (succ-ℕ n))
       ( map-sequential-diagram A n)
-      ( map-cocone-standard-sequential-colimit B n)
-      ( map-cocone-standard-sequential-colimit B (succ-ℕ n))
+      ( map-cocone-standard-sequential-colimit n)
+      ( map-cocone-standard-sequential-colimit (succ-ℕ n))
       ( map-sequential-diagram B n)
       ( map-hom-sequential-diagram B f n)
       ( map-hom-sequential-diagram B f (succ-ℕ n))
       ( map-hom-standard-sequential-colimit)
-      ( coherence-triangle-cocone-standard-sequential-colimit A n)
+      ( coherence-triangle-cocone-standard-sequential-colimit n)
       ( htpy-htpy-cocone-map-hom-standard-sequential-colimit n)
       ( htpy-htpy-cocone-map-hom-standard-sequential-colimit (succ-ℕ n))
       ( naturality-map-hom-sequential-diagram B f n)
-      ( coherence-triangle-cocone-standard-sequential-colimit B n)
+      ( coherence-triangle-cocone-standard-sequential-colimit n)
       ( inv-htpy (coherence-htpy-cocone-map-hom-standard-sequential-colimit n))
 ```
 
@@ -216,7 +213,7 @@ module _
 
 ```agda
 module _
-  { l1 : Level} (A : sequential-diagram l1)
+  { l1 : Level} {A : sequential-diagram l1}
   where
 
   htpy-preserves-id-map-hom-standard-sequential-colimit :
@@ -234,8 +231,7 @@ module _
       ( ( right-unit-htpy) ∙h
         ( inv-htpy
           ( left-unit-law-left-whisk-htpy
-            ( coherence-triangle-cocone-standard-sequential-colimit A
-              ( n))))))
+            ( coherence-triangle-cocone-standard-sequential-colimit n)))))
 
   preserves-id-map-hom-standard-sequential-colimit :
     map-hom-standard-sequential-colimit A
@@ -250,8 +246,8 @@ module _
 
 ```agda
 module _
-  { l1 l2 l3 : Level} (A : sequential-diagram l1) (B : sequential-diagram l2)
-  ( C : sequential-diagram l3)
+  { l1 l2 l3 : Level} {A : sequential-diagram l1} {B : sequential-diagram l2}
+  { C : sequential-diagram l3}
   ( g : hom-sequential-diagram B C) (f : hom-sequential-diagram A B)
   where
 
@@ -265,13 +261,13 @@ module _
     ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C
       ( comp-hom-sequential-diagram A B C g f) n) ∙h
     ( pasting-vertical-coherence-square-maps
-      ( map-cocone-standard-sequential-colimit A n)
+      ( map-cocone-standard-sequential-colimit n)
       ( map-hom-sequential-diagram B f n)
       ( map-hom-standard-sequential-colimit B f)
-      ( map-cocone-standard-sequential-colimit B n)
+      ( map-cocone-standard-sequential-colimit n)
       ( map-hom-sequential-diagram C g n)
       ( map-hom-standard-sequential-colimit C g)
-      ( map-cocone-standard-sequential-colimit C n)
+      ( map-cocone-standard-sequential-colimit n)
       ( inv-htpy
         ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f n))
       ( inv-htpy
@@ -280,7 +276,7 @@ module _
     ( inv-htpy-assoc-htpy
       ( ( map-hom-standard-sequential-colimit C
           ( comp-hom-sequential-diagram A B C g f)) ·l
-        ( coherence-triangle-cocone-standard-sequential-colimit A n))
+        ( coherence-triangle-cocone-standard-sequential-colimit n))
       ( ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C
           ( comp-hom-sequential-diagram A B C g f)
           ( succ-ℕ n)) ·r
@@ -305,43 +301,42 @@ module _
         ( comp-hom-sequential-diagram A B C g f)
         ( n))
       ( ( assoc-htpy
-          ( ( coherence-triangle-cocone-standard-sequential-colimit C
-              ( n)) ·r
+          ( ( coherence-triangle-cocone-standard-sequential-colimit n) ·r
             ( ( map-hom-sequential-diagram C g n) ∘
               ( map-hom-sequential-diagram B f n)))
-          ( map-cocone-standard-sequential-colimit C (succ-ℕ n) ·l _)
+          ( map-cocone-standard-sequential-colimit (succ-ℕ n) ·l _)
           ( _)) ∙h
         ( pasting-vertical-coherence-prism-maps
-          ( map-cocone-standard-sequential-colimit A n)
-          ( map-cocone-standard-sequential-colimit A (succ-ℕ n))
+          ( map-cocone-standard-sequential-colimit n)
+          ( map-cocone-standard-sequential-colimit (succ-ℕ n))
           ( map-sequential-diagram A n)
-          ( map-cocone-standard-sequential-colimit B n)
-          ( map-cocone-standard-sequential-colimit B (succ-ℕ n))
+          ( map-cocone-standard-sequential-colimit n)
+          ( map-cocone-standard-sequential-colimit (succ-ℕ n))
           ( map-sequential-diagram B n)
           ( map-hom-sequential-diagram B f n)
           ( map-hom-sequential-diagram B f (succ-ℕ n))
           ( map-hom-standard-sequential-colimit B f)
-          ( map-cocone-standard-sequential-colimit C n)
-          ( map-cocone-standard-sequential-colimit C (succ-ℕ n))
+          ( map-cocone-standard-sequential-colimit n)
+          ( map-cocone-standard-sequential-colimit (succ-ℕ n))
           ( map-sequential-diagram C n)
           ( map-hom-sequential-diagram C g n)
           ( map-hom-sequential-diagram C g (succ-ℕ n))
           ( map-hom-standard-sequential-colimit C g)
-          ( coherence-triangle-cocone-standard-sequential-colimit A n)
+          ( coherence-triangle-cocone-standard-sequential-colimit n)
           ( inv-htpy
             ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f n))
           ( inv-htpy
             ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f
               ( succ-ℕ n)))
           ( naturality-map-hom-sequential-diagram B f n)
-          ( coherence-triangle-cocone-standard-sequential-colimit B n)
+          ( coherence-triangle-cocone-standard-sequential-colimit n)
           ( inv-htpy
             ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g n))
           ( inv-htpy
             ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g
               ( succ-ℕ n)))
           ( naturality-map-hom-sequential-diagram C g n)
-          ( coherence-triangle-cocone-standard-sequential-colimit C n)
+          ( coherence-triangle-cocone-standard-sequential-colimit n)
           ( prism-htpy-cocone-map-hom-standard-sequential-colimit B f n)
           ( prism-htpy-cocone-map-hom-standard-sequential-colimit C g
             ( n))))) ∙h
@@ -352,14 +347,13 @@ module _
       ( _)
       ( ( ( map-hom-standard-sequential-colimit C g) ∘
           ( map-hom-standard-sequential-colimit B f)) ·l
-        ( coherence-triangle-cocone-standard-sequential-colimit A
-          ( n)))))
+        ( coherence-triangle-cocone-standard-sequential-colimit n))))
 
   preserves-comp-map-hom-standard-sequential-colimit :
-    map-hom-standard-sequential-colimit C
-      ( comp-hom-sequential-diagram A B C g f) ~
-    ( map-hom-standard-sequential-colimit C g ∘
-      map-hom-standard-sequential-colimit B f)
+    ( map-hom-standard-sequential-colimit C
+      ( comp-hom-sequential-diagram A B C g f)) ~
+    ( ( map-hom-standard-sequential-colimit C g) ∘
+      ( map-hom-standard-sequential-colimit B f))
   preserves-comp-map-hom-standard-sequential-colimit =
     htpy-htpy-out-of-standard-sequential-colimit A
       htpy-preserves-comp-map-hom-standard-sequential-colimit
@@ -395,12 +389,12 @@ module _
       ( id)
     is-section-inv-map-equiv-standard-sequential-colimit =
       ( inv-htpy
-        ( preserves-comp-map-hom-standard-sequential-colimit B A B
+        ( preserves-comp-map-hom-standard-sequential-colimit
           ( hom-equiv-sequential-diagram B e)
           ( hom-inv-equiv-sequential-diagram B e))) ∙h
       ( htpy-map-hom-standard-sequential-colimit-htpy-hom-sequential-diagram
         ( is-section-inv-equiv-sequential-diagram B e)) ∙h
-      ( preserves-id-map-hom-standard-sequential-colimit B)
+      ( preserves-id-map-hom-standard-sequential-colimit)
 
     is-retraction-inv-map-equiv-standard-sequential-colimit :
       ( ( inv-map-equiv-standard-sequential-colimit) ∘
@@ -408,12 +402,12 @@ module _
       ( id)
     is-retraction-inv-map-equiv-standard-sequential-colimit =
       ( inv-htpy
-        ( preserves-comp-map-hom-standard-sequential-colimit A B A
+        ( preserves-comp-map-hom-standard-sequential-colimit
           ( hom-inv-equiv-sequential-diagram B e)
           ( hom-equiv-sequential-diagram B e))) ∙h
       ( htpy-map-hom-standard-sequential-colimit-htpy-hom-sequential-diagram
         ( is-retraction-inv-equiv-sequential-diagram B e)) ∙h
-      ( preserves-id-map-hom-standard-sequential-colimit A)
+      ( preserves-id-map-hom-standard-sequential-colimit)
 
   is-equiv-map-hom-standard-sequential-colimit :
     is-equiv map-equiv-standard-sequential-colimit
@@ -426,8 +420,7 @@ module _
   equiv-equiv-standard-sequential-colimit :
     standard-sequential-colimit A ≃ standard-sequential-colimit B
   pr1 equiv-equiv-standard-sequential-colimit =
-    map-hom-standard-sequential-colimit B
-      ( hom-equiv-sequential-diagram B e)
+    map-hom-standard-sequential-colimit B (hom-equiv-sequential-diagram B e)
   pr2 equiv-equiv-standard-sequential-colimit =
     is-equiv-map-hom-standard-sequential-colimit
 ```

--- a/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
@@ -35,9 +35,12 @@ open import synthetic-homotopy-theory.universal-property-sequential-colimits
 
 ## Idea
 
-Taking a [sequential colimit](synthetic-homotopy-theory.sequential-colimits.md)
-of a [sequential diagram](synthetic-homotopy-theory.sequential-diagrams.md) is a
-functorial action `(A, a) ↦ A∞`. In particular, a
+Taking the
+[sequential colimit](synthetic-homotopy-theory.sequential-colimits.md) of a
+[sequential diagram](synthetic-homotopy-theory.sequential-diagrams.md) is a
+functorial action `(A, a) ↦ A∞`.
+
+In other words, a
 [morphism of sequential diagrams](synthetic-homotopy-theory.morphisms-sequential-diagrams.md)
 `f : (A, a) → (B, b)` induces a map `f∞ : A∞ → B∞` between the
 [standard sequential colimits](synthetic-homotopy-theory.sequential-colimits.md)

--- a/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
@@ -9,23 +9,21 @@ module synthetic-homotopy-theory.functoriality-sequential-colimits where
 ```agda
 open import elementary-number-theory.natural-numbers
 
-open import foundation.action-on-identifications-binary-functions
 open import foundation.action-on-identifications-functions
 open import foundation.commuting-prisms-of-maps
 open import foundation.commuting-squares-of-homotopies
 open import foundation.commuting-squares-of-maps
-open import foundation.commuting-triangles-of-maps
 open import foundation.dependent-pair-types
-open import foundation.equivalences
 open import foundation.function-extensionality
-open import foundation.function-types
 open import foundation.homotopies
-open import foundation.identity-types
 open import foundation.universe-levels
-open import foundation.whiskering-homotopies
+
+open import foundation-core.equivalences
+open import foundation-core.function-types
+open import foundation-core.functoriality-dependent-pair-types
+open import foundation-core.whiskering-homotopies
 
 open import synthetic-homotopy-theory.cocones-under-sequential-diagrams
-open import synthetic-homotopy-theory.dependent-universal-property-sequential-colimits
 open import synthetic-homotopy-theory.equivalences-sequential-diagrams
 open import synthetic-homotopy-theory.morphisms-sequential-diagrams
 open import synthetic-homotopy-theory.sequential-colimits
@@ -43,6 +41,10 @@ A
 [standard sequential colimits](synthetic-homotopy-theory.sequential-colimits.md)
 of the diagrams.
 
+Furthermore, an
+[equivalence of sequential diagrams](synthetic-homotopy-theory.equivalences-sequential-diagrams.md)
+`e : (A, a) ≃ (B, b)` induces an equivalence `e∞ : A∞ ≃ B∞`.
+
 ## Properties
 
 ### A morphism of sequential diagrams induces a map of cocones
@@ -53,9 +55,9 @@ module _
   ( f : hom-sequential-diagram A B) {X : UU l3}
   where
 
-  map-hom-cocone-sequential-colimit :
+  map-cocone-hom-sequential-diagram :
     cocone-sequential-diagram B X → cocone-sequential-diagram A X
-  map-hom-cocone-sequential-colimit c =
+  map-cocone-hom-sequential-diagram c =
     comp-hom-sequential-diagram A B
       ( constant-sequential-diagram X)
       ( c)
@@ -63,6 +65,43 @@ module _
 ```
 
 ### A morphism of sequential diagrams induces a map of sequential colimits
+
+The induced map
+
+```text
+        a₀      a₁      a₂
+    A₀ ---> A₁ ---> A₂ ---> ⋯ ---> A∞
+    |       |       |              |
+ f₀ |       | f₁    | f₂           | f∞
+    V       V       V              V
+    B₀ ---> B₁ ---> B₂ ---> ⋯ ---> B∞
+        b₀      b₁      b₂
+```
+
+then induces a cocone under `(A, a)` with codomain `B∞`, which is homotopic to
+the standard cocone under `(B, b)` precomposed by `f`.
+
+This homotopy provides
+[vertical commuting prisms of maps](foundation.commuting-prisms-of-maps.md),
+
+```text
+          Aₙ₊₁
+         ^| \
+       /  |   \
+     /    |fₙ₊₁ V
+    Aₙ ---------> A∞
+    |     |      |
+    |     V      |
+ fₙ |     Bₙ₊₁   | f∞
+    |    ^  \    |
+    |  /      \  |
+    |/          V|
+    Bₙ --------> B∞ ,
+```
+
+where the triangles are coherences of the cocones of the standard sequential
+colimits, the back left square is coherence of `f`, and the front and back right
+squares are provided by uniqueness of `f∞`.
 
 ```agda
 module _
@@ -73,10 +112,8 @@ module _
   map-hom-standard-sequential-colimit :
     standard-sequential-colimit A → standard-sequential-colimit B
   map-hom-standard-sequential-colimit =
-    map-universal-property-sequential-colimit A
-      ( cocone-standard-sequential-colimit A)
-      ( up-standard-sequential-colimit A)
-      ( map-hom-cocone-sequential-colimit f
+    cogap-standard-sequential-colimit A
+      ( map-cocone-hom-sequential-diagram f
         ( cocone-standard-sequential-colimit B))
 
   htpy-cocone-map-hom-standard-sequential-colimit :
@@ -84,13 +121,13 @@ module _
       ( cocone-map-sequential-diagram A
         ( cocone-standard-sequential-colimit A)
         ( map-hom-standard-sequential-colimit))
-      ( map-hom-cocone-sequential-colimit f
+      ( map-cocone-hom-sequential-diagram f
         ( cocone-standard-sequential-colimit B))
   htpy-cocone-map-hom-standard-sequential-colimit =
     htpy-cocone-universal-property-sequential-colimit A
       ( cocone-standard-sequential-colimit A)
       ( up-standard-sequential-colimit A)
-      ( map-hom-cocone-sequential-colimit f
+      ( map-cocone-hom-sequential-diagram f
         ( cocone-standard-sequential-colimit B))
 
   htpy-htpy-cocone-map-hom-standard-sequential-colimit :
@@ -108,15 +145,14 @@ module _
     ( n : ℕ) →
     coherence-square-homotopies
       ( htpy-htpy-cocone-map-hom-standard-sequential-colimit n)
-      ( map-hom-standard-sequential-colimit ·l
+      ( ( map-hom-standard-sequential-colimit) ·l
         ( coherence-triangle-cocone-standard-sequential-colimit A n))
-      ( (
-          pr2
-          (map-hom-cocone-sequential-colimit f
-          (cocone-standard-sequential-colimit B))
-          n))
-      ( htpy-htpy-cocone-map-hom-standard-sequential-colimit (succ-ℕ n)
-        ·r pr2 A n)
+      ( coherence-triangle-cocone-sequential-diagram A
+          ( map-cocone-hom-sequential-diagram f
+            ( cocone-standard-sequential-colimit B))
+          ( n))
+      ( ( htpy-htpy-cocone-map-hom-standard-sequential-colimit (succ-ℕ n)) ·r
+        ( map-sequential-diagram A n))
   coherence-htpy-cocone-map-hom-standard-sequential-colimit =
     coherence-htpy-htpy-cocone-sequential-diagram A
       ( htpy-cocone-map-hom-standard-sequential-colimit)
@@ -162,27 +198,6 @@ module _
 
 ```agda
 module _
-  { l1 l2 : Level} (A : sequential-diagram l1) {X : UU l2}
-  { f g : standard-sequential-colimit A → X}
-  ( H : htpy-standard-sequential-colimit A f g)
-  where
-
-  htpy-htpy-standard-sequential-colimit : f ~ g
-  htpy-htpy-standard-sequential-colimit =
-    map-dependent-universal-property-sequential-colimit A
-      ( cocone-standard-sequential-colimit A)
-      ( dup-standard-sequential-colimit A)
-      ( pr1 H ,
-        λ n a →
-        map-compute-dependent-identification-eq-value-function f g
-          ( coherence-triangle-cocone-standard-sequential-colimit A n a)
-          ( pr1 H n a)
-          ( (pr1 H (succ-ℕ n) ∘ pr2 A n) a)
-          ( pr2 H n a))
-```
-
-```agda
-module _
   { l1 l2 : Level} {A : sequential-diagram l1} {B : sequential-diagram l2}
   { f g : hom-sequential-diagram A B} (H : htpy-hom-sequential-diagram B f g)
   where
@@ -204,26 +219,34 @@ module _
   { l1 : Level} (A : sequential-diagram l1)
   where
 
+  htpy-preserves-id-map-hom-standard-sequential-colimit :
+    htpy-out-of-standard-sequential-colimit A
+      ( map-hom-standard-sequential-colimit A
+        ( id-hom-sequential-diagram A))
+      ( id)
+  pr1 htpy-preserves-id-map-hom-standard-sequential-colimit =
+    htpy-htpy-cocone-map-hom-standard-sequential-colimit A
+      ( id-hom-sequential-diagram A)
+  pr2 htpy-preserves-id-map-hom-standard-sequential-colimit n =
+    ( coherence-htpy-cocone-map-hom-standard-sequential-colimit A
+      ( id-hom-sequential-diagram A) n) ∙h
+    ( ap-concat-htpy _
+      ( ( right-unit-htpy) ∙h
+        ( inv-htpy
+          ( left-unit-law-left-whisk-htpy
+            ( coherence-triangle-cocone-standard-sequential-colimit A
+              ( n))))))
+
   preserves-id-map-hom-standard-sequential-colimit :
     map-hom-standard-sequential-colimit A
       ( id-hom-sequential-diagram A) ~
     id
   preserves-id-map-hom-standard-sequential-colimit =
-    htpy-htpy-standard-sequential-colimit A
-      ( ( htpy-htpy-cocone-map-hom-standard-sequential-colimit A
-          ( id-hom-sequential-diagram A)) ,
-        ( λ n →
-          ( coherence-htpy-cocone-map-hom-standard-sequential-colimit A
-            ( id-hom-sequential-diagram A) n) ∙h
-          ( horizontal-concat-htpy² refl-htpy
-            ( ( right-unit-htpy) ∙h
-              ( inv-htpy
-                ( left-unit-law-left-whisk-htpy
-                  ( coherence-triangle-cocone-standard-sequential-colimit A
-                    ( n))))))))
+    htpy-htpy-out-of-standard-sequential-colimit A
+      ( htpy-preserves-id-map-hom-standard-sequential-colimit)
 ```
 
-### Composition preservation
+### Composition of morphisms of sequential diagrams induces a composition of maps between sequential colimits
 
 ```agda
 module _
@@ -232,165 +255,120 @@ module _
   ( g : hom-sequential-diagram B C) (f : hom-sequential-diagram A B)
   where
 
+  htpy-preserves-comp-map-hom-standard-sequential-colimit :
+    htpy-out-of-standard-sequential-colimit A
+      ( map-hom-standard-sequential-colimit C
+        ( comp-hom-sequential-diagram A B C g f))
+      ( ( map-hom-standard-sequential-colimit C g) ∘
+        ( map-hom-standard-sequential-colimit B f))
+  pr1 htpy-preserves-comp-map-hom-standard-sequential-colimit n =
+    ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C
+      ( comp-hom-sequential-diagram A B C g f) n) ∙h
+    ( pasting-vertical-coherence-square-maps
+      ( map-cocone-standard-sequential-colimit A n)
+      ( map-hom-sequential-diagram B f n)
+      ( map-hom-standard-sequential-colimit B f)
+      ( map-cocone-standard-sequential-colimit B n)
+      ( map-hom-sequential-diagram C g n)
+      ( map-hom-standard-sequential-colimit C g)
+      ( map-cocone-standard-sequential-colimit C n)
+      ( inv-htpy
+        ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f n))
+      ( inv-htpy
+        ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g n)))
+  pr2 htpy-preserves-comp-map-hom-standard-sequential-colimit n =
+    ( inv-htpy-assoc-htpy
+      ( ( map-hom-standard-sequential-colimit C
+          ( comp-hom-sequential-diagram A B C g f)) ·l
+        ( coherence-triangle-cocone-standard-sequential-colimit A n))
+      ( ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C
+          ( comp-hom-sequential-diagram A B C g f)
+          ( succ-ℕ n)) ·r
+        ( map-sequential-diagram A n))
+      ( _)) ∙h
+    ( ap-concat-htpy' _
+      ( coherence-htpy-cocone-map-hom-standard-sequential-colimit C
+        ( comp-hom-sequential-diagram A B C g f)
+        ( n)) ∙h
+    ( assoc-htpy
+      ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C
+        ( comp-hom-sequential-diagram A B C g f)
+        ( n))
+      ( coherence-triangle-cocone-sequential-diagram A
+        ( map-cocone-hom-sequential-diagram
+          ( comp-hom-sequential-diagram A B C g f)
+          ( cocone-standard-sequential-colimit C))
+        ( n))
+      ( _)) ∙h
+    ( ap-concat-htpy
+      ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C
+        ( comp-hom-sequential-diagram A B C g f)
+        ( n))
+      ( ( assoc-htpy
+          ( ( coherence-triangle-cocone-standard-sequential-colimit C
+              ( n)) ·r
+            ( ( map-hom-sequential-diagram C g n) ∘
+              ( map-hom-sequential-diagram B f n)))
+          ( map-cocone-standard-sequential-colimit C (succ-ℕ n) ·l _)
+          ( _)) ∙h
+        ( pasting-vertical-coherence-prism-maps
+          ( map-cocone-standard-sequential-colimit A n)
+          ( map-cocone-standard-sequential-colimit A (succ-ℕ n))
+          ( map-sequential-diagram A n)
+          ( map-cocone-standard-sequential-colimit B n)
+          ( map-cocone-standard-sequential-colimit B (succ-ℕ n))
+          ( map-sequential-diagram B n)
+          ( map-hom-sequential-diagram B f n)
+          ( map-hom-sequential-diagram B f (succ-ℕ n))
+          ( map-hom-standard-sequential-colimit B f)
+          ( map-cocone-standard-sequential-colimit C n)
+          ( map-cocone-standard-sequential-colimit C (succ-ℕ n))
+          ( map-sequential-diagram C n)
+          ( map-hom-sequential-diagram C g n)
+          ( map-hom-sequential-diagram C g (succ-ℕ n))
+          ( map-hom-standard-sequential-colimit C g)
+          ( coherence-triangle-cocone-standard-sequential-colimit A n)
+          ( inv-htpy
+            ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f n))
+          ( inv-htpy
+            ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f
+              ( succ-ℕ n)))
+          ( naturality-map-hom-sequential-diagram B f n)
+          ( coherence-triangle-cocone-standard-sequential-colimit B n)
+          ( inv-htpy
+            ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g n))
+          ( inv-htpy
+            ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g
+              ( succ-ℕ n)))
+          ( naturality-map-hom-sequential-diagram C g n)
+          ( coherence-triangle-cocone-standard-sequential-colimit C n)
+          ( prism-htpy-cocone-map-hom-standard-sequential-colimit B f n)
+          ( prism-htpy-cocone-map-hom-standard-sequential-colimit C g
+            ( n))))) ∙h
+    ( inv-htpy-assoc-htpy
+      ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C
+        ( comp-hom-sequential-diagram A B C g f)
+        ( n))
+      ( _)
+      ( ( ( map-hom-standard-sequential-colimit C g) ∘
+          ( map-hom-standard-sequential-colimit B f)) ·l
+        ( coherence-triangle-cocone-standard-sequential-colimit A
+          ( n)))))
+
   preserves-comp-map-hom-standard-sequential-colimit :
     map-hom-standard-sequential-colimit C
       ( comp-hom-sequential-diagram A B C g f) ~
     ( map-hom-standard-sequential-colimit C g ∘
       map-hom-standard-sequential-colimit B f)
   preserves-comp-map-hom-standard-sequential-colimit =
-    htpy-htpy-standard-sequential-colimit A
-      ( ( λ n →
-          ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C
-            ( comp-hom-sequential-diagram A B C g f) n) ∙h
-          ( pasting-vertical-coherence-square-maps
-            ( map-cocone-standard-sequential-colimit A n)
-            ( map-hom-sequential-diagram B f n)
-            ( map-hom-standard-sequential-colimit B f)
-            ( map-cocone-standard-sequential-colimit B n)
-            ( map-hom-sequential-diagram C g n)
-            ( map-hom-standard-sequential-colimit C g)
-            ( map-cocone-standard-sequential-colimit C n)
-            ( inv-htpy
-              ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f n))
-            ( inv-htpy
-              ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g n)))) ,
-        ( λ n →
-          ( inv-htpy-assoc-htpy
-            ( ( map-hom-standard-sequential-colimit C
-                ( comp-hom-sequential-diagram A B C g f)) ·l
-              ( coherence-triangle-cocone-standard-sequential-colimit A n))
-            ( ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C
-                ( comp-hom-sequential-diagram A B C g f)
-                ( succ-ℕ n)) ·r
-              ( map-sequential-diagram A n))
-            ( ( pasting-vertical-coherence-square-maps
-                ( map-cocone-standard-sequential-colimit A (succ-ℕ n))
-                ( map-hom-sequential-diagram B f (succ-ℕ n))
-                ( map-hom-standard-sequential-colimit B f)
-                ( map-cocone-standard-sequential-colimit B (succ-ℕ n))
-                ( map-hom-sequential-diagram C g (succ-ℕ n))
-                ( map-hom-standard-sequential-colimit C g)
-                ( map-cocone-standard-sequential-colimit C (succ-ℕ n))
-                ( inv-htpy
-                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f
-                    ( succ-ℕ n)))
-                ( inv-htpy
-                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g
-                    ( succ-ℕ n)))) ·r
-              ( map-sequential-diagram A n))) ∙h
-          ( ap-concat-htpy'
-            ( ( pasting-vertical-coherence-square-maps
-                ( map-cocone-standard-sequential-colimit A (succ-ℕ n))
-                ( map-hom-sequential-diagram B f (succ-ℕ n))
-                ( map-hom-standard-sequential-colimit B f)
-                ( map-cocone-standard-sequential-colimit B (succ-ℕ n))
-                ( map-hom-sequential-diagram C g (succ-ℕ n))
-                ( map-hom-standard-sequential-colimit C g)
-                ( map-cocone-standard-sequential-colimit C (succ-ℕ n))
-                ( inv-htpy
-                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f
-                    ( succ-ℕ n)))
-                ( inv-htpy
-                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g
-                    ( succ-ℕ n)))) ·r
-              ( map-sequential-diagram A n))
-            ( coherence-htpy-cocone-map-hom-standard-sequential-colimit C
-              ( comp-hom-sequential-diagram A B C g f)
-              ( n)) ∙h
-          ( assoc-htpy
-            ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C
-              ( comp-hom-sequential-diagram A B C g f)
-              ( n))
-            ( coherence-triangle-cocone-sequential-diagram A
-              ( map-hom-cocone-sequential-colimit
-                ( comp-hom-sequential-diagram A B C g f)
-                ( cocone-standard-sequential-colimit C))
-              ( n))
-            ( ( pasting-vertical-coherence-square-maps
-                ( map-cocone-standard-sequential-colimit A (succ-ℕ n))
-                ( map-hom-sequential-diagram B f (succ-ℕ n))
-                ( map-hom-standard-sequential-colimit B f)
-                ( map-cocone-standard-sequential-colimit B (succ-ℕ n))
-                ( map-hom-sequential-diagram C g (succ-ℕ n))
-                ( map-hom-standard-sequential-colimit C g)
-                ( map-cocone-standard-sequential-colimit C (succ-ℕ n))
-                ( inv-htpy
-                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f
-                    ( succ-ℕ n)))
-                ( inv-htpy
-                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g
-                    ( succ-ℕ n)))) ·r
-              ( map-sequential-diagram A n))) ∙h
-          ( ap-concat-htpy
-            ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C
-              ( comp-hom-sequential-diagram A B C g f)
-              ( n))
-            ( ( assoc-htpy
-                ( ( coherence-triangle-cocone-standard-sequential-colimit C
-                    ( n)) ·r
-                  ( ( map-hom-sequential-diagram C g n) ∘
-                    ( map-hom-sequential-diagram B f n)))
-                ( map-cocone-standard-sequential-colimit C (succ-ℕ n) ·l _)
-                ( _)) ∙h
-              ( pasting-vertical-coherence-prism-maps
-                ( map-cocone-standard-sequential-colimit A n)
-                ( map-cocone-standard-sequential-colimit A (succ-ℕ n))
-                ( map-sequential-diagram A n)
-                ( map-cocone-standard-sequential-colimit B n)
-                ( map-cocone-standard-sequential-colimit B (succ-ℕ n))
-                ( map-sequential-diagram B n)
-                ( map-hom-sequential-diagram B f n)
-                ( map-hom-sequential-diagram B f (succ-ℕ n))
-                ( map-hom-standard-sequential-colimit B f)
-                ( map-cocone-standard-sequential-colimit C n)
-                ( map-cocone-standard-sequential-colimit C (succ-ℕ n))
-                ( map-sequential-diagram C n)
-                ( map-hom-sequential-diagram C g n)
-                ( map-hom-sequential-diagram C g (succ-ℕ n))
-                ( map-hom-standard-sequential-colimit C g)
-                ( coherence-triangle-cocone-standard-sequential-colimit A n)
-                ( inv-htpy
-                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f n))
-                ( inv-htpy
-                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f
-                    ( succ-ℕ n)))
-                ( naturality-map-hom-sequential-diagram B f n)
-                ( coherence-triangle-cocone-standard-sequential-colimit B n)
-                ( inv-htpy
-                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g n))
-                ( inv-htpy
-                  ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g
-                    ( succ-ℕ n)))
-                ( naturality-map-hom-sequential-diagram C g n)
-                ( coherence-triangle-cocone-standard-sequential-colimit C n)
-                ( prism-htpy-cocone-map-hom-standard-sequential-colimit B f n)
-                ( prism-htpy-cocone-map-hom-standard-sequential-colimit C g
-                  ( n))))) ∙h
-          ( inv-htpy-assoc-htpy
-            ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C
-              ( comp-hom-sequential-diagram A B C g f)
-              ( n))
-            ( pasting-vertical-coherence-square-maps
-              ( map-cocone-standard-sequential-colimit A n)
-              ( map-hom-sequential-diagram B f n)
-              ( map-hom-standard-sequential-colimit B f)
-              ( map-cocone-standard-sequential-colimit B n)
-              ( map-hom-sequential-diagram C g n)
-              ( map-hom-standard-sequential-colimit C g)
-              ( map-cocone-standard-sequential-colimit C n)
-              ( inv-htpy
-                ( htpy-htpy-cocone-map-hom-standard-sequential-colimit B f
-                  ( n)))
-              ( inv-htpy
-                ( htpy-htpy-cocone-map-hom-standard-sequential-colimit C g
-                  ( n))))
-            ( ( ( map-hom-standard-sequential-colimit C g) ∘
-                  ( map-hom-standard-sequential-colimit B f)) ·l
-                ( coherence-triangle-cocone-standard-sequential-colimit A
-                  ( n)))))))
+    htpy-htpy-out-of-standard-sequential-colimit A
+      htpy-preserves-comp-map-hom-standard-sequential-colimit
 ```
 
 ### An equivalence of sequential diagrams induces an equivalence of cocones
+
+Additionally, the inverse of the induced equivalence is the map induced by the
+inverse equivalence of sequential diagrams, i.e. `(e∞)⁻¹ ≐ (e⁻¹)∞`.
 
 ```agda
 module _
@@ -412,133 +390,34 @@ module _
 
   abstract
     is-section-inv-map-equiv-standard-sequential-colimit :
-      ( map-equiv-standard-sequential-colimit) ∘
-      ( inv-map-equiv-standard-sequential-colimit) ~
-      id
+      ( ( map-equiv-standard-sequential-colimit) ∘
+        ( inv-map-equiv-standard-sequential-colimit)) ~
+      ( id)
     is-section-inv-map-equiv-standard-sequential-colimit =
       ( inv-htpy
         ( preserves-comp-map-hom-standard-sequential-colimit B A B
           ( hom-equiv-sequential-diagram B e)
           ( hom-inv-equiv-sequential-diagram B e))) ∙h
       ( htpy-map-hom-standard-sequential-colimit-htpy-hom-sequential-diagram
-        ( ( λ n →
-            is-section-map-inv-equiv (equiv-equiv-sequential-diagram B e n)) ,
-          ( λ n →
-            inv-htpy
-              ( right-inverse-law-pasting-vertical-coherence-square-maps
-                ( map-sequential-diagram A n)
-                ( equiv-equiv-sequential-diagram B e n)
-                ( equiv-equiv-sequential-diagram B e (succ-ℕ n))
-                ( map-sequential-diagram B n)
-                ( naturality-equiv-sequential-diagram B e n))))) ∙h
+        ( is-section-inv-equiv-sequential-diagram B e)) ∙h
       ( preserves-id-map-hom-standard-sequential-colimit B)
 
     is-retraction-inv-map-equiv-standard-sequential-colimit :
-      ( inv-map-equiv-standard-sequential-colimit) ∘
-      ( map-equiv-standard-sequential-colimit) ~
-      id
+      ( ( inv-map-equiv-standard-sequential-colimit) ∘
+        ( map-equiv-standard-sequential-colimit)) ~
+      ( id)
     is-retraction-inv-map-equiv-standard-sequential-colimit =
       ( inv-htpy
         ( preserves-comp-map-hom-standard-sequential-colimit A B A
           ( hom-inv-equiv-sequential-diagram B e)
           ( hom-equiv-sequential-diagram B e))) ∙h
       ( htpy-map-hom-standard-sequential-colimit-htpy-hom-sequential-diagram
-        ( ( λ n →
-            is-retraction-map-inv-equiv
-              ( equiv-equiv-sequential-diagram B e n)) ,
-          ( λ n →
-            inv-htpy
-              ( left-inverse-law-pasting-vertical-coherence-square-maps
-                ( map-sequential-diagram A n)
-                ( equiv-equiv-sequential-diagram B e n)
-                ( equiv-equiv-sequential-diagram B e (succ-ℕ n))
-                ( map-sequential-diagram B n)
-                ( naturality-equiv-sequential-diagram B e n))))) ∙h
+        ( is-retraction-inv-equiv-sequential-diagram B e)) ∙h
       ( preserves-id-map-hom-standard-sequential-colimit A)
 
-  -- equiv-cocone-equiv-sequential-diagram :
-  --   { l3 : Level} {X : UU l3} →
-  --   cocone-sequential-diagram B X ≃ cocone-sequential-diagram A X
-  -- equiv-cocone-equiv-sequential-diagram {X = X} =
-  --   equiv-precomp-equiv-hom-sequential-diagram A B
-  --     ( constant-sequential-diagram X)
-  --     ( e)
-
-  -- triangle-equiv-cocone-equiv-sequential-diagram :
-  --   { l3 : Level} {X : UU l3} →
-  --   coherence-triangle-maps
-  --     ( cocone-map-sequential-diagram A
-  --       ( map-hom-cocone-sequential-colimit
-  --         ( hom-equiv-sequential-diagram B e)
-  --         ( cocone-standard-sequential-colimit B))
-  --       { Y = X})
-  --     ( map-equiv equiv-cocone-equiv-sequential-diagram)
-  --     ( cocone-map-sequential-diagram B (cocone-standard-sequential-colimit B))
-  -- triangle-equiv-cocone-equiv-sequential-diagram h =
-  --   eq-htpy-cocone-sequential-diagram A _ _
-  --     ( ( λ n → refl-htpy) ,
-  --       ( λ n →
-  --         ( right-unit-htpy) ∙h
-  --         ( λ a →
-  --           ( distributive-left-whisk-concat-htpy h
-  --             ( ( coherence-triangle-cocone-sequential-diagram B
-  --                 ( cocone-standard-sequential-colimit B)
-  --                 ( n)) ·r
-  --               ( map-equiv-sequential-diagram B e n))
-  --             ( ( map-cocone-sequential-diagram B
-  --                 ( cocone-standard-sequential-colimit B)
-  --                 ( succ-ℕ n) ·l
-  --               ( naturality-map-hom-sequential-diagram B
-  --                 ( hom-equiv-sequential-diagram B e) n)))
-  --             ( a)) ∙
-  --           ( ap
-  --             ( ap h
-  --               ( coherence-triangle-cocone-sequential-diagram B
-  --                 ( cocone-standard-sequential-colimit B)
-  --                 ( n)
-  --                 ( map-equiv-sequential-diagram B e n a)) ∙_)
-  --             ( associative-left-whisk-comp h
-  --               ( map-cocone-standard-sequential-colimit B (succ-ℕ n))
-  --               ( naturality-equiv-sequential-diagram B e n)
-  --               ( a))))))
-
-  -- map-up-cocone-equiv-sequential-diagram :
-  --   ( {l : Level} →
-  --     universal-property-sequential-colimit l A
-  --       ( map-hom-cocone-sequential-colimit
-  --         ( hom-equiv-sequential-diagram B e)
-  --         ( cocone-standard-sequential-colimit B)))
-  -- map-up-cocone-equiv-sequential-diagram Y =
-  --   is-equiv-left-map-triangle
-  --     ( cocone-map-sequential-diagram A
-  --       ( map-hom-cocone-sequential-colimit
-  --         ( hom-equiv-sequential-diagram B e)
-  --         ( cocone-standard-sequential-colimit B)))
-  --     ( map-equiv equiv-cocone-equiv-sequential-diagram)
-  --     ( cocone-map-sequential-diagram B (cocone-standard-sequential-colimit B))
-  --     ( triangle-equiv-cocone-equiv-sequential-diagram)
-  --     ( up-standard-sequential-colimit B Y)
-  --     ( is-equiv-map-equiv equiv-cocone-equiv-sequential-diagram)
-
-  -- is-equiv-map-hom-standard-sequential-colimit :
-  --   is-equiv map-equiv-standard-sequential-colimit
-  -- is-equiv-map-hom-standard-sequential-colimit =
-  --   is-equiv-universal-property-sequential-colimit-universal-property-sequential-colimit
-  --     ( A)
-  --     ( cocone-standard-sequential-colimit A)
-  --     ( map-hom-cocone-sequential-colimit
-  --       ( hom-equiv-sequential-diagram B e)
-  --       ( cocone-standard-sequential-colimit B))
-  --     ( map-hom-standard-sequential-colimit B
-  --       ( hom-equiv-sequential-diagram B e))
-  --     ( htpy-cocone-map-hom-standard-sequential-colimit B
-  --       ( hom-equiv-sequential-diagram B e))
-  --     ( up-standard-sequential-colimit A)
-  --     ( map-up-cocone-equiv-sequential-diagram)
-
-  is-equiv-map-hom-standard-sequential-colimit' :
+  is-equiv-map-hom-standard-sequential-colimit :
     is-equiv map-equiv-standard-sequential-colimit
-  is-equiv-map-hom-standard-sequential-colimit' =
+  is-equiv-map-hom-standard-sequential-colimit =
     is-equiv-is-invertible
       ( inv-map-equiv-standard-sequential-colimit)
       ( is-section-inv-map-equiv-standard-sequential-colimit)
@@ -550,5 +429,5 @@ module _
     map-hom-standard-sequential-colimit B
       ( hom-equiv-sequential-diagram B e)
   pr2 equiv-equiv-standard-sequential-colimit =
-    is-equiv-map-hom-standard-sequential-colimit'
+    is-equiv-map-hom-standard-sequential-colimit
 ```

--- a/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
@@ -140,20 +140,20 @@ module _
       ( naturality-map-hom-sequential-diagram B f n)
       ( coherence-triangle-cocone-standard-sequential-colimit B n)
   prism-htpy-cocone-map-hom-standard-sequential-colimit n =
-    [v]
-      ( map-sequential-diagram A n)
-      ( map-cocone-standard-sequential-colimit A (succ-ℕ n))
+    rotate-vertical-coherence-prism-maps
       ( map-cocone-standard-sequential-colimit A n)
+      ( map-cocone-standard-sequential-colimit A (succ-ℕ n))
+      ( map-sequential-diagram A n)
+      ( map-cocone-standard-sequential-colimit B n)
+      ( map-cocone-standard-sequential-colimit B (succ-ℕ n))
+      ( map-sequential-diagram B n)
       ( map-hom-sequential-diagram B f n)
       ( map-hom-sequential-diagram B f (succ-ℕ n))
       ( map-hom-standard-sequential-colimit)
-      ( map-sequential-diagram B n)
-      ( map-cocone-standard-sequential-colimit B (succ-ℕ n))
-      ( map-cocone-standard-sequential-colimit B n)
       ( coherence-triangle-cocone-standard-sequential-colimit A n)
-      ( naturality-map-hom-sequential-diagram B f n)
-      ( htpy-htpy-cocone-map-hom-standard-sequential-colimit (succ-ℕ n))
       ( htpy-htpy-cocone-map-hom-standard-sequential-colimit n)
+      ( htpy-htpy-cocone-map-hom-standard-sequential-colimit (succ-ℕ n))
+      ( naturality-map-hom-sequential-diagram B f n)
       ( coherence-triangle-cocone-standard-sequential-colimit B n)
       ( inv-htpy (coherence-htpy-cocone-map-hom-standard-sequential-colimit n))
 ```

--- a/src/synthetic-homotopy-theory/morphisms-sequential-diagrams.lagda.md
+++ b/src/synthetic-homotopy-theory/morphisms-sequential-diagrams.lagda.md
@@ -77,6 +77,12 @@ module _
 
 ### Components of morphisms of sequential diagrams
 
+_Implementation note:_ Ideally we would have both the domain and codomain of a
+morphism of sequential diagrams inferred by Agda. Unfortunately that's not the
+case with the current implementation, and the codomain needs to be provided
+explicitly. This arises also in
+[equivalences of sequential diagrams](synthetic-homotopy-theory.equivalences-sequential-diagrams.md).
+
 ```agda
 module _
   { l1 l2 : Level} {A : sequential-diagram l1} (B : sequential-diagram l2)

--- a/src/synthetic-homotopy-theory/sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/sequential-colimits.lagda.md
@@ -9,16 +9,19 @@ module synthetic-homotopy-theory.sequential-colimits where
 ```agda
 open import elementary-number-theory.natural-numbers
 
-open import foundation.commuting-squares-of-homotopies
-open import foundation.commuting-triangles-of-maps
 open import foundation.dependent-pair-types
-open import foundation.function-types
 open import foundation.homotopies
 open import foundation.universe-levels
-open import foundation.whiskering-homotopies
+
+open import foundation-core.commuting-triangles-of-maps
+open import foundation-core.equivalences
+open import foundation-core.function-types
+open import foundation-core.functoriality-dependent-function-types
+open import foundation-core.functoriality-dependent-pair-types
 
 open import synthetic-homotopy-theory.cocones-under-sequential-diagrams
 open import synthetic-homotopy-theory.coequalizers
+open import synthetic-homotopy-theory.dependent-cocones-under-sequential-diagrams
 open import synthetic-homotopy-theory.dependent-universal-property-sequential-colimits
 open import synthetic-homotopy-theory.sequential-diagrams
 open import synthetic-homotopy-theory.universal-property-sequential-colimits
@@ -107,7 +110,54 @@ module _
       ( cocone-standard-sequential-colimit)
 ```
 
+### Corollaries of the universal property of sequential colimits
+
+```agda
+module _
+  { l : Level} (A : sequential-diagram l)
+  where
+
+  equiv-up-standard-sequential-colimit :
+    { l : Level} {X : UU l} →
+    (standard-sequential-colimit A → X) ≃ (cocone-sequential-diagram A X)
+  pr1 equiv-up-standard-sequential-colimit =
+    cocone-map-sequential-diagram A (cocone-standard-sequential-colimit A)
+  pr2 (equiv-up-standard-sequential-colimit) =
+    up-standard-sequential-colimit A _
+
+  cogap-standard-sequential-colimit :
+    { l : Level} {X : UU l} →
+    cocone-sequential-diagram A X → standard-sequential-colimit A → X
+  cogap-standard-sequential-colimit =
+    map-inv-equiv equiv-up-standard-sequential-colimit
+
+  equiv-dup-standard-sequential-colimit :
+    { l : Level} {P : standard-sequential-colimit A → UU l} →
+    ( (x : standard-sequential-colimit A) → P x) ≃
+    ( dependent-cocone-sequential-diagram A
+      ( cocone-standard-sequential-colimit A)
+      ( P))
+  pr1 equiv-dup-standard-sequential-colimit =
+    dependent-cocone-map-sequential-diagram A
+      ( cocone-standard-sequential-colimit A)
+      ( _)
+  pr2 equiv-dup-standard-sequential-colimit =
+    dup-standard-sequential-colimit A _
+
+  dependent-cogap-standard-sequential-colimit :
+    { l : Level} {P : standard-sequential-colimit A → UU l} →
+    dependent-cocone-sequential-diagram A
+      ( cocone-standard-sequential-colimit A)
+      ( P) →
+    ( x : standard-sequential-colimit A) → P x
+  dependent-cogap-standard-sequential-colimit =
+    map-inv-equiv equiv-dup-standard-sequential-colimit
+```
+
 ### Homotopies between maps from the standard sequential colimit
+
+Maps from the standard sequential colimit induce cocones under the sequential
+diagrams, and a homotopy between the maps is exactly a homotopy of the cocones.
 
 ```agda
 module _
@@ -115,16 +165,42 @@ module _
   ( f g : standard-sequential-colimit A → X)
   where
 
-  htpy-standard-sequential-colimit : UU (l1 ⊔ l2)
-  htpy-standard-sequential-colimit =
-    Σ ( ( n : ℕ) →
-        f ∘ map-cocone-standard-sequential-colimit A n ~
-        g ∘ map-cocone-standard-sequential-colimit A n)
-      ( λ h →
-        ( n : ℕ) →
-        coherence-square-homotopies
-          ( h n)
-          ( f ·l coherence-triangle-cocone-standard-sequential-colimit A n)
-          ( g ·l coherence-triangle-cocone-standard-sequential-colimit A n)
-          ( h (succ-ℕ n) ·r map-sequential-diagram A n))
+  htpy-out-of-standard-sequential-colimit : UU (l1 ⊔ l2)
+  htpy-out-of-standard-sequential-colimit =
+    htpy-cocone-sequential-diagram A
+      ( cocone-map-sequential-diagram A
+        ( cocone-standard-sequential-colimit A)
+        ( f))
+      ( cocone-map-sequential-diagram A
+        ( cocone-standard-sequential-colimit A)
+        ( g))
+
+  equiv-htpy-htpy-out-of-standard-sequential-colimit :
+    htpy-out-of-standard-sequential-colimit ≃ (f ~ g)
+  equiv-htpy-htpy-out-of-standard-sequential-colimit =
+    ( inv-equiv (equiv-dup-standard-sequential-colimit A)) ∘e
+    ( equiv-tot
+      ( λ K →
+        equiv-Π-equiv-family
+          ( λ n →
+            equiv-Π-equiv-family
+              ( λ a →
+                compute-dependent-identification-eq-value-function f g
+                  ( coherence-triangle-cocone-standard-sequential-colimit A n a)
+                  ( K n a)
+                  ( K (succ-ℕ n) (map-sequential-diagram A n a))))))
+```
+
+We may then obtain a homotopy of maps from a homotopy of their induced cocones.
+
+```agda
+module _
+  { l1 l2 : Level} (A : sequential-diagram l1) {X : UU l2}
+  { f g : standard-sequential-colimit A → X}
+  ( H : htpy-out-of-standard-sequential-colimit A f g)
+  where
+
+  htpy-htpy-out-of-standard-sequential-colimit : f ~ g
+  htpy-htpy-out-of-standard-sequential-colimit =
+    map-equiv (equiv-htpy-htpy-out-of-standard-sequential-colimit A f g) H
 ```

--- a/src/synthetic-homotopy-theory/sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/sequential-colimits.lagda.md
@@ -57,47 +57,51 @@ to sequential colimits. Since all coequalizers exist, we conclude that all
 sequential colimits exist.
 
 ```agda
+abstract
+  standard-sequential-colimit : {l : Level} (A : sequential-diagram l) → UU l
+  standard-sequential-colimit A =
+    canonical-coequalizer
+      ( bottom-map-cofork-cocone-sequential-diagram A)
+      ( top-map-cofork-cocone-sequential-diagram A)
+
+  cocone-standard-sequential-colimit :
+    { l : Level} (A : sequential-diagram l) →
+    cocone-sequential-diagram A (standard-sequential-colimit A)
+  cocone-standard-sequential-colimit A =
+    cocone-sequential-diagram-cofork A
+      ( cofork-canonical-coequalizer
+        ( bottom-map-cofork-cocone-sequential-diagram A)
+        ( top-map-cofork-cocone-sequential-diagram A))
+
+  dup-standard-sequential-colimit :
+    { l : Level} {A : sequential-diagram l} →
+    dependent-universal-property-sequential-colimit A
+      ( cocone-standard-sequential-colimit A)
+  dup-standard-sequential-colimit {A = A} =
+    dependent-universal-property-sequential-colimit-dependent-universal-property-coequalizer
+      ( A)
+      ( cocone-standard-sequential-colimit A)
+      ( dup-canonical-coequalizer
+        ( bottom-map-cofork-cocone-sequential-diagram A)
+        ( top-map-cofork-cocone-sequential-diagram A))
+
+  up-standard-sequential-colimit :
+    { l : Level} {A : sequential-diagram l} →
+    universal-property-sequential-colimit A
+      (cocone-standard-sequential-colimit A)
+  up-standard-sequential-colimit {A = A} =
+    universal-property-dependent-universal-property-sequential-colimit A
+      ( cocone-standard-sequential-colimit A)
+      ( dup-standard-sequential-colimit)
+
 module _
-  { l : Level} (A : sequential-diagram l)
+  { l : Level} {A : sequential-diagram l}
   where
 
-  abstract
-    standard-sequential-colimit : UU l
-    standard-sequential-colimit =
-      canonical-coequalizer
-        ( bottom-map-cofork-cocone-sequential-diagram A)
-        ( top-map-cofork-cocone-sequential-diagram A)
-
-    cocone-standard-sequential-colimit :
-      cocone-sequential-diagram A standard-sequential-colimit
-    cocone-standard-sequential-colimit =
-      cocone-sequential-diagram-cofork A
-        ( cofork-canonical-coequalizer
-          ( bottom-map-cofork-cocone-sequential-diagram A)
-          ( top-map-cofork-cocone-sequential-diagram A))
-
-    dup-standard-sequential-colimit :
-      dependent-universal-property-sequential-colimit A
-        ( cocone-standard-sequential-colimit)
-    dup-standard-sequential-colimit =
-      dependent-universal-property-sequential-colimit-dependent-universal-property-coequalizer
-        ( A)
-        ( cocone-standard-sequential-colimit)
-        ( dup-canonical-coequalizer
-          ( bottom-map-cofork-cocone-sequential-diagram A)
-          ( top-map-cofork-cocone-sequential-diagram A))
-
-    up-standard-sequential-colimit :
-      universal-property-sequential-colimit A cocone-standard-sequential-colimit
-    up-standard-sequential-colimit =
-      universal-property-dependent-universal-property-sequential-colimit A
-        ( cocone-standard-sequential-colimit)
-        ( dup-standard-sequential-colimit)
-
   map-cocone-standard-sequential-colimit :
-    ( n : ℕ) → family-sequential-diagram A n → standard-sequential-colimit
+    ( n : ℕ) → family-sequential-diagram A n → standard-sequential-colimit A
   map-cocone-standard-sequential-colimit =
-    map-cocone-sequential-diagram A cocone-standard-sequential-colimit
+    map-cocone-sequential-diagram A (cocone-standard-sequential-colimit A)
 
   coherence-triangle-cocone-standard-sequential-colimit :
     ( n : ℕ) →
@@ -107,14 +111,14 @@ module _
       ( map-sequential-diagram A n)
   coherence-triangle-cocone-standard-sequential-colimit =
     coherence-triangle-cocone-sequential-diagram A
-      ( cocone-standard-sequential-colimit)
+      ( cocone-standard-sequential-colimit A)
 ```
 
 ### Corollaries of the universal property of sequential colimits
 
 ```agda
 module _
-  { l : Level} (A : sequential-diagram l)
+  { l : Level} {A : sequential-diagram l}
   where
 
   equiv-up-standard-sequential-colimit :
@@ -123,7 +127,7 @@ module _
   pr1 equiv-up-standard-sequential-colimit =
     cocone-map-sequential-diagram A (cocone-standard-sequential-colimit A)
   pr2 (equiv-up-standard-sequential-colimit) =
-    up-standard-sequential-colimit A _
+    up-standard-sequential-colimit _
 
   cogap-standard-sequential-colimit :
     { l : Level} {X : UU l} →
@@ -142,7 +146,7 @@ module _
       ( cocone-standard-sequential-colimit A)
       ( _)
   pr2 equiv-dup-standard-sequential-colimit =
-    dup-standard-sequential-colimit A _
+    dup-standard-sequential-colimit _
 
   dependent-cogap-standard-sequential-colimit :
     { l : Level} {P : standard-sequential-colimit A → UU l} →
@@ -178,7 +182,7 @@ module _
   equiv-htpy-htpy-out-of-standard-sequential-colimit :
     htpy-out-of-standard-sequential-colimit ≃ (f ~ g)
   equiv-htpy-htpy-out-of-standard-sequential-colimit =
-    ( inv-equiv (equiv-dup-standard-sequential-colimit A)) ∘e
+    ( inv-equiv equiv-dup-standard-sequential-colimit) ∘e
     ( equiv-tot
       ( λ K →
         equiv-Π-equiv-family
@@ -186,7 +190,7 @@ module _
             equiv-Π-equiv-family
               ( λ a →
                 compute-dependent-identification-eq-value-function f g
-                  ( coherence-triangle-cocone-standard-sequential-colimit A n a)
+                  ( coherence-triangle-cocone-standard-sequential-colimit n a)
                   ( K n a)
                   ( K (succ-ℕ n) (map-sequential-diagram A n a))))))
 ```

--- a/src/synthetic-homotopy-theory/sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/sequential-colimits.lagda.md
@@ -120,11 +120,11 @@ module _
 
 ```agda
 module _
-  { l : Level} {A : sequential-diagram l}
+  { l1 l2 : Level} {A : sequential-diagram l1}
   where
 
   equiv-up-standard-sequential-colimit :
-    { l : Level} {X : UU l} →
+    { X : UU l2} →
     (standard-sequential-colimit A → X) ≃ (cocone-sequential-diagram A X)
   pr1 equiv-up-standard-sequential-colimit =
     cocone-map-sequential-diagram A (cocone-standard-sequential-colimit A)
@@ -132,13 +132,13 @@ module _
     up-standard-sequential-colimit _
 
   cogap-standard-sequential-colimit :
-    { l : Level} {X : UU l} →
+    { X : UU l2} →
     cocone-sequential-diagram A X → standard-sequential-colimit A → X
   cogap-standard-sequential-colimit =
     map-inv-equiv equiv-up-standard-sequential-colimit
 
   equiv-dup-standard-sequential-colimit :
-    { l : Level} {P : standard-sequential-colimit A → UU l} →
+    { P : standard-sequential-colimit A → UU l2} →
     ( (x : standard-sequential-colimit A) → P x) ≃
     ( dependent-cocone-sequential-diagram A
       ( cocone-standard-sequential-colimit A)
@@ -151,7 +151,7 @@ module _
     dup-standard-sequential-colimit _
 
   dependent-cogap-standard-sequential-colimit :
-    { l : Level} {P : standard-sequential-colimit A → UU l} →
+    { P : standard-sequential-colimit A → UU l2} →
     dependent-cocone-sequential-diagram A
       ( cocone-standard-sequential-colimit A)
       ( P) →

--- a/src/synthetic-homotopy-theory/sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/sequential-colimits.lagda.md
@@ -32,17 +32,20 @@ open import synthetic-homotopy-theory.universal-property-sequential-colimits
 ## Idea
 
 Given a [sequential diagram](synthetic-homotopy-theory.sequential-diagrams.md)
-`(A, a)`, we can construct its **standard sequential colimit**, which is a
+`(A, a)`, we can construct its **standard sequential colimit** `A∞`, which is a
 [cocone under it](synthetic-homotopy-theory.cocones-under-sequential-diagrams.md)
 satisfying the
 [universal property of sequential colimits](synthetic-homotopy-theory.universal-property-sequential-colimits.md).
 
-In other words, the sequential colimit `A∞` universally completes the diagram
+In other words, the sequential colimit universally completes the diagram
 
 ```text
      a₀      a₁      a₂
- A₀ ---> A₁ ---> A₂ ---> ⋯ ---> A∞
+ A₀ ---> A₁ ---> A₂ ---> ⋯ ---> A∞ .
 ```
+
+We often abuse notation and write `A∞` for just the codomain of the universal
+cocone. You may also see the colimit written as `colimₙ Aₙ`.
 
 ## Properties
 
@@ -161,7 +164,8 @@ module _
 ### Homotopies between maps from the standard sequential colimit
 
 Maps from the standard sequential colimit induce cocones under the sequential
-diagrams, and a homotopy between the maps is exactly a homotopy of the cocones.
+diagrams, and a [homotopy](foundation-core.homotopies.md) between the maps is
+exactly a homotopy of the cocones.
 
 ```agda
 module _

--- a/src/synthetic-homotopy-theory/sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/sequential-colimits.lagda.md
@@ -74,8 +74,7 @@ module _
           ( top-map-cofork-cocone-sequential-diagram A))
 
     dup-standard-sequential-colimit :
-      { l2 : Level} →
-      dependent-universal-property-sequential-colimit l2 A
+      dependent-universal-property-sequential-colimit A
         ( cocone-standard-sequential-colimit)
     dup-standard-sequential-colimit =
       dependent-universal-property-sequential-colimit-dependent-universal-property-coequalizer
@@ -86,9 +85,7 @@ module _
           ( top-map-cofork-cocone-sequential-diagram A))
 
     up-standard-sequential-colimit :
-      { l2 : Level} →
-      universal-property-sequential-colimit l2 A
-        ( cocone-standard-sequential-colimit)
+      universal-property-sequential-colimit A cocone-standard-sequential-colimit
     up-standard-sequential-colimit =
       universal-property-dependent-universal-property-sequential-colimit A
         ( cocone-standard-sequential-colimit)

--- a/src/synthetic-homotopy-theory/sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/sequential-colimits.lagda.md
@@ -9,15 +9,14 @@ module synthetic-homotopy-theory.sequential-colimits where
 ```agda
 open import elementary-number-theory.natural-numbers
 
+open import foundation.commuting-triangles-of-maps
 open import foundation.dependent-pair-types
+open import foundation.equivalences
+open import foundation.function-types
+open import foundation.functoriality-dependent-function-types
+open import foundation.functoriality-dependent-pair-types
 open import foundation.homotopies
 open import foundation.universe-levels
-
-open import foundation-core.commuting-triangles-of-maps
-open import foundation-core.equivalences
-open import foundation-core.function-types
-open import foundation-core.functoriality-dependent-function-types
-open import foundation-core.functoriality-dependent-pair-types
 
 open import synthetic-homotopy-theory.cocones-under-sequential-diagrams
 open import synthetic-homotopy-theory.coequalizers

--- a/src/synthetic-homotopy-theory/sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/sequential-colimits.lagda.md
@@ -1,0 +1,133 @@
+# Sequential colimits
+
+```agda
+module synthetic-homotopy-theory.sequential-colimits where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import elementary-number-theory.natural-numbers
+
+open import foundation.commuting-squares-of-homotopies
+open import foundation.commuting-triangles-of-maps
+open import foundation.dependent-pair-types
+open import foundation.function-types
+open import foundation.homotopies
+open import foundation.universe-levels
+open import foundation.whiskering-homotopies
+
+open import synthetic-homotopy-theory.cocones-under-sequential-diagrams
+open import synthetic-homotopy-theory.coequalizers
+open import synthetic-homotopy-theory.dependent-universal-property-sequential-colimits
+open import synthetic-homotopy-theory.sequential-diagrams
+open import synthetic-homotopy-theory.universal-property-sequential-colimits
+```
+
+</details>
+
+## Idea
+
+Given a [sequential diagram](synthetic-homotopy-theory.sequential-diagrams.md)
+`(A, a)`, we can construct its **standard sequential colimit**, which is a
+[cocone under it](synthetic-homotopy-theory.cocones-under-sequential-diagrams.md)
+satisfying the
+[universal property of sequential colimits](synthetic-homotopy-theory.universal-property-sequential-colimits.md).
+
+In other words, the sequential colimit `A∞` universally completes the diagram
+
+```text
+     a₀      a₁      a₂
+ A₀ ---> A₁ ---> A₂ ---> ⋯ ---> A∞
+```
+
+## Properties
+
+### All sequential diagrams admit a standard colimit
+
+The standard colimit may be constructed from
+[coequalizers](synthetic-homotopy-theory.coequalizers.md), because we
+[have shown](synthetic-homotopy-theory.universal-property-sequential-colimits.md)
+that cocones of sequential diagrams correspond to a certain class of
+[coforks](synthetic-homotopy-theory.coforks.md), and the coequalizers correspond
+to sequential colimits. Since all coequalizers exist, we conclude that all
+sequential colimits exist.
+
+```agda
+module _
+  { l : Level} (A : sequential-diagram l)
+  where
+
+  abstract
+    standard-sequential-colimit : UU l
+    standard-sequential-colimit =
+      canonical-coequalizer
+        ( bottom-map-cofork-cocone-sequential-diagram A)
+        ( top-map-cofork-cocone-sequential-diagram A)
+
+    cocone-standard-sequential-colimit :
+      cocone-sequential-diagram A standard-sequential-colimit
+    cocone-standard-sequential-colimit =
+      cocone-sequential-diagram-cofork A
+        ( cofork-canonical-coequalizer
+          ( bottom-map-cofork-cocone-sequential-diagram A)
+          ( top-map-cofork-cocone-sequential-diagram A))
+
+    dup-standard-sequential-colimit :
+      { l2 : Level} →
+      dependent-universal-property-sequential-colimit l2 A
+        ( cocone-standard-sequential-colimit)
+    dup-standard-sequential-colimit =
+      dependent-universal-property-sequential-colimit-dependent-universal-property-coequalizer
+        ( A)
+        ( cocone-standard-sequential-colimit)
+        ( dup-canonical-coequalizer
+          ( bottom-map-cofork-cocone-sequential-diagram A)
+          ( top-map-cofork-cocone-sequential-diagram A))
+
+    up-standard-sequential-colimit :
+      { l2 : Level} →
+      universal-property-sequential-colimit l2 A
+        ( cocone-standard-sequential-colimit)
+    up-standard-sequential-colimit =
+      universal-property-dependent-universal-property-sequential-colimit A
+        ( cocone-standard-sequential-colimit)
+        ( dup-standard-sequential-colimit)
+
+  map-cocone-standard-sequential-colimit :
+    ( n : ℕ) → family-sequential-diagram A n → standard-sequential-colimit
+  map-cocone-standard-sequential-colimit =
+    map-cocone-sequential-diagram A cocone-standard-sequential-colimit
+
+  coherence-triangle-cocone-standard-sequential-colimit :
+    ( n : ℕ) →
+    coherence-triangle-maps
+      ( map-cocone-standard-sequential-colimit n)
+      ( map-cocone-standard-sequential-colimit (succ-ℕ n))
+      ( map-sequential-diagram A n)
+  coherence-triangle-cocone-standard-sequential-colimit =
+    coherence-triangle-cocone-sequential-diagram A
+      ( cocone-standard-sequential-colimit)
+```
+
+### Homotopies between maps from the standard sequential colimit
+
+```agda
+module _
+  { l1 l2 : Level} (A : sequential-diagram l1) {X : UU l2}
+  ( f g : standard-sequential-colimit A → X)
+  where
+
+  htpy-standard-sequential-colimit : UU (l1 ⊔ l2)
+  htpy-standard-sequential-colimit =
+    Σ ( ( n : ℕ) →
+        f ∘ map-cocone-standard-sequential-colimit A n ~
+        g ∘ map-cocone-standard-sequential-colimit A n)
+      ( λ h →
+        ( n : ℕ) →
+        coherence-square-homotopies
+          ( h n)
+          ( f ·l coherence-triangle-cocone-standard-sequential-colimit A n)
+          ( g ·l coherence-triangle-cocone-standard-sequential-colimit A n)
+          ( h (succ-ℕ n) ·r map-sequential-diagram A n))
+```

--- a/src/synthetic-homotopy-theory/sequential-diagrams.lagda.md
+++ b/src/synthetic-homotopy-theory/sequential-diagrams.lagda.md
@@ -10,7 +10,6 @@ module synthetic-homotopy-theory.sequential-diagrams where
 open import elementary-number-theory.natural-numbers
 
 open import foundation.dependent-pair-types
-open import foundation.function-types
 open import foundation.universe-levels
 ```
 
@@ -59,7 +58,7 @@ module _
 
   constant-sequential-diagram : sequential-diagram l
   pr1 constant-sequential-diagram _ = X
-  pr2 constant-sequential-diagram _ = id
+  pr2 constant-sequential-diagram _ x = x
 ```
 
 ## Properties

--- a/src/synthetic-homotopy-theory/sequential-diagrams.lagda.md
+++ b/src/synthetic-homotopy-theory/sequential-diagrams.lagda.md
@@ -10,6 +10,7 @@ module synthetic-homotopy-theory.sequential-diagrams where
 open import elementary-number-theory.natural-numbers
 
 open import foundation.dependent-pair-types
+open import foundation.function-types
 open import foundation.universe-levels
 ```
 
@@ -49,6 +50,16 @@ module _
   map-sequential-diagram :
     (n : ℕ) → family-sequential-diagram n → family-sequential-diagram (succ-ℕ n)
   map-sequential-diagram = pr2 A
+```
+
+```agda
+module _
+  { l : Level} (X : UU l)
+  where
+
+  constant-sequential-diagram : sequential-diagram l
+  pr1 constant-sequential-diagram _ = X
+  pr2 constant-sequential-diagram _ = id
 ```
 
 ## Properties

--- a/src/synthetic-homotopy-theory/sequentially-compact-types.lagda.md
+++ b/src/synthetic-homotopy-theory/sequentially-compact-types.lagda.md
@@ -42,9 +42,8 @@ module _
   is-sequentially-compact =
     {l2 l3 : Level} (A : sequential-diagram l2) {A∞ : UU l3}
     (c : cocone-sequential-diagram A A∞) →
-    ((l : Level) → universal-property-sequential-colimit l A c) →
-    (l : Level) →
-    universal-property-sequential-colimit l
+    universal-property-sequential-colimit A c →
+    universal-property-sequential-colimit
       ( postcomp-sequential-diagram X A)
       ( cocone-postcomp-sequential-diagram X A c)
 ```

--- a/src/synthetic-homotopy-theory/universal-property-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-sequential-colimits.lagda.md
@@ -62,14 +62,10 @@ module _
   ( c : cocone-sequential-diagram A X)
   where
 
-  universal-property-sequential-colimit-Level :
-    ( l : Level) → UU (l1 ⊔ l2 ⊔ lsuc l)
-  universal-property-sequential-colimit-Level l =
-    ( Y : UU l) → is-equiv (cocone-map-sequential-diagram A c {Y = Y})
-
   universal-property-sequential-colimit : UUω
   universal-property-sequential-colimit =
-    {l : Level} → universal-property-sequential-colimit-Level l
+    {l : Level} → (Y : UU l) →
+    is-equiv (cocone-map-sequential-diagram A c {Y = Y})
 ```
 
 ### The map induced by the universal property of sequential colimits

--- a/src/synthetic-homotopy-theory/universal-property-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-sequential-colimits.lagda.md
@@ -58,13 +58,18 @@ diagram
 
 ```agda
 module _
-  { l1 l2 : Level} (l : Level) (A : sequential-diagram l1) {X : UU l2}
+  { l1 l2 : Level} (A : sequential-diagram l1) {X : UU l2}
   ( c : cocone-sequential-diagram A X)
   where
 
-  universal-property-sequential-colimit : UU (l1 ⊔ l2 ⊔ lsuc l)
-  universal-property-sequential-colimit =
+  universal-property-sequential-colimit-Level :
+    ( l : Level) → UU (l1 ⊔ l2 ⊔ lsuc l)
+  universal-property-sequential-colimit-Level l =
     ( Y : UU l) → is-equiv (cocone-map-sequential-diagram A c {Y = Y})
+
+  universal-property-sequential-colimit : UUω
+  universal-property-sequential-colimit =
+    {l : Level} → universal-property-sequential-colimit-Level l
 ```
 
 ### The map induced by the universal property of sequential colimits
@@ -76,7 +81,7 @@ providing a cocone under the sequential diagram.
 module _
   { l1 l2 l3 : Level} (A : sequential-diagram l1) {X : UU l2}
   ( c : cocone-sequential-diagram A X) {Y : UU l3}
-  ( up-sequential-colimit : universal-property-sequential-colimit l3 A c)
+  ( up-sequential-colimit : universal-property-sequential-colimit A c)
   where
 
   map-universal-property-sequential-colimit :
@@ -93,7 +98,7 @@ module _
 module _
   { l1 l2 l3 : Level} (A : sequential-diagram l1) {X : UU l2}
   ( c : cocone-sequential-diagram A X) {Y : UU l3}
-  ( up-sequential-colimit : universal-property-sequential-colimit l3 A c)
+  ( up-sequential-colimit : universal-property-sequential-colimit A c)
   ( c' : cocone-sequential-diagram A Y)
   where
 
@@ -151,8 +156,7 @@ module _
         ( bottom-map-cofork-cocone-sequential-diagram A)
         ( top-map-cofork-cocone-sequential-diagram A)
         ( cofork-cocone-sequential-diagram A c)) →
-    ( {l : Level} →
-      universal-property-sequential-colimit l A c)
+    universal-property-sequential-colimit A c
   universal-property-sequential-colimit-universal-property-coequalizer
     ( up-cofork)
     ( Y) =
@@ -168,8 +172,7 @@ module _
       ( is-equiv-cocone-sequential-diagram-cofork A)
 
   universal-property-coequalizer-universal-property-sequential-colimit :
-    ( {l : Level} →
-      universal-property-sequential-colimit l A c) →
+    universal-property-sequential-colimit A c →
     ( {l : Level} →
       universal-property-coequalizer l
         ( bottom-map-cofork-cocone-sequential-diagram A)
@@ -233,8 +236,8 @@ module _
 
   abstract
     is-equiv-universal-property-sequential-colimit-universal-property-sequential-colimit :
-      ( {l : Level} → universal-property-sequential-colimit l A c) →
-      ( {l : Level} → universal-property-sequential-colimit l A c') →
+      universal-property-sequential-colimit A c →
+      universal-property-sequential-colimit A c' →
       is-equiv h
     is-equiv-universal-property-sequential-colimit-universal-property-sequential-colimit
       ( up-sequential-colimit)
@@ -250,9 +253,9 @@ module _
             ( up-sequential-colimit' Z))
 
     universal-property-sequential-colimit-is-equiv-universal-property-sequential-colomit :
-      ( {l : Level} → universal-property-sequential-colimit l A c) →
+      universal-property-sequential-colimit A c →
       is-equiv h →
-      ( {l : Level} → universal-property-sequential-colimit l A c')
+      universal-property-sequential-colimit A c'
     universal-property-sequential-colimit-is-equiv-universal-property-sequential-colomit
       ( up-sequential-colimit)
       ( is-equiv-h)
@@ -267,8 +270,8 @@ module _
 
     universal-property-sequential-colimit-universal-property-sequential-colimit-is-equiv :
       is-equiv h →
-      ( {l : Level} → universal-property-sequential-colimit l A c') →
-      ( {l : Level} → universal-property-sequential-colimit l A c)
+      universal-property-sequential-colimit A c' →
+      universal-property-sequential-colimit A c
     universal-property-sequential-colimit-universal-property-sequential-colimit-is-equiv
       ( is-equiv-h)
       ( up-sequential-colimit)
@@ -289,10 +292,8 @@ module _
   { l1 l2 l3 : Level} (A : sequential-diagram l1) {X : UU l2} {Y : UU l3}
   ( c : cocone-sequential-diagram A X)
   ( c' : cocone-sequential-diagram A Y)
-  ( up-sequential-diagram :
-    {l : Level} → universal-property-sequential-colimit l A c)
-  ( up-sequential-diagram' :
-    {l : Level} → universal-property-sequential-colimit l A c')
+  ( up-sequential-diagram : universal-property-sequential-colimit A c)
+  ( up-sequential-diagram' : universal-property-sequential-colimit A c')
   where
 
   abstract

--- a/src/synthetic-homotopy-theory/universal-property-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-sequential-colimits.lagda.md
@@ -288,8 +288,8 @@ module _
   { l1 l2 l3 : Level} (A : sequential-diagram l1) {X : UU l2} {Y : UU l3}
   ( c : cocone-sequential-diagram A X)
   ( c' : cocone-sequential-diagram A Y)
-  ( up-sequential-diagram : universal-property-sequential-colimit A c)
-  ( up-sequential-diagram' : universal-property-sequential-colimit A c')
+  ( up-c : universal-property-sequential-colimit A c)
+  ( up-c' : universal-property-sequential-colimit A c')
   where
 
   abstract
@@ -302,26 +302,16 @@ module _
                 ( c')))
     uniquely-unique-sequential-colimit =
       is-torsorial-Eq-subtype
-        ( uniqueness-map-universal-property-sequential-colimit A c
-          ( up-sequential-diagram)
-          ( c'))
+        ( uniqueness-map-universal-property-sequential-colimit A c up-c c')
         ( is-property-is-equiv)
-        ( map-universal-property-sequential-colimit A c
-          ( up-sequential-diagram)
-          ( c'))
-        ( htpy-cocone-universal-property-sequential-colimit A c
-          ( up-sequential-diagram)
-          ( c'))
+        ( map-universal-property-sequential-colimit A c up-c c')
+        ( htpy-cocone-universal-property-sequential-colimit A c up-c c')
         ( is-equiv-universal-property-sequential-colimit-universal-property-sequential-colimit
           ( A)
           ( c)
           ( c')
-          ( map-universal-property-sequential-colimit A c
-            ( up-sequential-diagram)
-            ( c'))
-          ( htpy-cocone-universal-property-sequential-colimit A c
-            ( up-sequential-diagram)
-            ( c'))
-          ( up-sequential-diagram)
-          ( up-sequential-diagram'))
+          ( map-universal-property-sequential-colimit A c up-c c')
+          ( htpy-cocone-universal-property-sequential-colimit A c up-c c')
+          ( up-c)
+          ( up-c'))
 ```


### PR DESCRIPTION
This PR:
- Introduces the concept of commuting prisms of maps (in multiple variations)
- Shows that vertically inverted squares of maps are inverses w.r.t. vertical composition
- Adds various lemmas about commuting squares of maps, such as associativity of vertical composition, naturality w.r.t. identifications, and commutativity of horizontal and vertical pasting
- Adds computation rules and coherence for transposing equivalences (i.e. turning `e x = y` into `x = e-inv y`)
- Adds various path-algebraic lemmas under the guise of performing operations on squares, such as whiskering them to get e.g. `(p . q) = (p' . q') -> ((r . p) . q) = ((r . p') . q')` (sneaky)
- Redefines universal properties of sequential colimits to not be a Level-wise property
- Adds inverses of equivalences of sequential diagrams
- Proves functoriality of sequential colimits - maps of diagrams induce maps of colimits, equivalences of diagrams induce equivalences of colimits, and the colimiting preserves identity and composition (Lemma 3.5 in Sequential Colimits in Homotopy Type Theory by Sojakova & van Doorn & Rijke)
- Shows existence of standard sequential colimits, and characterizes homotopies of maps out of them

Fixes #868 