### PR TITLE
Make type argument explicit for `terminal-map`

### DIFF
--- a/src/foundation/dependent-towers.lagda.md
+++ b/src/foundation/dependent-towers.lagda.md
@@ -145,7 +145,8 @@ left-shift-dependent-tower :
   dependent-tower l2 A → dependent-tower l2 (left-shift-tower A)
 pr1 (left-shift-dependent-tower {l2 = l2} B) zero-ℕ x = raise-unit l2
 pr1 (left-shift-dependent-tower B) (succ-ℕ n) = family-dependent-tower B n
-pr2 (left-shift-dependent-tower B) zero-ℕ _ = raise-terminal-map
+pr2 (left-shift-dependent-tower B) zero-ℕ x =
+  raise-terminal-map (family-dependent-tower (left-shift-dependent-tower B) 1 x)
 pr2 (left-shift-dependent-tower B) (succ-ℕ n) = map-dependent-tower B n
 ```
 

--- a/src/foundation/discrete-relaxed-sigma-decompositions.lagda.md
+++ b/src/foundation/discrete-relaxed-sigma-decompositions.lagda.md
@@ -85,10 +85,11 @@ module _
       ( right-unit-law-Σ-is-contr is-discrete ∘e
         matching-correspondence-Relaxed-Σ-Decomposition D))
   pr1 (pr2 equiv-discrete-is-discrete-Relaxed-Σ-Decomposition) x =
-    ( map-equiv (compute-raise-unit l4) ∘ terminal-map ,
+    ( map-equiv (compute-raise-unit l4) ∘
+      terminal-map (cotype-Relaxed-Σ-Decomposition D x) ,
       is-equiv-comp
         ( map-equiv (compute-raise-unit l4))
-        ( terminal-map)
+        ( terminal-map (cotype-Relaxed-Σ-Decomposition D x))
         ( is-equiv-terminal-map-is-contr (is-discrete x))
         ( is-equiv-map-equiv ( compute-raise-unit l4)))
   pr2 (pr2 equiv-discrete-is-discrete-Relaxed-Σ-Decomposition) a =

--- a/src/foundation/discrete-sigma-decompositions.lagda.md
+++ b/src/foundation/discrete-sigma-decompositions.lagda.md
@@ -87,10 +87,11 @@ module _
       ( right-unit-law-Σ-is-contr is-discrete ∘e
         matching-correspondence-Σ-Decomposition D))
   pr1 (pr2 equiv-discrete-is-discrete-Σ-Decomposition) x =
-    ( map-equiv (compute-raise-unit l4) ∘ terminal-map ,
+    ( map-equiv (compute-raise-unit l4) ∘
+      terminal-map (cotype-Σ-Decomposition D x) ,
       is-equiv-comp
         ( map-equiv (compute-raise-unit l4))
-        ( terminal-map)
+        ( terminal-map (cotype-Σ-Decomposition D x))
         ( is-equiv-terminal-map-is-contr (is-discrete x))
         ( is-equiv-map-equiv ( compute-raise-unit l4)))
   pr2 (pr2 equiv-discrete-is-discrete-Σ-Decomposition) a =

--- a/src/foundation/fiber-inclusions.lagda.md
+++ b/src/foundation/fiber-inclusions.lagda.md
@@ -146,7 +146,7 @@ module _
 
   cone-fiber-fam : cone (pr1 {B = B}) (point a) (B a)
   pr1 cone-fiber-fam = fiber-inclusion B a
-  pr1 (pr2 cone-fiber-fam) = terminal-map
+  pr1 (pr2 cone-fiber-fam) = terminal-map (B a)
   pr2 (pr2 cone-fiber-fam) = refl-htpy
 
   abstract

--- a/src/foundation/fibers-of-maps.lagda.md
+++ b/src/foundation/fibers-of-maps.lagda.md
@@ -71,22 +71,22 @@ module _
   where
 
   equiv-fiber-terminal-map :
-    (u : unit) → fiber (terminal-map {A = A}) u ≃ A
+    (u : unit) → fiber (terminal-map A) u ≃ A
   equiv-fiber-terminal-map u =
     right-unit-law-Σ-is-contr
-      ( λ a → is-prop-is-contr is-contr-unit (terminal-map a) u)
+      ( λ a → is-prop-is-contr is-contr-unit (terminal-map A a) u)
 
   inv-equiv-fiber-terminal-map :
-    (u : unit) → A ≃ fiber (terminal-map {A = A}) u
+    (u : unit) → A ≃ fiber (terminal-map A) u
   inv-equiv-fiber-terminal-map u =
     inv-equiv (equiv-fiber-terminal-map u)
 
   equiv-fiber-terminal-map-star :
-    fiber (terminal-map {A = A}) star ≃ A
+    fiber (terminal-map A) star ≃ A
   equiv-fiber-terminal-map-star = equiv-fiber-terminal-map star
 
   inv-equiv-fiber-terminal-map-star :
-    A ≃ fiber (terminal-map {A = A}) star
+    A ≃ fiber (terminal-map A) star
   inv-equiv-fiber-terminal-map-star =
     inv-equiv equiv-fiber-terminal-map-star
 ```
@@ -99,13 +99,13 @@ module _
   where
 
   equiv-total-fiber-terminal-map :
-    Σ unit (fiber (terminal-map {A = A})) ≃ A
+    Σ unit (fiber (terminal-map A)) ≃ A
   equiv-total-fiber-terminal-map =
     ( left-unit-law-Σ-is-contr is-contr-unit star) ∘e
     ( equiv-tot equiv-fiber-terminal-map)
 
   inv-equiv-total-fiber-terminal-map :
