### PR TITLE
Add operators of the form `Prop -> Prop`

### DIFF
--- a/src/category-theory/slice-precategories.lagda.md
+++ b/src/category-theory/slice-precategories.lagda.md
@@ -266,7 +266,11 @@ module _
         eq-hom-Slice-Precategory C A _ _ (pr2 (pr2 (pr1 (ϕ Z h₁ h₂ β₂))))
 
       q :
-        ∀ k →
+        (k :
+          hom-Precategory
+            ( Slice-Precategory C A)
+            ( Z , comp-hom-Precategory C f h₁)
+            ( W , p)) →
         is-prop
           ( ( comp-hom-Precategory
               (Slice-Precategory C A) (p₁ , α₁) k ＝ (h₁ , refl)) ×
@@ -278,7 +282,11 @@ module _
           ( is-set-hom-Slice-Precategory C A _ _ _ _)
 
       σ :
-        ∀ k →
+        (k :
+          hom-Precategory
+            ( Slice-Precategory C A)
+            ( Z , comp-hom-Precategory C f h₁)
+            ( W , p)) →
         ( ( comp-hom-Precategory
             ( Slice-Precategory C A)
             ( p₁ , α₁)
@@ -334,7 +342,7 @@ module _
                   ( p₂' , α')))))
 
       q :
-        ∀ k' →
+        (k' : hom-Precategory C W' W) →
         is-prop
           (( comp-hom-Precategory C p₁ k' ＝ p₁') ×
           ( comp-hom-Precategory C p₂ k' ＝ p₂'))

--- a/src/elementary-number-theory/initial-segments-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/initial-segments-natural-numbers.lagda.md
@@ -38,7 +38,7 @@ holds for every `n : ℕ`.
 ```agda
 is-initial-segment-subset-ℕ-Prop : {l : Level} (P : subtype l ℕ) → Prop l
 is-initial-segment-subset-ℕ-Prop P =
-  Π-Prop ℕ (λ n → implication-Prop (P (succ-ℕ n)) (P n))
+  Π-Prop ℕ (λ n → hom-Prop (P (succ-ℕ n)) (P n))
 
 is-initial-segment-subset-ℕ : {l : Level} (P : subtype l ℕ) → UU l
 is-initial-segment-subset-ℕ P = type-Prop (is-initial-segment-subset-ℕ-Prop P)

--- a/src/foundation-core/propositions.lagda.md
+++ b/src/foundation-core/propositions.lagda.md
@@ -310,6 +310,9 @@ pr2 (hom-Prop P Q) = is-prop-type-hom-Prop P Q
 
 infixr 5 _⇒_
 _⇒_ = hom-Prop
+
+infixr 5 _implies_
+_implies_ = type-hom-Prop
 ```
 
 ### The type of equivalences between two propositions is a proposition

--- a/src/foundation-core/propositions.lagda.md
+++ b/src/foundation-core/propositions.lagda.md
@@ -308,16 +308,8 @@ hom-Prop :
 pr1 (hom-Prop P Q) = type-hom-Prop P Q
 pr2 (hom-Prop P Q) = is-prop-type-hom-Prop P Q
 
-implication-Prop :
-  {l1 l2 : Level} → Prop l1 → Prop l2 → Prop (l1 ⊔ l2)
-implication-Prop = hom-Prop
-
-type-implication-Prop :
-  {l1 l2 : Level} → Prop l1 → Prop l2 → UU (l1 ⊔ l2)
-type-implication-Prop = type-hom-Prop
-
 infixr 5 _⇒_
-_⇒_ = type-implication-Prop
+_⇒_ = hom-Prop
 ```
 
 ### The type of equivalences between two propositions is a proposition

--- a/src/foundation/apartness-relations.lagda.md
+++ b/src/foundation/apartness-relations.lagda.md
@@ -55,7 +55,7 @@ module _
 
   is-cotransitive : UU (l1 ⊔ l2)
   is-cotransitive =
-    (a b c : A) → type-hom-Prop (R a b) (disjunction-Prop (R a c) (R b c))
+    (a b c : A) → (R a b) implies ((R a c) ∨ (R b c))
 
   is-apartness-relation : UU (l1 ⊔ l2)
   is-apartness-relation =

--- a/src/foundation/booleans.lagda.md
+++ b/src/foundation/booleans.lagda.md
@@ -11,6 +11,7 @@ open import foundation.dependent-pair-types
 open import foundation.negated-equality
 open import foundation.raising-universe-levels
 open import foundation.unit-type
+open import foundation-core.sections
 open import foundation.universe-levels
 
 open import foundation-core.constant-maps
@@ -237,7 +238,7 @@ neq-neg-bool false ()
 ### Boolean negation is an involution
 
 ```agda
-neg-neg-bool : (neg-bool ∘ neg-bool) ~ id
+neg-neg-bool : neg-bool ∘ neg-bool ~ id
 neg-neg-bool true = refl
 neg-neg-bool false = refl
 ```
@@ -261,8 +262,12 @@ pr2 equiv-neg-bool = is-equiv-neg-bool
 
 ```agda
 abstract
+  not-section-const : (b : bool) → ¬ (section (const bool bool b))
+  not-section-const true (g , G) = neq-true-false-bool (G false)
+  not-section-const false (g , G) = neq-false-true-bool (G true)
+
+abstract
   not-equiv-const :
     (b : bool) → ¬ (is-equiv (const bool bool b))
-  not-equiv-const true ((g , G) , _) = neq-true-false-bool (G false)
-  not-equiv-const false ((g , G) , _) = neq-false-true-bool (G true)
+  not-equiv-const b e = not-section-const b (section-is-equiv e)
 ```

--- a/src/foundation/booleans.lagda.md
+++ b/src/foundation/booleans.lagda.md
@@ -11,7 +11,6 @@ open import foundation.dependent-pair-types
 open import foundation.negated-equality
 open import foundation.raising-universe-levels
 open import foundation.unit-type
-open import foundation-core.sections
 open import foundation.universe-levels
 
 open import foundation-core.constant-maps
@@ -24,6 +23,7 @@ open import foundation-core.identity-types
 open import foundation-core.injective-maps
 open import foundation-core.negation
 open import foundation-core.propositions
+open import foundation-core.sections
 open import foundation-core.sets
 
 open import univalent-combinatorics.finite-types

--- a/src/foundation/conjunction.lagda.md
+++ b/src/foundation/conjunction.lagda.md
@@ -81,8 +81,7 @@ pr2 (intro-conjunction-Prop P Q p q) = q
 iff-universal-property-conjunction-Prop :
   {l1 l2 : Level} (P : Prop l1) (Q : Prop l2)
   {l3 : Level} (R : Prop l3) →
-  ( type-hom-Prop R P × type-hom-Prop R Q) ↔
-  ( type-hom-Prop R (conjunction-Prop P Q))
+  ((R ⇒ P) ∧ (R ⇒ Q)) iff (R ⇒ (P ∧ Q))
 pr1 (pr1 (iff-universal-property-conjunction-Prop P Q R) (f , g) r) = f r
 pr2 (pr1 (iff-universal-property-conjunction-Prop P Q R) (f , g) r) = g r
 pr1 (pr2 (iff-universal-property-conjunction-Prop P Q R) h) r = pr1 (h r)
@@ -91,11 +90,10 @@ pr2 (pr2 (iff-universal-property-conjunction-Prop P Q R) h) r = pr2 (h r)
 equiv-universal-property-conjunction-Prop :
   {l1 l2 : Level} (P : Prop l1) (Q : Prop l2)
   {l3 : Level} (R : Prop l3) →
-  ( type-hom-Prop R P × type-hom-Prop R Q) ≃
-  ( type-hom-Prop R (conjunction-Prop P Q))
+  type-Prop ((R ⇒ P) ∧ (R ⇒ Q)) ≃ type-Prop (R ⇒ (P ∧ Q))
 equiv-universal-property-conjunction-Prop P Q R =
   equiv-iff'
-    ( conjunction-Prop (hom-Prop R P) (hom-Prop R Q))
-    ( hom-Prop R (conjunction-Prop P Q))
+    ( (R ⇒ P) ∧ (R ⇒ Q))
+    ( R ⇒ (P ∧ Q))
     ( iff-universal-property-conjunction-Prop P Q R)
 ```

