### PR TITLE
Several facts about `k`-equivalences

### DIFF
--- a/src/foundation/connected-maps.lagda.md
+++ b/src/foundation/connected-maps.lagda.md
@@ -187,6 +187,25 @@ module _
 
 ## Properties
 
+### All maps are `(-2)`-connected
+
+```agda
+is-neg-two-connected-map :
+  {l1 l2 : Level} {A : UU l1} {B : UU l2} (f : A → B) →
+  is-connected-map neg-two-𝕋 f
+is-neg-two-connected-map f b = is-neg-two-connected (fiber f b)
+```
+
+### Equivalences are `k`-connected for any `k`
+
+```agda
+is-connected-map-is-equiv :
+  {l1 l2 : Level} {k : 𝕋} {A : UU l1} {B : UU l2} (f : A → B) →
+  is-equiv f → is-connected-map k f
+is-connected-map-is-equiv {k = k} f e b =
+  is-connected-is-contr k ( is-contr-map-is-equiv e b)
+```
+
 ### Dependent universal property for connected maps
 
 ```agda

--- a/src/foundation/connected-types.lagda.md
+++ b/src/foundation/connected-types.lagda.md
@@ -9,6 +9,7 @@ module foundation.connected-types where
 ```agda
 open import foundation.contractible-types
 open import foundation.dependent-pair-types
+open import foundation.functoriality-truncation
 open import foundation.inhabited-types
 open import foundation.propositional-truncations
 open import foundation.propositions
@@ -127,4 +128,37 @@ module _
   is-connected-is-contr : is-contr A → is-connected k A
   is-connected-is-contr c =
     is-contr-is-equiv' A unit-trunc (is-equiv-unit-trunc-is-contr k A c) c
+```
+
+### Being connected is invariant under equivalence
+
+```agda
+module _
+  {l1 l2 : Level} {k : 𝕋} {A : UU l1} {B : UU l2}
+  where
+
+  is-connected-is-equiv :
+    (f : A → B) → is-equiv f → is-connected k B → is-connected k A
+  is-connected-is-equiv f e =
+    is-contr-is-equiv
+      ( type-trunc k B)
+      ( map-trunc k f)
+      ( is-equiv-map-equiv-trunc k (f , e))
+
+  is-connected-equiv :
+    A ≃ B → is-connected k B → is-connected k A
+  is-connected-equiv f =
+    is-connected-is-equiv (map-equiv f) (is-equiv-map-equiv f)
+
+module _
+  {l1 l2 : Level} {k : 𝕋} {A : UU l1} {B : UU l2}
+  where
+
+  is-connected-equiv' :
+    A ≃ B → is-connected k A → is-connected k B
+  is-connected-equiv' f = is-connected-equiv (inv-equiv f)
+
+  is-connected-is-equiv' :
+    (f : A → B) → is-equiv f → is-connected k A → is-connected k B
+  is-connected-is-equiv' f e = is-connected-equiv' (f , e)
 ```

--- a/src/foundation/connected-types.lagda.md
+++ b/src/foundation/connected-types.lagda.md
@@ -45,6 +45,13 @@ is-prop-is-connected k A = is-prop-type-Prop (is-connected-Prop k A)
 
 ## Properties
 
+### All types are `(-2)`-connected
+
+```agda
+is-neg-two-connected : {l : Level} (A : UU l) → is-connected neg-two-𝕋 A
+is-neg-two-connected A = is-trunc-type-trunc
+```
+
 ### A type `A` is `k`-connected if and only if the map `B → (A → B)` is an equivalence for every `k`-truncated type `B`
 
 ```agda

--- a/src/foundation/connected-types.lagda.md
+++ b/src/foundation/connected-types.lagda.md
@@ -109,3 +109,15 @@ module _
                 ( λ where refl → refl)
                 ( center (K a x)))))
 ```
+
+### Contractible types are `k`-connected for any `k`
+
+```agda
+module _
+  (k : 𝕋) {l : Level} {A : UU l}
+  where
+
+  is-connected-is-contr : is-contr A → is-connected k A
+  is-connected-is-contr c =
+    is-contr-is-equiv' A unit-trunc (is-equiv-unit-trunc-is-contr k A c) c
+```

--- a/src/foundation/truncation-equivalences.lagda.md
+++ b/src/foundation/truncation-equivalences.lagda.md
@@ -17,7 +17,11 @@ open import foundation.fibers-of-maps
 open import foundation.functoriality-dependent-pair-types
 open import foundation.functoriality-truncation
 open import foundation.identity-types
+open import foundation.propositional-truncations
+open import foundation.sections
+open import foundation.surjective-maps
 open import foundation.truncations
+open import foundation.type-arithmetic-dependent-pair-types
 open import foundation.universal-property-dependent-pair-types
 open import foundation.universal-property-truncation
 open import foundation.universe-levels
@@ -26,6 +30,7 @@ open import foundation-core.equivalences
 open import foundation-core.function-types
 open import foundation-core.functoriality-function-types
 open import foundation-core.homotopies
+open import foundation-core.transport-along-identifications
 open import foundation-core.truncated-types
 open import foundation-core.truncation-levels
 ```