-    A ≃ Σ unit (fiber (terminal-map {A = A}))
+    A ≃ Σ unit (fiber (terminal-map A))
   inv-equiv-total-fiber-terminal-map =
     inv-equiv equiv-total-fiber-terminal-map
 ```

--- a/src/foundation/functoriality-function-types.lagda.md
+++ b/src/foundation/functoriality-function-types.lagda.md
@@ -75,7 +75,7 @@ module _
     {l3 : Level} (A : UU l3) → is-trunc-map k (postcomp A f)
   is-trunc-map-postcomp-is-trunc-map is-trunc-f A =
     is-trunc-map-map-Π-is-trunc-map' k
-      ( const A unit star)
+      ( terminal-map A)
       ( const unit (X → Y) f)
       ( const unit (is-trunc-map k f) is-trunc-f)
 

--- a/src/foundation/sigma-decompositions.lagda.md
+++ b/src/foundation/sigma-decompositions.lagda.md
@@ -111,7 +111,7 @@ module _
     (is-inhabited (indexing-type-Σ-Decomposition)) → (is-inhabited A)
   is-inhabited-base-is-inhabited-indexing-type-Σ-Decomposition p =
     map-is-inhabited
-      (map-inv-equiv matching-correspondence-Σ-Decomposition)
+      ( map-inv-equiv matching-correspondence-Σ-Decomposition)
       ( is-inhabited-Σ p is-inhabited-cotype-Σ-Decomposition)
 ```
 

--- a/src/foundation/subterminal-types.lagda.md
+++ b/src/foundation/subterminal-types.lagda.md
@@ -34,7 +34,7 @@ module _
   where
 
   is-subterminal : UU l
-  is-subterminal = is-emb (terminal-map {A = A})
+  is-subterminal = is-emb (terminal-map A)
 ```
 
 ## Properties
@@ -68,7 +68,7 @@ module _
     is-prop-is-subterminal H x y =
       is-contr-is-equiv
         ( star ＝ star)
-        ( ap terminal-map)
+        ( ap (terminal-map A))
         ( H x y)
         ( is-prop-is-contr is-contr-unit star star)
 

--- a/src/foundation/towers.lagda.md
+++ b/src/foundation/towers.lagda.md
@@ -76,7 +76,8 @@ We can **left shift** a tower of types by padding it with the
 left-shift-tower : {l : Level} → tower l → tower l
 pr1 (left-shift-tower {l} A) zero-ℕ = raise-unit l
 pr1 (left-shift-tower A) (succ-ℕ n) = type-tower A n
-pr2 (left-shift-tower A) zero-ℕ = raise-terminal-map
+pr2 (left-shift-tower A) zero-ℕ =
+  raise-terminal-map (type-tower (left-shift-tower A) 1)
 pr2 (left-shift-tower A) (succ-ℕ n) = map-tower A n
 
 iterated-left-shift-tower : {l : Level} (n : ℕ) → tower l → tower l

--- a/src/foundation/trivial-relaxed-sigma-decompositions.lagda.md
+++ b/src/foundation/trivial-relaxed-sigma-decompositions.lagda.md
@@ -82,10 +82,11 @@ module _
   equiv-trivial-is-trivial-Relaxed-Σ-Decomposition :
     equiv-Relaxed-Σ-Decomposition D (trivial-Relaxed-Σ-Decomposition l4 A)
   pr1 equiv-trivial-is-trivial-Relaxed-Σ-Decomposition =
-    ( map-equiv (compute-raise-unit l4) ∘ terminal-map ,
+    ( map-equiv (compute-raise-unit l4) ∘
+      terminal-map (indexing-type-Relaxed-Σ-Decomposition D) ,
       is-equiv-comp
         ( map-equiv (compute-raise-unit l4))
-        ( terminal-map)
+        ( terminal-map (indexing-type-Relaxed-Σ-Decomposition D))
         ( is-equiv-terminal-map-is-contr is-trivial)
         ( is-equiv-map-equiv ( compute-raise-unit l4)))
   pr1 (pr2 equiv-trivial-is-trivial-Relaxed-Σ-Decomposition) x =

--- a/src/foundation/trivial-sigma-decompositions.lagda.md
+++ b/src/foundation/trivial-sigma-decompositions.lagda.md
@@ -100,10 +100,11 @@ module _
         ( A)
         ( is-inhabited-base-type-is-trivial-Σ-Decomposition))
   pr1 equiv-trivial-is-trivial-Σ-Decomposition =
-    ( map-equiv (compute-raise-unit l4) ∘ terminal-map ,
+    ( map-equiv (compute-raise-unit l4) ∘
+      terminal-map (indexing-type-Σ-Decomposition D) ,
       is-equiv-comp
         ( map-equiv (compute-raise-unit l4))
-        ( terminal-map)
+        ( terminal-map (indexing-type-Σ-Decomposition D))
         ( is-equiv-terminal-map-is-contr is-trivial)
         ( is-equiv-map-equiv ( compute-raise-unit l4)))
   pr1 (pr2 equiv-trivial-is-trivial-Σ-Decomposition) =

--- a/src/foundation/type-arithmetic-dependent-function-types.lagda.md
+++ b/src/foundation/type-arithmetic-dependent-function-types.lagda.md
@@ -36,7 +36,7 @@ module _
     ( left-unit-law-Π ( λ _ → B a)) ∘e
     ( equiv-Π
       ( λ _ → B a)
-      ( terminal-map , is-equiv-terminal-map-is-contr C)
+      ( terminal-map A , is-equiv-terminal-map-is-contr C)
       ( λ a → equiv-eq (ap B ( eq-is-contr C))))
 ```
 

