### PR TITLE
Add NodeJS to the devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,7 @@
               python
               # pre-commit checks
               pkgs.pre-commit
+              pkgs.nodejs
             ] ++ (with pkgs-mdbook; [
               # working on the website
               mdbook


### PR DESCRIPTION
Pre-commit tries to run a downloaded NodeJS executable when NodeJS isn't available in the environment, but that fails to run on NixOS.