### PR TITLE
Render ASCII diagrams as SVGs using svgbob

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -84,6 +84,12 @@ jobs:
           crate: mdbook-catppuccin
           version: '1.2.0'
 
+      - name: Install mdbook-svgbob2
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: mdbook-svgbob2
+          version: '0.3.0'
+
       - uses: actions/setup-python@v4
         with:
           python-version: '3.8'

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -11,6 +11,7 @@
     "ms-python.vscode-pylance",
     "oderwat.indent-rainbow",
     "brunnerh.insert-unicode",
-    "editorconfig.editorconfig"
+    "editorconfig.editorconfig",
+    "tamasfe.even-better-toml"
   ]
 }

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,8 @@ install-website-dev:
 	@cargo install mdbook-katex@0.5.7
 	@cargo install mdbook-pagetoc@0.1.7
 	@cargo install mdbook-catppuccin@1.2.0
+	@cargo install mdbook-svgbob2@0.3.0
+
 
 .PHONY: unused-imports
 unused-imports:

--- a/book.toml
+++ b/book.toml
@@ -24,6 +24,23 @@ macros = "website/latex-macros.txt"
 [preprocessor.catppuccin]
 assets_version = "1.2.0" # DO NOT EDIT: Managed by `mdbook-catppuccin install`
 
+[preprocessor.svgbob2] # NOTE: Currently the default settings
+font_size = "14"
+font_family = "monospace"
+fill_color = "black"
+background = "transparent"
+stroke_color = "var(--fg)" # variable from the mdbook css files
+stroke_width = "2.0"
+scale = "8.0"
+enhance_circuitries = "true"
+include_backdrop = "true"
+include_styles = "true"
+include_defs = "true"
+merge_line_with_shapes = "false"
+
+# this is a non-svgbob custom setting
+font_color = "var(--fg)"
+
 [preprocessor.git-metadata]
 command = "python3 ./scripts/preprocessor_git_metadata.py"
 # Disable by default - it takes a non-trivial amount of time

--- a/book.toml
+++ b/book.toml
@@ -25,21 +25,21 @@ macros = "website/latex-macros.txt"
 assets_version = "1.2.0" # DO NOT EDIT: Managed by `mdbook-catppuccin install`
 
 [preprocessor.svgbob2] # NOTE: Currently the default settings
-font_size = "14"
-font_family = "monospace"
-fill_color = "black"
-background = "transparent"
-stroke_color = "var(--fg)" # variable from the mdbook css files
-stroke_width = "2.0"
-scale = "8.0"
-enhance_circuitries = "true"
-include_backdrop = "true"
-include_styles = "true"
-include_defs = "true"
-merge_line_with_shapes = "false"
+# font_size = "14"
+# font_family = "monospace"
+# fill_color = "black"
+# background = "transparent"
+# stroke_color = "var(--fg)" # variable from the mdbook css files
+# stroke_width = "2.0"
+# scale = "8.0"
+# enhance_circuitries = "true"
+# include_backdrop = "true"
+# include_styles = "true"
+# include_defs = "true"
+# merge_line_with_shapes = "false"
 
 # this is a non-svgbob custom setting
-font_color = "var(--fg)"
+# font_color = "var(--fg)"
 
 [preprocessor.git-metadata]
 command = "python3 ./scripts/preprocessor_git_metadata.py"

--- a/src/foundation-core/commuting-prisms-of-maps.lagda.md
+++ b/src/foundation-core/commuting-prisms-of-maps.lagda.md
@@ -21,7 +21,7 @@ open import foundation-core.whiskering-homotopies
 
 Consider an arrangment of maps composable into a diagram as follows:
 
-```text
+```svgbob
           hA
     A ---------> A'
     |\           |\
@@ -51,7 +51,7 @@ composite.
 
 We may also arrange the maps into a more vertical shape, like so:
 
-```text
+```svgbob
           B
       h  ^| \  g
        /  |   \

--- a/src/foundation/commuting-squares-of-maps.lagda.md
+++ b/src/foundation/commuting-squares-of-maps.lagda.md
@@ -36,7 +36,7 @@ open import foundation-core.identity-types
 
 Two [commuting triangles](foundation-core.commuting-triangles-of-maps.md)
 
-```text
+```svgbob
    A         A --> X
   | \         \    |
   |  \ H  L  K \   |
@@ -48,7 +48,7 @@ Two [commuting triangles](foundation-core.commuting-triangles-of-maps.md)
 with a [homotopic](foundation-core.homotopies.md) diagonal may be pasted into a
 commuting square
 
-```text
+```svgbob
   A -----> X
   |        |
   |        |

--- a/src/orthogonal-factorization-systems/lifting-squares.lagda.md
+++ b/src/orthogonal-factorization-systems/lifting-squares.lagda.md
@@ -43,7 +43,7 @@ A **lifting square** is a commuting square
 
 together with a diagonal map `j : X → B` such that the complete diagram
 
-```text
+```svgbob
        h
   A ------> B
   |       ^ |


### PR DESCRIPTION
This is a test PR to report my findings using `mdbook-svgbob2`. It is a simple wrapper for ASCII diagrams to render them as SVGs on the website. I have had some success so far, but I wouldn't say it is satisfactory yet. I will try it out a bit more and report some findings here.

This PR works towards resolving #641.

## Examples

### Success
The code
````text
```svgbob
          hA
    A ---------> A'
    |\           |\
    | \ h   ⇗    | \ h'
    |  \      f' |  \
    |   V        |   V
  f | ⇐ B ------ | -> B'
    |   /   hB   | ⇐ /
    |  / g       |  / g'
    | /     ⇗    | /
    VV           VV
    C ---------> C' ,
          hC
```
````

is rendered as
<img width="182" alt="image" src="https://github.com/UniMath/agda-unimath/assets/5176294/06ee7946-344b-4d55-8127-8f757b89ee86">

### Failure
The code
````text
```svgbob
          B
      h  ^| \  g
       /  |   \
     /  f | ⇑   V
    A ---------> C
    |     | hB   |
    | ⇗   V   ⇗  |
 hA |     B'     | hC
    | h' ^  \ g' |
    |  /  ⇑   \  |
    V/          VV
    A' --------> C' .
          f'
```
````
renders as
<img width="182" alt="image" src="https://github.com/UniMath/agda-unimath/assets/5176294/78d5a295-07fd-4137-9087-15fcde0f765f">

## Why use Svgbob
This option has a couple of benefits over possible alternatives:
1. It fails elegantly, meaning that ill-formatted ASCII diagrams will just display as ill-formatted SVGs, rather than causing errors.
2. The code is readable and intuitive.
3. It does not stray too far from our current approach, hopefully making the switch easy.

## Some references
- [Svgbob editor](https://ivanceras.github.io/svgbob-editor/)
- [Svgbob Specification](https://ivanceras.github.io/content/Svgbob/Specification.html)
- [`mdbook-svgbob2` on GitHub](https://github.com/matthiasbeyer/mdbook-svgbob2)