--- a/src/foundation/unit-type.lagda.md
+++ b/src/foundation/unit-type.lagda.md
@@ -49,7 +49,7 @@ ind-unit p star = p
 
 ```agda
 module _
-  {l : Level} {A : UU l}
+  {l : Level} (A : UU l)
   where
 
   terminal-map : A → unit
@@ -76,8 +76,8 @@ raise-unit l = raise l unit
 raise-star : {l : Level} → raise l unit
 raise-star = map-raise star
 
-raise-terminal-map : {l1 l2 : Level} {A : UU l1} → A → raise-unit l2
-raise-terminal-map {l2 = l2} = const _ (raise-unit l2) raise-star
+raise-terminal-map : {l1 l2 : Level} (A : UU l1) → A → raise-unit l2
+raise-terminal-map {l2 = l2} A = const A (raise-unit l2) raise-star
 
 compute-raise-unit : (l : Level) → unit ≃ raise-unit l
 compute-raise-unit l = compute-raise l unit
@@ -103,18 +103,18 @@ module _
 
   abstract
     is-equiv-terminal-map-is-contr :
-      is-contr A → is-equiv (terminal-map {A = A})
+      is-contr A → is-equiv (terminal-map A)
     pr1 (pr1 (is-equiv-terminal-map-is-contr H)) = ind-unit (center H)
     pr2 (pr1 (is-equiv-terminal-map-is-contr H)) = ind-unit refl
     pr1 (pr2 (is-equiv-terminal-map-is-contr H)) x = center H
     pr2 (pr2 (is-equiv-terminal-map-is-contr H)) = contraction H
 
   equiv-unit-is-contr : is-contr A → A ≃ unit
-  pr1 (equiv-unit-is-contr H) = terminal-map
+  pr1 (equiv-unit-is-contr H) = terminal-map A
   pr2 (equiv-unit-is-contr H) = is-equiv-terminal-map-is-contr H
 
   abstract
-    is-contr-is-equiv-const : is-equiv (terminal-map {A = A}) → is-contr A
+    is-contr-is-equiv-const : is-equiv (terminal-map A) → is-contr A
     pr1 (is-contr-is-equiv-const ((g , G) , (h , H))) = h star
     pr2 (is-contr-is-equiv-const ((g , G) , (h , H))) = H
 ```

--- a/src/foundation/universal-property-cartesian-product-types.lagda.md
+++ b/src/foundation/universal-property-cartesian-product-types.lagda.md
@@ -65,7 +65,7 @@ module _
   {l1 l2 : Level} (A : UU l1) (B : UU l2)
   where
 
-  cone-prod : cone (const A unit star) (const B unit star) (A × B)
+  cone-prod : cone (terminal-map A) (terminal-map B) (A × B)
   pr1 cone-prod = pr1
   pr1 (pr2 cone-prod) = pr2
   pr2 (pr2 cone-prod) = refl-htpy
@@ -74,11 +74,11 @@ module _
 Cartesian products are a special case of pullbacks.
 
 ```agda
-  gap-prod : A × B → standard-pullback (const A unit star) (const B unit star)
-  gap-prod = gap (const A unit star) (const B unit star) cone-prod
+  gap-prod : A × B → standard-pullback (terminal-map A) (terminal-map B)
+  gap-prod = gap (terminal-map A) (terminal-map B) cone-prod
 
   inv-gap-prod :
-    standard-pullback (const A unit star) (const B unit star) → A × B
+    standard-pullback (terminal-map A) (terminal-map B) → A × B
   pr1 (inv-gap-prod (pair a (pair b p))) = a
   pr2 (inv-gap-prod (pair a (pair b p))) = b
 
@@ -86,8 +86,8 @@ Cartesian products are a special case of pullbacks.
     is-section-inv-gap-prod : (gap-prod ∘ inv-gap-prod) ~ id
     is-section-inv-gap-prod (pair a (pair b p)) =
       map-extensionality-standard-pullback
-        ( const A unit star)
-        ( const B unit star)
+        ( terminal-map A)
+        ( terminal-map B)
         ( refl)
         ( refl)
         ( eq-is-contr (is-prop-is-contr is-contr-unit star star))
@@ -98,7 +98,7 @@ Cartesian products are a special case of pullbacks.
 
   abstract
     is-pullback-prod :
-      is-pullback (const A unit star) (const B unit star) cone-prod
+      is-pullback (terminal-map A) (terminal-map B) cone-prod
     is-pullback-prod =
       is-equiv-is-invertible
         inv-gap-prod
@@ -112,13 +112,13 @@ We conclude that cartesian products satisfy the universal property of pullbacks.
   abstract
     universal-property-pullback-prod :
       universal-property-pullback
-        ( const A unit star)
-        ( const B unit star)
+        ( terminal-map A)
+        ( terminal-map B)
         ( cone-prod)
     universal-property-pullback-prod =
       universal-property-pullback-is-pullback
-        ( const A unit star)
-        ( const B unit star)
+        ( terminal-map A)
+        ( terminal-map B)
         ( cone-prod)
         ( is-pullback-prod)
 ```

--- a/src/foundation/universal-property-propositional-truncation.lagda.md
+++ b/src/foundation/universal-property-propositional-truncation.lagda.md
@@ -290,11 +290,11 @@ abstract
 abstract
   is-propositional-truncation-terminal-map :
     { l1 : Level} (A : UU l1) (a : A) →
-    is-propositional-truncation unit-Prop (terminal-map {A = A})
+    is-propositional-truncation unit-Prop (terminal-map A)
   is-propositional-truncation-terminal-map A a =
     is-propositional-truncation-has-section
       ( unit-Prop)