--- a/src/foundation/truncation-equivalences.lagda.md
+++ b/src/foundation/truncation-equivalences.lagda.md
@@ -9,8 +9,11 @@ module foundation.truncation-equivalences where
 ```agda
 open import foundation.commuting-squares-of-maps
 open import foundation.dependent-pair-types
+open import foundation.functoriality-dependent-pair-types
 open import foundation.functoriality-truncation
 open import foundation.truncations
+open import foundation.universal-property-dependent-pair-types
+open import foundation.universal-property-truncation
 open import foundation.universe-levels
 
 open import foundation-core.equivalences
@@ -104,6 +107,38 @@ is-truncation-equivalence-is-equiv-precomp k {A} {B} f H =
         ( is-truncation-trunc X)
         ( is-truncation-trunc X)
         ( H _ X))
+```
+
+### The map on dependent pair types induced by the unit of the `(k+1)`-truncation is a `k`-equivalence
+
+This is Lemma 2.27 of Christensen, Opie, Rijke & Scoccola listed below.
+
+```agda
+module _
+  {l1 l2 : Level} {k : 𝕋}
+  {X : UU l1} (P : (type-trunc (succ-𝕋 k) X) → UU l2)
+  where
+
+  map-Σ-map-base-unit-trunc :
+    Σ X (P ∘ unit-trunc) → Σ (type-trunc (succ-𝕋 k) X) P
+  map-Σ-map-base-unit-trunc = map-Σ-map-base unit-trunc P
+
+  is-truncation-equivalence-map-Σ-map-base-unit-trunc :
+    is-truncation-equivalence k map-Σ-map-base-unit-trunc
+  is-truncation-equivalence-map-Σ-map-base-unit-trunc =
+    is-truncation-equivalence-is-equiv-precomp k
+      ( map-Σ-map-base-unit-trunc)
+      ( λ l X →
+        is-equiv-equiv
+          ( equiv-ev-pair)
+          ( equiv-ev-pair)
+          ( refl-htpy)
+          ( dependent-universal-property-trunc
+            ( λ t →
+              ( ( P t → type-Truncated-Type X) ,
+                ( is-trunc-succ-is-trunc k
+                  ( is-trunc-function-type k
+                    ( is-trunc-type-Truncated-Type X)))))))
 ```
 
 ## References

--- a/src/foundation/truncation-equivalences.lagda.md
+++ b/src/foundation/truncation-equivalences.lagda.md
@@ -8,6 +8,10 @@ module foundation.truncation-equivalences where
 
 ```agda
 open import foundation.commuting-squares-of-maps
+open import foundation.connected-maps
+open import foundation.connected-types
+open import foundation.contractible-maps
+open import foundation.contractible-types
 open import foundation.dependent-pair-types
 open import foundation.fibers-of-maps
 open import foundation.functoriality-dependent-pair-types
@@ -302,6 +306,45 @@ module _
   pr1 truncation-equivalence-fiber-map-trunc-fiber = fiber-map-trunc-fiber
   pr2 truncation-equivalence-fiber-map-trunc-fiber =
     is-truncation-equivalence-fiber-map-trunc-fiber
+```
+
+### Being `k`-connected is invariant under `k`-equivalences
+
+```agda
+module _
+  {l1 l2 : Level} {k : 𝕋} {A : UU l1} {B : UU l2}
+  where
+
+  is-connected-is-truncation-equivalence :
+    (f : A → B) → is-truncation-equivalence k f →
+    is-connected k B → is-connected k A
+  is-connected-is-truncation-equivalence f e =
+    is-contr-equiv (type-trunc k B) (map-trunc k f , e)
+
+  is-connected-truncation-equivalence :
+    truncation-equivalence k A B → is-connected k B → is-connected k A
+  is-connected-truncation-equivalence f =
+    is-connected-is-truncation-equivalence
+      ( map-truncation-equivalence k f)
+      ( is-truncation-equivalence-truncation-equivalence k f)
+```
+
+### Every `(k+1)`-equivalence is `k`-connected
+
+This is an instance of Proposition 2.30 in Christensen, Opie, Rijke & Scoccola
+listed below.
+
+```agda
+module _
+  {l1 l2 : Level} {k : 𝕋} {A : UU l1} {B : UU l2} (f : A → B)
+  where
+
+  is-connected-map-is-truncation-equivalence :
+    is-truncation-equivalence (succ-𝕋 k) f → is-connected-map k f
+  is-connected-map-is-truncation-equivalence e b =
+    is-connected-truncation-equivalence
+      ( truncation-equivalence-fiber-map-trunc-fiber f b)
+      ( is-connected-is-contr k (is-contr-map-is-equiv e (unit-trunc b)))
 ```
 
 ## References

