### PR TITLE
A small optimization to equivalence relations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,10 +27,7 @@
   "files.exclude": {
     "MAlonzo/": true,
     "**/MAlonzo/": true,
-    "_build/": true,
-    "**/_build/": true,
-    "agdaFiles": true,
-    "src/temp/": true
+    "agdaFiles": true
   },
 
   // Snippet setup

--- a/src/finite-group-theory/abstract-quaternion-group.lagda.md
+++ b/src/finite-group-theory/abstract-quaternion-group.lagda.md
@@ -866,14 +866,14 @@ is-noncommutative-mul-Q8 :
 is-noncommutative-mul-Q8 f = Eq-eq-Q8 (f i-Q8 j-Q8)
 
 map-equiv-count-Q8 : Fin 8 → Q8
-map-equiv-count-Q8 (inl (inl (inl (inl (inl (inl (inl (inr star)))))))) = e-Q8
-map-equiv-count-Q8 (inl (inl (inl (inl (inl (inl (inr star))))))) = -e-Q8
-map-equiv-count-Q8 (inl (inl (inl (inl (inl (inr star)))))) = i-Q8
-map-equiv-count-Q8 (inl (inl (inl (inl (inr star))))) = -i-Q8
-map-equiv-count-Q8 (inl (inl (inl (inr star)))) = j-Q8
-map-equiv-count-Q8 (inl (inl (inr star))) = -j-Q8
-map-equiv-count-Q8 (inl (inr star)) = k-Q8
-map-equiv-count-Q8 (inr star) = -k-Q8
+map-equiv-count-Q8 (inl (inl (inl (inl (inl (inl (inl (inr _)))))))) = e-Q8
+map-equiv-count-Q8 (inl (inl (inl (inl (inl (inl (inr _))))))) = -e-Q8
+map-equiv-count-Q8 (inl (inl (inl (inl (inl (inr _)))))) = i-Q8
+map-equiv-count-Q8 (inl (inl (inl (inl (inr _))))) = -i-Q8
+map-equiv-count-Q8 (inl (inl (inl (inr _)))) = j-Q8
+map-equiv-count-Q8 (inl (inl (inr _))) = -j-Q8
+map-equiv-count-Q8 (inl (inr _)) = k-Q8
+map-equiv-count-Q8 (inr _) = -k-Q8
 
 map-inv-equiv-count-Q8 : Q8 → Fin 8
 map-inv-equiv-count-Q8 e-Q8 = inl (inl (inl (inl (inl (inl (inl (inr star)))))))
@@ -899,16 +899,16 @@ is-section-map-inv-equiv-count-Q8 -k-Q8 = refl
 is-retraction-map-inv-equiv-count-Q8 :
   ( map-inv-equiv-count-Q8 ∘ map-equiv-count-Q8) ~ id
 is-retraction-map-inv-equiv-count-Q8
-  (inl (inl (inl (inl (inl (inl (inl (inr star)))))))) = refl
+  (inl (inl (inl (inl (inl (inl (inl (inr _)))))))) = refl
 is-retraction-map-inv-equiv-count-Q8
-  (inl (inl (inl (inl (inl (inl (inr star))))))) = refl
-is-retraction-map-inv-equiv-count-Q8 (inl (inl (inl (inl (inl (inr star)))))) =
+  (inl (inl (inl (inl (inl (inl (inr _))))))) = refl
+is-retraction-map-inv-equiv-count-Q8 (inl (inl (inl (inl (inl (inr _)))))) =
   refl
-is-retraction-map-inv-equiv-count-Q8 (inl (inl (inl (inl (inr star))))) = refl
-is-retraction-map-inv-equiv-count-Q8 (inl (inl (inl (inr star)))) = refl
-is-retraction-map-inv-equiv-count-Q8 (inl (inl (inr star))) = refl
-is-retraction-map-inv-equiv-count-Q8 (inl (inr star)) = refl
-is-retraction-map-inv-equiv-count-Q8 (inr star) = refl
+is-retraction-map-inv-equiv-count-Q8 (inl (inl (inl (inl (inr _))))) = refl
+is-retraction-map-inv-equiv-count-Q8 (inl (inl (inl (inr _)))) = refl
+is-retraction-map-inv-equiv-count-Q8 (inl (inl (inr _))) = refl
+is-retraction-map-inv-equiv-count-Q8 (inl (inr _)) = refl
+is-retraction-map-inv-equiv-count-Q8 (inr _) = refl
 
 is-equiv-map-equiv-count-Q8 : is-equiv map-equiv-count-Q8
 is-equiv-map-equiv-count-Q8 =