-      ( terminal-map)
+      ( terminal-map A)
       ( ind-unit a)
 ```
 

--- a/src/species/small-cauchy-composition-species-of-types-in-subuniverses.lagda.md
+++ b/src/species/small-cauchy-composition-species-of-types-in-subuniverses.lagda.md
@@ -202,7 +202,7 @@ module _
                   ( raise-unit l1)
                   ( X)
                   ( ( inv-equiv
-                        ( terminal-map , is-equiv-terminal-map-is-contr S)) ∘e
+                        ( terminal-map X , is-equiv-terminal-map-is-contr S)) ∘e
                     inv-equiv (compute-raise-unit l1)))
               ( C4) ,
             map-equiv-is-small (C5 X) S))

--- a/src/synthetic-homotopy-theory/0-acyclic-types.lagda.md
+++ b/src/synthetic-homotopy-theory/0-acyclic-types.lagda.md
@@ -66,7 +66,7 @@ module _
     map-trunc-Prop
       ( pr1)
       ( is-surjective-is-0-acyclic-map
-        ( terminal-map)
+        ( terminal-map A)
         ( is-truncated-acyclic-map-terminal-map-is-truncated-acyclic A ac)
         ( star))
 
@@ -74,10 +74,10 @@ module _
   is-0-acyclic-is-inhabited h =
     is-truncated-acyclic-is-truncated-acyclic-map-terminal-map A
       ( is-0-acyclic-map-is-surjective
-        ( terminal-map)
+        ( terminal-map A)
         ( λ u →
           map-trunc-Prop
-            (λ a → pair a (contraction is-contr-unit u))
+            (λ a → (a , (contraction is-contr-unit u)))
             ( h)))
 ```
 

--- a/src/synthetic-homotopy-theory/acyclic-maps.lagda.md
+++ b/src/synthetic-homotopy-theory/acyclic-maps.lagda.md
@@ -113,12 +113,12 @@ module _
   where
 
   is-acyclic-map-terminal-map-is-acyclic :
-    is-acyclic A → is-acyclic-map (terminal-map {A = A})
+    is-acyclic A → is-acyclic-map (terminal-map A)
   is-acyclic-map-terminal-map-is-acyclic ac u =
     is-acyclic-equiv (equiv-fiber-terminal-map u) ac
 
   is-acyclic-is-acyclic-map-terminal-map :
-    is-acyclic-map (terminal-map {A = A}) → is-acyclic A
+    is-acyclic-map (terminal-map A) → is-acyclic A
   is-acyclic-is-acyclic-map-terminal-map ac =
     is-acyclic-equiv inv-equiv-fiber-terminal-map-star (ac star)
 ```
@@ -143,9 +143,9 @@ module _
     {l' : Level} (X : UU l') → is-emb (const A X)
   is-emb-const-is-acyclic ac X =
     is-emb-comp
-      ( precomp terminal-map X)
+      ( precomp (terminal-map A) X)
       ( map-inv-left-unit-law-function-type X)
-      ( is-epimorphism-is-acyclic-map terminal-map
+      ( is-epimorphism-is-acyclic-map (terminal-map A)
         ( is-acyclic-map-terminal-map-is-acyclic A ac)
         ( X))
       ( is-emb-is-equiv (is-equiv-map-inv-left-unit-law-function-type X))
@@ -156,11 +156,11 @@ module _
   is-acyclic-is-emb-const e =
     is-acyclic-is-acyclic-map-terminal-map A
       ( is-acyclic-map-is-epimorphism
-        ( terminal-map)
+        ( terminal-map A)
         ( λ X →
           is-emb-triangle-is-equiv'
             ( const A X)
-            ( precomp terminal-map X)
+            ( precomp (terminal-map A) X)
             ( map-inv-left-unit-law-function-type X)
             ( refl-htpy)
             ( is-equiv-map-inv-left-unit-law-function-type X)
@@ -468,7 +468,7 @@ module _
     is-acyclic-is-acyclic-map-terminal-map
       ( Σ A B)
       ( is-acyclic-map-comp
-        ( terminal-map)
+        ( terminal-map A)
         ( pr1)
         ( is-acyclic-map-terminal-map-is-acyclic A ac-A)
         ( λ a → is-acyclic-equiv (equiv-fiber-pr1 B a) (ac-B a)))
@@ -487,12 +487,12 @@ module _
     is-acyclic-is-acyclic-map-terminal-map
       ( A × B)
       ( is-acyclic-map-comp
-        ( terminal-map)
+        ( terminal-map B)
         ( pr2)
         ( is-acyclic-map-terminal-map-is-acyclic B ac-B)
         ( is-acyclic-map-horizontal-map-cone-is-pullback
-          ( terminal-map)
-          ( terminal-map)
+          ( terminal-map A)
+          ( terminal-map B)
           ( cone-prod A B)
           ( is-pullback-prod A B)
           ( is-acyclic-map-terminal-map-is-acyclic A ac-A)))
@@ -515,7 +515,7 @@ module _
       ( λ a →
         is-acyclic-is-acyclic-map-terminal-map A
           ( is-acyclic-map-left-factor
-            ( terminal-map)
+            ( terminal-map A)
             ( point a)
             ( is-acyclic-map-terminal-map-is-acyclic unit is-acyclic-unit)
             ( λ b → is-acyclic-equiv (fiber-const a b) (l-ac a b))))

--- a/src/synthetic-homotopy-theory/codiagonals-of-maps.lagda.md
+++ b/src/synthetic-homotopy-theory/codiagonals-of-maps.lagda.md
@@ -88,8 +88,13 @@ module _
 
   universal-property-suspension-cocone-fiber :
     {l : Level} →
-    Σ ( cocone terminal-map terminal-map (fiber (codiagonal-map f) b))
-      ( universal-property-pushout l terminal-map terminal-map)
+    Σ ( cocone
+        ( terminal-map (fiber f b))
+        ( terminal-map (fiber f b))
+        ( fiber (codiagonal-map f) b))
+      ( universal-property-pushout l
+        ( terminal-map (fiber f b))
+        ( terminal-map (fiber f b)))
   universal-property-suspension-cocone-fiber =
     universal-property-pushout-cogap-fiber-up-to-equiv f f
       ( cocone-codiagonal-map f)
@@ -98,14 +103,14 @@ module _
       ( unit)
       ( unit)
       ( inv-equiv
-        ( terminal-map ,
+        ( terminal-map (fiber id b) ,
         ( is-equiv-terminal-map-is-contr (is-torsorial-path' b))))
       ( inv-equiv
-        ( terminal-map ,
+        ( terminal-map (fiber id b) ,
           ( is-equiv-terminal-map-is-contr (is-torsorial-path' b))))
       ( id-equiv)
-      ( terminal-map)
-      ( terminal-map)
+      ( terminal-map (fiber f b))
+      ( terminal-map (fiber f b))
       ( λ _ → eq-is-contr (is-torsorial-path' b))
       ( λ _ → eq-is-contr (is-torsorial-path' b))
 
@@ -117,8 +122,8 @@ module _
   universal-property-suspension-fiber :
     {l : Level} →
     universal-property-pushout l
-      ( terminal-map)
-      ( terminal-map)
+      ( terminal-map (fiber f b))
+      ( terminal-map (fiber f b))
       ( suspension-cocone-fiber)
   universal-property-suspension-fiber =
     pr2 universal-property-suspension-cocone-fiber
@@ -126,24 +131,24 @@ module _
   fiber-codiagonal-map-suspension-fiber :
     suspension (fiber f b) → fiber (codiagonal-map f) b
   fiber-codiagonal-map-suspension-fiber =
-    cogap terminal-map terminal-map suspension-cocone-fiber
+    cogap-suspension' suspension-cocone-fiber
 
   is-equiv-fiber-codiagonal-map-suspension-fiber :
     is-equiv fiber-codiagonal-map-suspension-fiber
   is-equiv-fiber-codiagonal-map-suspension-fiber =
     is-equiv-up-pushout-up-pushout
-      ( terminal-map)
-      ( terminal-map)
-      ( cocone-pushout terminal-map terminal-map)
+      ( terminal-map (fiber f b))
+      ( terminal-map (fiber f b))
+      ( cocone-suspension (fiber f b))
       ( suspension-cocone-fiber)
-      ( cogap terminal-map terminal-map (suspension-cocone-fiber))
+      ( cogap-suspension' (suspension-cocone-fiber))
       ( htpy-cocone-map-universal-property-pushout
-        ( terminal-map)
-        ( terminal-map)
-        ( cocone-pushout terminal-map terminal-map)
-        ( up-pushout terminal-map terminal-map)
+        ( terminal-map (fiber f b))
+        ( terminal-map (fiber f b))
+        ( cocone-suspension (fiber f b))
+        ( up-suspension' (fiber f b))
         ( suspension-cocone-fiber))
-      ( up-pushout terminal-map terminal-map)
+      ( up-suspension' (fiber f b))
       ( universal-property-suspension-fiber)
 
   equiv-fiber-codiagonal-map-suspension-fiber :

--- a/src/synthetic-homotopy-theory/cofibers.lagda.md
+++ b/src/synthetic-homotopy-theory/cofibers.lagda.md
@@ -38,11 +38,11 @@ module _
   where
 
   cofiber : (A → B) → UU (l1 ⊔ l2)
-  cofiber f = pushout f (const A unit star)
+  cofiber f = pushout f (terminal-map A)
 
   cocone-cofiber :
-    (f : A → B) → cocone f (const A unit star) (cofiber f)
-  cocone-cofiber f = cocone-pushout f (const A unit star)
+    (f : A → B) → cocone f (terminal-map A) (cofiber f)
+  cocone-cofiber f = cocone-pushout f (terminal-map A)
 
   inl-cofiber : (f : A → B) → B → cofiber f
   inl-cofiber f = pr1 (cocone-cofiber f)
@@ -59,8 +59,8 @@ module _
 
   universal-property-cofiber :
     (f : A → B) {l : Level} →
-    universal-property-pushout l f (const A unit star) (cocone-cofiber f)
-  universal-property-cofiber f = up-pushout f (const A unit star)
+    universal-property-pushout l f (terminal-map A) (cocone-cofiber f)
+  universal-property-cofiber f = up-pushout f (terminal-map A)
 ```
 
 ## Properties
