### PR TITLE
Some minor refactoring surrounding Dedekind reals

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,7 +37,6 @@
   "editor.inlineSuggest.enabled": true,
   "editor.acceptSuggestionOnEnter": "off",
   "editor.snippetSuggestions": "top",
-  "editor.wordBasedSuggestions": "off",
   "javascript.suggest.names": false,
 
   // Autoformatting

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,7 +37,7 @@
   "editor.inlineSuggest.enabled": true,
   "editor.acceptSuggestionOnEnter": "off",
   "editor.snippetSuggestions": "top",
-  "editor.wordBasedSuggestions": false,
+  "editor.wordBasedSuggestions": "off",
   "javascript.suggest.names": false,
 
   // Autoformatting

--- a/MIXFIX-OPERATORS.md
+++ b/MIXFIX-OPERATORS.md
@@ -178,7 +178,7 @@ Below, we outline a list of general rules when assigning associativities.
 | 15               | Parametric multiplicative operators like `_×_`,`_×∗_`, `_∧_`, `_∧∗_`, function composition operators like `_∘_`,`_∘∗_`, `_∘e_`, and `_∘iff_`, concatenation operators like `_∙_` and `_∙h_` |
 | 10               | Parametric additive operators like `_+_`, `_∨_`, `_∨∗_`, list concatenation, monadic bind operators for the type checking monad                                                             |
 | 6                | Parametric relational operators like `_＝_`, `_~_`, `_≃_`, and `_↔_`, elementhood relations, subtype relations                                                                              |
-| 5                | Directed function type-like formation operators, e.g. `_→∗_` and `_↪_`                                                                                                                      |
+| 5                | Directed function type-like formation operators, e.g. `_⇒_`, `_→∗_`, `_↠_`, `_↪_`, `_↪ᵈ_`, and `_⊆_`                                                                                        |
 | 3                | The pairing operators `_,_` and `_,ω_`                                                                                                                                                      |
 | 0-1              | Reasoning syntaxes                                                                                                                                                                          |
 | -∞               | Function type formation `_→_`                                                                                                                                                               |

--- a/src/commutative-algebra/prime-ideals-commutative-rings.lagda.md
+++ b/src/commutative-algebra/prime-ideals-commutative-rings.lagda.md
@@ -50,7 +50,7 @@ module _
           ( λ b →
             function-Prop
               ( is-in-ideal-Commutative-Ring R I (mul-Commutative-Ring R a b))
-              ( disj-Prop
+              ( disjunction-Prop
                 ( subset-ideal-Commutative-Ring R I a)
                 ( subset-ideal-Commutative-Ring R I b))))
 
@@ -164,7 +164,7 @@ is-radical-prime-ideal-Commutative-Ring R P x zero-ℕ p =
     ( p)
     ( x)
 is-radical-prime-ideal-Commutative-Ring R P x (succ-ℕ n) p =
-  elim-disj-Prop
+  elim-disjunction-Prop
     ( subset-prime-ideal-Commutative-Ring R P (power-Commutative-Ring R n x))
     ( subset-prime-ideal-Commutative-Ring R P x)
     ( subset-prime-ideal-Commutative-Ring R P x)

--- a/src/foundation-core/propositions.lagda.md
+++ b/src/foundation-core/propositions.lagda.md
@@ -317,7 +317,7 @@ type-implication-Prop :
 type-implication-Prop P Q = type-hom-Prop P Q
 
 infixr 5 _⇒_
-_⇒_ = implication-Prop
+_⇒_ = type-implication-Prop
 ```
 
 ### The type of equivalences between two propositions is a proposition

--- a/src/foundation-core/propositions.lagda.md
+++ b/src/foundation-core/propositions.lagda.md
@@ -315,6 +315,9 @@ implication-Prop P Q = hom-Prop P Q
 type-implication-Prop :
   {l1 l2 : Level} → Prop l1 → Prop l2 → UU (l1 ⊔ l2)
 type-implication-Prop P Q = type-hom-Prop P Q
+
+infixr 5 _⇒_
+_⇒_ = implication-Prop
 ```
 
 ### The type of equivalences between two propositions is a proposition

--- a/src/foundation/apartness-relations.lagda.md
+++ b/src/foundation/apartness-relations.lagda.md
@@ -55,7 +55,7 @@ module _
 
   is-cotransitive : UU (l1 ⊔ l2)
   is-cotransitive =
-    (a b c : A) → type-hom-Prop (R a b) (disj-Prop (R a c) (R b c))
+    (a b c : A) → type-hom-Prop (R a b) (disjunction-Prop (R a c) (R b c))
 
   is-apartness-relation : UU (l1 ⊔ l2)
   is-apartness-relation =
@@ -192,23 +192,23 @@ module _
       is-cotransitive (rel-apart-function-into-Type-With-Apartness X Y)
     is-cotransitive-apart-function-into-Type-With-Apartness f g h H =
       apply-universal-property-trunc-Prop H
