### PR TITLE
Experiment: both type arguments of const implicit

### DIFF
--- a/src/elementary-number-theory/sums-of-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/sums-of-natural-numbers.lagda.md
@@ -97,14 +97,14 @@ abstract
 ```agda
 abstract
   constant-sum-Fin-ℕ :
-    (m n : ℕ) → sum-Fin-ℕ m (const (Fin m) ℕ n) ＝ m *ℕ n
+    (m n : ℕ) → sum-Fin-ℕ m (const n) ＝ m *ℕ n
   constant-sum-Fin-ℕ zero-ℕ n = refl
   constant-sum-Fin-ℕ (succ-ℕ m) n = ap (_+ℕ n) (constant-sum-Fin-ℕ m n)
 
 abstract
   constant-sum-count-ℕ :
     {l : Level} {A : UU l} (e : count A) (n : ℕ) →
-    sum-count-ℕ e (const A ℕ n) ＝ (number-of-elements-count e) *ℕ n
+    sum-count-ℕ e (const n) ＝ (number-of-elements-count e) *ℕ n
   constant-sum-count-ℕ (pair m e) n = constant-sum-Fin-ℕ m n
 ```
 

--- a/src/foundation-core/constant-maps.lagda.md
+++ b/src/foundation-core/constant-maps.lagda.md
@@ -26,8 +26,11 @@ function
 ## Definition
 
 ```agda
-const : {l1 l2 : Level} (A : UU l1) (B : UU l2) → B → A → B
-const A B b x = b
+const' : {l1 l2 : Level} (A : UU l1) (B : UU l2) → B → A → B
+const' A B b x = b
+
+const : {l1 l2 : Level} {A : UU l1} {B : UU l2} → B → A → B
+const = const' _ _
 ```
 
 ## See also

--- a/src/foundation/action-on-equivalences-functions.lagda.md
+++ b/src/foundation/action-on-equivalences-functions.lagda.md
@@ -73,7 +73,7 @@ module _
 ```agda
 compute-action-equiv-function-const :
   {l1 l2 : Level} {B : UU l2} (b : B) {X Y : UU l1}
-  (e : X ≃ Y) → (action-equiv-function (const (UU l1) B b) e) ＝ refl
+  (e : X ≃ Y) → (action-equiv-function (const b) e) ＝ refl
 compute-action-equiv-function-const b e = ap-const b (eq-equiv e)
 ```
 

--- a/src/foundation/action-on-equivalences-type-families.lagda.md
+++ b/src/foundation/action-on-equivalences-type-families.lagda.md
@@ -131,7 +131,7 @@ compute-action-equiv-family-id e =
 ```agda
 compute-action-equiv-family-const :
   {l1 l2 : Level} (B : UU l2) {X Y : UU l1}
-  (e : X ≃ Y) → (action-equiv-family (const (UU l1) (UU l2) B) e) ＝ id-equiv
+  (e : X ≃ Y) → (action-equiv-family (const B) e) ＝ id-equiv
 compute-action-equiv-family-const B {X} {Y} e =
   ap equiv-eq (compute-action-equiv-function-const B e)
 ```

--- a/src/foundation/action-on-higher-identifications-functions.lagda.md
+++ b/src/foundation/action-on-higher-identifications-functions.lagda.md
@@ -179,7 +179,7 @@ module _
   compute-const-ap² :
     (b : B) →
     coherence-square-identifications
-      ( ap² (const A B b) α)
+      ( ap² (const b) α)
       ( ap-const b p)
       ( ap-const b q)
       ( refl)

--- a/src/foundation/action-on-identifications-functions.lagda.md
+++ b/src/foundation/action-on-identifications-functions.lagda.md
@@ -100,7 +100,7 @@ ap-inv f refl = refl
 ```agda
 ap-const :
   {l1 l2 : Level} {A : UU l1} {B : UU l2} (b : B) {x y : A}
-  (p : x ＝ y) → (ap (const A B b) p) ＝ refl
+  (p : x ＝ y) → (ap (const b) p) ＝ refl
 ap-const b refl = refl
 ```
 