@@ -83,7 +83,7 @@ is-contr-cofiber-is-equiv {A = A} f is-equiv-f =
     ( pr1 (pr2 (cocone-cofiber f)))
     ( is-equiv-universal-property-pushout
       ( f)
-      ( const A unit star)
+      ( terminal-map A)
       ( cocone-cofiber f)
       ( is-equiv-f)
       ( universal-property-cofiber f))
@@ -98,8 +98,8 @@ is-equiv-inl-cofiber-point :
 is-equiv-inl-cofiber-point {B = B} b =
   is-equiv-universal-property-pushout'
     ( const unit B b)
-    ( const unit unit star)
-    ( cocone-pushout (const unit B b) (const unit unit star))
-    ( is-equiv-is-contr (const unit unit star) is-contr-unit is-contr-unit)
-    ( up-pushout (const unit B b) (const unit unit star))
+    ( terminal-map unit)
+    ( cocone-pushout (const unit B b) (terminal-map unit))
+    ( is-equiv-is-contr (terminal-map unit) is-contr-unit is-contr-unit)
+    ( up-pushout (const unit B b) (terminal-map unit))
 ```

--- a/src/synthetic-homotopy-theory/dependent-suspension-structures.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-suspension-structures.lagda.md
@@ -54,7 +54,7 @@ south : (t : unit) → P (g t)
 together with a family of dependent identifications
 
 ```text
-merid : (x : X) → dependent-identification P (h x) ((north ∘ (const X unit star)) x) (south ∘ (const X unit star) x)
+merid : (x : X) → dependent-identification P (h x) ((north ∘ (terminal-map X)) x) (south ∘ (terminal-map X) x)
 ```
 
 Using the [universal property of `unit`](foundation.unit-type.md) and the
@@ -91,8 +91,8 @@ module _
   dependent-suspension-cocone : UU (l1 ⊔ l3)
   dependent-suspension-cocone =
     dependent-cocone
-      ( const X unit star)
-      ( const X unit star)
+      ( terminal-map X)
+      ( terminal-map X)
       ( c)
       ( B)
 ```

