### PR TITLE
Play with `hom-arrow` as a record

### DIFF
--- a/src/foundation/cones-over-cospans.lagda.md
+++ b/src/foundation/cones-over-cospans.lagda.md
@@ -73,12 +73,12 @@ module _
   coherence-square-cone = pr2 (pr2 c)
 
   hom-arrow-cone : hom-arrow vertical-map-cone g
-  pr1 hom-arrow-cone = horizontal-map-cone
-  pr1 (pr2 hom-arrow-cone) = f
-  pr2 (pr2 hom-arrow-cone) = coherence-square-cone
+  hom-arrow-cone .map-domain-hom-arrow = horizontal-map-cone
+  hom-arrow-cone .map-codomain-hom-arrow = f
+  hom-arrow-cone .coh-hom-arrow = coherence-square-cone
 
   hom-arrow-cone' : hom-arrow horizontal-map-cone f
-  hom-arrow-cone' = transpose-hom-arrow vertical-map-cone g hom-arrow-cone
+  hom-arrow-cone' = transpose-hom-arrow hom-arrow-cone
 ```
 
 ### Dependent cones over cospans

--- a/src/foundation/functoriality-fibers-of-maps.lagda.md
+++ b/src/foundation/functoriality-fibers-of-maps.lagda.md
@@ -130,7 +130,8 @@ module _
   tr-hom-arrow-inclusion-fiber :
     {b b' : B} (p : b ＝ b') →
     hom-arrow (inclusion-fiber f {b}) (inclusion-fiber f {b'})
-  tr-hom-arrow-inclusion-fiber p .map-domain-hom-arrow = tot (λ a → concat' (f a) p)
+  tr-hom-arrow-inclusion-fiber p .map-domain-hom-arrow =
+    tot (λ a → concat' (f a) p)
   tr-hom-arrow-inclusion-fiber p .map-codomain-hom-arrow = id
   tr-hom-arrow-inclusion-fiber p .coh-hom-arrow = refl-htpy
 ```

--- a/src/foundation/functoriality-fibers-of-maps.lagda.md
+++ b/src/foundation/functoriality-fibers-of-maps.lagda.md
@@ -72,35 +72,35 @@ module _
   where
 
   map-domain-hom-arrow-fiber :
-    fiber f b → fiber g (map-codomain-hom-arrow f g α b)
+    fiber f b → fiber g (map-codomain-hom-arrow α b)
   map-domain-hom-arrow-fiber =
     map-Σ _
-      ( map-domain-hom-arrow f g α)
+      ( map-domain-hom-arrow α)
       ( λ a p →
-        inv (coh-hom-arrow f g α a) ∙ ap (map-codomain-hom-arrow f g α) p)
+        inv (coh-hom-arrow α a) ∙ ap (map-codomain-hom-arrow α) p)
 
   map-fiber :
-    fiber f b → fiber g (map-codomain-hom-arrow f g α b)
+    fiber f b → fiber g (map-codomain-hom-arrow α b)
   map-fiber = map-domain-hom-arrow-fiber
 
   map-codomain-hom-arrow-fiber : A → X
-  map-codomain-hom-arrow-fiber = map-domain-hom-arrow f g α
+  map-codomain-hom-arrow-fiber = map-domain-hom-arrow α
 
   coh-hom-arrow-fiber :
     coherence-square-maps
       ( map-domain-hom-arrow-fiber)
       ( inclusion-fiber f)
       ( inclusion-fiber g)
-      ( map-domain-hom-arrow f g α)
+      ( map-domain-hom-arrow α)
   coh-hom-arrow-fiber = refl-htpy
 
   hom-arrow-fiber :
     hom-arrow
       ( inclusion-fiber f {b})
-      ( inclusion-fiber g {map-codomain-hom-arrow f g α b})
-  pr1 hom-arrow-fiber = map-domain-hom-arrow-fiber
-  pr1 (pr2 hom-arrow-fiber) = map-codomain-hom-arrow-fiber
-  pr2 (pr2 hom-arrow-fiber) = coh-hom-arrow-fiber
+      ( inclusion-fiber g {map-codomain-hom-arrow α b})
+  hom-arrow-fiber .map-domain-hom-arrow = map-domain-hom-arrow-fiber
+  hom-arrow-fiber .map-codomain-hom-arrow = map-codomain-hom-arrow-fiber
+  hom-arrow-fiber .coh-hom-arrow = coh-hom-arrow-fiber
 ```
 
 ### Any cone induces a family of maps between the fibers of the vertical maps
@@ -130,9 +130,9 @@ module _
   tr-hom-arrow-inclusion-fiber :
     {b b' : B} (p : b ＝ b') →
     hom-arrow (inclusion-fiber f {b}) (inclusion-fiber f {b'})
-  pr1 (tr-hom-arrow-inclusion-fiber p) = tot (λ a → concat' (f a) p)
-  pr1 (pr2 (tr-hom-arrow-inclusion-fiber p)) = id
-  pr2 (pr2 (tr-hom-arrow-inclusion-fiber p)) = refl-htpy
+  tr-hom-arrow-inclusion-fiber p .map-domain-hom-arrow = tot (λ a → concat' (f a) p)
+  tr-hom-arrow-inclusion-fiber p .map-codomain-hom-arrow = id
+  tr-hom-arrow-inclusion-fiber p .coh-hom-arrow = refl-htpy
 ```
 
 ## Properties
@@ -158,8 +158,6 @@ module _
 
   preserves-id-hom-arrow-fiber :
     htpy-hom-arrow
-      ( inclusion-fiber f)
-      ( inclusion-fiber f)
       ( hom-arrow-fiber f f id-hom-arrow b)
       ( id-hom-arrow)
   pr1 preserves-id-hom-arrow-fiber = preserves-id-map-fiber
@@ -178,22 +176,22 @@ module _
   where
 
   preserves-comp-map-fiber :
-    map-fiber f h (comp-hom-arrow f g h β α) b ~
-    map-fiber g h β (map-codomain-hom-arrow f g α b) ∘ map-fiber f g α b
+    map-fiber f h (comp-hom-arrow β α) b ~
+    map-fiber g h β (map-codomain-hom-arrow α b) ∘ map-fiber f g α b
   preserves-comp-map-fiber (a , refl) =
     ap
       ( pair _)
       ( ( right-unit) ∙
         ( distributive-inv-concat
-          ( ap (map-codomain-hom-arrow g h β) (coh-hom-arrow f g α a))
-          ( coh-hom-arrow g h β (map-domain-hom-arrow f g α a))) ∙
+          ( ap (map-codomain-hom-arrow β) (coh-hom-arrow α a))
+          ( coh-hom-arrow β (map-domain-hom-arrow α a))) ∙
         ( ap
-          ( concat (inv (coh-hom-arrow g h β (pr1 α a))) _)
+          ( concat (inv (coh-hom-arrow β (map-domain-hom-arrow α a))) _)
           ( inv
-            ( ( ap (ap (map-codomain-hom-arrow g h β)) right-unit) ∙
+            ( ( ap (ap (map-codomain-hom-arrow β)) right-unit) ∙
               ( ap-inv
-                ( map-codomain-hom-arrow g h β)
-                ( coh-hom-arrow f g α a))))))
+                ( map-codomain-hom-arrow β)
+                ( coh-hom-arrow α a))))))
 
   compute-left-whisker-inclusion-fiber-preserves-comp-map-fiber :
     inclusion-fiber h ·l preserves-comp-map-fiber ~ refl-htpy
@@ -205,17 +203,10 @@ module _
     coherence-square-homotopies
       ( refl-htpy)
       ( coh-hom-arrow
-        ( inclusion-fiber f)
-        ( inclusion-fiber h)
-        ( hom-arrow-fiber f h (comp-hom-arrow f g h β α) b))
+        ( hom-arrow-fiber f h (comp-hom-arrow β α) b))
       ( coh-hom-arrow
-        ( inclusion-fiber f)
-        ( inclusion-fiber h)
         ( comp-hom-arrow
-          ( inclusion-fiber f)
-          ( inclusion-fiber g)
-          ( inclusion-fiber h)
-          ( hom-arrow-fiber g h β (map-codomain-hom-arrow f g α b))
+          ( hom-arrow-fiber g h β (map-codomain-hom-arrow α b))
           ( hom-arrow-fiber f g α b)))
       ( inclusion-fiber h ·l preserves-comp-map-fiber)
   coh-preserves-comp-hom-arrow-fiber p =