--- a/src/foundation/conjunction.lagda.md
+++ b/src/foundation/conjunction.lagda.md
@@ -40,7 +40,7 @@ abstract
   is-prop-type-conjunction-Prop P Q = is-prop-type-Prop (conjunction-Prop P Q)
 
 infixr 15 _∧_
-_∧_ = type-conjunction-Prop
+_∧_ = conjunction-Prop
 ```
 
 **Note**: The symbol used for the conjunction `_∧_` is the

--- a/src/foundation/conjunction.lagda.md
+++ b/src/foundation/conjunction.lagda.md
@@ -41,6 +41,9 @@ abstract
 
 infixr 15 _∧_
 _∧_ = conjunction-Prop
+
+infixr 15 _and_
+_and_ = type-conjunction-Prop
 ```
 
 **Note**: The symbol used for the conjunction `_∧_` is the

--- a/src/foundation/decidable-subtypes.lagda.md
+++ b/src/foundation/decidable-subtypes.lagda.md
@@ -157,12 +157,12 @@ module _
   iff-universes-decidable-subtype :
     (l l' : Level) (S : decidable-subtype l X) →
     ( (x : X) →
-      prop-Decidable-Prop (S x) ⇔
-      prop-Decidable-Prop
+      type-Decidable-Prop (S x) ↔
+      type-Decidable-Prop
         ( map-equiv (equiv-universes-decidable-subtype l l') S x))
   iff-universes-decidable-subtype l l' S x =
     tr
-      ( λ P → prop-Decidable-Prop (S x) ⇔ prop-Decidable-Prop P)
+      ( λ P → type-Decidable-Prop (S x) ↔ type-Decidable-Prop P)
       ( inv
         ( compute-map-equiv-Π
           ( λ _ → Decidable-Prop l')

--- a/src/foundation/disjunction.lagda.md
+++ b/src/foundation/disjunction.lagda.md
@@ -78,12 +78,12 @@ pr2 (pr2 (disjunction-Decidable-Prop P Q)) =
 ```agda
 inl-disjunction-Prop :
   {l1 l2 : Level} (P : Prop l1) (Q : Prop l2) →
-  type-hom-Prop P (disjunction-Prop P Q)
+  (P) implies (P ∨ Q)
 inl-disjunction-Prop P Q = unit-trunc-Prop ∘ inl
 
 inr-disjunction-Prop :
   {l1 l2 : Level} (P : Prop l1) (Q : Prop l2) →
-  type-hom-Prop Q (disjunction-Prop P Q)
+  Q implies (P ∨ Q)
 inr-disjunction-Prop P Q = unit-trunc-Prop ∘ inr
 ```
 
@@ -92,18 +92,14 @@ inr-disjunction-Prop P Q = unit-trunc-Prop ∘ inr
 ```agda
 ev-disjunction-Prop :
   {l1 l2 l3 : Level} (P : Prop l1) (Q : Prop l2) (R : Prop l3) →
-  type-hom-Prop
-    ( hom-Prop (disjunction-Prop P Q) R)
-    ( conjunction-Prop (hom-Prop P R) (hom-Prop Q R))
+  ((P ∨ Q) ⇒ R) implies ((P ⇒ R) ∧ (Q ⇒ R))
 pr1 (ev-disjunction-Prop P Q R h) = h ∘ (inl-disjunction-Prop P Q)
 pr2 (ev-disjunction-Prop P Q R h) = h ∘ (inr-disjunction-Prop P Q)
 
 elim-disjunction-Prop :
   {l1 l2 l3 : Level} (P : Prop l1) (Q : Prop l2) (R : Prop l3) →
-  type-hom-Prop
-    ( conjunction-Prop (hom-Prop P R) (hom-Prop Q R))
-    ( hom-Prop (disjunction-Prop P Q) R)
-elim-disjunction-Prop P Q R (pair f g) =
+  ( (P ⇒ R) ∧ (Q ⇒ R)) implies ((P ∨ Q) ⇒ R)
+elim-disjunction-Prop P Q R (f , g) =
   map-universal-property-trunc-Prop R (ind-coprod (λ t → type-Prop R) f g)
 
 abstract
@@ -112,8 +108,8 @@ abstract
     is-equiv (ev-disjunction-Prop P Q R)
   is-equiv-ev-disjunction-Prop P Q R =
     is-equiv-is-prop
-      ( is-prop-type-Prop (hom-Prop (disjunction-Prop P Q) R))
-      ( is-prop-type-Prop (conjunction-Prop (hom-Prop P R) (hom-Prop Q R)))
+      ( is-prop-type-Prop ((P ∨ Q) ⇒ R))
+      ( is-prop-type-Prop ((P ⇒ R) ∧ (Q ⇒ R)))
       ( elim-disjunction-Prop P Q R)
 ```
 

--- a/src/foundation/disjunction.lagda.md
+++ b/src/foundation/disjunction.lagda.md
@@ -45,6 +45,9 @@ abstract
 
 infixr 10 _∨_
 _∨_ = disjunction-Prop
+
+infixr 10 _or_
+_or_ = type-disjunction-Prop
 ```
 
 **Note**: The symbol used for the disjunction `_∨_` is the

--- a/src/foundation/disjunction.lagda.md
+++ b/src/foundation/disjunction.lagda.md
@@ -44,7 +44,7 @@ abstract
   is-prop-type-disjunction-Prop P Q = is-prop-type-Prop (disjunction-Prop P Q)
 
 infixr 10 _∨_
-_∨_ = type-disjunction-Prop
+_∨_ = disjunction-Prop
 ```
 
 **Note**: The symbol used for the disjunction `_∨_` is the

--- a/src/foundation/dubuc-penon-compact-types.lagda.md
+++ b/src/foundation/dubuc-penon-compact-types.lagda.md
@@ -35,8 +35,8 @@ is-dubuc-penon-compact-Prop l1 l2 X =
         ( subtype l2 X)
         ( λ Q →
           function-Prop
-            ( (x : X) → type-disjunction-Prop P (Q x))
-            ( disjunction-Prop P (Π-Prop X Q))))
+            ( (x : X) → P or (Q x))
+            ( P ∨ (Π-Prop X Q))))
 
 is-dubuc-penon-compact :
   {l : Level} (l1 l2 : Level) → UU l → UU (l ⊔ lsuc l1 ⊔ lsuc l2)

--- a/src/foundation/exclusive-disjunction.lagda.md
+++ b/src/foundation/exclusive-disjunction.lagda.md
@@ -71,8 +71,8 @@ module _
   xor-Prop : Prop (l1 ⊔ l2)
   xor-Prop =
     coprod-Prop
-      ( conjunction-Prop P (neg-Prop Q))
-      ( conjunction-Prop Q (neg-Prop P))
+      ( P ∧ (neg-Prop Q))
+      ( Q ∧ (neg-Prop P))
       ( λ p q → pr2 q (pr1 p))
 
   type-xor-Prop : UU (l1 ⊔ l2)
@@ -252,7 +252,7 @@ module _
 {-
   eq-equiv-Prop
     ( ( ( equiv-coprod
-          ( ( ( left-unit-law-coprod (type-Prop (conjunction-Prop P (neg-Prop Q)))) ∘e
+          ( ( ( left-unit-law-coprod (type-Prop (P ∧ (neg-Prop Q)))) ∘e
               ( equiv-coprod
                 ( left-absorption-Σ
                   ( λ x →

--- a/src/foundation/existential-quantification.lagda.md
+++ b/src/foundation/existential-quantification.lagda.md
@@ -120,8 +120,9 @@ module _
   where
 
   iff-distributive-conjunction-exists-Prop :
-    ( conjunction-Prop P (exists-Prop A Q)) ⇔
-    ( exists-Prop A (λ a → conjunction-Prop P (Q a)))
+    type-iff-Prop
+      ( conjunction-Prop P (exists-Prop A Q))
+      ( exists-Prop A (λ a → conjunction-Prop P (Q a)))
   pr1 iff-distributive-conjunction-exists-Prop (p , e) =
     elim-exists-Prop Q
       ( exists-Prop A (λ a → conjunction-Prop P (Q a)))

--- a/src/foundation/existential-quantification.lagda.md
+++ b/src/foundation/existential-quantification.lagda.md
@@ -121,25 +121,25 @@ module _
 
   iff-distributive-conjunction-exists-Prop :
     type-iff-Prop
-      ( conjunction-Prop P (exists-Prop A Q))
-      ( exists-Prop A (λ a → conjunction-Prop P (Q a)))
+      ( P ∧ (exists-Prop A Q))
+      ( exists-Prop A (λ a → P ∧ (Q a)))
   pr1 iff-distributive-conjunction-exists-Prop (p , e) =
     elim-exists-Prop Q
-      ( exists-Prop A (λ a → conjunction-Prop P (Q a)))
+      ( exists-Prop A (λ a → P ∧ (Q a)))
       ( λ x q → intro-∃ x (p , q))
       ( e)
   pr2 iff-distributive-conjunction-exists-Prop =
     elim-exists-Prop
-      ( λ x → conjunction-Prop P (Q x))
-      ( conjunction-Prop P (exists-Prop A Q))
+      ( λ x → P ∧ (Q x))
+      ( P ∧ (exists-Prop A Q))
       ( λ x (p , q) → (p , intro-∃ x q))
 
   distributive-conjunction-exists-Prop :
-    conjunction-Prop P (exists-Prop A Q) ＝
-    exists-Prop A (λ a → conjunction-Prop P (Q a))
+    P ∧ (exists-Prop A Q) ＝
+    exists-Prop A (λ a → P ∧ (Q a))
   distributive-conjunction-exists-Prop =
     eq-iff'
-      ( conjunction-Prop P (exists-Prop A Q))
-      ( exists-Prop A (λ a → conjunction-Prop P (Q a)))
+      ( P ∧ (exists-Prop A Q))
+      ( exists-Prop A (λ a → P ∧ (Q a)))
       ( iff-distributive-conjunction-exists-Prop)
 ```

--- a/src/foundation/impredicative-encodings.lagda.md
+++ b/src/foundation/impredicative-encodings.lagda.md
@@ -45,13 +45,13 @@ impredicative-trunc-Prop {l} A =
 
 type-impredicative-trunc-Prop :
   {l : Level} → UU l → UU (lsuc l)
-type-impredicative-trunc-Prop {l} A =
+type-impredicative-trunc-Prop A =
   type-Prop (impredicative-trunc-Prop A)
 
 map-impredicative-trunc-Prop :
   {l : Level} (A : UU l) →
   type-trunc-Prop A → type-impredicative-trunc-Prop A
-map-impredicative-trunc-Prop {l} A =
+map-impredicative-trunc-Prop A =
   map-universal-property-trunc-Prop
     ( impredicative-trunc-Prop A)
     ( λ x Q f → f x)
@@ -91,14 +91,14 @@ type-impredicative-conjunction-Prop P1 P2 =
 map-impredicative-conjunction-Prop :
   {l1 l2 : Level} (P1 : Prop l1) (P2 : Prop l2) →
   type-conjunction-Prop P1 P2 → type-impredicative-conjunction-Prop P1 P2
-map-impredicative-conjunction-Prop {l1} {l2} P1 P2 (pair p1 p2) Q f =
+map-impredicative-conjunction-Prop P1 P2 (pair p1 p2) Q f =
   f p1 p2
 
 inv-map-impredicative-conjunction-Prop :
   {l1 l2 : Level} (P1 : Prop l1) (P2 : Prop l2) →
   type-impredicative-conjunction-Prop P1 P2 → type-conjunction-Prop P1 P2
 inv-map-impredicative-conjunction-Prop P1 P2 H =
-  H (conjunction-Prop P1 P2) (λ p1 p2 → pair p1 p2)
+  H (conjunction-Prop P1 P2) pair
 
 equiv-impredicative-conjunction-Prop :
   {l1 l2 : Level} (P1 : Prop l1) (P2 : Prop l2) →
@@ -120,9 +120,9 @@ impredicative-disjunction-Prop {l1} {l2} P1 P2 =
   Π-Prop
     ( Prop (l1 ⊔ l2))
     ( λ Q →
-      function-Prop
-        ( type-implication-Prop P1 Q)
-        ( function-Prop (type-implication-Prop P2 Q) Q))
+      hom-Prop
+        ( hom-Prop P1 Q)
+        ( hom-Prop (hom-Prop P2 Q) Q))
 
 type-impredicative-disjunction-Prop :
   {l1 l2 : Level} → Prop l1 → Prop l2 → UU (lsuc (l1 ⊔ l2))
@@ -132,7 +132,7 @@ type-impredicative-disjunction-Prop P1 P2 =
 map-impredicative-disjunction-Prop :
   {l1 l2 : Level} (P1 : Prop l1) (P2 : Prop l2) →
   type-disjunction-Prop P1 P2 → type-impredicative-disjunction-Prop P1 P2
-map-impredicative-disjunction-Prop {l1} {l2} P1 P2 =
+map-impredicative-disjunction-Prop P1 P2 =
   map-universal-property-trunc-Prop
     ( impredicative-disjunction-Prop P1 P2)
     ( ind-coprod
@@ -211,7 +211,7 @@ type-impredicative-exists-Prop P =
 map-impredicative-exists-Prop :
   {l1 l2 : Level} {A : UU l1} (P : A → Prop l2) →
   exists A P → type-impredicative-exists-Prop P
-map-impredicative-exists-Prop {l1} {l2} {A} P =
+map-impredicative-exists-Prop P =
   map-universal-property-trunc-Prop
     ( impredicative-exists-Prop P)
     ( ind-Σ (λ x y Q h → h x y))

--- a/src/foundation/impredicative-encodings.lagda.md
+++ b/src/foundation/impredicative-encodings.lagda.md
@@ -11,6 +11,7 @@ open import foundation.conjunction
 open import foundation.dependent-pair-types
 open import foundation.disjunction
 open import foundation.existential-quantification
+open import foundation.homotopies
 open import foundation.logical-equivalences
 open import foundation.negation
 open import foundation.propositional-truncations
@@ -79,9 +80,7 @@ equiv-impredicative-trunc-Prop A =
 impredicative-conjunction-Prop :
   {l1 l2 : Level} → Prop l1 → Prop l2 → Prop (lsuc (l1 ⊔ l2))
 impredicative-conjunction-Prop {l1} {l2} P1 P2 =
-  Π-Prop
-    ( Prop (l1 ⊔ l2))
-    ( λ Q → function-Prop (type-Prop P1 → (type-Prop P2 → type-Prop Q)) Q)
+  Π-Prop (Prop (l1 ⊔ l2)) (λ Q → (P1 ⇒ (P2 ⇒ Q)) ⇒ Q)
 
 type-impredicative-conjunction-Prop :
   {l1 l2 : Level} → Prop l1 → Prop l2 → UU (lsuc (l1 ⊔ l2))
@@ -91,21 +90,19 @@ type-impredicative-conjunction-Prop P1 P2 =
 map-impredicative-conjunction-Prop :
   {l1 l2 : Level} (P1 : Prop l1) (P2 : Prop l2) →
   type-conjunction-Prop P1 P2 → type-impredicative-conjunction-Prop P1 P2
-map-impredicative-conjunction-Prop P1 P2 (pair p1 p2) Q f =
-  f p1 p2
+map-impredicative-conjunction-Prop P1 P2 (p1 , p2) Q f = f p1 p2
 
 inv-map-impredicative-conjunction-Prop :
   {l1 l2 : Level} (P1 : Prop l1) (P2 : Prop l2) →
   type-impredicative-conjunction-Prop P1 P2 → type-conjunction-Prop P1 P2
-inv-map-impredicative-conjunction-Prop P1 P2 H =
-  H (conjunction-Prop P1 P2) pair
+inv-map-impredicative-conjunction-Prop P1 P2 H = H (P1 ∧ P2) pair
 
 equiv-impredicative-conjunction-Prop :
   {l1 l2 : Level} (P1 : Prop l1) (P2 : Prop l2) →
   type-conjunction-Prop P1 P2 ≃ type-impredicative-conjunction-Prop P1 P2
 equiv-impredicative-conjunction-Prop P1 P2 =
   equiv-iff
-    ( conjunction-Prop P1 P2)
+    ( P1 ∧ P2)
     ( impredicative-conjunction-Prop P1 P2)
     ( map-impredicative-conjunction-Prop P1 P2)
     ( inv-map-impredicative-conjunction-Prop P1 P2)
@@ -117,12 +114,7 @@ equiv-impredicative-conjunction-Prop P1 P2 =
 impredicative-disjunction-Prop :
   {l1 l2 : Level} → Prop l1 → Prop l2 → Prop (lsuc (l1 ⊔ l2))
 impredicative-disjunction-Prop {l1} {l2} P1 P2 =
-  Π-Prop
-    ( Prop (l1 ⊔ l2))
-    ( λ Q →
-      hom-Prop
-        ( hom-Prop P1 Q)
-        ( hom-Prop (hom-Prop P2 Q) Q))
+  Π-Prop (Prop (l1 ⊔ l2)) (λ Q → (P1 ⇒ Q) ⇒ ((P2 ⇒ Q) ⇒ Q))
 
 type-impredicative-disjunction-Prop :
   {l1 l2 : Level} → Prop l1 → Prop l2 → UU (lsuc (l1 ⊔ l2))
@@ -144,7 +136,7 @@ inv-map-impredicative-disjunction-Prop :
   {l1 l2 : Level} (P1 : Prop l1) (P2 : Prop l2) →
   type-impredicative-disjunction-Prop P1 P2 → type-disjunction-Prop P1 P2
 inv-map-impredicative-disjunction-Prop P1 P2 H =
-  H ( disjunction-Prop P1 P2)
+  H ( P1 ∨ P2)
     ( inl-disjunction-Prop P1 P2)
     ( inr-disjunction-Prop P1 P2)
 
@@ -153,7 +145,7 @@ equiv-impredicative-disjunction-Prop :
   type-disjunction-Prop P1 P2 ≃ type-impredicative-disjunction-Prop P1 P2
 equiv-impredicative-disjunction-Prop P1 P2 =
   equiv-iff
-    ( disjunction-Prop P1 P2)
+    ( P1 ∨ P2)
     ( impredicative-disjunction-Prop P1 P2)
     ( map-impredicative-disjunction-Prop P1 P2)
     ( inv-map-impredicative-disjunction-Prop P1 P2)
@@ -220,8 +212,7 @@ inv-map-impredicative-exists-Prop :
   {l1 l2 : Level} {A : UU l1} (P : A → Prop l2) →
   type-impredicative-exists-Prop P → exists A P
 inv-map-impredicative-exists-Prop {A = A} P H =
-  H ( exists-Prop A P)
-    ( λ x y → unit-trunc-Prop (pair x y))
+  H (exists-Prop A P) (λ x y → unit-trunc-Prop (x , y))
 
 equiv-impredicative-exists-Prop :
   {l1 l2 : Level} {A : UU l1} (P : A → Prop l2) →
@@ -256,14 +247,14 @@ inv-map-impredicative-based-id-Prop :
   {l : Level} (A : Set l) (a x : type-Set A) →
   type-impredicative-based-id-Prop A a x → a ＝ x
 inv-map-impredicative-based-id-Prop A a x H =
-  H (λ x → pair (a ＝ x) (is-set-type-Set A a x)) refl
+  H (Id-Prop A a) refl
 
 equiv-impredicative-based-id-Prop :
   {l : Level} (A : Set l) (a x : type-Set A) →
   (a ＝ x) ≃ type-impredicative-based-id-Prop A a x
 equiv-impredicative-based-id-Prop A a x =
   equiv-iff
-    ( pair (a ＝ x) (is-set-type-Set A a x))
+    ( Id-Prop A a x)
     ( impredicative-based-id-Prop A a x)
     ( map-impredicative-based-id-Prop A a x)
     ( inv-map-impredicative-based-id-Prop A a x)
@@ -292,14 +283,14 @@ inv-map-impredicative-id-Prop :
   {l : Level} (A : Set l) (x y : type-Set A) →
   type-impredicative-id-Prop A x y → x ＝ y
 inv-map-impredicative-id-Prop A x y H =
-  H (λ a b → pair (a ＝ b) (is-set-type-Set A a b)) (λ a → refl)
+  H (Id-Prop A) (refl-htpy)
 
 equiv-impredicative-id-Prop :
   {l : Level} (A : Set l) (x y : type-Set A) →
   (x ＝ y) ≃ type-impredicative-id-Prop A x y
 equiv-impredicative-id-Prop A x y =
   equiv-iff
-    ( pair (x ＝ y) (is-set-type-Set A x y))
+    ( Id-Prop A x y)
     ( impredicative-id-Prop A x y)
     ( map-impredicative-id-Prop A x y)
     ( inv-map-impredicative-id-Prop A x y)

--- a/src/foundation/logical-equivalences.lagda.md
+++ b/src/foundation/logical-equivalences.lagda.md
@@ -79,8 +79,13 @@ module _
 
   infix 6 _⇔_
 
-  _⇔_ : UU (l1 ⊔ l2)
-  _⇔_ = type-iff-Prop
+  _⇔_ : Prop (l1 ⊔ l2)
+  _⇔_ = iff-Prop
+
+  infix 6 _iff_
+
+  _iff_ : UU (l1 ⊔ l2)
+  _iff_ = type-iff-Prop
 ```
 
 ### Composition of logical equivalences
@@ -139,7 +144,7 @@ module _
   {l1 l2 : Level} (P : Prop l1) (Q : Prop l2)
   where
 
-  equiv-iff' : (P ⇔ Q) → (type-Prop P ≃ type-Prop Q)
+  equiv-iff' : (P iff Q) → (type-Prop P ≃ type-Prop Q)
   pr1 (equiv-iff' t) = pr1 t
   pr2 (equiv-iff' t) = is-equiv-is-prop (pr2 P) (pr2 Q) (pr2 t)
 
@@ -175,7 +180,7 @@ compute-fiber-iff-equiv {A = A} {B} (f , g) =
 ### Two equal propositions are logically equivalent
 
 ```agda
-iff-eq : {l1 : Level} {P Q : Prop l1} → P ＝ Q → P ⇔ Q
+iff-eq : {l1 : Level} {P Q : Prop l1} → P ＝ Q → P iff Q
 pr1 (iff-eq refl) = id
 pr2 (iff-eq refl) = id
 ```
@@ -195,7 +200,7 @@ abstract
 
 equiv-equiv-iff :
   {l1 l2 : Level} (P : Prop l1) (Q : Prop l2) →
-  (P ⇔ Q) ≃ (type-Prop P ≃ type-Prop Q)
+  (P iff Q) ≃ (type-Prop P ≃ type-Prop Q)
 pr1 (equiv-equiv-iff P Q) = equiv-iff' P Q
 pr2 (equiv-equiv-iff P Q) = is-equiv-equiv-iff P Q
 ```

--- a/src/foundation/negation.lagda.md
+++ b/src/foundation/negation.lagda.md
@@ -40,6 +40,12 @@ pr2 (neg-Prop' A) = is-prop-neg
 
 neg-Prop : {l1 : Level} → Prop l1 → Prop l1
 neg-Prop P = neg-Prop' (type-Prop P)
+
+type-neg-Prop : {l1 : Level} → Prop l1 → UU l1
+type-neg-Prop P = type-Prop (neg-Prop P)
+
+not_ : {l1 : Level} → Prop l1 → UU l1
+not_ = type-neg-Prop
 ```
 
 ### Reductio ad absurdum
@@ -74,6 +80,6 @@ no-fixed-points-neg A (pair f g) =
 ```agda
 abstract
   no-fixed-points-neg-Prop :
-    {l1 : Level} (P : Prop l1) → ¬ (P ⇔ neg-Prop P)
+    {l1 : Level} (P : Prop l1) → ¬ ((P) iff (neg-Prop P))
   no-fixed-points-neg-Prop P = no-fixed-points-neg (type-Prop P)
 ```

--- a/src/foundation/propositional-extensionality.lagda.md
+++ b/src/foundation/propositional-extensionality.lagda.md
@@ -38,7 +38,7 @@ open import foundation-core.torsorial-type-families
 ## Idea
 
 Propositional extensionality characterizes identifications of propositions. It
-asserts that for any two propositions `P` and `Q`, we have `Id P Q ≃ (P ⇔ Q)`.
+asserts that for any two propositions `P` and `Q`, we have `Id P Q ≃ (P iff Q)`.
 
 ## Properties
 
@@ -51,7 +51,7 @@ module _
 
   abstract
     is-torsorial-iff :
-      (P : Prop l1) → is-torsorial (λ (Q : Prop l1) → P ⇔ Q)
+      (P : Prop l1) → is-torsorial (λ (Q : Prop l1) → P iff Q)
     is-torsorial-iff P =
       is-contr-equiv
         ( Σ (Prop l1) (λ Q → type-Prop P ≃ type-Prop Q))
@@ -71,11 +71,11 @@ module _
         ( λ Q → iff-eq {P = P} {Q})
 
   propositional-extensionality :
-    (P Q : Prop l1) → (P ＝ Q) ≃ (P ⇔ Q)
+    (P Q : Prop l1) → (P ＝ Q) ≃ (P iff Q)
   pr1 (propositional-extensionality P Q) = iff-eq
   pr2 (propositional-extensionality P Q) = is-equiv-iff-eq P Q
 
-  eq-iff' : (P Q : Prop l1) → P ⇔ Q → P ＝ Q
+  eq-iff' : (P Q : Prop l1) → P iff Q → P ＝ Q
   eq-iff' P Q = map-inv-is-equiv (is-equiv-iff-eq P Q)
 
   eq-iff :
@@ -97,7 +97,7 @@ module _
     is-torsorial (λ Q → type-Prop P ≃ type-Prop Q)
   is-torsorial-equiv-Prop P =
     is-contr-equiv'
-      ( Σ (Prop l1) (λ Q → P ⇔ Q))
+      ( Σ (Prop l1) (λ Q → P iff Q))
       ( equiv-tot (equiv-equiv-iff P))
       ( is-torsorial-iff P)
 ```
@@ -134,7 +134,7 @@ abstract
     {l1 : Level} → is-torsorial (λ (P : Prop l1) → type-Prop P)
   is-torsorial-true-Prop {l1} =
     is-contr-equiv
-      ( Σ (Prop l1) (λ P → raise-unit-Prop l1 ⇔ P))
+      ( Σ (Prop l1) (λ P → (raise-unit-Prop l1) iff (P)))
       ( equiv-tot
         ( λ P →
           inv-equiv
@@ -159,7 +159,7 @@ abstract
     {l1 : Level} → is-torsorial (λ (P : Prop l1) → type-Prop (neg-Prop P))
   is-torsorial-false-Prop {l1} =
     is-contr-equiv
-      ( Σ (Prop l1) (λ P → raise-empty-Prop l1 ⇔ P))
+      ( Σ (Prop l1) (λ P → (raise-empty-Prop l1) iff (P)))
       ( equiv-tot
         ( λ P →
           inv-equiv

--- a/src/foundation/unions-subtypes.lagda.md
+++ b/src/foundation/unions-subtypes.lagda.md
@@ -37,7 +37,7 @@ module _
   where
 
   union-subtype : subtype l1 X → subtype l2 X → subtype (l1 ⊔ l2) X
-  union-subtype P Q x = disjunction-Prop (P x) (Q x)
+  union-subtype P Q x = (P x) ∨ (Q x)
 ```
 
 ### Unions of decidable subtypes

--- a/src/linear-algebra/vectors.lagda.md
+++ b/src/linear-algebra/vectors.lagda.md
@@ -49,7 +49,7 @@ infixr 10 _∷_
 
 data vec {l : Level} (A : UU l) : ℕ → UU l where
   empty-vec : vec A zero-ℕ
-  _∷_ : ∀ {n} → A → vec A n → vec A (succ-ℕ n)
+  _∷_ : {n : ℕ} → A → vec A n → vec A (succ-ℕ n)
 
 module _
   {l : Level} {A : UU l}

--- a/src/order-theory/total-preorders.lagda.md
+++ b/src/order-theory/total-preorders.lagda.md
@@ -36,7 +36,7 @@ module _
 
   incident-Preorder-Prop : (x y : type-Preorder X) → Prop l2
   incident-Preorder-Prop x y =
-    disjunction-Prop (leq-Preorder-Prop X x y) (leq-Preorder-Prop X y x)
+    (leq-Preorder-Prop X x y) ∨ (leq-Preorder-Prop X y x)
 
   incident-Preorder : (x y : type-Preorder X) → UU l2
   incident-Preorder x y = type-Prop (incident-Preorder-Prop x y)

--- a/src/organic-chemistry/alkanes.lagda.md
+++ b/src/organic-chemistry/alkanes.lagda.md
@@ -24,5 +24,6 @@ not have any double or triple carbon-carbon bonds.
 
 ```agda
 is-alkane-hydrocarbon : {l1 l2 : Level} → hydrocarbon l1 l2 → UU (l1 ⊔ l2)
-is-alkane-hydrocarbon H = ∀ c → is-saturated-carbon-hydrocarbon H c
+is-alkane-hydrocarbon H =
+  (c : vertex-hydrocarbon H) → is-saturated-carbon-hydrocarbon H c
 ```

--- a/src/primitives/machine-integers.lagda.md
+++ b/src/primitives/machine-integers.lagda.md
@@ -32,5 +32,5 @@ primitive
   primWord64ToNat : Word64 → ℕ
   primWord64FromNat : ℕ → Word64
   primWord64ToNatInjective :
-    ∀ a b → primWord64ToNat a ＝ primWord64ToNat b → a ＝ b
+    (a b : Word64) → primWord64ToNat a ＝ primWord64ToNat b → a ＝ b
 ```

--- a/src/real-numbers/dedekind-real-numbers.lagda.md
+++ b/src/real-numbers/dedekind-real-numbers.lagda.md
@@ -61,28 +61,19 @@ module _
   is-dedekind-cut-Prop : Prop (l1 ⊔ l2)
   is-dedekind-cut-Prop =
     prod-Prop
-      ( prod-Prop (exists-Prop ℚ L) (exists-Prop ℚ U))
+      ( (exists-Prop ℚ L) ∧ (exists-Prop ℚ U))
       ( prod-Prop
         ( prod-Prop
           ( Π-Prop ℚ
-            ( λ q →
-              iff-Prop
-                ( L q)
-                ( exists-Prop ℚ (λ r → prod-Prop (le-ℚ-Prop q r) (L r)))))
+            ( λ q → (L q) ⇔ (exists-Prop ℚ (λ r → (le-ℚ-Prop q r) ∧ (L r)))))
           ( Π-Prop ℚ
-            ( λ r →
-              iff-Prop
-                ( U r)
-                ( exists-Prop ℚ (λ q → prod-Prop (le-ℚ-Prop q r) (U q))))))
+            ( λ r → (U r) ⇔ (exists-Prop ℚ (λ q → (le-ℚ-Prop q r) ∧ (U q))))))
         ( prod-Prop
-          ( Π-Prop ℚ (λ q → neg-Prop (prod-Prop (L q) (U q))))
+          ( Π-Prop ℚ (λ q → neg-Prop ((L q) ∧ (U q))))
           ( Π-Prop ℚ
             ( λ q →
               Π-Prop ℚ
-                ( λ r →
-                  hom-Prop
-                    ( le-ℚ-Prop q r)
-                    ( disjunction-Prop (L q) (U r)))))))
+                ( λ r → (le-ℚ-Prop q r) ⇒ ((L q) ∨ (U r)))))))
 
   is-dedekind-cut : UU (l1 ⊔ l2)
   is-dedekind-cut = type-Prop is-dedekind-cut-Prop

--- a/src/real-numbers/dedekind-real-numbers.lagda.md
+++ b/src/real-numbers/dedekind-real-numbers.lagda.md
@@ -80,7 +80,7 @@ module _
             ( λ q →
               Π-Prop ℚ
                 ( λ r →
-                  implication-Prop
+                  hom-Prop
                     ( le-ℚ-Prop q r)
                     ( disjunction-Prop (L q) (U r)))))))
 

--- a/src/reflection/group-solver.lagda.md
+++ b/src/reflection/group-solver.lagda.md
@@ -36,10 +36,10 @@ The main entry-point is `solveExpr` below
 
 ```agda
 data Fin : ℕ → UU lzero where
-  zero-Fin : ∀ {n} → Fin (succ-ℕ n)
-  succ-Fin : ∀ {n} → Fin n → Fin (succ-ℕ n)
+  zero-Fin : {n : ℕ} → Fin (succ-ℕ n)
+  succ-Fin : {n : ℕ} → Fin n → Fin (succ-ℕ n)
 
-finEq : ∀ {n} → (a b : Fin n) → is-decidable (Id a b)
+finEq : {n : ℕ} → (a b : Fin n) → is-decidable (Id a b)
 finEq zero-Fin zero-Fin = inl refl
 finEq zero-Fin (succ-Fin b) = inr (λ ())
 finEq (succ-Fin a) zero-Fin = inr (λ ())
@@ -47,7 +47,7 @@ finEq (succ-Fin a) (succ-Fin b) with finEq a b
 ... | inl eq = inl (ap succ-Fin eq)
 ... | inr neq = inr (λ where refl → neq refl)
 
-getVec : ∀ {n} {l} {A : UU l} → vec A n → Fin n → A
+getVec : {n : ℕ} {l : Level} {A : UU l} → vec A n → Fin n → A
 getVec (x ∷ v) zero-Fin = x
 getVec (x ∷ v) (succ-Fin k) = getVec v k
 
@@ -61,7 +61,7 @@ data SimpleElem (n : ℕ) : UU where
   inv-SE : Fin n → SimpleElem n
   pure-SE : Fin n → SimpleElem n
 
-inv-SE' : ∀ {n} → SimpleElem n → SimpleElem n
+inv-SE' : {n : ℕ} → SimpleElem n → SimpleElem n
 inv-SE' (inv-SE k) = pure-SE k
 inv-SE' (pure-SE k) = inv-SE k
 
@@ -106,96 +106,134 @@ module _ {n : ℕ} where
 
   data GroupEqualityElem : GroupSyntax n → GroupSyntax n → UU where
     -- equivalence relation
-    xsym-GE : ∀ {x} {y} → GroupEqualityElem x y → GroupEqualityElem y x
+    xsym-GE :
+      {x y : GroupSyntax n} → GroupEqualityElem x y → GroupEqualityElem y x
 
     -- Variations on ap
-    -- xap-gMul : ∀ {x} {y} {z} {w} → GroupEqualityElem x y → GroupEqualityElem z w → GroupEqualityElem (gMul x z) (gMul y w)
+    -- xap-gMul :
+    --   {x y z w : GroupSyntax n} →
+    --   GroupEqualityElem x y → GroupEqualityElem z w →
+    --   GroupEqualityElem (gMul x z) (gMul y w)
     xap-gMul-l :
-      ∀ {x} {y} {z} →
+      {x y z : GroupSyntax n} →
       GroupEqualityElem x y → GroupEqualityElem (gMul x z) (gMul y z)
     xap-gMul-r :
-      ∀ {x} {y} {z} →
+      {x y z : GroupSyntax n} →
       GroupEqualityElem y z → GroupEqualityElem (gMul x y) (gMul x z)
     xap-gInv :
-      ∀ {x} {y} →
+      {x y : GroupSyntax n} →
       GroupEqualityElem x y → GroupEqualityElem (gInv x) (gInv y)
 
     -- Group laws
     xassoc-GE :
-      ∀ x y z → GroupEqualityElem (gMul (gMul x y) z) (gMul x (gMul y z))
-    xl-unit : ∀ x → GroupEqualityElem (gMul gUnit x) x
-    xr-unit : ∀ x → GroupEqualityElem (gMul x gUnit) x
-    xl-inv : ∀ x → GroupEqualityElem (gMul (gInv x) x) gUnit
-    xr-inv : ∀ x → GroupEqualityElem (gMul x (gInv x)) gUnit
+      (x y z : GroupSyntax n) →
+      GroupEqualityElem (gMul (gMul x y) z) (gMul x (gMul y z))
+    xl-unit :
+      (x : GroupSyntax n) → GroupEqualityElem (gMul gUnit x) x
+    xr-unit :
+      (x : GroupSyntax n) → GroupEqualityElem (gMul x gUnit) x
+    xl-inv :
+      (x : GroupSyntax n) → GroupEqualityElem (gMul (gInv x) x) gUnit
+    xr-inv :
+      (x : GroupSyntax n) → GroupEqualityElem (gMul x (gInv x)) gUnit
 
     -- Theorems that are provable from the others
-    xinv-unit-GE : GroupEqualityElem (gInv gUnit) gUnit
-    xinv-inv-GE : ∀ x → GroupEqualityElem (gInv (gInv x)) x
+    xinv-unit-GE :
+      GroupEqualityElem (gInv gUnit) gUnit
+    xinv-inv-GE :
+      (x : GroupSyntax n) → GroupEqualityElem (gInv (gInv x)) x
     xdistr-inv-mul-GE :
-      ∀ x y → GroupEqualityElem (gInv (gMul x y)) (gMul (gInv y) (gInv x))
+      (x y : GroupSyntax n) →
+      GroupEqualityElem (gInv (gMul x y)) (gMul (gInv y) (gInv x))
+
   data GroupEquality : GroupSyntax n → GroupSyntax n → UU where
-    refl-GE : ∀ {x} → GroupEquality x x
+    refl-GE :
+      {x : GroupSyntax n} → GroupEquality x x
     _∷GE_ :
-      ∀ {x} {y} {z} →
+      {x y z : GroupSyntax n} →
       GroupEqualityElem x y → GroupEquality y z → GroupEquality x z
 
   infixr 10 _∷GE_
 
   module _ where
     -- equivalence relation
-    singleton-GE : ∀ {x y} → GroupEqualityElem x y → GroupEquality x y
+    singleton-GE :
+      {x y : GroupSyntax n} → GroupEqualityElem x y → GroupEquality x y
     singleton-GE x = x ∷GE refl-GE
 
     _∙GE_ :
-      ∀ {x} {y} {z} → GroupEquality x y → GroupEquality y z → GroupEquality x z
+      {x y z : GroupSyntax n} →
+      GroupEquality x y → GroupEquality y z → GroupEquality x z
     refl-GE ∙GE b = b
     (x ∷GE a) ∙GE b = x ∷GE (a ∙GE b)
     infixr 15 _∙GE_
 
-    sym-GE : ∀ {x} {y} → GroupEquality x y → GroupEquality y x
+    sym-GE : {x y : GroupSyntax n} → GroupEquality x y → GroupEquality y x
     sym-GE refl-GE = refl-GE
     sym-GE (a ∷GE as) = sym-GE as ∙GE singleton-GE (xsym-GE a)
 
     -- Variations on ap
-    ap-gInv : ∀ {x} {y} → GroupEquality x y → GroupEquality (gInv x) (gInv y)
+    ap-gInv :
+      {x y : GroupSyntax n} →
+      GroupEquality x y → GroupEquality (gInv x) (gInv y)
     ap-gInv refl-GE = refl-GE
     ap-gInv (a ∷GE as) = xap-gInv a ∷GE ap-gInv as
+
     ap-gMul-l :
-      ∀ {x} {y} {z} → GroupEquality x y → GroupEquality (gMul x z) (gMul y z)
+      {x y z : GroupSyntax n} →
+      GroupEquality x y → GroupEquality (gMul x z) (gMul y z)
     ap-gMul-l refl-GE = refl-GE
     ap-gMul-l (x ∷GE xs) = xap-gMul-l x ∷GE ap-gMul-l xs
+
     ap-gMul-r :
-      ∀ {x} {y} {z} → GroupEquality y z → GroupEquality (gMul x y) (gMul x z)
+      {x y z : GroupSyntax n} →
+      GroupEquality y z → GroupEquality (gMul x y) (gMul x z)
     ap-gMul-r refl-GE = refl-GE
     ap-gMul-r (x ∷GE xs) = xap-gMul-r x ∷GE ap-gMul-r xs
+
     ap-gMul :
-      ∀ {x} {y} {z} {w} →
+      {x y z w : GroupSyntax n} →
       GroupEquality x y → GroupEquality z w →
       GroupEquality (gMul x z) (gMul y w)
     ap-gMul p q = ap-gMul-l p ∙GE ap-gMul-r q
 
     -- Group laws
-    assoc-GE : ∀ x y z → GroupEquality (gMul (gMul x y) z) (gMul x (gMul y z))
+    assoc-GE :
+      (x y z : GroupSyntax n) →
+      GroupEquality (gMul (gMul x y) z) (gMul x (gMul y z))
     assoc-GE x y z = singleton-GE (xassoc-GE x y z)
-    l-unit : ∀ x → GroupEquality (gMul gUnit x) x
+
+    l-unit :
+      (x : GroupSyntax n) → GroupEquality (gMul gUnit x) x
     l-unit x = singleton-GE (xl-unit x)
-    r-unit : ∀ x → GroupEquality (gMul x gUnit) x
+
+    r-unit :
+      (x : GroupSyntax n) → GroupEquality (gMul x gUnit) x
     r-unit x = singleton-GE (xr-unit x)
-    l-inv : ∀ x → GroupEquality (gMul (gInv x) x) gUnit
+
+    l-inv :
+      (x : GroupSyntax n) → GroupEquality (gMul (gInv x) x) gUnit
     l-inv x = singleton-GE (xl-inv x)
-    r-inv : ∀ x → GroupEquality (gMul x (gInv x)) gUnit
+
+    r-inv :
+      (x : GroupSyntax n) → GroupEquality (gMul x (gInv x)) gUnit
     r-inv x = singleton-GE (xr-inv x)
 
     -- Theorems that are provable from the others
     inv-unit-GE : GroupEquality (gInv gUnit) gUnit
     inv-unit-GE = singleton-GE (xinv-unit-GE)
-    inv-inv-GE : ∀ x → GroupEquality (gInv (gInv x)) x
+
+    inv-inv-GE : (x : GroupSyntax n) → GroupEquality (gInv (gInv x)) x
     inv-inv-GE x = singleton-GE (xinv-inv-GE x)
+
     distr-inv-mul-GE :
-      ∀ x y → GroupEquality (gInv (gMul x y)) (gMul (gInv y) (gInv x))
+      (x y : GroupSyntax n) →
+      GroupEquality (gInv (gMul x y)) (gMul (gInv y) (gInv x))
     distr-inv-mul-GE x y = singleton-GE (xdistr-inv-mul-GE x y)
 
-  assoc-GE' : ∀ x y z → GroupEquality (gMul x (gMul y z)) (gMul (gMul x y) z)
+  assoc-GE' :
+    (x y z : GroupSyntax n) →
+    GroupEquality (gMul x (gMul y z)) (gMul (gMul x y) z)
   assoc-GE' x y z = sym-GE (assoc-GE x y z)
 
   elim-inverses-remove-valid :
@@ -239,7 +277,7 @@ module _ {n : ℕ} where
     elim-inverses-valid x (elim-inverses y (concat-simplify a b))
 
   concat-simplify-valid :
-    ∀ (u w : Simple n) →
+    (u w : Simple n) →
     GroupEquality
       ( gMul (unquoteSimple w) (unquoteSimple u))
       ( unquoteSimple (concat-simplify u w))
@@ -247,7 +285,7 @@ module _ {n : ℕ} where
   concat-simplify-valid (cons x a) b = concat-simplify-nonempty-valid x a b
 
   inv-single-valid :
-    ∀ w →
+    (w : SimpleElem n) →
     GroupEquality
       ( gInv (unquoteSimpleElem w))
       ( unquoteSimpleElem (inv-SE' w))
@@ -280,7 +318,7 @@ module _ {n : ℕ} where
       ( unquoteSimple (concat-list xs (cons x nil)))
   gMul-concat-1 xs a = gMul-concat' xs (cons a nil)
 
-  -- inv-simplify-valid'-nonempty : ∀ (x : SimpleElem n) (xs : list (SimpleElem n)) →
+  -- inv-simplify-valid'-nonempty : (x : SimpleElem n) (xs : list (SimpleElem n)) →
   --                               GroupEquality (gInv (unquoteSimple (cons x xs)))
   --                               (unquoteSimple (reverse-list (map-list inv-SE' (cons x xs))))
   -- inv-simplify-valid'-nonempty x nil = inv-single-valid x
@@ -289,14 +327,14 @@ module _ {n : ℕ} where
   --   ap-gMul (inv-single-valid x) (inv-simplify-valid'-nonempty y xs) ∙GE
   --   gMul-concat-1 (concat-list (reverse-list (map-list inv-SE' xs)) (in-list (inv-SE' y))) (inv-SE' x)
 
-  -- inv-simplify-valid' : ∀ (w : list (SimpleElem n)) →
+  -- inv-simplify-valid' : (w : list (SimpleElem n)) →
   --                     GroupEquality (gInv (unquoteSimple w))
   --                     (unquoteSimple (reverse-list (map-list inv-SE' w)))
   -- inv-simplify-valid' nil = inv-unit-GE
   -- inv-simplify-valid' (cons x xs) =
   --   inv-simplify-valid'-nonempty x xs
 
-  -- simplifyValid : ∀ (g : GroupSyntax n) → GroupEquality g (unquoteSimple (simplifyGS g))
+  -- simplifyValid : (g : GroupSyntax n) → GroupEquality g (unquoteSimple (simplifyGS g))
   -- simplifyValid gUnit = refl-GE
   -- simplifyValid (gMul a b) =
   --   (ap-gMul (simplifyValid a) (simplifyValid b)) ∙GE
@@ -304,14 +342,14 @@ module _ {n : ℕ} where
   -- simplifyValid (gInv g) = ap-gInv (simplifyValid g) ∙GE inv-simplify-valid' (simplifyGS g)
   -- simplifyValid (inner _) = refl-GE
 
-  Env : ∀ {l} → ℕ → UU l → UU l
+  Env : {l : Level} → ℕ → UU l → UU l
   Env n A = vec A n
 
   module _
     {l : Level} (G : Group l)
     where
 
-    unQuoteGS : ∀ {n} → GroupSyntax n → Env n (type-Group G) → type-Group G
+    unQuoteGS : {n : ℕ} → GroupSyntax n → Env n (type-Group G) → type-Group G
     unQuoteGS gUnit e = unit-Group G
     unQuoteGS (gMul x y) e = mul-Group G (unQuoteGS x e) (unQuoteGS y e)
     unQuoteGS (gInv x) e = inv-Group G (unQuoteGS x e)
@@ -357,7 +395,7 @@ module _ {n : ℕ} where
       useGroupEqualityElem env x ∙ useGroupEquality env xs
 
     -- simplifyExpression :
-    --   ∀ (g : GroupSyntax n) (env : Env n (type-Group G)) →
+    --   (g : GroupSyntax n) (env : Env n (type-Group G)) →
     --   unQuoteGS g env ＝ unQuoteGS (unquoteSimple (simplifyGS g)) env
     -- simplifyExpression g env = useGroupEquality env (simplifyValid g)
 
@@ -366,19 +404,19 @@ module _ {n : ℕ} where
     n-args zero-ℕ A B = B
     n-args (succ-ℕ n) A B = A → n-args n A B
     map-n-args :
-      ∀ {A A' B : UU} (n : ℕ) → (A' → A) → n-args n A B → n-args n A' B
+      {A A' B : UU} (n : ℕ) → (A' → A) → n-args n A B → n-args n A' B
     map-n-args zero-ℕ f v = v
     map-n-args (succ-ℕ n) f v = λ x → map-n-args n f (v (f x))
-    apply-n-args-fin : ∀ {B : UU} (n : ℕ) → n-args n (Fin n) B → B
+    apply-n-args-fin : {B : UU} (n : ℕ) → n-args n (Fin n) B → B
     apply-n-args-fin zero-ℕ f = f
     apply-n-args-fin (succ-ℕ n) f =
       apply-n-args-fin n (map-n-args n succ-Fin (f zero-Fin))
-    apply-n-args : ∀ {B : UU} (n : ℕ) → n-args n (GroupSyntax n) B → B
+    apply-n-args : {B : UU} (n : ℕ) → n-args n (GroupSyntax n) B → B
     apply-n-args n f = apply-n-args-fin n (map-n-args n inner f)
 
     -- A variation of simplifyExpression which takes a function from the free variables to expr
     -- simplifyExpr :
-    --   ∀ (env : Env n (type-Group G)) (g : n-args n (GroupSyntax n) (GroupSyntax n)) →
+    --   (env : Env n (type-Group G)) (g : n-args n (GroupSyntax n) (GroupSyntax n)) →
     --   unQuoteGS (apply-n-args n g) env ＝ unQuoteGS (unquoteSimple (simplifyGS (apply-n-args n g))) env
     -- simplifyExpr env g = simplifyExpression (apply-n-args n g) env
 
@@ -386,7 +424,7 @@ module _ {n : ℕ} where
 ```
 
 ```agda
--- private _\*'_ : ∀ {n} → GroupSyntax n → GroupSyntax n → GroupSyntax n _\*'_ =
+-- private _\*'_ : {n : ℕ} → GroupSyntax n → GroupSyntax n → GroupSyntax n _\*'_ =
 -- gMul x : GroupSyntax 2 x = inner (zero-Fin) y : GroupSyntax 2 y = inner
 -- (succ-Fin zero-Fin)
 

--- a/src/reflection/metavariables.lagda.md
+++ b/src/reflection/metavariables.lagda.md
@@ -37,7 +37,8 @@ primitive
   primMetaLess : Meta → Meta → bool
   primShowMeta : Meta → String
   primMetaToNat : Meta → ℕ
-  primMetaToNatInjective : ∀ a b → primMetaToNat a ＝ primMetaToNat b → a ＝ b
+  primMetaToNatInjective :
+    (a b : Meta) → primMetaToNat a ＝ primMetaToNat b → a ＝ b
 
 data Blocker : UU lzero where
   blocker-any : list Blocker → Blocker

--- a/src/reflection/names.lagda.md
+++ b/src/reflection/names.lagda.md
@@ -40,7 +40,7 @@ primitive
   primShowQName : Name → String
   primQNameToWord64s : Name → Word64 × Word64
   primQNameToWord64sInjective :
-    ∀ a b → primQNameToWord64s a ＝ primQNameToWord64s b → a ＝ b
+    (a b : Name) → primQNameToWord64s a ＝ primQNameToWord64s b → a ＝ b
 ```
 
 ## Examples

--- a/src/reflection/type-checking-monad.lagda.md
+++ b/src/reflection/type-checking-monad.lagda.md
@@ -49,33 +49,33 @@ data ErrorPart : UU lzero where
 
 postulate
   -- The type checking monad
-  TC : ∀ {a} → UU a → UU a
-  returnTC : ∀ {a} {A : UU a} → A → TC A
-  bindTC : ∀ {a b} {A : UU a} {B : UU b} → TC A → (A → TC B) → TC B
+  TC : {l1 : Level} → UU l1 → UU l1
+  returnTC : {l1 : Level} {A : UU l1} → A → TC A
+  bindTC : {l1 l2 : Level} {A : UU l1} {B : UU l2} → TC A → (A → TC B) → TC B
   -- Tries the unify the first term with the second
   unify : Term → Term → TC unit
   -- Gives an error
-  typeError : ∀ {a} {A : UU a} → list ErrorPart → TC A
+  typeError : {l1 : Level} {A : UU l1} → list ErrorPart → TC A
   -- Infers the type of a goal
   inferType : Term → TC Term
   checkType : Term → Term → TC Term
   normalise : Term → TC Term
   reduce : Term → TC Term
   -- Tries the first computation, if it fails tries the second
-  catchTC : ∀ {a} {A : UU a} → TC A → TC A → TC A
-  quoteTC : ∀ {a} {A : UU a} → A → TC Term
-  unquoteTC : ∀ {a} {A : UU a} → Term → TC A
-  quoteωTC : ∀ {A : UUω} → A → TC Term
+  catchTC : {l1 : Level} {A : UU l1} → TC A → TC A → TC A
+  quoteTC : {l1 : Level} {A : UU l1} → A → TC Term
+  unquoteTC : {l1 : Level} {A : UU l1} → Term → TC A
+  quoteωTC : {A : UUω} → A → TC Term
   getContext : TC Telescope
-  extendContext : ∀ {a} {A : UU a} → String → Arg Term → TC A → TC A
-  inContext : ∀ {a} {A : UU a} → Telescope → TC A → TC A
+  extendContext : {l1 : Level} {A : UU l1} → String → Arg Term → TC A → TC A
+  inContext : {l1 : Level} {A : UU l1} → Telescope → TC A → TC A
   freshName : String → TC Name
   declareDef : Arg Name → Term → TC unit
   declarePostulate : Arg Name → Term → TC unit
   defineFun : Name → list Clause → TC unit
   getType : Name → TC Term
   getDefinition : Name → TC Definition
-  blockTC : ∀ {a} {A : UU a} → Blocker → TC A
+  blockTC : {l1 : Level} {A : UU l1} → Blocker → TC A
   commitTC : TC unit
   isMacro : Name → TC bool
 
@@ -87,31 +87,31 @@ postulate
 
   -- If 'true', makes the following primitives also normalise
   -- their results: inferType, checkType, quoteTC, getType, and getContext
-  withNormalisation : ∀ {a} {A : UU a} → bool → TC A → TC A
+  withNormalisation : {l1 : Level} {A : UU l1} → bool → TC A → TC A
   askNormalisation : TC bool
 
   -- If 'true', makes the following primitives to reconstruct hidden arguments:
   -- getDefinition, normalise, reduce, inferType, checkType and getContext
-  withReconstructed : ∀ {a} {A : UU a} → bool → TC A → TC A
+  withReconstructed : {l1 : Level} {A : UU l1} → bool → TC A → TC A
   askReconstructed : TC bool
 
   -- Whether implicit arguments at the end should be turned into metavariables
-  withExpandLast : ∀ {a} {A : UU a} → bool → TC A → TC A
+  withExpandLast : {l1 : Level} {A : UU l1} → bool → TC A → TC A
   askExpandLast : TC bool
 
   -- White/blacklist specific definitions for reduction while executing the TC computation
   -- 'true' for whitelist, 'false' for blacklist
-  withReduceDefs : ∀ {a} {A : UU a} → (Σ bool λ _ → list Name) → TC A → TC A
+  withReduceDefs : {l1 : Level} {A : UU l1} → (Σ bool λ _ → list Name) → TC A → TC A
   askReduceDefs : TC (Σ bool λ _ → list Name)
 
   -- Fail if the given computation gives rise to new, unsolved
   -- "blocking" constraints.
-  noConstraints : ∀ {a} {A : UU a} → TC A → TC A
+  noConstraints : {l1 : Level} {A : UU l1} → TC A → TC A
 
   -- Run the given TC action and return the first component. Resets to
   -- the old TC state if the second component is 'false', or keep the
   -- new TC state if it is 'true'.
-  runSpeculative : ∀ {a} {A : UU a} → TC (Σ A λ _ → bool) → TC A
+  runSpeculative : {l1 : Level} {A : UU l1} → TC (Σ A λ _ → bool) → TC A
 
   -- Get a list of all possible instance candidates for the given meta
   -- variable (it does not have to be an instance meta).

--- a/src/reflection/type-checking-monad.lagda.md
+++ b/src/reflection/type-checking-monad.lagda.md
@@ -101,7 +101,8 @@ postulate
 
   -- White/blacklist specific definitions for reduction while executing the TC computation
   -- 'true' for whitelist, 'false' for blacklist
-  withReduceDefs : {l1 : Level} {A : UU l1} → (Σ bool λ _ → list Name) → TC A → TC A
+  withReduceDefs :
+    {l1 : Level} {A : UU l1} → (Σ bool λ _ → list Name) → TC A → TC A
   askReduceDefs : TC (Σ bool λ _ → list Name)
 
   -- Fail if the given computation gives rise to new, unsolved

--- a/src/univalent-combinatorics/pi-finite-types.lagda.md
+++ b/src/univalent-combinatorics/pi-finite-types.lagda.md
@@ -143,9 +143,9 @@ mere-equiv-number-of-connected-components H =
 is-π-finite-Prop : {l : Level} (k : ℕ) → UU l → Prop l
 is-π-finite-Prop zero-ℕ X = has-finite-connected-components-Prop X
 is-π-finite-Prop (succ-ℕ k) X =
-  prod-Prop ( is-π-finite-Prop zero-ℕ X)
-            ( Π-Prop X
-              ( λ x → Π-Prop X (λ y → is-π-finite-Prop k (Id x y))))
+  prod-Prop
+    ( is-π-finite-Prop zero-ℕ X)
+    ( Π-Prop X (λ x → Π-Prop X (λ y → is-π-finite-Prop k (Id x y))))
 
 is-π-finite : {l : Level} (k : ℕ) → UU l → UU l
 is-π-finite k X = type-Prop (is-π-finite-Prop k X)


### PR DESCRIPTION
Tries adding operators on propositions that give propositions. The suggested scheme is to use unicode symbols when taking values in types, and spelled-out words when taking values in types. The base motivation is that if we want to have infix operators that take proposition as inputs, then they should also spit out propositions.

if you like this (and that's a big if), then I would also suggest renaming `¬` to something else, so we can use `¬` for the operator on propositions. The exists-operator is also an issue.

This PR will need some iterations before it can be merged, so feedback along the way is appreciated.