--- a/src/synthetic-homotopy-theory/dependent-universal-property-suspensions.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-universal-property-suspensions.lagda.md
@@ -68,8 +68,8 @@ module _
     ( ( map-equiv
         ( equiv-dependent-suspension-structure-suspension-cocone s B)) ∘
       ( dependent-cocone-map
-        ( const X unit star)
-        ( const X unit star)
+        ( terminal-map X)
+        ( terminal-map X)
         ( suspension-cocone-suspension-structure s)
         ( B))) ~
     ( dependent-ev-suspension s B)

--- a/src/synthetic-homotopy-theory/premanifolds.lagda.md
+++ b/src/synthetic-homotopy-theory/premanifolds.lagda.md
@@ -78,7 +78,7 @@ module _
     (x : type-Premanifold) →
     coherence-square-maps
       ( inclusion-tangent-sphere-Premanifold x)
-      ( terminal-map)
+      ( terminal-map (type-tangent-sphere-Premanifold x))
       ( inclusion-complement-Premanifold x)
       ( point x)
   coherence-square-Premanifold x =
@@ -87,7 +87,7 @@ module _
   cocone-Premanifold :
     (x : type-Premanifold) →
     cocone
-      ( terminal-map)
+      ( terminal-map (type-tangent-sphere-Premanifold x))
       ( inclusion-tangent-sphere-Premanifold x)
       ( type-Premanifold)
   cocone-Premanifold x =
@@ -96,7 +96,7 @@ module _
   is-pushout-Premanifold :
     (x : type-Premanifold) →
     is-pushout
-      ( terminal-map)
+      ( terminal-map (type-tangent-sphere-Premanifold x))
       ( inclusion-tangent-sphere-Premanifold x)
       ( cocone-Premanifold x)
   is-pushout-Premanifold x =

--- a/src/synthetic-homotopy-theory/suspension-structures.lagda.md
+++ b/src/synthetic-homotopy-theory/suspension-structures.lagda.md
@@ -74,7 +74,7 @@ We call this type of structure `suspension-structure`.
 ```agda
 suspension-cocone :
   {l1 l2 : Level} (X : UU l1) (Y : UU l2) → UU (l1 ⊔ l2)
-suspension-cocone X Y = cocone (terminal-map {A = X}) (terminal-map {A = X}) Y
+suspension-cocone X Y = cocone (terminal-map X) (terminal-map X) Y
 ```
 
 ### Suspension structures on a type

--- a/src/synthetic-homotopy-theory/suspension-structures.lagda.md
+++ b/src/synthetic-homotopy-theory/suspension-structures.lagda.md
@@ -47,7 +47,7 @@ g : unit → Y
 and a homotopy
 
 ```text
-h : (x : X) → (f ∘ (const X unit star)) x ＝ (g ∘ (const X unit star)) x
+h : (x : X) → (f ∘ (terminal-map X)) x ＝ (g ∘ (terminal-map X)) x
 ```
 
 Using the

--- a/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
@@ -68,23 +68,23 @@ they star in the freudenthal suspension theorem and give us a definition of
 ```agda
 suspension :
   {l : Level} → UU l → UU l
-suspension X = pushout (terminal-map {A = X}) (terminal-map {A = X})
+suspension X = pushout (terminal-map X) (terminal-map X)
 
 north-suspension :
   {l : Level} {X : UU l} → suspension X
 north-suspension {X = X} =
-  inl-pushout terminal-map terminal-map star
+  inl-pushout (terminal-map X) (terminal-map X) star
 
 south-suspension :
   {l : Level} {X : UU l} → suspension X
 south-suspension {X = X} =
-  inr-pushout terminal-map terminal-map star
+  inr-pushout (terminal-map X) (terminal-map X) star
 
 meridian-suspension :
   {l : Level} {X : UU l} → X →
   north-suspension {X = X} ＝ south-suspension {X = X}
 meridian-suspension {X = X} =
-  glue-pushout terminal-map terminal-map
+  glue-pushout (terminal-map X) (terminal-map X)
 
 suspension-structure-suspension :
   {l : Level} (X : UU l) → suspension-structure X (suspension X)
@@ -94,14 +94,22 @@ pr2 (pr2 (suspension-structure-suspension X)) = meridian-suspension
 
 cocone-suspension :
   {l : Level} (X : UU l) →
-  cocone terminal-map terminal-map (pushout terminal-map terminal-map)
+  cocone (terminal-map X) (terminal-map X) (suspension X)
 cocone-suspension X =
-  cocone-pushout (terminal-map {A = X}) (terminal-map {A = X})
+  cocone-pushout (terminal-map X) (terminal-map X)
 
 cogap-suspension' :
   {l1 l2 : Level} {X : UU l1} {Y : UU l2} →
-  cocone terminal-map terminal-map Y → pushout terminal-map terminal-map → Y
-cogap-suspension' {X = X} = cogap (terminal-map {A = X}) (terminal-map {A = X})
+  cocone (terminal-map X) (terminal-map X) Y → suspension X → Y
+cogap-suspension' {X = X} = cogap (terminal-map X) (terminal-map X)
+
+up-suspension' :
+  {l1 l2 : Level} (X : UU l1) →
+  universal-property-pushout l2
+    ( terminal-map X)
+    ( terminal-map X)
+    ( cocone-suspension X)
+up-suspension' X = up-pushout (terminal-map X) (terminal-map X)
 ```
 
 ### The cogap map of a suspension structure
@@ -147,7 +155,7 @@ module _
       ( cogap-suspension)
   is-section-cogap-suspension =
     ( suspension-structure-suspension-cocone) ·l
-    ( is-section-cogap terminal-map terminal-map) ·r
+    ( is-section-cogap (terminal-map X) (terminal-map X)) ·r
     ( suspension-cocone-suspension-structure)
 
   is-retraction-cogap-suspension :
@@ -155,7 +163,7 @@ module _
       ( ev-suspension (suspension-structure-suspension X) Z)
       ( cogap-suspension)
   is-retraction-cogap-suspension =
