### PR TITLE
Reformatting commented blocks of code

### DIFF
--- a/src/elementary-number-theory/sums-of-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/sums-of-natural-numbers.lagda.md
@@ -110,8 +110,8 @@ abstract
 
 ### Each of the summands is less than or equal to the total sum
 
-```agda
--- leq-sum-Fin-ℕ :
---   {k : ℕ} (f : Fin k → ℕ) (x : Fin k) → leq-ℕ (f x) (sum-Fin-ℕ f)
--- leq-sum-Fin-ℕ {succ-ℕ k} f x = {!leq-add-ℕ!}
+```text
+leq-sum-Fin-ℕ :
+  {k : ℕ} (f : Fin k → ℕ) (x : Fin k) → leq-ℕ (f x) (sum-Fin-ℕ f)
+leq-sum-Fin-ℕ {succ-ℕ k} f x = {!leq-add-ℕ!}
 ```

--- a/src/finite-algebra/semisimple-commutative-finite-rings.lagda.md
+++ b/src/finite-algebra/semisimple-commutative-finite-rings.lagda.md
@@ -93,11 +93,4 @@ module _
   pr1 (compute-structure-semisimple-commutative-ring-𝔽 (p , s)) =
     compute-structure-commutative-ring-𝔽 X p
   pr2 (compute-structure-semisimple-commutative-ring-𝔽 (p , s)) = s
-
---   is-finite-structure-semisimple-commutative-ring-𝔽 :
---     is-finite structure-semisimple-commutative-ring-𝔽
---   is-finite-structure-semisimple-commutative-ring-𝔽 =
---     is-finite-Σ
---       ( is-finite-structure-commutative-ring-𝔽 X)
---       ( λ c → {!!})
 ```

--- a/src/finite-group-theory/groups-of-order-2.lagda.md
+++ b/src/finite-group-theory/groups-of-order-2.lagda.md
@@ -163,20 +163,20 @@ module _
     map-equiv equiv-Group-of-Order-2
 ```
 
-```agda
---   specified-hom-Group-of-Order-2 :
---     hom-Group (group-Group-of-Order-2 G) (group-Group-of-Order-2 H)
---   specified-hom-Group-of-Order-2 = {!!}
+```text
+  specified-hom-Group-of-Order-2 :
+    hom-Group (group-Group-of-Order-2 G) (group-Group-of-Order-2 H)
+  specified-hom-Group-of-Order-2 = {!!}
 ```
 
 ### The type of groups of order 2 is contractible
 
