### PR TITLE
Definition of monads on precategories and categories (+ of whiskering and horizontal composition)

### DIFF
--- a/src/category-theory.lagda.md
+++ b/src/category-theory.lagda.md
@@ -96,6 +96,7 @@ open import category-theory.maps-from-small-to-large-categories public
 open import category-theory.maps-from-small-to-large-precategories public
 open import category-theory.maps-precategories public
 open import category-theory.maps-set-magmoids public
+open import category-theory.monads-on-precategories public
 open import category-theory.monomorphisms-in-large-precategories public
 open import category-theory.natural-isomorphisms-functors-categories public
 open import category-theory.natural-isomorphisms-functors-large-precategories public

--- a/src/category-theory.lagda.md
+++ b/src/category-theory.lagda.md
@@ -96,6 +96,7 @@ open import category-theory.maps-from-small-to-large-categories public
 open import category-theory.maps-from-small-to-large-precategories public
 open import category-theory.maps-precategories public
 open import category-theory.maps-set-magmoids public
+open import category-theory.monads-on-categories public
 open import category-theory.monads-on-precategories public
 open import category-theory.monomorphisms-in-large-precategories public
 open import category-theory.natural-isomorphisms-functors-categories public

--- a/src/category-theory/monads-on-categories.lagda.md
+++ b/src/category-theory/monads-on-categories.lagda.md
@@ -8,8 +8,8 @@ module category-theory.monads-on-categories where
 
 ```agda
 open import category-theory.categories
-open import category-theory.precategories
 open import category-theory.monads-on-precategories
+open import category-theory.precategories
 
 open import foundation.universe-levels
 ```

--- a/src/category-theory/monads-on-categories.lagda.md
+++ b/src/category-theory/monads-on-categories.lagda.md
@@ -1,0 +1,30 @@
+# Monads on categories
+
+```agda
+module category-theory.monads-on-categories where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import category-theory.categories
+open import category-theory.precategories
+open import category-theory.monads-on-precategories
+
+open import foundation.universe-levels
+```
+
+</details>
+
+## Definitions
+
+### The type of monads on categories
+
+```agda
+module _
+  {l : Level} (C : Category l l)
+  where
+
+  monad-Category : UU l
+  monad-Category = monad-Precategory l (precategory-Category C)
+```

--- a/src/category-theory/monads-on-precategories.lagda.md
+++ b/src/category-theory/monads-on-precategories.lagda.md
@@ -20,6 +20,22 @@ open import foundation-core.cartesian-product-types
 
 </details>
 
