### PR TITLE
Inline `pair`

### DIFF
--- a/src/foundation/dependent-pair-types.lagda.md
+++ b/src/foundation/dependent-pair-types.lagda.md
@@ -31,6 +31,7 @@ record Σ {l1 l2 : Level} (A : UU l1) (B : A → UU l2) : UU (l1 ⊔ l2) where
 open Σ public
 
 {-# BUILTIN SIGMA Σ #-}
+{-# INLINE pair #-}
 
 infixr 3 _,_
 pattern _,_ a b = pair a b


### PR DESCRIPTION
Sets the pragma
```agda
{-# INLINE pair #-}
```
https://agda.readthedocs.io/en/latest/language/pragmas.html#inlining-constructor-right-hand-sides
Presumably, this gives us the performance benefit of copattern matched definitions, while also giving us the flexibility to use `_,_` and `pair` to make definitions.