-```agda
--- is-contr-Group-of-Order-2 : (l : Level) → is-contr (Group-of-Order-2 l)
--- pr1 (is-contr-Group-of-Order-2 l) = symmetric-Group-of-Order-2 l
--- pr2 (is-contr-Group-of-Order-2 l) G =
---   eq-iso-Group-of-Order-2
---     ( symmetric-Group-of-Order-2 l)
---     ( G)
---     {!!}
+```text
+is-contr-Group-of-Order-2 : (l : Level) → is-contr (Group-of-Order-2 l)
+pr1 (is-contr-Group-of-Order-2 l) = symmetric-Group-of-Order-2 l
+pr2 (is-contr-Group-of-Order-2 l) G =
+  eq-iso-Group-of-Order-2
+    ( symmetric-Group-of-Order-2 l)
+    ( G)
+    {!!}
 ```

--- a/src/foundation/partitions.lagda.md
+++ b/src/foundation/partitions.lagda.md
@@ -671,23 +671,23 @@ pr2 (partition-Set-Indexed-Σ-Decomposition D) =
 
 #### The partition obtained from the set-indexed Σ-decomposition induced by a partition has the same blocks as the original partition
 
-```agda
--- module _
---   {l1 l2 l3 : Level} {A : UU l1} (P : partition (l1 ⊔ l2) l3 A)
---   where
+```text
+module _
+  {l1 l2 l3 : Level} {A : UU l1} (P : partition (l1 ⊔ l2) l3 A)
+  where
 
---   is-block-is-block-partition-set-indexed-Σ-decomposition-partition :
---     ( Q : inhabited-subtype (l1 ⊔ l2) A) →
---     is-block-partition
---       ( partition-Set-Indexed-Σ-Decomposition
---         ( set-indexed-Σ-decomposition-partition P))
---       ( Q) →
---     is-block-partition P Q
---   is-block-is-block-partition-set-indexed-Σ-decomposition-partition Q (i , H) =
---     apply-universal-property-trunc-Prop
---       ( is-inhabited-subtype-inhabited-subtype Q)
---       ( subtype-partition P Q)
---       ( λ (a , q) → {!  !})
+  is-block-is-block-partition-set-indexed-Σ-decomposition-partition :
+    ( Q : inhabited-subtype (l1 ⊔ l2) A) →
+    is-block-partition
+      ( partition-Set-Indexed-Σ-Decomposition
+        ( set-indexed-Σ-decomposition-partition P))
+      ( Q) →
+    is-block-partition P Q
+  is-block-is-block-partition-set-indexed-Σ-decomposition-partition Q (i , H) =
+    apply-universal-property-trunc-Prop
+      ( is-inhabited-subtype-inhabited-subtype Q)
+      ( subtype-partition P Q)
+      ( λ (a , q) → {!  !})
 
 {-  i : X  H : (x : A) → Q x ≃ (pr1 (inv-equiv
 (compute-total-block-partition P) x) ＝ i)  a : A  q : Q a
@@ -696,22 +696,22 @@ pr2 (partition-Set-Indexed-Σ-Decomposition D) =
 
  H' : (B : block)  -}
 
---   is-block-partition-set-indexed-Σ-decomposition-is-block-partition :
---     ( Q : inhabited-subtype (l1 ⊔ l2) A) →
---     is-block-partition P Q →
---     is-block-partition
---       ( partition-Set-Indexed-Σ-Decomposition
---         ( set-indexed-Σ-decomposition-partition P))
---       ( Q)
---   is-block-partition-set-indexed-Σ-decomposition-is-block-partition Q H = {!  !}
---
---   has-same-blocks-partition-set-indexed-Σ-decomposition-partition :
---     has-same-blocks-partition
---       ( partition-Set-Indexed-Σ-Decomposition
---         ( set-indexed-Σ-decomposition-partition P))
---       ( P)
---   pr1 (has-same-blocks-partition-set-indexed-Σ-decomposition-partition B) =
---     is-block-is-block-partition-set-indexed-Σ-decomposition-partition B
---   pr2 (has-same-blocks-partition-set-indexed-Σ-decomposition-partition B) =
---     is-block-partition-set-indexed-Σ-decomposition-is-block-partition B
+  is-block-partition-set-indexed-Σ-decomposition-is-block-partition :
+    ( Q : inhabited-subtype (l1 ⊔ l2) A) →
+    is-block-partition P Q →
+    is-block-partition
+      ( partition-Set-Indexed-Σ-Decomposition
+        ( set-indexed-Σ-decomposition-partition P))
+      ( Q)
+  is-block-partition-set-indexed-Σ-decomposition-is-block-partition Q H = {!  !}
+
+  has-same-blocks-partition-set-indexed-Σ-decomposition-partition :
+    has-same-blocks-partition
+      ( partition-Set-Indexed-Σ-Decomposition
+        ( set-indexed-Σ-decomposition-partition P))
+      ( P)
+  pr1 (has-same-blocks-partition-set-indexed-Σ-decomposition-partition B) =
+    is-block-is-block-partition-set-indexed-Σ-decomposition-partition B
+  pr2 (has-same-blocks-partition-set-indexed-Σ-decomposition-partition B) =
+    is-block-partition-set-indexed-Σ-decomposition-is-block-partition B
 ```

--- a/src/foundation/strongly-extensional-maps.lagda.md
+++ b/src/foundation/strongly-extensional-maps.lagda.md
@@ -36,11 +36,11 @@ strongly-extensional A B f =
 
 ## Properties
 
-```agda
--- is-strongly-extensional :
---   {l1 l2 l3 l4 : Level} (A : Type-With-Apartness l1 l2)
---   (B : Type-With-Apartness l3 l4) →
---   (f : type-Type-With-Apartness A → type-Type-With-Apartness B) →
---   strongly-extensional A B f
--- is-strongly-extensional A B f x y H = {!!}
+```text
+is-strongly-extensional :
+  {l1 l2 l3 l4 : Level} (A : Type-With-Apartness l1 l2)
+  (B : Type-With-Apartness l3 l4) →
+  (f : type-Type-With-Apartness A → type-Type-With-Apartness B) →
+  strongly-extensional A B f
+is-strongly-extensional A B f x y H = {!!}
 ```

--- a/src/group-theory/category-of-concrete-groups.lagda.md
+++ b/src/group-theory/category-of-concrete-groups.lagda.md
@@ -16,8 +16,8 @@ module group-theory.category-of-concrete-groups where
 
 ### The category of concrete groups
 
-```agda
--- is-category-Concrete-Group-Large-Precategory :
---   is-large-category-Large-Precategory Concrete-Group-Large-Precategory
---   is-category-Concrete-Group-Large-Precategory = {!!}
+```text
+is-category-Concrete-Group-Large-Precategory :
+  is-large-category-Large-Precategory Concrete-Group-Large-Precategory
+  is-category-Concrete-Group-Large-Precategory = {!!}
 ```