-    ( is-retraction-cogap terminal-map terminal-map)
+    ( is-retraction-cogap (terminal-map X) (terminal-map X))
 
 up-suspension :
   {l1 : Level} {X : UU l1} →
@@ -231,7 +239,7 @@ dup-suspension {X = X} B =
     ( ( equiv-dependent-suspension-structure-suspension-cocone
         ( suspension-structure-suspension X)
         ( B)) ∘e
-      ( equiv-dup-pushout terminal-map terminal-map B))
+      ( equiv-dup-pushout (terminal-map X) (terminal-map X) B))
     ( triangle-dependent-ev-suspension (suspension-structure-suspension X) B)
 
 equiv-dup-suspension :
@@ -515,15 +523,13 @@ is-contr-suspension-is-contr :
 is-contr-suspension-is-contr {l} {X} is-contr-X =
   is-contr-is-equiv'
     ( unit)
-    ( pr1 (pr2 (cocone-pushout terminal-map terminal-map)))
+    ( pr1 (pr2 (cocone-suspension X)))
     ( is-equiv-universal-property-pushout
-      ( terminal-map)
-      ( terminal-map)
-      ( cocone-pushout
-        ( terminal-map)
-        ( terminal-map))
-      ( is-equiv-is-contr terminal-map is-contr-X is-contr-unit)
-      ( up-pushout terminal-map terminal-map))
+      ( terminal-map X)
+      ( terminal-map X)
+      ( cocone-suspension X)
+      ( is-equiv-is-contr (terminal-map X) is-contr-X is-contr-unit)
+      ( up-suspension' X))
     ( is-contr-unit)
 ```
 
@@ -573,7 +579,8 @@ module _
         ( type-Truncated-Type Y))
       ( is-equiv-ev-suspension
         ( suspension-structure-suspension X)
-        ( up-pushout terminal-map terminal-map) (type-Truncated-Type Y))
+        ( up-suspension' X)
+        ( type-Truncated-Type Y))
       ( is-equiv-pr1-is-contr
         ( λ y →
           is-torsorial-fiber-Id

--- a/src/synthetic-homotopy-theory/tangent-spheres.lagda.md
+++ b/src/synthetic-homotopy-theory/tangent-spheres.lagda.md
@@ -71,10 +71,10 @@ module _
                 Σ ( C → X)
                   ( λ i →
                     Σ ( coherence-square-maps
-                          ( j)
-                          ( terminal-map (type-mere-sphere n T))
-                          ( i)
-                          ( point x))
+                        ( j)
+                        ( terminal-map (type-mere-sphere n T))
+                        ( i)
+                        ( point x))
                       ( λ H →
                         is-pushout
                           ( terminal-map (type-mere-sphere n T))

--- a/src/synthetic-homotopy-theory/tangent-spheres.lagda.md
+++ b/src/synthetic-homotopy-theory/tangent-spheres.lagda.md
@@ -70,9 +70,16 @@ module _
               ( λ j →
                 Σ ( C → X)
                   ( λ i →
-                    Σ ( coherence-square-maps j terminal-map i (point x))
+                    Σ ( coherence-square-maps
+                          ( j)
+                          ( terminal-map (type-mere-sphere n T))
+                          ( i)
+                          ( point x))
                       ( λ H →
-                        is-pushout terminal-map j (point x , i , H))))))
+                        is-pushout
+                          ( terminal-map (type-mere-sphere n T))
+                          ( j)
+                          ( point x , i , H))))))
 
 module _
   {l : Level} (n : ℕ) {X : UU l} {x : X} (T : has-tangent-sphere n x)
@@ -104,21 +111,24 @@ module _
   coherence-square-has-tangent-sphere :
     coherence-square-maps
       ( inclusion-tangent-sphere-has-tangent-sphere)
-      ( terminal-map)
+      ( terminal-map type-tangent-sphere-has-tangent-sphere)
       ( inclusion-complement-has-tangent-sphere)
       ( point x)
   coherence-square-has-tangent-sphere =
     pr1 (pr2 (pr2 (pr2 (pr2 T))))
 
   cocone-has-tangent-sphere :
-    cocone terminal-map inclusion-tangent-sphere-has-tangent-sphere X
+    cocone
+      ( terminal-map type-tangent-sphere-has-tangent-sphere)
+      ( inclusion-tangent-sphere-has-tangent-sphere)
+      ( X)
   pr1 cocone-has-tangent-sphere = point x
   pr1 (pr2 cocone-has-tangent-sphere) = inclusion-complement-has-tangent-sphere
   pr2 (pr2 cocone-has-tangent-sphere) = coherence-square-has-tangent-sphere
 
   is-pushout-has-tangent-sphere :
     is-pushout
-      ( terminal-map)
+      ( terminal-map type-tangent-sphere-has-tangent-sphere)
       ( inclusion-tangent-sphere-has-tangent-sphere)
       ( cocone-has-tangent-sphere)
   is-pushout-has-tangent-sphere =

--- a/src/synthetic-homotopy-theory/truncated-acyclic-maps.lagda.md
+++ b/src/synthetic-homotopy-theory/truncated-acyclic-maps.lagda.md
@@ -118,12 +118,12 @@ module _
 
   is-truncated-acyclic-map-terminal-map-is-truncated-acyclic :
     is-truncated-acyclic k A →
-    is-truncated-acyclic-map k (terminal-map {A = A})
+    is-truncated-acyclic-map k (terminal-map A)
   is-truncated-acyclic-map-terminal-map-is-truncated-acyclic ac u =
     is-truncated-acyclic-equiv (equiv-fiber-terminal-map u) ac
 
   is-truncated-acyclic-is-truncated-acyclic-map-terminal-map :
-    is-truncated-acyclic-map k (terminal-map {A = A}) →
+    is-truncated-acyclic-map k (terminal-map A) →
     is-truncated-acyclic k A
   is-truncated-acyclic-is-truncated-acyclic-map-terminal-map ac =
     is-truncated-acyclic-equiv inv-equiv-fiber-terminal-map-star (ac star)
@@ -150,9 +150,10 @@ module _
     is-emb (const A (type-Truncated-Type X))
   is-emb-const-is-truncated-acyclic-Truncated-Type ac X =
     is-emb-comp
-      ( precomp terminal-map (type-Truncated-Type X))
+      ( precomp (terminal-map A) (type-Truncated-Type X))
       ( map-inv-left-unit-law-function-type (type-Truncated-Type X))
-      ( is-epimorphism-is-truncated-acyclic-map-Truncated-Type terminal-map
+      ( is-epimorphism-is-truncated-acyclic-map-Truncated-Type
+        (terminal-map A)
         ( is-truncated-acyclic-map-terminal-map-is-truncated-acyclic A ac)
         ( X))
       ( is-emb-is-equiv
@@ -165,11 +166,11 @@ module _
   is-truncated-acyclic-is-emb-const-Truncated-Type e =
     is-truncated-acyclic-is-truncated-acyclic-map-terminal-map A
       ( is-truncated-acyclic-map-is-epimorphism-Truncated-Type
-        ( terminal-map)
+        ( terminal-map A)
         ( λ X →
           is-emb-triangle-is-equiv'
             ( const A (type-Truncated-Type X))
-            ( precomp terminal-map (type-Truncated-Type X))
+            ( precomp (terminal-map A) (type-Truncated-Type X))
             ( map-inv-left-unit-law-function-type (type-Truncated-Type X))
             ( refl-htpy)
             ( is-equiv-map-inv-left-unit-law-function-type
@@ -357,7 +358,7 @@ module _
   is-truncated-acyclic-succ-is-truncated-acyclic-succ-type-trunc ac =
     is-truncated-acyclic-is-truncated-acyclic-map-terminal-map A
       ( is-truncated-acyclic-map-comp
-        ( terminal-map)
+        ( terminal-map (type-trunc k A))
         ( unit-trunc)
         ( is-truncated-acyclic-map-terminal-map-is-truncated-acyclic
           ( type-trunc k A)
@@ -371,7 +372,7 @@ module _
     is-truncated-acyclic-is-truncated-acyclic-map-terminal-map
       ( type-trunc k A)
       ( is-truncated-acyclic-map-left-factor
-        ( terminal-map)
+        ( terminal-map (type-trunc k A))
         ( unit-trunc)
         ( is-truncated-acyclic-map-terminal-map-is-truncated-acyclic A ac)
         ( is-truncated-acyclic-map-succ-unit-trunc A))
@@ -441,7 +442,7 @@ module _
     is-truncated-acyclic-is-truncated-acyclic-map-terminal-map
       ( Σ A B)
       ( is-truncated-acyclic-map-comp
-        ( terminal-map)
+        ( terminal-map A)
         ( pr1)
         ( is-truncated-acyclic-map-terminal-map-is-truncated-acyclic A ac-A)
         ( λ a → is-truncated-acyclic-equiv (equiv-fiber-pr1 B a) (ac-B a)))
@@ -462,12 +463,12 @@ module _
     is-truncated-acyclic-is-truncated-acyclic-map-terminal-map
       ( A × B)
       ( is-truncated-acyclic-map-comp
-        ( terminal-map)
+        ( terminal-map B)
         ( pr2)
         ( is-truncated-acyclic-map-terminal-map-is-truncated-acyclic B ac-B)
         ( is-truncated-acyclic-map-horizontal-map-cone-is-pullback
-          ( terminal-map)
-          ( terminal-map)
+          ( terminal-map A)
+          ( terminal-map B)
           ( cone-prod A B)
           ( is-pullback-prod A B)
           ( is-truncated-acyclic-map-terminal-map-is-truncated-acyclic A ac-A)))
@@ -490,7 +491,7 @@ module _
       ( λ a →
         is-truncated-acyclic-is-truncated-acyclic-map-terminal-map A
           ( is-truncated-acyclic-map-left-factor
-            ( terminal-map)
+            ( terminal-map A)
             ( point a)
             ( is-truncated-acyclic-map-terminal-map-is-truncated-acyclic
               ( unit)

--- a/src/synthetic-homotopy-theory/universal-property-suspensions.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-suspensions.lagda.md
@@ -64,8 +64,8 @@ universal-property-pushout-suspension :
   (s : suspension-structure X Y) → UU (lsuc l ⊔ l1 ⊔ l2)
 universal-property-pushout-suspension l X Y s =
   universal-property-pushout l
-    ( const X unit star)
-    ( const X unit star)
+    ( terminal-map X)
+    ( terminal-map X)
     ( suspension-cocone-suspension-structure s)
 ```
 
@@ -78,8 +78,8 @@ triangle-ev-suspension :
   (Z : UU l3) →
   ( ( suspension-structure-suspension-cocone) ∘
     ( cocone-map
-      ( const X unit star)
-      ( const X unit star)
+      ( terminal-map X)
+      ( terminal-map X)
       ( suspension-cocone-suspension-structure s))) ~
   ( ev-suspension s Z)
 triangle-ev-suspension (N , S , merid) Z h = refl
@@ -94,8 +94,8 @@ is-equiv-ev-suspension {X = X} s up-Y Z =
     ( ev-suspension s Z)
     ( suspension-structure-suspension-cocone)
     ( cocone-map
-      ( const X unit star)
-      ( const X unit star)
+      ( terminal-map X)
+      ( terminal-map X)
       ( suspension-cocone-suspension-structure s))
     ( inv-htpy (triangle-ev-suspension s Z))
     ( up-Y Z)


### PR DESCRIPTION
Agda can't always infer the domain of `terminal-map`, and since we usually use `terminal-map` without evaluating it, I suggest we make the type argument explicit. This is in line with how we use `const`, `precomp`, and `postcomp`.