-        ( disj-Prop
+        ( disjunction-Prop
           ( rel-apart-function-into-Type-With-Apartness X Y f h)
           ( rel-apart-function-into-Type-With-Apartness X Y g h))
         ( λ (x , a) →
           apply-universal-property-trunc-Prop
             ( cotransitive-apart-Type-With-Apartness Y (f x) (g x) (h x) a)
-            ( disj-Prop
+            ( disjunction-Prop
               ( rel-apart-function-into-Type-With-Apartness X Y f h)
               ( rel-apart-function-into-Type-With-Apartness X Y g h))
             ( λ where
               ( inl b) →
-                inl-disj-Prop
+                inl-disjunction-Prop
                   ( rel-apart-function-into-Type-With-Apartness X Y f h)
                   ( rel-apart-function-into-Type-With-Apartness X Y g h)
                   ( unit-trunc-Prop (x , b))
               ( inr b) →
-                inr-disj-Prop
+                inr-disjunction-Prop
                   ( rel-apart-function-into-Type-With-Apartness X Y f h)
                   ( rel-apart-function-into-Type-With-Apartness X Y g h)
                   ( unit-trunc-Prop (x , b))))

--- a/src/foundation/conjunction.lagda.md
+++ b/src/foundation/conjunction.lagda.md
@@ -30,14 +30,6 @@ and `Q` is the proposition that both `P` and `Q` hold.
 ```agda
 conjunction-Prop = prod-Prop
 
-infixr 15 _∧_
-_∧_ = conjunction-Prop
-```
-
-**Note**: The symbol used for the conjunction `_∧_` is the
-[logical and](https://codepoints.net/U+2227) `∧` (agda-input: `\wedge` `\and`).
-
-```agda
 type-conjunction-Prop : {l1 l2 : Level} → Prop l1 → Prop l2 → UU (l1 ⊔ l2)
 type-conjunction-Prop P Q = type-Prop (conjunction-Prop P Q)
 
@@ -47,6 +39,14 @@ abstract
     is-prop (type-conjunction-Prop P Q)
   is-prop-type-conjunction-Prop P Q = is-prop-type-Prop (conjunction-Prop P Q)
 
+infixr 15 _∧_
+_∧_ = type-conjunction-Prop
+```
+
+**Note**: The symbol used for the conjunction `_∧_` is the
+[logical and](https://codepoints.net/U+2227) `∧` (agda-input: `\wedge` `\and`).
+
+```agda
 conjunction-Decidable-Prop :
   {l1 l2 : Level} → Decidable-Prop l1 → Decidable-Prop l2 →
   Decidable-Prop (l1 ⊔ l2)

--- a/src/foundation/conjunction.lagda.md
+++ b/src/foundation/conjunction.lagda.md
@@ -28,33 +28,33 @@ and `Q` is the proposition that both `P` and `Q` hold.
 ## Definition
 
 ```agda
-conj-Prop = prod-Prop
+conjunction-Prop = prod-Prop
 
 infixr 15 _∧_
-_∧_ = conj-Prop
+_∧_ = conjunction-Prop
 ```
 
 **Note**: The symbol used for the conjunction `_∧_` is the
 [logical and](https://codepoints.net/U+2227) `∧` (agda-input: `\wedge` `\and`).
 
 ```agda
-type-conj-Prop : {l1 l2 : Level} → Prop l1 → Prop l2 → UU (l1 ⊔ l2)
-type-conj-Prop P Q = type-Prop (conj-Prop P Q)
+type-conjunction-Prop : {l1 l2 : Level} → Prop l1 → Prop l2 → UU (l1 ⊔ l2)
+type-conjunction-Prop P Q = type-Prop (conjunction-Prop P Q)
 
 abstract
-  is-prop-type-conj-Prop :
+  is-prop-type-conjunction-Prop :
     {l1 l2 : Level} (P : Prop l1) (Q : Prop l2) →
-    is-prop (type-conj-Prop P Q)
-  is-prop-type-conj-Prop P Q = is-prop-type-Prop (conj-Prop P Q)
+    is-prop (type-conjunction-Prop P Q)
+  is-prop-type-conjunction-Prop P Q = is-prop-type-Prop (conjunction-Prop P Q)
 
-conj-Decidable-Prop :
+conjunction-Decidable-Prop :
   {l1 l2 : Level} → Decidable-Prop l1 → Decidable-Prop l2 →
   Decidable-Prop (l1 ⊔ l2)
-pr1 (conj-Decidable-Prop P Q) =
-  type-conj-Prop (prop-Decidable-Prop P) (prop-Decidable-Prop Q)
-pr1 (pr2 (conj-Decidable-Prop P Q)) =
-  is-prop-type-conj-Prop (prop-Decidable-Prop P) (prop-Decidable-Prop Q)
-pr2 (pr2 (conj-Decidable-Prop P Q)) =
+pr1 (conjunction-Decidable-Prop P Q) =
+  type-conjunction-Prop (prop-Decidable-Prop P) (prop-Decidable-Prop Q)
+pr1 (pr2 (conjunction-Decidable-Prop P Q)) =
+  is-prop-type-conjunction-Prop (prop-Decidable-Prop P) (prop-Decidable-Prop Q)
+pr2 (pr2 (conjunction-Decidable-Prop P Q)) =
   is-decidable-prod
     ( is-decidable-Decidable-Prop P)
     ( is-decidable-Decidable-Prop Q)
@@ -65,31 +65,34 @@ pr2 (pr2 (conj-Decidable-Prop P Q)) =
 ### Introduction rule for conjunction
 
 ```agda
-intro-conj-Prop :
+intro-conjunction-Prop :
   {l1 l2 : Level} (P : Prop l1) (Q : Prop l2) →
-  type-Prop P → type-Prop Q → type-conj-Prop P Q
-pr1 (intro-conj-Prop P Q p q) = p
-pr2 (intro-conj-Prop P Q p q) = q
+  type-Prop P → type-Prop Q → type-conjunction-Prop P Q
+pr1 (intro-conjunction-Prop P Q p q) = p
+pr2 (intro-conjunction-Prop P Q p q) = q
 ```
 
 ### The universal property of conjunction
 
 ```agda
-iff-universal-property-conj-Prop :
+iff-universal-property-conjunction-Prop :
   {l1 l2 : Level} (P : Prop l1) (Q : Prop l2)
   {l3 : Level} (R : Prop l3) →
-  (type-hom-Prop R P × type-hom-Prop R Q) ↔ type-hom-Prop R (conj-Prop P Q)
-pr1 (iff-universal-property-conj-Prop P Q R) (f , g) r = (f r , g r)
-pr1 (pr2 (iff-universal-property-conj-Prop P Q R) h) r = pr1 (h r)
-pr2 (pr2 (iff-universal-property-conj-Prop P Q R) h) r = pr2 (h r)
+  ( type-hom-Prop R P × type-hom-Prop R Q) ↔
+  ( type-hom-Prop R (conjunction-Prop P Q))
+pr1 (pr1 (iff-universal-property-conjunction-Prop P Q R) (f , g) r) = f r
+pr2 (pr1 (iff-universal-property-conjunction-Prop P Q R) (f , g) r) = g r
+pr1 (pr2 (iff-universal-property-conjunction-Prop P Q R) h) r = pr1 (h r)
+pr2 (pr2 (iff-universal-property-conjunction-Prop P Q R) h) r = pr2 (h r)
 
-equiv-universal-property-conj-Prop :
+equiv-universal-property-conjunction-Prop :
   {l1 l2 : Level} (P : Prop l1) (Q : Prop l2)
   {l3 : Level} (R : Prop l3) →
-  (type-hom-Prop R P × type-hom-Prop R Q) ≃ type-hom-Prop R (conj-Prop P Q)
-equiv-universal-property-conj-Prop P Q R =
+  ( type-hom-Prop R P × type-hom-Prop R Q) ≃
+  ( type-hom-Prop R (conjunction-Prop P Q))
+equiv-universal-property-conjunction-Prop P Q R =
   equiv-iff'
-    ( conj-Prop (hom-Prop R P) (hom-Prop R Q))
-    ( hom-Prop R (conj-Prop P Q))
-    ( iff-universal-property-conj-Prop P Q R)
+    ( conjunction-Prop (hom-Prop R P) (hom-Prop R Q))
+    ( hom-Prop R (conjunction-Prop P Q))
+    ( iff-universal-property-conjunction-Prop P Q R)
 ```

--- a/src/foundation/disjunction.lagda.md
+++ b/src/foundation/disjunction.lagda.md
@@ -91,14 +91,14 @@ ev-disjunction-Prop :
   {l1 l2 l3 : Level} (P : Prop l1) (Q : Prop l2) (R : Prop l3) →
   type-hom-Prop
     ( hom-Prop (disjunction-Prop P Q) R)
-    ( conj-Prop (hom-Prop P R) (hom-Prop Q R))
+    ( conjunction-Prop (hom-Prop P R) (hom-Prop Q R))
 pr1 (ev-disjunction-Prop P Q R h) = h ∘ (inl-disjunction-Prop P Q)
 pr2 (ev-disjunction-Prop P Q R h) = h ∘ (inr-disjunction-Prop P Q)
 
 elim-disjunction-Prop :
   {l1 l2 l3 : Level} (P : Prop l1) (Q : Prop l2) (R : Prop l3) →
   type-hom-Prop
-    ( conj-Prop (hom-Prop P R) (hom-Prop Q R))
+    ( conjunction-Prop (hom-Prop P R) (hom-Prop Q R))
     ( hom-Prop (disjunction-Prop P Q) R)
 elim-disjunction-Prop P Q R (pair f g) =
   map-universal-property-trunc-Prop R (ind-coprod (λ t → type-Prop R) f g)
@@ -110,7 +110,7 @@ abstract
   is-equiv-ev-disjunction-Prop P Q R =
     is-equiv-is-prop
       ( is-prop-type-Prop (hom-Prop (disjunction-Prop P Q) R))
-      ( is-prop-type-Prop (conj-Prop (hom-Prop P R) (hom-Prop Q R)))
+      ( is-prop-type-Prop (conjunction-Prop (hom-Prop P R) (hom-Prop Q R)))
       ( elim-disjunction-Prop P Q R)
 ```
 

--- a/src/foundation/disjunction.lagda.md
+++ b/src/foundation/disjunction.lagda.md
@@ -31,11 +31,11 @@ holds or `Q` holds.
 ## Definition
 
 ```agda
-disj-Prop : {l1 l2 : Level} → Prop l1 → Prop l2 → Prop (l1 ⊔ l2)
-disj-Prop P Q = trunc-Prop (type-Prop P + type-Prop Q)
+disjunction-Prop : {l1 l2 : Level} → Prop l1 → Prop l2 → Prop (l1 ⊔ l2)
+disjunction-Prop P Q = trunc-Prop (type-Prop P + type-Prop Q)
 
 infixr 10 _∨_
-_∨_ = disj-Prop
+_∨_ = disjunction-Prop
 ```
 
 **Note**: The symbol used for the disjunction `_∨_` is the
@@ -43,23 +43,23 @@ _∨_ = disj-Prop
 not the [latin small letter v](https://codepoints.net/U+0076) `v`.
 
 ```agda
-type-disj-Prop : {l1 l2 : Level} → Prop l1 → Prop l2 → UU (l1 ⊔ l2)
-type-disj-Prop P Q = type-Prop (disj-Prop P Q)
+type-disjunction-Prop : {l1 l2 : Level} → Prop l1 → Prop l2 → UU (l1 ⊔ l2)
+type-disjunction-Prop P Q = type-Prop (disjunction-Prop P Q)
 
 abstract
-  is-prop-type-disj-Prop :
+  is-prop-type-disjunction-Prop :
     {l1 l2 : Level} (P : Prop l1) (Q : Prop l2) →
-    is-prop (type-disj-Prop P Q)
-  is-prop-type-disj-Prop P Q = is-prop-type-Prop (disj-Prop P Q)
+    is-prop (type-disjunction-Prop P Q)
+  is-prop-type-disjunction-Prop P Q = is-prop-type-Prop (disjunction-Prop P Q)
 
-disj-Decidable-Prop :
+disjunction-Decidable-Prop :
   {l1 l2 : Level} →
   Decidable-Prop l1 → Decidable-Prop l2 → Decidable-Prop (l1 ⊔ l2)
-pr1 (disj-Decidable-Prop P Q) =
-  type-disj-Prop (prop-Decidable-Prop P) (prop-Decidable-Prop Q)
-pr1 (pr2 (disj-Decidable-Prop P Q)) =
-  is-prop-type-disj-Prop (prop-Decidable-Prop P) (prop-Decidable-Prop Q)
-pr2 (pr2 (disj-Decidable-Prop P Q)) =
+pr1 (disjunction-Decidable-Prop P Q) =
+  type-disjunction-Prop (prop-Decidable-Prop P) (prop-Decidable-Prop Q)
+pr1 (pr2 (disjunction-Decidable-Prop P Q)) =
+  is-prop-type-disjunction-Prop (prop-Decidable-Prop P) (prop-Decidable-Prop Q)
+pr2 (pr2 (disjunction-Decidable-Prop P Q)) =
   is-decidable-trunc-Prop-is-merely-decidable
     ( type-Decidable-Prop P + type-Decidable-Prop Q)
     ( unit-trunc-Prop
@@ -73,45 +73,45 @@ pr2 (pr2 (disj-Decidable-Prop P Q)) =
 ### The introduction rules for disjunction
 
 ```agda
-inl-disj-Prop :
+inl-disjunction-Prop :
   {l1 l2 : Level} (P : Prop l1) (Q : Prop l2) →
-  type-hom-Prop P (disj-Prop P Q)
-inl-disj-Prop P Q = unit-trunc-Prop ∘ inl
+  type-hom-Prop P (disjunction-Prop P Q)
+inl-disjunction-Prop P Q = unit-trunc-Prop ∘ inl
 
-inr-disj-Prop :
+inr-disjunction-Prop :
   {l1 l2 : Level} (P : Prop l1) (Q : Prop l2) →
-  type-hom-Prop Q (disj-Prop P Q)
-inr-disj-Prop P Q = unit-trunc-Prop ∘ inr
+  type-hom-Prop Q (disjunction-Prop P Q)
+inr-disjunction-Prop P Q = unit-trunc-Prop ∘ inr
 ```
 
 ### The elimination rule and universal property of disjunction
 
 ```agda
-ev-disj-Prop :
+ev-disjunction-Prop :
   {l1 l2 l3 : Level} (P : Prop l1) (Q : Prop l2) (R : Prop l3) →
   type-hom-Prop
-    ( hom-Prop (disj-Prop P Q) R)
+    ( hom-Prop (disjunction-Prop P Q) R)
     ( conj-Prop (hom-Prop P R) (hom-Prop Q R))
-pr1 (ev-disj-Prop P Q R h) = h ∘ (inl-disj-Prop P Q)
-pr2 (ev-disj-Prop P Q R h) = h ∘ (inr-disj-Prop P Q)
+pr1 (ev-disjunction-Prop P Q R h) = h ∘ (inl-disjunction-Prop P Q)
+pr2 (ev-disjunction-Prop P Q R h) = h ∘ (inr-disjunction-Prop P Q)
 
-elim-disj-Prop :
+elim-disjunction-Prop :
   {l1 l2 l3 : Level} (P : Prop l1) (Q : Prop l2) (R : Prop l3) →
   type-hom-Prop
     ( conj-Prop (hom-Prop P R) (hom-Prop Q R))
-    ( hom-Prop (disj-Prop P Q) R)
-elim-disj-Prop P Q R (pair f g) =
+    ( hom-Prop (disjunction-Prop P Q) R)
+elim-disjunction-Prop P Q R (pair f g) =
   map-universal-property-trunc-Prop R (ind-coprod (λ t → type-Prop R) f g)
 
 abstract
-  is-equiv-ev-disj-Prop :
+  is-equiv-ev-disjunction-Prop :
     {l1 l2 l3 : Level} (P : Prop l1) (Q : Prop l2) (R : Prop l3) →
-    is-equiv (ev-disj-Prop P Q R)
-  is-equiv-ev-disj-Prop P Q R =
+    is-equiv (ev-disjunction-Prop P Q R)
+  is-equiv-ev-disjunction-Prop P Q R =
     is-equiv-is-prop
-      ( is-prop-type-Prop (hom-Prop (disj-Prop P Q) R))
+      ( is-prop-type-Prop (hom-Prop (disjunction-Prop P Q) R))
       ( is-prop-type-Prop (conj-Prop (hom-Prop P R) (hom-Prop Q R)))
-      ( elim-disj-Prop P Q R)
+      ( elim-disjunction-Prop P Q R)
 ```
 
 ### The unit laws for disjunction
@@ -121,13 +121,13 @@ module _
   {l1 l2 : Level} (P : Prop l1) (Q : Prop l2)
   where
 
-  map-left-unit-law-disj-is-empty-Prop :
-    is-empty (type-Prop P) → type-disj-Prop P Q → type-Prop Q
-  map-left-unit-law-disj-is-empty-Prop f =
-    elim-disj-Prop P Q Q (ex-falso ∘ f , id)
+  map-left-unit-law-disjunction-is-empty-Prop :
+    is-empty (type-Prop P) → type-disjunction-Prop P Q → type-Prop Q
+  map-left-unit-law-disjunction-is-empty-Prop f =
+    elim-disjunction-Prop P Q Q (ex-falso ∘ f , id)
 
-  map-right-unit-law-disj-is-empty-Prop :
-    is-empty (type-Prop Q) → type-disj-Prop P Q → type-Prop P
-  map-right-unit-law-disj-is-empty-Prop f =
-    elim-disj-Prop P Q P (id , ex-falso ∘ f)
+  map-right-unit-law-disjunction-is-empty-Prop :
+    is-empty (type-Prop Q) → type-disjunction-Prop P Q → type-Prop P
+  map-right-unit-law-disjunction-is-empty-Prop f =
+    elim-disjunction-Prop P Q P (id , ex-falso ∘ f)
 ```

--- a/src/foundation/disjunction.lagda.md
+++ b/src/foundation/disjunction.lagda.md
@@ -34,15 +34,6 @@ holds or `Q` holds.
 disjunction-Prop : {l1 l2 : Level} → Prop l1 → Prop l2 → Prop (l1 ⊔ l2)
 disjunction-Prop P Q = trunc-Prop (type-Prop P + type-Prop Q)
 
-infixr 10 _∨_
-_∨_ = disjunction-Prop
-```
-
-**Note**: The symbol used for the disjunction `_∨_` is the
-[logical or](https://codepoints.net/U+2228) `∨` (agda-input: `\vee` `\or`), and
-not the [latin small letter v](https://codepoints.net/U+0076) `v`.
-
-```agda
 type-disjunction-Prop : {l1 l2 : Level} → Prop l1 → Prop l2 → UU (l1 ⊔ l2)
 type-disjunction-Prop P Q = type-Prop (disjunction-Prop P Q)
 
@@ -52,6 +43,15 @@ abstract
     is-prop (type-disjunction-Prop P Q)
   is-prop-type-disjunction-Prop P Q = is-prop-type-Prop (disjunction-Prop P Q)
 
+infixr 10 _∨_
+_∨_ = type-disjunction-Prop
+```
+
+**Note**: The symbol used for the disjunction `_∨_` is the
+[logical or](https://codepoints.net/U+2228) `∨` (agda-input: `\vee` `\or`), and
+not the [latin small letter v](https://codepoints.net/U+0076) `v`.
+
+```agda
 disjunction-Decidable-Prop :
   {l1 l2 : Level} →
   Decidable-Prop l1 → Decidable-Prop l2 → Decidable-Prop (l1 ⊔ l2)

--- a/src/foundation/dubuc-penon-compact-types.lagda.md
+++ b/src/foundation/dubuc-penon-compact-types.lagda.md
@@ -35,8 +35,8 @@ is-dubuc-penon-compact-Prop l1 l2 X =
         ( subtype l2 X)
         ( λ Q →
           function-Prop
-            ( (x : X) → type-disj-Prop P (Q x))
-            ( disj-Prop P (Π-Prop X Q))))
+            ( (x : X) → type-disjunction-Prop P (Q x))
+            ( disjunction-Prop P (Π-Prop X Q))))
 
 is-dubuc-penon-compact :
   {l : Level} (l1 l2 : Level) → UU l → UU (l ⊔ lsuc l1 ⊔ lsuc l2)

--- a/src/foundation/exclusive-disjunction.lagda.md
+++ b/src/foundation/exclusive-disjunction.lagda.md
@@ -71,8 +71,8 @@ module _
   xor-Prop : Prop (l1 ⊔ l2)
   xor-Prop =
     coprod-Prop
-      ( conj-Prop P (neg-Prop Q))
-      ( conj-Prop Q (neg-Prop P))
+      ( conjunction-Prop P (neg-Prop Q))
+      ( conjunction-Prop Q (neg-Prop P))
       ( λ p q → pr2 q (pr1 p))
 
   type-xor-Prop : UU (l1 ⊔ l2)
@@ -252,7 +252,7 @@ module _
 {-
   eq-equiv-Prop
     ( ( ( equiv-coprod
-          ( ( ( left-unit-law-coprod (type-Prop (conj-Prop P (neg-Prop Q)))) ∘e
+          ( ( ( left-unit-law-coprod (type-Prop (conjunction-Prop P (neg-Prop Q)))) ∘e
               ( equiv-coprod
                 ( left-absorption-Σ
                   ( λ x →

--- a/src/foundation/existential-quantification.lagda.md
+++ b/src/foundation/existential-quantification.lagda.md
@@ -119,24 +119,26 @@ module _
   {l1 l2 l3 : Level} (P : Prop l1) {A : UU l2} (Q : A → Prop l3)
   where
 
-  iff-distributive-conj-exists-Prop :
-    (conj-Prop P (exists-Prop A Q)) ⇔ (exists-Prop A (λ a → conj-Prop P (Q a)))
-  pr1 iff-distributive-conj-exists-Prop (p , e) =
+  iff-distributive-conjunction-exists-Prop :
+    ( conjunction-Prop P (exists-Prop A Q)) ⇔
+    ( exists-Prop A (λ a → conjunction-Prop P (Q a)))
+  pr1 iff-distributive-conjunction-exists-Prop (p , e) =
     elim-exists-Prop Q
-      ( exists-Prop A (λ a → conj-Prop P (Q a)))
+      ( exists-Prop A (λ a → conjunction-Prop P (Q a)))
       ( λ x q → intro-∃ x (p , q))
       ( e)
-  pr2 iff-distributive-conj-exists-Prop =
+  pr2 iff-distributive-conjunction-exists-Prop =
     elim-exists-Prop
-      ( λ x → conj-Prop P (Q x))
-      ( conj-Prop P (exists-Prop A Q))
+      ( λ x → conjunction-Prop P (Q x))
+      ( conjunction-Prop P (exists-Prop A Q))
       ( λ x (p , q) → (p , intro-∃ x q))
 
-  distributive-conj-exists-Prop :
-    conj-Prop P (exists-Prop A Q) ＝ exists-Prop A (λ a → conj-Prop P (Q a))
-  distributive-conj-exists-Prop =
+  distributive-conjunction-exists-Prop :
+    conjunction-Prop P (exists-Prop A Q) ＝
+    exists-Prop A (λ a → conjunction-Prop P (Q a))
+  distributive-conjunction-exists-Prop =
     eq-iff'
-      ( conj-Prop P (exists-Prop A Q))
-      ( exists-Prop A (λ a → conj-Prop P (Q a)))
-      ( iff-distributive-conj-exists-Prop)
+      ( conjunction-Prop P (exists-Prop A Q))
+      ( exists-Prop A (λ a → conjunction-Prop P (Q a)))
+      ( iff-distributive-conjunction-exists-Prop)
 ```

--- a/src/foundation/impredicative-encodings.lagda.md
+++ b/src/foundation/impredicative-encodings.lagda.md
@@ -114,9 +114,9 @@ equiv-impredicative-conj-Prop P1 P2 =
 ### The impredicative encoding of disjunction
 
 ```agda
-impredicative-disj-Prop :
+impredicative-disjunction-Prop :
   {l1 l2 : Level} → Prop l1 → Prop l2 → Prop (lsuc (l1 ⊔ l2))
-impredicative-disj-Prop {l1} {l2} P1 P2 =
+impredicative-disjunction-Prop {l1} {l2} P1 P2 =
   Π-Prop
     ( Prop (l1 ⊔ l2))
     ( λ Q →
@@ -124,37 +124,39 @@ impredicative-disj-Prop {l1} {l2} P1 P2 =
         ( type-implication-Prop P1 Q)
         ( function-Prop (type-implication-Prop P2 Q) Q))
 
-type-impredicative-disj-Prop :
+type-impredicative-disjunction-Prop :
   {l1 l2 : Level} → Prop l1 → Prop l2 → UU (lsuc (l1 ⊔ l2))
-type-impredicative-disj-Prop P1 P2 =
-  type-Prop (impredicative-disj-Prop P1 P2)
+type-impredicative-disjunction-Prop P1 P2 =
+  type-Prop (impredicative-disjunction-Prop P1 P2)
 
-map-impredicative-disj-Prop :
+map-impredicative-disjunction-Prop :
   {l1 l2 : Level} (P1 : Prop l1) (P2 : Prop l2) →
-  type-disj-Prop P1 P2 → type-impredicative-disj-Prop P1 P2
-map-impredicative-disj-Prop {l1} {l2} P1 P2 =
+  type-disjunction-Prop P1 P2 → type-impredicative-disjunction-Prop P1 P2
+map-impredicative-disjunction-Prop {l1} {l2} P1 P2 =
   map-universal-property-trunc-Prop
-    ( impredicative-disj-Prop P1 P2)
+    ( impredicative-disjunction-Prop P1 P2)
     ( ind-coprod
-      ( λ x → type-impredicative-disj-Prop P1 P2)
+      ( λ x → type-impredicative-disjunction-Prop P1 P2)
       ( λ x Q f1 f2 → f1 x)
       ( λ y Q f1 f2 → f2 y))
 
-inv-map-impredicative-disj-Prop :
+inv-map-impredicative-disjunction-Prop :
   {l1 l2 : Level} (P1 : Prop l1) (P2 : Prop l2) →
-  type-impredicative-disj-Prop P1 P2 → type-disj-Prop P1 P2
-inv-map-impredicative-disj-Prop P1 P2 H =
-  H (disj-Prop P1 P2) (inl-disj-Prop P1 P2) (inr-disj-Prop P1 P2)
+  type-impredicative-disjunction-Prop P1 P2 → type-disjunction-Prop P1 P2
+inv-map-impredicative-disjunction-Prop P1 P2 H =
+  H ( disjunction-Prop P1 P2)
+    ( inl-disjunction-Prop P1 P2)
+    ( inr-disjunction-Prop P1 P2)
 
-equiv-impredicative-disj-Prop :
+equiv-impredicative-disjunction-Prop :
   {l1 l2 : Level} (P1 : Prop l1) (P2 : Prop l2) →
-  type-disj-Prop P1 P2 ≃ type-impredicative-disj-Prop P1 P2
-equiv-impredicative-disj-Prop P1 P2 =
+  type-disjunction-Prop P1 P2 ≃ type-impredicative-disjunction-Prop P1 P2
+equiv-impredicative-disjunction-Prop P1 P2 =
   equiv-iff
-    ( disj-Prop P1 P2)
-    ( impredicative-disj-Prop P1 P2)
-    ( map-impredicative-disj-Prop P1 P2)
-    ( inv-map-impredicative-disj-Prop P1 P2)
+    ( disjunction-Prop P1 P2)
+    ( impredicative-disjunction-Prop P1 P2)
+    ( map-impredicative-disjunction-Prop P1 P2)
+    ( inv-map-impredicative-disjunction-Prop P1 P2)
 ```
 
 ### The impredicative encoding of negation

--- a/src/foundation/impredicative-encodings.lagda.md
+++ b/src/foundation/impredicative-encodings.lagda.md
@@ -76,39 +76,39 @@ equiv-impredicative-trunc-Prop A =
 ### The impredicative encoding of conjunction
 
 ```agda
-impredicative-conj-Prop :
+impredicative-conjunction-Prop :
   {l1 l2 : Level} → Prop l1 → Prop l2 → Prop (lsuc (l1 ⊔ l2))
-impredicative-conj-Prop {l1} {l2} P1 P2 =
+impredicative-conjunction-Prop {l1} {l2} P1 P2 =
   Π-Prop
     ( Prop (l1 ⊔ l2))
     ( λ Q → function-Prop (type-Prop P1 → (type-Prop P2 → type-Prop Q)) Q)
 
-type-impredicative-conj-Prop :
+type-impredicative-conjunction-Prop :
   {l1 l2 : Level} → Prop l1 → Prop l2 → UU (lsuc (l1 ⊔ l2))
-type-impredicative-conj-Prop P1 P2 =
-  type-Prop (impredicative-conj-Prop P1 P2)
+type-impredicative-conjunction-Prop P1 P2 =
+  type-Prop (impredicative-conjunction-Prop P1 P2)
 
-map-impredicative-conj-Prop :
+map-impredicative-conjunction-Prop :
   {l1 l2 : Level} (P1 : Prop l1) (P2 : Prop l2) →
-  type-conj-Prop P1 P2 → type-impredicative-conj-Prop P1 P2
-map-impredicative-conj-Prop {l1} {l2} P1 P2 (pair p1 p2) Q f =
+  type-conjunction-Prop P1 P2 → type-impredicative-conjunction-Prop P1 P2
+map-impredicative-conjunction-Prop {l1} {l2} P1 P2 (pair p1 p2) Q f =
   f p1 p2
 
-inv-map-impredicative-conj-Prop :
+inv-map-impredicative-conjunction-Prop :
   {l1 l2 : Level} (P1 : Prop l1) (P2 : Prop l2) →
-  type-impredicative-conj-Prop P1 P2 → type-conj-Prop P1 P2
-inv-map-impredicative-conj-Prop P1 P2 H =
-  H (conj-Prop P1 P2) (λ p1 p2 → pair p1 p2)
+  type-impredicative-conjunction-Prop P1 P2 → type-conjunction-Prop P1 P2
+inv-map-impredicative-conjunction-Prop P1 P2 H =
+  H (conjunction-Prop P1 P2) (λ p1 p2 → pair p1 p2)
 
-equiv-impredicative-conj-Prop :
+equiv-impredicative-conjunction-Prop :
   {l1 l2 : Level} (P1 : Prop l1) (P2 : Prop l2) →
-  type-conj-Prop P1 P2 ≃ type-impredicative-conj-Prop P1 P2
-equiv-impredicative-conj-Prop P1 P2 =
+  type-conjunction-Prop P1 P2 ≃ type-impredicative-conjunction-Prop P1 P2
+equiv-impredicative-conjunction-Prop P1 P2 =
   equiv-iff
-    ( conj-Prop P1 P2)
-    ( impredicative-conj-Prop P1 P2)
-    ( map-impredicative-conj-Prop P1 P2)
-    ( inv-map-impredicative-conj-Prop P1 P2)
+    ( conjunction-Prop P1 P2)
+    ( impredicative-conjunction-Prop P1 P2)
+    ( map-impredicative-conjunction-Prop P1 P2)
+    ( inv-map-impredicative-conjunction-Prop P1 P2)
 ```
 
 ### The impredicative encoding of disjunction

--- a/src/foundation/intersections-subtypes.lagda.md
+++ b/src/foundation/intersections-subtypes.lagda.md
@@ -70,7 +70,7 @@ module _
   intersection-decidable-subtype :
     decidable-subtype l1 X → decidable-subtype l2 X →
     decidable-subtype (l1 ⊔ l2) X
-  intersection-decidable-subtype P Q x = conj-Decidable-Prop (P x) (Q x)
+  intersection-decidable-subtype P Q x = conjunction-Decidable-Prop (P x) (Q x)
 ```
 
 ### The intersection of a family of subtypes

--- a/src/foundation/large-locale-of-propositions.lagda.md
+++ b/src/foundation/large-locale-of-propositions.lagda.md
@@ -58,10 +58,10 @@ antisymmetric-leq-Large-Poset Prop-Large-Poset P Q = eq-iff
 ```agda
 has-meets-Prop-Large-Locale :
   has-meets-Large-Poset Prop-Large-Poset
-meet-has-meets-Large-Poset has-meets-Prop-Large-Locale = conj-Prop
+meet-has-meets-Large-Poset has-meets-Prop-Large-Locale = conjunction-Prop
 is-greatest-binary-lower-bound-meet-has-meets-Large-Poset
   has-meets-Prop-Large-Locale =
-  iff-universal-property-conj-Prop
+  iff-universal-property-conjunction-Prop
 ```
 
 ### The largest element in the large poset of propositions
@@ -113,7 +113,7 @@ is-large-meet-semilattice-Large-Frame Prop-Large-Frame =
 is-large-suplattice-Large-Frame Prop-Large-Frame =
   is-large-suplattice-Prop-Large-Locale
 distributive-meet-sup-Large-Frame Prop-Large-Frame =
-  distributive-conj-exists-Prop
+  distributive-conjunction-exists-Prop
 ```
 
 ### The large locale of propositions

--- a/src/foundation/lesser-limited-principle-of-omniscience.lagda.md
+++ b/src/foundation/lesser-limited-principle-of-omniscience.lagda.md
@@ -32,7 +32,7 @@ or `f n ＝ 0` for all odd `n`.
 LLPO : UU lzero
 LLPO =
   (f : ℕ → Fin 2) → is-prop (fiber f (one-Fin 1)) →
-  type-disj-Prop
+  type-disjunction-Prop
     ( Π-Prop ℕ
       ( λ n →
         function-Prop (is-even-ℕ n) (Id-Prop (Fin-Set 2) (f n) (zero-Fin 1))))

--- a/src/foundation/limited-principle-of-omniscience.lagda.md
+++ b/src/foundation/limited-principle-of-omniscience.lagda.md
@@ -32,7 +32,7 @@ we have `f n ＝ 0`.
 LPO : UU lzero
 LPO =
   (f : ℕ → Fin 2) →
-  type-disj-Prop
+  type-disjunction-Prop
     ( ∃-Prop ℕ (λ n → f n ＝ one-Fin 1))
     ( Π-Prop ℕ (λ n → Id-Prop (Fin-Set 2) (f n) (zero-Fin 1)))
 ```

--- a/src/foundation/logical-equivalences.lagda.md
+++ b/src/foundation/logical-equivalences.lagda.md
@@ -60,24 +60,27 @@ module _
 ### Logical equivalences between propositions
 
 ```agda
-infix 6 _⇔_
+module _
+  {l1 l2 : Level} (P : Prop l1) (Q : Prop l2)
+  where
 
-_⇔_ :
-  {l1 l2 : Level} → Prop l1 → Prop l2 → UU (l1 ⊔ l2)
-P ⇔ Q = type-Prop P ↔ type-Prop Q
+  type-iff-Prop : UU (l1 ⊔ l2)
+  type-iff-Prop = type-Prop P ↔ type-Prop Q
 
-is-prop-iff-Prop :
-  {l1 l2 : Level} (P : Prop l1) (Q : Prop l2) →
-  is-prop (P ⇔ Q)
-is-prop-iff-Prop P Q =
-  is-prop-prod
-    ( is-prop-function-type (is-prop-type-Prop Q))
-    ( is-prop-function-type (is-prop-type-Prop P))
+  is-prop-iff-Prop : is-prop type-iff-Prop
+  is-prop-iff-Prop =
+    is-prop-prod
+      ( is-prop-function-type (is-prop-type-Prop Q))
+      ( is-prop-function-type (is-prop-type-Prop P))
 
-iff-Prop :
-  {l1 l2 : Level} → Prop l1 → Prop l2 → Prop (l1 ⊔ l2)
-pr1 (iff-Prop P Q) = P ⇔ Q
-pr2 (iff-Prop P Q) = is-prop-iff-Prop P Q
+  iff-Prop : Prop (l1 ⊔ l2)
+  pr1 iff-Prop = type-iff-Prop
+  pr2 iff-Prop = is-prop-iff-Prop
+
+  infix 6 _⇔_
+
+  _⇔_ : UU (l1 ⊔ l2)
+  _⇔_ = type-iff-Prop
 ```
 
 ### Composition of logical equivalences

--- a/src/foundation/unions-subtypes.lagda.md
+++ b/src/foundation/unions-subtypes.lagda.md
@@ -37,7 +37,7 @@ module _
   where
 
   union-subtype : subtype l1 X → subtype l2 X → subtype (l1 ⊔ l2) X
-  union-subtype P Q x = disj-Prop (P x) (Q x)
+  union-subtype P Q x = disjunction-Prop (P x) (Q x)
 ```
 
 ### Unions of decidable subtypes
@@ -46,7 +46,7 @@ module _
   union-decidable-subtype :
     decidable-subtype l1 X → decidable-subtype l2 X →
     decidable-subtype (l1 ⊔ l2) X
-  union-decidable-subtype P Q x = disj-Decidable-Prop (P x) (Q x)
+  union-decidable-subtype P Q x = disjunction-Decidable-Prop (P x) (Q x)
 ```
 
 ### Unions of families of subtypes

--- a/src/foundation/weak-limited-principle-of-omniscience.lagda.md
+++ b/src/foundation/weak-limited-principle-of-omniscience.lagda.md
@@ -31,7 +31,7 @@ restricted form of the law of excluded middle.
 WLPO : UU lzero
 WLPO =
   (f : ℕ → Fin 2) →
-  type-disj-Prop
+  type-disjunction-Prop
     ( Π-Prop ℕ (λ n → Id-Prop (Fin-Set 2) (f n) (zero-Fin 1)))
     ( neg-Prop (Π-Prop ℕ (λ n → Id-Prop (Fin-Set 2) (f n) (zero-Fin 1))))
 ```

--- a/src/group-theory/nontrivial-groups.lagda.md
+++ b/src/group-theory/nontrivial-groups.lagda.md
@@ -132,24 +132,24 @@ module _
             ( λ {P} {Q} α →
               eq-iff
                 ( λ p →
-                  map-left-unit-law-disj-is-empty-Prop
+                  map-left-unit-law-disjunction-is-empty-Prop
                     ( Id-Prop (set-Group G) _ _)
                     ( Q)
                     ( f)
                     ( forward-implication
                       ( iff-eq (ap (λ T → subset-Subgroup G T x) α))
-                      ( inr-disj-Prop
+                      ( inr-disjunction-Prop
                         ( Id-Prop (set-Group G) _ _)
                         ( P)
                         ( p))))
                 ( λ q →
-                  map-left-unit-law-disj-is-empty-Prop
+                  map-left-unit-law-disjunction-is-empty-Prop
                     ( Id-Prop (set-Group G) _ _)
                     ( P)
                     ( f)
                     ( backward-implication
                       ( iff-eq (ap (λ T → subset-Subgroup G T x) α))
-                      ( inr-disj-Prop
+                      ( inr-disjunction-Prop
                         ( Id-Prop (set-Group G) _ _)
                         ( Q)
                         ( q))))))

--- a/src/group-theory/subgroups.lagda.md
+++ b/src/group-theory/subgroups.lagda.md
@@ -668,12 +668,15 @@ module _
 
   subset-subgroup-Prop : subset-Group (l1 ⊔ l2) G
   subset-subgroup-Prop x =
-    disj-Prop (Id-Prop (set-Group G) (unit-Group G) x) P
+    disjunction-Prop (Id-Prop (set-Group G) (unit-Group G) x) P
 
   contains-unit-subgroup-Prop :
     contains-unit-subset-Group G subset-subgroup-Prop
   contains-unit-subgroup-Prop =
-    inl-disj-Prop (Id-Prop (set-Group G) (unit-Group G) (unit-Group G)) P refl
+    inl-disjunction-Prop
+      ( Id-Prop (set-Group G) (unit-Group G) (unit-Group G))
+      ( P)
+      ( refl)
 
   is-closed-under-multiplication-subgroup-Prop' :
     (x y : type-Group G) →
@@ -693,7 +696,7 @@ module _
     is-closed-under-multiplication-subset-Group G subset-subgroup-Prop
   is-closed-under-multiplication-subgroup-Prop H K =
     apply-twice-universal-property-trunc-Prop H K
-      ( disj-Prop (Id-Prop (set-Group G) _ _) P)
+      ( disjunction-Prop (Id-Prop (set-Group G) _ _) P)
       ( λ H' K' →
         unit-trunc-Prop
           ( is-closed-under-multiplication-subgroup-Prop' _ _ H' K'))
@@ -710,7 +713,7 @@ module _
     is-closed-under-inverses-subset-Group G subset-subgroup-Prop
   is-closed-under-inverses-subgroup-Prop {x} H =
     apply-universal-property-trunc-Prop H
-      ( disj-Prop (Id-Prop (set-Group G) _ _) P)
+      ( disjunction-Prop (Id-Prop (set-Group G) _ _) P)
       ( unit-trunc-Prop ∘ is-closed-under-inverses-subgroup-Prop')
 
   subgroup-Prop : Subgroup (l1 ⊔ l2) G

--- a/src/order-theory/total-preorders.lagda.md
+++ b/src/order-theory/total-preorders.lagda.md
@@ -36,7 +36,7 @@ module _
 
   incident-Preorder-Prop : (x y : type-Preorder X) → Prop l2
   incident-Preorder-Prop x y =
-    disj-Prop (leq-Preorder-Prop X x y) (leq-Preorder-Prop X y x)
+    disjunction-Prop (leq-Preorder-Prop X x y) (leq-Preorder-Prop X y x)
 
   incident-Preorder : (x y : type-Preorder X) → UU l2
   incident-Preorder x y = type-Prop (incident-Preorder-Prop x y)

--- a/src/orthogonal-factorization-systems/factorizations-of-maps-function-classes.lagda.md
+++ b/src/orthogonal-factorization-systems/factorizations-of-maps-function-classes.lagda.md
@@ -65,7 +65,9 @@ module _
 
   is-function-class-factorization-Prop : Prop (lL ⊔ lR)
   is-function-class-factorization-Prop =
-    conj-Prop (L (left-map-factorization F)) (R (right-map-factorization F))
+    conjunction-Prop
+      ( L (left-map-factorization F))
+      ( R (right-map-factorization F))
 
   is-function-class-factorization : UU (lL ⊔ lR)
   is-function-class-factorization =

--- a/src/polytopes/abstract-polytopes.lagda.md
+++ b/src/polytopes/abstract-polytopes.lagda.md
@@ -408,7 +408,7 @@ module _
       ( element-face-Prepolytope z)
   is-on-path-face-prepolytope-Prop
     ( cons-path-faces-Finitely-Graded-Poset {z = w} a p) z =
-    disj-Prop
+    disjunction-Prop
       ( is-on-path-face-prepolytope-Prop p z)
       ( Id-Prop
         ( set-Prepolytope)

--- a/src/real-numbers/dedekind-real-numbers.lagda.md
+++ b/src/real-numbers/dedekind-real-numbers.lagda.md
@@ -45,7 +45,7 @@ satisfying the following four conditions
 3. _Disjointness_. `L` and `U` are disjoint subsets of `ℚ`.
 4. _Locatedness_. If `q < r` then `q ∈ L` or `r ∈ U`.
 
-The {{#concept "type of Dedekind real numbers" Agda=ℝ}} is the type of all
+The type of {{#concept "Dedekind real numbers" Agda=ℝ}} is the type of all
 Dedekind cuts. The Dedekind real numbers will be taken as the standard
 definition of the real numbers in the `agda-unimath` library.
 

--- a/src/real-numbers/dedekind-real-numbers.lagda.md
+++ b/src/real-numbers/dedekind-real-numbers.lagda.md
@@ -17,6 +17,7 @@ open import foundation.logical-equivalences
 open import foundation.negation
 open import foundation.propositions
 open import foundation.sets
+open import foundation.subtypes
 open import foundation.truncated-types
 open import foundation.universe-levels
 
@@ -27,69 +28,82 @@ open import foundation-core.truncation-levels
 
 ## Idea
 
-A **Dedekind cut** consists a pair `(L , U)` of subtypes of `ℚ`, satisfying the
-following four conditions
+A
+{{#concept "Dedekind cut" Agda=is-dedekind-cut WD="Dedekind cut" WDID=Q851333}}
+consists of a [pair](foundation.dependent-pair-types.md) `(L , U)` of
+[subtypes](foundation-core.subtypes.md) of
+[the rational numbers](elementary-number-theory.rational-numbers.md) `ℚ`,
+satisfying the following four conditions
 
-1. _Inhabitedness_. Both `L` and `U` are inhabited subtypes of `ℚ`.
-2. _Roundedness_. A rational number `q` is in `L` if and only if there exists
-   `q < r` such that `r ∈ L`, and a rational number `r` is in `U` if and only if
-   there exists `q < r` such that `q ∈ U`.
+1. _Inhabitedness_. Both `L` and `U` are
+   [inhabited](foundation.inhabited-subtypes.md) subtypes of `ℚ`.
+2. _Roundedness_. A rational number `q` is in `L`
+   [if and only if](foundation.logical-equivalences.md) there
+   [exists](foundation.existential-quantification.md) `q < r` such that `r ∈ L`,
+   and a rational number `r` is in `U` if and only if there exists `q < r` such
+   that `q ∈ U`.
 3. _Disjointness_. `L` and `U` are disjoint subsets of `ℚ`.
 4. _Locatedness_. If `q < r` then `q ∈ L` or `r ∈ U`.
 
-The type of Dedekind real numbers is the type of all dedekind cuts. The Dedekind
-real numbers will be taken as the standard definition of the real numbers in the
-`agda-unimath` library.
+The {{#concept "type of Dedekind real numbers" Agda=ℝ}} is the type of all
+Dedekind cuts. The Dedekind real numbers will be taken as the standard
+definition of the real numbers in the `agda-unimath` library.
 
 ## Definition
 
 ### Dedekind cuts
 
 ```agda
-is-dedekind-cut-Prop :
-  {l : Level} → (ℚ → Prop l) → (ℚ → Prop l) → Prop l
-is-dedekind-cut-Prop L U =
-  prod-Prop
-    ( prod-Prop (exists-Prop ℚ L) (exists-Prop ℚ U))
-    ( prod-Prop
-      ( prod-Prop
-        ( Π-Prop ℚ
-          ( λ q →
-            iff-Prop
-              ( L q)
-              ( exists-Prop ℚ (λ r → prod-Prop (le-ℚ-Prop q r) (L r)))))
-        ( Π-Prop ℚ
-          ( λ r →
-            iff-Prop
-              ( U r)
-              ( exists-Prop ℚ (λ q → prod-Prop (le-ℚ-Prop q r) (U q))))))
-      ( prod-Prop
-        ( Π-Prop ℚ (λ q → neg-Prop (prod-Prop (L q) (U q))))
-        ( Π-Prop ℚ
-          ( λ q →
-            Π-Prop ℚ
-              ( λ r →
-                implication-Prop
-                  ( le-ℚ-Prop q r)
-                  ( disj-Prop (L q) (U r)))))))
+module _
+  {l1 l2 : Level} (L : subtype l1 ℚ) (U : subtype l2 ℚ)
+  where
 
-is-dedekind-cut :
-  {l : Level} → (ℚ → Prop l) → (ℚ → Prop l) → UU l
-is-dedekind-cut L U = type-Prop (is-dedekind-cut-Prop L U)
+  is-dedekind-cut-Prop : Prop (l1 ⊔ l2)
+  is-dedekind-cut-Prop =
+    prod-Prop
+      ( prod-Prop (exists-Prop ℚ L) (exists-Prop ℚ U))
+      ( prod-Prop
+        ( prod-Prop
+          ( Π-Prop ℚ
+            ( λ q →
+              iff-Prop
+                ( L q)
+                ( exists-Prop ℚ (λ r → prod-Prop (le-ℚ-Prop q r) (L r)))))
+          ( Π-Prop ℚ
+            ( λ r →
+              iff-Prop
+                ( U r)
+                ( exists-Prop ℚ (λ q → prod-Prop (le-ℚ-Prop q r) (U q))))))
+        ( prod-Prop
+          ( Π-Prop ℚ (λ q → neg-Prop (prod-Prop (L q) (U q))))
+          ( Π-Prop ℚ
+            ( λ q →
+              Π-Prop ℚ
+                ( λ r →
+                  implication-Prop
+                    ( le-ℚ-Prop q r)
+                    ( disj-Prop (L q) (U r)))))))
+
+  is-dedekind-cut : UU (l1 ⊔ l2)
+  is-dedekind-cut = type-Prop is-dedekind-cut-Prop
+
+  is-prop-is-dedekind-cut : is-prop is-dedekind-cut
+  is-prop-is-dedekind-cut = is-prop-type-Prop is-dedekind-cut-Prop
 ```
 
 ### The Dedekind real numbers
 
 ```agda
 ℝ : (l : Level) → UU (lsuc l)
-ℝ l = Σ (ℚ → Prop l) (λ L → Σ (ℚ → Prop l) (is-dedekind-cut L))
+ℝ l = Σ (subtype l ℚ) (λ L → Σ (subtype l ℚ) (is-dedekind-cut L))
 ```
 
-### ℝ is a set
+## Properties
+
+### The Dedekind real numbers form a set
 
 ```agda
 abstract
-
   is-set-ℝ : (l : Level) → is-set (ℝ l)
   is-set-ℝ l =
     is-set-Σ
@@ -106,3 +120,20 @@ abstract
 pr1 (ℝ-Set l) = ℝ l
 pr2 (ℝ-Set l) = is-set-ℝ l
 ```
+
+## References
+
+1. Section 11.2 of Univalent Foundations Project, _Homotopy Type Theory –
+   Univalent Foundations of Mathematics_ (2013)
+   ([website](https://homotopytypetheory.org/book/),
+   [arXiv:1308.0729](https://arxiv.org/abs/1308.0729))
+
+## External links
+
+- [DedekindReals.Type](https://www.cs.bham.ac.uk/~mhe/TypeTopology/DedekindReals.Type.html)
+  at TypeTopology
+- [Dedekind cut](https://ncatlab.org/nlab/show/Dedekind+cut) at $n$Lab
+- [Dedekind cut](https://en.wikipedia.org/wiki/Dedekind_cut) at Wikipedia
+- [Construction of the real numbers by Dedekind cuts](https://en.wikipedia.org/wiki/Construction_of_the_real_numbers#Construction_by_Dedekind_cuts)
+  at Wikipedia
+- [Dedekind cut](https://www.britannica.com/science/Dedekind-cut) at Britannica

--- a/src/real-numbers/dedekind-real-numbers.lagda.md
+++ b/src/real-numbers/dedekind-real-numbers.lagda.md
@@ -82,7 +82,7 @@ module _
                 ( λ r →
                   implication-Prop
                     ( le-ℚ-Prop q r)
-                    ( disj-Prop (L q) (U r)))))))
+                    ( disjunction-Prop (L q) (U r)))))))
 
   is-dedekind-cut : UU (l1 ⊔ l2)
   is-dedekind-cut = type-Prop is-dedekind-cut-Prop

--- a/src/ring-theory/local-rings.lagda.md
+++ b/src/ring-theory/local-rings.lagda.md
@@ -39,7 +39,7 @@ is-local-prop-Ring R =
         ( λ b →
           function-Prop
             ( is-invertible-element-Ring R (add-Ring R a b))
-            ( disj-Prop
+            ( disjunction-Prop
               ( is-invertible-element-prop-Ring R a)
               ( is-invertible-element-prop-Ring R b))))
 

--- a/src/synthetic-homotopy-theory/joins-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/joins-of-types.lagda.md
@@ -311,66 +311,69 @@ module _
   {l1 l2 : Level} (A : Prop l1) (B : Prop l2)
   where
 
-  cocone-disj : cocone pr1 pr2 (type-disj-Prop A B)
-  pr1 cocone-disj = inl-disj-Prop A B
-  pr1 (pr2 cocone-disj) = inr-disj-Prop A B
-  pr2 (pr2 cocone-disj) (a , b) =
+  cocone-disjunction : cocone pr1 pr2 (type-disjunction-Prop A B)
+  pr1 cocone-disjunction = inl-disjunction-Prop A B
+  pr1 (pr2 cocone-disjunction) = inr-disjunction-Prop A B
+  pr2 (pr2 cocone-disjunction) (a , b) =
     eq-is-prop'
-      ( is-prop-type-disj-Prop A B)
-      ( inl-disj-Prop A B a)
-      ( inr-disj-Prop A B b)
+      ( is-prop-type-disjunction-Prop A B)
+      ( inl-disjunction-Prop A B a)
+      ( inr-disjunction-Prop A B b)
 
-  map-disj-join-Prop : type-join-Prop A B → type-disj-Prop A B
-  map-disj-join-Prop =
-    cogap-join (type-disj-Prop A B) cocone-disj
+  map-disjunction-join-Prop : type-join-Prop A B → type-disjunction-Prop A B
+  map-disjunction-join-Prop =
+    cogap-join (type-disjunction-Prop A B) cocone-disjunction
 
-  map-join-disj-Prop : type-disj-Prop A B → type-join-Prop A B
-  map-join-disj-Prop =
-    elim-disj-Prop A B
+  map-join-disjunction-Prop : type-disjunction-Prop A B → type-join-Prop A B
+  map-join-disjunction-Prop =
+    elim-disjunction-Prop A B
       ( join-Prop A B)
       ( inl-join-Prop A B , inr-join-Prop A B)
 
-  is-equiv-map-disj-join-Prop : is-equiv map-disj-join-Prop
-  is-equiv-map-disj-join-Prop =
+  is-equiv-map-disjunction-join-Prop : is-equiv map-disjunction-join-Prop
+  is-equiv-map-disjunction-join-Prop =
     is-equiv-is-prop
       ( is-prop-type-join-Prop A B)
-      ( is-prop-type-disj-Prop A B)
-      ( map-join-disj-Prop)
+      ( is-prop-type-disjunction-Prop A B)
+      ( map-join-disjunction-Prop)
 
-  equiv-disj-join-Prop : (type-join-Prop A B) ≃ (type-disj-Prop A B)
-  pr1 equiv-disj-join-Prop = map-disj-join-Prop
-  pr2 equiv-disj-join-Prop = is-equiv-map-disj-join-Prop
+  equiv-disjunction-join-Prop :
+    (type-join-Prop A B) ≃ (type-disjunction-Prop A B)
+  pr1 equiv-disjunction-join-Prop = map-disjunction-join-Prop
+  pr2 equiv-disjunction-join-Prop = is-equiv-map-disjunction-join-Prop
 
-  is-equiv-map-join-disj-Prop : is-equiv map-join-disj-Prop
-  is-equiv-map-join-disj-Prop =
+  is-equiv-map-join-disjunction-Prop : is-equiv map-join-disjunction-Prop
+  is-equiv-map-join-disjunction-Prop =
     is-equiv-is-prop
-      ( is-prop-type-disj-Prop A B)
+      ( is-prop-type-disjunction-Prop A B)
       ( is-prop-type-join-Prop A B)
-      ( map-disj-join-Prop)
+      ( map-disjunction-join-Prop)
 
-  equiv-join-disj-Prop : (type-disj-Prop A B) ≃ (type-join-Prop A B)
-  pr1 equiv-join-disj-Prop = map-join-disj-Prop
-  pr2 equiv-join-disj-Prop = is-equiv-map-join-disj-Prop
+  equiv-join-disjunction-Prop :
+    (type-disjunction-Prop A B) ≃ (type-join-Prop A B)
+  pr1 equiv-join-disjunction-Prop = map-join-disjunction-Prop
+  pr2 equiv-join-disjunction-Prop = is-equiv-map-join-disjunction-Prop
 
-  up-join-disj : {l : Level} → universal-property-pushout l pr1 pr2 cocone-disj
-  up-join-disj =
+  up-join-disjunction :
+    {l : Level} → universal-property-pushout l pr1 pr2 cocone-disjunction
+  up-join-disjunction =
     up-pushout-up-pushout-is-equiv
       ( pr1)
       ( pr2)
       ( cocone-join)
-      ( cocone-disj)
-      ( map-disj-join-Prop)
-      ( ( λ _ → eq-is-prop (is-prop-type-disj-Prop A B)) ,
-        ( λ _ → eq-is-prop (is-prop-type-disj-Prop A B)) ,
+      ( cocone-disjunction)
+      ( map-disjunction-join-Prop)
+      ( ( λ _ → eq-is-prop (is-prop-type-disjunction-Prop A B)) ,
+        ( λ _ → eq-is-prop (is-prop-type-disjunction-Prop A B)) ,
         ( λ (a , b) → eq-is-contr
-          ( is-prop-type-disj-Prop A B
+          ( is-prop-type-disjunction-Prop A B
             ( horizontal-map-cocone pr1 pr2
               ( cocone-map pr1 pr2
                 ( cocone-join)
-                ( map-disj-join-Prop))
+                ( map-disjunction-join-Prop))
               ( a))
-            ( vertical-map-cocone pr1 pr2 cocone-disj b))))
-      ( is-equiv-map-disj-join-Prop)
+            ( vertical-map-cocone pr1 pr2 cocone-disjunction b))))
+      ( is-equiv-map-disjunction-join-Prop)
       ( up-join)
 ```
 


### PR DESCRIPTION
Arising from a discussion on the Discord earlier today, here are some mild refactors.

- [x] Touch up file about Dedekind reals
- [x] Rename `disj` to `disjunction` (disambiguates from `disjoint`)
- [x] Rename `conj` to `conjunction` (disambiguates from `conjugation`)
- [x] Introduce `_⇒_` notation for `type-implication-Prop`. This is consistent with the already-established `_⇔_`