@@ -225,14 +216,9 @@ module _
 
   preserves-comp-hom-arrow-fiber :
     htpy-hom-arrow
-      ( inclusion-fiber f)
-      ( inclusion-fiber h)
-      ( hom-arrow-fiber f h (comp-hom-arrow f g h β α) b)
+      ( hom-arrow-fiber f h (comp-hom-arrow β α) b)
       ( comp-hom-arrow
-        ( inclusion-fiber f)
-        ( inclusion-fiber g)
-        ( inclusion-fiber h)
-        ( hom-arrow-fiber g h β (map-codomain-hom-arrow f g α b))
+        ( hom-arrow-fiber g h β (map-codomain-hom-arrow α b))
         ( hom-arrow-fiber f g α b))
   pr1 preserves-comp-hom-arrow-fiber = preserves-comp-map-fiber
   pr1 (pr2 preserves-comp-hom-arrow-fiber) = refl-htpy
@@ -346,54 +332,54 @@ triangle commutes, and where we have written `i` for all fiber inclusions.
 ```agda
 module _
   {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
-  (f : A → B) (g : X → Y) (α β : hom-arrow f g) (γ : htpy-hom-arrow f g α β)
+  (f : A → B) (g : X → Y) (α β : hom-arrow f g) (γ : htpy-hom-arrow α β)
   (b : B)
   where
 
   htpy-fiber :
-    ( tot (λ x → concat' (g x) (htpy-codomain-htpy-hom-arrow f g α β γ b)) ∘
+    ( tot (λ x → concat' (g x) (htpy-codomain-htpy-hom-arrow α β γ b)) ∘
       map-fiber f g α b) ~
     ( map-fiber f g β b)
   htpy-fiber (a , refl) =
     eq-Eq-fiber g
-      ( map-codomain-hom-arrow f g β (f a))
-      ( htpy-domain-htpy-hom-arrow f g α β γ a)
+      ( map-codomain-hom-arrow β (f a))
+      ( htpy-domain-htpy-hom-arrow α β γ a)
       ( ( ap
           ( concat
-            ( ap g (htpy-domain-htpy-hom-arrow f g α β γ a))
-            ( map-codomain-hom-arrow f g β (f a)))
+            ( ap g (htpy-domain-htpy-hom-arrow α β γ a))
+            ( map-codomain-hom-arrow β (f a)))
           ( right-unit)) ∙
         ( double-transpose-eq-concat'
-          ( htpy-codomain-htpy-hom-arrow f g α β γ (f a))
-          ( coh-hom-arrow f g α a)
-          ( coh-hom-arrow f g β a)
-          ( ap g (htpy-domain-htpy-hom-arrow f g α β γ a))
-          ( coh-htpy-hom-arrow f g α β γ a)) ∙
+          ( htpy-codomain-htpy-hom-arrow α β γ (f a))
+          ( coh-hom-arrow α a)
+          ( coh-hom-arrow β a)
+          ( ap g (htpy-domain-htpy-hom-arrow α β γ a))
+          ( coh-htpy-hom-arrow α β γ a)) ∙
         ( inv
           ( ap
             ( concat'
-              ( g (map-domain-hom-arrow f g α a))
-              ( htpy-codomain-htpy-hom-arrow f g α β γ (f a)))
+              ( g (map-domain-hom-arrow α a))
+              ( htpy-codomain-htpy-hom-arrow α β γ (f a)))
             ( right-unit))))
 
   compute-left-whisker-inclusion-fiber-htpy-fiber :
     inclusion-fiber g ·l htpy-fiber ~
-    htpy-domain-htpy-hom-arrow f g α β γ ·r inclusion-fiber f
+    htpy-domain-htpy-hom-arrow α β γ ·r inclusion-fiber f
   compute-left-whisker-inclusion-fiber-htpy-fiber (a , refl) =
     compute-ap-inclusion-fiber-eq-Eq-fiber g
-      ( map-codomain-hom-arrow f g β (f a))
-      ( htpy-domain-htpy-hom-arrow f g α β γ a)
+      ( map-codomain-hom-arrow β (f a))
+      ( htpy-domain-htpy-hom-arrow α β γ a)
       ( _)
 
   htpy-codomain-htpy-hom-arrow-fiber :
     map-codomain-hom-arrow-fiber f g α b ~
     map-codomain-hom-arrow-fiber f g β b
   htpy-codomain-htpy-hom-arrow-fiber =
-    htpy-domain-htpy-hom-arrow f g α β γ
+    htpy-domain-htpy-hom-arrow α β γ
 
   coh-htpy-hom-arrow-fiber :
     coherence-square-homotopies
-      ( htpy-domain-htpy-hom-arrow f g α β γ ·r inclusion-fiber f)
+      ( htpy-domain-htpy-hom-arrow α β γ ·r inclusion-fiber f)
       ( refl-htpy)
       ( refl-htpy)
       ( inclusion-fiber g ·l htpy-fiber)
@@ -402,14 +388,9 @@ module _
 
   htpy-hom-arrow-fiber :
     htpy-hom-arrow
-      ( inclusion-fiber f)
-      ( inclusion-fiber g)
       ( comp-hom-arrow
-        ( inclusion-fiber f)
-        ( inclusion-fiber g)
-        ( inclusion-fiber g)
         ( tr-hom-arrow-inclusion-fiber g
-          ( htpy-codomain-htpy-hom-arrow f g α β γ b))
+          ( htpy-codomain-htpy-hom-arrow α β γ b))
         ( hom-arrow-fiber f g α b))
       ( hom-arrow-fiber f g β b)
   pr1 htpy-hom-arrow-fiber = htpy-fiber

--- a/src/foundation/morphisms-arrows.lagda.md
+++ b/src/foundation/morphisms-arrows.lagda.md
@@ -52,28 +52,23 @@ can be composed horizontally or vertically by pasting of squares.
 ### Morphisms of arrows
 
 ```agda