--- a/src/foundation/equivalence-relations.lagda.md
+++ b/src/foundation/equivalence-relations.lagda.md
@@ -126,24 +126,25 @@ module _
   is-block-partition-equivalence-relation Q =
     type-Prop (is-block-prop-partition-equivalence-relation Q)
 
-  is-partition-is-equivalence-class-inhabited-subtype-equivalence-relation :
-    is-partition (is-equivalence-class-inhabited-subtype-equivalence-relation R)
-  is-partition-is-equivalence-class-inhabited-subtype-equivalence-relation x =
-    is-contr-equiv
-      ( Σ ( Σ ( equivalence-class R)
-              ( λ C → is-in-equivalence-class R C x))
-          ( λ t → is-inhabited-subtype (subtype-equivalence-class R (pr1 t))))
-      ( ( equiv-right-swap-Σ) ∘e
-        ( equiv-Σ
-          ( λ Q → is-in-subtype (subtype-equivalence-class R (pr1 Q)) x)
-          ( equiv-right-swap-Σ)
-          ( λ Q → id-equiv)))
-      ( is-contr-Σ
-        ( is-torsorial-is-in-equivalence-class R x)
-        ( center-total-is-in-equivalence-class R x)
-        ( is-proof-irrelevant-is-prop
-          ( is-prop-type-trunc-Prop)
-          ( is-inhabited-subtype-equivalence-class R (class R x))))
+  abstract
+    is-partition-is-equivalence-class-inhabited-subtype-equivalence-relation :
+      is-partition (is-equivalence-class-inhabited-subtype-equivalence-relation R)
+    is-partition-is-equivalence-class-inhabited-subtype-equivalence-relation x =
+      is-contr-equiv
+        ( Σ ( Σ ( equivalence-class R)
+                ( λ C → is-in-equivalence-class R C x))
+            ( λ t → is-inhabited-subtype (subtype-equivalence-class R (pr1 t))))
+        ( ( equiv-right-swap-Σ) ∘e
+          ( equiv-Σ
+            ( λ Q → is-in-subtype (subtype-equivalence-class R (pr1 Q)) x)
+            ( equiv-right-swap-Σ)
+            ( λ Q → id-equiv)))
+        ( is-contr-Σ
+          ( is-torsorial-is-in-equivalence-class R x)
+          ( center-total-is-in-equivalence-class R x)
+          ( is-proof-irrelevant-is-prop
+            ( is-prop-type-trunc-Prop)
+            ( is-inhabited-subtype-equivalence-class R (class R x))))
 
   partition-equivalence-relation : partition l2 (l1 ⊔ l2) A
   pr1 partition-equivalence-relation =
@@ -333,79 +334,64 @@ module _
   {l1 l2 : Level} {A : UU l1} (P : partition l1 l2 A)
   where
 