+## Idea
+
+A monad on a precategory `C` consists of an endofunctor `T : C → C` together
+with two natural transformations: `η : 1_C ⇒ T` and `μ : T² ⇒ T` (where
+`1_C : C → C` is the identity functor for `C`, and `T²` is the functor
+`T ∘ T : C → C`).
+
+These must fulfill the _coherence conditions_:
+
+- `μ ∘ (T • μ) = μ ∘ (μ • T)`, and
+- `μ ∘ (T • η) = μ ∘ (η • T) = 1_T`.
+
+Here, `•` denotes
+[whiskering](category-theory.natural-transformations-functors-precategories.md#whiskering),
+and `1_T : T ⇒ T` denotes the identity natural transformation for `T`.
+
 ## Definitions
 
 ### The type of monads on precategories

--- a/src/category-theory/monads-on-precategories.lagda.md
+++ b/src/category-theory/monads-on-precategories.lagda.md
@@ -34,15 +34,13 @@ Monad-Precategory l C =
                     ( comp-functor-Precategory C C C T T)
                     ( T)
                     ( mu)
-                    ( horizontal-comp-natural-transformation-Precategory
-                      ( C)
-                      ( C)
-                      ( C)
+                    ( whiskering-functor-natural-transformation-Precategory
+                      {C = C}
+                      {D = C}
+                      {E = C}
                       ( comp-functor-Precategory C C C T T)
                       ( T)
                       ( T)
-                      ( T)
-                      ( id-natural-transformation-Precategory C C T)
                       ( mu))
                   ＝
                     comp-natural-transformation-Precategory
@@ -52,16 +50,14 @@ Monad-Precategory l C =
                       ( comp-functor-Precategory C C C T T)
                       ( T)
                       ( mu)
-                      ( horizontal-comp-natural-transformation-Precategory
-                        ( C)
-                        ( C)
-                        ( C)
-                        ( T)
-                        ( T)
+                      ( whiskering-natural-transformation-functor-Precategory
+                        {C = C}
+                        {D = C}
+                        {E = C}
                         ( comp-functor-Precategory C C C T T)
                         ( T)
                         ( mu)
-                        ( id-natural-transformation-Precategory C C T)))
+                        ( T)))
                   ( λ _ →
                     prod
                       ( comp-natural-transformation-Precategory
@@ -71,15 +67,13 @@ Monad-Precategory l C =
                           ( comp-functor-Precategory C C C T T)
                           ( T)
                           ( mu)
-                          ( horizontal-comp-natural-transformation-Precategory
-                            ( C)
-                            ( C)
-                            ( C)
+                          ( whiskering-functor-natural-transformation-Precategory
+                            {C = C}
+                            {D = C}
+                            {E = C}
                             ( id-functor-Precategory C)
                             ( T)
                             ( T)
-                            ( T)
-                            ( id-natural-transformation-Precategory C C T)
                             ( eta))
                       ＝
                         id-natural-transformation-Precategory C C T)
@@ -90,16 +84,14 @@ Monad-Precategory l C =
                           ( comp-functor-Precategory C C C T T)
                           ( T)
                           ( mu)
-                          ( horizontal-comp-natural-transformation-Precategory
-                            ( C)
-                            ( C)
-                            ( C)
-                            ( T)
-                            ( T)
+                          ( whiskering-natural-transformation-functor-Precategory
+                            {C = C}
+                            {D = C}
+                            {E = C}
                             ( id-functor-Precategory C)
                             ( T)
                             ( eta)
-                            ( id-natural-transformation-Precategory C C T))
+                            ( T))
                       ＝
                         id-natural-transformation-Precategory C C T)))))
 ```

--- a/src/category-theory/monads-on-precategories.lagda.md
+++ b/src/category-theory/monads-on-precategories.lagda.md
@@ -1,0 +1,52 @@
+# Monads on precategories
+
+```agda
+module category-theory.monads-on-precategories where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import category-theory.precategories
+open import category-theory.functors-precategories
+open import category-theory.natural-transformations-functors-precategories
+
+open import foundation.universe-levels
+open import foundation.dependent-pair-types
+open import foundation-core.cartesian-product-types
+open import foundation.identity-types
+```
+
+```agda
+Monad-Precategory :
+  (l : Level) (C : Precategory l l) → UU (lsuc l)
+Monad-Precategory l C =
+  Σ ( functor-Precategory C C)
+    ( λ T →
+      Σ ( natural-transformation-Precategory C C (id-functor-Precategory C) T)
+        ( λ eta →
+          Σ ( natural-transformation-Precategory C C (comp-functor-Precategory C C C T T) T)
+            ( λ mu →
+              Σ ( comp-natural-transformation-Precategory
+                    ( C)
+                    ( C)
+                    ( T)
+                    ( comp-functor-Precategory C C C T T)
+                    ( T)
+                    ( mu)
+                    ( horizontal-comp-natural-transformation-Precategory
+                      ( C)
+                      ( C)
+                      ( C)
+                      ( comp-functor-Precategory C C C {!  !} {!   !})
+                      ( T)
+                      ( T)
+                      ( T)
+                      ( id-natural-transformation-Precategory C C T)
+                      ( mu))
+                  ＝
+                    {!   !} )
+                  ( λ _ → prod {!   !} {!   !} ))))
+
+-- proposed solution: (comp-functor-Precategory C C C T T)
+```

--- a/src/category-theory/monads-on-precategories.lagda.md
+++ b/src/category-theory/monads-on-precategories.lagda.md
@@ -22,10 +22,12 @@ open import foundation-core.cartesian-product-types
 
 ## Idea
 
-A monad on a precategory `C` consists of an endofunctor `T : C → C` together
-with two natural transformations: `η : 1_C ⇒ T` and `μ : T² ⇒ T` (where
-`1_C : C → C` is the identity functor for `C`, and `T²` is the functor
-`T ∘ T : C → C`).
+A monad on a precategory `C` consists of an
+endo[functor](category-theory.functors-precategories.md) `T : C → C` together
+with two
+[natural transformations](category-theory.natural-transformations-functors-precategories.md):
+`η : 1_C ⇒ T` and `μ : T² ⇒ T` (where `1_C : C → C` is the identity functor for
+`C`, and `T²` is the functor `T ∘ T : C → C`).
 
 These must fulfill the _coherence conditions_:
 

--- a/src/category-theory/monads-on-precategories.lagda.md
+++ b/src/category-theory/monads-on-precategories.lagda.md
@@ -7,15 +7,18 @@ module category-theory.monads-on-precategories where
 <details><summary>Imports</summary>
 
 ```agda
