### PR TITLE
Bump Agda max heap limit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,12 @@
 everythingOpts := --guardedness --cohesion --flat-split
 # use "$ export AGDAVERBOSE=-v20" if you want to see all
 AGDAVERBOSE ?= -v1
+AGDARTS := +RTS -M4.0G -RTS
 AGDAFILES := $(shell find src -name temp -prune -o -type f \( -name "*.lagda.md" -not -name "everything.lagda.md" \) -print)
 CONTRIBUTORS_FILE := CONTRIBUTORS.toml
 
 AGDAHTMLFLAGS ?= --html --html-highlight=code --html-dir=docs --css=Agda.css --only-scope-checking
-AGDA ?= agda $(AGDAVERBOSE)
+AGDA ?= agda $(AGDAVERBOSE) $(AGDARTS)
 TIME ?= time
 
 METAFILES := \


### PR DESCRIPTION
By default, Agda has a hard limit on memory usage at 3.5 GB; this bumps it to 4.0 (which is also used by e.g. agda-stdlib).

Since the CI is mostly passing, and only sometimes runs out of memory, the extra 500 MB should be enough for now.