--- a/src/foundation/booleans.lagda.md
+++ b/src/foundation/booleans.lagda.md
@@ -262,7 +262,7 @@ pr2 equiv-neg-bool = is-equiv-neg-bool
 ```agda
 abstract
   not-equiv-const :
-    (b : bool) → ¬ (is-equiv (const bool bool b))
+    (b : bool) → ¬ (is-equiv (const' bool bool b))
   not-equiv-const true ((g , G) , _) = neq-true-false-bool (G false)
   not-equiv-const false ((g , G) , _) = neq-false-true-bool (G true)
 ```

--- a/src/foundation/connected-types.lagda.md
+++ b/src/foundation/connected-types.lagda.md
@@ -64,18 +64,18 @@ is-neg-two-connected A = is-trunc-type-trunc
 is-equiv-diagonal-is-connected :
   {l1 l2 : Level} {k : 𝕋} {A : UU l1} (B : Truncated-Type l2 k) →
   is-connected k A →
-  is-equiv (const A (type-Truncated-Type B))
+  is-equiv (const' A (type-Truncated-Type B))
 is-equiv-diagonal-is-connected B H =
   is-equiv-comp
     ( precomp unit-trunc (type-Truncated-Type B))
-    ( λ b → const _ _ b)
+    ( λ b → const b)
     ( is-equiv-diagonal-is-contr H (type-Truncated-Type B))
     ( is-truncation-trunc B)
 
 is-connected-is-equiv-diagonal :
   {l1 : Level} {k : 𝕋} {A : UU l1} →
   ({l2 : Level} (B : Truncated-Type l2 k) →
-  is-equiv (const A (type-Truncated-Type B))) →
+  is-equiv (const' A (type-Truncated-Type B))) →
   is-connected k A
 is-connected-is-equiv-diagonal {k = k} {A = A} H =
   tot

--- a/src/foundation/constant-maps.lagda.md
+++ b/src/foundation/constant-maps.lagda.md
@@ -51,7 +51,7 @@ module _
 
   compute-action-htpy-function-const :
     (c : C) (H : f ~ g) →
-    action-htpy-function (const ((x : A) → B x) C c) H ＝ refl
+    action-htpy-function (const c) H ＝ refl
   compute-action-htpy-function-const c H = ap-const c (eq-htpy H)
 ```
 
@@ -170,12 +170,12 @@ pr2 (point-faithful-map A x) =
 
 ```agda
 is-injective-const :
-  {l1 l2 : Level} (A : UU l1) (B : UU l2) → A → is-injective (const A B)
+  {l1 l2 : Level} (A : UU l1) (B : UU l2) → A → is-injective (const' A B)
 is-injective-const A B a p = htpy-eq p a
 
 const-injection :
   {l1 l2 : Level} (A : UU l1) (B : UU l2) → A → injection B (A → B)
-pr1 (const-injection A B a) = const A B
+pr1 (const-injection A B a) = const
 pr2 (const-injection A B a) = is-injective-const A B a
 ```
 
@@ -184,12 +184,12 @@ pr2 (const-injection A B a) = is-injective-const A B a
 ```agda
 htpy-diagonal-Id-ap-diagonal-htpy-eq :
   {l1 l2 : Level} (A : UU l1) {B : UU l2} (x y : B) →
-  htpy-eq ∘ ap (const A B) ~ const A (x ＝ y)
+  htpy-eq ∘ ap (const' A B) ~ const' A (x ＝ y)
 htpy-diagonal-Id-ap-diagonal-htpy-eq A x y refl = refl
 
 htpy-ap-diagonal-htpy-eq-diagonal-Id :
   {l1 l2 : Level} (A : UU l1) {B : UU l2} (x y : B) →
-  const A (x ＝ y) ~ htpy-eq ∘ ap (const A B)
+  const' A (x ＝ y) ~ htpy-eq ∘ ap (const' A B)
 htpy-ap-diagonal-htpy-eq-diagonal-Id A x y =
   inv-htpy (htpy-diagonal-Id-ap-diagonal-htpy-eq A x y)
 ```

--- a/src/foundation/contractible-types.lagda.md
+++ b/src/foundation/contractible-types.lagda.md
@@ -171,19 +171,19 @@ module _
 
   abstract
     is-equiv-self-diagonal-is-equiv-diagonal :
-      ({l : Level} (X : UU l) → is-equiv (λ x → const A X x)) →
-      is-equiv (λ x → const A A x)
+      ({l : Level} (X : UU l) → is-equiv (λ x → const' A X x)) →
+      is-equiv (λ x → const' A A x)
     is-equiv-self-diagonal-is-equiv-diagonal H = H A
 
   abstract
     is-contr-is-equiv-self-diagonal :
-      is-equiv (λ x → const A A x) → is-contr A
+      is-equiv (λ x → const' A A x) → is-contr A
     is-contr-is-equiv-self-diagonal H =
       tot (λ x → htpy-eq) (center (is-contr-map-is-equiv H id))
 
   abstract
     is-contr-is-equiv-diagonal :
-      ({l : Level} (X : UU l) → is-equiv (λ x → const A X x)) → is-contr A
+      ({l : Level} (X : UU l) → is-equiv (λ x → const' A X x)) → is-contr A
     is-contr-is-equiv-diagonal H =
       is-contr-is-equiv-self-diagonal
         ( is-equiv-self-diagonal-is-equiv-diagonal H)
@@ -191,7 +191,7 @@ module _
   abstract
     is-equiv-diagonal-is-contr :
       is-contr A →
-      {l : Level} (X : UU l) → is-equiv (const A X)
+      {l : Level} (X : UU l) → is-equiv (const' A X)
     is-equiv-diagonal-is-contr H X =
       is-equiv-is-invertible
         ( ev-point' (center H))
@@ -200,6 +200,6 @@ module _
 
   equiv-diagonal-is-contr :
     {l : Level} (X : UU l) → is-contr A → X ≃ (A → X)
-  pr1 (equiv-diagonal-is-contr X H) = const A X
+  pr1 (equiv-diagonal-is-contr X H) = const' A X
   pr2 (equiv-diagonal-is-contr X H) = is-equiv-diagonal-is-contr H X
 ```

--- a/src/foundation/surjective-maps.lagda.md
+++ b/src/foundation/surjective-maps.lagda.md
@@ -306,7 +306,7 @@ module _
       ( λ (h : (y : B) → type-Prop (P y)) x → h (f x)) ~
       ( ( λ h x → h (f x) (x , refl)) ∘
         ( λ h y → (h y) ∘ unit-trunc-Prop) ∘
-        ( λ h y → const (type-trunc-Prop (fiber f y)) (type-Prop (P y)) (h y)))
+        ( λ h y → const' (type-trunc-Prop (fiber f y)) (type-Prop (P y)) (h y)))
     square-dependent-universal-property-surj P = refl-htpy
 
   abstract
@@ -317,10 +317,11 @@ module _
         ( λ h x → h (f x) (x , refl))
         ( ( λ h y → (h y) ∘ unit-trunc-Prop) ∘
           ( λ h y →
-            const (type-trunc-Prop (fiber f y)) (type-Prop (P y)) (h y)))
+            const' (type-trunc-Prop (fiber f y)) (type-Prop (P y)) (h y)))
         ( is-equiv-comp
           ( λ h y → (h y) ∘ unit-trunc-Prop)
-          ( λ h y → const (type-trunc-Prop (fiber f y)) (type-Prop (P y)) (h y))
+          ( λ h y →
+            const' (type-trunc-Prop (fiber f y)) (type-Prop (P y)) (h y))
           ( is-equiv-map-Π-is-fiberwise-equiv
             ( λ y →
               is-equiv-diagonal-is-contr

--- a/src/foundation/unit-type.lagda.md
+++ b/src/foundation/unit-type.lagda.md
@@ -54,7 +54,7 @@ module _
   where
 
   terminal-map : A → unit
-  terminal-map = const A unit star
+  terminal-map = const star
 ```
 
 ### Points as maps out of the unit type
@@ -65,7 +65,7 @@ module _
   where
 
   point : A → (unit → A)
-  point = const unit A
+  point a = const a
 ```
 
 ### Raising the universe level of the unit type
@@ -78,7 +78,7 @@ raise-star : {l : Level} → raise l unit
 raise-star = map-raise star
 
 raise-terminal-map : {l1 l2 : Level} (A : UU l1) → A → raise-unit l2
-raise-terminal-map {l2 = l2} A = const A (raise-unit l2) raise-star
+raise-terminal-map {l2 = l2} A = const raise-star
 
 compute-raise-unit : (l : Level) → unit ≃ raise-unit l
 compute-raise-unit l = compute-raise l unit

--- a/src/foundation/universal-property-family-of-fibers-of-maps.lagda.md
+++ b/src/foundation/universal-property-family-of-fibers-of-maps.lagda.md
@@ -421,12 +421,12 @@ module _
 
   is-equiv-precomp-Π-fiber-condition :
     {l3 : Level} {C : B → UU l3} →
-    ((b : B) → is-equiv (λ (c : C b) → const (fiber f b) (C b) c)) →
+    ((b : B) → is-equiv (λ (c : C b) → const' (fiber f b) (C b) c)) →
     is-equiv (precomp-Π f C)
   is-equiv-precomp-Π-fiber-condition {l3} {C} H =
     is-equiv-comp
       ( ev-lift-family-of-elements-fiber f (λ b _ → C b))
-      ( map-Π (λ b → const (fiber f b) (C b)))
+      ( map-Π (λ b → const))
       ( is-equiv-map-Π-is-fiberwise-equiv H)
       ( universal-property-family-of-fibers-fiber f C)
 ```

--- a/src/foundation/universal-property-unit-type.lagda.md
+++ b/src/foundation/universal-property-unit-type.lagda.md
@@ -116,7 +116,7 @@ abstract
   is-equiv-diagonal-is-equiv-point :
     {l1 : Level} {X : UU l1} (x : X) →
     is-equiv (point x) →
-    ({l2 : Level} (Y : UU l2) → is-equiv (λ y → const X Y y))
+    ({l2 : Level} (Y : UU l2) → is-equiv (const' X Y))
   is-equiv-diagonal-is-equiv-point {X = X} x is-equiv-point Y =
     is-equiv-is-section
       ( universal-property-unit-is-equiv-point x is-equiv-point Y)

--- a/src/orthogonal-factorization-systems/null-types.lagda.md
+++ b/src/orthogonal-factorization-systems/null-types.lagda.md
@@ -42,10 +42,10 @@ module _
   where
 
   is-null : UU (l1 ⊔ l2)
-  is-null = is-equiv (const Y A)
+  is-null = is-equiv (const' Y A)
 
   is-prop-is-null : is-prop is-null
-  is-prop-is-null = is-property-is-equiv (const Y A)
+  is-prop-is-null = is-property-is-equiv (const' Y A)
 
   is-null-Prop : Prop (l1 ⊔ l2)
   pr1 is-null-Prop = is-null
@@ -64,7 +64,7 @@ module _
   is-local-is-null : is-null Y A → is-local (λ y → star) A
   is-local-is-null =
     is-equiv-comp
-      ( const Y A)
+      ( const)
       ( map-left-unit-law-function-type A)
       ( is-equiv-map-left-unit-law-function-type A)
 
@@ -78,7 +78,7 @@ module _
   equiv-is-local-is-null : is-null Y A ≃ is-local (λ y → star) A
   equiv-is-local-is-null =
     equiv-prop
-      ( is-property-is-equiv (const Y A))
+      ( is-property-is-equiv const)
       ( is-property-is-equiv (precomp (λ y → star) A))
       ( is-local-is-null)
       ( is-null-is-local)

--- a/src/structured-types/constant-pointed-maps.lagda.md
+++ b/src/structured-types/constant-pointed-maps.lagda.md
@@ -36,8 +36,7 @@ module _
   where
 
   map-constant-pointed-map : type-Pointed-Type A → type-Pointed-Type B
-  map-constant-pointed-map =
-    const (type-Pointed-Type A) (type-Pointed-Type B) (point-Pointed-Type B)
+  map-constant-pointed-map = const (point-Pointed-Type B)
 
   preserves-point-constant-pointed-map :
     map-constant-pointed-map (point-Pointed-Type A) ＝ point-Pointed-Type B

--- a/src/structured-types/involutive-type-of-h-space-structures.lagda.md
+++ b/src/structured-types/involutive-type-of-h-space-structures.lagda.md
@@ -115,10 +115,7 @@ module _
                 ( pr2 (pr2 μ)))
               ( map-equiv-symmetric-Id
                 ( equiv-concat
-                  ( H ( const
-                        ( type-2-Element-Type X)
-                        ( type-Pointed-Type A)
-                        ( point-Pointed-Type A)))
+                  ( H ( const (point-Pointed-Type A)))
                   ( point-Pointed-Type A))
                 ( ( X) ,
                   ( λ x →

--- a/src/synthetic-homotopy-theory/1-acyclic-types.lagda.md
+++ b/src/synthetic-homotopy-theory/1-acyclic-types.lagda.md
@@ -127,13 +127,13 @@ module _
               ( Id)
               ( htpy-eq
                 ( is-section-map-inv-equiv
-                  ( const A (type-Ω (pair (type-Truncated-Type BG) pt)) ,
+                  ( const ,
                     is-equiv-const-Id-is-acyclic-Truncated-Type A ac BG pt pt)
                   ( gen))
                 ( x))
               ( htpy-eq
                 ( is-section-map-inv-equiv
-                  ( const A (type-Ω (pair (type-Truncated-Type BG) pt)) ,
+                  ( const ,
                     is-equiv-const-Id-is-acyclic-Truncated-Type A ac BG pt pt)
                   ( gen))
                 ( y))

--- a/src/synthetic-homotopy-theory/acyclic-maps.lagda.md
+++ b/src/synthetic-homotopy-theory/acyclic-maps.lagda.md
@@ -140,7 +140,7 @@ module _
 
   is-emb-const-is-acyclic :
     is-acyclic A →
-    {l' : Level} (X : UU l') → is-emb (const A X)
+    {l' : Level} (X : UU l') → is-emb (const' A X)
   is-emb-const-is-acyclic ac X =
     is-emb-comp
       ( precomp (terminal-map A) X)
@@ -151,7 +151,7 @@ module _
       ( is-emb-is-equiv (is-equiv-map-inv-left-unit-law-function-type X))
 
   is-acyclic-is-emb-const :
-    ({l' : Level} (X : UU l') → is-emb (const A X)) →
+    ({l' : Level} (X : UU l') → is-emb (const' A X)) →
     is-acyclic A
   is-acyclic-is-emb-const e =
     is-acyclic-is-acyclic-map-terminal-map A
@@ -159,7 +159,7 @@ module _
         ( terminal-map A)
         ( λ X →
           is-emb-triangle-is-equiv'
-            ( const A X)
+            ( const)
             ( precomp (terminal-map A) X)
             ( map-inv-left-unit-law-function-type X)
             ( refl-htpy)
@@ -185,19 +185,19 @@ module _
 
   is-equiv-const-Id-is-acyclic :
     is-acyclic A →
-    {l' : Level} {X : UU l'} (x y : X) → is-equiv (const A (x ＝ y))
+    {l' : Level} {X : UU l'} (x y : X) → is-equiv (const' A (x ＝ y))
   is-equiv-const-Id-is-acyclic ac {X = X} x y =
     is-equiv-htpy
-      ( htpy-eq ∘ ap (const A X) {x} {y})
+      ( htpy-eq ∘ ap const {x} {y})
       ( htpy-ap-diagonal-htpy-eq-diagonal-Id A x y)
       ( is-equiv-comp
         ( htpy-eq)
-        ( ap (const A X))
+        ( ap const)
         ( is-emb-const-is-acyclic A ac X x y)
-        ( funext (const A X x) (const A X y)))
+        ( funext (const x) (const y)))
 
   is-acyclic-is-equiv-const-Id :
-    ({l' : Level} {X : UU l'} (x y : X) → is-equiv (const A (x ＝ y))) →
+    ({l' : Level} {X : UU l'} (x y : X) → is-equiv (const' A (x ＝ y))) →
     is-acyclic A
   is-acyclic-is-equiv-const-Id h =
     is-acyclic-is-emb-const A
@@ -205,10 +205,10 @@ module _
         ( λ x y →
           is-equiv-right-factor
             ( htpy-eq)
-            ( ap (const A X))
-            ( funext (const A X x) (const A X y))
+            ( ap const)
+            ( funext (const x) (const y))
             ( is-equiv-htpy
-              ( const A (x ＝ y))
+              ( const)
               ( htpy-diagonal-Id-ap-diagonal-htpy-eq A x y)
               ( h x y))))
 ```
@@ -249,7 +249,7 @@ module _
   is-dependent-epimorphism-is-acyclic-map ac C =
     is-emb-comp
       ( precomp-Π (map-inv-equiv-total-fiber f) (C ∘ pr1) ∘ ind-Σ)
-      ( map-Π (λ b → const (fiber f b) (C b)))
+      ( map-Π (λ b → const))
       ( is-emb-comp
         ( precomp-Π (map-inv-equiv-total-fiber f) (C ∘ pr1))
         ( ind-Σ)

--- a/src/synthetic-homotopy-theory/suspensions-of-pointed-types.lagda.md
+++ b/src/synthetic-homotopy-theory/suspensions-of-pointed-types.lagda.md
@@ -45,7 +45,7 @@ pr1 (constant-suspension-structure-Pointed-Type X Y) =
 pr1 (pr2 (constant-suspension-structure-Pointed-Type X Y)) =
   point-Pointed-Type Y
 pr2 (pr2 (constant-suspension-structure-Pointed-Type X Y)) =
-  const X (point-Pointed-Type Y ＝ point-Pointed-Type Y) refl
+  const refl
 ```
 
 #### Suspension structure induced by a map into a loop space

--- a/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
@@ -585,7 +585,7 @@ module _
         ( λ y →
           is-torsorial-fiber-Id
             ( λ y' →
-              ( const X (y ＝ y') ,
+              ( const ,
                 is-equiv-diagonal-is-connected (Id-Truncated-Type Y y y') c))))
 
   is-connected-succ-suspension-is-connected :
@@ -598,7 +598,7 @@ module _
             ( ev-suspension
               ( suspension-structure-suspension X)
               ( type-Truncated-Type Y)))
-          ( const (suspension X) (type-Truncated-Type Y))
+          ( const)
           ( is-equiv-north-suspension-ev-suspension-is-connected-Truncated-Type
               ( c)
               ( Y))

--- a/src/synthetic-homotopy-theory/truncated-acyclic-maps.lagda.md
+++ b/src/synthetic-homotopy-theory/truncated-acyclic-maps.lagda.md
@@ -148,7 +148,7 @@ module _
   is-emb-const-is-truncated-acyclic-Truncated-Type :
     is-truncated-acyclic k A →
     {l' : Level} (X : Truncated-Type l' k) →
-    is-emb (const A (type-Truncated-Type X))
+    is-emb (const' A (type-Truncated-Type X))
   is-emb-const-is-truncated-acyclic-Truncated-Type ac X =
     is-emb-comp
       ( precomp (terminal-map A) (type-Truncated-Type X))
@@ -162,7 +162,7 @@ module _
 
   is-truncated-acyclic-is-emb-const-Truncated-Type :
     ({l' : Level} (X : Truncated-Type l' k) →
-    is-emb (const A (type-Truncated-Type X))) →
+    is-emb (const' A (type-Truncated-Type X))) →
     is-truncated-acyclic k A
   is-truncated-acyclic-is-emb-const-Truncated-Type e =
     is-truncated-acyclic-is-truncated-acyclic-map-terminal-map A
@@ -170,7 +170,7 @@ module _
         ( terminal-map A)
         ( λ X →
           is-emb-triangle-is-equiv'
-            ( const A (type-Truncated-Type X))
+            ( const' A (type-Truncated-Type X))
             ( precomp (terminal-map A) (type-Truncated-Type X))
             ( map-inv-left-unit-law-function-type (type-Truncated-Type X))
             ( refl-htpy)
@@ -198,22 +198,20 @@ module _
   is-equiv-const-Id-is-acyclic-Truncated-Type :
     is-truncated-acyclic k A →
     {l' : Level} (X : Truncated-Type l' k) (x y : type-Truncated-Type X) →
-    is-equiv (const A (x ＝ y))
+    is-equiv (const' A (x ＝ y))
   is-equiv-const-Id-is-acyclic-Truncated-Type ac X x y =
     is-equiv-htpy
-      ( htpy-eq ∘ ap (const A (type-Truncated-Type X)) {x} {y})
+      ( htpy-eq ∘ ap const {x} {y})
       ( htpy-ap-diagonal-htpy-eq-diagonal-Id A x y)
       ( is-equiv-comp
         ( htpy-eq)
-        ( ap (const A (type-Truncated-Type X)))
+        ( ap const)
         ( is-emb-const-is-truncated-acyclic-Truncated-Type A ac X x y)
-        ( funext
-          ( const A (type-Truncated-Type X) x)
-          ( const A (type-Truncated-Type X) y)))
+        ( funext (const x) (const y)))
 
   is-truncated-acyclic-is-equiv-const-Id-Truncated-Type :
     ( {l' : Level} (X : Truncated-Type l' k) (x y : type-Truncated-Type X) →
-      is-equiv (const A (x ＝ y))) →
+      is-equiv (const' A (x ＝ y))) →
     is-truncated-acyclic k A
   is-truncated-acyclic-is-equiv-const-Id-Truncated-Type h =
     is-truncated-acyclic-is-emb-const-Truncated-Type A
@@ -221,12 +219,10 @@ module _
         ( λ x y →
           is-equiv-right-factor
             ( htpy-eq)
-            ( ap (const A (type-Truncated-Type X)))
-            ( funext
-              ( const A (type-Truncated-Type X) x)
-              ( const A (type-Truncated-Type X) y))
+            ( ap const)
+            ( funext (const x) (const y))
             ( is-equiv-htpy
-              ( const A (x ＝ y))
+              ( const)
               ( htpy-diagonal-Id-ap-diagonal-htpy-eq A x y)
               ( h X x y))))
 ```
@@ -254,7 +250,7 @@ module _
       ( precomp-Π
         ( map-inv-equiv-total-fiber f)
         ( type-Truncated-Type ∘ C ∘ pr1) ∘ ind-Σ)
-      ( map-Π (λ b → const (fiber f b) (type-Truncated-Type (C b))))
+      ( map-Π (λ b → const))
       ( is-emb-comp
         ( precomp-Π
           ( map-inv-equiv-total-fiber f)

--- a/src/univalent-combinatorics/pi-finite-types.lagda.md
+++ b/src/univalent-combinatorics/pi-finite-types.lagda.md
@@ -761,7 +761,7 @@ is-0-connected-unit =
 abstract
   is-contr-im :
     {l1 l2 : Level} {A : UU l1} (B : Set l2) {f : A → type-Set B}
-    (a : A) (H : f ~ const A (type-Set B) (f a)) → is-contr (im f)
+    (a : A) (H : f ~ const (f a)) → is-contr (im f)
   pr1 (is-contr-im B {f} a H) = map-unit-im f a
   pr2 (is-contr-im B {f} a H) (x , u) =
     apply-dependent-universal-property-trunc-Prop


### PR DESCRIPTION
Testing out whether it is feasible to make both type arguments in `const` can be made implicit.

This PR is not to be merged. Its purpose is merely to facilitate a discussion about changes that were proposed in #1096.