--- a/src/lists/lists-discrete-types.lagda.md
+++ b/src/lists/lists-discrete-types.lagda.md
@@ -120,8 +120,5 @@ is-nil-union-is-nil-list d nil l' p = (refl , p)
 is-nil-union-is-nil-list d (cons x l) l' p with (elem-list d x l') in q
 ... | true =
   ex-falso (is-nonnil-elem-list d x l' q p)
-    -- ( is-nonnil-elem-list d x l' q
-    --   (pr2 (is-nil-union-is-nil-list d l l' p)))
 ... | false = ex-falso (is-nonnil-cons-list x l' p)
-    -- (is-nonnil-cons-list x (union-list d l l') p)
 ```

--- a/src/species/hasse-weil-species.lagda.md
+++ b/src/species/hasse-weil-species.lagda.md
@@ -37,7 +37,9 @@ is-closed-under-products-function-from-Commutative-Ring-𝔽 :
 is-closed-under-products-function-from-Commutative-Ring-𝔽 {l1} {l2} S =
   (R1 R2 : Commutative-Ring-𝔽 l1) →
   type-𝔽 (S (prod-Commutative-Ring-𝔽 R1 R2)) ≃ (type-𝔽 (S R1) × type-𝔽 (S R2))
+```
 
+```text
 module _
   {l1 l2 : Level}
   (l3 l4 : Level)
@@ -45,16 +47,16 @@ module _
   (C : is-closed-under-products-function-from-Commutative-Ring-𝔽 S)
   where
 
---   hasse-weil-species-Inhabited-𝔽 :
---     species-Inhabited-𝔽 l1 (l1 ⊔ l2 ⊔ lsuc l3 ⊔ lsuc l4)
---   hasse-weil-species-Inhabited-𝔽 ( k , (f , i)) =
---     Σ-𝔽 {!!}
---         ( λ p →
---           S
---             ( commutative-finite-ring-Semisimple-Commutative-Ring-𝔽
---               ( compute-structure-semisimple-commutative-ring-𝔽
---                 ( l3)
---                 ( l4)
---                 ( k , f)
---                 ( p))))
+  hasse-weil-species-Inhabited-𝔽 :
+    species-Inhabited-𝔽 l1 (l1 ⊔ l2 ⊔ lsuc l3 ⊔ lsuc l4)
+  hasse-weil-species-Inhabited-𝔽 ( k , (f , i)) =
+    Σ-𝔽 {!!}
+        ( λ p →
+          S
+            ( commutative-finite-ring-Semisimple-Commutative-Ring-𝔽
+              ( compute-structure-semisimple-commutative-ring-𝔽
+                ( l3)
+                ( l4)
+                ( k , f)
+                ( p))))
 ```

--- a/src/synthetic-homotopy-theory/infinite-cyclic-types.lagda.md
+++ b/src/synthetic-homotopy-theory/infinite-cyclic-types.lagda.md
@@ -206,11 +206,6 @@ module _
     ( extensionality-Infinite-Cyclic-Type
         ℤ-Infinite-Cyclic-Type
         ℤ-Infinite-Cyclic-Type)
-
--- Infinite-Cyclic-Type-𝕊¹ : 𝕊¹ → Infinite-Cyclic-Type
--- pr1 (pr1 (Infinite-Cyclic-Type-𝕊¹ x)) = Id x x
--- pr2 (pr1 (Infinite-Cyclic-Type-𝕊¹ x)) = {!!}
--- pr2 (Infinite-Cyclic-Type-𝕊¹ x) = {!!}
 ```
 
 ## See also

--- a/src/trees/undirected-trees.lagda.md
+++ b/src/trees/undirected-trees.lagda.md
@@ -365,47 +365,47 @@ has-decidable-equality-node-Undirected-Tree T x y =
 
 ### Any trail in a tree is a path
 
-```agda
--- module _
---   {l1 l2 : Level} (T : Tree l1 l2)
---   where
+```text
+module _
+  {l1 l2 : Level} (T : Tree l1 l2)
+  where
 
---   is-path-is-trail-walk-Undirected-Tree :
---     {x y : node-Undirected-Tree T} (w : walk-Undirected-Tree T x y) →
---     is-trail-walk-Undirected-Tree T w → is-path-walk-Undirected-Tree T w
---   is-path-is-trail-walk-Undirected-Tree {x} {y} w H {pair u KU} {pair v K} p with
---     is-vertex-on-first-or-second-segment-walk-Undirected-Graph
---       (undirected-graph-Undirected-Tree T) w (pair u KU) (pair v K)
---   ... | inl L = {!!}
---     where
---     w1' : walk-Undirected-Tree T x u
---     w1' =
---       first-segment-walk-Undirected-Graph (undirected-graph-Undirected-Tree T) w (pair u KU)
---     w1 : walk-Undirected-Tree T x v
---     w1 =
---       first-segment-walk-Undirected-Graph
---         ( undirected-graph-Undirected-Tree T)
---         ( w1')
---         ( pair v L)
---     w' : walk-Undirected-Tree T v u
---     w' = {!!}
---   ... | inr L = {!!}
---     where
---     w1 : walk-Undirected-Tree T x u
---     w1 =
---       first-segment-walk-Undirected-Graph (undirected-graph-Undirected-Tree T) w (pair u KU)
+  is-path-is-trail-walk-Undirected-Tree :
+    {x y : node-Undirected-Tree T} (w : walk-Undirected-Tree T x y) →
+    is-trail-walk-Undirected-Tree T w → is-path-walk-Undirected-Tree T w
+  is-path-is-trail-walk-Undirected-Tree {x} {y} w H {pair u KU} {pair v K} p with
+    is-vertex-on-first-or-second-segment-walk-Undirected-Graph
+      (undirected-graph-Undirected-Tree T) w (pair u KU) (pair v K)
+  ... | inl L = {!!}
+    where
+    w1' : walk-Undirected-Tree T x u
+    w1' =
+      first-segment-walk-Undirected-Graph (undirected-graph-Undirected-Tree T) w (pair u KU)
+    w1 : walk-Undirected-Tree T x v
+    w1 =
+      first-segment-walk-Undirected-Graph
+        ( undirected-graph-Undirected-Tree T)
+        ( w1')
+        ( pair v L)
+    w' : walk-Undirected-Tree T v u
+    w' = {!!}
+  ... | inr L = {!!}
+    where
+    w1 : walk-Undirected-Tree T x u
+    w1 =
+      first-segment-walk-Undirected-Graph (undirected-graph-Undirected-Tree T) w (pair u KU)
 
--- {-
---     where
---     w1 : walk-Undirected-Tree T x (node-node-on-walk-Undirected-Tree T w u)
---     w1 =
---       first-segment-walk-Undirected-Graph (undirected-graph-Undirected-Tree T) w u
---     w2' : walk-Undirected-Tree T (node-node-on-walk-Undirected-Tree T w u) y
---     w2' =
---       second-segment-walk-Undirected-Graph (undirected-graph-Undirected-Tree T) w u
---     w2 : walk-Undirected-Tree T (node-node-on-walk-Undirected-Tree T w u) (node-node-on-walk-Undirected-Tree T w v)
---     w2 = {!first-segment-walk-Undirected-Graph (undirected-graph-Undirected-Tree T) w2' !}
---   -}
+{-
+    where
+    w1 : walk-Undirected-Tree T x (node-node-on-walk-Undirected-Tree T w u)
+    w1 =
+      first-segment-walk-Undirected-Graph (undirected-graph-Undirected-Tree T) w u
+    w2' : walk-Undirected-Tree T (node-node-on-walk-Undirected-Tree T w u) y
+    w2' =
+      second-segment-walk-Undirected-Graph (undirected-graph-Undirected-Tree T) w u
+    w2 : walk-Undirected-Tree T (node-node-on-walk-Undirected-Tree T w u) (node-node-on-walk-Undirected-Tree T w v)
+    w2 = {!first-segment-walk-Undirected-Graph (undirected-graph-Undirected-Tree T) w2' !}
+  -}
 ```
 
 ## See also

--- a/src/univalent-combinatorics/repetitions-of-values-sequences.lagda.md
+++ b/src/univalent-combinatorics/repetitions-of-values-sequences.lagda.md
@@ -14,13 +14,11 @@ module univalent-combinatorics.repetitions-of-values-sequences where
 
 ## Properties
 
-```agda
-{-
+```text
 is-decidable-is-ordered-repetition-of-values-ℕ-Fin :
   (k : ℕ) (f : ℕ → Fin k) (x : ℕ) →
   is-decidable (is-ordered-repetition-of-values-ℕ f x)
 is-decidable-is-ordered-repetition-of-values-ℕ-Fin k f x = {!!}
--}
 
 {-
   is-decidable-strictly-bounded-Σ-ℕ' x
@@ -28,12 +26,10 @@ is-decidable-is-ordered-repetition-of-values-ℕ-Fin k f x = {!!}
     ( λ y → has-decidable-equality-Fin k (f y) (f x))
 -}
 
-{-
 is-decidable-is-ordered-repetition-of-values-ℕ-count :
   {l : Level} {A : UU l} (e : count A) (f : ℕ → A) (x : ℕ) →
   is-decidable (is-ordered-repetition-of-values-ℕ f x)
 is-decidable-is-ordered-repetition-of-values-ℕ-count e f x = {!!}
--}
 
 {-
   is-decidable-strictly-bounded-Σ-ℕ' x

--- a/src/univalent-combinatorics/repetitions-of-values.lagda.md
+++ b/src/univalent-combinatorics/repetitions-of-values.lagda.md
@@ -84,30 +84,30 @@ repetition-of-values-is-not-injective-Fin k l f N =
 
 ### On the standard finite sets, `is-repetition-of-values f x` is decidable
 
-```agda
--- is-decidable-is-repetition-of-values-Fin :
---   {k l : ℕ} (f : Fin k → Fin l) (x : Fin k) →
---   is-decidable (is-repetition-of-values f x)
--- is-decidable-is-repetition-of-values-Fin f x =
---   is-decidable-Σ-Fin
---     ( λ y →
---       is-decidable-prod
---         ( is-decidable-neg (has-decidable-equality-Fin x y))
---         ( has-decidable-equality-Fin (f x) (f y)))
+```text
+is-decidable-is-repetition-of-values-Fin :
+  {k l : ℕ} (f : Fin k → Fin l) (x : Fin k) →
+  is-decidable (is-repetition-of-values f x)
+is-decidable-is-repetition-of-values-Fin f x =
+  is-decidable-Σ-Fin
+    ( λ y →
+      is-decidable-prod
+        ( is-decidable-neg (has-decidable-equality-Fin x y))
+        ( has-decidable-equality-Fin (f x) (f y)))
 ```
 
 ### On the standard finite sets, `is-repeated-value f x` is decidable
 
-```agda
--- is-decidable-is-repeated-value-Fin :
---   (k l : ℕ) (f : Fin k → Fin l) (x : Fin k) →
---   is-decidable (is-repeated-value f x)
--- is-decidable-is-repeated-value-Fin k l f x =
---   is-decidable-Σ-Fin k
---     ( λ y →
---       is-decidable-prod
---         ( is-decidable-neg (has-decidable-equality-Fin k x y))
---         ( has-decidable-equality-Fin l (f x) (f y)))
+```text
+is-decidable-is-repeated-value-Fin :
+  (k l : ℕ) (f : Fin k → Fin l) (x : Fin k) →
+  is-decidable (is-repeated-value f x)
+is-decidable-is-repeated-value-Fin k l f x =
+  is-decidable-Σ-Fin k
+    ( λ y →
+      is-decidable-prod
+        ( is-decidable-neg (has-decidable-equality-Fin k x y))
+        ( has-decidable-equality-Fin l (f x) (f y)))
 ```
 
 ### The predicate that `f` maps two different elements to the same value
@@ -117,45 +117,45 @@ This remains to be defined.
 
 ### On the standard finite sets, `has-repetition-of-values f` is decidable
 
-```agda
--- is-decidable-has-repetition-of-values-Fin :
---   (k l : ℕ) (f : Fin k → Fin l) → is-decidable (has-repetition-of-values f)
--- is-decidable-has-repetition-of-values-Fin k l f =
---   is-decidable-Σ-Fin k (is-decidable-is-repetition-of-values-Fin k l f)
+```text
+is-decidable-has-repetition-of-values-Fin :
+  (k l : ℕ) (f : Fin k → Fin l) → is-decidable (has-repetition-of-values f)
+is-decidable-has-repetition-of-values-Fin k l f =
+  is-decidable-Σ-Fin k (is-decidable-is-repetition-of-values-Fin k l f)
 ```
 
 ### If `f` is not injective, then it has a `repetition-of-values`
 
-```agda
+```text
 is-injective-map-Fin-zero-Fin :
   {k : ℕ} (f : Fin zero-ℕ → Fin k) → is-injective f
 is-injective-map-Fin-zero-Fin f {()} {y}
 
--- is-injective-map-Fin-one-Fin : {k : ℕ} (f : Fin 1 → Fin k) → is-injective f
--- is-injective-map-Fin-one-Fin f {inr star} {inr star} p = refl
+is-injective-map-Fin-one-Fin : {k : ℕ} (f : Fin 1 → Fin k) → is-injective f
+is-injective-map-Fin-one-Fin f {inr star} {inr star} p = refl
 
--- has-repetition-of-values-is-not-injective-Fin :
---   (k l : ℕ) (f : Fin l → Fin k) →
---   is-not-injective f → has-repetition-of-values f
--- has-repetition-of-values-is-not-injective-Fin k zero-ℕ f H =
---   ex-falso (H (is-injective-map-Fin-zero-Fin {k} f))
--- has-repetition-of-values-is-not-injective-Fin k (succ-ℕ l) f H with
---   is-decidable-is-repetition-of-values-Fin (succ-ℕ l) k f (inr star)
--- ... | inl r = pair (inr star) r
--- ... | inr g =
---   α (has-repetition-of-values-is-not-injective-Fin k l (f ∘ inl) K)
---   where
---   K : is-not-injective (f ∘ inl)
---   K I = H (λ {x} {y} → J x y)
---     where
---     J : (x y : Fin (succ-ℕ l)) → Id (f x) (f y) → Id x y
---     J (inl x) (inl y) p = ap inl (I p)
---     J (inl x) (inr star) p =
---       ex-falso (g (triple (inl x) (Eq-Fin-eq (succ-ℕ l)) (inv p)))
---     J (inr star) (inl y) p =
---       ex-falso (g (triple (inl y) (Eq-Fin-eq (succ-ℕ l)) p))
---     J (inr star) (inr star) p = refl
---     α : has-repetition-of-values (f ∘ inl) → has-repetition-of-values f
---     α (pair x (pair y (pair h q))) =
---       pair (inl x) (pair (inl y) (pair (λ r → h (is-injective-inl r)) q))
+has-repetition-of-values-is-not-injective-Fin :
+  (k l : ℕ) (f : Fin l → Fin k) →
+  is-not-injective f → has-repetition-of-values f
+has-repetition-of-values-is-not-injective-Fin k zero-ℕ f H =
+  ex-falso (H (is-injective-map-Fin-zero-Fin {k} f))
+has-repetition-of-values-is-not-injective-Fin k (succ-ℕ l) f H with
+  is-decidable-is-repetition-of-values-Fin (succ-ℕ l) k f (inr star)
+... | inl r = pair (inr star) r
+... | inr g =
+  α (has-repetition-of-values-is-not-injective-Fin k l (f ∘ inl) K)
+  where
+  K : is-not-injective (f ∘ inl)
+  K I = H (λ {x} {y} → J x y)
+    where
+    J : (x y : Fin (succ-ℕ l)) → Id (f x) (f y) → Id x y
+    J (inl x) (inl y) p = ap inl (I p)
+    J (inl x) (inr star) p =
+      ex-falso (g (triple (inl x) (Eq-Fin-eq (succ-ℕ l)) (inv p)))
+    J (inr star) (inl y) p =
+      ex-falso (g (triple (inl y) (Eq-Fin-eq (succ-ℕ l)) p))
+    J (inr star) (inr star) p = refl
+    α : has-repetition-of-values (f ∘ inl) → has-repetition-of-values f
+    α (pair x (pair y (pair h q))) =
+      pair (inl x) (pair (inl y) (pair (λ r → h (is-injective-inl r)) q))
 ```


### PR DESCRIPTION
This is a trivial pull request that merely reformats commented code to use `text` blocks. The purpose is that the commented code then displays better on the website, i.e., as a block of unhighlighted code that is uninterrupted with `--` on every line.