### PR TITLE
Fix link name for the Formatting section of the codestyle

### DIFF
--- a/CODINGSTYLE.md
+++ b/CODINGSTYLE.md
@@ -346,7 +346,7 @@ Here is a list of our naming conventions:
   [full width equals sign](https://codepoints.net/U+ff1d) for the identity type,
   as the standard equals sign is a reserved symbol in Agda.
 
-## <a name="formatting"></a>Formatting: Indentation, line breaks, and parentheses
+## Formatting: Indentation, line breaks, and parentheses { #formatting }
 
 Code formatting is like punctuation in a novel - it helps readers make sense of
 the story. Here's how we handle indentation and line breaks in the


### PR DESCRIPTION
The previous attempt to have the section linkable actually resulted in the heading not being clickable and not showing up in the page TOC. This is the proper way to set the ID of a heading, as per the [mdbook documentation](https://rust-lang.github.io/mdBook/format/markdown.html#heading-attributes).