### PR TITLE
Escape Agda definitions when translating them to regex

### DIFF
--- a/scripts/preprocessor_concepts.py
+++ b/scripts/preprocessor_concepts.py
@@ -33,7 +33,7 @@ LEFTOVER_CONCEPT_REGEX = re.compile(r'\{\{#concept.*')
 
 def make_definition_regex(definition):
     return re.compile(
-        r'<a id="(\d+)" href="[^"]+" class="[^"]+">' + definition + r'</a>')
+        r'<a id="(\d+)" href="[^"]+" class="[^"]+">' + re.escape(definition) + r'</a>')
 
 
 def does_support(backend):


### PR DESCRIPTION
The concept macro looks for Agda definitions when the Agda= component is specified. Until now the definition name was not escaped, so concepts like the coproduct type `_+_` could not be found by the macro.

Fixes #1073 