--- a/src/foundation/truncation-equivalences.lagda.md
+++ b/src/foundation/truncation-equivalences.lagda.md
@@ -128,16 +128,17 @@ module _
   {l1 l2 l3 : Level} {k : 𝕋} {A : UU l1} {B : UU l2} {C : UU l3}
   where
 
-  is-truncation-equivalence-comp :
-    (g : B → C) (f : A → B) →
-    is-truncation-equivalence k f →
-    is-truncation-equivalence k g →
-    is-truncation-equivalence k (g ∘ f)
-  is-truncation-equivalence-comp g f ef eg =
-    is-equiv-htpy
-      ( map-trunc k g ∘ map-trunc k f)
-      ( preserves-comp-map-trunc k g f)
-      ( is-equiv-comp (map-trunc k g) (map-trunc k f) ef eg)
+  abstract
+    is-truncation-equivalence-comp :
+      (g : B → C) (f : A → B) →
+      is-truncation-equivalence k f →
+      is-truncation-equivalence k g →
+      is-truncation-equivalence k (g ∘ f)
+    is-truncation-equivalence-comp g f ef eg =
+      is-equiv-htpy
+        ( map-trunc k g ∘ map-trunc k f)
+          ( preserves-comp-map-trunc k g f)
+        ( is-equiv-comp (map-trunc k g) (map-trunc k f) ef eg)
 
   truncation-equivalence-comp :
     truncation-equivalence k B C →

--- a/src/foundation/truncation-equivalences.lagda.md
+++ b/src/foundation/truncation-equivalences.lagda.md
@@ -109,6 +109,38 @@ is-truncation-equivalence-is-equiv-precomp k {A} {B} f H =
         ( H _ X))
 ```
 
+### The `k`-equivalences are closed under composition
+
+```agda
+module _
+  {l1 l2 l3 : Level} {k : 𝕋} {A : UU l1} {B : UU l2} {C : UU l3}
+  where
+
+  is-truncation-equivalence-comp :
+    (g : B → C) (f : A → B) →
+    is-truncation-equivalence k f →
+    is-truncation-equivalence k g →
+    is-truncation-equivalence k (g ∘ f)
+  is-truncation-equivalence-comp g f ef eg =
+    is-equiv-htpy
+      ( map-trunc k g ∘ map-trunc k f)
+      ( preserves-comp-map-trunc k g f)
+      ( is-equiv-comp (map-trunc k g) (map-trunc k f) ef eg)
+
+  truncation-equivalence-comp :
+    truncation-equivalence k B C →
+    truncation-equivalence k A B →
+    truncation-equivalence k A C
+  pr1 (truncation-equivalence-comp g f) =
+    map-truncation-equivalence k g ∘ map-truncation-equivalence k f
+  pr2 (truncation-equivalence-comp g f) =
+    is-truncation-equivalence-comp
+      ( map-truncation-equivalence k g)
+      ( map-truncation-equivalence k f)
+      ( is-truncation-equivalence-truncation-equivalence k f)
+      ( is-truncation-equivalence-truncation-equivalence k g)
+```
+
 ### The map on dependent pair types induced by the unit of the `(k+1)`-truncation is a `k`-equivalence
 
 This is Lemma 2.27 of Christensen, Opie, Rijke & Scoccola listed below.

--- a/src/foundation/truncation-equivalences.lagda.md
+++ b/src/foundation/truncation-equivalences.lagda.md
@@ -154,6 +154,56 @@ module _
       ( is-truncation-equivalence-truncation-equivalence k g)
 ```
 
