### PR TITLE
Rebase infrastructure for coequalizers to double arrows

### DIFF
--- a/src/foundation.lagda.md
+++ b/src/foundation.lagda.md
@@ -128,6 +128,7 @@ open import foundation.discrete-relaxed-sigma-decompositions public
 open import foundation.discrete-sigma-decompositions public
 open import foundation.discrete-types public
 open import foundation.disjunction public
+open import foundation.double-arrows public
 open import foundation.double-negation public
 open import foundation.double-negation-modality public
 open import foundation.double-powersets public
@@ -152,6 +153,7 @@ open import foundation.equivalence-relations public
 open import foundation.equivalences public
 open import foundation.equivalences-arrows public
 open import foundation.equivalences-cospans public
+open import foundation.equivalences-double-arrows public
 open import foundation.equivalences-inverse-sequential-diagrams public
 open import foundation.equivalences-maybe public
 open import foundation.equivalences-span-diagrams public
@@ -248,6 +250,7 @@ open import foundation.morphisms-arrows public
 open import foundation.morphisms-binary-relations public
 open import foundation.morphisms-cospan-diagrams public
 open import foundation.morphisms-cospans public
+open import foundation.morphisms-double-arrows public
 open import foundation.morphisms-inverse-sequential-diagrams public
 open import foundation.morphisms-span-diagrams public
 open import foundation.morphisms-spans public