-module _
-  {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
-  (f : A → B) (g : X → Y)
+record hom-arrow
+  {l1 l2 l3 l4 : Level}
+  {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
+  (f : A → B) (g : X → Y) :
+  UU (l1 ⊔ l2 ⊔ l3 ⊔ l4)
   where
+  field
+    map-domain-hom-arrow : A → X
+    map-codomain-hom-arrow : B → Y
+    coh-hom-arrow :
+      coherence-square-maps
+        ( map-domain-hom-arrow)
+        ( f)
+        ( g)
+        ( map-codomain-hom-arrow)
 
-  hom-arrow : UU (l1 ⊔ l2 ⊔ l3 ⊔ l4)
-  hom-arrow = Σ (A → X) (λ i → Σ (B → Y) (coherence-square-maps i f g))
-
-  map-domain-hom-arrow : hom-arrow → A → X
-  map-domain-hom-arrow = pr1
-
-  map-codomain-hom-arrow : hom-arrow → B → Y
-  map-codomain-hom-arrow = pr1 ∘ pr2
-
-  coh-hom-arrow :
-    (h : hom-arrow) →
-    coherence-square-maps
-      ( map-domain-hom-arrow h)
-      ( f)
-      ( g)
-      ( map-codomain-hom-arrow h)
-  coh-hom-arrow = pr2 ∘ pr2
+open hom-arrow public
 ```
 
 ### Transposing morphisms of arrows
@@ -81,14 +76,14 @@ module _
 ```agda
 module _
   {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
-  (f : A → B) (g : X → Y) (α : hom-arrow f g)
+  {f : A → B} {g : X → Y} (α : hom-arrow f g)
   where
 
   transpose-hom-arrow :
-    hom-arrow (map-domain-hom-arrow f g α) (map-codomain-hom-arrow f g α)
-  pr1 transpose-hom-arrow = f
-  pr1 (pr2 transpose-hom-arrow) = g
-  pr2 (pr2 transpose-hom-arrow) = inv-htpy (coh-hom-arrow f g α)
+    hom-arrow (map-domain-hom-arrow α) (map-codomain-hom-arrow α)
+  map-domain-hom-arrow transpose-hom-arrow = f
+  map-codomain-hom-arrow transpose-hom-arrow = g
+  coh-hom-arrow transpose-hom-arrow = inv-htpy (coh-hom-arrow α)
 ```
 
 ### The identity morphism of arrows
@@ -99,9 +94,9 @@ module _
   where
 
   id-hom-arrow : hom-arrow f f
-  pr1 id-hom-arrow = id
-  pr1 (pr2 id-hom-arrow) = id
-  pr2 (pr2 id-hom-arrow) = refl-htpy
+  id-hom-arrow .map-domain-hom-arrow = id
+  id-hom-arrow .map-codomain-hom-arrow = id
+  id-hom-arrow .coh-hom-arrow = refl-htpy
 ```
 
 ### Composition of morphisms of arrows
@@ -125,16 +120,16 @@ maps.
 module _
   {l1 l2 l3 l4 l5 l6 : Level}
   {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4} {U : UU l5} {V : UU l6}
-  (f : A → B) (g : X → Y) (h : U → V) (b : hom-arrow g h) (a : hom-arrow f g)
+  {f : A → B} {g : X → Y} {h : U → V} (β : hom-arrow g h) (α : hom-arrow f g)
   where
 
   map-domain-comp-hom-arrow : A → U
   map-domain-comp-hom-arrow =
-    map-domain-hom-arrow g h b ∘ map-domain-hom-arrow f g a
+    map-domain-hom-arrow β ∘ map-domain-hom-arrow α
 
   map-codomain-comp-hom-arrow : B → V
   map-codomain-comp-hom-arrow =
-    map-codomain-hom-arrow g h b ∘ map-codomain-hom-arrow f g a
+    map-codomain-hom-arrow β ∘ map-codomain-hom-arrow α
 
   coh-comp-hom-arrow :
     coherence-square-maps
@@ -144,23 +139,20 @@ module _
       ( map-codomain-comp-hom-arrow)
   coh-comp-hom-arrow =
     pasting-horizontal-coherence-square-maps
-      ( map-domain-hom-arrow f g a)
-      ( map-domain-hom-arrow g h b)
+      ( map-domain-hom-arrow α)
+      ( map-domain-hom-arrow β)
       ( f)
       ( g)
       ( h)
-      ( map-codomain-hom-arrow f g a)
-      ( map-codomain-hom-arrow g h b)
-      ( coh-hom-arrow f g a)
-      ( coh-hom-arrow g h b)
+      ( map-codomain-hom-arrow α)
+      ( map-codomain-hom-arrow β)
+      ( coh-hom-arrow α)
+      ( coh-hom-arrow β)
 
   comp-hom-arrow : hom-arrow f h
-  pr1 comp-hom-arrow =
-    map-domain-comp-hom-arrow
-  pr1 (pr2 comp-hom-arrow) =
-    map-codomain-comp-hom-arrow
-  pr2 (pr2 comp-hom-arrow) =
-    coh-comp-hom-arrow
+  comp-hom-arrow .map-domain-hom-arrow = map-domain-comp-hom-arrow
+  comp-hom-arrow .map-codomain-hom-arrow = map-codomain-comp-hom-arrow
+  comp-hom-arrow .coh-hom-arrow = coh-comp-hom-arrow
 ```
 
 ### Homotopies of morphsims of arrows
@@ -185,27 +177,27 @@ commutes.
 ```agda
 module _
   {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
-  (f : A → B) (g : X → Y) (α : hom-arrow f g)
+  {f : A → B} {g : X → Y} (α : hom-arrow f g)
   where
 
   coherence-htpy-hom-arrow :
     (β : hom-arrow f g)
-    (I : map-domain-hom-arrow f g α ~ map-domain-hom-arrow f g β)
-    (J : map-codomain-hom-arrow f g α ~ map-codomain-hom-arrow f g β) →
+    (I : map-domain-hom-arrow α ~ map-domain-hom-arrow β)
+    (J : map-codomain-hom-arrow α ~ map-codomain-hom-arrow β) →
     UU (l1 ⊔ l4)
   coherence-htpy-hom-arrow β I J =
     coherence-square-homotopies
       ( J ·r f)
-      ( coh-hom-arrow f g α)
-      ( coh-hom-arrow f g β)
+      ( coh-hom-arrow α)
+      ( coh-hom-arrow β)
       ( g ·l I)
 
   htpy-hom-arrow :
     (β : hom-arrow f g) → UU (l1 ⊔ l2 ⊔ l3 ⊔ l4)
   htpy-hom-arrow β =
-    Σ ( map-domain-hom-arrow f g α ~ map-domain-hom-arrow f g β)
+    Σ ( map-domain-hom-arrow α ~ map-domain-hom-arrow β)
       ( λ I →
-        Σ ( map-codomain-hom-arrow f g α ~ map-codomain-hom-arrow f g β)
+        Σ ( map-codomain-hom-arrow α ~ map-codomain-hom-arrow β)
           ( coherence-htpy-hom-arrow β I))
 
   module _
@@ -213,18 +205,18 @@ module _
     where
 
     htpy-domain-htpy-hom-arrow :
-      map-domain-hom-arrow f g α ~ map-domain-hom-arrow f g β
+      map-domain-hom-arrow α ~ map-domain-hom-arrow β
     htpy-domain-htpy-hom-arrow = pr1 η
 
     htpy-codomain-htpy-hom-arrow :
-      map-codomain-hom-arrow f g α ~ map-codomain-hom-arrow f g β
+      map-codomain-hom-arrow α ~ map-codomain-hom-arrow β
     htpy-codomain-htpy-hom-arrow = pr1 (pr2 η)
 
     coh-htpy-hom-arrow :
       coherence-square-homotopies
         ( htpy-codomain-htpy-hom-arrow ·r f)
-        ( coh-hom-arrow f g α)
-        ( coh-hom-arrow f g β)
+        ( coh-hom-arrow α)
+        ( coh-hom-arrow β)
         ( g ·l htpy-domain-htpy-hom-arrow)
     coh-htpy-hom-arrow = pr2 (pr2 η)
 
@@ -233,35 +225,34 @@ module _
   pr1 (pr2 refl-htpy-hom-arrow) = refl-htpy
   pr2 (pr2 refl-htpy-hom-arrow) = right-unit-htpy
 
-  is-torsorial-htpy-hom-arrow :
-    is-torsorial htpy-hom-arrow
-  is-torsorial-htpy-hom-arrow =
-    is-torsorial-Eq-structure
-      ( λ i jH I → Σ _ _)
-      ( is-torsorial-htpy (map-domain-hom-arrow f g α))
-      ( map-domain-hom-arrow f g α , refl-htpy)
-      ( is-torsorial-Eq-structure
-        ( λ j H J → _)
-        ( is-torsorial-htpy (map-codomain-hom-arrow f g α))
-        ( map-codomain-hom-arrow f g α , refl-htpy)
-        ( is-torsorial-htpy (coh-hom-arrow f g α ∙h refl-htpy)))
+  -- is-torsorial-htpy-hom-arrow : is-torsorial htpy-hom-arrow
+  -- is-torsorial-htpy-hom-arrow =
+    -- is-torsorial-Eq-structure
+    --   ( λ i jH I → Σ _ _)
+    --   ( is-torsorial-htpy (map-domain-hom-arrow α))
+    --   ( map-domain-hom-arrow α , refl-htpy)
+    --   ( is-torsorial-Eq-structure
+    --     ( λ j H J → _)
+    --     ( is-torsorial-htpy (map-codomain-hom-arrow α))
+    --     ( map-codomain-hom-arrow α , refl-htpy)
+    --     ( is-torsorial-htpy (coh-hom-arrow α ∙h refl-htpy)))
 
-  htpy-eq-hom-arrow : (β : hom-arrow f g) → (α ＝ β) → htpy-hom-arrow β
-  htpy-eq-hom-arrow β refl = refl-htpy-hom-arrow
+  -- htpy-eq-hom-arrow : (β : hom-arrow f g) → (α ＝ β) → htpy-hom-arrow β
+  -- htpy-eq-hom-arrow β refl = refl-htpy-hom-arrow
 
-  is-equiv-htpy-eq-hom-arrow :
-    (β : hom-arrow f g) → is-equiv (htpy-eq-hom-arrow β)
-  is-equiv-htpy-eq-hom-arrow =
-    fundamental-theorem-id is-torsorial-htpy-hom-arrow htpy-eq-hom-arrow
+  -- is-equiv-htpy-eq-hom-arrow :
+  --   (β : hom-arrow f g) → is-equiv (htpy-eq-hom-arrow β)
+  -- is-equiv-htpy-eq-hom-arrow =
+  --   fundamental-theorem-id is-torsorial-htpy-hom-arrow htpy-eq-hom-arrow
 
-  extensionality-hom-arrow :
-    (β : hom-arrow f g) → (α ＝ β) ≃ htpy-hom-arrow β
-  pr1 (extensionality-hom-arrow β) = htpy-eq-hom-arrow β
-  pr2 (extensionality-hom-arrow β) = is-equiv-htpy-eq-hom-arrow β
+  -- extensionality-hom-arrow :
+  --   (β : hom-arrow f g) → (α ＝ β) ≃ htpy-hom-arrow β
+  -- pr1 (extensionality-hom-arrow β) = htpy-eq-hom-arrow β
+  -- pr2 (extensionality-hom-arrow β) = is-equiv-htpy-eq-hom-arrow β
 
-  eq-htpy-hom-arrow :
-    (β : hom-arrow f g) → htpy-hom-arrow β → α ＝ β
-  eq-htpy-hom-arrow β = map-inv-equiv (extensionality-hom-arrow β)
+  -- eq-htpy-hom-arrow :
+  --   (β : hom-arrow f g) → htpy-hom-arrow β → α ＝ β
+  -- eq-htpy-hom-arrow β = map-inv-equiv (extensionality-hom-arrow β)
 ```
 
 ### Concatenation of homotopies of morphisms of arrows
@@ -269,40 +260,40 @@ module _
 ```agda
 module _
   {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
-  (f : A → B) (g : X → Y) (α β γ : hom-arrow f g)
-  (H : htpy-hom-arrow f g α β) (K : htpy-hom-arrow f g β γ)
+  {f : A → B} {g : X → Y} (α β γ : hom-arrow f g)
+  (H : htpy-hom-arrow α β) (K : htpy-hom-arrow β γ)
   where
 
   htpy-domain-concat-htpy-hom-arrow :
-    map-domain-hom-arrow f g α ~ map-domain-hom-arrow f g γ
+    map-domain-hom-arrow α ~ map-domain-hom-arrow γ
   htpy-domain-concat-htpy-hom-arrow =
-    htpy-domain-htpy-hom-arrow f g α β H ∙h
-    htpy-domain-htpy-hom-arrow f g β γ K
+    htpy-domain-htpy-hom-arrow α β H ∙h
+    htpy-domain-htpy-hom-arrow β γ K
 
   htpy-codomain-concat-htpy-hom-arrow :
-    map-codomain-hom-arrow f g α ~ map-codomain-hom-arrow f g γ
+    map-codomain-hom-arrow α ~ map-codomain-hom-arrow γ
   htpy-codomain-concat-htpy-hom-arrow =
-    htpy-codomain-htpy-hom-arrow f g α β H ∙h
-    htpy-codomain-htpy-hom-arrow f g β γ K
+    htpy-codomain-htpy-hom-arrow α β H ∙h
+    htpy-codomain-htpy-hom-arrow β γ K
 
   coh-concat-htpy-hom-arrow :
-    coherence-htpy-hom-arrow f g α γ
+    coherence-htpy-hom-arrow α γ
       ( htpy-domain-concat-htpy-hom-arrow)
       ( htpy-codomain-concat-htpy-hom-arrow)
   coh-concat-htpy-hom-arrow a =
     ( ap
-      ( concat (coh-hom-arrow f g α a) (g (map-domain-hom-arrow f g γ a)))
+      ( concat (coh-hom-arrow α a) (g (map-domain-hom-arrow γ a)))
       ( ap-concat g
-        ( htpy-domain-htpy-hom-arrow f g α β H a)
-        ( htpy-domain-htpy-hom-arrow f g β γ K a))) ∙
+        ( htpy-domain-htpy-hom-arrow α β H a)
+        ( htpy-domain-htpy-hom-arrow β γ K a))) ∙
     ( coherence-square-identifications-comp-horizontal
-      ( coh-hom-arrow f g α a)
-      ( coh-hom-arrow f g β a)
-      ( coh-hom-arrow f g γ a)
-      ( coh-htpy-hom-arrow f g α β H a)
-      ( coh-htpy-hom-arrow f g β γ K a))
+      ( coh-hom-arrow α a)
+      ( coh-hom-arrow β a)
+      ( coh-hom-arrow γ a)
+      ( coh-htpy-hom-arrow α β H a)
+      ( coh-htpy-hom-arrow β γ K a))
 
-  concat-htpy-hom-arrow : htpy-hom-arrow f g α γ
+  concat-htpy-hom-arrow : htpy-hom-arrow α γ
   pr1 concat-htpy-hom-arrow = htpy-domain-concat-htpy-hom-arrow
   pr1 (pr2 concat-htpy-hom-arrow) = htpy-codomain-concat-htpy-hom-arrow
   pr2 (pr2 concat-htpy-hom-arrow) = coh-concat-htpy-hom-arrow
@@ -313,35 +304,35 @@ module _
 ```agda
 module _
   {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
-  (f : A → B) (g : X → Y) (α β : hom-arrow f g) (H : htpy-hom-arrow f g α β)
+  {f : A → B} {g : X → Y} (α β : hom-arrow f g) (H : htpy-hom-arrow α β)
   where
 
   htpy-domain-inv-htpy-hom-arrow :
-    map-domain-hom-arrow f g β ~ map-domain-hom-arrow f g α
+    map-domain-hom-arrow β ~ map-domain-hom-arrow α
   htpy-domain-inv-htpy-hom-arrow =
-    inv-htpy (htpy-domain-htpy-hom-arrow f g α β H)
+    inv-htpy (htpy-domain-htpy-hom-arrow α β H)
 
   htpy-codomain-inv-htpy-hom-arrow :
-    map-codomain-hom-arrow f g β ~ map-codomain-hom-arrow f g α
+    map-codomain-hom-arrow β ~ map-codomain-hom-arrow α
   htpy-codomain-inv-htpy-hom-arrow =
-    inv-htpy (htpy-codomain-htpy-hom-arrow f g α β H)
+    inv-htpy (htpy-codomain-htpy-hom-arrow α β H)
 
   coh-inv-htpy-hom-arrow :
-    coherence-htpy-hom-arrow f g β α
+    coherence-htpy-hom-arrow β α
       ( htpy-domain-inv-htpy-hom-arrow)
       ( htpy-codomain-inv-htpy-hom-arrow)
   coh-inv-htpy-hom-arrow a =
     ( ap
-      ( concat (coh-hom-arrow f g β a) _)
-      ( ap-inv g (htpy-domain-htpy-hom-arrow f g α β H a))) ∙
+      ( concat (coh-hom-arrow β a) (g (map-domain-hom-arrow α a)))
+      ( ap-inv g (htpy-domain-htpy-hom-arrow α β H a))) ∙
     ( double-transpose-eq-concat'
-      ( coh-hom-arrow f g α a)
-      ( htpy-codomain-htpy-hom-arrow f g α β H (f a))
-      ( ap g (htpy-domain-htpy-hom-arrow f g α β H a))
-      ( coh-hom-arrow f g β a)
-      ( inv (coh-htpy-hom-arrow f g α β H a)))
+      ( coh-hom-arrow α a)
+      ( htpy-codomain-htpy-hom-arrow α β H (f a))
+      ( ap g (htpy-domain-htpy-hom-arrow α β H a))
+      ( coh-hom-arrow β a)
+      ( inv (coh-htpy-hom-arrow α β H a)))
 
-  inv-htpy-hom-arrow : htpy-hom-arrow f g β α
+  inv-htpy-hom-arrow : htpy-hom-arrow β α
   pr1 inv-htpy-hom-arrow = htpy-domain-inv-htpy-hom-arrow
   pr1 (pr2 inv-htpy-hom-arrow) = htpy-codomain-inv-htpy-hom-arrow
   pr2 (pr2 inv-htpy-hom-arrow) = coh-inv-htpy-hom-arrow
@@ -355,25 +346,24 @@ module _
 module _
   {l1 l2 l3 l4 l5 l6 : Level}
   {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4} {U : UU l5} {V : UU l6}
-  (f : A → B) (g : X → Y) (h : U → V)
-  (γ : hom-arrow g h) (α β : hom-arrow f g) (H : htpy-hom-arrow f g α β)
+  {f : A → B} {g : X → Y} {h : U → V}
+  (γ : hom-arrow g h) (α β : hom-arrow f g) (H : htpy-hom-arrow α β)
   where
 
   htpy-domain-left-whisker-htpy-hom-arrow :
-    map-domain-comp-hom-arrow f g h γ α ~ map-domain-comp-hom-arrow f g h γ β
+    map-domain-comp-hom-arrow γ α ~ map-domain-comp-hom-arrow γ β
   htpy-domain-left-whisker-htpy-hom-arrow =
-    map-domain-hom-arrow g h γ ·l htpy-domain-htpy-hom-arrow f g α β H
+    map-domain-hom-arrow γ ·l htpy-domain-htpy-hom-arrow α β H
 
   htpy-codomain-left-whisker-htpy-hom-arrow :
-    map-codomain-comp-hom-arrow f g h γ α ~
-    map-codomain-comp-hom-arrow f g h γ β
+    map-codomain-comp-hom-arrow γ α ~ map-codomain-comp-hom-arrow γ β
   htpy-codomain-left-whisker-htpy-hom-arrow =
-    map-codomain-hom-arrow g h γ ·l htpy-codomain-htpy-hom-arrow f g α β H
+    map-codomain-hom-arrow γ ·l htpy-codomain-htpy-hom-arrow α β H
 
   coh-left-whisker-htpy-hom-arrow :
-    coherence-htpy-hom-arrow f h
-      ( comp-hom-arrow f g h γ α)
-      ( comp-hom-arrow f g h γ β)
+    coherence-htpy-hom-arrow
+      ( comp-hom-arrow γ α)
+      ( comp-hom-arrow γ β)
       ( htpy-domain-left-whisker-htpy-hom-arrow)
       ( htpy-codomain-left-whisker-htpy-hom-arrow)
   coh-left-whisker-htpy-hom-arrow a =
@@ -381,61 +371,61 @@ module _
       ( ap
         ( concat _ _)
         ( ap-comp h
-          ( map-domain-hom-arrow g h γ)
-          ( htpy-domain-htpy-hom-arrow f g α β H a)))) ∙
+          ( map-domain-hom-arrow γ)
+          ( htpy-domain-htpy-hom-arrow α β H x)))) ∙
     ( assoc
-      ( ap (map-codomain-hom-arrow g h γ) (coh-hom-arrow f g α a))
-      ( coh-hom-arrow g h γ (map-domain-hom-arrow f g α a))
+      ( ap (map-codomain-hom-arrow γ) (coh-hom-arrow α x))
+      ( coh-hom-arrow γ (map-domain-hom-arrow α x))
       ( ap
-        ( h ∘ map-domain-hom-arrow g h γ)
-        ( htpy-domain-htpy-hom-arrow f g α β H a))) ∙
+        ( h ∘ map-domain-hom-arrow γ)
+        ( htpy-domain-htpy-hom-arrow α β H x))) ∙
     ( ap
       ( concat
-        ( ap (map-codomain-hom-arrow g h γ) (coh-hom-arrow f g α a))
-        ( h _))
+        ( ap (map-codomain-hom-arrow γ) (coh-hom-arrow α x))
+        ( h (map-domain-hom-arrow γ (map-domain-hom-arrow β x))))
       ( nat-htpy
-        ( coh-hom-arrow g h γ)
-        ( htpy-domain-htpy-hom-arrow f g α β H a))) ∙
+        ( coh-hom-arrow γ)
+        ( htpy-domain-htpy-hom-arrow α β H x))) ∙
     ( inv
       ( assoc
-        ( ap (map-codomain-hom-arrow g h γ) (coh-hom-arrow f g α a))
+        ( ap (map-codomain-hom-arrow γ) (coh-hom-arrow α x))
         ( ap
-          ( map-codomain-hom-arrow g h γ ∘ g)
-          ( htpy-domain-htpy-hom-arrow f g α β H a))
-        ( coh-hom-arrow g h γ (map-domain-hom-arrow f g β a)))) ∙
+          ( map-codomain-hom-arrow γ ∘ g)
+          ( htpy-domain-htpy-hom-arrow α β H x))
+        ( coh-hom-arrow γ (map-domain-hom-arrow β x)))) ∙
     ( ap
-      ( concat' _ (coh-hom-arrow g h γ (map-domain-hom-arrow f g β a)))
+      ( concat' _ (coh-hom-arrow γ (map-domain-hom-arrow β x)))
       ( ( ap
           ( concat
-            ( ap (map-codomain-hom-arrow g h γ) (coh-hom-arrow f g α a))
-            ( _))
+            ( ap (map-codomain-hom-arrow γ) (coh-hom-arrow α x))
+            ( map-codomain-hom-arrow γ (g (map-domain-hom-arrow β x))))
           ( ap-comp
-            ( map-codomain-hom-arrow g h γ)
+            ( map-codomain-hom-arrow γ)
             ( g)
-            ( htpy-domain-htpy-hom-arrow f g α β H a))) ∙
-        ( ( inv
-            ( ap-concat
-              ( map-codomain-hom-arrow g h γ)
-              ( coh-hom-arrow f g α a)
-              ( ap g (htpy-domain-htpy-hom-arrow f g α β H a)))) ∙
-          ( ap
-            ( ap (map-codomain-hom-arrow g h γ))
-            ( coh-htpy-hom-arrow f g α β H a)) ∙
+            ( htpy-domain-htpy-hom-arrow α β H x))) ∙
+        ( inv
           ( ap-concat
-            ( map-codomain-hom-arrow g h γ)
-            ( htpy-codomain-htpy-hom-arrow f g α β H (f a))
-            ( coh-hom-arrow f g β a))))) ∙
+            ( map-codomain-hom-arrow γ)
+            ( coh-hom-arrow α x)
+            ( ap g (htpy-domain-htpy-hom-arrow α β H x)))) ∙
+        ( ap
+          ( ap (map-codomain-hom-arrow γ))
+          ( coh-htpy-hom-arrow α β H x)) ∙
+        ( ap-concat
+          ( map-codomain-hom-arrow γ)
+          ( htpy-codomain-htpy-hom-arrow α β H (f x))
+          ( coh-hom-arrow β x)))) ∙
     ( assoc
       ( ap
-        ( map-codomain-hom-arrow g h γ)
-        ( htpy-codomain-htpy-hom-arrow f g α β H (f a)))
-      ( ap (map-codomain-hom-arrow g h γ) (coh-hom-arrow f g β a))
-      ( coh-hom-arrow g h γ (map-domain-hom-arrow f g β a)))
+        ( map-codomain-hom-arrow γ)
+        ( htpy-codomain-htpy-hom-arrow α β H (f x)))
+      ( ap (map-codomain-hom-arrow γ) (coh-hom-arrow β x))
+      ( coh-hom-arrow γ (map-domain-hom-arrow β x)))
 
   left-whisker-htpy-hom-arrow :
-    htpy-hom-arrow f h
-      ( comp-hom-arrow f g h γ α)
-      ( comp-hom-arrow f g h γ β)
+    htpy-hom-arrow
+      ( comp-hom-arrow γ α)
+      ( comp-hom-arrow γ β)
   pr1 left-whisker-htpy-hom-arrow =
     htpy-domain-left-whisker-htpy-hom-arrow
   pr1 (pr2 left-whisker-htpy-hom-arrow) =
@@ -469,56 +459,56 @@ associativity of horizontal pasting of commutative squares of maps.
 module _
   {l1 l2 l3 l4 l5 l6 l7 l8 : Level}
   {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4} {U : UU l5} {V : UU l6}
-  {K : UU l7} {L : UU l8} (f : A → B) (g : X → Y) (h : U → V) (i : K → L)
+  {K : UU l7} {L : UU l8} {f : A → B} {g : X → Y} {h : U → V} {i : K → L}
   (γ : hom-arrow h i) (β : hom-arrow g h) (α : hom-arrow f g)
   where
 
   assoc-comp-hom-arrow :
-    htpy-hom-arrow f i
-      ( comp-hom-arrow f g i (comp-hom-arrow g h i γ β) α)
-      ( comp-hom-arrow f h i γ (comp-hom-arrow f g h β α))
+    htpy-hom-arrow
+      ( comp-hom-arrow (comp-hom-arrow γ β) α)
+      ( comp-hom-arrow γ (comp-hom-arrow β α))
   pr1 assoc-comp-hom-arrow = refl-htpy
   pr1 (pr2 assoc-comp-hom-arrow) = refl-htpy
   pr2 (pr2 assoc-comp-hom-arrow) =
     ( right-unit-htpy) ∙h
     ( inv-htpy
       ( assoc-pasting-horizontal-coherence-square-maps
-        ( map-domain-hom-arrow f g α)
-        ( map-domain-hom-arrow g h β)
-        ( map-domain-hom-arrow h i γ)
+        ( map-domain-hom-arrow α)
+        ( map-domain-hom-arrow β)
+        ( map-domain-hom-arrow γ)
         ( f)
         ( g)
         ( h)
         ( i)
-        ( map-codomain-hom-arrow f g α)
-        ( map-codomain-hom-arrow g h β)
-        ( map-codomain-hom-arrow h i γ)
-        ( coh-hom-arrow f g α)
-        ( coh-hom-arrow g h β)
-        ( coh-hom-arrow h i γ)))
+        ( map-codomain-hom-arrow α)
+        ( map-codomain-hom-arrow β)
+        ( map-codomain-hom-arrow γ)
+        ( coh-hom-arrow α)
+        ( coh-hom-arrow β)
+        ( coh-hom-arrow γ)))
 
   inv-assoc-comp-hom-arrow :
-    htpy-hom-arrow f i
-      ( comp-hom-arrow f h i γ (comp-hom-arrow f g h β α))
-      ( comp-hom-arrow f g i (comp-hom-arrow g h i γ β) α)
+    htpy-hom-arrow
+      ( comp-hom-arrow γ (comp-hom-arrow β α))
+      ( comp-hom-arrow (comp-hom-arrow γ β) α)
   pr1 inv-assoc-comp-hom-arrow = refl-htpy
   pr1 (pr2 inv-assoc-comp-hom-arrow) = refl-htpy
   pr2 (pr2 inv-assoc-comp-hom-arrow) =
     ( right-unit-htpy) ∙h
     ( assoc-pasting-horizontal-coherence-square-maps
-      ( map-domain-hom-arrow f g α)
-      ( map-domain-hom-arrow g h β)
-      ( map-domain-hom-arrow h i γ)
+      ( map-domain-hom-arrow α)
+      ( map-domain-hom-arrow β)
+      ( map-domain-hom-arrow γ)
       ( f)
       ( g)
       ( h)
       ( i)
-      ( map-codomain-hom-arrow f g α)
-      ( map-codomain-hom-arrow g h β)
-      ( map-codomain-hom-arrow h i γ)
-      ( coh-hom-arrow f g α)
-      ( coh-hom-arrow g h β)
-      ( coh-hom-arrow h i γ))
+      ( map-codomain-hom-arrow α)
+      ( map-codomain-hom-arrow β)
+      ( map-codomain-hom-arrow γ)
+      ( coh-hom-arrow α)
+      ( coh-hom-arrow β)
+      ( coh-hom-arrow γ))
 ```
 
 ### The left unit law for composition of morphisms of arrows
@@ -526,23 +516,21 @@ module _
 ```agda
 module _
   {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
-  (f : A → B) (g : X → Y) (α : hom-arrow f g)
+  {f : A → B} {g : X → Y} (α : hom-arrow f g)
   where
 
   left-unit-law-comp-hom-arrow :
-    htpy-hom-arrow f g
-      ( comp-hom-arrow f g g id-hom-arrow α)
-      ( α)
+    htpy-hom-arrow (comp-hom-arrow id-hom-arrow α) α
   pr1 left-unit-law-comp-hom-arrow = refl-htpy
   pr1 (pr2 left-unit-law-comp-hom-arrow) = refl-htpy
   pr2 (pr2 left-unit-law-comp-hom-arrow) =
     ( right-unit-htpy) ∙h
     ( right-unit-law-pasting-horizontal-coherence-square-maps
-      ( map-domain-hom-arrow f g α)
+      ( map-domain-hom-arrow α)
       ( f)
       ( g)
-      ( map-codomain-hom-arrow f g α)
-      ( coh-hom-arrow f g α))
+      ( map-codomain-hom-arrow α)
+      ( coh-hom-arrow α))
 ```
 
 ### The right unit law for composition of morphisms of arrows
@@ -550,13 +538,11 @@ module _
 ```agda
 module _
   {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
-  (f : A → B) (g : X → Y) (α : hom-arrow f g)
+  {f : A → B} {g : X → Y} (α : hom-arrow f g)
   where
 
   right-unit-law-comp-hom-arrow :
-    htpy-hom-arrow f g
-      ( comp-hom-arrow f f g α id-hom-arrow)
-      ( α)
+    htpy-hom-arrow (comp-hom-arrow α id-hom-arrow) α
   pr1 right-unit-law-comp-hom-arrow = refl-htpy
   pr1 (pr2 right-unit-law-comp-hom-arrow) = refl-htpy
   pr2 (pr2 right-unit-law-comp-hom-arrow) = right-unit-htpy

--- a/src/foundation/morphisms-arrows.lagda.md
+++ b/src/foundation/morphisms-arrows.lagda.md
@@ -366,7 +366,7 @@ module _
       ( comp-hom-arrow γ β)
       ( htpy-domain-left-whisker-htpy-hom-arrow)
       ( htpy-codomain-left-whisker-htpy-hom-arrow)
-  coh-left-whisker-htpy-hom-arrow a =
+  coh-left-whisker-htpy-hom-arrow x =
     ( inv
       ( ap
         ( concat _ _)

--- a/src/foundation/morphisms-arrows.lagda.md
+++ b/src/foundation/morphisms-arrows.lagda.md
@@ -11,6 +11,8 @@ open import foundation.action-on-identifications-functions
 open import foundation.commuting-squares-of-homotopies
 open import foundation.commuting-squares-of-identifications
 open import foundation.dependent-pair-types
+open import foundation-core.functoriality-dependent-pair-types
+open import foundation-core.contractible-types
 open import foundation.fundamental-theorem-of-identity-types
 open import foundation.homotopy-induction
 open import foundation.structure-identity-principle
@@ -69,6 +71,41 @@ record hom-arrow
         ( map-codomain-hom-arrow)
 
 open hom-arrow public
+```
+
+### Morphisms of arrows as a Σ-type
+
+```agda
+hom-arrow-Σ :
+  {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
+  (f : A → B) (g : X → Y) → UU (l1 ⊔ l2 ⊔ l3 ⊔ l4)
+hom-arrow-Σ {A = A} {B} {X} {Y} f g =
+  Σ (A → X) (λ i →  Σ (B → Y) (coherence-square-maps i f g))
+
+module _
+  {l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} {X : UU l3} {Y : UU l4}
+  (f : A → B) (g : X → Y)
+  where
+
+  map-hom-arrow-Σ : hom-arrow-Σ f g → hom-arrow f g
+  map-domain-hom-arrow (map-hom-arrow-Σ (j , i , H)) = j
+  map-codomain-hom-arrow (map-hom-arrow-Σ (j , i , H)) = i
+  coh-hom-arrow (map-hom-arrow-Σ (j , i , H)) = H
+
+  map-Σ-hom-arrow : hom-arrow f g → hom-arrow-Σ f g
+  pr1 (map-Σ-hom-arrow α) = map-domain-hom-arrow α
+  pr1 (pr2 (map-Σ-hom-arrow α)) = map-codomain-hom-arrow α
+  pr2 (pr2 (map-Σ-hom-arrow α)) = coh-hom-arrow α
+
+  is-equiv-hom-arrow-Σ : is-equiv map-hom-arrow-Σ
+  pr1 (pr1 is-equiv-hom-arrow-Σ) = map-Σ-hom-arrow
+  pr2 (pr1 is-equiv-hom-arrow-Σ) = refl-htpy
+  pr1 (pr2 is-equiv-hom-arrow-Σ) = map-Σ-hom-arrow
+  pr2 (pr2 is-equiv-hom-arrow-Σ) = refl-htpy
+
+  equiv-hom-arrow-Σ : hom-arrow-Σ f g ≃ hom-arrow f g
+  pr1 equiv-hom-arrow-Σ = map-hom-arrow-Σ
+  pr2 equiv-hom-arrow-Σ = is-equiv-hom-arrow-Σ
 ```
 
 ### Transposing morphisms of arrows
@@ -225,34 +262,37 @@ module _
   pr1 (pr2 refl-htpy-hom-arrow) = refl-htpy
   pr2 (pr2 refl-htpy-hom-arrow) = right-unit-htpy
 
-  -- is-torsorial-htpy-hom-arrow : is-torsorial htpy-hom-arrow
-  -- is-torsorial-htpy-hom-arrow =
-    -- is-torsorial-Eq-structure
-    --   ( λ i jH I → Σ _ _)
-    --   ( is-torsorial-htpy (map-domain-hom-arrow α))
-    --   ( map-domain-hom-arrow α , refl-htpy)
-    --   ( is-torsorial-Eq-structure
-    --     ( λ j H J → _)
-    --     ( is-torsorial-htpy (map-codomain-hom-arrow α))
-    --     ( map-codomain-hom-arrow α , refl-htpy)
-    --     ( is-torsorial-htpy (coh-hom-arrow α ∙h refl-htpy)))
+  is-torsorial-htpy-hom-arrow : is-torsorial htpy-hom-arrow
+  is-torsorial-htpy-hom-arrow =
+    is-contr-equiv
+      {!   !}
+      {!  equiv-tot ? !}
+      ( is-torsorial-Eq-structure
+        ( λ i jH I → Σ _ _)
+        ( is-torsorial-htpy (map-domain-hom-arrow α))
+        ( map-domain-hom-arrow α , refl-htpy)
+        ( is-torsorial-Eq-structure
+          ( λ j H J → _)
+          ( is-torsorial-htpy (map-codomain-hom-arrow α))
+          ( map-codomain-hom-arrow α , refl-htpy)
+          ( is-torsorial-htpy (coh-hom-arrow α ∙h refl-htpy))))
 
-  -- htpy-eq-hom-arrow : (β : hom-arrow f g) → (α ＝ β) → htpy-hom-arrow β
-  -- htpy-eq-hom-arrow β refl = refl-htpy-hom-arrow
+  htpy-eq-hom-arrow : (β : hom-arrow f g) → (α ＝ β) → htpy-hom-arrow β
+  htpy-eq-hom-arrow β refl = refl-htpy-hom-arrow
 
-  -- is-equiv-htpy-eq-hom-arrow :
-  --   (β : hom-arrow f g) → is-equiv (htpy-eq-hom-arrow β)
-  -- is-equiv-htpy-eq-hom-arrow =
-  --   fundamental-theorem-id is-torsorial-htpy-hom-arrow htpy-eq-hom-arrow
+  is-equiv-htpy-eq-hom-arrow :
+    (β : hom-arrow f g) → is-equiv (htpy-eq-hom-arrow β)
+  is-equiv-htpy-eq-hom-arrow =
+    fundamental-theorem-id is-torsorial-htpy-hom-arrow htpy-eq-hom-arrow
 
-  -- extensionality-hom-arrow :
-  --   (β : hom-arrow f g) → (α ＝ β) ≃ htpy-hom-arrow β
-  -- pr1 (extensionality-hom-arrow β) = htpy-eq-hom-arrow β
-  -- pr2 (extensionality-hom-arrow β) = is-equiv-htpy-eq-hom-arrow β
+  extensionality-hom-arrow :
+    (β : hom-arrow f g) → (α ＝ β) ≃ htpy-hom-arrow β
+  pr1 (extensionality-hom-arrow β) = htpy-eq-hom-arrow β
+  pr2 (extensionality-hom-arrow β) = is-equiv-htpy-eq-hom-arrow β
 
-  -- eq-htpy-hom-arrow :
-  --   (β : hom-arrow f g) → htpy-hom-arrow β → α ＝ β
-  -- eq-htpy-hom-arrow β = map-inv-equiv (extensionality-hom-arrow β)
+  eq-htpy-hom-arrow :
+    (β : hom-arrow f g) → htpy-hom-arrow β → α ＝ β
+  eq-htpy-hom-arrow β = map-inv-equiv (extensionality-hom-arrow β)
 ```
 
 ### Concatenation of homotopies of morphisms of arrows

--- a/src/foundation/retracts-of-maps.lagda.md
+++ b/src/foundation/retracts-of-maps.lagda.md
@@ -82,8 +82,8 @@ module _
 
   is-retraction-hom-arrow : UU (l1 ⊔ l2)
   is-retraction-hom-arrow =
-    htpy-hom-arrow f f
-      ( comp-hom-arrow f g f r i)
+    htpy-hom-arrow
+      ( comp-hom-arrow r i)
       ( id-hom-arrow)
 ```
 
@@ -130,13 +130,13 @@ module _
   where
 
   coherence-retract-map :
-    is-retraction (map-domain-hom-arrow f g i) (map-domain-hom-arrow g f r) →
+    is-retraction (map-domain-hom-arrow i) (map-domain-hom-arrow r) →
     is-retraction
-      ( map-codomain-hom-arrow f g i)
-      ( map-codomain-hom-arrow g f r) →
+      ( map-codomain-hom-arrow i)
+      ( map-codomain-hom-arrow r) →
     UU (l1 ⊔ l2)
   coherence-retract-map =
-    coherence-htpy-hom-arrow f f (comp-hom-arrow f g f r i) id-hom-arrow
+    coherence-htpy-hom-arrow (comp-hom-arrow r i) id-hom-arrow
 ```
 
 ### The binary relation `g f ↦ g retract-of-map f` asserting that `g` is a retract of the map `f`
@@ -162,11 +162,11 @@ module _
 
   map-domain-inclusion-retract-map : A → X
   map-domain-inclusion-retract-map =
-    map-domain-hom-arrow f g inclusion-retract-map
+    map-domain-hom-arrow inclusion-retract-map
 
   map-codomain-inclusion-retract-map : B → Y
   map-codomain-inclusion-retract-map =
-    map-codomain-hom-arrow f g inclusion-retract-map
+    map-codomain-hom-arrow inclusion-retract-map
 
   coh-inclusion-retract-map :
     coherence-square-maps
@@ -175,7 +175,7 @@ module _
       ( g)
       ( map-codomain-inclusion-retract-map)
   coh-inclusion-retract-map =
-    coh-hom-arrow f g inclusion-retract-map
+    coh-hom-arrow inclusion-retract-map
 
   retraction-retract-map : retraction-hom-arrow f g inclusion-retract-map
   retraction-retract-map = pr2 R
@@ -186,11 +186,11 @@ module _
 
   map-domain-hom-retraction-retract-map : X → A
   map-domain-hom-retraction-retract-map =
-    map-domain-hom-arrow g f hom-retraction-retract-map
+    map-domain-hom-arrow hom-retraction-retract-map
 
   map-codomain-hom-retraction-retract-map : Y → B
   map-codomain-hom-retraction-retract-map =
-    map-codomain-hom-arrow g f hom-retraction-retract-map
+    map-codomain-hom-arrow hom-retraction-retract-map
 
   coh-hom-retraction-retract-map :
     coherence-square-maps
@@ -199,7 +199,7 @@ module _
       ( f)
       ( map-codomain-hom-retraction-retract-map)
   coh-hom-retraction-retract-map =
-    coh-hom-arrow g f hom-retraction-retract-map
+    coh-hom-arrow hom-retraction-retract-map
 
   is-retraction-hom-retraction-retract-map :
     is-retraction-hom-arrow f g inclusion-retract-map hom-retraction-retract-map
@@ -213,8 +213,8 @@ module _
       ( map-domain-inclusion-retract-map)
       ( map-domain-hom-retraction-retract-map)
   is-retraction-map-domain-hom-retraction-retract-map =
-    htpy-domain-htpy-hom-arrow f f
-      ( comp-hom-arrow f g f hom-retraction-retract-map inclusion-retract-map)
+    htpy-domain-htpy-hom-arrow
+      ( comp-hom-arrow hom-retraction-retract-map inclusion-retract-map)
       ( id-hom-arrow)
       ( is-retraction-hom-retraction-retract-map)
 
@@ -232,8 +232,8 @@ module _
       ( map-codomain-inclusion-retract-map)
       ( map-codomain-hom-retraction-retract-map)
   is-retraction-map-codomain-hom-retraction-retract-map =
-    htpy-codomain-htpy-hom-arrow f f
-      ( comp-hom-arrow f g f hom-retraction-retract-map inclusion-retract-map)
+    htpy-codomain-htpy-hom-arrow
+      ( comp-hom-arrow hom-retraction-retract-map inclusion-retract-map)
       ( id-hom-arrow)
       ( is-retraction-hom-retraction-retract-map)
 
@@ -252,8 +252,8 @@ module _
       ( is-retraction-map-domain-hom-retraction-retract-map)
       ( is-retraction-map-codomain-hom-retraction-retract-map)
   coh-retract-map =
-    coh-htpy-hom-arrow f f
-      ( comp-hom-arrow f g f hom-retraction-retract-map inclusion-retract-map)
+    coh-htpy-hom-arrow
+      ( comp-hom-arrow hom-retraction-retract-map inclusion-retract-map)
       ( id-hom-arrow)
       ( is-retraction-hom-retraction-retract-map)
 ```
@@ -497,9 +497,6 @@ module _
       ( inclusion-fiber f {b})
   hom-retraction-retract-map-inclusion-fiber-retract-map =
     comp-hom-arrow
-      ( inclusion-fiber g)
-      ( inclusion-fiber f)
-      ( inclusion-fiber f)
       ( tr-hom-arrow-inclusion-fiber f
         ( is-retraction-map-codomain-hom-retraction-retract-map f g R b))
       ( hom-arrow-fiber g f
@@ -514,16 +511,8 @@ module _
       ( hom-retraction-retract-map-inclusion-fiber-retract-map)
   is-retraction-hom-retraction-retract-map-inclusion-fiber-retract-map =
     concat-htpy-hom-arrow
-      ( inclusion-fiber f)
-      ( inclusion-fiber f)
       ( comp-hom-arrow
-        ( inclusion-fiber f)
-        ( inclusion-fiber g)
-        ( inclusion-fiber f)
         ( comp-hom-arrow
-          ( inclusion-fiber g)
-          ( inclusion-fiber f)
-          ( inclusion-fiber f)
           ( tr-hom-arrow-inclusion-fiber f
             ( is-retraction-map-codomain-hom-retraction-retract-map f g R b))
           ( hom-arrow-fiber g f
@@ -531,25 +520,15 @@ module _
             ( map-codomain-inclusion-retract-map f g R b)))
         ( inclusion-retract-map-inclusion-fiber-retract-map))
       ( comp-hom-arrow
-        ( inclusion-fiber f)
-        ( inclusion-fiber f)
-        ( inclusion-fiber f)
         ( tr-hom-arrow-inclusion-fiber f
           ( is-retraction-map-codomain-hom-retraction-retract-map f g R b))
         ( comp-hom-arrow
-          ( inclusion-fiber f)
-          ( inclusion-fiber g)
-          ( inclusion-fiber f)
           ( hom-arrow-fiber g f
             ( hom-retraction-retract-map f g R)
             ( map-codomain-inclusion-retract-map f g R b))
           ( inclusion-retract-map-inclusion-fiber-retract-map)))
       ( id-hom-arrow)
       ( inv-assoc-comp-hom-arrow
-        ( inclusion-fiber f)
-        ( inclusion-fiber g)
-        ( inclusion-fiber f)
-        ( inclusion-fiber f)
         ( tr-hom-arrow-inclusion-fiber f
           ( is-retraction-map-codomain-hom-retraction-retract-map f g R b))
         ( hom-arrow-fiber g f
@@ -557,65 +536,43 @@ module _
           ( map-codomain-inclusion-retract-map f g R b))
         ( inclusion-retract-map-inclusion-fiber-retract-map))
       ( concat-htpy-hom-arrow
-        ( inclusion-fiber f)
-        ( inclusion-fiber f)
         ( comp-hom-arrow
-          ( inclusion-fiber f)
-          ( inclusion-fiber f)
-          ( inclusion-fiber f)
           ( tr-hom-arrow-inclusion-fiber f
             ( is-retraction-map-codomain-hom-retraction-retract-map f g R b))
           ( comp-hom-arrow
-            ( inclusion-fiber f)
-            ( inclusion-fiber g)
-            ( inclusion-fiber f)
             ( hom-arrow-fiber g f
               ( hom-retraction-retract-map f g R)
               ( map-codomain-inclusion-retract-map f g R b))
             ( inclusion-retract-map-inclusion-fiber-retract-map)))
         ( comp-hom-arrow
-          ( inclusion-fiber f)
-          ( inclusion-fiber f)
-          ( inclusion-fiber f)
           ( tr-hom-arrow-inclusion-fiber f
             ( is-retraction-map-codomain-hom-retraction-retract-map f g R b))
           ( hom-arrow-fiber f f
-            ( comp-hom-arrow f g f
+            ( comp-hom-arrow
               ( hom-retraction-retract-map f g R)
               ( inclusion-retract-map f g R))
             ( b)))
         ( id-hom-arrow)
         ( left-whisker-htpy-hom-arrow
-          ( inclusion-fiber f)
-          ( inclusion-fiber f)
-          ( inclusion-fiber f)
           ( tr-hom-arrow-inclusion-fiber f
             ( is-retraction-map-codomain-hom-retraction-retract-map f g R b))
           ( comp-hom-arrow
-            ( inclusion-fiber f)
-            ( inclusion-fiber g)
-            ( inclusion-fiber f)
             ( hom-arrow-fiber g f
               ( hom-retraction-retract-map f g R)
               ( map-codomain-inclusion-retract-map f g R b))
             ( hom-arrow-fiber f g (inclusion-retract-map f g R) b))
           ( hom-arrow-fiber f f
-            ( comp-hom-arrow f g f
+            ( comp-hom-arrow
               ( hom-retraction-retract-map f g R)
               ( inclusion-retract-map f g R))
             ( b))
           ( inv-htpy-hom-arrow
-            ( inclusion-fiber f)
-            ( inclusion-fiber f)
             ( hom-arrow-fiber f f
-              ( comp-hom-arrow f g f
+              ( comp-hom-arrow
                 ( hom-retraction-retract-map f g R)
                 ( inclusion-retract-map f g R))
               ( b))
             ( comp-hom-arrow
-              ( inclusion-fiber f)
-              ( inclusion-fiber g)
-              ( inclusion-fiber f)
               ( hom-arrow-fiber g f
                 ( hom-retraction-retract-map f g R)
                 ( map-codomain-inclusion-retract-map f g R b))
@@ -625,23 +582,18 @@ module _
               ( inclusion-retract-map f g R)
               ( b))))
         ( concat-htpy-hom-arrow
-          ( inclusion-fiber f)
-          ( inclusion-fiber f)
           ( comp-hom-arrow
-            ( inclusion-fiber f)
-            ( inclusion-fiber f)
-            ( inclusion-fiber f)
             ( tr-hom-arrow-inclusion-fiber f
               ( is-retraction-map-codomain-hom-retraction-retract-map f g R b))
             ( hom-arrow-fiber f f
-              ( comp-hom-arrow f g f
+              ( comp-hom-arrow
                 ( hom-retraction-retract-map f g R)
                 ( inclusion-retract-map f g R))
               ( b)))
           ( hom-arrow-fiber f f id-hom-arrow b)
           ( id-hom-arrow)
           ( htpy-hom-arrow-fiber f f
-            ( comp-hom-arrow f g f
+            ( comp-hom-arrow
               ( hom-retraction-retract-map f g R)
               ( inclusion-retract-map f g R))
             ( id-hom-arrow)


### PR DESCRIPTION
So after seeing Egbert's proof of the fact that every retract of maps also defines a retract on fiber inclusions, I wanted to put records to the test to see what the fuzz was all about. This PR is purely for demonstration and I am not trying to outright advocate for using records, but we can already see a pretty good mileage out of changing just one definition to a record. I.e., perhaps it is good to consider using records for just very particular definitions? For instance, the mentioned proof becomes 48 lines shorter after the change.