+### Composing `k`-equivalences with equivalences
+
+```agda
+module _
+  {l1 l2 l3 : Level} {k : 𝕋} {A : UU l1} {B : UU l2} {C : UU l3}
+  where
+
+  is-truncation-equivalence-is-equiv-is-truncation-equivalence :
+    (g : B → C) (f : A → B) →
+    is-truncation-equivalence k g →
+    is-equiv f →
+    is-truncation-equivalence k (g ∘ f)
+  is-truncation-equivalence-is-equiv-is-truncation-equivalence g f eg ef =
+    is-truncation-equivalence-comp g f
+      ( is-truncation-equivalence-is-equiv f ef)
+      ( eg)
+
+  is-truncation-equivalence-is-truncation-equivalence-is-equiv :
+    (g : B → C) (f : A → B) →
+    is-equiv g →
+    is-truncation-equivalence k f →
+    is-truncation-equivalence k (g ∘ f)
+  is-truncation-equivalence-is-truncation-equivalence-is-equiv g f eg ef =
+    is-truncation-equivalence-comp g f
+      ( ef)
+      ( is-truncation-equivalence-is-equiv g eg)
+
+  is-truncation-equivalence-equiv-is-truncation-equivalence :
+    (g : B → C) (f : A ≃ B) →
+    is-truncation-equivalence k g →
+    is-truncation-equivalence k (g ∘ map-equiv f)
+  is-truncation-equivalence-equiv-is-truncation-equivalence g f eg =
+    is-truncation-equivalence-is-equiv-is-truncation-equivalence g
+      ( map-equiv f)
+      ( eg)
+      ( is-equiv-map-equiv f)
+
+  is-truncation-equivalence-is-truncation-equivalence-equiv :
+    (g : B ≃ C) (f : A → B) →
+    is-truncation-equivalence k f →
+    is-truncation-equivalence k (map-equiv g ∘ f)
+  is-truncation-equivalence-is-truncation-equivalence-equiv g f ef =
+    is-truncation-equivalence-is-truncation-equivalence-is-equiv
+      ( map-equiv g)
+      ( f)
+      ( is-equiv-map-equiv g)
+      ( ef)
+```
+
+
 ### The map on dependent pair types induced by the unit of the `(k+1)`-truncation is a `k`-equivalence
 
 This is Lemma 2.27 of Christensen, Opie, Rijke & Scoccola listed below.

--- a/src/foundation/truncation-equivalences.lagda.md
+++ b/src/foundation/truncation-equivalences.lagda.md
@@ -109,6 +109,18 @@ is-truncation-equivalence-is-equiv-precomp k {A} {B} f H =
         ( H _ X))
 ```
 
+### An equivalence is a `k`-equivalence for all `k`
+
+```agda
+module _
+  {l1 l2 : Level} {k : 𝕋} {A : UU l1} {B : UU l2} (f : A → B)
+  where
+
+  is-truncation-equivalence-is-equiv :
+    is-equiv f → is-truncation-equivalence k f
+  is-truncation-equivalence-is-equiv e = is-equiv-map-equiv-trunc k (f , e)
+```
+
 ### The `k`-equivalences are closed under composition
 
 ```agda

--- a/src/foundation/truncation-equivalences.lagda.md
+++ b/src/foundation/truncation-equivalences.lagda.md
@@ -9,8 +9,10 @@ module foundation.truncation-equivalences where
 ```agda
 open import foundation.commuting-squares-of-maps
 open import foundation.dependent-pair-types
+open import foundation.fibers-of-maps
 open import foundation.functoriality-dependent-pair-types
 open import foundation.functoriality-truncation
+open import foundation.identity-types
 open import foundation.truncations
 open import foundation.universal-property-dependent-pair-types
 open import foundation.universal-property-truncation
@@ -206,7 +208,7 @@ module _
 
 ### The map on dependent pair types induced by the unit of the `(k+1)`-truncation is a `k`-equivalence
 
-This is Lemma 2.27 of Christensen, Opie, Rijke & Scoccola listed below.
+This is an instance of Lemma 2.27 in Christensen, Opie, Rijke & Scoccola listed below.
 
 ```agda
 module _
@@ -234,6 +236,71 @@ module _
                 ( is-trunc-succ-is-trunc k
                   ( is-trunc-function-type k
                     ( is-trunc-type-Truncated-Type X)))))))
