### PR TITLE
Extensions of types

### DIFF
--- a/src/foundation.lagda.md
+++ b/src/foundation.lagda.md
@@ -136,7 +136,7 @@ open import foundation.equivalences-maybe public
 open import foundation.exclusive-disjunction public
 open import foundation.existential-quantification public
 open import foundation.exponents-set-quotients public
-open import foundation.extensions-of-types public
+open import foundation.extensions-types public
 open import foundation.faithful-maps public
 open import foundation.families-of-equivalences public
 open import foundation.families-of-maps public

--- a/src/foundation.lagda.md
+++ b/src/foundation.lagda.md
@@ -136,6 +136,7 @@ open import foundation.equivalences-maybe public
 open import foundation.exclusive-disjunction public
 open import foundation.existential-quantification public
 open import foundation.exponents-set-quotients public
+open import foundation.extensions-of-types public
 open import foundation.faithful-maps public
 open import foundation.families-of-equivalences public
 open import foundation.families-of-maps public

--- a/src/foundation/extensions-of-types.lagda.md
+++ b/src/foundation/extensions-of-types.lagda.md
@@ -1,0 +1,39 @@
+# Extensions of types
+
+```agda
+module foundation.extensions-of-types where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.dependent-pair-types
+open import foundation.universe-levels
+```
+
+</details>
+
+## Idea
+
+Consider a type `X`. An {{#concept "extension" Disambiguation="type"}} of `X` is
+an object of the coslice category of `X`, i.e., it consists of a type `Y` and a
+map `f : X → Y`.
+
+## Definitions
+
+### Extensions of types
+
+```agda
+extension-type : {l1 : Level} (l2 : Level) (X : UU l1) → UU (l1 ⊔ lsuc l2)
+extension-type l2 X = Σ (UU l2) (λ Y → X → Y)
+
+module _
+  {l1 l2 : Level} {X : UU l1} (Y : extension-type l2 X)
+  where
+
+  type-extension-type : UU l2
+  type-extension-type = pr1 Y
+
+  inclusion-extension-type : X → type-extension-type
+  inclusion-extension-type = pr2 Y
+```

--- a/src/foundation/extensions-types.lagda.md
+++ b/src/foundation/extensions-types.lagda.md
@@ -17,7 +17,7 @@ open import foundation.universe-levels
 
 Consider a type `X`. An
 {{#concept "extension" Disambiguation="type" Agda=extension-type}} of `X` is an
-object of the coslice category of `X`, i.e., it consists of a type `Y` and a map
+object in the [coslice](foundation.coslice.md) under `X`, i.e., it consists of a type `Y` and a map
 `f : X → Y`.
 
 In the above definition of extensions of types our aim is to capture the most

--- a/src/foundation/extensions-types.lagda.md
+++ b/src/foundation/extensions-types.lagda.md
@@ -15,7 +15,7 @@ open import foundation.universe-levels
 
 ## Idea
 
-Consider a type `X`. An {{#concept "extension" Disambiguation="type"}} of `X` is
+Consider a type `X`. An {{#concept "extension" Disambiguation="type" Agda=extension-type}} of `X` is
 an object of the coslice category of `X`, i.e., it consists of a type `Y` and a
 map `f : X → Y`.
 

--- a/src/foundation/extensions-types.lagda.md
+++ b/src/foundation/extensions-types.lagda.md
@@ -1,7 +1,7 @@
 # Extensions of types
 
 ```agda
-module foundation.extensions-of-types where
+module foundation.extensions-types where
 ```
 
 <details><summary>Imports</summary>

--- a/src/foundation/extensions-types.lagda.md
+++ b/src/foundation/extensions-types.lagda.md
@@ -17,8 +17,8 @@ open import foundation.universe-levels
 
 Consider a type `X`. An
 {{#concept "extension" Disambiguation="type" Agda=extension-type}} of `X` is an
-object in the [coslice](foundation.coslice.md) under `X`, i.e., it consists of a type `Y` and a map
-`f : X → Y`.
+object in the [coslice](foundation.coslice.md) under `X`, i.e., it consists of a
+type `Y` and a map `f : X → Y`.
 
 In the above definition of extensions of types our aim is to capture the most
 general concept of what it means to be an extension of a type. Similarly, in any

--- a/src/foundation/extensions-types.lagda.md
+++ b/src/foundation/extensions-types.lagda.md
@@ -20,6 +20,14 @@ Consider a type `X`. An
 object of the coslice category of `X`, i.e., it consists of a type `Y` and a map
 `f : X → Y`.
 
+In the above definition of extensions of types our aim is to capture the most
+general concept of what it means to be an extension of a type. Similarly, in any
+[category](category-theory.categories.md) we would say that an extension of an
+object `X` consists of an object `Y` equipped with a morphism `f : X → Y`.
+
+Our notion of extensions of types are not to be confused with extension types of
+cubical or simplicial homotopy type theory.
+
 ## Definitions
 
 ### Extensions of types

--- a/src/foundation/extensions-types.lagda.md
+++ b/src/foundation/extensions-types.lagda.md
@@ -26,7 +26,8 @@ general concept of what it means to be an extension of a type. Similarly, in any
 object `X` consists of an object `Y` equipped with a morphism `f : X → Y`.
 
 Our notion of extensions of types are not to be confused with extension types of
-cubical or simplicial homotopy type theory.
+cubical type theory or
+[extension types of simplicial type theory](https://arxiv.org/abs/1705.07442).
 
 ## Definitions
 

--- a/src/foundation/extensions-types.lagda.md
+++ b/src/foundation/extensions-types.lagda.md
@@ -15,9 +15,10 @@ open import foundation.universe-levels
 
 ## Idea
 
-Consider a type `X`. An {{#concept "extension" Disambiguation="type" Agda=extension-type}} of `X` is
-an object of the coslice category of `X`, i.e., it consists of a type `Y` and a
-map `f : X → Y`.
+Consider a type `X`. An
+{{#concept "extension" Disambiguation="type" Agda=extension-type}} of `X` is an
+object of the coslice category of `X`, i.e., it consists of a type `Y` and a map
+`f : X → Y`.
 
 ## Definitions
 


### PR DESCRIPTION
This pull request proposes a definition for extension types, following the discussion in #885. I think this is a useful definition to have, and it could help easing off the load of definitions in `surjective-maps` by being able to separate it into their own concepts, such as `surjective-extensions-types` and friends.

This PR is intentionally kept small and is ready for review.