### PR TITLE
Fix line height in lists

### DIFF
--- a/theme/css/chrome.css
+++ b/theme/css/chrome.css
@@ -277,6 +277,7 @@ pre > .buttons button {
 }
 pre > code {
   padding: 1rem;
+  line-height: normal;
 }
 
 /* FIXME: ACE editors overlap their buttons because ACE does absolute


### PR DESCRIPTION
An issue discovered by @fredrik-bakke — code blocks in lists inherit bigger line spacing, making the ASCII diagrams more stretched.

Compare
![20240416 133603 screen](https://github.com/UniMath/agda-unimath/assets/15523887/20ff88b2-a26b-4153-9ffe-0a892fee5376)