+```
+
+### There is an `k`-equivalence between the fiber of a map and the fiber of its `(k+1)`-truncation
+
+This is an instance of Corollary 2.29 in Christensen, Opie, Rijke & Scoccola listed below.
+
+We consider the following composition of maps
+
+```text
+   fiber f b = Σ A (λ a → f a = b)
+             → Σ A (λ a → ∥ f a ＝ b ∥)
+             ≃ Σ A (λ a → | f a | = | b |
+             ≃ Σ A (λ a → ∥ f ∥ | a | = | b |)
+             → Σ ∥ A ∥ (λ t → ∥ f ∥ t = | b |)
+             = fiber ∥ f ∥ | b |
+```
+
+where the first and last maps are `k`-equivalences.
+
+```agda
+module _
+  {l1 l2 : Level} {k : 𝕋} {A : UU l1} {B : UU l2} (f : A → B) (b : B)
+  where
+
+  fiber-map-trunc-fiber :
+    fiber f b → fiber (map-trunc (succ-𝕋 k) f) (unit-trunc b)
+  fiber-map-trunc-fiber =
+    ( map-Σ-map-base-unit-trunc
+      ( λ t → map-trunc (succ-𝕋 k) f t ＝ unit-trunc b)) ∘
+    ( tot
+      ( λ a →
+        ( concat (naturality-unit-trunc (succ-𝕋 k) f a) (unit-trunc b)) ∘
+        ( map-effectiveness-trunc k (f a) b) ∘
+        ( unit-trunc)))
+
+  is-truncation-equivalence-fiber-map-trunc-fiber :
+    is-truncation-equivalence k fiber-map-trunc-fiber
+  is-truncation-equivalence-fiber-map-trunc-fiber =
+    is-truncation-equivalence-comp
+      ( map-Σ-map-base-unit-trunc
+        ( λ t → map-trunc (succ-𝕋 k) f t ＝ unit-trunc b))
+      ( tot
+        ( λ a →
+          ( concat (naturality-unit-trunc (succ-𝕋 k) f a) (unit-trunc b)) ∘
+          ( map-effectiveness-trunc k (f a) b) ∘
+          ( unit-trunc)))
+      ( is-truncation-equivalence-is-truncation-equivalence-equiv
+        ( equiv-tot
+          ( λ a →
+            ( equiv-concat
+              ( naturality-unit-trunc (succ-𝕋 k) f a)
+              ( unit-trunc b)) ∘e
+            ( effectiveness-trunc k (f a) b)))
+        ( λ (a , p) → a , unit-trunc p)
+        ( is-equiv-map-equiv (equiv-trunc-Σ k)))
+      ( is-truncation-equivalence-map-Σ-map-base-unit-trunc
+        ( λ t → map-trunc (succ-𝕋 k) f t ＝ unit-trunc b))
+
+  truncation-equivalence-fiber-map-trunc-fiber :
+    truncation-equivalence k
+      ( fiber f b)
+      ( fiber (map-trunc (succ-𝕋 k) f) (unit-trunc b))
+  pr1 truncation-equivalence-fiber-map-trunc-fiber = fiber-map-trunc-fiber
+  pr2 truncation-equivalence-fiber-map-trunc-fiber =
+    is-truncation-equivalence-fiber-map-trunc-fiber
 ```
 
 ## References

--- a/src/foundation/truncation-equivalences.lagda.md
+++ b/src/foundation/truncation-equivalences.lagda.md
@@ -395,6 +395,110 @@ module _
       ( is-connected-is-contr k (is-contr-map-is-equiv e (unit-trunc b)))
 ```
 
+### The codomain of a `k`-connected map is `(k+1)`-connected if its domain is `(k+1)`-connected
+
+This follows part of the proof of Proposition 2.31 in [CORS'20].
+
+```agda
+module _
+  {l1 l2 : Level} {k : 𝕋} {A : UU l1} {B : UU l2} (f : A → B)
+  where
+
+  is-trunc-fiber-map-trunc-is-succ-connected :
+    is-connected (succ-𝕋 k) A →
+    (b : B) →
+    is-trunc k (fiber (map-trunc (succ-𝕋 k) f) (unit-trunc b))
+  is-trunc-fiber-map-trunc-is-succ-connected c b =
+    is-trunc-equiv k
+      ( map-trunc (succ-𝕋 k) f (center c) ＝ unit-trunc b)
+      ( left-unit-law-Σ-is-contr c (center c))
+      ( is-trunc-type-trunc (map-trunc (succ-𝕋 k) f (center c)) (unit-trunc b))
+
+  is-succ-connected-is-connected-map-is-succ-connected :
+    is-connected (succ-𝕋 k) A →
+    is-connected-map k f →
+    is-connected (succ-𝕋 k) B
+  is-succ-connected-is-connected-map-is-succ-connected cA cf =
+    is-contr-is-equiv'
+      ( type-trunc (succ-𝕋 k) A)
+      ( map-trunc (succ-𝕋 k) f)
+      ( is-equiv-is-contr-map
+        ( λ t →
+          apply-universal-property-trunc-Prop
+            ( is-surjective-is-truncation
+              ( trunc (succ-𝕋 k) B)
+              ( is-truncation-trunc)
+              ( t))
+            ( is-contr-Prop (fiber (map-trunc (succ-𝕋 k) f) t))
+            ( λ (b , p) →
+              tr
+                ( λ s → is-contr (fiber (map-trunc (succ-𝕋 k) f) s))
+                ( p)
+                ( is-contr-equiv'
+                  ( type-trunc k (fiber f b))
+                  ( ( inv-equiv
+                      ( equiv-unit-trunc
+                        ( fiber (map-trunc (succ-𝕋 k) f) (unit-trunc b) ,
+                          is-trunc-fiber-map-trunc-is-succ-connected cA b))) ∘e
+                    ( map-trunc k (fiber-map-trunc-fiber f b) ,
+                      is-truncation-equivalence-fiber-map-trunc-fiber f b))
+                  ( cf b)))))
+      ( cA)
+```
+
+### If `g ∘ f` is `(k+1)`-connected, then `f` is `k`-connected if and only if `g` is `(k+1)`-connected
+
+This is an instance of Proposition 2.31 in [CORS'20].
+
+```agda
+module _
+  {l1 l2 l3 : Level} {k : 𝕋} {A : UU l1} {B : UU l2} {C : UU l3}
+  (g : B → C) (f : A → B) (cgf : is-connected-map (succ-𝕋 k) (g ∘ f))
+  where
+
+  is-connected-map-right-factor-is-succ-connected-map-left-factor :
+    is-connected-map (succ-𝕋 k) g → is-connected-map k f
+  is-connected-map-right-factor-is-succ-connected-map-left-factor cg =
+    is-connected-map-is-succ-truncation-equivalence f
+      ( is-truncation-equivalence-right-factor g f
+        ( is-truncation-equivalence-is-connected-map (g ∘ f) cgf)
+        ( is-truncation-equivalence-is-connected-map g cg))
+
+  is-connected-map-right-factor-is-succ-connected-map-right-factor :
+    is-connected-map k f → is-connected-map (succ-𝕋 k) g
+  is-connected-map-right-factor-is-succ-connected-map-right-factor cf c =
+    is-succ-connected-is-connected-map-is-succ-connected
+      ( pr1)
+      ( is-connected-equiv' (equiv-compute-fiber-comp g f c) (cgf c))
+      ( λ p →
+        is-connected-equiv
+          ( equiv-fiber-pr1 (fiber f ∘ pr1) p)
+          ( cf (pr1 p)))
+```
+
+### A `k`-equivalence with a section is `k`-connected
+
+```agda
+module _
+  {l1 l2 : Level} {A : UU l1} {B : UU l2} (f : A → B)
+  where
+
+  is-connected-map-is-truncation-equivalence-section :
+    (k : 𝕋) →
+    section f → is-truncation-equivalence k f → is-connected-map k f
+  is-connected-map-is-truncation-equivalence-section neg-two-𝕋 (s , h) e =
+    is-neg-two-connected-map f
+  is-connected-map-is-truncation-equivalence-section (succ-𝕋 k) (s , h) e =
+    is-connected-map-right-factor-is-succ-connected-map-right-factor f s
+      ( is-connected-map-is-equiv (f ∘ s) (is-equiv-htpy id h is-equiv-id))
+      ( is-connected-map-is-succ-truncation-equivalence s
+        ( is-truncation-equivalence-right-factor f s
+          ( is-truncation-equivalence-is-equiv
+            ( f ∘ s)
+            ( is-equiv-htpy id h is-equiv-id))
+          ( e)))
+```
+
 ## References
 
 The notion of `k`-equivalence is a special case of the notion of

--- a/src/foundation/truncation-equivalences.lagda.md
+++ b/src/foundation/truncation-equivalences.lagda.md
@@ -148,17 +148,16 @@ module _
   {l1 l2 l3 : Level} {k : 𝕋} {A : UU l1} {B : UU l2} {C : UU l3}
   where
 
-  abstract
-    is-truncation-equivalence-comp :
-      (g : B → C) (f : A → B) →
-      is-truncation-equivalence k f →
-      is-truncation-equivalence k g →
-      is-truncation-equivalence k (g ∘ f)
-    is-truncation-equivalence-comp g f ef eg =
-      is-equiv-htpy
-        ( map-trunc k g ∘ map-trunc k f)
-          ( preserves-comp-map-trunc k g f)
-        ( is-equiv-comp (map-trunc k g) (map-trunc k f) ef eg)
+  is-truncation-equivalence-comp :
+    (g : B → C) (f : A → B) →
+    is-truncation-equivalence k f →
+    is-truncation-equivalence k g →
+    is-truncation-equivalence k (g ∘ f)
+  is-truncation-equivalence-comp g f ef eg =
+    is-equiv-htpy
+      ( map-trunc k g ∘ map-trunc k f)
+        ( preserves-comp-map-trunc k g f)
+      ( is-equiv-comp (map-trunc k g) (map-trunc k f) ef eg)
 
   truncation-equivalence-comp :
     truncation-equivalence k B C →
@@ -225,8 +224,8 @@ module _
 
 ### The map on dependent pair types induced by the unit of the `(k+1)`-truncation is a `k`-equivalence
 
-This is an instance of Lemma 2.27 in Christensen, Opie, Rijke & Scoccola listed
-below.
+This is an instance of Lemma 2.27 in Christensen, Opie, Rijke & Scoccola
+[CORS'20] listed below.
 
 ```agda
 module _
@@ -258,8 +257,7 @@ module _
 
 ### There is an `k`-equivalence between the fiber of a map and the fiber of its `(k+1)`-truncation
 
-This is an instance of Corollary 2.29 in Christensen, Opie, Rijke & Scoccola
-listed below.
+This is an instance of Corollary 2.29 in [CORS'20].
 
 We consider the following composition of maps
 
@@ -368,7 +366,7 @@ The notion of `k`-equivalence is a special case of the notion of
 paper
 
 - J. D. Christensen, M. Opie, E. Rijke, and L. Scoccola. Localization in
-  Homotopy Type Theory. Higher Structures, 2020.
+  Homotopy Type Theory. Higher Structures, 2020. [CORS'20]
 
 The class of `k`-equivalences is left orthogonal to the class of `k`-étale maps.
 This was shown in

--- a/src/foundation/truncation-equivalences.lagda.md
+++ b/src/foundation/truncation-equivalences.lagda.md
@@ -127,6 +127,20 @@ module _
   is-truncation-equivalence-is-equiv e = is-equiv-map-equiv-trunc k (f , e)
 ```
 
+### Every `k`-connected map is a `k`-equivalence
+
+```agda
+module _
+  {l1 l2 : Level} {k : 𝕋} {A : UU l1} {B : UU l2} (f : A → B)
+  where
+
+  is-truncation-equivalence-is-connected-map :
+    is-connected-map k f → is-truncation-equivalence k f
+  is-truncation-equivalence-is-connected-map c =
+    is-truncation-equivalence-is-equiv-precomp k f
+      ( λ l X → dependent-universal-property-is-connected-map k c (λ _ → X))
+```
+
 ### The `k`-equivalences are closed under composition
 
 ```agda

--- a/src/foundation/truncation-equivalences.lagda.md
+++ b/src/foundation/truncation-equivalences.lagda.md
@@ -364,34 +364,33 @@ module _
   {l1 l2 : Level} {k : 𝕋} {A : UU l1} {B : UU l2}
   where
 
-  is-connected-is-truncation-equivalence :
+  is-connected-is-truncation-equivalence-is-connected :
     (f : A → B) → is-truncation-equivalence k f →
     is-connected k B → is-connected k A
-  is-connected-is-truncation-equivalence f e =
+  is-connected-is-truncation-equivalence-is-connected f e =
     is-contr-equiv (type-trunc k B) (map-trunc k f , e)
 
-  is-connected-truncation-equivalence :
+  is-connected-truncation-equivalence-is-connected :
     truncation-equivalence k A B → is-connected k B → is-connected k A
-  is-connected-truncation-equivalence f =
-    is-connected-is-truncation-equivalence
+  is-connected-truncation-equivalence-is-connected f =
+    is-connected-is-truncation-equivalence-is-connected
       ( map-truncation-equivalence k f)
       ( is-truncation-equivalence-truncation-equivalence k f)
 ```
 
 ### Every `(k+1)`-equivalence is `k`-connected
 
-This is an instance of Proposition 2.30 in Christensen, Opie, Rijke & Scoccola
-listed below.
+This is an instance of Proposition 2.30 in [CORS'20].
 
 ```agda
 module _
   {l1 l2 : Level} {k : 𝕋} {A : UU l1} {B : UU l2} (f : A → B)
   where
 
-  is-connected-map-is-truncation-equivalence :
+  is-connected-map-is-succ-truncation-equivalence :
     is-truncation-equivalence (succ-𝕋 k) f → is-connected-map k f
-  is-connected-map-is-truncation-equivalence e b =
-    is-connected-truncation-equivalence
+  is-connected-map-is-succ-truncation-equivalence e b =
+    is-connected-truncation-equivalence-is-connected
       ( truncation-equivalence-fiber-map-trunc-fiber f b)
       ( is-connected-is-contr k (is-contr-map-is-equiv e (unit-trunc b)))
 ```

--- a/src/foundation/truncation-equivalences.lagda.md
+++ b/src/foundation/truncation-equivalences.lagda.md
@@ -173,6 +173,38 @@ module _
       ( is-truncation-equivalence-truncation-equivalence k g)
 ```
 
+### The class of `k`-equivalences has the 3-for-2 property
+
+```agda
+module _
+  {l1 l2 l3 : Level} {k : 𝕋} {A : UU l1} {B : UU l2} {C : UU l3}
+  (g : B → C) (f : A → B) (e : is-truncation-equivalence k (g ∘ f))
+  where
+
+  is-truncation-equivalence-left-factor :
+    is-truncation-equivalence k f → is-truncation-equivalence k g
+  is-truncation-equivalence-left-factor ef =
+    is-equiv-left-factor
+      ( map-trunc k g)
+      ( map-trunc k f)
+      ( is-equiv-htpy
+        ( map-trunc k (g ∘ f))
+        ( inv-htpy (preserves-comp-map-trunc k g f)) e)
+      ( ef)
+
+  is-truncation-equivalence-right-factor :
+    is-truncation-equivalence k g → is-truncation-equivalence k f
+  is-truncation-equivalence-right-factor eg =
+    is-equiv-right-factor
+      ( map-trunc k g)
+      ( map-trunc k f)
+      ( eg)
+      ( is-equiv-htpy
+        ( map-trunc k (g ∘ f))
+        ( inv-htpy (preserves-comp-map-trunc k g f))
+        ( e))
+```
+
 ### Composing `k`-equivalences with equivalences
 
 ```agda

--- a/src/foundation/truncation-equivalences.lagda.md
+++ b/src/foundation/truncation-equivalences.lagda.md
@@ -205,10 +205,10 @@ module _
       ( ef)
 ```
 
-
 ### The map on dependent pair types induced by the unit of the `(k+1)`-truncation is a `k`-equivalence
 
-This is an instance of Lemma 2.27 in Christensen, Opie, Rijke & Scoccola listed below.
+This is an instance of Lemma 2.27 in Christensen, Opie, Rijke & Scoccola listed
+below.
 
 ```agda
 module _
@@ -240,7 +240,8 @@ module _
 
 ### There is an `k`-equivalence between the fiber of a map and the fiber of its `(k+1)`-truncation
 
-This is an instance of Corollary 2.29 in Christensen, Opie, Rijke & Scoccola listed below.
+This is an instance of Corollary 2.29 in Christensen, Opie, Rijke & Scoccola
+listed below.
 
 We consider the following composition of maps
 

--- a/src/foundation/truncations.lagda.md
+++ b/src/foundation/truncations.lagda.md
@@ -8,6 +8,7 @@ module foundation.truncations where
 
 ```agda
 open import foundation.action-on-identifications-functions
+open import foundation.contractible-types
 open import foundation.dependent-pair-types
 open import foundation.function-extensionality
 open import foundation.functoriality-dependent-function-types
@@ -18,7 +19,6 @@ open import foundation.universal-property-dependent-pair-types
 open import foundation.universe-levels
 
 open import foundation-core.contractible-maps
-open import foundation-core.contractible-types
 open import foundation-core.equality-dependent-pair-types
 open import foundation-core.equivalences
 open import foundation-core.fibers-of-maps
@@ -353,6 +353,18 @@ module _
     type-Truncated-Type A ≃ type-trunc k (type-Truncated-Type A)
   pr1 equiv-unit-trunc = unit-trunc
   pr2 equiv-unit-trunc = is-equiv-unit-trunc
+```
+
+### A contractible type is equivalent to its `k`-truncation
+
+```agda
+module _
+  {l : Level} (k : 𝕋) (A : UU l)
+  where
+
+  is-equiv-unit-trunc-is-contr : is-contr A → is-equiv unit-trunc
+  is-equiv-unit-trunc-is-contr c =
+    is-equiv-unit-trunc (A , is-trunc-is-contr k c)
 ```
 
 ### Truncation is idempotent


### PR DESCRIPTION
The highlights are the following two results:

1. If `g ∘ f` is `(k+1)`-connected, then `f` is `k`-connected if and only if `g` is `(k+1)`-connected. This is an instance of Proposition 2.31 in [CORS'20] for the truncation modality.
2. Every `k`-equivalence with a section is `k`-connected. This follows from the above as observed by @UlrikBuchholtz.