--- a/src/foundation/double-arrows.lagda.md
+++ b/src/foundation/double-arrows.lagda.md
@@ -1,0 +1,81 @@
+# Double arrows
+
+```agda
+module foundation.double-arrows where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.cartesian-product-types
+open import foundation.dependent-pair-types
+open import foundation.universe-levels
+```
+
+</details>
+
+## Idea
+
+A {{#concept "double arrow" Agda=double-arrow}} is a
+[pair](foundation.dependent-pair-types.md) of types `A`, `B`
+[equipped](foundation.structure.md) with a pair of
+[maps](foundation.function-types.md) `f, g : A → B`.
+
+We draw a double arrow as
+
+```text
+     g
+   ----->
+ A -----> B ,
+     f
+```
+
+where `f` is the first map in the structure and `g` is the second map in the
+structure. We also call `f` the _bottom map_ and `g` the _top map_. By
+convention, [homotopies](foundation-core.homotopies.md) go from the bottom map
+to the top map.
+
+## Definitions
+
+### Double arrows
+
+```agda
+double-arrow : (l1 l2 : Level) → UU (lsuc l1 ⊔ lsuc l2)
+double-arrow l1 l2 = Σ (UU l1) (λ A → Σ (UU l2) (λ B → (A → B) × (A → B)))
+
+module _
+  {l1 l2 : Level} {A : UU l1} {B : UU l2}
+  (f : A → B) (g : A → B)
+  where
+
+  make-double-arrow : double-arrow l1 l2
+  pr1 make-double-arrow = A
+  pr1 (pr2 make-double-arrow) = B
+  pr1 (pr2 (pr2 make-double-arrow)) = f
+  pr2 (pr2 (pr2 make-double-arrow)) = g
+```
+
+### Components of a double arrow
+
+```agda
+module _
+  {l1 l2 : Level} (a : double-arrow l1 l2)
+  where
+
+  domain-double-arrow : UU l1
+  domain-double-arrow = pr1 a
+
+  codomain-double-arrow : UU l2
+  codomain-double-arrow = pr1 (pr2 a)
+
+  bottom-map-double-arrow : domain-double-arrow → codomain-double-arrow
+  bottom-map-double-arrow = pr1 (pr2 (pr2 a))
+
+  top-map-double-arrow : domain-double-arrow → codomain-double-arrow
+  top-map-double-arrow = pr2 (pr2 (pr2 a))
+```
+
+## See also
+
+- Colimits of double arrows are
+  [coqualizers](synthetic-homotopy-theory.coequalizers.md)

--- a/src/foundation/double-arrows.lagda.md
+++ b/src/foundation/double-arrows.lagda.md
@@ -50,10 +50,9 @@ module _
   where
 
   make-double-arrow : double-arrow l1 l2
-  pr1 make-double-arrow = A
-  pr1 (pr2 make-double-arrow) = B
-  pr1 (pr2 (pr2 make-double-arrow)) = f
-  pr2 (pr2 (pr2 make-double-arrow)) = g
+  make-double-arrow = (A , B , f , g)
+
+  {-# INLINE make-double-arrow #-}
 ```
 
 ### Components of a double arrow

--- a/src/foundation/double-arrows.lagda.md
+++ b/src/foundation/double-arrows.lagda.md
@@ -24,16 +24,17 @@ A {{#concept "double arrow" Agda=double-arrow}} is a
 We draw a double arrow as
 
 ```text
-     g
-   ----->
- A -----> B ,
-     f
+     A
+    | |
+  f | | g
+    | |
+    ∨ ∨
+     B
 ```
 
 where `f` is the first map in the structure and `g` is the second map in the
-structure. We also call `f` the _bottom map_ and `g` the _top map_. By
-convention, [homotopies](foundation-core.homotopies.md) go from the bottom map
-to the top map.
+structure. We also call `f` the _left map_ and `g` the _right map_. By
+convention, [homotopies](foundation-core.homotopies.md) go from left to right.
 
 ## Definitions
 
@@ -68,11 +69,11 @@ module _
   codomain-double-arrow : UU l2
   codomain-double-arrow = pr1 (pr2 a)
 
-  bottom-map-double-arrow : domain-double-arrow → codomain-double-arrow
-  bottom-map-double-arrow = pr1 (pr2 (pr2 a))
+  left-map-double-arrow : domain-double-arrow → codomain-double-arrow
+  left-map-double-arrow = pr1 (pr2 (pr2 a))
 
-  top-map-double-arrow : domain-double-arrow → codomain-double-arrow
-  top-map-double-arrow = pr2 (pr2 (pr2 a))
+  right-map-double-arrow : domain-double-arrow → codomain-double-arrow
+  right-map-double-arrow = pr2 (pr2 (pr2 a))
 ```
 
 ## See also

--- a/src/foundation/double-arrows.lagda.md
+++ b/src/foundation/double-arrows.lagda.md
@@ -16,8 +16,8 @@ open import foundation.universe-levels
 
 ## Idea
 
-A {{#concept "double arrow" Agda=double-arrow}} is a
-[pair](foundation.dependent-pair-types.md) of types `A`, `B`
+A {{#concept "double arrow" Disambiguation="between types" Agda=double-arrow}}
+is a [pair](foundation.dependent-pair-types.md) of types `A`, `B`
 [equipped](foundation.structure.md) with a pair of
 [maps](foundation.function-types.md) `f, g : A → B`.
 
@@ -79,4 +79,4 @@ module _
 ## See also
 
 - Colimits of double arrows are
-  [coqualizers](synthetic-homotopy-theory.coequalizers.md)
+  [coequalizers](synthetic-homotopy-theory.coequalizers.md)

--- a/src/foundation/equivalences-double-arrows.lagda.md
+++ b/src/foundation/equivalences-double-arrows.lagda.md
@@ -12,6 +12,8 @@ open import foundation.commuting-squares-of-maps
 open import foundation.dependent-pair-types
 open import foundation.double-arrows
 open import foundation.equivalences
+open import foundation.equivalences-arrows
+open import foundation.homotopies
 open import foundation.morphisms-double-arrows
 open import foundation.universe-levels
 ```
@@ -20,7 +22,29 @@ open import foundation.universe-levels
 
 ## Idea
 
-TODO
+An {{#concept "equivalence of double arrows" Agda=equiv-double-arrow}} from a
+[double arrow](foundation.double-arrows.md) `f, g : A → B` to a double arrow
+`h, k : X → Y` is a pair of [equivalences](foundation-core.equivalences.md)
+`i : A ≃ X` and `j : B ≃ Y`, such that the two squares in
+
+```text
+           i
+     A --------> X
+    | |    ≃    | |
+  f | | g     h | | k
+    | |         | |
+    ∨ ∨    ≃    ∨ ∨
+     B --------> Y
+           j
+```
+
+[commute](foundation-core.commuting-squares-of-maps.md). The equivalence `i` is
+referred to as the _domain equivalence_, and the `j` as the _codomain
+equivalence_.
+
+Alternatively, an equivalence of double arrows is a pair of
+[equivalences of arrows](foundation.equivalences-arrows.md) `f ≃ h` and `g ≃ k`
+that share the underlying maps.
 
 ## Definitions
 
@@ -32,19 +56,19 @@ module _
   (a : double-arrow l1 l2) (a' : double-arrow l3 l4)
   where
 
-  bottom-coherence-equiv-double-arrow :
+  left-coherence-equiv-double-arrow :
     (domain-double-arrow a ≃ domain-double-arrow a') →
     (codomain-double-arrow a ≃ codomain-double-arrow a') →
     UU (l1 ⊔ l4)
-  bottom-coherence-equiv-double-arrow eA eB =
-    bottom-coherence-hom-double-arrow a a' (map-equiv eA) (map-equiv eB)
+  left-coherence-equiv-double-arrow eA eB =
+    left-coherence-hom-double-arrow a a' (map-equiv eA) (map-equiv eB)
 
-  top-coherence-equiv-double-arrow :
+  right-coherence-equiv-double-arrow :
     (domain-double-arrow a ≃ domain-double-arrow a') →
     (codomain-double-arrow a ≃ codomain-double-arrow a') →
     UU (l1 ⊔ l4)
-  top-coherence-equiv-double-arrow eA eB =
-    top-coherence-hom-double-arrow a a' (map-equiv eA) (map-equiv eB)
+  right-coherence-equiv-double-arrow eA eB =
+    right-coherence-hom-double-arrow a a' (map-equiv eA) (map-equiv eB)
 
   equiv-double-arrow :
     UU (l1 ⊔ l2 ⊔ l3 ⊔ l4)
@@ -53,8 +77,8 @@ module _
       ( λ eA →
         Σ ( codomain-double-arrow a ≃ codomain-double-arrow a')
           ( λ eB →
-            bottom-coherence-equiv-double-arrow eA eB ×
-            top-coherence-equiv-double-arrow eA eB))
+            left-coherence-equiv-double-arrow eA eB ×
+            right-coherence-equiv-double-arrow eA eB))
 ```
 
 ### Components of an equivalence of double arrows
@@ -92,17 +116,35 @@ module _
   is-equiv-codomain-map-equiv-double-arrow =
     is-equiv-map-equiv codomain-equiv-equiv-double-arrow
 
-  bottom-coherence-square-equiv-double-arrow :
-    bottom-coherence-equiv-double-arrow a a'
+  left-square-equiv-double-arrow :
+    left-coherence-equiv-double-arrow a a'
       ( domain-equiv-equiv-double-arrow)
       ( codomain-equiv-equiv-double-arrow)
-  bottom-coherence-square-equiv-double-arrow = pr1 (pr2 (pr2 e))
+  left-square-equiv-double-arrow = pr1 (pr2 (pr2 e))
 
-  top-coherence-square-equiv-double-arrow :
-    top-coherence-equiv-double-arrow a a'
+  left-equiv-arrow-equiv-double-arrow :
+    equiv-arrow (left-map-double-arrow a) (left-map-double-arrow a')
+  pr1 left-equiv-arrow-equiv-double-arrow =
+    domain-equiv-equiv-double-arrow
+  pr1 (pr2 left-equiv-arrow-equiv-double-arrow) =
+    codomain-equiv-equiv-double-arrow
+  pr2 (pr2 left-equiv-arrow-equiv-double-arrow) =
+    left-square-equiv-double-arrow
+
+  right-square-equiv-double-arrow :
+    right-coherence-equiv-double-arrow a a'
       ( domain-equiv-equiv-double-arrow)
       ( codomain-equiv-equiv-double-arrow)
-  top-coherence-square-equiv-double-arrow = pr2 (pr2 (pr2 e))
+  right-square-equiv-double-arrow = pr2 (pr2 (pr2 e))
+
+  right-equiv-arrow-equiv-double-arrow :
+    equiv-arrow (right-map-double-arrow a) (right-map-double-arrow a')
+  pr1 right-equiv-arrow-equiv-double-arrow =
+    domain-equiv-equiv-double-arrow
+  pr1 (pr2 right-equiv-arrow-equiv-double-arrow) =
+    codomain-equiv-equiv-double-arrow
+  pr2 (pr2 right-equiv-arrow-equiv-double-arrow) =
+    right-square-equiv-double-arrow
 
   hom-double-arrow-equiv-double-arrow : hom-double-arrow a a'
   pr1 hom-double-arrow-equiv-double-arrow =
@@ -110,7 +152,72 @@ module _
   pr1 (pr2 hom-double-arrow-equiv-double-arrow) =
     codomain-map-equiv-double-arrow
   pr1 (pr2 (pr2 hom-double-arrow-equiv-double-arrow)) =
-    bottom-coherence-square-equiv-double-arrow
+    left-square-equiv-double-arrow
   pr2 (pr2 (pr2 hom-double-arrow-equiv-double-arrow)) =
-    top-coherence-square-equiv-double-arrow
+    right-square-equiv-double-arrow
+```
+
+### The identity equivalence of double arrows
+
+```agda
+module _
+  {l1 l2 : Level} (a : double-arrow l1 l2)
+  where
+
+  id-equiv-double-arrow : equiv-double-arrow a a
+  pr1 id-equiv-double-arrow = id-equiv
+  pr1 (pr2 id-equiv-double-arrow) = id-equiv
+  pr2 (pr2 id-equiv-double-arrow) = (refl-htpy , refl-htpy)
+```
+
+### Composition of equivalences of double arrows
+
+```agda
+module _
+  {l1 l2 l3 l4 l5 l6 : Level}
+  (a : double-arrow l1 l2) (b : double-arrow l3 l4) (c : double-arrow l5 l6)
+  (f : equiv-double-arrow b c) (e : equiv-double-arrow a b)
+  where
+
+  domain-equiv-comp-equiv-double-arrow :
+    domain-double-arrow a ≃ domain-double-arrow c
+  domain-equiv-comp-equiv-double-arrow =
+    domain-equiv-equiv-double-arrow b c f ∘e
+    domain-equiv-equiv-double-arrow a b e
+
+  codomain-equiv-comp-equiv-double-arrow :
+    codomain-double-arrow a ≃ codomain-double-arrow c
+  codomain-equiv-comp-equiv-double-arrow =
+    codomain-equiv-equiv-double-arrow b c f ∘e
+    codomain-equiv-equiv-double-arrow a b e
+
+  left-square-comp-equiv-double-arrow :
+    left-coherence-equiv-double-arrow a c
+      ( domain-equiv-comp-equiv-double-arrow)
+      ( codomain-equiv-comp-equiv-double-arrow)
+  left-square-comp-equiv-double-arrow =
+    coh-comp-equiv-arrow
+      ( left-map-double-arrow a)
+      ( left-map-double-arrow b)
+      ( left-map-double-arrow c)
+      ( left-equiv-arrow-equiv-double-arrow b c f)
+      ( left-equiv-arrow-equiv-double-arrow a b e)
+
+  right-square-comp-equiv-double-arrow :
+    right-coherence-equiv-double-arrow a c
+      ( domain-equiv-comp-equiv-double-arrow)
+      ( codomain-equiv-comp-equiv-double-arrow)
+  right-square-comp-equiv-double-arrow =
+    coh-comp-equiv-arrow
+      ( right-map-double-arrow a)
+      ( right-map-double-arrow b)
+      ( right-map-double-arrow c)
+      ( right-equiv-arrow-equiv-double-arrow b c f)
+      ( right-equiv-arrow-equiv-double-arrow a b e)
+
+  comp-equiv-double-arrow : equiv-double-arrow a c
+  pr1 comp-equiv-double-arrow = domain-equiv-comp-equiv-double-arrow
+  pr1 (pr2 comp-equiv-double-arrow) = codomain-equiv-comp-equiv-double-arrow
+  pr1 (pr2 (pr2 comp-equiv-double-arrow)) = left-square-comp-equiv-double-arrow
+  pr2 (pr2 (pr2 comp-equiv-double-arrow)) = right-square-comp-equiv-double-arrow
 ```

--- a/src/foundation/equivalences-double-arrows.lagda.md
+++ b/src/foundation/equivalences-double-arrows.lagda.md
@@ -1,0 +1,116 @@
+# Equivalences of double arrows
+
+```agda
+module foundation.equivalences-double-arrows where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.cartesian-product-types
+open import foundation.commuting-squares-of-maps
+open import foundation.dependent-pair-types
+open import foundation.double-arrows
+open import foundation.equivalences
+open import foundation.morphisms-double-arrows
+open import foundation.universe-levels
+```
+
+</details>
+
+## Idea
+
+TODO
+
+## Definitions
+
+### Equivalences of double arrows
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level}
+  (a : double-arrow l1 l2) (a' : double-arrow l3 l4)
+  where
+
+  bottom-coherence-equiv-double-arrow :
+    (domain-double-arrow a ≃ domain-double-arrow a') →
+    (codomain-double-arrow a ≃ codomain-double-arrow a') →
+    UU (l1 ⊔ l4)
+  bottom-coherence-equiv-double-arrow eA eB =
+    bottom-coherence-hom-double-arrow a a' (map-equiv eA) (map-equiv eB)
+
+  top-coherence-equiv-double-arrow :
+    (domain-double-arrow a ≃ domain-double-arrow a') →
+    (codomain-double-arrow a ≃ codomain-double-arrow a') →
+    UU (l1 ⊔ l4)
+  top-coherence-equiv-double-arrow eA eB =
+    top-coherence-hom-double-arrow a a' (map-equiv eA) (map-equiv eB)
+
+  equiv-double-arrow :
+    UU (l1 ⊔ l2 ⊔ l3 ⊔ l4)
+  equiv-double-arrow =
+    Σ ( domain-double-arrow a ≃ domain-double-arrow a')
+      ( λ eA →
+        Σ ( codomain-double-arrow a ≃ codomain-double-arrow a')
+          ( λ eB →
+            bottom-coherence-equiv-double-arrow eA eB ×
+            top-coherence-equiv-double-arrow eA eB))
+```
+
+### Components of an equivalence of double arrows
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level}
+  (a : double-arrow l1 l2) (a' : double-arrow l3 l4)
+  (e : equiv-double-arrow a a')
+  where
+
+  domain-equiv-equiv-double-arrow :
+    domain-double-arrow a ≃ domain-double-arrow a'
+  domain-equiv-equiv-double-arrow = pr1 e
+
+  domain-map-equiv-double-arrow :
+    domain-double-arrow a → domain-double-arrow a'
+  domain-map-equiv-double-arrow = map-equiv domain-equiv-equiv-double-arrow
+
+  is-equiv-domain-map-equiv-double-arrow :
+    is-equiv domain-map-equiv-double-arrow
+  is-equiv-domain-map-equiv-double-arrow =
+    is-equiv-map-equiv domain-equiv-equiv-double-arrow
+
+  codomain-equiv-equiv-double-arrow :
+    codomain-double-arrow a ≃ codomain-double-arrow a'
+  codomain-equiv-equiv-double-arrow = pr1 (pr2 e)
+
+  codomain-map-equiv-double-arrow :
+    codomain-double-arrow a → codomain-double-arrow a'
+  codomain-map-equiv-double-arrow = map-equiv codomain-equiv-equiv-double-arrow
+
+  is-equiv-codomain-map-equiv-double-arrow :
+    is-equiv codomain-map-equiv-double-arrow
+  is-equiv-codomain-map-equiv-double-arrow =
+    is-equiv-map-equiv codomain-equiv-equiv-double-arrow
+
+  bottom-coherence-square-equiv-double-arrow :
+    bottom-coherence-equiv-double-arrow a a'
+      ( domain-equiv-equiv-double-arrow)
+      ( codomain-equiv-equiv-double-arrow)
+  bottom-coherence-square-equiv-double-arrow = pr1 (pr2 (pr2 e))
+
+  top-coherence-square-equiv-double-arrow :
+    top-coherence-equiv-double-arrow a a'
+      ( domain-equiv-equiv-double-arrow)
+      ( codomain-equiv-equiv-double-arrow)
+  top-coherence-square-equiv-double-arrow = pr2 (pr2 (pr2 e))
+
+  hom-double-arrow-equiv-double-arrow : hom-double-arrow a a'
+  pr1 hom-double-arrow-equiv-double-arrow =
+    domain-map-equiv-double-arrow
+  pr1 (pr2 hom-double-arrow-equiv-double-arrow) =
+    codomain-map-equiv-double-arrow
+  pr1 (pr2 (pr2 hom-double-arrow-equiv-double-arrow)) =
+    bottom-coherence-square-equiv-double-arrow
+  pr2 (pr2 (pr2 hom-double-arrow-equiv-double-arrow)) =
+    top-coherence-square-equiv-double-arrow
+```

--- a/src/foundation/equivalences-double-arrows.lagda.md
+++ b/src/foundation/equivalences-double-arrows.lagda.md
@@ -22,20 +22,22 @@ open import foundation.universe-levels
 
 ## Idea
 
-An {{#concept "equivalence of double arrows" Agda=equiv-double-arrow}} from a
-[double arrow](foundation.double-arrows.md) `f, g : A → B` to a double arrow
-`h, k : X → Y` is a pair of [equivalences](foundation-core.equivalences.md)
-`i : A ≃ X` and `j : B ≃ Y`, such that the two squares in
+An
+{{#concept "equivalence of double arrows" Disambiguation="between types" Agda=equiv-double-arrow}}
+from a [double arrow](foundation.double-arrows.md) `f, g : A → B` to a double
+arrow `h, k : X → Y` is a pair of
+[equivalences](foundation-core.equivalences.md) `i : A ≃ X` and `j : B ≃ Y`,
+such that the squares
 
 ```text
-           i
-     A --------> X
-    | |    ≃    | |
-  f | | g     h | | k
-    | |         | |
-    ∨ ∨    ≃    ∨ ∨
-     B --------> Y
-           j
+           i                   i
+     A --------> X       A --------> X
+     |     ≃     |       |     ≃     |
+   f |           | h   g |           | k
+     |           |       |           |
+     ∨     ≃     ∨       ∨     ≃     ∨
+     B --------> Y       B --------> Y
+           j                   j
 ```
 
 [commute](foundation-core.commuting-squares-of-maps.md). The equivalence `i` is

--- a/src/foundation/morphisms-double-arrows.lagda.md
+++ b/src/foundation/morphisms-double-arrows.lagda.md
@@ -1,0 +1,167 @@
+# Morphisms of double arrows
+
+```agda
+module foundation.morphisms-double-arrows where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.cartesian-product-types
+open import foundation.commuting-squares-of-maps
+open import foundation.dependent-pair-types
+open import foundation.double-arrows
+open import foundation.function-types
+open import foundation.homotopies
+open import foundation.universe-levels
+```
+
+</details>
+
+## Idea
+
+TODO
+
+## Definitions
+
+### Morphisms of double arrows
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level} (a : double-arrow l1 l2) (a' : double-arrow l3 l4)
+  where
+
+  bottom-coherence-hom-double-arrow :
+    (domain-double-arrow a → domain-double-arrow a') →
+    (codomain-double-arrow a → codomain-double-arrow a') →
+    UU (l1 ⊔ l4)
+  bottom-coherence-hom-double-arrow hA hB =
+    coherence-square-maps'
+      ( bottom-map-double-arrow a)
+      ( hA)
+      ( hB)
+      ( bottom-map-double-arrow a')
+
+  top-coherence-hom-double-arrow :
+    (domain-double-arrow a → domain-double-arrow a') →
+    (codomain-double-arrow a → codomain-double-arrow a') →
+    UU (l1 ⊔ l4)
+  top-coherence-hom-double-arrow hA hB =
+    coherence-square-maps'
+      ( top-map-double-arrow a)
+      ( hA)
+      ( hB)
+      ( top-map-double-arrow a')
+
+  hom-double-arrow : UU (l1 ⊔ l2 ⊔ l3 ⊔ l4)
+  hom-double-arrow =
+    Σ ( domain-double-arrow a → domain-double-arrow a')
+      ( λ hA →
+        Σ ( codomain-double-arrow a → codomain-double-arrow a')
+          ( λ hB →
+            bottom-coherence-hom-double-arrow hA hB ×
+            top-coherence-hom-double-arrow hA hB))
+```
+
+### Components of a morphism of double arrows
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level} (a : double-arrow l1 l2) (a' : double-arrow l3 l4)
+  (h : hom-double-arrow a a')
+  where
+
+  domain-map-hom-double-arrow : domain-double-arrow a → domain-double-arrow a'
+  domain-map-hom-double-arrow = pr1 h
+
+  codomain-map-hom-double-arrow :
+    codomain-double-arrow a → codomain-double-arrow a'
+  codomain-map-hom-double-arrow = pr1 (pr2 h)
+
+  bottom-coherence-square-hom-double-arrow :
+    bottom-coherence-hom-double-arrow a a'
+      ( domain-map-hom-double-arrow)
+      ( codomain-map-hom-double-arrow)
+  bottom-coherence-square-hom-double-arrow = pr1 (pr2 (pr2 h))
+
+  top-coherence-square-hom-double-arrow :
+    top-coherence-hom-double-arrow a a'
+      ( domain-map-hom-double-arrow)
+      ( codomain-map-hom-double-arrow)
+  top-coherence-square-hom-double-arrow = pr2 (pr2 (pr2 h))
+```
+
+### The identity morphism of double arrows
+
+```agda
+module _
+  {l1 l2 : Level} (a : double-arrow l1 l2)
+  where
+
+  id-hom-double-arrow : hom-double-arrow a a
+  pr1 id-hom-double-arrow = id
+  pr1 (pr2 id-hom-double-arrow) = id
+  pr2 (pr2 id-hom-double-arrow) = (refl-htpy , refl-htpy)
+```
+
+### Composition of morphisms of double arrows
+
+```agda
+module _
+  {l1 l2 l3 l4 l5 l6 : Level}
+  (a : double-arrow l1 l2) (b : double-arrow l3 l4) (c : double-arrow l5 l6)
+  (g : hom-double-arrow b c) (f : hom-double-arrow a b)
+  where
+
+  domain-map-comp-hom-double-arrow :
+    domain-double-arrow a → domain-double-arrow c
+  domain-map-comp-hom-double-arrow =
+    domain-map-hom-double-arrow b c g ∘ domain-map-hom-double-arrow a b f
+
+  codomain-map-comp-hom-double-arrow :
+    codomain-double-arrow a → codomain-double-arrow c
+  codomain-map-comp-hom-double-arrow =
+    codomain-map-hom-double-arrow b c g ∘ codomain-map-hom-double-arrow a b f
+
+  bottom-coherence-square-comp-hom-double-arrow :
+    bottom-coherence-hom-double-arrow a c
+      ( domain-map-comp-hom-double-arrow)
+      ( codomain-map-comp-hom-double-arrow)
+  bottom-coherence-square-comp-hom-double-arrow =
+    pasting-horizontal-coherence-square-maps
+      ( domain-map-hom-double-arrow a b f)
+      ( domain-map-hom-double-arrow b c g)
+      ( bottom-map-double-arrow a)
+      ( bottom-map-double-arrow b)
+      ( bottom-map-double-arrow c)
+      ( codomain-map-hom-double-arrow a b f)
+      ( codomain-map-hom-double-arrow b c g)
+      ( bottom-coherence-square-hom-double-arrow a b f)
+      ( bottom-coherence-square-hom-double-arrow b c g)
+
+  top-coherence-square-comp-hom-double-arrow :
+    top-coherence-hom-double-arrow a c
+      ( domain-map-comp-hom-double-arrow)
+      ( codomain-map-comp-hom-double-arrow)
+  top-coherence-square-comp-hom-double-arrow =
+    pasting-horizontal-coherence-square-maps
+      ( domain-map-hom-double-arrow a b f)
+      ( domain-map-hom-double-arrow b c g)
+      ( top-map-double-arrow a)
+      ( top-map-double-arrow b)
+      ( top-map-double-arrow c)
+      ( codomain-map-hom-double-arrow a b f)
+      ( codomain-map-hom-double-arrow b c g)
+      ( top-coherence-square-hom-double-arrow a b f)
+      ( top-coherence-square-hom-double-arrow b c g)
+
+  comp-hom-double-arrow : hom-double-arrow a c
+  pr1 comp-hom-double-arrow =
+    domain-map-comp-hom-double-arrow
+  pr1 (pr2 comp-hom-double-arrow) =
+    codomain-map-comp-hom-double-arrow
+  pr1 (pr2 (pr2 comp-hom-double-arrow)) =
+    bottom-coherence-square-comp-hom-double-arrow
+  pr2 (pr2 (pr2 comp-hom-double-arrow)) =
+    top-coherence-square-comp-hom-double-arrow
+```

--- a/src/foundation/morphisms-double-arrows.lagda.md
+++ b/src/foundation/morphisms-double-arrows.lagda.md
@@ -21,20 +21,21 @@ open import foundation.universe-levels
 
 ## Idea
 
-A {{#concept "morphism of double arrows" Agda=hom-double-arrow}} from a
-[double arrow](foundation.double-arrows.md) `f, g : A → B` to a double arrow
-`h, k : X → Y` is a pair of maps `i : A → X` and `j : B → Y`, such that the two
-squares in
+A
+{{#concept "morphism of double arrows" Disambiguation="between types" Agda=hom-double-arrow}}
+from a [double arrow](foundation.double-arrows.md) `f, g : A → B` to a double
+arrow `h, k : X → Y` is a pair of maps `i : A → X` and `j : B → Y`, such that
+the squares
 
 ```text
-           i
-     A --------> X
-    | |         | |
-  f | | g     h | | k
-    | |         | |
-    ∨ ∨         ∨ ∨
-     B --------> Y
-           j
+           i                   i
+     A --------> X       A --------> X
+     |           |       |           |
+   f |           | h   g |           | k
+     |           |       |           |
+     ∨           ∨       ∨           ∨
+     B --------> Y       B --------> Y
+           j                   j
 ```
 
 [commute](foundation-core.commuting-squares-of-maps.md). The map `i` is referred

--- a/src/foundation/morphisms-double-arrows.lagda.md
+++ b/src/foundation/morphisms-double-arrows.lagda.md
@@ -13,6 +13,7 @@ open import foundation.dependent-pair-types
 open import foundation.double-arrows
 open import foundation.function-types
 open import foundation.homotopies
+open import foundation.morphisms-arrows
 open import foundation.universe-levels
 ```
 
@@ -20,7 +21,28 @@ open import foundation.universe-levels
 
 ## Idea
 
-TODO
+A {{#concept "morphism of double arrows" Agda=hom-double-arrow}} from a
+[double arrow](foundation.double-arrows.md) `f, g : A → B` to a double arrow
+`h, k : X → Y` is a pair of maps `i : A → X` and `j : B → Y`, such that the two
+squares in
+
+```text
+           i
+     A --------> X
+    | |         | |
+  f | | g     h | | k
+    | |         | |
+    ∨ ∨         ∨ ∨
+     B --------> Y
+           j
+```
+
+[commute](foundation-core.commuting-squares-of-maps.md). The map `i` is referred
+to as the _domain map_, and the `j` as the _codomain map_.
+
+Alternatively, a morphism of double arrows is a pair of
+[morphisms of arrows](foundation.morphisms-arrows.md) `f → h` and `g → k` that
+share the underlying maps.
 
 ## Definitions
 
@@ -31,27 +53,27 @@ module _
   {l1 l2 l3 l4 : Level} (a : double-arrow l1 l2) (a' : double-arrow l3 l4)
   where
 
-  bottom-coherence-hom-double-arrow :
+  left-coherence-hom-double-arrow :
     (domain-double-arrow a → domain-double-arrow a') →
     (codomain-double-arrow a → codomain-double-arrow a') →
     UU (l1 ⊔ l4)
-  bottom-coherence-hom-double-arrow hA hB =
-    coherence-square-maps'
-      ( bottom-map-double-arrow a)
+  left-coherence-hom-double-arrow hA hB =
+    coherence-square-maps
       ( hA)
+      ( left-map-double-arrow a)
+      ( left-map-double-arrow a')
       ( hB)
-      ( bottom-map-double-arrow a')
 
-  top-coherence-hom-double-arrow :
+  right-coherence-hom-double-arrow :
     (domain-double-arrow a → domain-double-arrow a') →
     (codomain-double-arrow a → codomain-double-arrow a') →
     UU (l1 ⊔ l4)
-  top-coherence-hom-double-arrow hA hB =
-    coherence-square-maps'
-      ( top-map-double-arrow a)
+  right-coherence-hom-double-arrow hA hB =
+    coherence-square-maps
       ( hA)
+      ( right-map-double-arrow a)
+      ( right-map-double-arrow a')
       ( hB)
-      ( top-map-double-arrow a')
 
   hom-double-arrow : UU (l1 ⊔ l2 ⊔ l3 ⊔ l4)
   hom-double-arrow =
@@ -59,8 +81,8 @@ module _
       ( λ hA →
         Σ ( codomain-double-arrow a → codomain-double-arrow a')
           ( λ hB →
-            bottom-coherence-hom-double-arrow hA hB ×
-            top-coherence-hom-double-arrow hA hB))
+            left-coherence-hom-double-arrow hA hB ×
+            right-coherence-hom-double-arrow hA hB))
 ```
 
 ### Components of a morphism of double arrows
@@ -78,17 +100,35 @@ module _
     codomain-double-arrow a → codomain-double-arrow a'
   codomain-map-hom-double-arrow = pr1 (pr2 h)
 
-  bottom-coherence-square-hom-double-arrow :
-    bottom-coherence-hom-double-arrow a a'
+  left-square-hom-double-arrow :
+    left-coherence-hom-double-arrow a a'
       ( domain-map-hom-double-arrow)
       ( codomain-map-hom-double-arrow)
-  bottom-coherence-square-hom-double-arrow = pr1 (pr2 (pr2 h))
+  left-square-hom-double-arrow = pr1 (pr2 (pr2 h))
 
-  top-coherence-square-hom-double-arrow :
-    top-coherence-hom-double-arrow a a'
+  left-hom-arrow-hom-double-arrow :
+    hom-arrow (left-map-double-arrow a) (left-map-double-arrow a')
+  pr1 left-hom-arrow-hom-double-arrow =
+    domain-map-hom-double-arrow
+  pr1 (pr2 left-hom-arrow-hom-double-arrow) =
+    codomain-map-hom-double-arrow
+  pr2 (pr2 left-hom-arrow-hom-double-arrow) =
+    left-square-hom-double-arrow
+
+  right-square-hom-double-arrow :
+    right-coherence-hom-double-arrow a a'
       ( domain-map-hom-double-arrow)
       ( codomain-map-hom-double-arrow)
-  top-coherence-square-hom-double-arrow = pr2 (pr2 (pr2 h))
+  right-square-hom-double-arrow = pr2 (pr2 (pr2 h))
+
+  right-hom-arrow-hom-double-arrow :
+    hom-arrow (right-map-double-arrow a) (right-map-double-arrow a')
+  pr1 right-hom-arrow-hom-double-arrow =
+    domain-map-hom-double-arrow
+  pr1 (pr2 right-hom-arrow-hom-double-arrow) =
+    codomain-map-hom-double-arrow
+  pr2 (pr2 right-hom-arrow-hom-double-arrow) =
+    right-square-hom-double-arrow
 ```
 
 ### The identity morphism of double arrows
@@ -123,37 +163,29 @@ module _
   codomain-map-comp-hom-double-arrow =
     codomain-map-hom-double-arrow b c g ∘ codomain-map-hom-double-arrow a b f
 
-  bottom-coherence-square-comp-hom-double-arrow :
-    bottom-coherence-hom-double-arrow a c
+  left-square-comp-hom-double-arrow :
+    left-coherence-hom-double-arrow a c
       ( domain-map-comp-hom-double-arrow)
       ( codomain-map-comp-hom-double-arrow)
-  bottom-coherence-square-comp-hom-double-arrow =
-    pasting-horizontal-coherence-square-maps
-      ( domain-map-hom-double-arrow a b f)
-      ( domain-map-hom-double-arrow b c g)
-      ( bottom-map-double-arrow a)
-      ( bottom-map-double-arrow b)
-      ( bottom-map-double-arrow c)
-      ( codomain-map-hom-double-arrow a b f)
-      ( codomain-map-hom-double-arrow b c g)
-      ( bottom-coherence-square-hom-double-arrow a b f)
-      ( bottom-coherence-square-hom-double-arrow b c g)
+  left-square-comp-hom-double-arrow =
+    coh-comp-hom-arrow
+      ( left-map-double-arrow a)
+      ( left-map-double-arrow b)
+      ( left-map-double-arrow c)
+      ( left-hom-arrow-hom-double-arrow b c g)
+      ( left-hom-arrow-hom-double-arrow a b f)
 
-  top-coherence-square-comp-hom-double-arrow :
-    top-coherence-hom-double-arrow a c
+  right-square-comp-hom-double-arrow :
+    right-coherence-hom-double-arrow a c
       ( domain-map-comp-hom-double-arrow)
       ( codomain-map-comp-hom-double-arrow)
-  top-coherence-square-comp-hom-double-arrow =
-    pasting-horizontal-coherence-square-maps
-      ( domain-map-hom-double-arrow a b f)
-      ( domain-map-hom-double-arrow b c g)
-      ( top-map-double-arrow a)
-      ( top-map-double-arrow b)
-      ( top-map-double-arrow c)
-      ( codomain-map-hom-double-arrow a b f)
-      ( codomain-map-hom-double-arrow b c g)
-      ( top-coherence-square-hom-double-arrow a b f)
-      ( top-coherence-square-hom-double-arrow b c g)
+  right-square-comp-hom-double-arrow =
+    coh-comp-hom-arrow
+      ( right-map-double-arrow a)
+      ( right-map-double-arrow b)
+      ( right-map-double-arrow c)
+      ( right-hom-arrow-hom-double-arrow b c g)
+      ( right-hom-arrow-hom-double-arrow a b f)
 
   comp-hom-double-arrow : hom-double-arrow a c
   pr1 comp-hom-double-arrow =
@@ -161,7 +193,7 @@ module _
   pr1 (pr2 comp-hom-double-arrow) =
     codomain-map-comp-hom-double-arrow
   pr1 (pr2 (pr2 comp-hom-double-arrow)) =
-    bottom-coherence-square-comp-hom-double-arrow
+    left-square-comp-hom-double-arrow
   pr2 (pr2 (pr2 comp-hom-double-arrow)) =
-    top-coherence-square-comp-hom-double-arrow
+    right-square-comp-hom-double-arrow
 ```

--- a/src/synthetic-homotopy-theory.lagda.md
+++ b/src/synthetic-homotopy-theory.lagda.md
@@ -45,6 +45,7 @@ open import synthetic-homotopy-theory.descent-circle-function-types public
 open import synthetic-homotopy-theory.descent-circle-subtypes public
 open import synthetic-homotopy-theory.double-loop-spaces public
 open import synthetic-homotopy-theory.eckmann-hilton-argument public
+open import synthetic-homotopy-theory.equivalences-coforks public
 open import synthetic-homotopy-theory.equivalences-sequential-diagrams public
 open import synthetic-homotopy-theory.flattening-lemma-coequalizers public
 open import synthetic-homotopy-theory.flattening-lemma-pushouts public
@@ -67,6 +68,7 @@ open import synthetic-homotopy-theory.joins-of-types public
 open import synthetic-homotopy-theory.loop-spaces public
 open import synthetic-homotopy-theory.maps-of-prespectra public
 open import synthetic-homotopy-theory.mere-spheres public
+open import synthetic-homotopy-theory.morphisms-coforks public
 open import synthetic-homotopy-theory.morphisms-descent-data-circle public
 open import synthetic-homotopy-theory.morphisms-sequential-diagrams public
 open import synthetic-homotopy-theory.multiplication-circle public

--- a/src/synthetic-homotopy-theory/cocones-under-sequential-diagrams.lagda.md
+++ b/src/synthetic-homotopy-theory/cocones-under-sequential-diagrams.lagda.md
@@ -336,13 +336,13 @@ module _
   { l1 : Level} (A : sequential-diagram l1)
   where
 
-  bottom-map-cofork-cocone-sequential-diagram :
+  left-map-cofork-cocone-sequential-diagram :
     Σ ℕ (family-sequential-diagram A) → Σ ℕ (family-sequential-diagram A)
-  bottom-map-cofork-cocone-sequential-diagram = id
+  left-map-cofork-cocone-sequential-diagram = id
 
-  top-map-cofork-cocone-sequential-diagram :
+  right-map-cofork-cocone-sequential-diagram :
     Σ ℕ (family-sequential-diagram A) → Σ ℕ (family-sequential-diagram A)
-  top-map-cofork-cocone-sequential-diagram =
+  right-map-cofork-cocone-sequential-diagram =
     map-Σ
       ( family-sequential-diagram A)
       ( succ-ℕ)
@@ -351,8 +351,8 @@ module _
   double-arrow-sequential-diagram : double-arrow l1 l1
   double-arrow-sequential-diagram =
     make-double-arrow
-      ( bottom-map-cofork-cocone-sequential-diagram)
-      ( top-map-cofork-cocone-sequential-diagram)
+      ( left-map-cofork-cocone-sequential-diagram)
+      ( right-map-cofork-cocone-sequential-diagram)
 
   module _
     { l2 : Level} {X : UU l2}

--- a/src/synthetic-homotopy-theory/cocones-under-sequential-diagrams.lagda.md
+++ b/src/synthetic-homotopy-theory/cocones-under-sequential-diagrams.lagda.md
@@ -14,8 +14,8 @@ open import foundation.binary-homotopies
 open import foundation.commuting-squares-of-homotopies
 open import foundation.commuting-triangles-of-maps
 open import foundation.dependent-pair-types
+open import foundation.double-arrows
 open import foundation.equivalences
-open import foundation.function-extensionality
 open import foundation.function-types
 open import foundation.functoriality-dependent-pair-types
 open import foundation.fundamental-theorem-of-identity-types
@@ -348,35 +348,27 @@ module _
       ( succ-ℕ)
       ( map-sequential-diagram A)
 
+  double-arrow-sequential-diagram : double-arrow l1 l1
+  double-arrow-sequential-diagram =
+    make-double-arrow
+      ( bottom-map-cofork-cocone-sequential-diagram)
+      ( top-map-cofork-cocone-sequential-diagram)
+
   module _
     { l2 : Level} {X : UU l2}
     where
 
     cocone-sequential-diagram-cofork :
-      cofork
-        ( bottom-map-cofork-cocone-sequential-diagram)
-        ( top-map-cofork-cocone-sequential-diagram)
-        ( X) →
+      cofork double-arrow-sequential-diagram X →
       cocone-sequential-diagram A X
     pr1 (cocone-sequential-diagram-cofork e) =
-      ev-pair
-        ( map-cofork
-          ( bottom-map-cofork-cocone-sequential-diagram)
-          ( top-map-cofork-cocone-sequential-diagram)
-          ( e))
+      ev-pair (map-cofork double-arrow-sequential-diagram e)
     pr2 (cocone-sequential-diagram-cofork e) =
-      ev-pair
-        ( coherence-cofork
-          ( bottom-map-cofork-cocone-sequential-diagram)
-          ( top-map-cofork-cocone-sequential-diagram)
-          ( e))
+      ev-pair (coh-cofork double-arrow-sequential-diagram e)
 
     cofork-cocone-sequential-diagram :
       cocone-sequential-diagram A X →
-      cofork
-        ( bottom-map-cofork-cocone-sequential-diagram)
-        ( top-map-cofork-cocone-sequential-diagram)
-        ( X)
+      cofork double-arrow-sequential-diagram X
     pr1 (cofork-cocone-sequential-diagram c) =
       ind-Σ (map-cocone-sequential-diagram c)
     pr2 (cofork-cocone-sequential-diagram c) =
@@ -387,8 +379,7 @@ module _
         cofork-cocone-sequential-diagram ∘ cocone-sequential-diagram-cofork ~ id
       is-section-cocone-sequential-diagram-cofork e =
         eq-htpy-cofork
-          ( bottom-map-cofork-cocone-sequential-diagram)
-          ( top-map-cofork-cocone-sequential-diagram)
+          ( double-arrow-sequential-diagram)
           ( cofork-cocone-sequential-diagram
             ( cocone-sequential-diagram-cofork e))
           ( e)
@@ -413,10 +404,7 @@ module _
         ( is-section-cocone-sequential-diagram-cofork)
 
     equiv-cocone-sequential-diagram-cofork :
-      cofork
-        ( bottom-map-cofork-cocone-sequential-diagram)
-        ( top-map-cofork-cocone-sequential-diagram)
-        ( X) ≃
+      cofork double-arrow-sequential-diagram X ≃
       cocone-sequential-diagram A X
     pr1 equiv-cocone-sequential-diagram-cofork =
       cocone-sequential-diagram-cofork
@@ -430,16 +418,14 @@ module _
       ( cocone-map-sequential-diagram c {Y = Y})
       ( cocone-sequential-diagram-cofork)
       ( cofork-map
-        ( bottom-map-cofork-cocone-sequential-diagram)
-        ( top-map-cofork-cocone-sequential-diagram)
+        ( double-arrow-sequential-diagram)
         ( cofork-cocone-sequential-diagram c))
   triangle-cocone-sequential-diagram-cofork c h =
     eq-htpy-cocone-sequential-diagram A
       ( cocone-map-sequential-diagram c h)
       ( cocone-sequential-diagram-cofork
         ( cofork-map
-          ( bottom-map-cofork-cocone-sequential-diagram)
-          ( top-map-cofork-cocone-sequential-diagram)
+          ( double-arrow-sequential-diagram)
           ( cofork-cocone-sequential-diagram c)
           ( h)))
       ( ev-pair refl-htpy ,

--- a/src/synthetic-homotopy-theory/coequalizers.lagda.md
+++ b/src/synthetic-homotopy-theory/coequalizers.lagda.md
@@ -7,6 +7,7 @@ module synthetic-homotopy-theory.coequalizers where
 <details><summary>Imports</summary>
 
 ```agda
+open import foundation.double-arrows
 open import foundation.equivalences
 open import foundation.identity-types
 open import foundation.transport-along-identifications
@@ -55,57 +56,56 @@ the definition is marked abstract.
 
 ```agda
 module _
-  { l1 l2 : Level} {A : UU l1} {B : UU l2} (f g : A → B)
+  {l1 l2 : Level} (a : double-arrow l1 l2)
   where
 
   abstract
     canonical-coequalizer : UU (l1 ⊔ l2)
     canonical-coequalizer =
       pushout
-        ( vertical-map-span-cocone-cofork f g)
-        ( horizontal-map-span-cocone-cofork f g)
+        ( vertical-map-span-cocone-cofork a)
+        ( horizontal-map-span-cocone-cofork a)
 
-    cofork-canonical-coequalizer : cofork f g canonical-coequalizer
+    cofork-canonical-coequalizer : cofork a canonical-coequalizer
     cofork-canonical-coequalizer =
-      cofork-cocone-codiagonal f g
+      cofork-cocone-codiagonal a
         ( cocone-pushout
-          ( vertical-map-span-cocone-cofork f g)
-          ( horizontal-map-span-cocone-cofork f g))
+          ( vertical-map-span-cocone-cofork a)
+          ( horizontal-map-span-cocone-cofork a))
 
     dup-canonical-coequalizer :
-      { l : Level} →
-      dependent-universal-property-coequalizer l f g
+      {l : Level} →
+      dependent-universal-property-coequalizer l a
         ( cofork-canonical-coequalizer)
     dup-canonical-coequalizer =
       dependent-universal-property-coequalizer-dependent-universal-property-pushout
-        ( f)
-        ( g)
+        ( a)
         ( cofork-canonical-coequalizer)
         ( λ P →
           tr
             ( λ c →
               is-equiv
                 ( dependent-cocone-map
-                  ( vertical-map-span-cocone-cofork f g)
-                  ( horizontal-map-span-cocone-cofork f g)
+                  ( vertical-map-span-cocone-cofork a)
+                  ( horizontal-map-span-cocone-cofork a)
                   ( c)
                   ( P)))
             ( inv
               ( is-retraction-map-inv-is-equiv
-                ( is-equiv-cofork-cocone-codiagonal f g)
+                ( is-equiv-cofork-cocone-codiagonal a)
                 ( cocone-pushout
-                  ( vertical-map-span-cocone-cofork f g)
-                  ( horizontal-map-span-cocone-cofork f g))))
+                  ( vertical-map-span-cocone-cofork a)
+                  ( horizontal-map-span-cocone-cofork a))))
             ( dup-pushout
-              ( vertical-map-span-cocone-cofork f g)
-              ( horizontal-map-span-cocone-cofork f g)
+              ( vertical-map-span-cocone-cofork a)
+              ( horizontal-map-span-cocone-cofork a)
               ( P)))
 
     up-canonical-coequalizer :
-      { l : Level} →
-      universal-property-coequalizer l f g cofork-canonical-coequalizer
+      {l : Level} →
+      universal-property-coequalizer l a cofork-canonical-coequalizer
     up-canonical-coequalizer =
-      universal-property-dependent-universal-property-coequalizer f g
+      universal-property-dependent-universal-property-coequalizer a
         ( cofork-canonical-coequalizer)
         ( dup-canonical-coequalizer)
 ```

--- a/src/synthetic-homotopy-theory/coequalizers.lagda.md
+++ b/src/synthetic-homotopy-theory/coequalizers.lagda.md
@@ -33,8 +33,10 @@ i.e. a cofork with the
 
 ### All double arrows admit a coequalizer
 
-The {{#concept "canonical coequalizer" Agda=canonical-coequalizer}} may be
-obtained as a [pushout](synthetic-homotopy-theory.pushouts.md) of the span
+The
+{{#concept "canonical coequalizer" Disambiguation="of types" Agda=canonical-coequalizer}}
+may be obtained as a [pushout](synthetic-homotopy-theory.pushouts.md) of the
+span
 
 ```text
      ∇         [f,g]

--- a/src/synthetic-homotopy-theory/coequalizers.lagda.md
+++ b/src/synthetic-homotopy-theory/coequalizers.lagda.md
@@ -24,16 +24,17 @@ open import synthetic-homotopy-theory.universal-property-coequalizers
 
 ## Idea
 
-The **coequalizer** of a parallel pair `f, g : A → B` is the colimiting
-[cofork](synthetic-homotopy-theory.coforks.md), i.e. a cofork with the
+The **coequalizer** of a [double arrow](foundation.double-arrows.md)
+`f, g : A → B` is the colimiting [cofork](synthetic-homotopy-theory.coforks.md),
+i.e. a cofork with the
 [universal property of coequalizers](synthetic-homotopy-theory.universal-property-coequalizers.md).
 
 ## Properties
 
-### All parallel pairs admit a coequalizer
+### All double arrows admit a coequalizer
 
-The **canonical coequalizer** may be obtained as a
-[pushout](synthetic-homotopy-theory.pushouts.md) of the span
+The {{#concept "canonical coequalizer" Agda=canonical-coequalizer}} may be
+obtained as a [pushout](synthetic-homotopy-theory.pushouts.md) of the span
 
 ```text
      ∇         [f,g]

--- a/src/synthetic-homotopy-theory/coforks.lagda.md
+++ b/src/synthetic-homotopy-theory/coforks.lagda.md
@@ -39,7 +39,7 @@ open import synthetic-homotopy-theory.cocones-under-spans
 
 ## Idea
 
-A {{#concept "cofork" Agda=cofork}} of a
+A {{#concept "cofork" Disambiguation="of types" Agda=cofork}} of a
 [double arrow](foundation.double-arrows.md) `f, g : A → B` with vertext `X` is a
 map `e : B → X` together with a [homotopy](foundation.homotopies.md)
 `H : e ∘ f ~ e ∘ g`. The name comes from the diagram
@@ -396,13 +396,13 @@ A [morphism of double arrows](foundation.morphisms-double-arrows.md)
 induces a [morphism of span diagrams](foundation.morphisms-span-diagrams.md)
 
 ```text
-         ∇            [f,g]
+          ∇           [f,g]
     A <------- A + A -------> B
     |            |            |
   i |            | i + i      | j
-    V            V            V
+    ∨            ∨            ∨
     X <------- X + X -------> Y
-         ∇            [h,k]
+          ∇           [h,k]
 ```
 
 ```agda
@@ -474,13 +474,13 @@ induces an
 [equivalence of span diagrams](foundation.equivalences-span-diagrams.md)
 
 ```text
-         ∇            [f,g]
+          ∇           [f,g]
     A <------- A + A -------> B
     |            |            |
   i | ≃        ≃ | i + i    ≃ | j
-    V            V            V
+    ∨            ∨            ∨
     X <------- X + X -------> Y
-         ∇            [h,k]
+          ∇           [h,k]
 ```
 
 ```agda

--- a/src/synthetic-homotopy-theory/coforks.lagda.md
+++ b/src/synthetic-homotopy-theory/coforks.lagda.md
@@ -55,7 +55,7 @@ which looks like a fork if you flip the arrows, hence a cofork.
 
 Coforks are an analogue of
 [cocones under spans](synthetic-homotopy-theory.cocones-under-spans.md) for
-parallel pairs. The universal cofork of a pair is their
+double arrows. The universal cofork of a double arrow is their
 [coequalizer](synthetic-homotopy-theory.coequalizers.md).
 
 ## Definitions
@@ -69,8 +69,8 @@ module _
 
   coherence-cofork : {X : UU l3} → (codomain-double-arrow a → X) → UU (l1 ⊔ l3)
   coherence-cofork e =
-    e ∘ bottom-map-double-arrow a ~
-    e ∘ top-map-double-arrow a
+    e ∘ left-map-double-arrow a ~
+    e ∘ right-map-double-arrow a
 
   cofork : UU l3 → UU (l1 ⊔ l2 ⊔ l3)
   cofork X =
@@ -103,8 +103,8 @@ module _
     (K : map-cofork a e ~ map-cofork a e') →
     UU (l1 ⊔ l3)
   coherence-htpy-cofork e e' K =
-    ( (coh-cofork a e) ∙h (K ·r top-map-double-arrow a)) ~
-    ( (K ·r bottom-map-double-arrow a) ∙h (coh-cofork a e'))
+    ( (coh-cofork a e) ∙h (K ·r right-map-double-arrow a)) ~
+    ( (K ·r left-map-double-arrow a) ∙h (coh-cofork a e'))
 
   htpy-cofork : cofork a X → cofork a X → UU (l1 ⊔ l2 ⊔ l3)
   htpy-cofork e e' =
@@ -223,8 +223,8 @@ module _
 
 ### Coforks are special cases of cocones under spans
 
-The type of coforks of parallel pairs is equivalent to the type of
-[cocones](synthetic-homotopy-theory.cocones-under-spans.md) under the span
+The type of coforks of a double arrow `f, g : A → B` is equivalent to the type
+of [cocones](synthetic-homotopy-theory.cocones-under-spans.md) under the span
 
 ```text
      ∇         [f,g]
@@ -242,8 +242,8 @@ module _
 
   horizontal-map-span-cocone-cofork :
     domain-double-arrow a + domain-double-arrow a → codomain-double-arrow a
-  horizontal-map-span-cocone-cofork (inl x) = bottom-map-double-arrow a x
-  horizontal-map-span-cocone-cofork (inr x) = top-map-double-arrow a x
+  horizontal-map-span-cocone-cofork (inl x) = left-map-double-arrow a x
+  horizontal-map-span-cocone-cofork (inr x) = right-map-double-arrow a x
 
   span-diagram-cofork : span-diagram l1 l2 l1
   span-diagram-cofork =
@@ -252,7 +252,7 @@ module _
       ( horizontal-map-span-cocone-cofork)
 
   module _
-    { l3 : Level} {X : UU l3}
+    {l3 : Level} {X : UU l3}
     where
 
     cofork-cocone-codiagonal :
@@ -280,13 +280,13 @@ module _
         ( inr))
 
     horizontal-map-cocone-cofork : cofork a X → domain-double-arrow a → X
-    horizontal-map-cocone-cofork e = map-cofork a e ∘ bottom-map-double-arrow a
+    horizontal-map-cocone-cofork e = map-cofork a e ∘ left-map-double-arrow a
 
     vertical-map-cocone-cofork : cofork a X → codomain-double-arrow a → X
     vertical-map-cocone-cofork e = map-cofork a e
 
     coherence-square-cocone-cofork :
-      ( e : cofork a X) →
+      (e : cofork a X) →
       coherence-square-maps
         ( horizontal-map-span-cocone-cofork)
         ( vertical-map-span-cocone-cofork)
@@ -356,8 +356,8 @@ module _
     pr2 equiv-cocone-codiagonal-cofork = is-equiv-cofork-cocone-codiagonal
 
   triangle-cofork-cocone :
-    { l3 l4 : Level} {X : UU l3} {Y : UU l4} →
-    ( e : cofork a X) →
+    {l3 l4 : Level} {X : UU l3} {Y : UU l4} →
+    (e : cofork a X) →
     coherence-triangle-maps
       ( cofork-map a e {Y = Y})
       ( cofork-cocone-codiagonal)
@@ -378,12 +378,37 @@ module _
         right-unit-htpy)
 ```
 
-### Morphisms between double arrows create morphisms between cofork span diagrams
+### Morphisms between double arrows induce morphisms between cofork span diagrams
+
+A [morphism of double arrows](foundation.morphisms-double-arrows.md)
+
+```text
+           i
+     A --------> X
+    | |         | |
+  f | | g     h | | k
+    | |         | |
+    ∨ ∨         ∨ ∨
+     B --------> Y
+           j
+```
+
+induces a [morphism of span diagrams](foundation.morphisms-span-diagrams.md)
+
+```text
+         ∇            [f,g]
+    A <------- A + A -------> B
+    |            |            |
+  i |            | i + i      | j
+    V            V            V
+    X <------- X + X -------> Y
+         ∇            [h,k]
+```
 
 ```agda
 module _
   {l1 l2 l3 l4 : Level} (a : double-arrow l1 l2) (a' : double-arrow l3 l4)
-  ( h : hom-double-arrow a a')
+  (h : hom-double-arrow a a')
   where
 
   spanning-map-hom-span-diagram-cofork-hom-double-arrow :
@@ -411,8 +436,8 @@ module _
       ( horizontal-map-span-cocone-cofork a')
   right-square-hom-span-diagram-cofork-hom-double-arrow =
     ind-coproduct _
-      ( bottom-coherence-square-hom-double-arrow a a' h)
-      ( top-coherence-square-hom-double-arrow a a' h)
+      ( left-square-hom-double-arrow a a' h)
+      ( right-square-hom-double-arrow a a' h)
 
   hom-span-diagram-cofork-hom-double-arrow :
     hom-span-diagram
@@ -430,7 +455,33 @@ module _
     right-square-hom-span-diagram-cofork-hom-double-arrow
 ```
 
-### Equivalences between double arrows create equivalences between cofork span diagrams
+### Equivalences between double arrows induce equivalences between cofork span diagrams
+
+An [equivalence of double arrows](foundation.equivalences-double-arrows.md)
+
+```text
+           i
+     A --------> X
+    | |    ≃    | |
+  f | | g     h | | k
+    | |         | |
+    ∨ ∨    ≃    ∨ ∨
+     B --------> Y
+           j
+```
+
+induces an
+[equivalence of span diagrams](foundation.equivalences-span-diagrams.md)
+
+```text
+         ∇            [f,g]
+    A <------- A + A -------> B
+    |            |            |
+  i | ≃        ≃ | i + i    ≃ | j
+    V            V            V
+    X <------- X + X -------> Y
+         ∇            [h,k]
+```
 
 ```agda
 module _
@@ -446,6 +497,26 @@ module _
       ( domain-equiv-equiv-double-arrow a a' e)
       ( domain-equiv-equiv-double-arrow a a' e)
 
+  left-square-equiv-span-diagram-cofork-equiv-double-arrow :
+    coherence-square-maps'
+      ( vertical-map-span-cocone-cofork a)
+      ( map-equiv spanning-equiv-equiv-span-diagram-cofork-equiv-double-arrow)
+      ( domain-map-equiv-double-arrow a a' e)
+      ( vertical-map-span-cocone-cofork a')
+  left-square-equiv-span-diagram-cofork-equiv-double-arrow =
+    ind-coproduct _ refl-htpy refl-htpy
+
+  right-square-equiv-span-diagram-cofork-equiv-double-arrow :
+    coherence-square-maps'
+      ( horizontal-map-span-cocone-cofork a)
+      ( map-equiv spanning-equiv-equiv-span-diagram-cofork-equiv-double-arrow)
+      ( codomain-map-equiv-double-arrow a a' e)
+      ( horizontal-map-span-cocone-cofork a')
+  right-square-equiv-span-diagram-cofork-equiv-double-arrow =
+    ind-coproduct _
+      ( left-square-equiv-double-arrow a a' e)
+      ( right-square-equiv-double-arrow a a' e)
+
   equiv-span-diagram-cofork-equiv-double-arrow :
     equiv-span-diagram
       ( span-diagram-cofork a)
@@ -457,9 +528,7 @@ module _
   pr1 (pr2 (pr2 (equiv-span-diagram-cofork-equiv-double-arrow))) =
     spanning-equiv-equiv-span-diagram-cofork-equiv-double-arrow
   pr1 (pr2 (pr2 (pr2 (equiv-span-diagram-cofork-equiv-double-arrow)))) =
-    ind-coproduct _ refl-htpy refl-htpy
+    left-square-equiv-span-diagram-cofork-equiv-double-arrow
   pr2 (pr2 (pr2 (pr2 (equiv-span-diagram-cofork-equiv-double-arrow)))) =
-    ind-coproduct _
-      ( bottom-coherence-square-equiv-double-arrow a a' e)
-      ( top-coherence-square-equiv-double-arrow a a' e)
+    right-square-equiv-span-diagram-cofork-equiv-double-arrow
 ```

--- a/src/synthetic-homotopy-theory/dependent-cocones-under-sequential-diagrams.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-cocones-under-sequential-diagrams.lagda.md
@@ -310,31 +310,27 @@ module _
 
     dependent-cocone-sequential-diagram-dependent-cofork :
       dependent-cofork
-        ( bottom-map-cofork-cocone-sequential-diagram A)
-        ( top-map-cofork-cocone-sequential-diagram A)
+        ( double-arrow-sequential-diagram A)
         ( cofork-cocone-sequential-diagram A c)
         ( P) →
       dependent-cocone-sequential-diagram c P
     pr1 (dependent-cocone-sequential-diagram-dependent-cofork e) =
       ev-pair
         ( map-dependent-cofork
-          ( bottom-map-cofork-cocone-sequential-diagram A)
-          ( top-map-cofork-cocone-sequential-diagram A)
+          ( double-arrow-sequential-diagram A)
           ( P)
           ( e))
     pr2 (dependent-cocone-sequential-diagram-dependent-cofork e) =
       ev-pair
         ( coherence-dependent-cofork
-          ( bottom-map-cofork-cocone-sequential-diagram A)
-          ( top-map-cofork-cocone-sequential-diagram A)
+          ( double-arrow-sequential-diagram A)
           ( P)
           ( e))
 
     dependent-cofork-dependent-cocone-sequential-diagram :
       dependent-cocone-sequential-diagram c P →
       dependent-cofork
-        ( bottom-map-cofork-cocone-sequential-diagram A)
-        ( top-map-cofork-cocone-sequential-diagram A)
+        ( double-arrow-sequential-diagram A)
         ( cofork-cocone-sequential-diagram A c)
         ( P)
     pr1 (dependent-cofork-dependent-cocone-sequential-diagram d) =
@@ -349,8 +345,7 @@ module _
         ( id)
       is-section-dependent-cocone-sequential-diagram-dependent-cofork e =
         eq-htpy-dependent-cofork
-          ( bottom-map-cofork-cocone-sequential-diagram A)
-          ( top-map-cofork-cocone-sequential-diagram A)
+          ( double-arrow-sequential-diagram A)
           ( P)
           ( dependent-cofork-dependent-cocone-sequential-diagram
             ( dependent-cocone-sequential-diagram-dependent-cofork e))
@@ -378,8 +373,7 @@ module _
 
     equiv-dependent-cocone-sequential-diagram-dependent-cofork :
       dependent-cofork
-        ( bottom-map-cofork-cocone-sequential-diagram A)
-        ( top-map-cofork-cocone-sequential-diagram A)
+        ( double-arrow-sequential-diagram A)
         ( cofork-cocone-sequential-diagram A c)
         ( P) ≃
       dependent-cocone-sequential-diagram c P
@@ -394,16 +388,14 @@ module _
       ( dependent-cocone-map-sequential-diagram c P)
       ( dependent-cocone-sequential-diagram-dependent-cofork P)
       ( dependent-cofork-map
-        ( bottom-map-cofork-cocone-sequential-diagram A)
-        ( top-map-cofork-cocone-sequential-diagram A)
+        ( double-arrow-sequential-diagram A)
         ( cofork-cocone-sequential-diagram A c))
   triangle-dependent-cocone-sequential-diagram-dependent-cofork P h =
     eq-htpy-dependent-cocone-sequential-diagram P
       ( dependent-cocone-map-sequential-diagram c P h)
       ( dependent-cocone-sequential-diagram-dependent-cofork P
         ( dependent-cofork-map
-          ( bottom-map-cofork-cocone-sequential-diagram A)
-          ( top-map-cofork-cocone-sequential-diagram A)
+          ( double-arrow-sequential-diagram A)
           ( cofork-cocone-sequential-diagram A c)
           ( h)))
       ( ev-pair refl-htpy , ev-pair right-unit-htpy)

--- a/src/synthetic-homotopy-theory/dependent-coforks.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-coforks.lagda.md
@@ -27,6 +27,7 @@ open import foundation.structure-identity-principle
 open import foundation.torsorial-type-families
 open import foundation.transport-along-identifications
 open import foundation.universe-levels
+open import foundation.whiskering-homotopies-composition
 open import foundation.whiskering-identifications-concatenation
 
 open import synthetic-homotopy-theory.coforks
@@ -37,12 +38,13 @@ open import synthetic-homotopy-theory.dependent-cocones-under-spans
 
 ## Idea
 
-Given a parallel pair `f, g : A → B`, a
+Given a [double arrow](foundation.double-arrows.md) `f, g : A → B`, a
 [cofork](synthetic-homotopy-theory.coforks.md) `e : B → X` with vertex `X`, and
-a type family `P : X → 𝓤` over `X`, we may construct _dependent_ coforks on `P`
+a type family `P : X → 𝒰` over `X`, we may construct _dependent_ coforks on `P`
 over `e`.
 
-A **dependent cofork** on `P` over `e` consists of a dependent map
+A {{#concept "dependent cofork" Agda=dependent-cofork}} on `P` over `e` consists
+of a dependent map
 
 ```text
 k : (b : B) → P (e b)
@@ -58,7 +60,7 @@ and a family of
 
 Dependent coforks are an analogue of
 [dependent cocones under spans](synthetic-homotopy-theory.dependent-cocones-under-spans.md)
-for parallel pairs.
+for double arrows.
 
 ## Definitions
 
@@ -77,8 +79,8 @@ module _
         (x : domain-double-arrow a) →
         dependent-identification P
           ( coh-cofork a e x)
-          ( k (bottom-map-double-arrow a x))
-          ( k (top-map-double-arrow a x)))
+          ( k (left-map-double-arrow a x))
+          ( k (right-map-double-arrow a x)))
 
 module _
   {l1 l2 l3 l4 : Level} (a : double-arrow l1 l2) {X : UU l3}
@@ -93,8 +95,8 @@ module _
     (x : domain-double-arrow a) →
     dependent-identification P
       ( coh-cofork a e x)
-      ( map-dependent-cofork (bottom-map-double-arrow a x))
-      ( map-dependent-cofork (top-map-double-arrow a x))
+      ( map-dependent-cofork (left-map-double-arrow a x))
+      ( map-dependent-cofork (right-map-double-arrow a x))
   coherence-dependent-cofork = pr2 k
 ```
 
@@ -114,10 +116,9 @@ module _
     (K : map-dependent-cofork a P k ~ map-dependent-cofork a P k') →
     UU (l1 ⊔ l4)
   coherence-htpy-dependent-cofork k k' K =
-    (x : domain-double-arrow a) →
-    ( ( coherence-dependent-cofork a P k x) ∙ (K (top-map-double-arrow a x))) ＝
-    ( ( ap (tr P (coh-cofork a e x)) (K (bottom-map-double-arrow a x))) ∙
-      ( coherence-dependent-cofork a P k' x))
+    ( (coherence-dependent-cofork a P k) ∙h (K ·r right-map-double-arrow a)) ~
+    ( ( (λ {x} → tr P (coh-cofork a e x)) ·l (K ·r left-map-double-arrow a)) ∙h
+      ( coherence-dependent-cofork a P k'))
 
   htpy-dependent-cofork :
     (k k' : dependent-cofork a e P) →
@@ -198,7 +199,7 @@ module _
     map-inv-is-equiv (is-equiv-htpy-dependent-cofork-eq k k')
 ```
 
-### Dependent coforks on constant type families are equivalent to regular coforks
+### Dependent coforks on constant type families are equivalent to nondependent coforks
 
 ```agda
 module _
@@ -217,8 +218,8 @@ module _
               ( inv
                 ( tr-constant-type-family
                   ( coh-cofork a e x)
-                  ( h (bottom-map-double-arrow a x))))
-              ( h (top-map-double-arrow a x))))
+                  ( h (left-map-double-arrow a x))))
+              ( h (right-map-double-arrow a x))))
 
   map-compute-dependent-cofork-constant-family :
     dependent-cofork a e (λ _ → Y) → cofork a Y
@@ -299,7 +300,7 @@ module _
         ( cocone-codiagonal-cofork a e)
         ( P)
     pr1 (dependent-cocone-codiagonal-dependent-cofork k) =
-      map-dependent-cofork a P k ∘ bottom-map-double-arrow a
+      map-dependent-cofork a P k ∘ left-map-double-arrow a
     pr1 (pr2 (dependent-cocone-codiagonal-dependent-cofork k)) =
       map-dependent-cofork a P k
     pr2 (pr2 (dependent-cocone-codiagonal-dependent-cofork k)) (inl a) =

--- a/src/synthetic-homotopy-theory/dependent-coforks.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-coforks.lagda.md
@@ -14,6 +14,7 @@ open import foundation.constant-type-families
 open import foundation.coproduct-types
 open import foundation.dependent-identifications
 open import foundation.dependent-pair-types
+open import foundation.double-arrows
 open import foundation.equivalences
 open import foundation.function-types
 open import foundation.functoriality-dependent-function-types
@@ -65,35 +66,35 @@ for parallel pairs.
 
 ```agda
 module _
-  { l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} (f g : A → B) {X : UU l3}
-  ( e : cofork f g X) (P : X → UU l4)
+  {l1 l2 l3 l4 : Level} (a : double-arrow l1 l2) {X : UU l3}
+  (e : cofork a X) (P : X → UU l4)
   where
 
   dependent-cofork : UU (l1 ⊔ l2 ⊔ l4)
   dependent-cofork =
-    Σ ( (b : B) → P (map-cofork f g e b))
+    Σ ( (b : codomain-double-arrow a) → P (map-cofork a e b))
       ( λ k →
-        ( a : A) →
+        (x : domain-double-arrow a) →
         dependent-identification P
-          ( coherence-cofork f g e a)
-          ( k (f a))
-          ( k (g a)))
+          ( coh-cofork a e x)
+          ( k (bottom-map-double-arrow a x))
+          ( k (top-map-double-arrow a x)))
 
 module _
-  { l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} (f g : A → B) {X : UU l3}
-  { e : cofork f g X} (P : X → UU l4)
-  ( k : dependent-cofork f g e P)
+  {l1 l2 l3 l4 : Level} (a : double-arrow l1 l2) {X : UU l3}
+  {e : cofork a X} (P : X → UU l4)
+  (k : dependent-cofork a e P)
   where
 
-  map-dependent-cofork : (b : B) → P (map-cofork f g e b)
+  map-dependent-cofork : (b : codomain-double-arrow a) → P (map-cofork a e b)
   map-dependent-cofork = pr1 k
 
   coherence-dependent-cofork :
-    ( a : A) →
+    (x : domain-double-arrow a) →
     dependent-identification P
-      ( coherence-cofork f g e a)
-      ( map-dependent-cofork (f a))
-      ( map-dependent-cofork (g a))
+      ( coh-cofork a e x)
+      ( map-dependent-cofork (bottom-map-double-arrow a x))
+      ( map-dependent-cofork (top-map-double-arrow a x))
   coherence-dependent-cofork = pr2 k
 ```
 
@@ -104,25 +105,25 @@ together with a coherence condition.
 
 ```agda
 module _
-  { l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} (f g : A → B) {X : UU l3}
-  { e : cofork f g X} (P : X → UU l4)
+  {l1 l2 l3 l4 : Level} (a : double-arrow l1 l2) {X : UU l3}
+  {e : cofork a X} (P : X → UU l4)
   where
 
   coherence-htpy-dependent-cofork :
-    ( k k' : dependent-cofork f g e P) →
-    ( K : map-dependent-cofork f g P k ~ map-dependent-cofork f g P k') →
+    (k k' : dependent-cofork a e P) →
+    (K : map-dependent-cofork a P k ~ map-dependent-cofork a P k') →
     UU (l1 ⊔ l4)
   coherence-htpy-dependent-cofork k k' K =
-    ( a : A) →
-    ( ( coherence-dependent-cofork f g P k a) ∙ (K (g a))) ＝
-    ( ( ap (tr P (coherence-cofork f g e a)) (K (f a))) ∙
-      ( coherence-dependent-cofork f g P k' a))
+    (x : domain-double-arrow a) →
+    ( ( coherence-dependent-cofork a P k x) ∙ (K (top-map-double-arrow a x))) ＝
+    ( ( ap (tr P (coh-cofork a e x)) (K (bottom-map-double-arrow a x))) ∙
+      ( coherence-dependent-cofork a P k' x))
 
   htpy-dependent-cofork :
-    ( k k' : dependent-cofork f g e P) →
+    (k k' : dependent-cofork a e P) →
     UU (l1 ⊔ l2 ⊔ l4)
   htpy-dependent-cofork k k' =
-    Σ ( map-dependent-cofork f g P k ~ map-dependent-cofork f g P k')
+    Σ ( map-dependent-cofork a P k ~ map-dependent-cofork a P k')
       ( coherence-htpy-dependent-cofork k k')
 ```
 
@@ -140,14 +141,14 @@ a dependent map, according to the diagram
 
 ```agda
 module _
-  { l1 l2 l3 : Level} {A : UU l1} {B : UU l2} (f g : A → B) {X : UU l3}
-  ( e : cofork f g X)
+  {l1 l2 l3 : Level} (a : double-arrow l1 l2) {X : UU l3}
+  (e : cofork a X)
   where
 
   dependent-cofork-map :
-    { l : Level} {P : X → UU l} → ((x : X) → P x) → dependent-cofork f g e P
-  pr1 (dependent-cofork-map h) = h ∘ map-cofork f g e
-  pr2 (dependent-cofork-map h) = apd h ∘ coherence-cofork f g e
+    {l : Level} {P : X → UU l} → ((x : X) → P x) → dependent-cofork a e P
+  pr1 (dependent-cofork-map h) = h ∘ map-cofork a e
+  pr2 (dependent-cofork-map h) = apd h ∘ coh-cofork a e
 ```
 
 ## Properties
@@ -156,34 +157,34 @@ module _
 
 ```agda
 module _
-  { l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} (f g : A → B) {X : UU l3}
-  { e : cofork f g X} (P : X → UU l4)
+  {l1 l2 l3 l4 : Level} (a : double-arrow l1 l2) {X : UU l3}
+  {e : cofork a X} (P : X → UU l4)
   where
 
   reflexive-htpy-dependent-cofork :
-    ( k : dependent-cofork f g e P) →
-    htpy-dependent-cofork f g P k k
+    (k : dependent-cofork a e P) →
+    htpy-dependent-cofork a P k k
   pr1 (reflexive-htpy-dependent-cofork k) = refl-htpy
   pr2 (reflexive-htpy-dependent-cofork k) = right-unit-htpy
 
   htpy-dependent-cofork-eq :
-    ( k k' : dependent-cofork f g e P) →
-    ( k ＝ k') → htpy-dependent-cofork f g P k k'
+    (k k' : dependent-cofork a e P) →
+    (k ＝ k') → htpy-dependent-cofork a P k k'
   htpy-dependent-cofork-eq k .k refl = reflexive-htpy-dependent-cofork k
 
   abstract
     is-torsorial-htpy-dependent-cofork :
-      ( k : dependent-cofork f g e P) →
-      is-torsorial (htpy-dependent-cofork f g P k)
+      (k : dependent-cofork a e P) →
+      is-torsorial (htpy-dependent-cofork a P k)
     is-torsorial-htpy-dependent-cofork k =
       is-torsorial-Eq-structure
-        ( is-torsorial-htpy (map-dependent-cofork f g P k))
-        ( map-dependent-cofork f g P k , refl-htpy)
+        ( is-torsorial-htpy (map-dependent-cofork a P k))
+        ( map-dependent-cofork a P k , refl-htpy)
         ( is-torsorial-htpy
-          ( coherence-dependent-cofork f g P k ∙h refl-htpy))
+          ( coherence-dependent-cofork a P k ∙h refl-htpy))
 
     is-equiv-htpy-dependent-cofork-eq :
-      ( k k' : dependent-cofork f g e P) →
+      (k k' : dependent-cofork a e P) →
       is-equiv (htpy-dependent-cofork-eq k k')
     is-equiv-htpy-dependent-cofork-eq k =
       fundamental-theorem-id
@@ -191,8 +192,8 @@ module _
         ( htpy-dependent-cofork-eq k)
 
   eq-htpy-dependent-cofork :
-    ( k k' : dependent-cofork f g e P) →
-    htpy-dependent-cofork f g P k k' → k ＝ k'
+    (k k' : dependent-cofork a e P) →
+    htpy-dependent-cofork a P k k' → k ＝ k'
   eq-htpy-dependent-cofork k k' =
     map-inv-is-equiv (is-equiv-htpy-dependent-cofork-eq k k')
 ```
@@ -201,42 +202,44 @@ module _
 
 ```agda
 module _
-  { l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} (f g : A → B) {X : UU l3}
-  ( e : cofork f g X) (Y : UU l4)
+  {l1 l2 l3 l4 : Level} (a : double-arrow l1 l2) {X : UU l3}
+  (e : cofork a X) (Y : UU l4)
   where
 
   compute-dependent-cofork-constant-family :
-    dependent-cofork f g e (λ _ → Y) ≃ cofork f g Y
+    dependent-cofork a e (λ _ → Y) ≃ cofork a Y
   compute-dependent-cofork-constant-family =
     equiv-tot
       ( λ h →
         equiv-Π-equiv-family
-          ( λ a →
+          ( λ x →
             equiv-concat
               ( inv
-                ( tr-constant-type-family (coherence-cofork f g e a) (h (f a))))
-              ( h (g a))))
+                ( tr-constant-type-family
+                  ( coh-cofork a e x)
+                  ( h (bottom-map-double-arrow a x))))
+              ( h (top-map-double-arrow a x))))
 
   map-compute-dependent-cofork-constant-family :
-    dependent-cofork f g e (λ _ → Y) → cofork f g Y
+    dependent-cofork a e (λ _ → Y) → cofork a Y
   map-compute-dependent-cofork-constant-family =
     map-equiv compute-dependent-cofork-constant-family
 
   triangle-compute-dependent-cofork-constant-family :
     coherence-triangle-maps
-      ( cofork-map f g e)
+      ( cofork-map a e)
       ( map-compute-dependent-cofork-constant-family)
-      ( dependent-cofork-map f g e)
+      ( dependent-cofork-map a e)
   triangle-compute-dependent-cofork-constant-family h =
-    eq-htpy-cofork f g
-      ( cofork-map f g e h)
+    eq-htpy-cofork a
+      ( cofork-map a e h)
       ( map-compute-dependent-cofork-constant-family
-        ( dependent-cofork-map f g e h))
+        ( dependent-cofork-map a e h))
       ( ( refl-htpy) ,
         ( right-unit-htpy ∙h
-          ( λ a →
+          ( λ x →
             left-transpose-eq-concat _ _ _
-              ( inv (apd-constant-type-family h (coherence-cofork f g e a))))))
+              ( inv (apd-constant-type-family h (coh-cofork a e x))))))
 ```
 
 ### Dependent coforks are special cases of dependent cocones under spans
@@ -247,62 +250,62 @@ on `P` over a cocone corresponding to `e` via `cocone-codiagonal-cofork`.
 
 ```agda
 module _
-  { l1 l2 l3 : Level} {A : UU l1} {B : UU l2} (f g : A → B) {X : UU l3}
-  ( e : cofork f g X)
+  {l1 l2 l3 : Level} (a : double-arrow l1 l2) {X : UU l3}
+  (e : cofork a X)
   where
 
   module _
-    { l4 : Level} (P : X → UU l4)
+    {l4 : Level} (P : X → UU l4)
     where
 
     dependent-cofork-dependent-cocone-codiagonal :
       dependent-cocone
-        ( vertical-map-span-cocone-cofork f g)
-        ( horizontal-map-span-cocone-cofork f g)
-        ( cocone-codiagonal-cofork f g e)
+        ( vertical-map-span-cocone-cofork a)
+        ( horizontal-map-span-cocone-cofork a)
+        ( cocone-codiagonal-cofork a e)
         ( P) →
-      dependent-cofork f g e P
+      dependent-cofork a e P
     pr1 (dependent-cofork-dependent-cocone-codiagonal k) =
       vertical-map-dependent-cocone
-        ( vertical-map-span-cocone-cofork f g)
-        ( horizontal-map-span-cocone-cofork f g)
-        ( cocone-codiagonal-cofork f g e)
+        ( vertical-map-span-cocone-cofork a)
+        ( horizontal-map-span-cocone-cofork a)
+        ( cocone-codiagonal-cofork a e)
         ( P)
         ( k)
-    pr2 (dependent-cofork-dependent-cocone-codiagonal k) a =
+    pr2 (dependent-cofork-dependent-cocone-codiagonal k) x =
       inv
         ( ap
-          ( tr P (coherence-cofork f g e a))
+          ( tr P (coh-cofork a e x))
           ( coherence-square-dependent-cocone
-            ( vertical-map-span-cocone-cofork f g)
-            ( horizontal-map-span-cocone-cofork f g)
-            ( cocone-codiagonal-cofork f g e)
+            ( vertical-map-span-cocone-cofork a)
+            ( horizontal-map-span-cocone-cofork a)
+            ( cocone-codiagonal-cofork a e)
             ( P)
             ( k)
-            ( inl a))) ∙
+            ( inl x))) ∙
       coherence-square-dependent-cocone
-        ( vertical-map-span-cocone-cofork f g)
-        ( horizontal-map-span-cocone-cofork f g)
-        ( cocone-codiagonal-cofork f g e)
+        ( vertical-map-span-cocone-cofork a)
+        ( horizontal-map-span-cocone-cofork a)
+        ( cocone-codiagonal-cofork a e)
         ( P)
         ( k)
-        ( inr a)
+        ( inr x)
 
     dependent-cocone-codiagonal-dependent-cofork :
-      dependent-cofork f g e P →
+      dependent-cofork a e P →
       dependent-cocone
-        ( vertical-map-span-cocone-cofork f g)
-        ( horizontal-map-span-cocone-cofork f g)
-        ( cocone-codiagonal-cofork f g e)
+        ( vertical-map-span-cocone-cofork a)
+        ( horizontal-map-span-cocone-cofork a)
+        ( cocone-codiagonal-cofork a e)
         ( P)
     pr1 (dependent-cocone-codiagonal-dependent-cofork k) =
-      map-dependent-cofork f g P k ∘ f
+      map-dependent-cofork a P k ∘ bottom-map-double-arrow a
     pr1 (pr2 (dependent-cocone-codiagonal-dependent-cofork k)) =
-      map-dependent-cofork f g P k
+      map-dependent-cofork a P k
     pr2 (pr2 (dependent-cocone-codiagonal-dependent-cofork k)) (inl a) =
       refl
-    pr2 (pr2 (dependent-cocone-codiagonal-dependent-cofork k)) (inr a) =
-      coherence-dependent-cofork f g P k a
+    pr2 (pr2 (dependent-cocone-codiagonal-dependent-cofork k)) (inr x) =
+      coherence-dependent-cofork a P k x
 
     abstract
       is-section-dependent-cocone-codiagonal-dependent-cofork :
@@ -310,7 +313,7 @@ module _
           ( dependent-cocone-codiagonal-dependent-cofork)) ~
         ( id)
       is-section-dependent-cocone-codiagonal-dependent-cofork k =
-        eq-htpy-dependent-cofork f g P
+        eq-htpy-dependent-cofork a P
           ( dependent-cofork-dependent-cocone-codiagonal
             ( dependent-cocone-codiagonal-dependent-cofork k))
           ( k)
@@ -322,70 +325,70 @@ module _
         ( id)
       is-retraction-dependent-cocone-codiagonal-dependent-cofork d =
         eq-htpy-dependent-cocone
-          ( vertical-map-span-cocone-cofork f g)
-          ( horizontal-map-span-cocone-cofork f g)
-          ( cocone-codiagonal-cofork f g e)
+          ( vertical-map-span-cocone-cofork a)
+          ( horizontal-map-span-cocone-cofork a)
+          ( cocone-codiagonal-cofork a e)
           ( P)
           ( dependent-cocone-codiagonal-dependent-cofork
             ( dependent-cofork-dependent-cocone-codiagonal d))
           ( d)
           ( inv-htpy
             ( ( coherence-square-dependent-cocone
-                ( vertical-map-span-cocone-cofork f g)
-                ( horizontal-map-span-cocone-cofork f g)
-                ( cocone-codiagonal-cofork f g e)
+                ( vertical-map-span-cocone-cofork a)
+                ( horizontal-map-span-cocone-cofork a)
+                ( cocone-codiagonal-cofork a e)
                 ( P)
                 ( d)) ∘
               ( inl)) ,
             ( refl-htpy) ,
             ( right-unit-htpy ∙h
               ( λ where
-                ( inl a) →
+                (inl x) →
                   inv
                     ( ( right-whisker-concat
                         ( ap-id
                           ( inv
                             ( coherence-square-dependent-cocone
-                              ( vertical-map-span-cocone-cofork f g)
-                              ( horizontal-map-span-cocone-cofork f g)
-                              ( cocone-codiagonal-cofork f g e)
+                              ( vertical-map-span-cocone-cofork a)
+                              ( horizontal-map-span-cocone-cofork a)
+                              ( cocone-codiagonal-cofork a e)
                               ( P)
                               ( d)
-                              ( inl a))))
+                              ( inl x))))
                         ( coherence-square-dependent-cocone
-                          ( vertical-map-span-cocone-cofork f g)
-                          ( horizontal-map-span-cocone-cofork f g)
-                          ( cocone-codiagonal-cofork f g e)
+                          ( vertical-map-span-cocone-cofork a)
+                          ( horizontal-map-span-cocone-cofork a)
+                          ( cocone-codiagonal-cofork a e)
                           ( P)
                           ( d)
-                          ( inl a))) ∙
+                          ( inl x))) ∙
                       ( left-inv
                         ( coherence-square-dependent-cocone
-                          ( vertical-map-span-cocone-cofork f g)
-                          ( horizontal-map-span-cocone-cofork f g)
-                          ( cocone-codiagonal-cofork f g e)
+                          ( vertical-map-span-cocone-cofork a)
+                          ( horizontal-map-span-cocone-cofork a)
+                          ( cocone-codiagonal-cofork a e)
                           ( P)
                           ( d)
-                          ( inl a))))
-                ( inr a) →
+                          ( inl x))))
+                (inr x) →
                   right-whisker-concat
                     ( inv
                       ( ap-inv
-                        ( tr P (coherence-cofork f g e a))
+                        ( tr P (coh-cofork a e x))
                         ( coherence-square-dependent-cocone
-                          ( vertical-map-span-cocone-cofork f g)
-                          ( horizontal-map-span-cocone-cofork f g)
-                          ( cocone-codiagonal-cofork f g e)
+                          ( vertical-map-span-cocone-cofork a)
+                          ( horizontal-map-span-cocone-cofork a)
+                          ( cocone-codiagonal-cofork a e)
                           ( P)
                           ( d)
-                          ( inl a))))
+                          ( inl x))))
                     ( coherence-square-dependent-cocone
-                      ( vertical-map-span-cocone-cofork f g)
-                      ( horizontal-map-span-cocone-cofork f g)
-                      ( cocone-codiagonal-cofork f g e)
+                      ( vertical-map-span-cocone-cofork a)
+                      ( horizontal-map-span-cocone-cofork a)
+                      ( cocone-codiagonal-cofork a e)
                       ( P)
                       ( d)
-                      ( inr a)))))
+                      ( inr x)))))
 
     is-equiv-dependent-cofork-dependent-cocone-codiagonal :
       is-equiv dependent-cofork-dependent-cocone-codiagonal
@@ -397,34 +400,34 @@ module _
 
     equiv-dependent-cofork-dependent-cocone-codiagonal :
       dependent-cocone
-        ( vertical-map-span-cocone-cofork f g)
-        ( horizontal-map-span-cocone-cofork f g)
-        ( cocone-codiagonal-cofork f g e)
+        ( vertical-map-span-cocone-cofork a)
+        ( horizontal-map-span-cocone-cofork a)
+        ( cocone-codiagonal-cofork a e)
         ( P) ≃
-      dependent-cofork f g e P
+      dependent-cofork a e P
     pr1 equiv-dependent-cofork-dependent-cocone-codiagonal =
       dependent-cofork-dependent-cocone-codiagonal
     pr2 equiv-dependent-cofork-dependent-cocone-codiagonal =
       is-equiv-dependent-cofork-dependent-cocone-codiagonal
 
   triangle-dependent-cofork-dependent-cocone-codiagonal :
-    { l4 : Level} (P : X → UU l4) →
+    {l4 : Level} (P : X → UU l4) →
     coherence-triangle-maps
-      ( dependent-cofork-map f g e)
+      ( dependent-cofork-map a e)
       ( dependent-cofork-dependent-cocone-codiagonal P)
       ( dependent-cocone-map
-        ( vertical-map-span-cocone-cofork f g)
-        ( horizontal-map-span-cocone-cofork f g)
-        ( cocone-codiagonal-cofork f g e)
+        ( vertical-map-span-cocone-cofork a)
+        ( horizontal-map-span-cocone-cofork a)
+        ( cocone-codiagonal-cofork a e)
         ( P))
   triangle-dependent-cofork-dependent-cocone-codiagonal P h =
-    eq-htpy-dependent-cofork f g P
-      ( dependent-cofork-map f g e h)
+    eq-htpy-dependent-cofork a P
+      ( dependent-cofork-map a e h)
       ( dependent-cofork-dependent-cocone-codiagonal P
         ( dependent-cocone-map
-          ( vertical-map-span-cocone-cofork f g)
-          ( horizontal-map-span-cocone-cofork f g)
-          ( cocone-codiagonal-cofork f g e)
+          ( vertical-map-span-cocone-cofork a)
+          ( horizontal-map-span-cocone-cofork a)
+          ( cocone-codiagonal-cofork a e)
           ( P)
           ( h)))
       ( refl-htpy ,

--- a/src/synthetic-homotopy-theory/dependent-coforks.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-coforks.lagda.md
@@ -43,8 +43,9 @@ Given a [double arrow](foundation.double-arrows.md) `f, g : A → B`, a
 a type family `P : X → 𝒰` over `X`, we may construct _dependent_ coforks on `P`
 over `e`.
 
-A {{#concept "dependent cofork" Agda=dependent-cofork}} on `P` over `e` consists
-of a dependent map
+A
+{{#concept "dependent cofork" Disambiguation="of types" Agda=dependent-cofork}}
+on `P` over `e` consists of a dependent map
 
 ```text
 k : (b : B) → P (e b)

--- a/src/synthetic-homotopy-theory/dependent-universal-property-coequalizers.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-universal-property-coequalizers.lagda.md
@@ -10,6 +10,7 @@ module synthetic-homotopy-theory.dependent-universal-property-coequalizers where
 open import foundation.contractible-maps
 open import foundation.contractible-types
 open import foundation.dependent-pair-types
+open import foundation.double-arrows
 open import foundation.equivalences
 open import foundation.fibers-of-maps
 open import foundation.functoriality-dependent-pair-types
@@ -42,22 +43,22 @@ dependent-cofork-map : ((x : X) → P x) → dependent-cocone e P.
 
 ```agda
 module _
-  { l1 l2 l3 : Level} (l : Level) {A : UU l1} {B : UU l2} (f g : A → B)
-  { X : UU l3} (e : cofork f g X)
+  {l1 l2 l3 : Level} (l : Level) (a : double-arrow l1 l2) {X : UU l3}
+  (e : cofork a X)
   where
 
   dependent-universal-property-coequalizer : UU (l1 ⊔ l2 ⊔ l3 ⊔ lsuc l)
   dependent-universal-property-coequalizer =
-    (P : X → UU l) → is-equiv (dependent-cofork-map f g e {P = P})
+    (P : X → UU l) → is-equiv (dependent-cofork-map a e {P = P})
 
 module _
-  { l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} (f g : A → B) {X : UU l3}
-  ( e : cofork f g X) {P : X → UU l4}
-  ( dup-coequalizer : dependent-universal-property-coequalizer l4 f g e)
+  {l1 l2 l3 l4 : Level} (a : double-arrow l1 l2) {X : UU l3}
+  (e : cofork a X) {P : X → UU l4}
+  (dup-coequalizer : dependent-universal-property-coequalizer l4 a e)
   where
 
   map-dependent-universal-property-coequalizer :
-    dependent-cofork f g e P →
+    dependent-cofork a e P →
     (x : X) → P x
   map-dependent-universal-property-coequalizer =
     map-inv-is-equiv (dup-coequalizer P)
@@ -69,23 +70,23 @@ module _
 
 ```agda
 module _
-  { l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} (f g : A → B) {X : UU l3}
-  ( e : cofork f g X) {P : X → UU l4}
-  ( dup-coequalizer : dependent-universal-property-coequalizer l4 f g e)
-  ( k : dependent-cofork f g e P)
+  {l1 l2 l3 l4 : Level} (a : double-arrow l1 l2) {X : UU l3}
+  (e : cofork a X) {P : X → UU l4}
+  (dup-coequalizer : dependent-universal-property-coequalizer l4 a e)
+  (k : dependent-cofork a e P)
   where
 
   htpy-dependent-cofork-dependent-universal-property-coequalizer :
-    htpy-dependent-cofork f g P
-      ( dependent-cofork-map f g e
-        ( map-dependent-universal-property-coequalizer f g e
+    htpy-dependent-cofork a P
+      ( dependent-cofork-map a e
+        ( map-dependent-universal-property-coequalizer a e
           ( dup-coequalizer)
           ( k)))
       ( k)
   htpy-dependent-cofork-dependent-universal-property-coequalizer =
-    htpy-dependent-cofork-eq f g P
-      ( dependent-cofork-map f g e
-        ( map-dependent-universal-property-coequalizer f g e
+    htpy-dependent-cofork-eq a P
+      ( dependent-cofork-map a e
+        ( map-dependent-universal-property-coequalizer a e
           ( dup-coequalizer)
           ( k)))
       ( k)
@@ -95,17 +96,17 @@ module _
     uniqueness-dependent-universal-property-coequalizer :
       is-contr
         ( Σ ((x : X) → P x)
-          ( λ h → htpy-dependent-cofork f g P (dependent-cofork-map f g e h) k))
+          ( λ h → htpy-dependent-cofork a P (dependent-cofork-map a e h) k))
     uniqueness-dependent-universal-property-coequalizer =
       is-contr-is-equiv'
-        ( fiber (dependent-cofork-map f g e) k)
+        ( fiber (dependent-cofork-map a e) k)
         ( tot
           ( λ h →
-            htpy-dependent-cofork-eq f g P (dependent-cofork-map f g e h) k))
+            htpy-dependent-cofork-eq a P (dependent-cofork-map a e h) k))
         ( is-equiv-tot-is-fiberwise-equiv
           ( λ h →
-            is-equiv-htpy-dependent-cofork-eq f g P
-              ( dependent-cofork-map f g e h)
+            is-equiv-htpy-dependent-cofork-eq a P
+              ( dependent-cofork-map a e h)
               ( k)))
         ( is-contr-map-is-equiv (dup-coequalizer P) k)
 ```
@@ -120,54 +121,54 @@ precise, asserting that under this mapping,
 
 ```agda
 module _
-  { l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3} (f g : A → B)
-  ( e : cofork f g X)
+  {l1 l2 l3 : Level} (a : double-arrow l1 l2) {X : UU l3}
+  (e : cofork a X)
   where
 
   dependent-universal-property-coequalizer-dependent-universal-property-pushout :
-    ( {l : Level} →
+    ({l : Level} →
       dependent-universal-property-pushout l
-        ( vertical-map-span-cocone-cofork f g)
-        ( horizontal-map-span-cocone-cofork f g)
-        ( cocone-codiagonal-cofork f g e)) →
-    ( {l : Level} →
-      dependent-universal-property-coequalizer l f g e)
+        ( vertical-map-span-cocone-cofork a)
+        ( horizontal-map-span-cocone-cofork a)
+        ( cocone-codiagonal-cofork a e)) →
+    ({l : Level} →
+      dependent-universal-property-coequalizer l a e)
   dependent-universal-property-coequalizer-dependent-universal-property-pushout
     ( dup-pushout)
     ( P) =
     is-equiv-left-map-triangle
-      ( dependent-cofork-map f g e)
-      ( dependent-cofork-dependent-cocone-codiagonal f g e P)
+      ( dependent-cofork-map a e)
+      ( dependent-cofork-dependent-cocone-codiagonal a e P)
       ( dependent-cocone-map
-        ( vertical-map-span-cocone-cofork f g)
-        ( horizontal-map-span-cocone-cofork f g)
-        ( cocone-codiagonal-cofork f g e)
+        ( vertical-map-span-cocone-cofork a)
+        ( horizontal-map-span-cocone-cofork a)
+        ( cocone-codiagonal-cofork a e)
         ( P))
-      ( triangle-dependent-cofork-dependent-cocone-codiagonal f g e P)
+      ( triangle-dependent-cofork-dependent-cocone-codiagonal a e P)
       ( dup-pushout P)
-      ( is-equiv-dependent-cofork-dependent-cocone-codiagonal f g e P)
+      ( is-equiv-dependent-cofork-dependent-cocone-codiagonal a e P)
 
   dependent-universal-property-pushout-dependent-universal-property-coequalizer :
-    ( {l : Level} →
-      dependent-universal-property-coequalizer l f g e) →
-    ( {l : Level} →
+    ({l : Level} →
+      dependent-universal-property-coequalizer l a e) →
+    ({l : Level} →
       dependent-universal-property-pushout l
-        ( vertical-map-span-cocone-cofork f g)
-        ( horizontal-map-span-cocone-cofork f g)
-        ( cocone-codiagonal-cofork f g e))
+        ( vertical-map-span-cocone-cofork a)
+        ( horizontal-map-span-cocone-cofork a)
+        ( cocone-codiagonal-cofork a e))
   dependent-universal-property-pushout-dependent-universal-property-coequalizer
     ( dup-coequalizer)
     ( P) =
     is-equiv-top-map-triangle
-      ( dependent-cofork-map f g e)
-      ( dependent-cofork-dependent-cocone-codiagonal f g e P)
+      ( dependent-cofork-map a e)
+      ( dependent-cofork-dependent-cocone-codiagonal a e P)
       ( dependent-cocone-map
-        ( vertical-map-span-cocone-cofork f g)
-        ( horizontal-map-span-cocone-cofork f g)
-        ( cocone-codiagonal-cofork f g e)
+        ( vertical-map-span-cocone-cofork a)
+        ( horizontal-map-span-cocone-cofork a)
+        ( cocone-codiagonal-cofork a e)
         ( P))
-      ( triangle-dependent-cofork-dependent-cocone-codiagonal f g e P)
-      ( is-equiv-dependent-cofork-dependent-cocone-codiagonal f g e P)
+      ( triangle-dependent-cofork-dependent-cocone-codiagonal a e P)
+      ( is-equiv-dependent-cofork-dependent-cocone-codiagonal a e P)
       ( dup-coequalizer P)
 ```
 
@@ -175,37 +176,36 @@ module _
 
 ```agda
 module _
-  { l1 l2 l3 : Level} {A : UU l1} {B : UU l2} (f g : A → B) {X : UU l3}
-  ( e : cofork f g X)
+  {l1 l2 l3 : Level} (a : double-arrow l1 l2) {X : UU l3}
+  (e : cofork a X)
   where
 
   universal-property-dependent-universal-property-coequalizer :
-    ( {l : Level} → dependent-universal-property-coequalizer l f g e) →
-    ( {l : Level} → universal-property-coequalizer l f g e)
+    ({l : Level} → dependent-universal-property-coequalizer l a e) →
+    ({l : Level} → universal-property-coequalizer l a e)
   universal-property-dependent-universal-property-coequalizer
     ( dup-coequalizer)
     ( Y) =
     is-equiv-left-map-triangle
-      ( cofork-map f g e)
-      ( map-compute-dependent-cofork-constant-family f g e Y)
-      ( dependent-cofork-map f g e)
-      ( triangle-compute-dependent-cofork-constant-family f g e Y)
+      ( cofork-map a e)
+      ( map-compute-dependent-cofork-constant-family a e Y)
+      ( dependent-cofork-map a e)
+      ( triangle-compute-dependent-cofork-constant-family a e Y)
       ( dup-coequalizer (λ _ → Y))
       ( is-equiv-map-equiv
-        ( compute-dependent-cofork-constant-family f g e Y))
+        ( compute-dependent-cofork-constant-family a e Y))
 
   dependent-universal-property-universal-property-coequalizer :
-    ( {l : Level} → universal-property-coequalizer l f g e) →
-    ( {l : Level} → dependent-universal-property-coequalizer l f g e)
+    ({l : Level} → universal-property-coequalizer l a e) →
+    ({l : Level} → dependent-universal-property-coequalizer l a e)
   dependent-universal-property-universal-property-coequalizer up-coequalizer =
     dependent-universal-property-coequalizer-dependent-universal-property-pushout
-      ( f)
-      ( g)
+      ( a)
       ( e)
       ( dependent-universal-property-universal-property-pushout
-          ( vertical-map-span-cocone-cofork f g)
-          ( horizontal-map-span-cocone-cofork f g)
-          ( cocone-codiagonal-cofork f g e)
-          ( universal-property-pushout-universal-property-coequalizer f g e
+          ( vertical-map-span-cocone-cofork a)
+          ( horizontal-map-span-cocone-cofork a)
+          ( cocone-codiagonal-cofork a e)
+          ( universal-property-pushout-universal-property-coequalizer a e
             ( up-coequalizer)))
 ```

--- a/src/synthetic-homotopy-theory/dependent-universal-property-coequalizers.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-universal-property-coequalizers.lagda.md
@@ -28,10 +28,11 @@ open import synthetic-homotopy-theory.universal-property-coequalizers
 ## Idea
 
 The **dependent universal property of coequalizers** is a property of
-[coequalizers](synthetic-homotopy-theory.coequalizers.md) of a parallel pair
-`f, g : A → B`, asserting that for any type family `P : X → 𝓤` over the
-coequalizer `e : B → X`, there is an equivalence between sections of `P` and
-dependent cocones on `P` over `e`, given by the map
+[coequalizers](synthetic-homotopy-theory.coequalizers.md) of a
+[double arrow](foundation.double-arrows.md) `f, g : A → B`, asserting that for
+any type family `P : X → 𝒰` over the coequalizer `e : B → X`, there is an
+equivalence between sections of `P` and dependent cocones on `P` over `e`, given
+by the map
 
 ```text
 dependent-cofork-map : ((x : X) → P x) → dependent-cocone e P.
@@ -113,9 +114,9 @@ module _
 
 ### A cofork has the dependent universal property of coequalizers if and only if the corresponding cocone has the dependent universal property of pushouts
 
-As mentioned in [coforks](synthetic-homotopy-theory.coforks.md), coforks can be
-thought of as special cases of cocones under spans. This theorem makes it more
-precise, asserting that under this mapping,
+As mentioned in [`coforks`](synthetic-homotopy-theory.coforks.md), coforks can
+be thought of as special cases of cocones under spans. This theorem makes it
+more precise, asserting that under this mapping,
 [coequalizers](synthetic-homotopy-theory.coequalizers.md) correspond to
 [pushouts](synthetic-homotopy-theory.pushouts.md).
 

--- a/src/synthetic-homotopy-theory/dependent-universal-property-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-universal-property-sequential-colimits.lagda.md
@@ -153,8 +153,7 @@ module _
   dependent-universal-property-sequential-colimit-dependent-universal-property-coequalizer :
     ( {l : Level} →
       dependent-universal-property-coequalizer l
-        ( bottom-map-cofork-cocone-sequential-diagram A)
-        ( top-map-cofork-cocone-sequential-diagram A)
+        ( double-arrow-sequential-diagram A)
         ( cofork-cocone-sequential-diagram A c)) →
     dependent-universal-property-sequential-colimit c
   dependent-universal-property-sequential-colimit-dependent-universal-property-coequalizer
@@ -164,8 +163,7 @@ module _
       ( dependent-cocone-map-sequential-diagram c P)
       ( dependent-cocone-sequential-diagram-dependent-cofork c P)
       ( dependent-cofork-map
-        ( bottom-map-cofork-cocone-sequential-diagram A)
-        ( top-map-cofork-cocone-sequential-diagram A)
+        ( double-arrow-sequential-diagram A)
         ( cofork-cocone-sequential-diagram A c))
       ( triangle-dependent-cocone-sequential-diagram-dependent-cofork c P)
       ( dup-coequalizer P)
@@ -175,8 +173,7 @@ module _
     dependent-universal-property-sequential-colimit c →
     ( {l : Level} →
       dependent-universal-property-coequalizer l
-        ( bottom-map-cofork-cocone-sequential-diagram A)
-        ( top-map-cofork-cocone-sequential-diagram A)
+        ( double-arrow-sequential-diagram A)
         ( cofork-cocone-sequential-diagram A c))
   dependent-universal-property-coequalizer-dependent-universal-property-sequential-colimit
     ( dup-c)
@@ -185,8 +182,7 @@ module _
       ( dependent-cocone-map-sequential-diagram c P)
       ( dependent-cocone-sequential-diagram-dependent-cofork c P)
       ( dependent-cofork-map
-        ( bottom-map-cofork-cocone-sequential-diagram A)
-        ( top-map-cofork-cocone-sequential-diagram A)
+        ( double-arrow-sequential-diagram A)
         ( cofork-cocone-sequential-diagram A c))
       ( triangle-dependent-cocone-sequential-diagram-dependent-cofork c P)
       ( is-equiv-dependent-cocone-sequential-diagram-dependent-cofork c P)
@@ -225,8 +221,7 @@ module _
     dependent-universal-property-sequential-colimit-dependent-universal-property-coequalizer
       ( c)
       ( dependent-universal-property-universal-property-coequalizer
-        ( bottom-map-cofork-cocone-sequential-diagram A)
-        ( top-map-cofork-cocone-sequential-diagram A)
+        ( double-arrow-sequential-diagram A)
         ( cofork-cocone-sequential-diagram A c)
         ( universal-property-coequalizer-universal-property-sequential-colimit
           ( c)

--- a/src/synthetic-homotopy-theory/equivalences-coforks.lagda.md
+++ b/src/synthetic-homotopy-theory/equivalences-coforks.lagda.md
@@ -1,0 +1,87 @@
+# Equivalences of coforks
+
+```agda
+module synthetic-homotopy-theory.equivalences-coforks where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.commuting-squares-of-maps
+open import foundation.dependent-pair-types
+open import foundation.double-arrows
+open import foundation.equivalences
+open import foundation.equivalences-double-arrows
+open import foundation.homotopies
+open import foundation.universe-levels
+open import foundation.whiskering-homotopies-composition
+
+open import synthetic-homotopy-theory.coforks
+```
+
+</details>
+
+## Idea
+
+TODO
+
+## Definitions
+
+### Equivalences of coforks
+
+```agda
+module _
+  {l1 l2 l3 l4 l5 l6 : Level}
+  {a : double-arrow l1 l2} {X : UU l3} (c : cofork a X)
+  {a' : double-arrow l4 l5} {Y : UU l6} (c' : cofork a' Y)
+  (e : equiv-double-arrow a a')
+  where
+
+  coherence-equiv-cofork : (X ≃ Y) → UU (l2 ⊔ l6)
+  coherence-equiv-cofork u =
+    coherence-square-maps'
+      ( map-cofork a c)
+      ( codomain-map-equiv-double-arrow a a' e)
+      ( map-equiv u)
+      ( map-cofork a' c')
+
+  coherence-equiv-cofork' :
+    (u : X ≃ Y) → coherence-equiv-cofork u →
+    UU (l1 ⊔ l6)
+  coherence-equiv-cofork' u H =
+    ( ( H ·r (bottom-map-double-arrow a)) ∙h
+      ( ( map-cofork a' c') ·l
+        ( bottom-coherence-square-equiv-double-arrow a a' e)) ∙h
+      ( (coh-cofork a' c') ·r (domain-map-equiv-double-arrow a a' e))) ~
+    ( ( (map-equiv u) ·l (coh-cofork a c)) ∙h
+      ( H ·r (top-map-double-arrow a)) ∙h
+      ( (map-cofork a' c') ·l (top-coherence-square-equiv-double-arrow a a' e)))
+
+  equiv-cofork : UU (l1 ⊔ l2 ⊔ l3 ⊔ l6)
+  equiv-cofork =
+    Σ ( X ≃ Y)
+      ( λ u →
+        Σ ( coherence-equiv-cofork u)
+          ( coherence-equiv-cofork' u))
+
+  module _
+    (e' : equiv-cofork)
+    where
+
+    equiv-equiv-cofork : X ≃ Y
+    equiv-equiv-cofork = pr1 e'
+
+    map-equiv-cofork : X → Y
+    map-equiv-cofork = map-equiv equiv-equiv-cofork
+
+    is-equiv-map-equiv-cofork : is-equiv map-equiv-cofork
+    is-equiv-map-equiv-cofork =
+      is-equiv-map-equiv equiv-equiv-cofork
+
+    coh-equiv-cofork : coherence-equiv-cofork equiv-equiv-cofork
+    coh-equiv-cofork = pr1 (pr2 e')
+
+    coh-equiv-cofork' :
+      coherence-equiv-cofork' equiv-equiv-cofork coh-equiv-cofork
+    coh-equiv-cofork' = pr2 (pr2 e')
+```

--- a/src/synthetic-homotopy-theory/equivalences-coforks.lagda.md
+++ b/src/synthetic-homotopy-theory/equivalences-coforks.lagda.md
@@ -32,8 +32,9 @@ Consider two [double arrows](foundation.double-arrows.md) `f, g : A → B` and
 [equivalence of double arrows](foundation.equivalences-double-arrows.md)
 `e : (f, g) ≃ (h, k)`.
 
-Then an {{#concept "equivalence of coforks" Agda=equiv-cofork}} over `e` is a
-triple `(m, H, K)`, with `m : X ≃ Y` an
+Then an
+{{#concept "equivalence of coforks" Disambiguation="of types" Agda=equiv-cofork}}
+over `e` is a triple `(m, H, K)`, with `m : X ≃ Y` an
 [equivalence](foundation-core.equivalences.md) of vertices of the coforks, `H` a
 [homotopy](foundation-core.homotopies.md) witnessing that the bottom square in
 
@@ -72,9 +73,44 @@ datum filling the inside --- we have two stacks of squares
            m                        m
 ```
 
-glued along `i` and the bottom square, with the coherences of `c` and `c'`
-filling the sides, which give us two homotopies `m ∘ c ∘ f ~ c' ∘ k ∘ i`, and we
-need to ensure these are homotopic.
+which share the top map `i` and the bottom square, and the coherences of `c` and
+`c'` filling the sides; that gives us the homotopies
+
+```text
+                                                i                 i
+     A                  A                 A --------> U     A --------> U
+     |                  |                             |                 |
+   f |                f |                             | h               | k
+     |                  |                             |                 |
+     ∨                  ∨     j                       ∨                 ∨
+     B         ~        B --------> V       ~         V        ~        V
+     |                              |                 |                 |
+   c |                              | c'              | c'              | c'
+     |                              |                 |                 |
+     ∨                              ∨                 ∨                 ∨
+     X --------> Y                  Y                 Y                 Y
+           m
+```
+
+and
+
+```text
+                                                                  i
+     A                 A               A                    A --------> U
+     |                 |               |                                |
+   f |               g |             g |                                | k
+     |                 |               |                                |
+     ∨                 ∨               ∨     j                          ∨
+     B         ~       B       ~       B --------> V           ~        V
+     |                 |                           |                    |
+   c |               c |                           | c'                 | c'
+     |                 |                           |                    |
+     ∨                 ∨                           ∨                    ∨
+     X --------> Y     X --------> Y               Y                    Y ,
+           m                 m
+```
+
+which we require to be homotopic.
 
 ## Definitions
 

--- a/src/synthetic-homotopy-theory/equivalences-coforks.lagda.md
+++ b/src/synthetic-homotopy-theory/equivalences-coforks.lagda.md
@@ -37,6 +37,7 @@ Then an
 over `e` is a triple `(m, H, K)`, with `m : X ≃ Y` an
 [equivalence](foundation-core.equivalences.md) of vertices of the coforks, `H` a
 [homotopy](foundation-core.homotopies.md) witnessing that the bottom square in
+the diagram
 
 ```text
            i
@@ -55,7 +56,7 @@ over `e` is a triple `(m, H, K)`, with `m : X ≃ Y` an
 ```
 
 [commutes](foundation-core.commuting-squares-of-maps.md), and `K` a coherence
-datum filling the inside --- we have two stacks of squares
+datum "filling the inside" --- we have two stacks of squares
 
 ```text
            i                        i
@@ -74,7 +75,7 @@ datum filling the inside --- we have two stacks of squares
 ```
 
 which share the top map `i` and the bottom square, and the coherences of `c` and
-`c'` filling the sides; that gives us the homotopies
+`c'` filling the sides; that gives the homotopies
 
 ```text
                                                 i                 i
@@ -110,7 +111,7 @@ and
            m                 m
 ```
 
-which we require to be homotopic.
+which are required to be homotopic.
 
 ## Definitions
 

--- a/src/synthetic-homotopy-theory/equivalences-coforks.lagda.md
+++ b/src/synthetic-homotopy-theory/equivalences-coforks.lagda.md
@@ -11,19 +11,70 @@ open import foundation.commuting-squares-of-maps
 open import foundation.dependent-pair-types
 open import foundation.double-arrows
 open import foundation.equivalences
+open import foundation.equivalences-arrows
 open import foundation.equivalences-double-arrows
 open import foundation.homotopies
+open import foundation.morphisms-arrows
 open import foundation.universe-levels
 open import foundation.whiskering-homotopies-composition
 
 open import synthetic-homotopy-theory.coforks
+open import synthetic-homotopy-theory.morphisms-coforks
 ```
 
 </details>
 
 ## Idea
 
-TODO
+Consider two [double arrows](foundation.double-arrows.md) `f, g : A → B` and
+`h, k : U → V`, equipped with [coforks](synthetic-homotopy-theory.coforks.md)
+`c : B → X` and `c' : V → Y`, respectively, and an
+[equivalence of double arrows](foundation.equivalences-double-arrows.md)
+`e : (f, g) ≃ (h, k)`.
+
+Then an {{#concept "equivalence of coforks" Agda=equiv-cofork}} over `e` is a
+triple `(m, H, K)`, with `m : X ≃ Y` an
+[equivalence](foundation-core.equivalences.md) of vertices of the coforks, `H` a
+[homotopy](foundation-core.homotopies.md) witnessing that the bottom square in
+
+```text
+           i
+     A --------> U
+    | |    ≃    | |
+  f | | g     h | | k
+    | |         | |
+    ∨ ∨    ≃    ∨ ∨
+     B --------> V
+     |     j     |
+   c |           | c'
+     |           |
+     ∨     ≃     ∨
+     X --------> Y
+           m
+```
+
+[commutes](foundation-core.commuting-squares-of-maps.md), and `K` a coherence
+datum filling the inside --- we have two stacks of squares
+
+```text
+           i                        i
+     A --------> U            A --------> U
+     |     ≃     |            |     ≃     |
+   f |           | h        g |           | k
+     |           |            |           |
+     ∨     ≃     ∨            ∨     ≃     ∨
+     B --------> V            B --------> V
+     |     j     |            |     j     |
+   c |           | c'       c |           | c'
+     |           |            |           |
+     ∨     ≃     ∨            ∨     ≃     ∨
+     X --------> Y            X --------> Y
+           m                        m
+```
+
+glued along `i` and the bottom square, with the coherences of `c` and `c'`
+filling the sides, which give us two homotopies `m ∘ c ∘ f ~ c' ∘ k ∘ i`, and we
+need to ensure these are homotopic.
 
 ## Definitions
 
@@ -37,32 +88,32 @@ module _
   (e : equiv-double-arrow a a')
   where
 
-  coherence-equiv-cofork : (X ≃ Y) → UU (l2 ⊔ l6)
-  coherence-equiv-cofork u =
-    coherence-square-maps'
-      ( map-cofork a c)
+  coherence-map-cofork-equiv-cofork : (X ≃ Y) → UU (l2 ⊔ l6)
+  coherence-map-cofork-equiv-cofork m =
+    coherence-square-maps
       ( codomain-map-equiv-double-arrow a a' e)
-      ( map-equiv u)
+      ( map-cofork a c)
       ( map-cofork a' c')
+      ( map-equiv m)
 
-  coherence-equiv-cofork' :
-    (u : X ≃ Y) → coherence-equiv-cofork u →
+  coherence-equiv-cofork :
+    (m : X ≃ Y) → coherence-map-cofork-equiv-cofork m →
     UU (l1 ⊔ l6)
-  coherence-equiv-cofork' u H =
-    ( ( H ·r (bottom-map-double-arrow a)) ∙h
+  coherence-equiv-cofork m H =
+    ( ( H ·r (left-map-double-arrow a)) ∙h
       ( ( map-cofork a' c') ·l
-        ( bottom-coherence-square-equiv-double-arrow a a' e)) ∙h
+        ( left-square-equiv-double-arrow a a' e)) ∙h
       ( (coh-cofork a' c') ·r (domain-map-equiv-double-arrow a a' e))) ~
-    ( ( (map-equiv u) ·l (coh-cofork a c)) ∙h
-      ( H ·r (top-map-double-arrow a)) ∙h
-      ( (map-cofork a' c') ·l (top-coherence-square-equiv-double-arrow a a' e)))
+    ( ( (map-equiv m) ·l (coh-cofork a c)) ∙h
+      ( H ·r (right-map-double-arrow a)) ∙h
+      ( (map-cofork a' c') ·l (right-square-equiv-double-arrow a a' e)))
 
   equiv-cofork : UU (l1 ⊔ l2 ⊔ l3 ⊔ l6)
   equiv-cofork =
     Σ ( X ≃ Y)
-      ( λ u →
-        Σ ( coherence-equiv-cofork u)
-          ( coherence-equiv-cofork' u))
+      ( λ m →
+        Σ ( coherence-map-cofork-equiv-cofork m)
+          ( coherence-equiv-cofork m))
 
   module _
     (e' : equiv-cofork)
@@ -78,10 +129,31 @@ module _
     is-equiv-map-equiv-cofork =
       is-equiv-map-equiv equiv-equiv-cofork
 
-    coh-equiv-cofork : coherence-equiv-cofork equiv-equiv-cofork
-    coh-equiv-cofork = pr1 (pr2 e')
+    coh-map-cofork-equiv-cofork :
+      coherence-map-cofork-equiv-cofork equiv-equiv-cofork
+    coh-map-cofork-equiv-cofork = pr1 (pr2 e')
 
-    coh-equiv-cofork' :
-      coherence-equiv-cofork' equiv-equiv-cofork coh-equiv-cofork
-    coh-equiv-cofork' = pr2 (pr2 e')
+    equiv-map-cofork-equiv-cofork :
+      equiv-arrow (map-cofork a c) (map-cofork a' c')
+    pr1 equiv-map-cofork-equiv-cofork = codomain-equiv-equiv-double-arrow a a' e
+    pr1 (pr2 equiv-map-cofork-equiv-cofork) = equiv-equiv-cofork
+    pr2 (pr2 equiv-map-cofork-equiv-cofork) = coh-map-cofork-equiv-cofork
+
+    hom-map-cofork-equiv-cofork :
+      hom-arrow (map-cofork a c) (map-cofork a' c')
+    hom-map-cofork-equiv-cofork =
+      hom-equiv-arrow
+        ( map-cofork a c)
+        ( map-cofork a' c')
+        ( equiv-map-cofork-equiv-cofork)
+
+    coh-equiv-cofork :
+      coherence-equiv-cofork equiv-equiv-cofork coh-map-cofork-equiv-cofork
+    coh-equiv-cofork = pr2 (pr2 e')
+
+    hom-cofork-equiv-cofork :
+      hom-cofork c c' (hom-double-arrow-equiv-double-arrow a a' e)
+    pr1 hom-cofork-equiv-cofork = map-equiv-cofork
+    pr1 (pr2 hom-cofork-equiv-cofork) = coh-map-cofork-equiv-cofork
+    pr2 (pr2 hom-cofork-equiv-cofork) = coh-equiv-cofork
 ```

--- a/src/synthetic-homotopy-theory/flattening-lemma-coequalizers.lagda.md
+++ b/src/synthetic-homotopy-theory/flattening-lemma-coequalizers.lagda.md
@@ -10,7 +10,7 @@ module synthetic-homotopy-theory.flattening-lemma-coequalizers where
 open import foundation.action-on-identifications-functions
 open import foundation.coproduct-types
 open import foundation.dependent-pair-types
-open import foundation.equality-dependent-pair-types
+open import foundation.double-arrows
 open import foundation.equivalences
 open import foundation.function-types
 open import foundation.functoriality-dependent-pair-types
@@ -61,39 +61,50 @@ is again a coequalizer.
 
 ```agda
 module _
-  { l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} (f g : A → B) {X : UU l3}
-  ( P : X → UU l4) (e : cofork f g X)
+  {l1 l2 l3 l4 : Level} (a : double-arrow l1 l2) {X : UU l3}
+  (P : X → UU l4) (e : cofork a X)
   where
 
   bottom-map-cofork-flattening-lemma-coequalizer :
-    Σ A (P ∘ map-cofork f g e ∘ f) → Σ B (P ∘ map-cofork f g e)
+    Σ (domain-double-arrow a) (P ∘ map-cofork a e ∘ bottom-map-double-arrow a) →
+    Σ (codomain-double-arrow a) (P ∘ map-cofork a e)
   bottom-map-cofork-flattening-lemma-coequalizer =
-    map-Σ-map-base f (P ∘ map-cofork f g e)
+    map-Σ-map-base
+      ( bottom-map-double-arrow a)
+      ( P ∘ map-cofork a e)
 
   top-map-cofork-flattening-lemma-coequalizer :
-    Σ A (P ∘ map-cofork f g e ∘ f) → Σ B (P ∘ map-cofork f g e)
+    Σ (domain-double-arrow a) (P ∘ map-cofork a e ∘ bottom-map-double-arrow a) →
+    Σ (codomain-double-arrow a) (P ∘ map-cofork a e)
   top-map-cofork-flattening-lemma-coequalizer =
-    map-Σ (P ∘ map-cofork f g e) g (λ a → tr P (coherence-cofork f g e a))
+    map-Σ
+      ( P ∘ map-cofork a e)
+      ( top-map-double-arrow a)
+      ( λ x → tr P (coh-cofork a e x))
 
-  cofork-flattening-lemma-coequalizer :
-    cofork
+  double-arrow-flattening-lemma-coequalizer : double-arrow (l1 ⊔ l4) (l2 ⊔ l4)
+  double-arrow-flattening-lemma-coequalizer =
+    make-double-arrow
       ( bottom-map-cofork-flattening-lemma-coequalizer)
       ( top-map-cofork-flattening-lemma-coequalizer)
-      ( Σ X P)
-  pr1 cofork-flattening-lemma-coequalizer = map-Σ-map-base (map-cofork f g e) P
+
+  cofork-flattening-lemma-coequalizer :
+    cofork double-arrow-flattening-lemma-coequalizer (Σ X P)
+  pr1 cofork-flattening-lemma-coequalizer = map-Σ-map-base (map-cofork a e) P
   pr2 cofork-flattening-lemma-coequalizer =
-    coherence-square-maps-map-Σ-map-base P g f
-      ( map-cofork f g e)
-      ( map-cofork f g e)
-      ( coherence-cofork f g e)
+    coherence-square-maps-map-Σ-map-base P
+      ( top-map-double-arrow a)
+      ( bottom-map-double-arrow a)
+      ( map-cofork a e)
+      ( map-cofork a e)
+      ( coh-cofork a e)
 
   flattening-lemma-coequalizer-statement : UUω
   flattening-lemma-coequalizer-statement =
-    ( {l : Level} → dependent-universal-property-coequalizer l f g e) →
-    { l : Level} →
+    ({l : Level} → dependent-universal-property-coequalizer l a e) →
+    {l : Level} →
     universal-property-coequalizer l
-      ( bottom-map-cofork-flattening-lemma-coequalizer)
-      ( top-map-cofork-flattening-lemma-coequalizer)
+      ( double-arrow-flattening-lemma-coequalizer)
       ( cofork-flattening-lemma-coequalizer)
 ```
 
@@ -117,88 +128,87 @@ is a pushout.
 
 ```agda
 module _
-  { l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} (f g : A → B) {X : UU l3}
-  ( P : X → UU l4) (e : cofork f g X)
+  { l1 l2 l3 l4 : Level} (a : double-arrow l1 l2) {X : UU l3}
+  ( P : X → UU l4) (e : cofork a X)
   where
 
   abstract
     flattening-lemma-coequalizer :
-      flattening-lemma-coequalizer-statement f g P e
+      flattening-lemma-coequalizer-statement a P e
     flattening-lemma-coequalizer dup-coequalizer =
       universal-property-coequalizer-universal-property-pushout
-        ( bottom-map-cofork-flattening-lemma-coequalizer f g P e)
-        ( top-map-cofork-flattening-lemma-coequalizer f g P e)
-        ( cofork-flattening-lemma-coequalizer f g P e)
+        ( double-arrow-flattening-lemma-coequalizer a P e)
+        ( cofork-flattening-lemma-coequalizer a P e)
         ( universal-property-pushout-bottom-universal-property-pushout-top-cube-is-equiv
           ( vertical-map-span-cocone-cofork
-            ( bottom-map-cofork-flattening-lemma-coequalizer f g P e)
-            ( top-map-cofork-flattening-lemma-coequalizer f g P e))
+            ( double-arrow-flattening-lemma-coequalizer a P e))
           ( horizontal-map-span-cocone-cofork
-            ( bottom-map-cofork-flattening-lemma-coequalizer f g P e)
-            ( top-map-cofork-flattening-lemma-coequalizer f g P e))
+            ( double-arrow-flattening-lemma-coequalizer a P e))
           ( horizontal-map-cocone-flattening-pushout P
-            ( vertical-map-span-cocone-cofork f g)
-            ( horizontal-map-span-cocone-cofork f g)
-            ( cocone-codiagonal-cofork f g e))
+            ( vertical-map-span-cocone-cofork a)
+            ( horizontal-map-span-cocone-cofork a)
+            ( cocone-codiagonal-cofork a e))
           ( vertical-map-cocone-flattening-pushout P
-            ( vertical-map-span-cocone-cofork f g)
-            ( horizontal-map-span-cocone-cofork f g)
-            ( cocone-codiagonal-cofork f g e))
+            ( vertical-map-span-cocone-cofork a)
+            ( horizontal-map-span-cocone-cofork a)
+            ( cocone-codiagonal-cofork a e))
           ( vertical-map-span-flattening-pushout P
-            ( vertical-map-span-cocone-cofork f g)
-            ( horizontal-map-span-cocone-cofork f g)
-            ( cocone-codiagonal-cofork f g e))
+            ( vertical-map-span-cocone-cofork a)
+            ( horizontal-map-span-cocone-cofork a)
+            ( cocone-codiagonal-cofork a e))
           ( horizontal-map-span-flattening-pushout P
-            ( vertical-map-span-cocone-cofork f g)
-            ( horizontal-map-span-cocone-cofork f g)
-            ( cocone-codiagonal-cofork f g e))
+            ( vertical-map-span-cocone-cofork a)
+            ( horizontal-map-span-cocone-cofork a)
+            ( cocone-codiagonal-cofork a e))
           ( horizontal-map-cocone-flattening-pushout P
-            ( vertical-map-span-cocone-cofork f g)
-            ( horizontal-map-span-cocone-cofork f g)
-            ( cocone-codiagonal-cofork f g e))
+            ( vertical-map-span-cocone-cofork a)
+            ( horizontal-map-span-cocone-cofork a)
+            ( cocone-codiagonal-cofork a e))
           ( vertical-map-cocone-flattening-pushout P
-            ( vertical-map-span-cocone-cofork f g)
-            ( horizontal-map-span-cocone-cofork f g)
-            ( cocone-codiagonal-cofork f g e))
+            ( vertical-map-span-cocone-cofork a)
+            ( horizontal-map-span-cocone-cofork a)
+            ( cocone-codiagonal-cofork a e))
           ( map-equiv
-            ( right-distributive-Σ-coproduct A A
+            ( right-distributive-Σ-coproduct
+              ( domain-double-arrow a)
+              ( domain-double-arrow a)
               ( ( P) ∘
-                ( horizontal-map-cocone-cofork f g e) ∘
-                ( vertical-map-span-cocone-cofork f g))))
+                ( horizontal-map-cocone-cofork a e) ∘
+                ( vertical-map-span-cocone-cofork a))))
           ( id)
           ( id)
           ( id)
           ( coherence-square-cocone-flattening-pushout P
-            ( vertical-map-span-cocone-cofork f g)
-            ( horizontal-map-span-cocone-cofork f g)
-            ( cocone-codiagonal-cofork f g e))
+            ( vertical-map-span-cocone-cofork a)
+            ( horizontal-map-span-cocone-cofork a)
+            ( cocone-codiagonal-cofork a e))
           ( ind-Σ (ind-coproduct _ (ev-pair refl-htpy) (ev-pair refl-htpy)))
           ( ind-Σ (ind-coproduct _ (ev-pair refl-htpy) (ev-pair refl-htpy)))
           ( refl-htpy)
           ( refl-htpy)
           ( coherence-square-cocone-cofork
-            ( bottom-map-cofork-flattening-lemma-coequalizer f g P e)
-            ( top-map-cofork-flattening-lemma-coequalizer f g P e)
-            ( cofork-flattening-lemma-coequalizer f g P e))
+            ( double-arrow-flattening-lemma-coequalizer a P e)
+            ( cofork-flattening-lemma-coequalizer a P e))
           ( ind-Σ
             ( ind-coproduct _
               ( ev-pair refl-htpy)
               ( ev-pair (λ t → ap-id _ ∙ inv right-unit))))
           ( is-equiv-map-equiv
-            ( right-distributive-Σ-coproduct A A
+            ( right-distributive-Σ-coproduct
+              ( domain-double-arrow a)
+              ( domain-double-arrow a)
               ( ( P) ∘
-                ( horizontal-map-cocone-cofork f g e) ∘
-                ( vertical-map-span-cocone-cofork f g))))
+                ( horizontal-map-cocone-cofork a e) ∘
+                ( vertical-map-span-cocone-cofork a))))
           ( is-equiv-id)
           ( is-equiv-id)
           ( is-equiv-id)
           ( flattening-lemma-pushout P
-            ( vertical-map-span-cocone-cofork f g)
-            ( horizontal-map-span-cocone-cofork f g)
-            ( cocone-codiagonal-cofork f g e)
+            ( vertical-map-span-cocone-cofork a)
+            ( horizontal-map-span-cocone-cofork a)
+            ( cocone-codiagonal-cofork a e)
             ( dependent-universal-property-pushout-dependent-universal-property-coequalizer
-              ( f)
-              ( g)
+              ( a)
               ( e)
               ( dup-coequalizer))))
 ```

--- a/src/synthetic-homotopy-theory/flattening-lemma-coequalizers.lagda.md
+++ b/src/synthetic-homotopy-theory/flattening-lemma-coequalizers.lagda.md
@@ -65,36 +65,36 @@ module _
   (P : X → UU l4) (e : cofork a X)
   where
 
-  bottom-map-cofork-flattening-lemma-coequalizer :
-    Σ (domain-double-arrow a) (P ∘ map-cofork a e ∘ bottom-map-double-arrow a) →
+  left-map-double-arrow-flattening-lemma-coequalizer :
+    Σ (domain-double-arrow a) (P ∘ map-cofork a e ∘ left-map-double-arrow a) →
     Σ (codomain-double-arrow a) (P ∘ map-cofork a e)
-  bottom-map-cofork-flattening-lemma-coequalizer =
+  left-map-double-arrow-flattening-lemma-coequalizer =
     map-Σ-map-base
-      ( bottom-map-double-arrow a)
+      ( left-map-double-arrow a)
       ( P ∘ map-cofork a e)
 
-  top-map-cofork-flattening-lemma-coequalizer :
-    Σ (domain-double-arrow a) (P ∘ map-cofork a e ∘ bottom-map-double-arrow a) →
+  right-map-double-arrow-flattening-lemma-coequalizer :
+    Σ (domain-double-arrow a) (P ∘ map-cofork a e ∘ left-map-double-arrow a) →
     Σ (codomain-double-arrow a) (P ∘ map-cofork a e)
-  top-map-cofork-flattening-lemma-coequalizer =
+  right-map-double-arrow-flattening-lemma-coequalizer =
     map-Σ
       ( P ∘ map-cofork a e)
-      ( top-map-double-arrow a)
+      ( right-map-double-arrow a)
       ( λ x → tr P (coh-cofork a e x))
 
   double-arrow-flattening-lemma-coequalizer : double-arrow (l1 ⊔ l4) (l2 ⊔ l4)
   double-arrow-flattening-lemma-coequalizer =
     make-double-arrow
-      ( bottom-map-cofork-flattening-lemma-coequalizer)
-      ( top-map-cofork-flattening-lemma-coequalizer)
+      ( left-map-double-arrow-flattening-lemma-coequalizer)
+      ( right-map-double-arrow-flattening-lemma-coequalizer)
 
   cofork-flattening-lemma-coequalizer :
     cofork double-arrow-flattening-lemma-coequalizer (Σ X P)
   pr1 cofork-flattening-lemma-coequalizer = map-Σ-map-base (map-cofork a e) P
   pr2 cofork-flattening-lemma-coequalizer =
     coherence-square-maps-map-Σ-map-base P
-      ( top-map-double-arrow a)
-      ( bottom-map-double-arrow a)
+      ( right-map-double-arrow a)
+      ( left-map-double-arrow a)
       ( map-cofork a e)
       ( map-cofork a e)
       ( coh-cofork a e)
@@ -133,8 +133,7 @@ module _
   where
 
   abstract
-    flattening-lemma-coequalizer :
-      flattening-lemma-coequalizer-statement a P e
+    flattening-lemma-coequalizer : flattening-lemma-coequalizer-statement a P e
     flattening-lemma-coequalizer dup-coequalizer =
       universal-property-coequalizer-universal-property-pushout
         ( double-arrow-flattening-lemma-coequalizer a P e)

--- a/src/synthetic-homotopy-theory/flattening-lemma-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/flattening-lemma-sequential-colimits.lagda.md
@@ -12,6 +12,7 @@ open import elementary-number-theory.natural-numbers
 open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
 open import foundation.equivalences
+open import foundation.equivalences-double-arrows
 open import foundation.function-types
 open import foundation.functoriality-dependent-pair-types
 open import foundation.homotopies
@@ -19,10 +20,12 @@ open import foundation.identity-types
 open import foundation.transport-along-identifications
 open import foundation.type-arithmetic-dependent-pair-types
 open import foundation.universe-levels
+open import foundation.whiskering-homotopies-composition
 
 open import synthetic-homotopy-theory.cocones-under-sequential-diagrams
 open import synthetic-homotopy-theory.coforks
 open import synthetic-homotopy-theory.dependent-universal-property-sequential-colimits
+open import synthetic-homotopy-theory.equivalences-coforks
 open import synthetic-homotopy-theory.flattening-lemma-coequalizers
 open import synthetic-homotopy-theory.sequential-diagrams
 open import synthetic-homotopy-theory.universal-property-coequalizers
@@ -146,6 +149,50 @@ module _
   ( P : X → UU l3)
   where
 
+  equiv-double-arrow-flattening-lemma-sequential-colimit :
+    equiv-double-arrow
+      ( double-arrow-sequential-diagram
+        ( sequential-diagram-flattening-lemma c P))
+      ( double-arrow-flattening-lemma-coequalizer
+        ( double-arrow-sequential-diagram A)
+        ( P)
+        ( cofork-cocone-sequential-diagram A c))
+  pr1 equiv-double-arrow-flattening-lemma-sequential-colimit =
+    inv-associative-Σ
+      ( ℕ)
+      ( family-sequential-diagram A)
+      ( P ∘ ind-Σ (map-cocone-sequential-diagram c))
+  pr1 (pr2 equiv-double-arrow-flattening-lemma-sequential-colimit) =
+    inv-associative-Σ
+      ( ℕ)
+      ( family-sequential-diagram A)
+      ( P ∘ ind-Σ (map-cocone-sequential-diagram c))
+  pr1 (pr2 (pr2 equiv-double-arrow-flattening-lemma-sequential-colimit)) =
+    refl-htpy
+  pr2 (pr2 (pr2 equiv-double-arrow-flattening-lemma-sequential-colimit)) =
+    refl-htpy
+
+  equiv-cofork-flattening-lemma-sequential-colimit :
+    equiv-cofork
+      ( cofork-cocone-sequential-diagram _
+        ( cocone-sequential-diagram-flattening-lemma c P))
+      ( cofork-flattening-lemma-coequalizer
+        ( double-arrow-sequential-diagram A)
+        ( P)
+        ( cofork-cocone-sequential-diagram A c))
+      ( equiv-double-arrow-flattening-lemma-sequential-colimit)
+  pr1 equiv-cofork-flattening-lemma-sequential-colimit = id-equiv
+  pr1 (pr2 equiv-cofork-flattening-lemma-sequential-colimit) =
+    refl-htpy
+  pr2 (pr2 equiv-cofork-flattening-lemma-sequential-colimit) =
+    inv-htpy
+      ( ( right-unit-htpy) ∙h
+        ( right-unit-htpy) ∙h
+        ( left-unit-law-left-whisker-comp
+          ( coh-cofork _
+            ( cofork-cocone-sequential-diagram _
+              ( cocone-sequential-diagram-flattening-lemma c P)))))
+
   abstract
     flattening-lemma-sequential-colimit :
       statement-flattening-lemma-sequential-colimit c P
@@ -153,51 +200,16 @@ module _
       universal-property-sequential-colimit-universal-property-coequalizer
         ( cocone-sequential-diagram-flattening-lemma c P)
         ( universal-property-coequalizer-top-universal-property-coequalizer-bottom-hom-arrow-is-equiv
-          ( map-inv-associative-Σ ℕ
-            ( family-sequential-diagram A)
-            ( P ∘ ind-Σ (map-cocone-sequential-diagram c)))
-          ( map-inv-associative-Σ ℕ
-            ( family-sequential-diagram A)
-            ( P ∘ ind-Σ (map-cocone-sequential-diagram c)))
-          ( id)
-          ( ( bottom-map-cofork-cocone-sequential-diagram
-              ( sequential-diagram-flattening-lemma c P)) ,
-            ( bottom-map-cofork-flattening-lemma-coequalizer _ _
-              ( P)
-              ( cofork-cocone-sequential-diagram A c)) ,
-            ( refl-htpy))
-          ( ( top-map-cofork-cocone-sequential-diagram
-              ( sequential-diagram-flattening-lemma c P)) ,
-            ( top-map-cofork-flattening-lemma-coequalizer _ _
-              ( P)
-              ( cofork-cocone-sequential-diagram A c)) ,
-            ( refl-htpy))
-          ( ( map-cofork _ _
-              ( cofork-cocone-sequential-diagram
-                ( sequential-diagram-flattening-lemma c P)
-                ( cocone-sequential-diagram-flattening-lemma c P))) ,
-            ( map-cofork _ _
-              ( cofork-flattening-lemma-coequalizer _ _ P
-                ( cofork-cocone-sequential-diagram A c))) ,
-            ( refl-htpy))
-          ( ind-Σ
-            ( coherence-cocone-sequential-diagram
-              ( cocone-sequential-diagram-flattening-lemma c P)) ,
-            ( coherence-cofork _ _
-              ( cofork-flattening-lemma-coequalizer _ _ P
-                ( cofork-cocone-sequential-diagram A c))) ,
-            ( ind-Σ (λ n → ind-Σ (λ a p → ap-id _ ∙ inv right-unit))))
-          ( is-equiv-map-equiv
-            ( inv-associative-Σ ℕ
-              ( family-sequential-diagram A)
-              ( P ∘ ind-Σ (map-cocone-sequential-diagram c))))
-          ( is-equiv-map-inv-associative-Σ ℕ
-            ( family-sequential-diagram A)
-            ( P ∘ ind-Σ (map-cocone-sequential-diagram c)))
-          ( is-equiv-id)
-          ( flattening-lemma-coequalizer
-            ( bottom-map-cofork-cocone-sequential-diagram A)
-            ( top-map-cofork-cocone-sequential-diagram A)
+          ( _)
+          ( cofork-cocone-sequential-diagram _
+            ( cocone-sequential-diagram-flattening-lemma c P))
+          ( _)
+          ( cofork-flattening-lemma-coequalizer _
+            ( P)
+            ( cofork-cocone-sequential-diagram A c))
+          ( equiv-double-arrow-flattening-lemma-sequential-colimit)
+          ( equiv-cofork-flattening-lemma-sequential-colimit)
+          ( flattening-lemma-coequalizer _
             ( P)
             ( cofork-cocone-sequential-diagram A c)
             ( dependent-universal-property-coequalizer-dependent-universal-property-sequential-colimit

--- a/src/synthetic-homotopy-theory/flattening-lemma-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/flattening-lemma-sequential-colimits.lagda.md
@@ -199,11 +199,9 @@ module _
     flattening-lemma-sequential-colimit dup-c =
       universal-property-sequential-colimit-universal-property-coequalizer
         ( cocone-sequential-diagram-flattening-lemma c P)
-        ( universal-property-coequalizer-top-universal-property-coequalizer-bottom-hom-arrow-is-equiv
-          ( _)
+        ( universal-property-coequalizer-equiv-cofork
           ( cofork-cocone-sequential-diagram _
             ( cocone-sequential-diagram-flattening-lemma c P))
-          ( _)
           ( cofork-flattening-lemma-coequalizer _
             ( P)
             ( cofork-cocone-sequential-diagram A c))

--- a/src/synthetic-homotopy-theory/morphisms-coforks.lagda.md
+++ b/src/synthetic-homotopy-theory/morphisms-coforks.lagda.md
@@ -1,0 +1,65 @@
+# Morphisms of coforks
+
+```agda
+module synthetic-homotopy-theory.morphisms-coforks where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.commuting-squares-of-maps
+open import foundation.dependent-pair-types
+open import foundation.double-arrows
+open import foundation.homotopies
+open import foundation.morphisms-double-arrows
+open import foundation.universe-levels
+open import foundation.whiskering-homotopies-composition
+
+open import synthetic-homotopy-theory.coforks
+```
+
+</details>
+
+## Idea
+
+TODO
+
+## Definitions
+
+### Morphisms of coforks
+
+```agda
+module _
+  {l1 l2 l3 l4 l5 l6 : Level}
+  (a : double-arrow l1 l2) {X : UU l3} (c : cofork a X)
+  (a' : double-arrow l4 l5) {Y : UU l6} (c' : cofork a' Y)
+  (h : hom-double-arrow a a')
+  where
+
+  coherence-hom-cofork : (X → Y) → UU (l2 ⊔ l6)
+  coherence-hom-cofork u =
+    coherence-square-maps'
+      ( map-cofork a c)
+      ( codomain-map-hom-double-arrow a a' h)
+      ( u)
+      ( map-cofork a' c')
+
+  coherence-hom-cofork' :
+    (u : X → Y) → coherence-hom-cofork u →
+    UU (l1 ⊔ l6)
+  coherence-hom-cofork' u H =
+    ( ( H ·r (bottom-map-double-arrow a)) ∙h
+      ( ( map-cofork a' c') ·l
+        ( bottom-coherence-square-hom-double-arrow a a' h)) ∙h
+      ( (coh-cofork a' c') ·r (domain-map-hom-double-arrow a a' h))) ~
+    ( ( u ·l (coh-cofork a c)) ∙h
+      ( H ·r (top-map-double-arrow a)) ∙h
+      ( (map-cofork a' c') ·l (top-coherence-square-hom-double-arrow a a' h)))
+
+  hom-cofork : UU (l1 ⊔ l2 ⊔ l3 ⊔ l6)
+  hom-cofork =
+    Σ ( X → Y)
+      ( λ u →
+        Σ ( coherence-hom-cofork u)
+          ( coherence-hom-cofork' u))
+```

--- a/src/synthetic-homotopy-theory/morphisms-coforks.lagda.md
+++ b/src/synthetic-homotopy-theory/morphisms-coforks.lagda.md
@@ -33,7 +33,7 @@ Then a
 {{#concept "morphism of coforks" Disambiguation="of types" Agda=hom-cofork}}
 over `e` is a triple `(m, H, K)`, with `m : X → Y` a map of vertices of the
 coforks, `H` a [homotopy](foundation-core.homotopies.md) witnessing that the
-bottom square in
+bottom square in the diagram
 
 ```text
            i
@@ -52,7 +52,7 @@ bottom square in
 ```
 
 [commutes](foundation-core.commuting-squares-of-maps.md), and `K` a coherence
-datum filling the inside --- we have two stacks of squares
+datum "filling the inside" --- we have two stacks of squares
 
 ```text
            i                        i
@@ -71,7 +71,7 @@ datum filling the inside --- we have two stacks of squares
 ```
 
 which share the top map `i` and the bottom square, and the coherences of `c` and
-`c'` filling the sides; that gives us the homotopies
+`c'` filling the sides; that gives the homotopies
 
 ```text
                                                 i                 i
@@ -107,7 +107,7 @@ and
            m                 m
 ```
 
-which we require to be homotopic.
+which are required to be homotopic.
 
 ## Definitions
 

--- a/src/synthetic-homotopy-theory/morphisms-coforks.lagda.md
+++ b/src/synthetic-homotopy-theory/morphisms-coforks.lagda.md
@@ -29,9 +29,11 @@ Consider two [double arrows](foundation.double-arrows.md) `f, g : A → B` and
 [morphism of double arrows](foundation.morphisms-double-arrows.md)
 `e : (f, g) → (h, k)`.
 
-Then a {{#concept "morphism of coforks" Agda=hom-cofork}} over `e` is a triple
-`(m, H, K)`, with `m : X → Y` a map of vertices of the coforks, `H` a
-[homotopy](foundation-core.homotopies.md) witnessing that the bottom square in
+Then a
+{{#concept "morphism of coforks" Disambiguation="of types" Agda=hom-cofork}}
+over `e` is a triple `(m, H, K)`, with `m : X → Y` a map of vertices of the
+coforks, `H` a [homotopy](foundation-core.homotopies.md) witnessing that the
+bottom square in
 
 ```text
            i
@@ -68,9 +70,44 @@ datum filling the inside --- we have two stacks of squares
            m                        m
 ```
 
-glued along `i` and the bottom square, with the coherences of `c` and `c'`
-filling the sides, which give us two homotopies `m ∘ c ∘ f ~ c' ∘ k ∘ i`, and we
-need to ensure these are homotopic.
+which share the top map `i` and the bottom square, and the coherences of `c` and
+`c'` filling the sides; that gives us the homotopies
+
+```text
+                                                i                 i
+     A                  A                 A --------> U     A --------> U
+     |                  |                             |                 |
+   f |                f |                             | h               | k
+     |                  |                             |                 |
+     ∨                  ∨     j                       ∨                 ∨
+     B         ~        B --------> V       ~         V        ~        V
+     |                              |                 |                 |
+   c |                              | c'              | c'              | c'
+     |                              |                 |                 |
+     ∨                              ∨                 ∨                 ∨
+     X --------> Y                  Y                 Y                 Y
+           m
+```
+
+and
+
+```text
+                                                                  i
+     A                 A               A                    A --------> U
+     |                 |               |                                |
+   f |               g |             g |                                | k
+     |                 |               |                                |
+     ∨                 ∨               ∨     j                          ∨
+     B         ~       B       ~       B --------> V           ~        V
+     |                 |                           |                    |
+   c |               c |                           | c'                 | c'
+     |                 |                           |                    |
+     ∨                 ∨                           ∨                    ∨
+     X --------> Y     X --------> Y               Y                    Y ,
+           m                 m
+```
+
+which we require to be homotopic.
 
 ## Definitions
 

--- a/src/synthetic-homotopy-theory/morphisms-coforks.lagda.md
+++ b/src/synthetic-homotopy-theory/morphisms-coforks.lagda.md
@@ -11,6 +11,7 @@ open import foundation.commuting-squares-of-maps
 open import foundation.dependent-pair-types
 open import foundation.double-arrows
 open import foundation.homotopies
+open import foundation.morphisms-arrows
 open import foundation.morphisms-double-arrows
 open import foundation.universe-levels
 open import foundation.whiskering-homotopies-composition
@@ -22,7 +23,54 @@ open import synthetic-homotopy-theory.coforks
 
 ## Idea
 
-TODO
+Consider two [double arrows](foundation.double-arrows.md) `f, g : A → B` and
+`h, k : U → V`, equipped with [coforks](synthetic-homotopy-theory.coforks.md)
+`c : B → X` and `c' : V → Y`, respectively, and a
+[morphism of double arrows](foundation.morphisms-double-arrows.md)
+`e : (f, g) → (h, k)`.
+
+Then a {{#concept "morphism of coforks" Agda=hom-cofork}} over `e` is a triple
+`(m, H, K)`, with `m : X → Y` a map of vertices of the coforks, `H` a
+[homotopy](foundation-core.homotopies.md) witnessing that the bottom square in
+
+```text
+           i
+     A --------> U
+    | |         | |
+  f | | g     h | | k
+    | |         | |
+    ∨ ∨         ∨ ∨
+     B --------> V
+     |     j     |
+   c |           | c'
+     |           |
+     ∨           ∨
+     X --------> Y
+           m
+```
+
+[commutes](foundation-core.commuting-squares-of-maps.md), and `K` a coherence
+datum filling the inside --- we have two stacks of squares
+
+```text
+           i                        i
+     A --------> U            A --------> U
+     |           |            |           |
+   f |           | h        g |           | k
+     |           |            |           |
+     ∨           ∨            ∨           ∨
+     B --------> V            B --------> V
+     |     j     |            |     j     |
+   c |           | c'       c |           | c'
+     |           |            |           |
+     ∨           ∨            ∨           ∨
+     X --------> Y            X --------> Y
+           m                        m
+```
+
+glued along `i` and the bottom square, with the coherences of `c` and `c'`
+filling the sides, which give us two homotopies `m ∘ c ∘ f ~ c' ∘ k ∘ i`, and we
+need to ensure these are homotopic.
 
 ## Definitions
 
@@ -31,35 +79,55 @@ TODO
 ```agda
 module _
   {l1 l2 l3 l4 l5 l6 : Level}
-  (a : double-arrow l1 l2) {X : UU l3} (c : cofork a X)
-  (a' : double-arrow l4 l5) {Y : UU l6} (c' : cofork a' Y)
+  {a : double-arrow l1 l2} {X : UU l3} (c : cofork a X)
+  {a' : double-arrow l4 l5} {Y : UU l6} (c' : cofork a' Y)
   (h : hom-double-arrow a a')
   where
 
-  coherence-hom-cofork : (X → Y) → UU (l2 ⊔ l6)
-  coherence-hom-cofork u =
-    coherence-square-maps'
-      ( map-cofork a c)
+  coherence-map-cofork-hom-cofork : (X → Y) → UU (l2 ⊔ l6)
+  coherence-map-cofork-hom-cofork u =
+    coherence-square-maps
       ( codomain-map-hom-double-arrow a a' h)
-      ( u)
+      ( map-cofork a c)
       ( map-cofork a' c')
+      ( u)
 
-  coherence-hom-cofork' :
-    (u : X → Y) → coherence-hom-cofork u →
+  coherence-hom-cofork :
+    (u : X → Y) → coherence-map-cofork-hom-cofork u →
     UU (l1 ⊔ l6)
-  coherence-hom-cofork' u H =
-    ( ( H ·r (bottom-map-double-arrow a)) ∙h
+  coherence-hom-cofork u H =
+    ( ( H ·r (left-map-double-arrow a)) ∙h
       ( ( map-cofork a' c') ·l
-        ( bottom-coherence-square-hom-double-arrow a a' h)) ∙h
+        ( left-square-hom-double-arrow a a' h)) ∙h
       ( (coh-cofork a' c') ·r (domain-map-hom-double-arrow a a' h))) ~
     ( ( u ·l (coh-cofork a c)) ∙h
-      ( H ·r (top-map-double-arrow a)) ∙h
-      ( (map-cofork a' c') ·l (top-coherence-square-hom-double-arrow a a' h)))
+      ( H ·r (right-map-double-arrow a)) ∙h
+      ( (map-cofork a' c') ·l (right-square-hom-double-arrow a a' h)))
 
   hom-cofork : UU (l1 ⊔ l2 ⊔ l3 ⊔ l6)
   hom-cofork =
     Σ ( X → Y)
       ( λ u →
-        Σ ( coherence-hom-cofork u)
-          ( coherence-hom-cofork' u))
+        Σ ( coherence-map-cofork-hom-cofork u)
+          ( coherence-hom-cofork u))
+
+  module _
+    (h' : hom-cofork)
+    where
+
+    map-hom-cofork : X → Y
+    map-hom-cofork = pr1 h'
+
+    coh-map-cofork-hom-cofork : coherence-map-cofork-hom-cofork map-hom-cofork
+    coh-map-cofork-hom-cofork = pr1 (pr2 h')
+
+    hom-map-cofork-hom-cofork :
+      hom-arrow (map-cofork a c) (map-cofork a' c')
+    pr1 hom-map-cofork-hom-cofork = codomain-map-hom-double-arrow a a' h
+    pr1 (pr2 hom-map-cofork-hom-cofork) = map-hom-cofork
+    pr2 (pr2 hom-map-cofork-hom-cofork) = coh-map-cofork-hom-cofork
+
+    coh-map-cofork :
+      coherence-hom-cofork map-hom-cofork coh-map-cofork-hom-cofork
+    coh-map-cofork = pr2 (pr2 h')
 ```

--- a/src/synthetic-homotopy-theory/sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/sequential-colimits.lagda.md
@@ -115,18 +115,14 @@ sequential colimits exist.
 abstract
   standard-sequential-colimit : {l : Level} (A : sequential-diagram l) → UU l
   standard-sequential-colimit A =
-    canonical-coequalizer
-      ( bottom-map-cofork-cocone-sequential-diagram A)
-      ( top-map-cofork-cocone-sequential-diagram A)
+    canonical-coequalizer (double-arrow-sequential-diagram A)
 
   cocone-standard-sequential-colimit :
     { l : Level} (A : sequential-diagram l) →
     cocone-sequential-diagram A (standard-sequential-colimit A)
   cocone-standard-sequential-colimit A =
     cocone-sequential-diagram-cofork A
-      ( cofork-canonical-coequalizer
-        ( bottom-map-cofork-cocone-sequential-diagram A)
-        ( top-map-cofork-cocone-sequential-diagram A))
+      ( cofork-canonical-coequalizer (double-arrow-sequential-diagram A))
 
   dup-standard-sequential-colimit :
     { l : Level} {A : sequential-diagram l} →
@@ -135,9 +131,7 @@ abstract
   dup-standard-sequential-colimit {A = A} =
     dependent-universal-property-sequential-colimit-dependent-universal-property-coequalizer
       ( cocone-standard-sequential-colimit A)
-      ( dup-canonical-coequalizer
-        ( bottom-map-cofork-cocone-sequential-diagram A)
-        ( top-map-cofork-cocone-sequential-diagram A))
+      ( dup-canonical-coequalizer (double-arrow-sequential-diagram A))
 
   up-standard-sequential-colimit :
     { l : Level} {A : sequential-diagram l} →

--- a/src/synthetic-homotopy-theory/universal-property-coequalizers.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-coequalizers.lagda.md
@@ -158,7 +158,7 @@ module _
       ( up-coequalizer Y)
 ```
 
-### In an equivalences of coforks, one cofork is a coequalizer if and only if the other is
+### In an equivalence of coforks, one cofork is a coequalizer if and only if the other is
 
 In other words, given two coforks connected vertically with equivalences, as in
 the following diagram:

--- a/src/synthetic-homotopy-theory/universal-property-coequalizers.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-coequalizers.lagda.md
@@ -33,7 +33,7 @@ open import synthetic-homotopy-theory.universal-property-pushouts
 ## Idea
 
 Given a [double arrow](foundation.double-arrows.md) `f, g : A → B`, consider a
-[cofork](synthetic-homotopy-theory.coforks.md) `e : B → X` with vertex X. The
+[cofork](synthetic-homotopy-theory.coforks.md) `e : B → X` with vertex `X`. The
 **universal property of coequalizers** is the statement that the cofork
 postcomposition map
 

--- a/src/synthetic-homotopy-theory/universal-property-coequalizers.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-coequalizers.lagda.md
@@ -32,7 +32,7 @@ open import synthetic-homotopy-theory.universal-property-pushouts
 
 ## Idea
 
-Given a parallel pair `f, g : A → B`, consider a
+Given a [double arrow](foundation.double-arrows.md) `f, g : A → B`, consider a
 [cofork](synthetic-homotopy-theory.coforks.md) `e : B → X` with vertex X. The
 **universal property of coequalizers** is the statement that the cofork
 postcomposition map
@@ -105,9 +105,9 @@ module _
 
 ### A cofork has the universal property of coequalizers if and only if the corresponding cocone has the universal property of pushouts
 
-As mentioned in [coforks](synthetic-homotopy-theory.coforks.md), coforks can be
-thought of as special cases of cocones under spans. This theorem makes it more
-precise, asserting that under this mapping,
+As mentioned in [`coforks`](synthetic-homotopy-theory.coforks.md), coforks can
+be thought of as special cases of cocones under spans. This theorem makes it
+more precise, asserting that under this mapping,
 [coequalizers](synthetic-homotopy-theory.coequalizers.md) correspond to
 [pushouts](synthetic-homotopy-theory.pushouts.md).
 
@@ -158,38 +158,46 @@ module _
       ( up-coequalizer Y)
 ```
 
-### In a cofork on equivalences in the category of arrows, the domain cofork is a coequalizer if and only if the codomain cofork is a coequalizer
+### In an equivalences of coforks, one cofork is a coequalizer if and only if the other is
 
 In other words, given two coforks connected vertically with equivalences, as in
 the following diagram:
 
+Given an
+[equivalence of coforks](synthetic-homotopy-theory.equivalences-coforks.md)
+between coforks `c` and `c'`
+
 ```text
-    ----->
-  A -----> B -----> C
-  |        |        |
- ≃|        |≃       |≃
-  V  ----> V        V
-  A' ----> B' ----> C' ,
+           ≃
+     A --------> A'
+    | |         | |
+  f | | g    f' | | g'
+    | |         | |
+    ∨ ∨         ∨ ∨
+     B --------> B'
+     |     ≃     |
+   c |           | c'
+     |           |
+     ∨           ∨
+     X --------> Y ,
+           ≃
 ```
 
-equipped with [commuting squares](foundation.commuting-squares-of-maps.md) for
-the three small squares, and a coherence datum expressing that the right square
-coequalizes the left squares in the category of arrows, we have that the top
-cofork is a coequalizer if and only if the bottom cofork is a coequalizer.
+we have that the left cofork is a coequalizer if and only if the right cofork is
+a coequalizer.
 
 ```agda
 module _
   {l1 l2 l3 l4 l5 l6 : Level}
-  (a : double-arrow l1 l2) {X : UU l3} (c : cofork a X)
-  (a' : double-arrow l4 l5) {Y : UU l6} (c' : cofork a' Y)
+  {a : double-arrow l1 l2} {X : UU l3} (c : cofork a X)
+  {a' : double-arrow l4 l5} {Y : UU l6} (c' : cofork a' Y)
   (e : equiv-double-arrow a a') (e' : equiv-cofork c c' e)
   where
 
-  universal-property-coequalizer-top-universal-property-coequalizer-bottom-hom-arrow-is-equiv :
+  universal-property-coequalizer-equiv-cofork :
     ({l : Level} → universal-property-coequalizer l a' c') →
     ({l : Level} → universal-property-coequalizer l a c)
-  universal-property-coequalizer-top-universal-property-coequalizer-bottom-hom-arrow-is-equiv
-    ( up-c') =
+  universal-property-coequalizer-equiv-cofork up-c' =
     universal-property-coequalizer-universal-property-pushout a c
       ( universal-property-pushout-top-universal-property-pushout-bottom-cube-is-equiv
         ( vertical-map-span-cocone-cofork a')
@@ -215,15 +223,15 @@ module _
         ( inv-htpy
           ( pasting-vertical-coherence-square-maps
             ( domain-map-equiv-double-arrow a a' e)
-            ( bottom-map-double-arrow a)
-            ( bottom-map-double-arrow a')
+            ( left-map-double-arrow a)
+            ( left-map-double-arrow a')
             ( codomain-map-equiv-double-arrow a a' e)
             ( map-cofork a c)
             ( map-cofork a' c')
             ( map-equiv-cofork c c' e e')
-            ( bottom-coherence-square-equiv-double-arrow a a' e)
-            ( coh-equiv-cofork c c' e e')))
-        ( inv-htpy (coh-equiv-cofork c c' e e'))
+            ( left-square-equiv-double-arrow a a' e)
+            ( coh-map-cofork-equiv-cofork c c' e e')))
+        ( inv-htpy (coh-map-cofork-equiv-cofork c c' e e'))
         ( coherence-square-cocone-cofork a' c')
         ( coherence-cube-maps-rotate-120
           ( horizontal-map-cocone-cofork a c)
@@ -244,22 +252,22 @@ module _
           ( coherence-square-cocone-cofork a c)
           ( left-square-hom-span-diagram-cofork-hom-double-arrow a a'
             ( hom-double-arrow-equiv-double-arrow a a' e))
-          ( coh-equiv-cofork c c' e e')
+          ( coh-map-cofork-equiv-cofork c c' e e')
           ( coherence-square-cocone-cofork a' c')
           ( pasting-vertical-coherence-square-maps
             ( domain-map-equiv-double-arrow a a' e)
-            ( bottom-map-double-arrow a)
-            ( bottom-map-double-arrow a')
+            ( left-map-double-arrow a)
+            ( left-map-double-arrow a')
             ( codomain-map-equiv-double-arrow a a' e)
             ( map-cofork a c)
             ( map-cofork a' c')
             ( map-equiv-cofork c c' e e')
-            ( bottom-coherence-square-equiv-double-arrow a a' e)
-            ( coh-equiv-cofork c c' e e'))
+            ( left-square-equiv-double-arrow a a' e)
+            ( coh-map-cofork-equiv-cofork c c' e e'))
           ( inv-htpy
             ( ind-coproduct _
               ( right-unit-htpy)
-              ( coh-equiv-cofork' c c' e e'))))
+              ( coh-equiv-cofork c c' e e'))))
         ( is-equiv-map-coproduct
           ( is-equiv-domain-map-equiv-double-arrow a a' e)
           ( is-equiv-domain-map-equiv-double-arrow a a' e))
@@ -269,11 +277,10 @@ module _
         ( universal-property-pushout-universal-property-coequalizer a' c'
           ( up-c')))
 
-  universal-property-coequalizer-bottom-universal-property-coequalizer-top-hom-arrow-is-equiv :
+  universal-property-coequalizer-equiv-cofork' :
     ({l : Level} → universal-property-coequalizer l a c) →
     ({l : Level} → universal-property-coequalizer l a' c')
-  universal-property-coequalizer-bottom-universal-property-coequalizer-top-hom-arrow-is-equiv
-    ( up-c) =
+  universal-property-coequalizer-equiv-cofork' up-c =
     universal-property-coequalizer-universal-property-pushout a' c'
       ( universal-property-pushout-bottom-universal-property-pushout-top-cube-is-equiv
         ( vertical-map-span-cocone-cofork a')
@@ -299,15 +306,15 @@ module _
         ( inv-htpy
           ( pasting-vertical-coherence-square-maps
             ( domain-map-equiv-double-arrow a a' e)
-            ( bottom-map-double-arrow a)
-            ( bottom-map-double-arrow a')
+            ( left-map-double-arrow a)
+            ( left-map-double-arrow a')
             ( codomain-map-equiv-double-arrow a a' e)
             ( map-cofork a c)
             ( map-cofork a' c')
             ( map-equiv-cofork c c' e e')
-            ( bottom-coherence-square-equiv-double-arrow a a' e)
-            ( coh-equiv-cofork c c' e e')))
-        ( inv-htpy (coh-equiv-cofork c c' e e'))
+            ( left-square-equiv-double-arrow a a' e)
+            ( coh-map-cofork-equiv-cofork c c' e e')))
+        ( inv-htpy (coh-map-cofork-equiv-cofork c c' e e'))
         ( coherence-square-cocone-cofork a' c')
         ( coherence-cube-maps-rotate-120
           ( horizontal-map-cocone-cofork a c)
@@ -328,22 +335,22 @@ module _
           ( coherence-square-cocone-cofork a c)
           ( left-square-hom-span-diagram-cofork-hom-double-arrow a a'
             ( hom-double-arrow-equiv-double-arrow a a' e))
-          ( coh-equiv-cofork c c' e e')
+          ( coh-map-cofork-equiv-cofork c c' e e')
           ( coherence-square-cocone-cofork a' c')
           ( pasting-vertical-coherence-square-maps
             ( domain-map-equiv-double-arrow a a' e)
-            ( bottom-map-double-arrow a)
-            ( bottom-map-double-arrow a')
+            ( left-map-double-arrow a)
+            ( left-map-double-arrow a')
             ( codomain-map-equiv-double-arrow a a' e)
             ( map-cofork a c)
             ( map-cofork a' c')
             ( map-equiv-cofork c c' e e')
-            ( bottom-coherence-square-equiv-double-arrow a a' e)
-            ( coh-equiv-cofork c c' e e'))
+            ( left-square-equiv-double-arrow a a' e)
+            ( coh-map-cofork-equiv-cofork c c' e e'))
           ( inv-htpy
             ( ind-coproduct _
               ( right-unit-htpy)
-              ( coh-equiv-cofork' c c' e e'))))
+              ( coh-equiv-cofork c c' e e'))))
         ( is-equiv-map-coproduct
           ( is-equiv-domain-map-equiv-double-arrow a a' e)
           ( is-equiv-domain-map-equiv-double-arrow a a' e))

--- a/src/synthetic-homotopy-theory/universal-property-coequalizers.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-coequalizers.lagda.md
@@ -7,22 +7,24 @@ module synthetic-homotopy-theory.universal-property-coequalizers where
 <details><summary>Imports</summary>
 
 ```agda
+open import foundation.commuting-cubes-of-maps
+open import foundation.commuting-squares-of-maps
 open import foundation.contractible-maps
 open import foundation.contractible-types
 open import foundation.coproduct-types
 open import foundation.dependent-pair-types
+open import foundation.double-arrows
 open import foundation.equivalences
+open import foundation.equivalences-double-arrows
 open import foundation.fibers-of-maps
 open import foundation.functoriality-coproduct-types
 open import foundation.functoriality-dependent-pair-types
 open import foundation.homotopies
-open import foundation.homotopies-morphisms-arrows
-open import foundation.identity-types
-open import foundation.morphisms-arrows
 open import foundation.universe-levels
 
 open import synthetic-homotopy-theory.cocones-under-spans
 open import synthetic-homotopy-theory.coforks
+open import synthetic-homotopy-theory.equivalences-coforks
 open import synthetic-homotopy-theory.universal-property-pushouts
 ```
 
@@ -47,21 +49,21 @@ is an [equivalence](foundation.equivalences.md).
 
 ```agda
 module _
-  { l1 l2 l3 : Level} (l : Level) {A : UU l1} {B : UU l2} (f g : A → B)
-  { X : UU l3} (e : cofork f g X)
+  {l1 l2 l3 : Level} (l : Level) (a : double-arrow l1 l2) {X : UU l3}
+  (e : cofork a X)
   where
 
   universal-property-coequalizer : UU (l1 ⊔ l2 ⊔ l3 ⊔ lsuc l)
   universal-property-coequalizer =
-    ( Y : UU l) → is-equiv (cofork-map f g e {Y = Y})
+    (Y : UU l) → is-equiv (cofork-map a e {Y = Y})
 
 module _
-  { l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} (f g : A → B) {X : UU l3}
-  ( e : cofork f g X) {Y : UU l4}
-  ( up-coequalizer : universal-property-coequalizer l4 f g e)
+  {l1 l2 l3 l4 : Level} (a : double-arrow l1 l2) {X : UU l3}
+  (e : cofork a X) {Y : UU l4}
+  (up-coequalizer : universal-property-coequalizer l4 a e)
   where
 
-  map-universal-property-coequalizer : cofork f g Y → (X → Y)
+  map-universal-property-coequalizer : cofork a Y → (X → Y)
   map-universal-property-coequalizer = map-inv-is-equiv (up-coequalizer Y)
 ```
 
@@ -71,33 +73,33 @@ module _
 
 ```agda
 module _
-  { l1 l2 l3 l4 : Level} {A : UU l1} {B : UU l2} (f g : A → B) {X : UU l3}
-  ( e : cofork f g X) {Y : UU l4}
-  ( up-coequalizer : universal-property-coequalizer l4 f g e)
-  ( e' : cofork f g Y)
+  {l1 l2 l3 l4 : Level} (a : double-arrow l1 l2) {X : UU l3}
+  (e : cofork a X) {Y : UU l4}
+  (up-coequalizer : universal-property-coequalizer l4 a e)
+  (e' : cofork a Y)
   where
 
   htpy-cofork-map-universal-property-coequalizer :
-    htpy-cofork f g
-      ( cofork-map f g e
-        ( map-universal-property-coequalizer f g e up-coequalizer e'))
+    htpy-cofork a
+      ( cofork-map a e
+        ( map-universal-property-coequalizer a e up-coequalizer e'))
       ( e')
   htpy-cofork-map-universal-property-coequalizer =
-    htpy-cofork-eq f g
-      ( cofork-map f g e
-        ( map-universal-property-coequalizer f g e up-coequalizer e'))
+    htpy-cofork-eq a
+      ( cofork-map a e
+        ( map-universal-property-coequalizer a e up-coequalizer e'))
       ( e')
       ( is-section-map-inv-is-equiv (up-coequalizer Y) e')
 
   abstract
     uniqueness-map-universal-property-coequalizer :
-      is-contr (Σ (X → Y) (λ h → htpy-cofork f g (cofork-map f g e h) e'))
+      is-contr (Σ (X → Y) (λ h → htpy-cofork a (cofork-map a e h) e'))
     uniqueness-map-universal-property-coequalizer =
       is-contr-is-equiv'
-        ( fiber (cofork-map f g e) e')
-        ( tot (λ h → htpy-cofork-eq f g (cofork-map f g e h) e'))
+        ( fiber (cofork-map a e) e')
+        ( tot (λ h → htpy-cofork-eq a (cofork-map a e h) e'))
         ( is-equiv-tot-is-fiberwise-equiv
-          ( λ h → is-equiv-htpy-cofork-eq f g (cofork-map f g e h) e'))
+          ( λ h → is-equiv-htpy-cofork-eq a (cofork-map a e h) e'))
         ( is-contr-map-is-equiv (up-coequalizer Y) e')
 ```
 
@@ -111,48 +113,48 @@ precise, asserting that under this mapping,
 
 ```agda
 module _
-  { l1 l2 l3 : Level} {A : UU l1} {B : UU l2} {X : UU l3} (f g : A → B)
-  ( e : cofork f g X)
+  {l1 l2 l3 : Level} (a : double-arrow l1 l2) {X : UU l3}
+  (e : cofork a X)
   where
 
   universal-property-coequalizer-universal-property-pushout :
-    ( {l : Level} →
+    ({l : Level} →
       universal-property-pushout l
-        ( vertical-map-span-cocone-cofork f g)
-        ( horizontal-map-span-cocone-cofork f g)
-        ( cocone-codiagonal-cofork f g e)) →
-    ( {l : Level} →
-      universal-property-coequalizer l f g e)
+        ( vertical-map-span-cocone-cofork a)
+        ( horizontal-map-span-cocone-cofork a)
+        ( cocone-codiagonal-cofork a e)) →
+    ({l : Level} →
+      universal-property-coequalizer l a e)
   universal-property-coequalizer-universal-property-pushout up-pushout Y =
     is-equiv-left-map-triangle
-      ( cofork-map f g e)
-      ( cofork-cocone-codiagonal f g)
+      ( cofork-map a e)
+      ( cofork-cocone-codiagonal a)
       ( cocone-map
-        ( vertical-map-span-cocone-cofork f g)
-        ( horizontal-map-span-cocone-cofork f g)
-        ( cocone-codiagonal-cofork f g e))
-      ( triangle-cofork-cocone f g e)
+        ( vertical-map-span-cocone-cofork a)
+        ( horizontal-map-span-cocone-cofork a)
+        ( cocone-codiagonal-cofork a e))
+      ( triangle-cofork-cocone a e)
       ( up-pushout Y)
-      ( is-equiv-cofork-cocone-codiagonal f g)
+      ( is-equiv-cofork-cocone-codiagonal a)
 
   universal-property-pushout-universal-property-coequalizer :
-    ( {l : Level} →
-      universal-property-coequalizer l f g e) →
-    ( {l : Level} →
+    ({l : Level} →
+      universal-property-coequalizer l a e) →
+    ({l : Level} →
       universal-property-pushout l
-        ( vertical-map-span-cocone-cofork f g)
-        ( horizontal-map-span-cocone-cofork f g)
-        ( cocone-codiagonal-cofork f g e))
+        ( vertical-map-span-cocone-cofork a)
+        ( horizontal-map-span-cocone-cofork a)
+        ( cocone-codiagonal-cofork a e))
   universal-property-pushout-universal-property-coequalizer up-coequalizer Y =
     is-equiv-top-map-triangle
-      ( cofork-map f g e)
-      ( cofork-cocone-codiagonal f g)
+      ( cofork-map a e)
+      ( cofork-cocone-codiagonal a)
       ( cocone-map
-        ( vertical-map-span-cocone-cofork f g)
-        ( horizontal-map-span-cocone-cofork f g)
-        ( cocone-codiagonal-cofork f g e))
-      ( triangle-cofork-cocone f g e)
-      ( is-equiv-cofork-cocone-codiagonal f g)
+        ( vertical-map-span-cocone-cofork a)
+        ( horizontal-map-span-cocone-cofork a)
+        ( cocone-codiagonal-cofork a e))
+      ( triangle-cofork-cocone a e)
+      ( is-equiv-cofork-cocone-codiagonal a)
       ( up-coequalizer Y)
 ```
 
@@ -177,113 +179,176 @@ cofork is a coequalizer if and only if the bottom cofork is a coequalizer.
 
 ```agda
 module _
-  { l1 l2 l3 l4 l5 l6 : Level}
-  { A : UU l1} {B : UU l2} {C : UU l3}
-  { A' : UU l4} {B' : UU l5} {C' : UU l6}
-  ( hA : A → A') (hB : B → B') (hC : C → C')
-  ( f : hom-arrow hA hB) (g : hom-arrow hA hB) (c : hom-arrow hB hC)
-  ( H :
-    htpy-hom-arrow hA hC
-      ( comp-hom-arrow hA hB hC c f)
-      ( comp-hom-arrow hA hB hC c g))
-  ( is-equiv-hA : is-equiv hA) (is-equiv-hB : is-equiv hB)
-  ( is-equiv-hC : is-equiv hC)
+  {l1 l2 l3 l4 l5 l6 : Level}
+  (a : double-arrow l1 l2) {X : UU l3} (c : cofork a X)
+  (a' : double-arrow l4 l5) {Y : UU l6} (c' : cofork a' Y)
+  (e : equiv-double-arrow a a') (e' : equiv-cofork c c' e)
   where
 
-  top-cofork-hom-arrow :
-    cofork (map-domain-hom-arrow hA hB f) (map-domain-hom-arrow hA hB g) C
-  pr1 top-cofork-hom-arrow = map-domain-hom-arrow hB hC c
-  pr2 top-cofork-hom-arrow = htpy-domain-htpy-hom-arrow hA hC _ _ H
-
-  bottom-cofork-hom-arrow :
-    cofork (map-codomain-hom-arrow hA hB f) (map-codomain-hom-arrow hA hB g) C'
-  pr1 bottom-cofork-hom-arrow = map-codomain-hom-arrow hB hC c
-  pr2 bottom-cofork-hom-arrow = htpy-codomain-htpy-hom-arrow hA hC _ _ H
-
   universal-property-coequalizer-top-universal-property-coequalizer-bottom-hom-arrow-is-equiv :
-    ({l : Level} →
-      universal-property-coequalizer l _ _ bottom-cofork-hom-arrow) →
-    ({l : Level} → universal-property-coequalizer l _ _ top-cofork-hom-arrow)
+    ({l : Level} → universal-property-coequalizer l a' c') →
+    ({l : Level} → universal-property-coequalizer l a c)
   universal-property-coequalizer-top-universal-property-coequalizer-bottom-hom-arrow-is-equiv
     ( up-c') =
-    universal-property-coequalizer-universal-property-pushout _ _
-      ( top-cofork-hom-arrow)
+    universal-property-coequalizer-universal-property-pushout a c
       ( universal-property-pushout-top-universal-property-pushout-bottom-cube-is-equiv
-        ( vertical-map-span-cocone-cofork
-          ( map-codomain-hom-arrow hA hB f)
-          ( map-codomain-hom-arrow hA hB g))
-        ( horizontal-map-span-cocone-cofork
-          ( map-codomain-hom-arrow hA hB f)
-          ( map-codomain-hom-arrow hA hB g))
-        ( horizontal-map-cocone-cofork _ _ bottom-cofork-hom-arrow)
-        ( vertical-map-cocone-cofork _ _ bottom-cofork-hom-arrow)
-        ( vertical-map-span-cocone-cofork
-          ( map-domain-hom-arrow hA hB f)
-          ( map-domain-hom-arrow hA hB g))
-        ( horizontal-map-span-cocone-cofork
-          ( map-domain-hom-arrow hA hB f)
-          ( map-domain-hom-arrow hA hB g))
-        ( horizontal-map-cocone-cofork _ _ top-cofork-hom-arrow)
-        ( vertical-map-cocone-cofork _ _ top-cofork-hom-arrow)
-        ( map-coproduct hA hA)
-        ( hA)
-        ( hB)
-        ( hC)
-        ( coherence-square-cocone-cofork _ _ top-cofork-hom-arrow)
-        ( ind-coproduct _ refl-htpy refl-htpy)
-        ( ind-coproduct _ (coh-hom-arrow hA hB f) (coh-hom-arrow hA hB g))
-        ( coh-comp-hom-arrow hA hB hC c f)
-        ( coh-hom-arrow hB hC c)
-        ( coherence-square-cocone-cofork _ _ bottom-cofork-hom-arrow)
-        ( ind-coproduct _ (λ _ → right-unit) (coh-htpy-hom-arrow hA hC _ _ H))
-        ( is-equiv-map-coproduct is-equiv-hA is-equiv-hA)
-        ( is-equiv-hA)
-        ( is-equiv-hB)
-        ( is-equiv-hC)
-        ( universal-property-pushout-universal-property-coequalizer _ _
-          ( bottom-cofork-hom-arrow)
+        ( vertical-map-span-cocone-cofork a')
+        ( horizontal-map-span-cocone-cofork a')
+        ( horizontal-map-cocone-cofork a' c')
+        ( vertical-map-cocone-cofork a' c')
+        ( vertical-map-span-cocone-cofork a)
+        ( horizontal-map-span-cocone-cofork a)
+        ( horizontal-map-cocone-cofork a c)
+        ( vertical-map-cocone-cofork a c)
+        ( spanning-map-hom-span-diagram-cofork-hom-double-arrow a a'
+          ( hom-double-arrow-equiv-double-arrow a a' e))
+        ( domain-map-equiv-double-arrow a a' e)
+        ( codomain-map-equiv-double-arrow a a' e)
+        ( map-equiv-cofork c c' e e')
+        ( coherence-square-cocone-cofork a c)
+        ( inv-htpy
+          ( left-square-hom-span-diagram-cofork-hom-double-arrow a a'
+            ( hom-double-arrow-equiv-double-arrow a a' e)))
+        ( inv-htpy
+          ( right-square-hom-span-diagram-cofork-hom-double-arrow a a'
+            ( hom-double-arrow-equiv-double-arrow a a' e)))
+        ( inv-htpy
+          ( pasting-vertical-coherence-square-maps
+            ( domain-map-equiv-double-arrow a a' e)
+            ( bottom-map-double-arrow a)
+            ( bottom-map-double-arrow a')
+            ( codomain-map-equiv-double-arrow a a' e)
+            ( map-cofork a c)
+            ( map-cofork a' c')
+            ( map-equiv-cofork c c' e e')
+            ( bottom-coherence-square-equiv-double-arrow a a' e)
+            ( coh-equiv-cofork c c' e e')))
+        ( inv-htpy (coh-equiv-cofork c c' e e'))
+        ( coherence-square-cocone-cofork a' c')
+        ( coherence-cube-maps-rotate-120
+          ( horizontal-map-cocone-cofork a c)
+          ( domain-map-equiv-double-arrow a a' e)
+          ( map-equiv-cofork c c' e e')
+          ( horizontal-map-cocone-cofork a' c')
+          ( horizontal-map-span-cocone-cofork a)
+          ( spanning-map-hom-span-diagram-cofork-hom-double-arrow a a'
+            ( hom-double-arrow-equiv-double-arrow a a' e))
+          ( codomain-map-equiv-double-arrow a a' e)
+          ( horizontal-map-span-cocone-cofork a')
+          ( vertical-map-span-cocone-cofork a)
+          ( vertical-map-cocone-cofork a c)
+          ( vertical-map-span-cocone-cofork a')
+          ( vertical-map-cocone-cofork a' c')
+          ( right-square-hom-span-diagram-cofork-hom-double-arrow a a'
+            ( hom-double-arrow-equiv-double-arrow a a' e))
+          ( coherence-square-cocone-cofork a c)
+          ( left-square-hom-span-diagram-cofork-hom-double-arrow a a'
+            ( hom-double-arrow-equiv-double-arrow a a' e))
+          ( coh-equiv-cofork c c' e e')
+          ( coherence-square-cocone-cofork a' c')
+          ( pasting-vertical-coherence-square-maps
+            ( domain-map-equiv-double-arrow a a' e)
+            ( bottom-map-double-arrow a)
+            ( bottom-map-double-arrow a')
+            ( codomain-map-equiv-double-arrow a a' e)
+            ( map-cofork a c)
+            ( map-cofork a' c')
+            ( map-equiv-cofork c c' e e')
+            ( bottom-coherence-square-equiv-double-arrow a a' e)
+            ( coh-equiv-cofork c c' e e'))
+          ( inv-htpy
+            ( ind-coproduct _
+              ( right-unit-htpy)
+              ( coh-equiv-cofork' c c' e e'))))
+        ( is-equiv-map-coproduct
+          ( is-equiv-domain-map-equiv-double-arrow a a' e)
+          ( is-equiv-domain-map-equiv-double-arrow a a' e))
+        ( is-equiv-domain-map-equiv-double-arrow a a' e)
+        ( is-equiv-codomain-map-equiv-double-arrow a a' e)
+        ( is-equiv-map-equiv-cofork c c' e e')
+        ( universal-property-pushout-universal-property-coequalizer a' c'
           ( up-c')))
 
   universal-property-coequalizer-bottom-universal-property-coequalizer-top-hom-arrow-is-equiv :
-    ({l : Level} → universal-property-coequalizer l _ _ top-cofork-hom-arrow) →
-    ({l : Level} → universal-property-coequalizer l _ _ bottom-cofork-hom-arrow)
+    ({l : Level} → universal-property-coequalizer l a c) →
+    ({l : Level} → universal-property-coequalizer l a' c')
   universal-property-coequalizer-bottom-universal-property-coequalizer-top-hom-arrow-is-equiv
     ( up-c) =
-    universal-property-coequalizer-universal-property-pushout _ _
-      ( bottom-cofork-hom-arrow)
+    universal-property-coequalizer-universal-property-pushout a' c'
       ( universal-property-pushout-bottom-universal-property-pushout-top-cube-is-equiv
-        ( vertical-map-span-cocone-cofork
-          ( map-codomain-hom-arrow hA hB f)
-          ( map-codomain-hom-arrow hA hB g))
-        ( horizontal-map-span-cocone-cofork
-          ( map-codomain-hom-arrow hA hB f)
-          ( map-codomain-hom-arrow hA hB g))
-        ( horizontal-map-cocone-cofork _ _ bottom-cofork-hom-arrow)
-        ( vertical-map-cocone-cofork _ _ bottom-cofork-hom-arrow)
-        ( vertical-map-span-cocone-cofork
-          ( map-domain-hom-arrow hA hB f)
-          ( map-domain-hom-arrow hA hB g))
-        ( horizontal-map-span-cocone-cofork
-          ( map-domain-hom-arrow hA hB f)
-          ( map-domain-hom-arrow hA hB g))
-        ( horizontal-map-cocone-cofork _ _ top-cofork-hom-arrow)
-        ( vertical-map-cocone-cofork _ _ top-cofork-hom-arrow)
-        ( map-coproduct hA hA)
-        ( hA)
-        ( hB)
-        ( hC)
-        ( coherence-square-cocone-cofork _ _ top-cofork-hom-arrow)
-        ( ind-coproduct _ refl-htpy refl-htpy)
-        ( ind-coproduct _ (coh-hom-arrow hA hB f) (coh-hom-arrow hA hB g))
-        ( coh-comp-hom-arrow hA hB hC c f)
-        ( coh-hom-arrow hB hC c)
-        ( coherence-square-cocone-cofork _ _ bottom-cofork-hom-arrow)
-        ( ind-coproduct _ (λ _ → right-unit) (coh-htpy-hom-arrow hA hC _ _ H))
-        ( is-equiv-map-coproduct is-equiv-hA is-equiv-hA)
-        ( is-equiv-hA)
-        ( is-equiv-hB)
-        ( is-equiv-hC)
-        ( universal-property-pushout-universal-property-coequalizer _ _
-          ( top-cofork-hom-arrow)
-          ( up-c)))
+        ( vertical-map-span-cocone-cofork a')
+        ( horizontal-map-span-cocone-cofork a')
+        ( horizontal-map-cocone-cofork a' c')
+        ( vertical-map-cocone-cofork a' c')
+        ( vertical-map-span-cocone-cofork a)
+        ( horizontal-map-span-cocone-cofork a)
+        ( horizontal-map-cocone-cofork a c)
+        ( vertical-map-cocone-cofork a c)
+        ( spanning-map-hom-span-diagram-cofork-hom-double-arrow a a'
+          ( hom-double-arrow-equiv-double-arrow a a' e))
+        ( domain-map-equiv-double-arrow a a' e)
+        ( codomain-map-equiv-double-arrow a a' e)
+        ( map-equiv-cofork c c' e e')
+        ( coherence-square-cocone-cofork a c)
+        ( inv-htpy
+          ( left-square-hom-span-diagram-cofork-hom-double-arrow a a'
+            ( hom-double-arrow-equiv-double-arrow a a' e)))
+        ( inv-htpy
+          ( right-square-hom-span-diagram-cofork-hom-double-arrow a a'
+            ( hom-double-arrow-equiv-double-arrow a a' e)))
+        ( inv-htpy
+          ( pasting-vertical-coherence-square-maps
+            ( domain-map-equiv-double-arrow a a' e)
+            ( bottom-map-double-arrow a)
+            ( bottom-map-double-arrow a')
+            ( codomain-map-equiv-double-arrow a a' e)
+            ( map-cofork a c)
+            ( map-cofork a' c')
+            ( map-equiv-cofork c c' e e')
+            ( bottom-coherence-square-equiv-double-arrow a a' e)
+            ( coh-equiv-cofork c c' e e')))
+        ( inv-htpy (coh-equiv-cofork c c' e e'))
+        ( coherence-square-cocone-cofork a' c')
+        ( coherence-cube-maps-rotate-120
+          ( horizontal-map-cocone-cofork a c)
+          ( domain-map-equiv-double-arrow a a' e)
+          ( map-equiv-cofork c c' e e')
+          ( horizontal-map-cocone-cofork a' c')
+          ( horizontal-map-span-cocone-cofork a)
+          ( spanning-map-hom-span-diagram-cofork-hom-double-arrow a a'
+            ( hom-double-arrow-equiv-double-arrow a a' e))
+          ( codomain-map-equiv-double-arrow a a' e)
+          ( horizontal-map-span-cocone-cofork a')
+          ( vertical-map-span-cocone-cofork a)
+          ( vertical-map-cocone-cofork a c)
+          ( vertical-map-span-cocone-cofork a')
+          ( vertical-map-cocone-cofork a' c')
+          ( right-square-hom-span-diagram-cofork-hom-double-arrow a a'
+            ( hom-double-arrow-equiv-double-arrow a a' e))
+          ( coherence-square-cocone-cofork a c)
+          ( left-square-hom-span-diagram-cofork-hom-double-arrow a a'
+            ( hom-double-arrow-equiv-double-arrow a a' e))
+          ( coh-equiv-cofork c c' e e')
+          ( coherence-square-cocone-cofork a' c')
+          ( pasting-vertical-coherence-square-maps
+            ( domain-map-equiv-double-arrow a a' e)
+            ( bottom-map-double-arrow a)
+            ( bottom-map-double-arrow a')
+            ( codomain-map-equiv-double-arrow a a' e)
+            ( map-cofork a c)
+            ( map-cofork a' c')
+            ( map-equiv-cofork c c' e e')
+            ( bottom-coherence-square-equiv-double-arrow a a' e)
+            ( coh-equiv-cofork c c' e e'))
+          ( inv-htpy
+            ( ind-coproduct _
+              ( right-unit-htpy)
+              ( coh-equiv-cofork' c c' e e'))))
+        ( is-equiv-map-coproduct
+          ( is-equiv-domain-map-equiv-double-arrow a a' e)
+          ( is-equiv-domain-map-equiv-double-arrow a a' e))
+        ( is-equiv-domain-map-equiv-double-arrow a a' e)
+        ( is-equiv-codomain-map-equiv-double-arrow a a' e)
+        ( is-equiv-map-equiv-cofork c c' e e')
+        ( universal-property-pushout-universal-property-coequalizer a c up-c))
 ```

--- a/src/synthetic-homotopy-theory/universal-property-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-sequential-colimits.lagda.md
@@ -156,8 +156,7 @@ module _
   universal-property-sequential-colimit-universal-property-coequalizer :
     ( {l : Level} →
       universal-property-coequalizer l
-        ( bottom-map-cofork-cocone-sequential-diagram A)
-        ( top-map-cofork-cocone-sequential-diagram A)
+        ( double-arrow-sequential-diagram A)
         ( cofork-cocone-sequential-diagram A c)) →
     universal-property-sequential-colimit c
   universal-property-sequential-colimit-universal-property-coequalizer
@@ -167,8 +166,7 @@ module _
       ( cocone-map-sequential-diagram c)
       ( cocone-sequential-diagram-cofork A)
       ( cofork-map
-        ( bottom-map-cofork-cocone-sequential-diagram A)
-        ( top-map-cofork-cocone-sequential-diagram A)
+        ( double-arrow-sequential-diagram A)
         ( cofork-cocone-sequential-diagram A c))
       ( triangle-cocone-sequential-diagram-cofork A c)
       ( up-cofork Y)
@@ -178,8 +176,7 @@ module _
     universal-property-sequential-colimit c →
     ( {l : Level} →
       universal-property-coequalizer l
-        ( bottom-map-cofork-cocone-sequential-diagram A)
-        ( top-map-cofork-cocone-sequential-diagram A)
+        ( double-arrow-sequential-diagram A)
         ( cofork-cocone-sequential-diagram A c))
   universal-property-coequalizer-universal-property-sequential-colimit
     ( up-sequential-colimit)
@@ -188,8 +185,7 @@ module _
       ( cocone-map-sequential-diagram c)
       ( cocone-sequential-diagram-cofork A)
       ( cofork-map
-        ( bottom-map-cofork-cocone-sequential-diagram A)
-        ( top-map-cofork-cocone-sequential-diagram A)
+        ( double-arrow-sequential-diagram A)
         ( cofork-cocone-sequential-diagram A c))
       ( triangle-cocone-sequential-diagram-cofork A c)
       ( is-equiv-cocone-sequential-diagram-cofork A)


### PR DESCRIPTION
In anticipation for #885. The proof of the universal property of coequalizers being preserved by equivalences of coforks got a bit unwieldy, but it should become more conceptual once morphisms and equivalences of cocones under spans are integrated (for now they exist only in the other PR).