### PR TITLE
Respect agda flags set in the Makefile during CI builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,12 +25,6 @@ concurrency:
   group: '${{ github.workflow }}-${{ github.head_ref || github.run_id }}'
   cancel-in-progress: true
 
-env:
-  AGDAHTMLFLAGS:
-    --only-scope-checking --html --html-highlight=code --html-dir=docs
-    --css=docs/Agda.css
-  AGDA: agda
-
 jobs:
   typecheck:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -17,11 +17,6 @@ concurrency:
   group: '${{ github.workflow }}-${{ github.head_ref || github.run_id }}'
   cancel-in-progress: true
 
-env:
-  AGDAHTMLFLAGS:
-    --html --html-highlight=auto --html-dir=docs --only-scope-checking
-    --css=Agda.css
-  AGDA: agda
 jobs:
   website:
     runs-on: macOS-latest

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,15 @@ AGDARTS := +RTS -M4.0G -RTS
 AGDAFILES := $(shell find src -name temp -prune -o -type f \( -name "*.lagda.md" -not -name "everything.lagda.md" \) -print)
 CONTRIBUTORS_FILE := CONTRIBUTORS.toml
 
-AGDAHTMLFLAGS ?= --html --html-highlight=code --html-dir=docs --css=Agda.css --only-scope-checking
+# All our code is in literate Agda, so we could set highlight=code and drop the
+# css flag, which only affects how files with the .agda extension are processed.
+# However, the HTML backend also processes referenced library files
+# (Agda.Primitive at the time of writing), which is a pure Agda file, and
+# setting higlight=code would make it not recognized as code at all, so the
+# resulting page looks garbled. With highlight=auto and the default Agda.css, it
+# at is at least in a proper code block with syntax highlighting, albeit without
+# the agda-unimath chrome.
+AGDAHTMLFLAGS ?= --html --html-highlight=auto --html-dir=docs --css=website/css/Agda.css --only-scope-checking
 AGDA ?= agda $(AGDAVERBOSE) $(AGDARTS)
 TIME ?= time
 


### PR DESCRIPTION
Arguments to the `agda` command were overridden in the CI configs, so the recent bump of available memory had no effect.