-  is-block-is-equivalence-class-equivalence-relation-partition :
-    (Q : inhabited-subtype l1 A) →
-    is-equivalence-class
-      ( equivalence-relation-partition P)
-      ( subtype-inhabited-subtype Q) →
-    is-block-partition P Q
-  is-block-is-equivalence-class-equivalence-relation-partition Q H =
-    apply-universal-property-trunc-Prop H
-      ( subtype-partition P Q)
-      ( λ (a , K) →
-        tr
-          ( is-block-partition P)
-          ( inv
-            ( eq-has-same-elements-inhabited-subtype Q
-              ( inhabited-subtype-block-partition P (class-partition P a))
-              ( λ x →
-                logical-equivalence-reasoning
-                  is-in-inhabited-subtype Q x
-                    ↔ Σ ( block-partition P)
-                        ( λ B →
-                          is-in-block-partition P B a ×
-                          is-in-block-partition P B x)
-                      by K x
-                    ↔ is-in-block-partition P (class-partition P a) x
-                      by
-                      iff-equiv
-                        ( ( left-unit-law-Σ-is-contr
-                            ( is-contr-block-containing-element-partition P a)
-                            ( center-block-containing-element-partition P a)) ∘e
-                          ( inv-associative-Σ
-                            ( block-partition P)
-                            ( λ B → is-in-block-partition P B a)
-                            ( λ B → is-in-block-partition P (pr1 B) x))))))
-          ( is-block-class-partition P a))
-
-  is-equivalence-class-is-block-partition :
-    (Q : inhabited-subtype l1 A) →
-    is-block-partition P Q →
-    is-equivalence-class
-      ( equivalence-relation-partition P)
-      ( subtype-inhabited-subtype Q)
-  is-equivalence-class-is-block-partition Q H =
-    apply-universal-property-trunc-Prop
-      ( is-inhabited-subtype-inhabited-subtype Q)
-      ( is-equivalence-class-Prop
+  abstract
+    is-block-is-equivalence-class-equivalence-relation-partition :
+      (Q : inhabited-subtype l1 A) →
+      is-equivalence-class
         ( equivalence-relation-partition P)
-        ( subtype-inhabited-subtype Q))
-      ( λ (a , q) →
-        unit-trunc-Prop
-          ( pair
-            ( a)
-            ( λ x →
-              iff-equiv
-              ( equivalence-reasoning
-                is-in-inhabited-subtype Q x
-                  ≃ is-in-block-partition P (make-block-partition P Q H) x
-                    by
-                    compute-is-in-block-partition P Q H x
-                  ≃ Σ ( block-partition P)
-                      ( λ B →
-                        is-in-block-partition P B a ×
-                        is-in-block-partition P B x)
-                    by
-                    inv-equiv
-                      ( ( left-unit-law-Σ-is-contr
-                          ( is-contr-block-containing-element-partition P a)
-                          ( pair
-                            ( make-block-partition P Q H)
-                            ( make-is-in-block-partition P Q H a q))) ∘e
-                        ( inv-associative-Σ
-                          ( block-partition P)
-                          ( λ B → is-in-block-partition P B a)
-                          ( λ B → is-in-block-partition P (pr1 B) x)))))))
+        ( subtype-inhabited-subtype Q) →
+      is-block-partition P Q
+    is-block-is-equivalence-class-equivalence-relation-partition Q H =
+      apply-universal-property-trunc-Prop H
+        ( subtype-partition P Q)
+        ( λ (a , K) →
+          tr
+            ( is-block-partition P)
+            ( inv
+              ( eq-has-same-elements-inhabited-subtype Q
+                ( inhabited-subtype-block-partition P (class-partition P a))
+                ( λ x →
+                  ( iff-equiv
+                    ( ( left-unit-law-Σ-is-contr
+                        ( is-contr-block-containing-element-partition P a)
+                        ( center-block-containing-element-partition P a)) ∘e
+                      ( inv-associative-Σ
+                        ( block-partition P)
+                        ( λ B → is-in-block-partition P B a)
+                        ( λ B → is-in-block-partition P (pr1 B) x)))) ∘iff
+                  ( K x))))
+            ( is-block-class-partition P a))
+
+  abstract
+    is-equivalence-class-is-block-partition :
+      (Q : inhabited-subtype l1 A) →
+      is-block-partition P Q →
+      is-equivalence-class
+        ( equivalence-relation-partition P)
+        ( subtype-inhabited-subtype Q)
+    is-equivalence-class-is-block-partition Q H =
+      apply-universal-property-trunc-Prop
+        ( is-inhabited-subtype-inhabited-subtype Q)
+        ( is-equivalence-class-Prop
+          ( equivalence-relation-partition P)
+          ( subtype-inhabited-subtype Q))
+        ( λ (a , q) →
+          unit-trunc-Prop
+            ( pair
+              ( a)
+              ( λ x →
+                iff-equiv
+                ( ( inv-equiv
+                    ( ( left-unit-law-Σ-is-contr
+                        ( is-contr-block-containing-element-partition P a)
+                        ( pair
+                          ( make-block-partition P Q H)
+                          ( make-is-in-block-partition P Q H a q))) ∘e
+                      ( inv-associative-Σ
+                        ( block-partition P)
+                        ( λ B → is-in-block-partition P B a)
+                        ( λ B → is-in-block-partition P (pr1 B) x)))) ∘e
+                  ( compute-is-in-block-partition P Q H x)))))
 
   has-same-elements-partition-equivalence-relation-partition :
     has-same-elements-subtype