-open import category-theory.precategories
 open import category-theory.functors-precategories
 open import category-theory.natural-transformations-functors-precategories
+open import category-theory.precategories
 
-open import foundation.universe-levels
 open import foundation.dependent-pair-types
-open import foundation-core.cartesian-product-types
 open import foundation.identity-types
+open import foundation.universe-levels
+
+open import foundation-core.cartesian-product-types
 ```
+
+</details>
 
 ```agda
 Monad-Precategory :
@@ -25,12 +28,20 @@ Monad-Precategory l C =
     ( λ T →
       Σ ( natural-transformation-Precategory C C (id-functor-Precategory C) T)
         ( λ eta →
-          Σ ( natural-transformation-Precategory C C (comp-functor-Precategory C C C T T) T)
+          Σ ( natural-transformation-Precategory
+              ( C)
+              ( C)
+              ( comp-functor-Precategory C C C T T) T)
             ( λ mu →
               Σ ( comp-natural-transformation-Precategory
                     ( C)
                     ( C)
-                    (comp-functor-Precategory C C C T (comp-functor-Precategory C C C T T))
+                    ( comp-functor-Precategory
+                      ( C)
+                      ( C)
+                      ( C)
+                      ( T)
+                      ( comp-functor-Precategory C C C T T))
                     ( comp-functor-Precategory C C C T T)
                     ( T)
                     ( mu)
@@ -46,7 +57,11 @@ Monad-Precategory l C =
                     comp-natural-transformation-Precategory
                       ( C)
                       ( C)
-                      (comp-functor-Precategory C C C (comp-functor-Precategory C C C T T) T)
+                      (comp-functor-Precategory
+                        ( C)
+                        ( C)
+                        ( C)
+                        ( comp-functor-Precategory C C C T T) T)
                       ( comp-functor-Precategory C C C T T)
                       ( T)
                       ( mu)

--- a/src/category-theory/monads-on-precategories.lagda.md
+++ b/src/category-theory/monads-on-precategories.lagda.md
@@ -19,7 +19,7 @@ open import foundation.identity-types
 
 ```agda
 Monad-Precategory :
-  (l : Level) (C : Precategory l l) → UU (lsuc l)
+  (l : Level) (C : Precategory l l) → UU l
 Monad-Precategory l C =
   Σ ( functor-Precategory C C)
     ( λ T →
@@ -30,7 +30,7 @@ Monad-Precategory l C =
               Σ ( comp-natural-transformation-Precategory
                     ( C)
                     ( C)
-                    ( T)
+                    (comp-functor-Precategory C C C T (comp-functor-Precategory C C C T T))
                     ( comp-functor-Precategory C C C T T)
                     ( T)
                     ( mu)
@@ -38,15 +38,68 @@ Monad-Precategory l C =
                       ( C)
                       ( C)
                       ( C)
-                      ( comp-functor-Precategory C C C {!  !} {!   !})
+                      ( comp-functor-Precategory C C C T T)
                       ( T)
                       ( T)
                       ( T)
                       ( id-natural-transformation-Precategory C C T)
                       ( mu))
                   ＝
-                    {!   !} )
-                  ( λ _ → prod {!   !} {!   !} ))))
-
--- proposed solution: (comp-functor-Precategory C C C T T)
+                    comp-natural-transformation-Precategory
+                      ( C)
+                      ( C)
+                      (comp-functor-Precategory C C C (comp-functor-Precategory C C C T T) T)
+                      ( comp-functor-Precategory C C C T T)
+                      ( T)
+                      ( mu)
+                      ( horizontal-comp-natural-transformation-Precategory
+                        ( C)
+                        ( C)
+                        ( C)
+                        ( T)
+                        ( T)
+                        ( comp-functor-Precategory C C C T T)
+                        ( T)
+                        ( mu)
+                        ( id-natural-transformation-Precategory C C T)))
+                  ( λ _ →
+                    prod
+                      ( comp-natural-transformation-Precategory
+                          ( C)
+                          ( C)
+                          ( T)
+                          ( comp-functor-Precategory C C C T T)
+                          ( T)
+                          ( mu)
+                          ( horizontal-comp-natural-transformation-Precategory
+                            ( C)
+                            ( C)
+                            ( C)
+                            ( id-functor-Precategory C)
+                            ( T)
+                            ( T)
+                            ( T)
+                            ( id-natural-transformation-Precategory C C T)
+                            ( eta))
+                      ＝
+                        id-natural-transformation-Precategory C C T)
+                      ( comp-natural-transformation-Precategory
+                          ( C)
+                          ( C)
+                          ( T)
+                          ( comp-functor-Precategory C C C T T)
+                          ( T)
+                          ( mu)
+                          ( horizontal-comp-natural-transformation-Precategory
+                            ( C)
+                            ( C)
+                            ( C)
+                            ( T)
+                            ( T)
+                            ( id-functor-Precategory C)
+                            ( T)
+                            ( eta)
+                            ( id-natural-transformation-Precategory C C T))
+                      ＝
+                        id-natural-transformation-Precategory C C T)))))
 ```

--- a/src/category-theory/monads-on-precategories.lagda.md
+++ b/src/category-theory/monads-on-precategories.lagda.md
@@ -20,10 +20,14 @@ open import foundation-core.cartesian-product-types
 
 </details>
 
+## Definitions
+
+### The type of monads on precategories
+
 ```agda
-Monad-Precategory :
+monad-Precategory :
   (l : Level) (C : Precategory l l) → UU l
-Monad-Precategory l C =
+monad-Precategory l C =
   Σ ( functor-Precategory C C)
     ( λ T →
       Σ ( natural-transformation-Precategory C C (id-functor-Precategory C) T)

--- a/src/category-theory/natural-transformations-functors-precategories.lagda.md
+++ b/src/category-theory/natural-transformations-functors-precategories.lagda.md
@@ -259,11 +259,45 @@ module _
       ( map-functor-Precategory C D I)
 ```
 
-## Composition of natural transformations
+## Whiskering and horizontal composition
 
 ```agda
 module _
-  {l1 l2 l3 l4 l5 l6 : Level} (C : Precategory l1 l2) (D : Precategory l3 l4) (E : Precategory l5 l6)
+  {l1 l2 l3 l4 l5 l6 : Level}
+  {C : Precategory l1 l2}
+  {D : Precategory l3 l4}
+  {E : Precategory l5 l6}
+  where
+
+  whiskering-functor-natural-transformation-Precategory :
+    (F G : functor-Precategory C D)
+    (H : functor-Precategory D E)
+    (α : natural-transformation-Precategory C D F G) →
+    natural-transformation-Precategory
+      ( C)
+      ( E)
+      ( comp-functor-Precategory C D E H F)
+      ( comp-functor-Precategory C D E H G)
+  whiskering-functor-natural-transformation-Precategory = {!   !}
+
+  whiskering-natural-transformation-functor-Precategory :
+    (F G : functor-Precategory C D)
+    (α : natural-transformation-Precategory C D F G)
+    (K : functor-Precategory E C) →
+    natural-transformation-Precategory
+      ( E)
+      ( D)
+      ( comp-functor-Precategory E C D F K)
+      ( comp-functor-Precategory E C D G K)
+  whiskering-natural-transformation-functor-Precategory = {!   !}
+```
+
+```agda
+module _
+  {l1 l2 l3 l4 l5 l6 : Level}
+  (C : Precategory l1 l2)
+  (D : Precategory l3 l4)
+  (E : Precategory l5 l6)
   where
   horizontal-comp-natural-transformation-Precategory :
     (F G : functor-Precategory C D)
@@ -275,5 +309,13 @@ module _
       ( E)
       ( comp-functor-Precategory C D E H F)
       ( comp-functor-Precategory C D E I G)
-  horizontal-comp-natural-transformation-Precategory = {!   !}
+  horizontal-comp-natural-transformation-Precategory F G H I β α =
+    comp-natural-transformation-Precategory
+      ( C)
+      ( E)
+      ( comp-functor-Precategory C D E H F)
+      ( comp-functor-Precategory C D E H G)
+      ( comp-functor-Precategory C D E I G)
+      (whiskering-natural-transformation-functor-Precategory H I β G)
+      (whiskering-functor-natural-transformation-Precategory F G H α)
 ```

--- a/src/category-theory/natural-transformations-functors-precategories.lagda.md
+++ b/src/category-theory/natural-transformations-functors-precategories.lagda.md
@@ -281,7 +281,21 @@ module _
       ( comp-functor-Precategory C D E H G)
   whiskering-functor-natural-transformation-Precategory F G H α =
     ( λ x → (pr1 (pr2 H)) ((pr1 α) x)) ,
-    ( λ f → ({!   !} ∙ ap (pr1 (pr2 H)) ((pr2 α) f)) ∙ {!   !})
+    ( λ {x} {y} → λ f →
+      inv
+        ( preserves-comp-functor-Precategory
+          ( D)
+          ( E)
+          ( H)
+          ( (pr1 (pr2 G)) f)
+          ( (pr1 α) x)) ∙
+      ( ap (pr1 (pr2 H)) ((pr2 α) f)) ∙
+      ( preserves-comp-functor-Precategory
+        ( D)
+        ( E)
+        ( H)
+        ( (pr1 α) y)
+        ( (pr1 (pr2 F)) f)))
 
   whiskering-natural-transformation-functor-Precategory :
     (F G : functor-Precategory C D)

--- a/src/category-theory/natural-transformations-functors-precategories.lagda.md
+++ b/src/category-theory/natural-transformations-functors-precategories.lagda.md
@@ -324,11 +324,14 @@ module _
 
 ## Horizontal composition
 
-Horizontal composition (here denoted by `*`) is generalized whiskering (here
-denoted by `•`), and also defined by it. Given natural transformations
+Horizontal composition (here denoted by `*`) is generalized
+[whiskering](category-theory.natural-transformations-functors-precategories.md#whiskering)
+(here denoted by `•`), and also defined by it. Given natural transformations
 `α : F ⇒ G`, `F, G : C → D`, and `β : H ⇒ I`, `H, I : D → E`, we can form a
-natural transformation `β * α : H ∘ F ⇒ I ∘ G`. Its componentat at `x` is
-`(β * α)(x) = (β • G)(x) ∘ (H • α)(x)`.
+natural transformation `β * α : H ∘ F ⇒ I ∘ G`.
+
+More precisely, `β * α = (β • G) ∘ (H • α)`, that is, we compose two natural
+transformations obtained by whiskering.
 
 ```agda
 module _

--- a/src/category-theory/natural-transformations-functors-precategories.lagda.md
+++ b/src/category-theory/natural-transformations-functors-precategories.lagda.md
@@ -21,6 +21,7 @@ open import foundation.identity-types
 open import foundation.propositions
 open import foundation.sets
 open import foundation.universe-levels
+open import foundation.action-on-identifications-functions
 ```
 
 </details>
@@ -278,7 +279,9 @@ module _
       ( E)
       ( comp-functor-Precategory C D E H F)
       ( comp-functor-Precategory C D E H G)
-  whiskering-functor-natural-transformation-Precategory = {!   !}
+  whiskering-functor-natural-transformation-Precategory F G H α =
+    ( λ x → (pr1 (pr2 H)) ((pr1 α) x)) ,
+    ( λ f → ({!   !} ∙ ap (pr1 (pr2 H)) ((pr2 α) f)) ∙ {!   !})
 
   whiskering-natural-transformation-functor-Precategory :
     (F G : functor-Precategory C D)
@@ -289,15 +292,16 @@ module _
       ( D)
       ( comp-functor-Precategory E C D F K)
       ( comp-functor-Precategory E C D G K)
-  whiskering-natural-transformation-functor-Precategory = {!   !}
+  whiskering-natural-transformation-functor-Precategory F G α K =
+    (λ x → (pr1 α) ((pr1 K) x)) , (λ f → (pr2 α) ((pr1 (pr2 K)) f))
 ```
 
 ```agda
 module _
   {l1 l2 l3 l4 l5 l6 : Level}
-  (C : Precategory l1 l2)
-  (D : Precategory l3 l4)
-  (E : Precategory l5 l6)
+  {C : Precategory l1 l2}
+  {D : Precategory l3 l4}
+  {E : Precategory l5 l6}
   where
   horizontal-comp-natural-transformation-Precategory :
     (F G : functor-Precategory C D)
@@ -316,6 +320,6 @@ module _
       ( comp-functor-Precategory C D E H F)
       ( comp-functor-Precategory C D E H G)
       ( comp-functor-Precategory C D E I G)
-      (whiskering-natural-transformation-functor-Precategory H I β G)
-      (whiskering-functor-natural-transformation-Precategory F G H α)
+      ( whiskering-natural-transformation-functor-Precategory {C = D} {D = E} {E = C} H I β G)
+      ( whiskering-functor-natural-transformation-Precategory {C = C} {D = D} {E = E} F G H α)
 ```

--- a/src/category-theory/natural-transformations-functors-precategories.lagda.md
+++ b/src/category-theory/natural-transformations-functors-precategories.lagda.md
@@ -1,6 +1,8 @@
 # Natural transformations between functors between precategories
 
 ```agda
+{-# OPTIONS --allow-unsolved-metas #-}
+
 module category-theory.natural-transformations-functors-precategories where
 ```
 
@@ -255,4 +257,23 @@ module _
       ( map-functor-Precategory C D G)
       ( map-functor-Precategory C D H)
       ( map-functor-Precategory C D I)
+```
+
+## Composition of natural transformations
+
+```agda
+module _
+  {l1 l2 l3 l4 l5 l6 : Level} (C : Precategory l1 l2) (D : Precategory l3 l4) (E : Precategory l5 l6)
+  where
+  horizontal-comp-natural-transformation-Precategory :
+    (F G : functor-Precategory C D)
+    (H I : functor-Precategory D E)
+    (β : natural-transformation-Precategory D E H I)
+    (α : natural-transformation-Precategory C D F G) →
+    natural-transformation-Precategory
+      ( C)
+      ( E)
+      ( comp-functor-Precategory C D E H F)
+      ( comp-functor-Precategory C D E I G)
+  horizontal-comp-natural-transformation-Precategory = {!   !}
 ```

--- a/src/category-theory/natural-transformations-functors-precategories.lagda.md
+++ b/src/category-theory/natural-transformations-functors-precategories.lagda.md
@@ -13,6 +13,7 @@ open import category-theory.functors-precategories
 open import category-theory.natural-transformations-maps-precategories
 open import category-theory.precategories
 
+open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
 open import foundation.embeddings
 open import foundation.equivalences
@@ -21,7 +22,6 @@ open import foundation.identity-types
 open import foundation.propositions
 open import foundation.sets
 open import foundation.universe-levels
-open import foundation.action-on-identifications-functions
 ```
 
 </details>
@@ -334,6 +334,20 @@ module _
       ( comp-functor-Precategory C D E H F)
       ( comp-functor-Precategory C D E H G)
       ( comp-functor-Precategory C D E I G)
-      ( whiskering-natural-transformation-functor-Precategory {C = D} {D = E} {E = C} H I β G)
-      ( whiskering-functor-natural-transformation-Precategory {C = C} {D = D} {E = E} F G H α)
+      ( whiskering-natural-transformation-functor-Precategory
+        {C = D}
+        {D = E}
+        {E = C}
+        ( H)
+        ( I)
+        ( β)
+        ( G))
+      ( whiskering-functor-natural-transformation-Precategory
+        {C = C}
+        {D = D}
+        {E = E}
+        ( F)
+        ( G)
+        ( H)
+        ( α))
 ```

--- a/src/category-theory/natural-transformations-functors-precategories.lagda.md
+++ b/src/category-theory/natural-transformations-functors-precategories.lagda.md
@@ -260,7 +260,19 @@ module _
       ( map-functor-Precategory C D I)
 ```
 
-## Whiskering and horizontal composition
+## Whiskering
+
+If `α : F ⇒ G` is a natural transformations between functors `F, G : C → D`, and
+`H : D → E` is another functor, we can form the natural transformation
+`H • α : H ∘ F ⇒ H ∘ G`. Its component at `x` is `(H • α)(x) = H(α(x))`.
+
+On the other hand, if we have a functor `K : B → C`, we can form a natural
+transformation `α • K : F ∘ K ⇒ G ∘ K`. Its component at `x` is
+`(α • K)(x) = α(K(x))`.
+
+Here, `•` denotes _whiskering_. Note that there are two kinds of whiskering,
+depending on whether the first or the second parameter expects a natural
+transformation.
 
 ```agda
 module _
@@ -309,6 +321,14 @@ module _
   whiskering-natural-transformation-functor-Precategory F G α K =
     (λ x → (pr1 α) ((pr1 K) x)) , (λ f → (pr2 α) ((pr1 (pr2 K)) f))
 ```
+
+## Horizontal composition
+
+Horizontal composition (here denoted by `*`) is generalized whiskering (here
+denoted by `•`), and also defined by it. Given natural transformations
+`α : F ⇒ G`, `F, G : C → D`, and `β : H ⇒ I`, `H, I : D → E`, we can form a
+natural transformation `β * α : H ∘ F ⇒ I ∘ G`. Its componentat at `x` is
+`(β * α)(x) = (β • G)(x) ∘ (H • α)(x)`.
 
 ```agda
 module _


### PR DESCRIPTION
Note: I wanted to utilize implicit parameters more, but when I used them, Agda colored some text as yellow and weird and very long terms began appearing in the bottom "Agda" section of the screen, though they did not register as errors, and type checking also passed. So I decided to explicate all parameters, even the implicit ones.

Update: after adding explanation of the defined concepts in Markdown, there might be a problem with a link. I included this link to the section Whiskering:

```
[whiskering](category-theory.natural-transformations-functors-precategories.md#whiskering)
```

I don't know if this link format is supported.