@@ -430,14 +416,15 @@ is-retraction-equivalence-relation-partition-equivalence-relation P =
 #### The map `equivalence-relation-partition` is an equivalence
 
 ```agda
-is-equiv-equivalence-relation-partition :
-  {l : Level} {A : UU l} →
-  is-equiv (equivalence-relation-partition {l} {l} {l} {A})
-is-equiv-equivalence-relation-partition =
-  is-equiv-is-invertible
-    partition-equivalence-relation
-    is-section-equivalence-relation-partition-equivalence-relation
-    is-retraction-equivalence-relation-partition-equivalence-relation
+abstract
+  is-equiv-equivalence-relation-partition :
+    {l : Level} {A : UU l} →
+    is-equiv (equivalence-relation-partition {l} {l} {l} {A})
+  is-equiv-equivalence-relation-partition =
+    is-equiv-is-invertible
+      partition-equivalence-relation
+      is-section-equivalence-relation-partition-equivalence-relation
+      is-retraction-equivalence-relation-partition-equivalence-relation
 
 equiv-equivalence-relation-partition :
   {l : Level} {A : UU l} → partition l l A ≃ equivalence-relation l A

--- a/src/foundation/partitions.lagda.md
+++ b/src/foundation/partitions.lagda.md
@@ -286,40 +286,43 @@ will have no more use for the large type of blocks of a partition.
     is-prop-is-in-block-partition-Large-Type
       ( map-inv-compute-block-partition B)
 
-  compute-is-in-block-partition :
-    (B : inhabited-subtype l2 A) (H : is-block-partition B) (x : A) →
-    is-in-inhabited-subtype B x ≃
-    is-in-block-partition (make-block-partition B H) x
-  compute-is-in-block-partition B H x =
-    equiv-tr
-      ( λ C → is-in-block-partition-Large-Type C x)
-      ( inv (is-retraction-map-inv-compute-block-partition (B , H)))
+  abstract
+    compute-is-in-block-partition :
+      (B : inhabited-subtype l2 A) (H : is-block-partition B) (x : A) →
+      is-in-inhabited-subtype B x ≃
+      is-in-block-partition (make-block-partition B H) x
+    compute-is-in-block-partition B H x =
+      equiv-tr
+        ( λ C → is-in-block-partition-Large-Type C x)
+        ( inv (is-retraction-map-inv-compute-block-partition (B , H)))
 
-  make-is-in-block-partition :
-    (B : inhabited-subtype l2 A) (H : is-block-partition B) (x : A) →
-    is-in-inhabited-subtype B x →
-    is-in-block-partition (make-block-partition B H) x
-  make-is-in-block-partition B H x K =
-    map-equiv (compute-is-in-block-partition B H x) K
+  abstract
+    make-is-in-block-partition :
+      (B : inhabited-subtype l2 A) (H : is-block-partition B) (x : A) →
+      is-in-inhabited-subtype B x →
+      is-in-block-partition (make-block-partition B H) x
+    make-is-in-block-partition B H x K =
+      map-equiv (compute-is-in-block-partition B H x) K
 
   block-containing-element-partition : A → UU (l1 ⊔ l2)
   block-containing-element-partition a =
     Σ block-partition (λ B → is-in-block-partition B a)
 
-  is-contr-block-containing-element-partition :
-    (a : A) → is-contr (block-containing-element-partition a)
-  is-contr-block-containing-element-partition a =
-    is-contr-equiv'
-      ( Σ block-partition-Large-Type
-        ( λ B → is-in-block-partition-Large-Type B a))
-      ( equiv-Σ
-        ( λ B → is-in-block-partition B a)
-        ( compute-block-partition)
-        ( λ B →
-          equiv-tr
-            ( λ C → is-in-block-partition-Large-Type C a)
-            ( inv (is-retraction-map-inv-compute-block-partition B))))
-      ( is-partition-subtype-partition a)
+  abstract
+    is-contr-block-containing-element-partition :
+      (a : A) → is-contr (block-containing-element-partition a)
+    is-contr-block-containing-element-partition a =
+      is-contr-equiv'
+        ( Σ block-partition-Large-Type
+          ( λ B → is-in-block-partition-Large-Type B a))
+        ( equiv-Σ
+          ( λ B → is-in-block-partition B a)
+          ( compute-block-partition)
+          ( λ B →
+            equiv-tr
+              ( λ C → is-in-block-partition-Large-Type C a)
+              ( inv (is-retraction-map-inv-compute-block-partition B))))
+        ( is-partition-subtype-partition a)
 
   center-block-containing-element-partition :
     (a : A) → block-containing-element-partition a
@@ -415,22 +418,23 @@ module _
     refl-has-same-elements-inhabited-subtype
       ( inhabited-subtype-block-partition P B)
 
-  is-torsorial-has-same-elements-block-partition :
-    is-torsorial has-same-elements-block-partition
-  is-torsorial-has-same-elements-block-partition =
-    is-contr-equiv'
-      ( Σ ( block-partition P)
+  abstract
+    is-torsorial-has-same-elements-block-partition :
+      is-torsorial has-same-elements-block-partition
+    is-torsorial-has-same-elements-block-partition =
+      is-contr-equiv'
+        ( Σ ( block-partition P)
+            ( λ C →
+              inhabited-subtype-block-partition P B ＝
+              inhabited-subtype-block-partition P C))
+        ( equiv-tot
           ( λ C →
-            inhabited-subtype-block-partition P B ＝
-            inhabited-subtype-block-partition P C))
-      ( equiv-tot
-        ( λ C →
-          extensionality-inhabited-subtype
-            ( inhabited-subtype-block-partition P B)
-            ( inhabited-subtype-block-partition P C)))
-      ( fundamental-theorem-id'
-        ( λ C → ap (inhabited-subtype-block-partition P))
-        ( is-emb-inhabited-subtype-block-partition P B))
+            extensionality-inhabited-subtype
+              ( inhabited-subtype-block-partition P B)
+              ( inhabited-subtype-block-partition P C)))
+        ( fundamental-theorem-id'
+          ( λ C → ap (inhabited-subtype-block-partition P))
+          ( is-emb-inhabited-subtype-block-partition P B))
 
   has-same-elements-eq-block-partition :
     (C : block-partition P) → (B ＝ C) →
@@ -615,50 +619,51 @@ module _
   pr2 (subtype-partition-Set-Indexed-Σ-Decomposition Q) =
     is-prop-is-block-partition-Set-Indexed-Σ-Decomposition Q
 
-  is-partition-subtype-partition-Set-Indexed-Σ-Decomposition :
-    is-partition (subtype-partition-Set-Indexed-Σ-Decomposition {l2})
-  is-partition-subtype-partition-Set-Indexed-Σ-Decomposition a =
-    is-contr-equiv
-      ( Σ ( inhabited-subtype l2 A)
-          ( has-same-elements-inhabited-subtype
-              ( pair
-                ( λ x →
-                  Id-Prop
-                    ( indexing-set-Set-Indexed-Σ-Decomposition D)
-                    ( index-Set-Indexed-Σ-Decomposition D x)
-                    ( index-Set-Indexed-Σ-Decomposition D a))
-                ( unit-trunc-Prop (pair a refl)))))
-      ( ( equiv-tot
-          ( λ Q →
-            ( ( ( equiv-Π-equiv-family
+  abstract
+    is-partition-subtype-partition-Set-Indexed-Σ-Decomposition :
+      is-partition (subtype-partition-Set-Indexed-Σ-Decomposition {l2})
+    is-partition-subtype-partition-Set-Indexed-Σ-Decomposition a =
+      is-contr-equiv
+        ( Σ ( inhabited-subtype l2 A)
+            ( has-same-elements-inhabited-subtype
+                ( pair
                   ( λ x →
-                    inv-equiv
-                      ( equiv-equiv-iff
-                        ( Id-Prop
-                          ( indexing-set-Set-Indexed-Σ-Decomposition D)
-                          ( index-Set-Indexed-Σ-Decomposition D x)
-                          ( index-Set-Indexed-Σ-Decomposition D a))
-                        ( subtype-inhabited-subtype Q x)) ∘e
-                    ( equiv-inv-equiv))) ∘e
-                ( left-unit-law-Σ-is-contr
-                  ( is-torsorial-Id (index-Set-Indexed-Σ-Decomposition D a))
-                  ( pair
-                    ( index-Set-Indexed-Σ-Decomposition D a)
-                    ( refl)))) ∘e
-              ( equiv-right-swap-Σ)) ∘e
-            ( equiv-tot (λ ie → pr2 ie a)))) ∘e
-        ( associative-Σ
-          ( inhabited-subtype l2 A)
-          ( is-block-partition-Set-Indexed-Σ-Decomposition)
-          ( λ B → is-in-inhabited-subtype (pr1 B) a)))
-      ( is-torsorial-has-same-elements-inhabited-subtype
-        ( pair
-          ( λ x →
-            Id-Prop
-              ( indexing-set-Set-Indexed-Σ-Decomposition D)
-              ( index-Set-Indexed-Σ-Decomposition D x)
-              ( index-Set-Indexed-Σ-Decomposition D a))
-          ( unit-trunc-Prop (pair a refl))))
+                    Id-Prop
+                      ( indexing-set-Set-Indexed-Σ-Decomposition D)
+                      ( index-Set-Indexed-Σ-Decomposition D x)
+                      ( index-Set-Indexed-Σ-Decomposition D a))
+                  ( unit-trunc-Prop (pair a refl)))))
+        ( ( equiv-tot
+            ( λ Q →
+              ( ( ( equiv-Π-equiv-family
+                    ( λ x →
+                      inv-equiv
+                        ( equiv-equiv-iff
+                          ( Id-Prop
+                            ( indexing-set-Set-Indexed-Σ-Decomposition D)
+                            ( index-Set-Indexed-Σ-Decomposition D x)
+                            ( index-Set-Indexed-Σ-Decomposition D a))
+                          ( subtype-inhabited-subtype Q x)) ∘e
+                      ( equiv-inv-equiv))) ∘e
+                  ( left-unit-law-Σ-is-contr
+                    ( is-torsorial-Id (index-Set-Indexed-Σ-Decomposition D a))
+                    ( pair
+                      ( index-Set-Indexed-Σ-Decomposition D a)
+                      ( refl)))) ∘e
+                ( equiv-right-swap-Σ)) ∘e
+              ( equiv-tot (λ ie → pr2 ie a)))) ∘e
+          ( associative-Σ
+            ( inhabited-subtype l2 A)
+            ( is-block-partition-Set-Indexed-Σ-Decomposition)
+            ( λ B → is-in-inhabited-subtype (pr1 B) a)))
+        ( is-torsorial-has-same-elements-inhabited-subtype
+          ( pair
+            ( λ x →
+              Id-Prop
+                ( indexing-set-Set-Indexed-Σ-Decomposition D)
+                ( index-Set-Indexed-Σ-Decomposition D x)
+                ( index-Set-Indexed-Σ-Decomposition D a))
+            ( unit-trunc-Prop (pair a refl))))
 
 partition-Set-Indexed-Σ-Decomposition :
   {l1 l2 l3 : Level} {A : UU l1} →


### PR DESCRIPTION
makes equivalence relations typecheck in about half the time. I also had a look at `category-of-functors-from-small-to-large-categories`, and I really can't find anything wrong, so I'm a bit puzzled.