### PR TITLE
chore: Universal properties of colimits quantify over all universe levels

### DIFF
--- a/src/foundation/epimorphisms.lagda.md
+++ b/src/foundation/epimorphisms.lagda.md
@@ -99,7 +99,7 @@ module _
 
   universal-property-pushout-is-epimorphism :
     is-epimorphism f →
-    {l : Level} → universal-property-pushout l f f (cocone-codiagonal-map f)
+    universal-property-pushout f f (cocone-codiagonal-map f)
   universal-property-pushout-is-epimorphism e X =
     is-equiv-comp
       ( map-equiv (compute-total-fiber-precomp f X))
@@ -134,7 +134,7 @@ If the map `f : A → B` is epi, then its codiagonal is an equivalence.
 ```agda
   is-epimorphism-universal-property-pushout-Level :
     {l : Level} →
-    universal-property-pushout l f f (cocone-codiagonal-map f) →
+    universal-property-pushout-Level l f f (cocone-codiagonal-map f) →
     is-epimorphism-Level l f
   is-epimorphism-universal-property-pushout-Level up-c X =
     is-emb-is-contr-fibers-values
@@ -153,7 +153,7 @@ If the map `f : A → B` is epi, then its codiagonal is an equivalence.
             ( g)))
 
   is-epimorphism-universal-property-pushout :
-    ({l : Level} → universal-property-pushout l f f (cocone-codiagonal-map f)) →
+    universal-property-pushout f f (cocone-codiagonal-map f) →
     is-epimorphism f
   is-epimorphism-universal-property-pushout up-c =
     is-epimorphism-universal-property-pushout-Level up-c

--- a/src/synthetic-homotopy-theory/26-descent.lagda.md
+++ b/src/synthetic-homotopy-theory/26-descent.lagda.md
@@ -218,7 +218,7 @@ triangle-desc-fam {l = l} {S} {A} {B} {X} (pair i (pair j H)) P =
 is-equiv-desc-fam :
   {l1 l2 l3 l4 l : Level} {S : UU l1} {A : UU l2} {B : UU l3} {X : UU l4}
   {f : S → A} {g : S → B} (c : cocone f g X) →
-  ({l' : Level} → universal-property-pushout l' f g c) →
+  universal-property-pushout f g c →
   is-equiv (desc-fam {l = l} {f = f} {g} c)
 is-equiv-desc-fam {l = l} {f = f} {g} c up-c =
   is-equiv-left-map-triangle
@@ -232,7 +232,7 @@ is-equiv-desc-fam {l = l} {f = f} {g} c up-c =
 equiv-desc-fam :
   {l1 l2 l3 l4 l : Level} {S : UU l1} {A : UU l2} {B : UU l3} {X : UU l4}
   {f : S → A} {g : S → B} (c : cocone f g X) →
-  ({l' : Level} → universal-property-pushout l' f g c) →
+  universal-property-pushout f g c →
   (X → UU l) ≃ Fam-pushout l f g
 equiv-desc-fam c up-c =
   pair
@@ -246,7 +246,7 @@ equiv-desc-fam c up-c =
 uniqueness-Fam-pushout :
   {l1 l2 l3 l4 l : Level} {S : UU l1} {A : UU l2} {B : UU l3} {X : UU l4}
   (f : S → A) (g : S → B) (c : cocone f g X) →
-  ({l' : Level} → universal-property-pushout l' f g c) →
+  universal-property-pushout f g c →
   ( P : Fam-pushout l f g) →
   is-contr
     ( Σ (X → UU l) (λ Q →
@@ -262,16 +262,16 @@ uniqueness-Fam-pushout {l = l} f g c up-c P =
 fam-Fam-pushout :
   {l1 l2 l3 l4 l : Level} {S : UU l1} {A : UU l2} {B : UU l3} {X : UU l4}
   {f : S → A} {g : S → B} (c : cocone f g X) →
-  (up-X : {l' : Level} → universal-property-pushout l' f g c) →
-  Fam-pushout l f g → (X → UU l)
+  universal-property-pushout f g c →
+  Fam-pushout l f g → X → UU l
 fam-Fam-pushout {f = f} {g} c up-X P =
   pr1 (center (uniqueness-Fam-pushout f g c up-X P))
 
 is-section-fam-Fam-pushout :
   {l1 l2 l3 l4 l : Level} {S : UU l1} {A : UU l2} {B : UU l3} {X : UU l4}
   {f : S → A} {g : S → B} (c : cocone f g X) →
-  (up-X : {l' : Level} → universal-property-pushout l' f g c) →
-  ((desc-fam {l = l} c) ∘ (fam-Fam-pushout c up-X)) ~ id
+  (up-X : universal-property-pushout f g c) →
+  desc-fam {l = l} c ∘ fam-Fam-pushout c up-X ~ id
 is-section-fam-Fam-pushout {f = f} {g} c up-X P =
   inv
     ( eq-equiv-Fam-pushout (pr2 (center (uniqueness-Fam-pushout f g c up-X P))))
@@ -279,7 +279,7 @@ is-section-fam-Fam-pushout {f = f} {g} c up-X P =
 compute-left-fam-Fam-pushout :
   { l1 l2 l3 l4 l : Level} {S : UU l1} {A : UU l2} {B : UU l3} {X : UU l4}
   { f : S → A} {g : S → B} (c : cocone f g X) →
-  ( up-X : {l' : Level} → universal-property-pushout l' f g c) →
+  ( up-X : universal-property-pushout f g c) →
   ( P : Fam-pushout l f g) →
   ( a : A) → (pr1 P a) ≃ (fam-Fam-pushout c up-X P (pr1 c a))
 compute-left-fam-Fam-pushout {f = f} {g} c up-X P =
@@ -288,7 +288,7 @@ compute-left-fam-Fam-pushout {f = f} {g} c up-X P =
 compute-right-fam-Fam-pushout :
   { l1 l2 l3 l4 l : Level} {S : UU l1} {A : UU l2} {B : UU l3} {X : UU l4}
   { f : S → A} {g : S → B} (c : cocone f g X) →
-  ( up-X : {l' : Level} → universal-property-pushout l' f g c) →
+  ( up-X : universal-property-pushout f g c) →
   ( P : Fam-pushout l f g) →
   ( b : B) → (pr1 (pr2 P) b) ≃ (fam-Fam-pushout c up-X P (pr1 (pr2 c) b))
 compute-right-fam-Fam-pushout {f = f} {g} c up-X P =
@@ -297,7 +297,7 @@ compute-right-fam-Fam-pushout {f = f} {g} c up-X P =
 compute-path-fam-Fam-pushout :
   { l1 l2 l3 l4 l : Level} {S : UU l1} {A : UU l2} {B : UU l3} {X : UU l4}
   { f : S → A} {g : S → B} (c : cocone f g X) →
-  ( up-X : {l' : Level} → universal-property-pushout l' f g c) →
+  ( up-X : universal-property-pushout f g c) →
   ( P : Fam-pushout l f g) →
   ( s : S) →
     ( ( map-equiv (compute-right-fam-Fam-pushout c up-X P (g s))) ∘

--- a/src/synthetic-homotopy-theory/26-id-pushout.lagda.md
+++ b/src/synthetic-homotopy-theory/26-id-pushout.lagda.md
@@ -440,7 +440,7 @@ equiv-is-equiv-hom-Fam-pushout P Q h is-equiv-h =
 hom-identity-is-universal-Fam-pushout :
   { l1 l2 l3 l4 l5 : Level} {S : UU l1} {A : UU l2} {B : UU l3} {X : UU l5}
   { f : S → A} {g : S → B} (c : cocone f g X) →
-  ( up-X : (l : Level) → universal-property-pushout l f g c) →
+  ( up-X : universal-property-pushout f g c) →
   ( P : Fam-pushout l4 f g) (a : A) (p : pr1 P a) →
   is-universal-Fam-pushout l5 P a p →
   Σ ( hom-Fam-pushout P (desc-fam c (Id (pr1 c a))))
@@ -451,7 +451,7 @@ hom-identity-is-universal-Fam-pushout {f = f} {g} c up-X P a p is-univ-P =
 is-identity-is-universal-Fam-pushout :
   { l1 l2 l3 l4 l5 : Level} {S : UU l1} {A : UU l2} {B : UU l3} {X : UU l5}
   { f : S → A} {g : S → B} (c : cocone f g X) →
-  ( up-X : (l : Level) → universal-property-pushout l f g c) →
+  ( up-X : universal-property-pushout f g c) →
   ( P : Fam-pushout l4 f g) (a : A) (p : pr1 P a) →
   is-universal-Fam-pushout l5 P a p →
   Σ ( equiv-Fam-pushout P (desc-fam c (Id (pr1 c a))))

--- a/src/synthetic-homotopy-theory/26-id-pushout.lagda.md
+++ b/src/synthetic-homotopy-theory/26-id-pushout.lagda.md
@@ -247,7 +247,7 @@ triangle-hom-Fam-pushout-dependent-cocone {f = f} {g} c P Q h =
 is-equiv-hom-Fam-pushout-map :
   { l1 l2 l3 l4 l5 l6 : Level} {S : UU l1} {A : UU l2} {B : UU l3} {X : UU l4}
   { f : S → A} {g : S → B} (c : cocone f g X) →
-  ( up-X : {l : Level} → universal-property-pushout l f g c)
+  ( up-X : universal-property-pushout f g c)
   ( P : X → UU l5) (Q : X → UU l6) →
   is-equiv (hom-Fam-pushout-map c P Q)
 is-equiv-hom-Fam-pushout-map {l5 = l5} {l6} {f = f} {g} c up-X P Q =
@@ -263,7 +263,7 @@ is-equiv-hom-Fam-pushout-map {l5 = l5} {l6} {f = f} {g} c up-X P Q =
 equiv-hom-Fam-pushout-map :
   { l1 l2 l3 l4 l5 l6 : Level} {S : UU l1} {A : UU l2} {B : UU l3} {X : UU l4}
   { f : S → A} {g : S → B} (c : cocone f g X) →
-  ( up-X : {l : Level} → universal-property-pushout l f g c)
+  ( up-X : universal-property-pushout f g c)
   ( P : X → UU l5) (Q : X → UU l6) →
   ( (x : X) → P x → Q x) ≃
   hom-Fam-pushout (desc-fam c P) (desc-fam c Q)
@@ -308,7 +308,7 @@ triangle-is-universal-id-Fam-pushout' c a Q = refl-htpy
 is-universal-id-Fam-pushout' :
   { l l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3} {X : UU l4}
   { f : S → A} {g : S → B} (c : cocone f g X)
-  ( up-X : {l' : Level} → universal-property-pushout l' f g c) (a : A) →
+  ( up-X : universal-property-pushout f g c) (a : A) →
   ( Q : (x : X) → UU l) →
   is-equiv
     ( ev-point-hom-Fam-pushout
@@ -331,7 +331,7 @@ is-universal-id-Fam-pushout :
   { l1 l2 l3 l4 l : Level}
   { S : UU l1} {A : UU l2} {B : UU l3} {X : UU l4}
   { f : S → A} {g : S → B} (c : cocone f g X)
-  ( up-X : {l' : Level} → universal-property-pushout l' f g c) (a : A) →
+  ( up-X : universal-property-pushout f g c) (a : A) →
   is-universal-Fam-pushout l (desc-fam c (Id (pr1 c a))) a refl
 is-universal-id-Fam-pushout {S = S} {A} {B} {X} {f} {g} c up-X a Q =
   map-inv-equiv

--- a/src/synthetic-homotopy-theory/circle.lagda.md
+++ b/src/synthetic-homotopy-theory/circle.lagda.md
@@ -67,7 +67,7 @@ free-loop-𝕊¹ = base-𝕊¹ , loop-𝕊¹
 𝕊¹-Pointed-Type = 𝕊¹ , base-𝕊¹
 
 postulate
-  ind-𝕊¹ : {l : Level} → induction-principle-circle l free-loop-𝕊¹
+  ind-𝕊¹ : induction-principle-circle free-loop-𝕊¹
 ```
 
 ## Properties
@@ -76,7 +76,7 @@ postulate
 
 ```agda
 dependent-universal-property-𝕊¹ :
-  {l : Level} → dependent-universal-property-circle l free-loop-𝕊¹
+  dependent-universal-property-circle free-loop-𝕊¹
 dependent-universal-property-𝕊¹ =
   dependent-universal-property-induction-principle-circle free-loop-𝕊¹ ind-𝕊¹
 
@@ -128,7 +128,7 @@ module _
 
 ```agda
 universal-property-𝕊¹ :
-  {l : Level} → universal-property-circle l free-loop-𝕊¹
+  universal-property-circle free-loop-𝕊¹
 universal-property-𝕊¹ =
   universal-property-dependent-universal-property-circle
     free-loop-𝕊¹

--- a/src/synthetic-homotopy-theory/circle.lagda.md
+++ b/src/synthetic-homotopy-theory/circle.lagda.md
@@ -127,12 +127,11 @@ module _
 ### The universal property of the circle
 
 ```agda
-universal-property-𝕊¹ :
-  universal-property-circle free-loop-𝕊¹
+universal-property-𝕊¹ : universal-property-circle free-loop-𝕊¹
 universal-property-𝕊¹ =
   universal-property-dependent-universal-property-circle
-    free-loop-𝕊¹
-    dependent-universal-property-𝕊¹
+    ( free-loop-𝕊¹)
+    ( dependent-universal-property-𝕊¹)
 
 uniqueness-universal-property-𝕊¹ :
   {l : Level} {X : UU l} (α : free-loop X) →

--- a/src/synthetic-homotopy-theory/cocartesian-morphisms-arrows.lagda.md
+++ b/src/synthetic-homotopy-theory/cocartesian-morphisms-arrows.lagda.md
@@ -109,8 +109,7 @@ module _
     cocone-hom-arrow f g hom-arrow-cocartesian-hom-arrow
 
   universal-property-cocartesian-hom-arrow :
-    {l : Level} →
-    universal-property-pushout l
+    universal-property-pushout
       ( f)
       ( map-domain-cocartesian-hom-arrow)
       ( cocone-cocartesian-hom-arrow)

--- a/src/synthetic-homotopy-theory/codiagonals-of-maps.lagda.md
+++ b/src/synthetic-homotopy-theory/codiagonals-of-maps.lagda.md
@@ -93,7 +93,7 @@ module _
         ( terminal-map (fiber f b))
         ( terminal-map (fiber f b))
         ( fiber (codiagonal-map f) b))
-      ( universal-property-pushout l
+      ( universal-property-pushout-Level l
         ( terminal-map (fiber f b))
         ( terminal-map (fiber f b)))
   universal-property-suspension-cocone-fiber =
@@ -121,8 +121,7 @@ module _
     pr1 (universal-property-suspension-cocone-fiber {lzero})
 
   universal-property-suspension-fiber :
-    {l : Level} →
-    universal-property-pushout l
+    universal-property-pushout
       ( terminal-map (fiber f b))
       ( terminal-map (fiber f b))
       ( suspension-cocone-fiber)

--- a/src/synthetic-homotopy-theory/coequalizers.lagda.md
+++ b/src/synthetic-homotopy-theory/coequalizers.lagda.md
@@ -77,7 +77,7 @@ module _
           ( horizontal-map-span-cocone-cofork a))
 
     dup-standard-coequalizer :
-      dependent-universal-property-coequalizer a (cofork-standard-coequalizer)
+      dependent-universal-property-coequalizer a cofork-standard-coequalizer
     dup-standard-coequalizer =
       dependent-universal-property-coequalizer-dependent-universal-property-pushout
         ( a)

--- a/src/synthetic-homotopy-theory/coequalizers.lagda.md
+++ b/src/synthetic-homotopy-theory/coequalizers.lagda.md
@@ -77,9 +77,7 @@ module _
           ( horizontal-map-span-cocone-cofork a))
 
     dup-standard-coequalizer :
-      {l : Level} →
-      dependent-universal-property-coequalizer l a
-        ( cofork-standard-coequalizer)
+      dependent-universal-property-coequalizer a (cofork-standard-coequalizer)
     dup-standard-coequalizer =
       dependent-universal-property-coequalizer-dependent-universal-property-pushout
         ( a)
@@ -105,8 +103,7 @@ module _
               ( P)))
 
     up-standard-coequalizer :
-      {l : Level} →
-      universal-property-coequalizer l a cofork-standard-coequalizer
+      universal-property-coequalizer a cofork-standard-coequalizer
     up-standard-coequalizer =
       universal-property-dependent-universal-property-coequalizer a
         ( cofork-standard-coequalizer)

--- a/src/synthetic-homotopy-theory/cofibers.lagda.md
+++ b/src/synthetic-homotopy-theory/cofibers.lagda.md
@@ -58,8 +58,8 @@ module _
   pr2 (cofiber-Pointed-Type f) = point-cofiber f
 
   universal-property-cofiber :
-    (f : A → B) {l : Level} →
-    universal-property-pushout l f (terminal-map A) (cocone-cofiber f)
+    (f : A → B) →
+    universal-property-pushout f (terminal-map A) (cocone-cofiber f)
   universal-property-cofiber f = up-pushout f (terminal-map A)
 ```
 

--- a/src/synthetic-homotopy-theory/dependent-pullback-property-pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-pullback-property-pushouts.lagda.md
@@ -68,11 +68,11 @@ pr2 (pr2 (cone-dependent-pullback-property-pushout f g (i , j , H) P)) h =
   eq-htpy (λ s → apd h (H s))
 
 dependent-pullback-property-pushout :
-  {l1 l2 l3 l4 : Level} (l : Level) {S : UU l1} {A : UU l2} {B : UU l3}
+  {l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3}
   (f : S → A) (g : S → B) {X : UU l4} (c : cocone f g X) →
-  UU (l1 ⊔ l2 ⊔ l3 ⊔ l4 ⊔ lsuc l)
-dependent-pullback-property-pushout l {S} {A} {B} f g {X} (i , j , H) =
-  (P : X → UU l) →
+  UUω
+dependent-pullback-property-pushout {S = S} {A} {B} f g {X} (i , j , H) =
+  {l : Level} (P : X → UU l) →
   is-pullback
     ( λ (h : (a : A) → P (i a)) → λ s → tr P (H s) (h (f s)))
     ( λ (h : (b : B) → P (j b)) → λ s → h (g s))
@@ -105,8 +105,8 @@ module _
   where
 
   pullback-property-dependent-pullback-property-pushout :
-    ({l : Level} → dependent-pullback-property-pushout l f g c) →
-    ({l : Level} → pullback-property-pushout l f g c)
+    dependent-pullback-property-pushout f g c →
+    pullback-property-pushout f g c
   pullback-property-dependent-pullback-property-pushout dpp-c Y =
     is-pullback-htpy
       ( λ h →
@@ -222,7 +222,7 @@ pullback property.
 
   is-pullback-cone-family-dependent-pullback-family :
     {l : Level} (P : X → UU l) →
-    ({l : Level} → pullback-property-pushout l f g c) →
+    pullback-property-pushout f g c →
     (γ : X → X) →
     is-pullback
       ( ( tr
@@ -271,8 +271,8 @@ pullback property.
         ( pp-c (Σ X P)))
 
   dependent-pullback-property-pullback-property-pushout :
-    ({l : Level} → pullback-property-pushout l f g c) →
-    ({l : Level} → dependent-pullback-property-pushout l f g c)
+    pullback-property-pushout f g c →
+    dependent-pullback-property-pushout f g c
   dependent-pullback-property-pullback-property-pushout pp-c P =
     is-pullback-htpy'
       ( ( tr-lift-family-of-elements-precomp P id

--- a/src/synthetic-homotopy-theory/dependent-universal-property-coequalizers.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-universal-property-coequalizers.lagda.md
@@ -127,11 +127,10 @@ module _
   where
 
   dependent-universal-property-coequalizer-dependent-universal-property-pushout :
-    ({l : Level} →
-      dependent-universal-property-pushout l
-        ( vertical-map-span-cocone-cofork a)
-        ( horizontal-map-span-cocone-cofork a)
-        ( cocone-codiagonal-cofork a e)) →
+    dependent-universal-property-pushout
+      ( vertical-map-span-cocone-cofork a)
+      ( horizontal-map-span-cocone-cofork a)
+      ( cocone-codiagonal-cofork a e) →
     ({l : Level} →
       dependent-universal-property-coequalizer l a e)
   dependent-universal-property-coequalizer-dependent-universal-property-pushout
@@ -152,11 +151,10 @@ module _
   dependent-universal-property-pushout-dependent-universal-property-coequalizer :
     ({l : Level} →
       dependent-universal-property-coequalizer l a e) →
-    ({l : Level} →
-      dependent-universal-property-pushout l
-        ( vertical-map-span-cocone-cofork a)
-        ( horizontal-map-span-cocone-cofork a)
-        ( cocone-codiagonal-cofork a e))
+    dependent-universal-property-pushout
+      ( vertical-map-span-cocone-cofork a)
+      ( horizontal-map-span-cocone-cofork a)
+      ( cocone-codiagonal-cofork a e)
   dependent-universal-property-pushout-dependent-universal-property-coequalizer
     ( dup-coequalizer)
     ( P) =

--- a/src/synthetic-homotopy-theory/dependent-universal-property-coequalizers.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-universal-property-coequalizers.lagda.md
@@ -44,18 +44,18 @@ dependent-cofork-map : ((x : X) → P x) → dependent-cocone e P.
 
 ```agda
 module _
-  {l1 l2 l3 : Level} (l : Level) (a : double-arrow l1 l2) {X : UU l3}
+  {l1 l2 l3 : Level} (a : double-arrow l1 l2) {X : UU l3}
   (e : cofork a X)
   where
 
-  dependent-universal-property-coequalizer : UU (l1 ⊔ l2 ⊔ l3 ⊔ lsuc l)
+  dependent-universal-property-coequalizer : UUω
   dependent-universal-property-coequalizer =
-    (P : X → UU l) → is-equiv (dependent-cofork-map a e {P = P})
+    {l : Level} (P : X → UU l) → is-equiv (dependent-cofork-map a e {P = P})
 
 module _
   {l1 l2 l3 l4 : Level} (a : double-arrow l1 l2) {X : UU l3}
   (e : cofork a X) {P : X → UU l4}
-  (dup-coequalizer : dependent-universal-property-coequalizer l4 a e)
+  (dup-coequalizer : dependent-universal-property-coequalizer a e)
   where
 
   map-dependent-universal-property-coequalizer :
@@ -73,7 +73,7 @@ module _
 module _
   {l1 l2 l3 l4 : Level} (a : double-arrow l1 l2) {X : UU l3}
   (e : cofork a X) {P : X → UU l4}
-  (dup-coequalizer : dependent-universal-property-coequalizer l4 a e)
+  (dup-coequalizer : dependent-universal-property-coequalizer a e)
   (k : dependent-cofork a e P)
   where
 
@@ -131,8 +131,7 @@ module _
       ( vertical-map-span-cocone-cofork a)
       ( horizontal-map-span-cocone-cofork a)
       ( cocone-codiagonal-cofork a e) →
-    ({l : Level} →
-      dependent-universal-property-coequalizer l a e)
+    dependent-universal-property-coequalizer a e
   dependent-universal-property-coequalizer-dependent-universal-property-pushout
     ( dup-pushout)
     ( P) =
@@ -149,8 +148,7 @@ module _
       ( is-equiv-dependent-cofork-dependent-cocone-codiagonal a e P)
 
   dependent-universal-property-pushout-dependent-universal-property-coequalizer :
-    ({l : Level} →
-      dependent-universal-property-coequalizer l a e) →
+    dependent-universal-property-coequalizer a e →
     dependent-universal-property-pushout
       ( vertical-map-span-cocone-cofork a)
       ( horizontal-map-span-cocone-cofork a)
@@ -180,8 +178,8 @@ module _
   where
 
   universal-property-dependent-universal-property-coequalizer :
-    ({l : Level} → dependent-universal-property-coequalizer l a e) →
-    ({l : Level} → universal-property-coequalizer l a e)
+    dependent-universal-property-coequalizer a e →
+    universal-property-coequalizer a e
   universal-property-dependent-universal-property-coequalizer
     ( dup-coequalizer)
     ( Y) =
@@ -195,8 +193,8 @@ module _
         ( compute-dependent-cofork-constant-family a e Y))
 
   dependent-universal-property-universal-property-coequalizer :
-    ({l : Level} → universal-property-coequalizer l a e) →
-    ({l : Level} → dependent-universal-property-coequalizer l a e)
+    universal-property-coequalizer a e →
+    dependent-universal-property-coequalizer a e
   dependent-universal-property-universal-property-coequalizer up-coequalizer =
     dependent-universal-property-coequalizer-dependent-universal-property-pushout
       ( a)

--- a/src/synthetic-homotopy-theory/dependent-universal-property-pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-universal-property-pushouts.lagda.md
@@ -48,11 +48,11 @@ the pushout.
 
 ```agda
 dependent-universal-property-pushout :
-  {l1 l2 l3 l4 : Level} (l : Level) {S : UU l1} {A : UU l2} {B : UU l3}
+  {l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3}
   (f : S → A) (g : S → B) {X : UU l4} (c : cocone f g X) →
-  UU (l1 ⊔ l2 ⊔ l3 ⊔ l4 ⊔ lsuc l)
-dependent-universal-property-pushout l f g {X} c =
-  (P : X → UU l) → is-equiv (dependent-cocone-map f g c P)
+  UUω
+dependent-universal-property-pushout f g {X} c =
+  {l : Level} (P : X → UU l) → is-equiv (dependent-cocone-map f g c P)
 ```
 
 ## Properties
@@ -62,10 +62,10 @@ dependent-universal-property-pushout l f g {X} c =
 ```agda
 abstract
   uniqueness-dependent-universal-property-pushout :
-    { l1 l2 l3 l4 l : Level} {S : UU l1} {A : UU l2} {B : UU l3} {X : UU l4} →
+    { l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3} {X : UU l4} →
     ( f : S → A) (g : S → B) (c : cocone f g X)
-    ( dup-c : dependent-universal-property-pushout l f g c) →
-    ( P : X → UU l) ( h : dependent-cocone f g c P) →
+    ( dup-c : dependent-universal-property-pushout f g c) →
+    {l : Level} (P : X → UU l) ( h : dependent-cocone f g c P) →
     is-contr
       ( Σ ( (x : X) → P x)
           ( λ k →
@@ -149,7 +149,7 @@ module _
 
   dependent-universal-property-pushout-induction-principle-pushout :
     ({l : Level} → induction-principle-pushout l f g c) →
-    ({l : Level} → dependent-universal-property-pushout l f g c)
+    dependent-universal-property-pushout f g c
   dependent-universal-property-pushout-induction-principle-pushout ind-c P =
     is-equiv-is-invertible
       ( ind-induction-principle-pushout f g c ind-c P)
@@ -163,7 +163,7 @@ module _
 induction-principle-pushout-dependent-universal-property-pushout :
   {l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3}
   (f : S → A) (g : S → B) {X : UU l4} (c : cocone f g X) →
-  ({l : Level} → dependent-universal-property-pushout l f g c) →
+  dependent-universal-property-pushout f g c →
   ({l : Level} → induction-principle-pushout l f g c)
 induction-principle-pushout-dependent-universal-property-pushout
   f g c dup-c P = pr1 (dup-c P)
@@ -193,7 +193,7 @@ triangle-dependent-pullback-property-pushout f g (pair i (pair j H)) P h =
 dependent-pullback-property-dependent-universal-property-pushout :
   {l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3}
   (f : S → A) (g : S → B) {X : UU l4} (c : cocone f g X) →
-  ({l : Level} → dependent-universal-property-pushout l f g c) →
+  dependent-universal-property-pushout f g c →
   ({l : Level} → dependent-pullback-property-pushout l f g c)
 dependent-pullback-property-dependent-universal-property-pushout
   f g (pair i (pair j H)) I P =
@@ -220,7 +220,7 @@ dependent-universal-property-dependent-pullback-property-pushout :
   {l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3}
   (f : S → A) (g : S → B) {X : UU l4} (c : cocone f g X) →
   ({l : Level} → dependent-pullback-property-pushout l f g c) →
-  ({l : Level} → dependent-universal-property-pushout l f g c)
+  dependent-universal-property-pushout f g c
 dependent-universal-property-dependent-pullback-property-pushout
   f g (pair i (pair j H)) dpullback-c P =
   let c = (pair i (pair j H)) in
@@ -253,7 +253,7 @@ module _
   where
 
   universal-property-dependent-universal-property-pushout :
-    ({l : Level} → dependent-universal-property-pushout l f g c) →
+    dependent-universal-property-pushout f g c →
     universal-property-pushout f g c
   universal-property-dependent-universal-property-pushout dup-c {l} =
     universal-property-pushout-pullback-property-pushout-Level l f g c
@@ -263,7 +263,7 @@ module _
 
   dependent-universal-property-universal-property-pushout :
     universal-property-pushout f g c →
-    ({l : Level} → dependent-universal-property-pushout l f g c)
+    dependent-universal-property-pushout f g c
   dependent-universal-property-universal-property-pushout up-c =
     dependent-universal-property-dependent-pullback-property-pushout f g c
       ( dependent-pullback-property-pullback-property-pushout f g c

--- a/src/synthetic-homotopy-theory/dependent-universal-property-pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-universal-property-pushouts.lagda.md
@@ -254,18 +254,18 @@ module _
 
   universal-property-dependent-universal-property-pushout :
     ({l : Level} → dependent-universal-property-pushout l f g c) →
-    ({l : Level} → universal-property-pushout l f g c)
+    universal-property-pushout f g c
   universal-property-dependent-universal-property-pushout dup-c {l} =
-    universal-property-pushout-pullback-property-pushout l f g c
+    universal-property-pushout-pullback-property-pushout-Level l f g c
       ( pullback-property-dependent-pullback-property-pushout f g c
         ( dependent-pullback-property-dependent-universal-property-pushout f g c
           ( dup-c)))
 
   dependent-universal-property-universal-property-pushout :
-    ({l : Level} → universal-property-pushout l f g c) →
+    universal-property-pushout f g c →
     ({l : Level} → dependent-universal-property-pushout l f g c)
   dependent-universal-property-universal-property-pushout up-c =
     dependent-universal-property-dependent-pullback-property-pushout f g c
       ( dependent-pullback-property-pullback-property-pushout f g c
-        ( pullback-property-pushout-universal-property-pushout f g c up-c))
+        ( pullback-property-pushout-universal-property-pushout-Level f g c up-c))
 ```

--- a/src/synthetic-homotopy-theory/dependent-universal-property-pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-universal-property-pushouts.lagda.md
@@ -193,7 +193,7 @@ dependent-pullback-property-dependent-universal-property-pushout :
   {l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3}
   (f : S → A) (g : S → B) {X : UU l4} (c : cocone f g X) →
   dependent-universal-property-pushout f g c →
-  ({l : Level} → dependent-pullback-property-pushout l f g c)
+  dependent-pullback-property-pushout f g c
 dependent-pullback-property-dependent-universal-property-pushout
   f g (pair i (pair j H)) I P =
   let c = (pair i (pair j H)) in
@@ -218,7 +218,7 @@ dependent-pullback-property-dependent-universal-property-pushout
 dependent-universal-property-dependent-pullback-property-pushout :
   {l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3}
   (f : S → A) (g : S → B) {X : UU l4} (c : cocone f g X) →
-  ({l : Level} → dependent-pullback-property-pushout l f g c) →
+  dependent-pullback-property-pushout f g c →
   dependent-universal-property-pushout f g c
 dependent-universal-property-dependent-pullback-property-pushout
   f g (pair i (pair j H)) dpullback-c P =
@@ -255,7 +255,7 @@ module _
     dependent-universal-property-pushout f g c →
     universal-property-pushout f g c
   universal-property-dependent-universal-property-pushout dup-c {l} =
-    universal-property-pushout-pullback-property-pushout-Level l f g c
+    universal-property-pushout-pullback-property-pushout f g c
       ( pullback-property-dependent-pullback-property-pushout f g c
         ( dependent-pullback-property-dependent-universal-property-pushout f g c
           ( dup-c)))
@@ -266,5 +266,5 @@ module _
   dependent-universal-property-universal-property-pushout up-c =
     dependent-universal-property-dependent-pullback-property-pushout f g c
       ( dependent-pullback-property-pullback-property-pushout f g c
-        ( pullback-property-pushout-universal-property-pushout-Level f g c up-c))
+        ( pullback-property-pushout-universal-property-pushout f g c up-c))
 ```

--- a/src/synthetic-homotopy-theory/dependent-universal-property-pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-universal-property-pushouts.lagda.md
@@ -95,11 +95,10 @@ module _
   where
 
   htpy-eq-dependent-cocone-map :
-    { l : Level} →
-    induction-principle-pushout l f g c →
-    { P : X → UU l} (h h' : (x : X) → P x) →
+    induction-principle-pushout f g c →
+    { l : Level} {P : X → UU l} (h h' : (x : X) → P x) →
     dependent-cocone-map f g c P h ＝ dependent-cocone-map f g c P h' → h ~ h'
-  htpy-eq-dependent-cocone-map ind-c {P} h h' p =
+  htpy-eq-dependent-cocone-map ind-c {P = P} h h' p =
     ind-induction-principle-pushout f g c ind-c
       ( λ x → h x ＝ h' x)
       ( ( horizontal-htpy-eq-dependent-cocone f g c P
@@ -130,7 +129,7 @@ module _
               ( s))))
 
   is-retraction-ind-induction-principle-pushout :
-    (H : {l : Level} → induction-principle-pushout l f g c) →
+    (H : induction-principle-pushout f g c) →
     {l : Level} (P : X → UU l) →
     is-retraction
       ( dependent-cocone-map f g c P)
@@ -148,7 +147,7 @@ module _
           ( dependent-cocone-map f g c P h)))
 
   dependent-universal-property-pushout-induction-principle-pushout :
-    ({l : Level} → induction-principle-pushout l f g c) →
+    induction-principle-pushout f g c →
     dependent-universal-property-pushout f g c
   dependent-universal-property-pushout-induction-principle-pushout ind-c P =
     is-equiv-is-invertible
@@ -164,7 +163,7 @@ induction-principle-pushout-dependent-universal-property-pushout :
   {l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3}
   (f : S → A) (g : S → B) {X : UU l4} (c : cocone f g X) →
   dependent-universal-property-pushout f g c →
-  ({l : Level} → induction-principle-pushout l f g c)
+  induction-principle-pushout f g c
 induction-principle-pushout-dependent-universal-property-pushout
   f g c dup-c P = pr1 (dup-c P)
 ```

--- a/src/synthetic-homotopy-theory/dependent-universal-property-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-universal-property-sequential-colimits.lagda.md
@@ -152,10 +152,9 @@ module _
   where
 
   dependent-universal-property-sequential-colimit-dependent-universal-property-coequalizer :
-    ( {l : Level} →
-      dependent-universal-property-coequalizer l
-        ( double-arrow-sequential-diagram A)
-        ( cofork-cocone-sequential-diagram c)) →
+    dependent-universal-property-coequalizer
+      ( double-arrow-sequential-diagram A)
+      ( cofork-cocone-sequential-diagram c) →
     dependent-universal-property-sequential-colimit c
   dependent-universal-property-sequential-colimit-dependent-universal-property-coequalizer
     ( dup-coequalizer)
@@ -172,10 +171,9 @@ module _
 
   dependent-universal-property-coequalizer-dependent-universal-property-sequential-colimit :
     dependent-universal-property-sequential-colimit c →
-    ( {l : Level} →
-      dependent-universal-property-coequalizer l
-        ( double-arrow-sequential-diagram A)
-        ( cofork-cocone-sequential-diagram c))
+    dependent-universal-property-coequalizer
+      ( double-arrow-sequential-diagram A)
+      ( cofork-cocone-sequential-diagram c)
   dependent-universal-property-coequalizer-dependent-universal-property-sequential-colimit
     ( dup-c)
     ( P) =

--- a/src/synthetic-homotopy-theory/dependent-universal-property-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-universal-property-sequential-colimits.lagda.md
@@ -64,7 +64,7 @@ module _
 
   dependent-universal-property-sequential-colimit : UUω
   dependent-universal-property-sequential-colimit =
-    { l : Level} → (P : X → UU l) →
+    {l : Level} (P : X → UU l) →
     is-equiv (dependent-cocone-map-sequential-diagram c P)
 ```
 

--- a/src/synthetic-homotopy-theory/descent-circle-equivalence-types.lagda.md
+++ b/src/synthetic-homotopy-theory/descent-circle-equivalence-types.lagda.md
@@ -126,7 +126,7 @@ module _
   where
 
   equiv-section-descent-data-circle-equiv-equiv-descent-data-circle :
-    dependent-universal-property-circle (l2 ⊔ l3) l →
+    dependent-universal-property-circle l →
     ( ( t : S) →
       ( family-family-with-descent-data-circle A t) ≃
       ( family-family-with-descent-data-circle B t)) ≃

--- a/src/synthetic-homotopy-theory/descent-circle-function-types.lagda.md
+++ b/src/synthetic-homotopy-theory/descent-circle-function-types.lagda.md
@@ -162,7 +162,7 @@ module _
         ( equiv-funext))
 
   equiv-descent-data-family-circle-function-type-hom :
-    dependent-universal-property-circle (l2 ⊔ l3) l →
+    dependent-universal-property-circle l →
     ( (x : S) → family-descent-data-circle-function-type l A B x) ≃
     hom-descent-data-circle
       ( descent-data-family-with-descent-data-circle A)

--- a/src/synthetic-homotopy-theory/descent-circle-subtypes.lagda.md
+++ b/src/synthetic-homotopy-theory/descent-circle-subtypes.lagda.md
@@ -133,7 +133,7 @@ module _
           ( λ x → is-in-subtype subtype-descent-data-circle-subtype (pr1 x))
 
   equiv-section-descent-data-circle-subtype-fixpoint-in-subtype :
-    dependent-universal-property-circle (l2 ⊔ l3) l →
+    dependent-universal-property-circle l →
     ( (x : S) → family-descent-data-circle-dependent-pair-type l A B x) ≃
     ( Σ ( fixpoint-descent-data-circle
           ( descent-data-family-with-descent-data-circle A))

--- a/src/synthetic-homotopy-theory/descent-circle.lagda.md
+++ b/src/synthetic-homotopy-theory/descent-circle.lagda.md
@@ -333,7 +333,7 @@ module _
       ( id-equiv , (htpy-eq (inv (compute-map-eq-ap (loop-free-loop l)))))
 
   is-equiv-descent-data-family-circle-universal-property-circle :
-    ( up-circle : universal-property-circle (lsuc l2) l) →
+    ( up-circle : universal-property-circle l) →
     is-equiv (descent-data-family-circle l)
   is-equiv-descent-data-family-circle-universal-property-circle up-circle =
     is-equiv-left-map-triangle
@@ -352,7 +352,7 @@ unique-family-property-circle l2 {S} l =
 
 module _
   { l1 l2 : Level} {S : UU l1} (l : free-loop S)
-  ( up-circle : universal-property-circle (lsuc l2) l)
+  ( up-circle : universal-property-circle l)
   where
 
   unique-family-property-universal-property-circle :

--- a/src/synthetic-homotopy-theory/flattening-lemma-coequalizers.lagda.md
+++ b/src/synthetic-homotopy-theory/flattening-lemma-coequalizers.lagda.md
@@ -101,9 +101,8 @@ module _
 
   flattening-lemma-coequalizer-statement : UUω
   flattening-lemma-coequalizer-statement =
-    ({l : Level} → dependent-universal-property-coequalizer l a e) →
-    {l : Level} →
-    universal-property-coequalizer l
+    dependent-universal-property-coequalizer a e →
+    universal-property-coequalizer
       ( double-arrow-flattening-lemma-coequalizer)
       ( cofork-flattening-lemma-coequalizer)
 ```

--- a/src/synthetic-homotopy-theory/flattening-lemma-pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/flattening-lemma-pushouts.lagda.md
@@ -125,7 +125,7 @@ module _
 
   flattening-lemma-pushout-statement : UUω
   flattening-lemma-pushout-statement =
-    ( {l : Level} → dependent-universal-property-pushout l f g c) →
+    dependent-universal-property-pushout f g c →
     universal-property-pushout
       ( vertical-map-span-flattening-pushout)
       ( horizontal-map-span-flattening-pushout)
@@ -197,7 +197,7 @@ module _
 
   flattening-lemma-descent-data-pushout-statement : UUω
   flattening-lemma-descent-data-pushout-statement =
-    ( {l : Level} → dependent-universal-property-pushout l f g c) →
+    dependent-universal-property-pushout f g c →
     universal-property-pushout
       ( vertical-map-span-flattening-descent-data-pushout)
       ( horizontal-map-span-flattening-descent-data-pushout)

--- a/src/synthetic-homotopy-theory/flattening-lemma-pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/flattening-lemma-pushouts.lagda.md
@@ -126,8 +126,7 @@ module _
   flattening-lemma-pushout-statement : UUω
   flattening-lemma-pushout-statement =
     ( {l : Level} → dependent-universal-property-pushout l f g c) →
-    { l : Level} →
-    universal-property-pushout l
+    universal-property-pushout
       ( vertical-map-span-flattening-pushout)
       ( horizontal-map-span-flattening-pushout)
       ( cocone-flattening-pushout)
@@ -199,8 +198,7 @@ module _
   flattening-lemma-descent-data-pushout-statement : UUω
   flattening-lemma-descent-data-pushout-statement =
     ( {l : Level} → dependent-universal-property-pushout l f g c) →
-    { l : Level} →
-    universal-property-pushout l
+    universal-property-pushout
       ( vertical-map-span-flattening-descent-data-pushout)
       ( horizontal-map-span-flattening-descent-data-pushout)
       ( cocone-flattening-descent-data-pushout)

--- a/src/synthetic-homotopy-theory/induction-principle-pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/induction-principle-pushouts.lagda.md
@@ -44,18 +44,18 @@ of pushouts is shown in
 
 ```agda
 induction-principle-pushout :
-  { l1 l2 l3 l4 : Level} (l : Level) →
+  { l1 l2 l3 l4 : Level} →
   { S : UU l1} {A : UU l2} {B : UU l3} {X : UU l4} →
   ( f : S → A) (g : S → B) (c : cocone f g X) →
-  UU (lsuc l ⊔ l1 ⊔ l2 ⊔ l3 ⊔ l4)
-induction-principle-pushout l {X = X} f g c =
-  (P : X → UU l) → section (dependent-cocone-map f g c P)
+  UUω
+induction-principle-pushout {X = X} f g c =
+  {l : Level} (P : X → UU l) → section (dependent-cocone-map f g c P)
 
 module _
-  { l1 l2 l3 l4 l : Level} {S : UU l1} {A : UU l2} {B : UU l3} {X : UU l4}
+  { l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3} {X : UU l4}
   ( f : S → A) (g : S → B) (c : cocone f g X)
-  ( ind-c : induction-principle-pushout l f g c)
-  ( P : X → UU l)
+  ( ind-c : induction-principle-pushout f g c)
+  {l : Level} ( P : X → UU l)
   where
 
   ind-induction-principle-pushout : dependent-cocone f g c P → (x : X) → P x

--- a/src/synthetic-homotopy-theory/joins-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/joins-of-types.lagda.md
@@ -76,8 +76,7 @@ module _
   {l1 l2 : Level} {A : UU l1} {B : UU l2}
   where
 
-  up-join :
-    universal-property-pushout {A = A} {B} pr1 pr2 cocone-join
+  up-join : universal-property-pushout {A = A} {B} pr1 pr2 cocone-join
   up-join = up-pushout pr1 pr2
 
   equiv-up-join :
@@ -412,8 +411,7 @@ module _
   pr1 equiv-join-disjunction-Prop = map-join-disjunction-Prop
   pr2 equiv-join-disjunction-Prop = is-equiv-map-join-disjunction-Prop
 
-  up-join-disjunction :
-    universal-property-pushout pr1 pr2 cocone-disjunction
+  up-join-disjunction : universal-property-pushout pr1 pr2 cocone-disjunction
   up-join-disjunction =
     up-pushout-up-pushout-is-equiv
       ( pr1)

--- a/src/synthetic-homotopy-theory/joins-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/joins-of-types.lagda.md
@@ -77,7 +77,7 @@ module _
   where
 
   up-join :
-    {l : Level} → universal-property-pushout l {A = A} {B} pr1 pr2 cocone-join
+    universal-property-pushout {A = A} {B} pr1 pr2 cocone-join
   up-join = up-pushout pr1 pr2
 
   equiv-up-join :
@@ -413,7 +413,7 @@ module _
   pr2 equiv-join-disjunction-Prop = is-equiv-map-join-disjunction-Prop
 
   up-join-disjunction :
-    {l : Level} → universal-property-pushout l pr1 pr2 cocone-disjunction
+    universal-property-pushout pr1 pr2 cocone-disjunction
   up-join-disjunction =
     up-pushout-up-pushout-is-equiv
       ( pr1)

--- a/src/synthetic-homotopy-theory/pullback-property-pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/pullback-property-pushouts.lagda.md
@@ -66,11 +66,11 @@ pr2 (pr2 (cone-pullback-property-pushout f g c Y)) =
     ( Y)
 
 pullback-property-pushout :
-  {l1 l2 l3 l4 : Level} (l : Level) {S : UU l1} {A : UU l2} {B : UU l3}
+  {l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3}
   (f : S → A) (g : S → B) {X : UU l4} (c : cocone f g X) →
-  UU (l1 ⊔ l2 ⊔ l3 ⊔ l4 ⊔ lsuc l)
-pullback-property-pushout l f g c =
-  (Y : UU l) →
+  UUω
+pullback-property-pushout f g c =
+  {l : Level} (Y : UU l) →
   is-pullback
     ( precomp f Y)
     ( precomp g Y)

--- a/src/synthetic-homotopy-theory/pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/pushouts.lagda.md
@@ -212,7 +212,7 @@ module _
       ( htpy-compute-dependent-cogap f g c)
 
   induction-principle-pushout' :
-    {l : Level} → induction-principle-pushout l f g (cocone-pushout f g)
+    induction-principle-pushout f g (cocone-pushout f g)
   induction-principle-pushout' P =
     ( dependent-cogap f g , is-section-dependent-cogap)
 

--- a/src/synthetic-homotopy-theory/pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/pushouts.lagda.md
@@ -297,9 +297,9 @@ module _
 
 ```agda
 up-pushout :
-  {l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3}
+  {l1 l2 l3 : Level} {S : UU l1} {A : UU l2} {B : UU l3}
   (f : S → A) (g : S → B) →
-  universal-property-pushout l4 f g (cocone-pushout f g)
+  universal-property-pushout f g (cocone-pushout f g)
 up-pushout f g P =
   is-equiv-is-invertible
     ( cogap f g)
@@ -432,7 +432,7 @@ module _
   where
 
   universal-property-pushout-is-pushout :
-    is-pushout f g c → {l : Level} → universal-property-pushout l f g c
+    is-pushout f g c → universal-property-pushout f g c
   universal-property-pushout-is-pushout po =
     up-pushout-up-pushout-is-equiv f g
       ( cocone-pushout f g)
@@ -446,7 +446,7 @@ module _
       ( up-pushout f g)
 
   is-pushout-universal-property-pushout :
-    ({l : Level} → universal-property-pushout l f g c) → is-pushout f g c
+    universal-property-pushout f g c → is-pushout f g c
   is-pushout-universal-property-pushout =
     is-equiv-up-pushout-up-pushout f g
       ( cocone-pushout f g)
@@ -545,7 +545,7 @@ square commute (almost) trivially.
         ( horizontal-map-span-cogap-fiber)
         ( vertical-map-span-cogap-fiber)
         ( fiber (cogap f g c) x))
-      ( universal-property-pushout l
+      ( universal-property-pushout-Level l
         ( horizontal-map-span-cogap-fiber)
         ( vertical-map-span-cogap-fiber))
 
@@ -633,7 +633,7 @@ fibers.
     universal-property-pushout-cogap-fiber-up-to-equiv :
       { l : Level} →
       ( Σ ( cocone u v (fiber (cogap f g c) x))
-          ( λ c → universal-property-pushout l u v c))
+          ( λ c → universal-property-pushout-Level l u v c))
     universal-property-pushout-cogap-fiber-up-to-equiv {l} =
       universal-property-pushout-extension-by-equivalences
         ( horizontal-map-span-cogap-fiber)
@@ -661,8 +661,8 @@ module _
   where
 
   universal-property-pushout-swap-cocone-universal-property-pushout :
-    {l : Level} → universal-property-pushout l f g c →
-    universal-property-pushout l g f (swap-cocone f g X c)
+    universal-property-pushout f g c →
+    universal-property-pushout g f (swap-cocone f g X c)
   universal-property-pushout-swap-cocone-universal-property-pushout up Y =
     is-equiv-equiv'
       ( id-equiv)

--- a/src/synthetic-homotopy-theory/pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/pushouts.lagda.md
@@ -232,19 +232,19 @@ module _
 
 ```agda
 module _
-  {l1 l2 l3 l : Level} {S : UU l1} {A : UU l2} {B : UU l3}
+  {l1 l2 l3 : Level} {S : UU l1} {A : UU l2} {B : UU l3}
   (f : S → A) (g : S → B)
   where
 
   dup-pushout :
-    dependent-universal-property-pushout l f g (cocone-pushout f g)
+    dependent-universal-property-pushout f g (cocone-pushout f g)
   dup-pushout =
     dependent-universal-property-pushout-induction-principle-pushout f g
       ( cocone-pushout f g)
       ( induction-principle-pushout' f g)
 
   equiv-dup-pushout :
-    (P : pushout f g → UU l) →
+    {l : Level} (P : pushout f g → UU l) →
     ((x : pushout f g) → P x) ≃ dependent-cocone f g (cocone-pushout f g) P
   pr1 (equiv-dup-pushout P) = dependent-cocone-map f g (cocone-pushout f g) P
   pr2 (equiv-dup-pushout P) = dup-pushout P

--- a/src/synthetic-homotopy-theory/sections-descent-circle.lagda.md
+++ b/src/synthetic-homotopy-theory/sections-descent-circle.lagda.md
@@ -233,7 +233,7 @@ module _
     is-equiv-map-equiv equiv-fixpoint-descent-data-circle-free-dependent-loop
 
   is-equiv-ev-fixpoint-descent-data-circle :
-    ( dependent-universal-property-circle l2 l) →
+    dependent-universal-property-circle l →
     is-equiv ev-fixpoint-descent-data-circle
   is-equiv-ev-fixpoint-descent-data-circle dup-circle =
     is-equiv-top-map-triangle
@@ -245,7 +245,7 @@ module _
       ( dup-circle (family-family-with-descent-data-circle A))
 
   equiv-ev-fixpoint-descent-data-circle :
-    ( dependent-universal-property-circle l2 l) →
+    dependent-universal-property-circle l →
     ( (x : S) → (family-family-with-descent-data-circle A) x) ≃
     ( fixpoint-descent-data-circle
       ( descent-data-family-with-descent-data-circle A))

--- a/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
+++ b/src/synthetic-homotopy-theory/suspensions-of-types.lagda.md
@@ -105,8 +105,8 @@ cogap-suspension' :
 cogap-suspension' {X = X} = cogap (terminal-map X) (terminal-map X)
 
 up-suspension' :
-  {l1 l2 : Level} (X : UU l1) →
-  universal-property-pushout l2
+  {l1 : Level} (X : UU l1) →
+  universal-property-pushout
     ( terminal-map X)
     ( terminal-map X)
     ( cocone-suspension X)

--- a/src/synthetic-homotopy-theory/universal-cover-circle.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-cover-circle.lagda.md
@@ -10,6 +10,7 @@ module synthetic-homotopy-theory.universal-cover-circle where
 
 ```agda
 open import elementary-number-theory.integers
+open import elementary-number-theory.nonzero-integers
 open import elementary-number-theory.universal-property-integers
 
 open import foundation.action-on-identifications-dependent-functions
@@ -27,6 +28,8 @@ open import foundation.functoriality-dependent-pair-types
 open import foundation.fundamental-theorem-of-identity-types
 open import foundation.homotopies
 open import foundation.identity-types
+open import foundation.injective-maps
+open import foundation.negation
 open import foundation.precomposition-dependent-functions
 open import foundation.raising-universe-levels
 open import foundation.sets
@@ -38,12 +41,13 @@ open import foundation.universe-levels
 
 open import synthetic-homotopy-theory.descent-circle
 open import synthetic-homotopy-theory.free-loops
+open import synthetic-homotopy-theory.loop-spaces
 open import synthetic-homotopy-theory.universal-property-circle
 ```
 
 </details>
 
-### 12.2 The fundamental cover of the circle
+### 12.2 The universal cover of the circle
 
 We show that if a type with a free loop satisfies the induction principle of the
 circle with respect to any universe level, then it satisfies the induction
@@ -108,66 +112,73 @@ abstract
             ( f x p₀)))
 ```
 
-### The fundamental cover
+### The universal cover
 
 ```agda
 module _
   { l1 : Level} {S : UU l1} (l : free-loop S)
   where
 
-  descent-data-Fundamental-cover-circle :
-    descent-data-circle lzero
-  pr1 descent-data-Fundamental-cover-circle = ℤ
-  pr2 descent-data-Fundamental-cover-circle = equiv-succ-ℤ
+  descent-data-universal-cover-circle : descent-data-circle lzero
+  pr1 descent-data-universal-cover-circle = ℤ
+  pr2 descent-data-universal-cover-circle = equiv-succ-ℤ
 
   module _
     ( dup-circle : dependent-universal-property-circle l)
     where
 
     abstract
-      Fundamental-cover-circle : family-with-descent-data-circle l lzero
-      Fundamental-cover-circle =
+      universal-cover-family-with-descent-data-circle :
+        family-with-descent-data-circle l lzero
+      universal-cover-family-with-descent-data-circle =
         family-with-descent-data-circle-descent-data l
           ( universal-property-dependent-universal-property-circle l dup-circle)
-          ( descent-data-Fundamental-cover-circle)
+          ( descent-data-universal-cover-circle)
 
-      fundamental-cover-circle : S → UU lzero
-      fundamental-cover-circle =
-        family-family-with-descent-data-circle Fundamental-cover-circle
+      universal-cover-circle : S → UU lzero
+      universal-cover-circle =
+        family-family-with-descent-data-circle
+          universal-cover-family-with-descent-data-circle
 
-      compute-fiber-fundamental-cover-circle :
-        ℤ ≃ fundamental-cover-circle (base-free-loop l)
-      compute-fiber-fundamental-cover-circle =
-        equiv-family-with-descent-data-circle Fundamental-cover-circle
+      compute-fiber-universal-cover-circle :
+        ℤ ≃ universal-cover-circle (base-free-loop l)
+      compute-fiber-universal-cover-circle =
+        equiv-family-with-descent-data-circle
+          universal-cover-family-with-descent-data-circle
 
-      compute-tr-fundamental-cover-circle :
+      compute-tr-universal-cover-circle :
         coherence-square-maps
-          ( map-equiv compute-fiber-fundamental-cover-circle)
+          ( map-equiv compute-fiber-universal-cover-circle)
           ( succ-ℤ)
-          ( tr fundamental-cover-circle (loop-free-loop l))
-          ( map-equiv compute-fiber-fundamental-cover-circle)
-      compute-tr-fundamental-cover-circle =
+          ( tr universal-cover-circle (loop-free-loop l))
+          ( map-equiv compute-fiber-universal-cover-circle)
+      compute-tr-universal-cover-circle =
         coherence-square-family-with-descent-data-circle
-          Fundamental-cover-circle
+          universal-cover-family-with-descent-data-circle
+
+    map-compute-fiber-universal-cover-circle :
+      ℤ → universal-cover-circle (base-free-loop l)
+    map-compute-fiber-universal-cover-circle =
+      map-equiv compute-fiber-universal-cover-circle
 ```
 
-### The fundamental cover of the circle is a family of sets
+### The universal cover of the circle is a family of sets
 
 ```agda
 abstract
-  is-set-fundamental-cover-circle :
+  is-set-universal-cover-circle :
     { l1 : Level} {X : UU l1} (l : free-loop X) →
     ( dup-circle : dependent-universal-property-circle l) →
-    ( x : X) → is-set (fundamental-cover-circle l dup-circle x)
-  is-set-fundamental-cover-circle l dup-circle =
+    ( x : X) → is-set (universal-cover-circle l dup-circle x)
+  is-set-universal-cover-circle l dup-circle =
     is-connected-circle' l
       ( dup-circle)
-      ( λ x → is-set (fundamental-cover-circle l dup-circle x))
-      ( λ x → is-prop-is-set (fundamental-cover-circle l dup-circle x))
+      ( λ x → is-set (universal-cover-circle l dup-circle x))
+      ( λ x → is-prop-is-set (universal-cover-circle l dup-circle x))
       ( is-trunc-is-equiv' zero-𝕋 ℤ
-        ( map-equiv (compute-fiber-fundamental-cover-circle l dup-circle))
+        ( map-equiv (compute-fiber-universal-cover-circle l dup-circle))
         ( is-equiv-map-equiv
-          ( compute-fiber-fundamental-cover-circle l dup-circle))
+          ( compute-fiber-universal-cover-circle l dup-circle))
         ( is-set-ℤ))
 ```
 
@@ -360,240 +371,264 @@ equiv-dependent-identification-contraction-total-space'
 ```
 
 We use the above construction to provide sufficient conditions for the total
-space of the fundamental cover to be contractible.
+space of the universal cover to be contractible.
 
 ```agda
-center-total-fundamental-cover-circle :
+center-total-universal-cover-circle :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
   ( dup-circle : dependent-universal-property-circle l) →
-  Σ X (fundamental-cover-circle l dup-circle)
-pr1 (center-total-fundamental-cover-circle l dup-circle) = base-free-loop l
-pr2 (center-total-fundamental-cover-circle l dup-circle) =
-  map-equiv ( compute-fiber-fundamental-cover-circle l dup-circle) zero-ℤ
+  Σ X (universal-cover-circle l dup-circle)
+pr1 (center-total-universal-cover-circle l dup-circle) = base-free-loop l
+pr2 (center-total-universal-cover-circle l dup-circle) =
+  map-equiv ( compute-fiber-universal-cover-circle l dup-circle) zero-ℤ
 
-dependent-identification-loop-contraction-total-fundamental-cover-circle :
+dependent-identification-loop-contraction-total-universal-cover-circle :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
   ( dup-circle : dependent-universal-property-circle l) →
   ( h :
     contraction-total-space'
-      ( center-total-fundamental-cover-circle l dup-circle)
+      ( center-total-universal-cover-circle l dup-circle)
       ( base-free-loop l)
-      ( compute-fiber-fundamental-cover-circle l dup-circle)) →
+      ( compute-fiber-universal-cover-circle l dup-circle)) →
   ( p :
     dependent-identification-contraction-total-space'
-      ( center-total-fundamental-cover-circle l dup-circle)
+      ( center-total-universal-cover-circle l dup-circle)
       ( loop-free-loop l)
       ( equiv-succ-ℤ)
-      ( compute-fiber-fundamental-cover-circle l dup-circle)
-      ( compute-fiber-fundamental-cover-circle l dup-circle)
-      ( compute-tr-fundamental-cover-circle l dup-circle)
+      ( compute-fiber-universal-cover-circle l dup-circle)
+      ( compute-fiber-universal-cover-circle l dup-circle)
+      ( compute-tr-universal-cover-circle l dup-circle)
       ( h)
       ( h)) →
   dependent-identification
     ( contraction-total-space
-      ( center-total-fundamental-cover-circle l dup-circle))
+      ( center-total-universal-cover-circle l dup-circle))
     ( pr2 l)
     ( map-inv-equiv
       ( equiv-contraction-total-space
-        ( center-total-fundamental-cover-circle l dup-circle)
+        ( center-total-universal-cover-circle l dup-circle)
         ( base-free-loop l)
-        ( compute-fiber-fundamental-cover-circle l dup-circle))
+        ( compute-fiber-universal-cover-circle l dup-circle))
       ( h))
     ( map-inv-equiv
       ( equiv-contraction-total-space
-        ( center-total-fundamental-cover-circle l dup-circle)
+        ( center-total-universal-cover-circle l dup-circle)
         ( base-free-loop l)
-        ( compute-fiber-fundamental-cover-circle l dup-circle))
+        ( compute-fiber-universal-cover-circle l dup-circle))
       ( h))
-dependent-identification-loop-contraction-total-fundamental-cover-circle
+dependent-identification-loop-contraction-total-universal-cover-circle
   l dup-circle h p =
   map-dependent-identification-contraction-total-space'
-    ( center-total-fundamental-cover-circle l dup-circle)
+    ( center-total-universal-cover-circle l dup-circle)
     ( loop-free-loop l)
     ( equiv-succ-ℤ)
-    ( compute-fiber-fundamental-cover-circle l dup-circle)
-    ( compute-fiber-fundamental-cover-circle l dup-circle)
-    ( compute-tr-fundamental-cover-circle l dup-circle)
+    ( compute-fiber-universal-cover-circle l dup-circle)
+    ( compute-fiber-universal-cover-circle l dup-circle)
+    ( compute-tr-universal-cover-circle l dup-circle)
     ( h)
     ( h)
     ( p)
 
-contraction-total-fundamental-cover-circle-data :
+contraction-total-universal-cover-circle-data :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
   ( dup-circle : dependent-universal-property-circle l) →
   ( h :
     contraction-total-space'
-      ( center-total-fundamental-cover-circle l dup-circle)
+      ( center-total-universal-cover-circle l dup-circle)
       ( base-free-loop l)
-      ( compute-fiber-fundamental-cover-circle l dup-circle)) →
+      ( compute-fiber-universal-cover-circle l dup-circle)) →
   ( p :
     dependent-identification-contraction-total-space'
-      ( center-total-fundamental-cover-circle l dup-circle)
+      ( center-total-universal-cover-circle l dup-circle)
       ( loop-free-loop l)
       ( equiv-succ-ℤ)
-      ( compute-fiber-fundamental-cover-circle l dup-circle)
-      ( compute-fiber-fundamental-cover-circle l dup-circle)
-      ( compute-tr-fundamental-cover-circle l dup-circle)
+      ( compute-fiber-universal-cover-circle l dup-circle)
+      ( compute-fiber-universal-cover-circle l dup-circle)
+      ( compute-tr-universal-cover-circle l dup-circle)
       ( h)
       ( h)) →
-  ( t : Σ X (fundamental-cover-circle l dup-circle)) →
-  Id (center-total-fundamental-cover-circle l dup-circle) t
-contraction-total-fundamental-cover-circle-data
+  ( t : Σ X (universal-cover-circle l dup-circle)) →
+  Id (center-total-universal-cover-circle l dup-circle) t
+contraction-total-universal-cover-circle-data
   {l1} l dup-circle h p (pair x y) =
   map-inv-is-equiv
     ( dup-circle
       ( contraction-total-space
-        ( center-total-fundamental-cover-circle l dup-circle)))
+        ( center-total-universal-cover-circle l dup-circle)))
     ( pair
       ( map-inv-equiv
         ( equiv-contraction-total-space
-          ( center-total-fundamental-cover-circle l dup-circle)
+          ( center-total-universal-cover-circle l dup-circle)
           ( base-free-loop l)
-          ( compute-fiber-fundamental-cover-circle l dup-circle))
+          ( compute-fiber-universal-cover-circle l dup-circle))
         ( h))
-      ( dependent-identification-loop-contraction-total-fundamental-cover-circle
+      ( dependent-identification-loop-contraction-total-universal-cover-circle
         l dup-circle h p))
     x y
 
-is-torsorial-fundamental-cover-circle-data :
+is-torsorial-universal-cover-circle-data :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
   ( dup-circle : dependent-universal-property-circle l) →
   ( h :
     contraction-total-space'
-      ( center-total-fundamental-cover-circle l dup-circle)
+      ( center-total-universal-cover-circle l dup-circle)
       ( base-free-loop l)
-      ( compute-fiber-fundamental-cover-circle l dup-circle)) →
+      ( compute-fiber-universal-cover-circle l dup-circle)) →
   ( p :
     dependent-identification-contraction-total-space'
-      ( center-total-fundamental-cover-circle l dup-circle)
+      ( center-total-universal-cover-circle l dup-circle)
       ( loop-free-loop l)
       ( equiv-succ-ℤ)
-      ( compute-fiber-fundamental-cover-circle l dup-circle)
-      ( compute-fiber-fundamental-cover-circle l dup-circle)
-      ( compute-tr-fundamental-cover-circle l dup-circle)
+      ( compute-fiber-universal-cover-circle l dup-circle)
+      ( compute-fiber-universal-cover-circle l dup-circle)
+      ( compute-tr-universal-cover-circle l dup-circle)
       ( h)
       ( h)) →
-  is-torsorial (fundamental-cover-circle l dup-circle)
-pr1 (is-torsorial-fundamental-cover-circle-data l dup-circle h p) =
-  center-total-fundamental-cover-circle l dup-circle
-pr2 (is-torsorial-fundamental-cover-circle-data l dup-circle h p) =
-  contraction-total-fundamental-cover-circle-data l dup-circle h p
+  is-torsorial (universal-cover-circle l dup-circle)
+pr1 (is-torsorial-universal-cover-circle-data l dup-circle h p) =
+  center-total-universal-cover-circle l dup-circle
+pr2 (is-torsorial-universal-cover-circle-data l dup-circle h p) =
+  contraction-total-universal-cover-circle-data l dup-circle h p
 ```
 
 ### Section 12.5 The identity type of the circle
 
 ```agda
-path-total-fundamental-cover-circle :
+path-total-universal-cover-circle :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
   ( dup-circle : dependent-universal-property-circle l)
   ( k : ℤ) →
   Id
-    { A = Σ X (fundamental-cover-circle l dup-circle)}
+    { A = Σ X (universal-cover-circle l dup-circle)}
     ( pair
       ( base-free-loop l)
-      ( map-equiv (compute-fiber-fundamental-cover-circle l dup-circle) k))
+      ( map-equiv (compute-fiber-universal-cover-circle l dup-circle) k))
     ( pair
       ( base-free-loop l)
       ( map-equiv
-        ( compute-fiber-fundamental-cover-circle l dup-circle)
+        ( compute-fiber-universal-cover-circle l dup-circle)
         ( succ-ℤ k)))
-path-total-fundamental-cover-circle l dup-circle k =
+path-total-universal-cover-circle l dup-circle k =
   segment-Σ
     ( loop-free-loop l)
     ( equiv-succ-ℤ)
-    ( compute-fiber-fundamental-cover-circle l dup-circle)
-    ( compute-fiber-fundamental-cover-circle l dup-circle)
-    ( compute-tr-fundamental-cover-circle l dup-circle)
+    ( compute-fiber-universal-cover-circle l dup-circle)
+    ( compute-fiber-universal-cover-circle l dup-circle)
+    ( compute-tr-universal-cover-circle l dup-circle)
     k
 
-CONTRACTION-fundamental-cover-circle :
+CONTRACTION-universal-cover-circle :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
   ( dup-circle : dependent-universal-property-circle l) →
   UU l1
-CONTRACTION-fundamental-cover-circle l dup-circle =
+CONTRACTION-universal-cover-circle l dup-circle =
   ELIM-ℤ
     ( λ k →
       Id
-        ( center-total-fundamental-cover-circle l dup-circle)
+        ( center-total-universal-cover-circle l dup-circle)
         ( pair
           ( base-free-loop l)
           ( map-equiv
-            ( compute-fiber-fundamental-cover-circle l dup-circle)
+            ( compute-fiber-universal-cover-circle l dup-circle)
             ( k))))
     ( refl)
     ( λ k → equiv-concat'
-      ( center-total-fundamental-cover-circle l dup-circle)
-      ( path-total-fundamental-cover-circle l dup-circle k))
+      ( center-total-universal-cover-circle l dup-circle)
+      ( path-total-universal-cover-circle l dup-circle k))
 
-Contraction-fundamental-cover-circle :
+Contraction-universal-cover-circle :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
   ( dup-circle : dependent-universal-property-circle l) →
-  CONTRACTION-fundamental-cover-circle l dup-circle
-Contraction-fundamental-cover-circle l dup-circle =
+  CONTRACTION-universal-cover-circle l dup-circle
+Contraction-universal-cover-circle l dup-circle =
   Elim-ℤ
     ( λ k →
       Id
-        ( center-total-fundamental-cover-circle l dup-circle)
+        ( center-total-universal-cover-circle l dup-circle)
         ( pair
           ( base-free-loop l)
           ( map-equiv
-            ( compute-fiber-fundamental-cover-circle l dup-circle)
+            ( compute-fiber-universal-cover-circle l dup-circle)
             ( k))))
     ( refl)
     ( λ k → equiv-concat'
-      ( center-total-fundamental-cover-circle l dup-circle)
-      ( path-total-fundamental-cover-circle l dup-circle k))
+      ( center-total-universal-cover-circle l dup-circle)
+      ( path-total-universal-cover-circle l dup-circle k))
 
 abstract
-  is-torsorial-fundamental-cover-circle :
+  is-torsorial-universal-cover-circle :
     { l1 : Level} {X : UU l1} (l : free-loop X) →
     ( dup-circle : dependent-universal-property-circle l) →
-    is-torsorial (fundamental-cover-circle l dup-circle)
-  is-torsorial-fundamental-cover-circle l dup-circle =
-    is-torsorial-fundamental-cover-circle-data l dup-circle
-      ( pr1 (Contraction-fundamental-cover-circle l dup-circle))
+    is-torsorial (universal-cover-circle l dup-circle)
+  is-torsorial-universal-cover-circle l dup-circle =
+    is-torsorial-universal-cover-circle-data l dup-circle
+      ( pr1 (Contraction-universal-cover-circle l dup-circle))
       ( inv-htpy
-        ( pr2 (pr2 (Contraction-fundamental-cover-circle l dup-circle))))
+        ( pr2 (pr2 (Contraction-universal-cover-circle l dup-circle))))
 
-point-fundamental-cover-circle :
+point-universal-cover-circle :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
   ( dup-circle : dependent-universal-property-circle l) →
-  fundamental-cover-circle l dup-circle (base-free-loop l)
-point-fundamental-cover-circle l dup-circle =
-  map-equiv (compute-fiber-fundamental-cover-circle l dup-circle) zero-ℤ
+  universal-cover-circle l dup-circle (base-free-loop l)
+point-universal-cover-circle l dup-circle =
+  map-equiv (compute-fiber-universal-cover-circle l dup-circle) zero-ℤ
 
-fundamental-cover-circle-eq :
+universal-cover-circle-eq :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
   ( dup-circle : dependent-universal-property-circle l) →
-  ( x : X) → Id (base-free-loop l) x → fundamental-cover-circle l dup-circle x
-fundamental-cover-circle-eq l dup-circle .(base-free-loop l) refl =
-  point-fundamental-cover-circle l dup-circle
+  ( x : X) → Id (base-free-loop l) x → universal-cover-circle l dup-circle x
+universal-cover-circle-eq l dup-circle .(base-free-loop l) refl =
+  point-universal-cover-circle l dup-circle
 
 abstract
-  is-equiv-fundamental-cover-circle-eq :
+  is-equiv-universal-cover-circle-eq :
     { l1 : Level} {X : UU l1} (l : free-loop X) →
     ( dup-circle : dependent-universal-property-circle l) →
-    ( x : X) → is-equiv (fundamental-cover-circle-eq l dup-circle x)
-  is-equiv-fundamental-cover-circle-eq l dup-circle =
+    ( x : X) → is-equiv (universal-cover-circle-eq l dup-circle x)
+  is-equiv-universal-cover-circle-eq l dup-circle =
     fundamental-theorem-id
-      ( is-torsorial-fundamental-cover-circle l dup-circle)
-      ( fundamental-cover-circle-eq l dup-circle)
+      ( is-torsorial-universal-cover-circle l dup-circle)
+      ( universal-cover-circle-eq l dup-circle)
 
-equiv-fundamental-cover-circle :
+equiv-universal-cover-circle :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
   ( dup-circle : dependent-universal-property-circle l) →
   ( x : X) →
-  ( Id (base-free-loop l) x) ≃ (fundamental-cover-circle l dup-circle x)
-equiv-fundamental-cover-circle l dup-circle x =
+  ( Id (base-free-loop l) x) ≃ (universal-cover-circle l dup-circle x)
+equiv-universal-cover-circle l dup-circle x =
   pair
-    ( fundamental-cover-circle-eq l dup-circle x)
-    ( is-equiv-fundamental-cover-circle-eq l dup-circle x)
+    ( universal-cover-circle-eq l dup-circle x)
+    ( is-equiv-universal-cover-circle-eq l dup-circle x)
 
 compute-loop-space-circle :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
   ( dup-circle : dependent-universal-property-circle l) →
-  ( Id (base-free-loop l) (base-free-loop l)) ≃ ℤ
+  type-Ω (X , base-free-loop l) ≃ ℤ
 compute-loop-space-circle l dup-circle =
-  ( inv-equiv (compute-fiber-fundamental-cover-circle l dup-circle)) ∘e
-  ( equiv-fundamental-cover-circle l dup-circle (base-free-loop l))
+  ( inv-equiv (compute-fiber-universal-cover-circle l dup-circle)) ∘e
+  ( equiv-universal-cover-circle l dup-circle (base-free-loop l))
+```
+
+### The loop of the circle is nontrivial
+
+```agda
+module _
+  {l1 : Level} {X : UU l1} (l : free-loop X)
+  (H : dependent-universal-property-circle l)
+  where
+
+  is-nontrivial-loop-dependent-universal-property-circle :
+    ¬ (loop-free-loop l ＝ refl)
+  is-nontrivial-loop-dependent-universal-property-circle p =
+    is-nonzero-one-ℤ
+      ( is-injective-equiv
+        ( compute-fiber-universal-cover-circle l H)
+        ( ( compute-tr-universal-cover-circle l H zero-ℤ) ∙
+          ( ap
+            ( λ q →
+              tr
+                ( universal-cover-circle l H)
+                ( q)
+                ( map-compute-fiber-universal-cover-circle l H zero-ℤ))
+            ( p))))
 ```

--- a/src/synthetic-homotopy-theory/universal-cover-circle.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-cover-circle.lagda.md
@@ -106,31 +106,6 @@ abstract
           ( is-equiv-concat
             ( inv (preserves-tr f l p₀))
             ( f x p₀)))
-
-abstract
-  lower-dependent-universal-property-circle :
-    { l1 l2 : Level} (l3 : Level) {X : UU l1} (l : free-loop X) →
-    dependent-universal-property-circle (l2 ⊔ l3) l →
-    dependent-universal-property-circle l3 l
-  lower-dependent-universal-property-circle {l1} {l2} l3 l dup-circle P =
-    is-equiv-left-is-equiv-right-square
-      ( ev-free-loop-Π l P)
-      ( ev-free-loop-Π l (λ x → raise l2 (P x)))
-      ( map-Π (λ x → map-raise))
-      ( functor-free-dependent-loop l (λ x → map-raise))
-      ( square-functor-free-dependent-loop l (λ x → map-raise))
-      ( is-equiv-map-Π-is-fiberwise-equiv (λ x → is-equiv-map-raise))
-      ( is-equiv-functor-free-dependent-loop-is-fiberwise-equiv l
-        ( λ x → is-equiv-map-raise))
-      ( dup-circle (λ x → raise l2 (P x)))
-
-abstract
-  lower-lzero-dependent-universal-property-circle :
-    { l1 l2 : Level} {X : UU l1} (l : free-loop X) →
-    dependent-universal-property-circle l2 l →
-    dependent-universal-property-circle lzero l
-  lower-lzero-dependent-universal-property-circle =
-    lower-dependent-universal-property-circle lzero
 ```
 
 ### The fundamental cover
@@ -146,11 +121,10 @@ module _
   pr2 descent-data-Fundamental-cover-circle = equiv-succ-ℤ
 
   module _
-    ( dup-circle : {l2 : Level} → dependent-universal-property-circle l2 l)
+    ( dup-circle : dependent-universal-property-circle l)
     where
 
     abstract
-
       Fundamental-cover-circle : family-with-descent-data-circle l lzero
       Fundamental-cover-circle =
         family-with-descent-data-circle-descent-data l
@@ -183,7 +157,7 @@ module _
 abstract
   is-set-fundamental-cover-circle :
     { l1 : Level} {X : UU l1} (l : free-loop X) →
-    ( dup-circle : {l2 : Level} → dependent-universal-property-circle l2 l) →
+    ( dup-circle : dependent-universal-property-circle l) →
     ( x : X) → is-set (fundamental-cover-circle l dup-circle x)
   is-set-fundamental-cover-circle l dup-circle =
     is-connected-circle' l
@@ -391,7 +365,7 @@ space of the fundamental cover to be contractible.
 ```agda
 center-total-fundamental-cover-circle :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
-  ( dup-circle : {l2 : Level} → dependent-universal-property-circle l2 l) →
+  ( dup-circle : dependent-universal-property-circle l) →
   Σ X (fundamental-cover-circle l dup-circle)
 pr1 (center-total-fundamental-cover-circle l dup-circle) = base-free-loop l
 pr2 (center-total-fundamental-cover-circle l dup-circle) =
@@ -399,7 +373,7 @@ pr2 (center-total-fundamental-cover-circle l dup-circle) =
 
 dependent-identification-loop-contraction-total-fundamental-cover-circle :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
-  ( dup-circle : {l2 : Level} → dependent-universal-property-circle l2 l) →
+  ( dup-circle : dependent-universal-property-circle l) →
   ( h :
     contraction-total-space'
       ( center-total-fundamental-cover-circle l dup-circle)
@@ -446,7 +420,7 @@ dependent-identification-loop-contraction-total-fundamental-cover-circle
 
 contraction-total-fundamental-cover-circle-data :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
-  ( dup-circle : {l2 : Level} → dependent-universal-property-circle l2 l) →
+  ( dup-circle : dependent-universal-property-circle l) →
   ( h :
     contraction-total-space'
       ( center-total-fundamental-cover-circle l dup-circle)
@@ -467,8 +441,7 @@ contraction-total-fundamental-cover-circle-data :
 contraction-total-fundamental-cover-circle-data
   {l1} l dup-circle h p (pair x y) =
   map-inv-is-equiv
-    ( lower-dependent-universal-property-circle
-      { l2 = lsuc lzero} l1 l dup-circle
+    ( dup-circle
       ( contraction-total-space
         ( center-total-fundamental-cover-circle l dup-circle)))
     ( pair
@@ -484,7 +457,7 @@ contraction-total-fundamental-cover-circle-data
 
 is-torsorial-fundamental-cover-circle-data :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
-  ( dup-circle : {l2 : Level} → dependent-universal-property-circle l2 l) →
+  ( dup-circle : dependent-universal-property-circle l) →
   ( h :
     contraction-total-space'
       ( center-total-fundamental-cover-circle l dup-circle)
@@ -512,7 +485,7 @@ pr2 (is-torsorial-fundamental-cover-circle-data l dup-circle h p) =
 ```agda
 path-total-fundamental-cover-circle :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
-  ( dup-circle : {l2 : Level} → dependent-universal-property-circle l2 l)
+  ( dup-circle : dependent-universal-property-circle l)
   ( k : ℤ) →
   Id
     { A = Σ X (fundamental-cover-circle l dup-circle)}
@@ -535,7 +508,7 @@ path-total-fundamental-cover-circle l dup-circle k =
 
 CONTRACTION-fundamental-cover-circle :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
-  ( dup-circle : {l2 : Level} → dependent-universal-property-circle l2 l) →
+  ( dup-circle : dependent-universal-property-circle l) →
   UU l1
 CONTRACTION-fundamental-cover-circle l dup-circle =
   ELIM-ℤ
@@ -554,7 +527,7 @@ CONTRACTION-fundamental-cover-circle l dup-circle =
 
 Contraction-fundamental-cover-circle :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
-  ( dup-circle : {l2 : Level} → dependent-universal-property-circle l2 l) →
+  ( dup-circle : dependent-universal-property-circle l) →
   CONTRACTION-fundamental-cover-circle l dup-circle
 Contraction-fundamental-cover-circle l dup-circle =
   Elim-ℤ
@@ -574,7 +547,7 @@ Contraction-fundamental-cover-circle l dup-circle =
 abstract
   is-torsorial-fundamental-cover-circle :
     { l1 : Level} {X : UU l1} (l : free-loop X) →
-    ( dup-circle : {l2 : Level} → dependent-universal-property-circle l2 l) →
+    ( dup-circle : dependent-universal-property-circle l) →
     is-torsorial (fundamental-cover-circle l dup-circle)
   is-torsorial-fundamental-cover-circle l dup-circle =
     is-torsorial-fundamental-cover-circle-data l dup-circle
@@ -584,14 +557,14 @@ abstract
 
 point-fundamental-cover-circle :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
-  ( dup-circle : {l2 : Level} → dependent-universal-property-circle l2 l) →
+  ( dup-circle : dependent-universal-property-circle l) →
   fundamental-cover-circle l dup-circle (base-free-loop l)
 point-fundamental-cover-circle l dup-circle =
   map-equiv (compute-fiber-fundamental-cover-circle l dup-circle) zero-ℤ
 
 fundamental-cover-circle-eq :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
-  ( dup-circle : {l2 : Level} → dependent-universal-property-circle l2 l) →
+  ( dup-circle : dependent-universal-property-circle l) →
   ( x : X) → Id (base-free-loop l) x → fundamental-cover-circle l dup-circle x
 fundamental-cover-circle-eq l dup-circle .(base-free-loop l) refl =
   point-fundamental-cover-circle l dup-circle
@@ -599,7 +572,7 @@ fundamental-cover-circle-eq l dup-circle .(base-free-loop l) refl =
 abstract
   is-equiv-fundamental-cover-circle-eq :
     { l1 : Level} {X : UU l1} (l : free-loop X) →
-    ( dup-circle : {l2 : Level} → dependent-universal-property-circle l2 l) →
+    ( dup-circle : dependent-universal-property-circle l) →
     ( x : X) → is-equiv (fundamental-cover-circle-eq l dup-circle x)
   is-equiv-fundamental-cover-circle-eq l dup-circle =
     fundamental-theorem-id
@@ -608,7 +581,7 @@ abstract
 
 equiv-fundamental-cover-circle :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
-  ( dup-circle : {l2 : Level} → dependent-universal-property-circle l2 l) →
+  ( dup-circle : dependent-universal-property-circle l) →
   ( x : X) →
   ( Id (base-free-loop l) x) ≃ (fundamental-cover-circle l dup-circle x)
 equiv-fundamental-cover-circle l dup-circle x =
@@ -618,7 +591,7 @@ equiv-fundamental-cover-circle l dup-circle x =
 
 compute-loop-space-circle :
   { l1 : Level} {X : UU l1} (l : free-loop X) →
-  ( dup-circle : {l2 : Level} → dependent-universal-property-circle l2 l) →
+  ( dup-circle : dependent-universal-property-circle l) →
   ( Id (base-free-loop l) (base-free-loop l)) ≃ ℤ
 compute-loop-space-circle l dup-circle =
   ( inv-equiv (compute-fiber-fundamental-cover-circle l dup-circle)) ∘e

--- a/src/synthetic-homotopy-theory/universal-property-circle.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-circle.lagda.md
@@ -48,11 +48,12 @@ module _
 
 ```agda
 module _
-  {l1 : Level} (l2 : Level) {X : UU l1} (α : free-loop X)
+  {l1 : Level} {X : UU l1} (α : free-loop X)
   where
 
-  universal-property-circle : UU (l1 ⊔ lsuc l2)
-  universal-property-circle = (Y : UU l2) → is-equiv (ev-free-loop α Y)
+  universal-property-circle : UUω
+  universal-property-circle =
+    {l : Level} (Y : UU l) → is-equiv (ev-free-loop α Y)
 ```
 
 ### Evaluating a dependent function at a free loop
@@ -71,15 +72,16 @@ module _
 
 ```agda
 module _
-  {l1 : Level} (l2 : Level) {X : UU l1} (α : free-loop X)
+  {l1 : Level} {X : UU l1} (α : free-loop X)
   where
 
-  induction-principle-circle : UU (lsuc l2 ⊔ l1)
-  induction-principle-circle = (P : X → UU l2) → section (ev-free-loop-Π α P)
+  induction-principle-circle : UUω
+  induction-principle-circle =
+    {l2 : Level} (P : X → UU l2) → section (ev-free-loop-Π α P)
 
 module _
   {l1 l2 : Level} {X : UU l1} (α : free-loop X)
-  (H : {l : Level} → induction-principle-circle l α) (P : X → UU l2)
+  (H : induction-principle-circle α) (P : X → UU l2)
   (β : free-dependent-loop α P)
   where
 
@@ -95,12 +97,12 @@ module _
 
 ```agda
 module _
-  {l1 : Level} (l2 : Level) {X : UU l1} (α : free-loop X)
+  {l1 : Level} {X : UU l1} (α : free-loop X)
   where
 
-  dependent-universal-property-circle : UU (lsuc l2 ⊔ l1)
+  dependent-universal-property-circle : UUω
   dependent-universal-property-circle =
-    (P : X → UU l2) → is-equiv (ev-free-loop-Π α P)
+    {l2 : Level} (P : X → UU l2) → is-equiv (ev-free-loop-Π α P)
 ```
 
 ## Properties
@@ -127,7 +129,7 @@ module _
     map-compute-dependent-identification-eq-value f g (loop-free-loop α) p p q
 
   is-retraction-ind-circle :
-    ( ind-circle : {l : Level} → induction-principle-circle l α)
+    ( ind-circle : induction-principle-circle α)
     { l2 : Level} (P : X → UU l2) →
     ( ( function-induction-principle-circle α ind-circle P) ∘
       ( ev-free-loop-Π α P)) ~
@@ -146,8 +148,8 @@ module _
 
   abstract
     dependent-universal-property-induction-principle-circle :
-      ({l : Level} → induction-principle-circle l α) →
-      ({l : Level} → dependent-universal-property-circle l α)
+      induction-principle-circle α →
+      dependent-universal-property-circle α
     dependent-universal-property-induction-principle-circle ind-circle P =
       is-equiv-is-invertible
         ( function-induction-principle-circle α ind-circle P)
@@ -164,7 +166,7 @@ module _
 
   abstract
     uniqueness-universal-property-circle :
-      ({l : Level} → universal-property-circle l α) →
+      universal-property-circle α →
       {l2 : Level} (Y : UU l2) (α' : free-loop Y) →
       is-contr (Σ (X → Y) (λ f → Eq-free-loop (ev-free-loop α Y f) α'))
     uniqueness-universal-property-circle up-circle Y α' =
@@ -184,7 +186,7 @@ module _
   where
 
   uniqueness-dependent-universal-property-circle :
-    ({l : Level} → dependent-universal-property-circle l α) →
+    dependent-universal-property-circle α →
     {l2 : Level} {P : X → UU l2} (k : free-dependent-loop α P) →
     is-contr
       ( Σ ( (x : X) → P x)
@@ -223,8 +225,8 @@ module _
 
   abstract
     universal-property-dependent-universal-property-circle :
-      ({l : Level} → dependent-universal-property-circle l α) →
-      ({l : Level} → universal-property-circle l α)
+      dependent-universal-property-circle α →
+      universal-property-circle α
     universal-property-dependent-universal-property-circle dup-circle Y =
       is-equiv-top-map-triangle
         ( ev-free-loop-Π α (λ x → Y))
@@ -244,8 +246,8 @@ module _
 
   abstract
     universal-property-induction-principle-circle :
-      ({l : Level} → induction-principle-circle l α) →
-      ({l : Level} → universal-property-circle l α)
+      induction-principle-circle α →
+      universal-property-circle α
     universal-property-induction-principle-circle X =
       universal-property-dependent-universal-property-circle α
         ( dependent-universal-property-induction-principle-circle α X)
@@ -257,7 +259,7 @@ module _
 abstract
   is-connected-circle' :
     { l1 l2 : Level} {X : UU l1} (l : free-loop X) →
-    ( dup-circle : dependent-universal-property-circle l2 l)
+    ( dup-circle : dependent-universal-property-circle l)
     ( P : X → UU l2) (is-prop-P : (x : X) → is-prop (P x)) →
     P (base-free-loop l) → (x : X) → P x
   is-connected-circle' l dup-circle P is-prop-P p =

--- a/src/synthetic-homotopy-theory/universal-property-coequalizers.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-coequalizers.lagda.md
@@ -118,11 +118,10 @@ module _
   where
 
   universal-property-coequalizer-universal-property-pushout :
-    ({l : Level} →
-      universal-property-pushout l
-        ( vertical-map-span-cocone-cofork a)
-        ( horizontal-map-span-cocone-cofork a)
-        ( cocone-codiagonal-cofork a e)) →
+    universal-property-pushout
+      ( vertical-map-span-cocone-cofork a)
+      ( horizontal-map-span-cocone-cofork a)
+      ( cocone-codiagonal-cofork a e) →
     ({l : Level} →
       universal-property-coequalizer l a e)
   universal-property-coequalizer-universal-property-pushout up-pushout Y =
@@ -140,11 +139,10 @@ module _
   universal-property-pushout-universal-property-coequalizer :
     ({l : Level} →
       universal-property-coequalizer l a e) →
-    ({l : Level} →
-      universal-property-pushout l
-        ( vertical-map-span-cocone-cofork a)
-        ( horizontal-map-span-cocone-cofork a)
-        ( cocone-codiagonal-cofork a e))
+    universal-property-pushout
+      ( vertical-map-span-cocone-cofork a)
+      ( horizontal-map-span-cocone-cofork a)
+      ( cocone-codiagonal-cofork a e)
   universal-property-pushout-universal-property-coequalizer up-coequalizer Y =
     is-equiv-top-map-triangle
       ( cofork-map a e)

--- a/src/synthetic-homotopy-theory/universal-property-coequalizers.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-coequalizers.lagda.md
@@ -49,18 +49,18 @@ is an [equivalence](foundation.equivalences.md).
 
 ```agda
 module _
-  {l1 l2 l3 : Level} (l : Level) (a : double-arrow l1 l2) {X : UU l3}
+  {l1 l2 l3 : Level} (a : double-arrow l1 l2) {X : UU l3}
   (e : cofork a X)
   where
 
-  universal-property-coequalizer : UU (l1 ⊔ l2 ⊔ l3 ⊔ lsuc l)
+  universal-property-coequalizer : UUω
   universal-property-coequalizer =
-    (Y : UU l) → is-equiv (cofork-map a e {Y = Y})
+    {l : Level} (Y : UU l) → is-equiv (cofork-map a e {Y = Y})
 
 module _
   {l1 l2 l3 l4 : Level} (a : double-arrow l1 l2) {X : UU l3}
   (e : cofork a X) {Y : UU l4}
-  (up-coequalizer : universal-property-coequalizer l4 a e)
+  (up-coequalizer : universal-property-coequalizer a e)
   where
 
   map-universal-property-coequalizer : cofork a Y → (X → Y)
@@ -75,7 +75,7 @@ module _
 module _
   {l1 l2 l3 l4 : Level} (a : double-arrow l1 l2) {X : UU l3}
   (e : cofork a X) {Y : UU l4}
-  (up-coequalizer : universal-property-coequalizer l4 a e)
+  (up-coequalizer : universal-property-coequalizer a e)
   (e' : cofork a Y)
   where
 
@@ -122,8 +122,7 @@ module _
       ( vertical-map-span-cocone-cofork a)
       ( horizontal-map-span-cocone-cofork a)
       ( cocone-codiagonal-cofork a e) →
-    ({l : Level} →
-      universal-property-coequalizer l a e)
+      universal-property-coequalizer a e
   universal-property-coequalizer-universal-property-pushout up-pushout Y =
     is-equiv-left-map-triangle
       ( cofork-map a e)
@@ -137,8 +136,7 @@ module _
       ( is-equiv-cofork-cocone-codiagonal a)
 
   universal-property-pushout-universal-property-coequalizer :
-    ({l : Level} →
-      universal-property-coequalizer l a e) →
+    universal-property-coequalizer a e →
     universal-property-pushout
       ( vertical-map-span-cocone-cofork a)
       ( horizontal-map-span-cocone-cofork a)
@@ -193,8 +191,8 @@ module _
   where
 
   universal-property-coequalizer-equiv-cofork-equiv-double-arrow :
-    ({l : Level} → universal-property-coequalizer l a' c') →
-    ({l : Level} → universal-property-coequalizer l a c)
+    universal-property-coequalizer a' c' →
+    universal-property-coequalizer a c
   universal-property-coequalizer-equiv-cofork-equiv-double-arrow up-c' =
     universal-property-coequalizer-universal-property-pushout a c
       ( universal-property-pushout-top-universal-property-pushout-bottom-cube-is-equiv
@@ -276,8 +274,8 @@ module _
           ( up-c')))
 
   universal-property-coequalizer-equiv-cofork-equiv-double-arrow' :
-    ({l : Level} → universal-property-coequalizer l a c) →
-    ({l : Level} → universal-property-coequalizer l a' c')
+    universal-property-coequalizer a c →
+    universal-property-coequalizer a' c'
   universal-property-coequalizer-equiv-cofork-equiv-double-arrow' up-c =
     universal-property-coequalizer-universal-property-pushout a' c'
       ( universal-property-pushout-bottom-universal-property-pushout-top-cube-is-equiv

--- a/src/synthetic-homotopy-theory/universal-property-pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-pushouts.lagda.md
@@ -431,8 +431,8 @@ module _
   where
 
   universal-property-pushout-rectangle-universal-property-pushout-right :
-    ( universal-property-pushout (vertical-map-cocone f g c) k d) →
-    ( universal-property-pushout f (k ∘ g) (cocone-comp-horizontal f g k c d))
+    universal-property-pushout (vertical-map-cocone f g c) k d →
+    universal-property-pushout f (k ∘ g) (cocone-comp-horizontal f g k c d)
   universal-property-pushout-rectangle-universal-property-pushout-right
     ( up-d)
     { l} =
@@ -496,7 +496,7 @@ module _
       ( f)
       ( k ∘ g)
       ( cocone-comp-horizontal f g k c d) →
-    ( universal-property-pushout (vertical-map-cocone f g c) k d)
+    universal-property-pushout (vertical-map-cocone f g c) k d
   universal-property-pushout-right-universal-property-pushout-rectangle
     ( up-r)
     { l} =
@@ -697,8 +697,8 @@ module _
               ( W))))
 
   universal-property-pushout-top-universal-property-pushout-rectangle :
-    ( universal-property-pushout (k ∘ f) g (cocone-comp-vertical f g k c d)) →
-    ( universal-property-pushout k (horizontal-map-cocone f g c) d)
+    universal-property-pushout (k ∘ f) g (cocone-comp-vertical f g k c d) →
+    universal-property-pushout k (horizontal-map-cocone f g c) d
   universal-property-pushout-top-universal-property-pushout-rectangle
     ( up-r)
     { l} =
@@ -857,7 +857,7 @@ module _
 
   universal-property-pushout-extension-by-equivalences :
     {l : Level} → is-equiv i → is-equiv j → is-equiv k →
-    Σ (cocone f' g' X) (λ d → universal-property-pushout-Level l f' g' d)
+    Σ (cocone f' g' X) (universal-property-pushout-Level l f' g')
   universal-property-pushout-extension-by-equivalences ie je ke =
     universal-property-pushout-top-extension-by-equivalences
       ( f')
@@ -916,8 +916,8 @@ module _
   where
 
   universal-property-pushout-top-universal-property-pushout-bottom-cube-is-equiv :
-    ( universal-property-pushout f g (h , k , bottom)) →
-    ( universal-property-pushout f' g' (h' , k' , top))
+    universal-property-pushout f g (h , k , bottom) →
+    universal-property-pushout f' g' (h' , k' , top)
   universal-property-pushout-top-universal-property-pushout-bottom-cube-is-equiv
     ( up-bottom)
     { l = l} =
@@ -962,8 +962,8 @@ module _
             ( W)))
 
   universal-property-pushout-bottom-universal-property-pushout-top-cube-is-equiv :
-    ( universal-property-pushout f' g' (h' , k' , top)) →
-    ( universal-property-pushout f g (h , k , bottom))
+    universal-property-pushout f' g' (h' , k' , top) →
+    universal-property-pushout f g (h , k , bottom)
   universal-property-pushout-bottom-universal-property-pushout-top-cube-is-equiv
     ( up-top)
     { l = l} =

--- a/src/synthetic-homotopy-theory/universal-property-pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-pushouts.lagda.md
@@ -67,21 +67,32 @@ found in the following table:
 
 ## Definition
 
+### The universal property of pushouts at a universe level
+
+```agda
+universal-property-pushout-Level :
+  {l1 l2 l3 l4 : Level} (l : Level) {S : UU l1} {A : UU l2} {B : UU l3}
+  (f : S → A) (g : S → B) {X : UU l4} →
+  cocone f g X → UU (l1 ⊔ l2 ⊔ l3 ⊔ l4 ⊔ lsuc l)
+universal-property-pushout-Level l f g c =
+  (Y : UU l) → is-equiv (cocone-map f g {Y = Y} c)
+```
+
 ### The universal property of pushouts
 
 ```agda
 universal-property-pushout :
-  {l1 l2 l3 l4 : Level} (l : Level) {S : UU l1} {A : UU l2} {B : UU l3}
+  {l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3}
   (f : S → A) (g : S → B) {X : UU l4} →
-  cocone f g X → UU (l1 ⊔ l2 ⊔ l3 ⊔ l4 ⊔ lsuc l)
-universal-property-pushout l f g c =
-  (Y : UU l) → is-equiv (cocone-map f g {Y = Y} c)
+  cocone f g X → UUω
+universal-property-pushout f g c =
+  {l : Level} → universal-property-pushout-Level l f g c
 
 module _
   {l1 l2 l3 l4 l5 : Level}
   {S : UU l1} {A : UU l2} {B : UU l3} {X : UU l4} {Y : UU l5}
   (f : S → A) (g : S → B) (c : cocone f g X)
-  (up-c : {l : Level} → universal-property-pushout l f g c)
+  (up-c : universal-property-pushout f g c)
   (d : cocone f g Y)
   where
 
@@ -168,8 +179,8 @@ module _
           ( eq-htpy-cocone f g (cocone-map f g c h) d KLM)))
 
   is-equiv-up-pushout-up-pushout :
-    ( up-c : {l : Level} → universal-property-pushout l f g c) →
-    ( up-d : {l : Level} → universal-property-pushout l f g d) →
+    universal-property-pushout f g c →
+    universal-property-pushout f g d →
     is-equiv h
   is-equiv-up-pushout-up-pushout up-c up-d =
     is-equiv-is-equiv-precomp h
@@ -184,8 +195,8 @@ module _
 
   up-pushout-up-pushout-is-equiv :
     is-equiv h →
-    ( up-c : {l : Level} → universal-property-pushout l f g c) →
-    {l : Level} → universal-property-pushout l f g d
+    universal-property-pushout f g c →
+    universal-property-pushout f g d
   up-pushout-up-pushout-is-equiv is-equiv-h up-c Z =
     is-equiv-left-map-triangle
       ( cocone-map f g d)
@@ -196,9 +207,9 @@ module _
       ( up-c Z)
 
   up-pushout-is-equiv-up-pushout :
-    ( up-d : {l : Level} → universal-property-pushout l f g d) →
+    universal-property-pushout f g d →
     is-equiv h →
-    {l : Level} → universal-property-pushout l f g c
+    universal-property-pushout f g c
   up-pushout-is-equiv-up-pushout up-d is-equiv-h Z =
     is-equiv-right-map-triangle
       ( cocone-map f g d)
@@ -216,8 +227,8 @@ uniquely-unique-pushout :
   { l1 l2 l3 l4 l5 : Level}
   { S : UU l1} {A : UU l2} {B : UU l3} {X : UU l4} {Y : UU l5}
   ( f : S → A) (g : S → B) (c : cocone f g X) (d : cocone f g Y) →
-  ( up-c : {l : Level} → universal-property-pushout l f g c) →
-  ( up-d : {l : Level} → universal-property-pushout l f g d) →
+  universal-property-pushout f g c →
+  universal-property-pushout f g d →
   is-contr
     ( Σ (X ≃ Y) (λ e → htpy-cocone f g (cocone-map f g c (map-equiv e)) d))
 uniquely-unique-pushout f g c d up-c up-d =
@@ -246,18 +257,18 @@ triangle-pullback-property-pushout-universal-property-pushout :
   {B : UU l3} (f : S → A) (g : S → B) {X : UU l4} (c : cocone f g X) →
   {l : Level} (Y : UU l) →
   ( cocone-map f g c) ~
-  ( ( tot (λ i' → tot (λ j' → htpy-eq))) ∘
-    ( gap (_∘ f) (_∘ g) (cone-pullback-property-pushout f g c Y)))
+  ( tot (λ i' → tot (λ j' → htpy-eq))) ∘
+  ( gap (_∘ f) (_∘ g) (cone-pullback-property-pushout f g c Y))
 triangle-pullback-property-pushout-universal-property-pushout f g c Y h =
     eq-pair-eq-fiber
       ( eq-pair-eq-fiber
         ( inv (is-section-eq-htpy (h ·l coherence-square-cocone f g c))))
 
-pullback-property-pushout-universal-property-pushout :
+pullback-property-pushout-universal-property-pushout-Level :
   {l1 l2 l3 l4 l : Level} {S : UU l1} {A : UU l2}
   {B : UU l3} (f : S → A) (g : S → B) {X : UU l4} (c : cocone f g X) →
-  universal-property-pushout l f g c → pullback-property-pushout l f g c
-pullback-property-pushout-universal-property-pushout f g c up-c Y =
+  universal-property-pushout-Level l f g c → pullback-property-pushout l f g c
+pullback-property-pushout-universal-property-pushout-Level f g c up-c Y =
   is-equiv-top-map-triangle
     ( cocone-map f g c)
     ( tot (λ i' → tot (λ j' → htpy-eq)))
@@ -268,11 +279,11 @@ pullback-property-pushout-universal-property-pushout f g c up-c Y =
         is-equiv-tot-is-fiberwise-equiv (λ j' → funext (i' ∘ f) (j' ∘ g))))
     ( up-c Y)
 
-universal-property-pushout-pullback-property-pushout :
+universal-property-pushout-pullback-property-pushout-Level :
   {l1 l2 l3 l4 : Level} (l : Level) {S : UU l1} {A : UU l2}
   {B : UU l3} (f : S → A) (g : S → B) {X : UU l4} (c : cocone f g X) →
-  pullback-property-pushout l f g c → universal-property-pushout l f g c
-universal-property-pushout-pullback-property-pushout l f g c pb-c Y =
+  pullback-property-pushout l f g c → universal-property-pushout-Level l f g c
+universal-property-pushout-pullback-property-pushout-Level l f g c pb-c Y =
   is-equiv-left-map-triangle
     ( cocone-map f g c)
     ( tot (λ i' → tot (λ j' → htpy-eq)))
@@ -291,7 +302,7 @@ is-equiv-universal-property-pushout :
   {l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3} {C : UU l4}
   (f : S → A) (g : S → B) (c : cocone f g C) →
   is-equiv f →
-  ({l : Level} → universal-property-pushout l f g c) →
+  universal-property-pushout f g c →
   is-equiv (vertical-map-cocone f g c)
 is-equiv-universal-property-pushout f g (i , j , H) is-equiv-f up-c =
   is-equiv-is-equiv-precomp j
@@ -301,7 +312,7 @@ is-equiv-universal-property-pushout f g (i , j , H) is-equiv-f up-c =
         ( _∘ g)
         ( cone-pullback-property-pushout f g (i , j , H) T)
         ( is-equiv-precomp-is-equiv f is-equiv-f T)
-        ( pullback-property-pushout-universal-property-pushout f g
+        ( pullback-property-pushout-universal-property-pushout-Level f g
           ( i , j , H)
           ( up-c)
           ( T)))
@@ -309,7 +320,7 @@ is-equiv-universal-property-pushout f g (i , j , H) is-equiv-f up-c =
 equiv-universal-property-pushout :
   {l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3} {C : UU l4}
   (e : S ≃ A) (g : S → B) (c : cocone (map-equiv e) g C) →
-  ({l : Level} → universal-property-pushout l (map-equiv e) g c) →
+  universal-property-pushout (map-equiv e) g c →
   B ≃ C
 pr1 (equiv-universal-property-pushout e g c up-c) =
   vertical-map-cocone (map-equiv e) g c
@@ -325,11 +336,11 @@ universal-property-pushout-is-equiv :
   {l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3} {C : UU l4}
   (f : S → A) (g : S → B) (c : cocone f g C) →
   is-equiv f → is-equiv (vertical-map-cocone f g c) →
-  ({l : Level} → universal-property-pushout l f g c)
+  universal-property-pushout f g c
 universal-property-pushout-is-equiv
   f g (i , j , H) is-equiv-f is-equiv-j {l} =
   let c = (i , j , H) in
-  universal-property-pushout-pullback-property-pushout l f g c
+  universal-property-pushout-pullback-property-pushout-Level l f g c
     ( λ T →
       is-pullback-is-equiv-horizontal-maps
         ( _∘ f)
@@ -346,7 +357,7 @@ is-equiv-universal-property-pushout' :
   {l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3} {C : UU l4}
   (f : S → A) (g : S → B) (c : cocone f g C) →
   is-equiv g →
-  ({l : Level} → universal-property-pushout l f g c) →
+  universal-property-pushout f g c →
   is-equiv (horizontal-map-cocone f g c)
 is-equiv-universal-property-pushout' f g c is-equiv-g up-c =
   is-equiv-is-equiv-precomp
@@ -357,12 +368,12 @@ is-equiv-universal-property-pushout' f g c is-equiv-g up-c =
         ( precomp g T)
         ( cone-pullback-property-pushout f g c T)
         ( is-equiv-precomp-is-equiv g is-equiv-g T)
-        ( pullback-property-pushout-universal-property-pushout f g c up-c T))
+        ( pullback-property-pushout-universal-property-pushout-Level f g c up-c T))
 
 equiv-universal-property-pushout' :
   {l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3} {C : UU l4}
   (f : S → A) (e : S ≃ B) (c : cocone f (map-equiv e) C) →
-  ({l : Level} → universal-property-pushout l f (map-equiv e) c) →
+  universal-property-pushout f (map-equiv e) c →
   A ≃ C
 pr1 (equiv-universal-property-pushout' f e c up-c) = pr1 c
 pr2 (equiv-universal-property-pushout' f e c up-c) =
@@ -377,10 +388,10 @@ universal-property-pushout-is-equiv' :
   {l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3} {C : UU l4}
   (f : S → A) (g : S → B) (c : cocone f g C) →
   is-equiv g → is-equiv (pr1 c) →
-  ({l : Level} → universal-property-pushout l f g c)
+  universal-property-pushout f g c
 universal-property-pushout-is-equiv' f g (i , j , H) is-equiv-g is-equiv-i {l} =
   let c = (i , j , H) in
-  universal-property-pushout-pullback-property-pushout l f g c
+  universal-property-pushout-pullback-property-pushout-Level l f g c
     ( λ T →
       is-pullback-is-equiv-vertical-maps
         ( precomp f T)
@@ -412,18 +423,16 @@ module _
   { A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4} {Y : UU l5} {Z : UU l6}
   ( f : A → X) (g : A → B) (k : B → C)
   ( c : cocone f g Y) (d : cocone (vertical-map-cocone f g c) k Z)
-  ( up-c : {l : Level} → universal-property-pushout l f g c)
+  ( up-c : universal-property-pushout f g c)
   where
 
   universal-property-pushout-rectangle-universal-property-pushout-right :
-    ( {l : Level} →
-      universal-property-pushout l (vertical-map-cocone f g c) k d) →
-    ( {l : Level} →
-      universal-property-pushout l f (k ∘ g) (cocone-comp-horizontal f g k c d))
+    ( universal-property-pushout (vertical-map-cocone f g c) k d) →
+    ( universal-property-pushout f (k ∘ g) (cocone-comp-horizontal f g k c d))
   universal-property-pushout-rectangle-universal-property-pushout-right
     ( up-d)
     { l} =
-    universal-property-pushout-pullback-property-pushout l f
+    universal-property-pushout-pullback-property-pushout-Level l f
       ( k ∘ g)
       ( cocone-comp-horizontal f g k c d)
       ( λ W →
@@ -468,10 +477,10 @@ module _
             ( precomp k W)
             ( cone-pullback-property-pushout f g c W)
             ( cone-pullback-property-pushout (vertical-map-cocone f g c) k d W)
-            ( pullback-property-pushout-universal-property-pushout f g c
+            ( pullback-property-pushout-universal-property-pushout-Level f g c
               ( up-c)
               ( W))
-            ( pullback-property-pushout-universal-property-pushout
+            ( pullback-property-pushout-universal-property-pushout-Level
               ( vertical-map-cocone f g c)
               ( k)
               ( d)
@@ -479,18 +488,15 @@ module _
               ( W))))
 
   universal-property-pushout-right-universal-property-pushout-rectangle :
-    ( {l : Level} →
-      universal-property-pushout
-        ( l)
-        ( f)
-        ( k ∘ g)
-        ( cocone-comp-horizontal f g k c d)) →
-    ( {l : Level} →
-      universal-property-pushout l (vertical-map-cocone f g c) k d)
+    universal-property-pushout
+      ( f)
+      ( k ∘ g)
+      ( cocone-comp-horizontal f g k c d) →
+    ( universal-property-pushout (vertical-map-cocone f g c) k d)
   universal-property-pushout-right-universal-property-pushout-rectangle
     ( up-r)
     { l} =
-    universal-property-pushout-pullback-property-pushout l
+    universal-property-pushout-pullback-property-pushout-Level l
       ( vertical-map-cocone f g c)
       ( k)
       ( d)
@@ -501,7 +507,7 @@ module _
           ( precomp k W)
           ( cone-pullback-property-pushout f g c W)
           ( cone-pullback-property-pushout (vertical-map-cocone f g c) k d W)
-          ( pullback-property-pushout-universal-property-pushout f g c
+          ( pullback-property-pushout-universal-property-pushout-Level f g c
             ( up-c)
             ( W))
           ( tr
@@ -537,7 +543,7 @@ module _
                   ( horizontal-map-cocone (vertical-map-cocone f g c) k d)
                   ( coherence-square-cocone f g c)
                   ( coherence-square-cocone (vertical-map-cocone f g c) k d))))
-            ( pullback-property-pushout-universal-property-pushout f
+            ( pullback-property-pushout-universal-property-pushout-Level f
               ( k ∘ g)
               ( cocone-comp-horizontal f g k c d)
               ( up-r)
@@ -569,14 +575,13 @@ module _
   { S : UU l1} {A : UU l2} {B : UU l3} {X : UU l4} {S' : UU l5} {A' : UU l6}
   ( f : S → A) (g : S → B) (i : S' → S) (j : A' → A) (f' : S' → A')
   ( c : cocone f g X)
-  ( up-c : {l : Level} → universal-property-pushout l f g c)
+  ( up-c : universal-property-pushout f g c)
   ( coh : coherence-square-maps i f' f j)
   where
 
   universal-property-pushout-left-extended-by-equivalences :
     is-equiv i → is-equiv j →
-    {l : Level} →
-    universal-property-pushout l
+    universal-property-pushout
       ( f')
       ( g ∘ i)
       ( cocone-comp-horizontal' f' i g f j c coh)
@@ -589,7 +594,7 @@ module _
 
   universal-property-pushout-left-extension-by-equivalences :
     {l : Level} → is-equiv i → is-equiv j →
-    Σ (cocone f' (g ∘ i) X) (universal-property-pushout l f' (g ∘ i))
+    Σ (cocone f' (g ∘ i) X) (universal-property-pushout-Level l f' (g ∘ i))
   pr1 (universal-property-pushout-left-extension-by-equivalences ie je) =
     cocone-comp-horizontal' f' i g f j c coh
   pr2 (universal-property-pushout-left-extension-by-equivalences ie je) =
@@ -620,18 +625,16 @@ module _
   { A : UU l1} {B : UU l2} {C : UU l3} {X : UU l4} {Y : UU l5} {Z : UU l6}
   ( f : A → B) (g : A → X) (k : B → C)
   ( c : cocone f g Y) (d : cocone k (horizontal-map-cocone f g c) Z)
-  ( up-c : {l : Level} → universal-property-pushout l f g c)
+  ( up-c : universal-property-pushout f g c)
   where
 
   universal-property-pushout-rectangle-universal-property-pushout-top :
-    ( {l : Level} →
-      universal-property-pushout l k (horizontal-map-cocone f g c) d) →
-    ( {l : Level} →
-      universal-property-pushout l (k ∘ f) g (cocone-comp-vertical f g k c d))
+    ( universal-property-pushout k (horizontal-map-cocone f g c) d) →
+    ( universal-property-pushout (k ∘ f) g (cocone-comp-vertical f g k c d))
   universal-property-pushout-rectangle-universal-property-pushout-top
     ( up-d)
     { l} =
-    universal-property-pushout-pullback-property-pushout l
+    universal-property-pushout-pullback-property-pushout-Level l
       ( k ∘ f)
       ( g)
       ( cocone-comp-vertical f g k c d)
@@ -680,24 +683,22 @@ module _
               ( horizontal-map-cocone f g c)
               ( d)
               ( W))
-            ( pullback-property-pushout-universal-property-pushout f g c
+            ( pullback-property-pushout-universal-property-pushout-Level f g c
               ( up-c)
               ( W))
-            ( pullback-property-pushout-universal-property-pushout k
+            ( pullback-property-pushout-universal-property-pushout-Level k
               ( horizontal-map-cocone f g c)
               ( d)
               ( up-d)
               ( W))))
 
   universal-property-pushout-top-universal-property-pushout-rectangle :
-    ( {l : Level} →
-      universal-property-pushout l (k ∘ f) g (cocone-comp-vertical f g k c d)) →
-    ( {l : Level} →
-      universal-property-pushout l k (horizontal-map-cocone f g c) d)
+    ( universal-property-pushout (k ∘ f) g (cocone-comp-vertical f g k c d)) →
+    ( universal-property-pushout k (horizontal-map-cocone f g c) d)
   universal-property-pushout-top-universal-property-pushout-rectangle
     ( up-r)
     { l} =
-    universal-property-pushout-pullback-property-pushout l k
+    universal-property-pushout-pullback-property-pushout-Level l k
       ( horizontal-map-cocone f g c)
       ( d)
       ( λ W →
@@ -707,7 +708,7 @@ module _
           ( precomp g W)
           ( cone-pullback-property-pushout f g c W)
           ( cone-pullback-property-pushout k (horizontal-map-cocone f g c) d W)
-          ( pullback-property-pushout-universal-property-pushout f g c up-c W)
+          ( pullback-property-pushout-universal-property-pushout-Level f g c up-c W)
           ( tr
             ( is-pullback (precomp (k ∘ f) W) (precomp g W))
             ( eq-htpy-cone
@@ -746,7 +747,7 @@ module _
                   ( coherence-square-cocone k
                     ( horizontal-map-cocone f g c)
                     ( d)))))
-            ( pullback-property-pushout-universal-property-pushout (k ∘ f) g
+            ( pullback-property-pushout-universal-property-pushout-Level (k ∘ f) g
               ( cocone-comp-vertical f g k c d)
               ( up-r)
               ( W))))
@@ -779,14 +780,13 @@ module _
   { S : UU l1} {A : UU l2} {B : UU l3} {X : UU l4} {S' : UU l5} {B' : UU l6}
   ( f : S → A) (g : S → B) (i : S' → S) (j : B' → B) (g' : S' → B')
   ( c : cocone f g X)
-  ( up-c : {l : Level} → universal-property-pushout l f g c)
+  ( up-c : universal-property-pushout f g c)
   ( coh : coherence-square-maps g' i j g)
   where
 
   universal-property-pushout-top-extended-by-equivalences :
     is-equiv i → is-equiv j →
-    {l : Level} →
-    universal-property-pushout l
+    universal-property-pushout
       ( f ∘ i)
       ( g')
       ( cocone-comp-vertical' i g' j g f c coh)
@@ -799,7 +799,7 @@ module _
 
   universal-property-pushout-top-extension-by-equivalences :
     {l : Level} → is-equiv i → is-equiv j →
-    Σ (cocone (f ∘ i) g' X) (universal-property-pushout l (f ∘ i) g')
+    Σ (cocone (f ∘ i) g' X) (universal-property-pushout-Level l (f ∘ i) g')
   pr1 (universal-property-pushout-top-extension-by-equivalences ie je) =
     cocone-comp-vertical' i g' j g f c coh
   pr2 (universal-property-pushout-top-extension-by-equivalences ie je) =
@@ -846,14 +846,14 @@ module _
   ( f : S → A) (g : S → B) (f' : S' → A') (g' : S' → B')
   ( i : A' → A) (j : B' → B) (k : S' → S)
   ( c : cocone f g X)
-  ( up-c : {l : Level} → universal-property-pushout l f g c)
+  ( up-c : universal-property-pushout f g c)
   ( coh-l : coherence-square-maps k f' f i)
   ( coh-r : coherence-square-maps g' k j g)
   where
 
   universal-property-pushout-extension-by-equivalences :
     {l : Level} → is-equiv i → is-equiv j → is-equiv k →
-    Σ (cocone f' g' X) (λ d → universal-property-pushout l f' g' d)
+    Σ (cocone f' g' X) (λ d → universal-property-pushout-Level l f' g' d)
   universal-property-pushout-extension-by-equivalences ie je ke =
     universal-property-pushout-top-extension-by-equivalences
       ( f')
@@ -875,8 +875,7 @@ module _
 
   universal-property-pushout-extended-by-equivalences :
     is-equiv i → is-equiv j → is-equiv k →
-    {l : Level} →
-    universal-property-pushout l
+    universal-property-pushout
       ( f')
       ( g')
       ( comp-cocone-hom-span f g f' g' i j k c coh-l coh-r)
@@ -913,14 +912,12 @@ module _
   where
 
   universal-property-pushout-top-universal-property-pushout-bottom-cube-is-equiv :
-    ( {l : Level} →
-      universal-property-pushout l f g (h , k , bottom)) →
-    ( {l : Level} →
-      universal-property-pushout l f' g' (h' , k' , top))
+    ( universal-property-pushout f g (h , k , bottom)) →
+    ( universal-property-pushout f' g' (h' , k' , top))
   universal-property-pushout-top-universal-property-pushout-bottom-cube-is-equiv
     ( up-bottom)
     { l = l} =
-    universal-property-pushout-pullback-property-pushout l f' g'
+    universal-property-pushout-pullback-property-pushout-Level l f' g'
       ( h' , k' , top)
       ( λ W →
         is-pullback-bottom-is-pullback-top-cube-is-equiv
@@ -955,20 +952,18 @@ module _
           ( is-equiv-precomp-is-equiv hB is-equiv-hB W)
           ( is-equiv-precomp-is-equiv hC is-equiv-hC W)
           ( is-equiv-precomp-is-equiv hA is-equiv-hA W)
-          ( pullback-property-pushout-universal-property-pushout f g
+          ( pullback-property-pushout-universal-property-pushout-Level f g
             ( h , k , bottom)
             ( up-bottom)
             ( W)))
 
   universal-property-pushout-bottom-universal-property-pushout-top-cube-is-equiv :
-    ( {l : Level} →
-      universal-property-pushout l f' g' (h' , k' , top)) →
-    ( {l : Level} →
-      universal-property-pushout l f g (h , k , bottom))
+    ( universal-property-pushout f' g' (h' , k' , top)) →
+    ( universal-property-pushout f g (h , k , bottom))
   universal-property-pushout-bottom-universal-property-pushout-top-cube-is-equiv
     ( up-top)
     { l = l} =
-    universal-property-pushout-pullback-property-pushout l f g
+    universal-property-pushout-pullback-property-pushout-Level l f g
       ( h , k , bottom)
       ( λ W →
         is-pullback-top-is-pullback-bottom-cube-is-equiv
@@ -1003,7 +998,7 @@ module _
           ( is-equiv-precomp-is-equiv hB is-equiv-hB W)
           ( is-equiv-precomp-is-equiv hC is-equiv-hC W)
           ( is-equiv-precomp-is-equiv hA is-equiv-hA W)
-          ( pullback-property-pushout-universal-property-pushout f' g'
+          ( pullback-property-pushout-universal-property-pushout-Level f' g'
             ( h' , k' , top)
             ( up-top)
             ( W)))

--- a/src/synthetic-homotopy-theory/universal-property-pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-pushouts.lagda.md
@@ -264,11 +264,11 @@ triangle-pullback-property-pushout-universal-property-pushout f g c Y h =
       ( eq-pair-eq-fiber
         ( inv (is-section-eq-htpy (h ·l coherence-square-cocone f g c))))
 
-pullback-property-pushout-universal-property-pushout-Level :
-  {l1 l2 l3 l4 l : Level} {S : UU l1} {A : UU l2}
+pullback-property-pushout-universal-property-pushout :
+  {l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2}
   {B : UU l3} (f : S → A) (g : S → B) {X : UU l4} (c : cocone f g X) →
-  universal-property-pushout-Level l f g c → pullback-property-pushout l f g c
-pullback-property-pushout-universal-property-pushout-Level f g c up-c Y =
+  universal-property-pushout f g c → pullback-property-pushout f g c
+pullback-property-pushout-universal-property-pushout f g c up-c Y =
   is-equiv-top-map-triangle
     ( cocone-map f g c)
     ( tot (λ i' → tot (λ j' → htpy-eq)))
@@ -279,11 +279,11 @@ pullback-property-pushout-universal-property-pushout-Level f g c up-c Y =
         is-equiv-tot-is-fiberwise-equiv (λ j' → funext (i' ∘ f) (j' ∘ g))))
     ( up-c Y)
 
-universal-property-pushout-pullback-property-pushout-Level :
-  {l1 l2 l3 l4 : Level} (l : Level) {S : UU l1} {A : UU l2}
+universal-property-pushout-pullback-property-pushout :
+  {l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2}
   {B : UU l3} (f : S → A) (g : S → B) {X : UU l4} (c : cocone f g X) →
-  pullback-property-pushout l f g c → universal-property-pushout-Level l f g c
-universal-property-pushout-pullback-property-pushout-Level l f g c pb-c Y =
+  pullback-property-pushout f g c → universal-property-pushout f g c
+universal-property-pushout-pullback-property-pushout f g c pb-c Y =
   is-equiv-left-map-triangle
     ( cocone-map f g c)
     ( tot (λ i' → tot (λ j' → htpy-eq)))
@@ -312,7 +312,7 @@ is-equiv-universal-property-pushout f g (i , j , H) is-equiv-f up-c =
         ( _∘ g)
         ( cone-pullback-property-pushout f g (i , j , H) T)
         ( is-equiv-precomp-is-equiv f is-equiv-f T)
-        ( pullback-property-pushout-universal-property-pushout-Level f g
+        ( pullback-property-pushout-universal-property-pushout f g
           ( i , j , H)
           ( up-c)
           ( T)))
@@ -340,7 +340,7 @@ universal-property-pushout-is-equiv :
 universal-property-pushout-is-equiv
   f g (i , j , H) is-equiv-f is-equiv-j {l} =
   let c = (i , j , H) in
-  universal-property-pushout-pullback-property-pushout-Level l f g c
+  universal-property-pushout-pullback-property-pushout f g c
     ( λ T →
       is-pullback-is-equiv-horizontal-maps
         ( _∘ f)
@@ -368,7 +368,7 @@ is-equiv-universal-property-pushout' f g c is-equiv-g up-c =
         ( precomp g T)
         ( cone-pullback-property-pushout f g c T)
         ( is-equiv-precomp-is-equiv g is-equiv-g T)
-        ( pullback-property-pushout-universal-property-pushout-Level f g c up-c T))
+        ( pullback-property-pushout-universal-property-pushout f g c up-c T))
 
 equiv-universal-property-pushout' :
   {l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2} {B : UU l3} {C : UU l4}
@@ -391,7 +391,7 @@ universal-property-pushout-is-equiv' :
   universal-property-pushout f g c
 universal-property-pushout-is-equiv' f g (i , j , H) is-equiv-g is-equiv-i {l} =
   let c = (i , j , H) in
-  universal-property-pushout-pullback-property-pushout-Level l f g c
+  universal-property-pushout-pullback-property-pushout f g c
     ( λ T →
       is-pullback-is-equiv-vertical-maps
         ( precomp f T)
@@ -432,7 +432,7 @@ module _
   universal-property-pushout-rectangle-universal-property-pushout-right
     ( up-d)
     { l} =
-    universal-property-pushout-pullback-property-pushout-Level l f
+    universal-property-pushout-pullback-property-pushout f
       ( k ∘ g)
       ( cocone-comp-horizontal f g k c d)
       ( λ W →
@@ -477,10 +477,10 @@ module _
             ( precomp k W)
             ( cone-pullback-property-pushout f g c W)
             ( cone-pullback-property-pushout (vertical-map-cocone f g c) k d W)
-            ( pullback-property-pushout-universal-property-pushout-Level f g c
+            ( pullback-property-pushout-universal-property-pushout f g c
               ( up-c)
               ( W))
-            ( pullback-property-pushout-universal-property-pushout-Level
+            ( pullback-property-pushout-universal-property-pushout
               ( vertical-map-cocone f g c)
               ( k)
               ( d)
@@ -496,7 +496,7 @@ module _
   universal-property-pushout-right-universal-property-pushout-rectangle
     ( up-r)
     { l} =
-    universal-property-pushout-pullback-property-pushout-Level l
+    universal-property-pushout-pullback-property-pushout
       ( vertical-map-cocone f g c)
       ( k)
       ( d)
@@ -507,7 +507,7 @@ module _
           ( precomp k W)
           ( cone-pullback-property-pushout f g c W)
           ( cone-pullback-property-pushout (vertical-map-cocone f g c) k d W)
-          ( pullback-property-pushout-universal-property-pushout-Level f g c
+          ( pullback-property-pushout-universal-property-pushout f g c
             ( up-c)
             ( W))
           ( tr
@@ -543,7 +543,7 @@ module _
                   ( horizontal-map-cocone (vertical-map-cocone f g c) k d)
                   ( coherence-square-cocone f g c)
                   ( coherence-square-cocone (vertical-map-cocone f g c) k d))))
-            ( pullback-property-pushout-universal-property-pushout-Level f
+            ( pullback-property-pushout-universal-property-pushout f
               ( k ∘ g)
               ( cocone-comp-horizontal f g k c d)
               ( up-r)
@@ -634,7 +634,7 @@ module _
   universal-property-pushout-rectangle-universal-property-pushout-top
     ( up-d)
     { l} =
-    universal-property-pushout-pullback-property-pushout-Level l
+    universal-property-pushout-pullback-property-pushout
       ( k ∘ f)
       ( g)
       ( cocone-comp-vertical f g k c d)
@@ -683,10 +683,10 @@ module _
               ( horizontal-map-cocone f g c)
               ( d)
               ( W))
-            ( pullback-property-pushout-universal-property-pushout-Level f g c
+            ( pullback-property-pushout-universal-property-pushout f g c
               ( up-c)
               ( W))
-            ( pullback-property-pushout-universal-property-pushout-Level k
+            ( pullback-property-pushout-universal-property-pushout k
               ( horizontal-map-cocone f g c)
               ( d)
               ( up-d)
@@ -698,7 +698,7 @@ module _
   universal-property-pushout-top-universal-property-pushout-rectangle
     ( up-r)
     { l} =
-    universal-property-pushout-pullback-property-pushout-Level l k
+    universal-property-pushout-pullback-property-pushout k
       ( horizontal-map-cocone f g c)
       ( d)
       ( λ W →
@@ -708,7 +708,7 @@ module _
           ( precomp g W)
           ( cone-pullback-property-pushout f g c W)
           ( cone-pullback-property-pushout k (horizontal-map-cocone f g c) d W)
-          ( pullback-property-pushout-universal-property-pushout-Level f g c up-c W)
+          ( pullback-property-pushout-universal-property-pushout f g c up-c W)
           ( tr
             ( is-pullback (precomp (k ∘ f) W) (precomp g W))
             ( eq-htpy-cone
@@ -747,7 +747,7 @@ module _
                   ( coherence-square-cocone k
                     ( horizontal-map-cocone f g c)
                     ( d)))))
-            ( pullback-property-pushout-universal-property-pushout-Level (k ∘ f) g
+            ( pullback-property-pushout-universal-property-pushout (k ∘ f) g
               ( cocone-comp-vertical f g k c d)
               ( up-r)
               ( W))))
@@ -917,7 +917,7 @@ module _
   universal-property-pushout-top-universal-property-pushout-bottom-cube-is-equiv
     ( up-bottom)
     { l = l} =
-    universal-property-pushout-pullback-property-pushout-Level l f' g'
+    universal-property-pushout-pullback-property-pushout f' g'
       ( h' , k' , top)
       ( λ W →
         is-pullback-bottom-is-pullback-top-cube-is-equiv
@@ -952,7 +952,7 @@ module _
           ( is-equiv-precomp-is-equiv hB is-equiv-hB W)
           ( is-equiv-precomp-is-equiv hC is-equiv-hC W)
           ( is-equiv-precomp-is-equiv hA is-equiv-hA W)
-          ( pullback-property-pushout-universal-property-pushout-Level f g
+          ( pullback-property-pushout-universal-property-pushout f g
             ( h , k , bottom)
             ( up-bottom)
             ( W)))
@@ -963,7 +963,7 @@ module _
   universal-property-pushout-bottom-universal-property-pushout-top-cube-is-equiv
     ( up-top)
     { l = l} =
-    universal-property-pushout-pullback-property-pushout-Level l f g
+    universal-property-pushout-pullback-property-pushout f g
       ( h , k , bottom)
       ( λ W →
         is-pullback-top-is-pullback-bottom-cube-is-equiv
@@ -998,7 +998,7 @@ module _
           ( is-equiv-precomp-is-equiv hB is-equiv-hB W)
           ( is-equiv-precomp-is-equiv hC is-equiv-hC W)
           ( is-equiv-precomp-is-equiv hA is-equiv-hA W)
-          ( pullback-property-pushout-universal-property-pushout-Level f' g'
+          ( pullback-property-pushout-universal-property-pushout f' g'
             ( h' , k' , top)
             ( up-top)
             ( W)))

--- a/src/synthetic-homotopy-theory/universal-property-pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-pushouts.lagda.md
@@ -69,6 +69,10 @@ found in the following table:
 
 ### The universal property of pushouts at a universe level
 
+**Warning.** This definition is here only because of backward compatibility
+reasons, and will be removed in the future. Do not use this definition in new
+formalizations.
+
 ```agda
 universal-property-pushout-Level :
   {l1 l2 l3 l4 : Level} (l : Level) {S : UU l1} {A : UU l2} {B : UU l3}

--- a/src/synthetic-homotopy-theory/universal-property-pushouts.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-pushouts.lagda.md
@@ -260,9 +260,9 @@ triangle-pullback-property-pushout-universal-property-pushout :
   {l1 l2 l3 l4 : Level} {S : UU l1} {A : UU l2}
   {B : UU l3} (f : S → A) (g : S → B) {X : UU l4} (c : cocone f g X) →
   {l : Level} (Y : UU l) →
-  ( cocone-map f g c) ~
-  ( tot (λ i' → tot (λ j' → htpy-eq))) ∘
-  ( gap (_∘ f) (_∘ g) (cone-pullback-property-pushout f g c Y))
+  cocone-map f g c ~
+  ( tot (λ i' → tot (λ j' → htpy-eq)) ∘
+    gap (_∘ f) (_∘ g) (cone-pullback-property-pushout f g c Y))
 triangle-pullback-property-pushout-universal-property-pushout f g c Y h =
     eq-pair-eq-fiber
       ( eq-pair-eq-fiber
@@ -492,10 +492,7 @@ module _
               ( W))))
 
   universal-property-pushout-right-universal-property-pushout-rectangle :
-    universal-property-pushout
-      ( f)
-      ( k ∘ g)
-      ( cocone-comp-horizontal f g k c d) →
+    universal-property-pushout f (k ∘ g) (cocone-comp-horizontal f g k c d) →
     universal-property-pushout (vertical-map-cocone f g c) k d
   universal-property-pushout-right-universal-property-pushout-rectangle
     ( up-r)
@@ -633,11 +630,9 @@ module _
   where
 
   universal-property-pushout-rectangle-universal-property-pushout-top :
-    ( universal-property-pushout k (horizontal-map-cocone f g c) d) →
-    ( universal-property-pushout (k ∘ f) g (cocone-comp-vertical f g k c d))
-  universal-property-pushout-rectangle-universal-property-pushout-top
-    ( up-d)
-    { l} =
+    universal-property-pushout k (horizontal-map-cocone f g c) d →
+    universal-property-pushout (k ∘ f) g (cocone-comp-vertical f g k c d)
+  universal-property-pushout-rectangle-universal-property-pushout-top up-d =
     universal-property-pushout-pullback-property-pushout
       ( k ∘ f)
       ( g)
@@ -699,9 +694,7 @@ module _
   universal-property-pushout-top-universal-property-pushout-rectangle :
     universal-property-pushout (k ∘ f) g (cocone-comp-vertical f g k c d) →
     universal-property-pushout k (horizontal-map-cocone f g c) d
-  universal-property-pushout-top-universal-property-pushout-rectangle
-    ( up-r)
-    { l} =
+  universal-property-pushout-top-universal-property-pushout-rectangle up-r =
     universal-property-pushout-pullback-property-pushout k
       ( horizontal-map-cocone f g c)
       ( d)

--- a/src/synthetic-homotopy-theory/universal-property-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-sequential-colimits.lagda.md
@@ -75,8 +75,7 @@ module _
 
   universal-property-sequential-colimit : UUω
   universal-property-sequential-colimit =
-    {l : Level} → (Y : UU l) →
-    is-equiv (cocone-map-sequential-diagram c {Y = Y})
+    {l : Level} (Y : UU l) → is-equiv (cocone-map-sequential-diagram c {Y = Y})
 ```
 
 ### The map induced by the universal property of sequential colimits

--- a/src/synthetic-homotopy-theory/universal-property-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-sequential-colimits.lagda.md
@@ -165,10 +165,9 @@ module _
   where
 
   universal-property-sequential-colimit-universal-property-coequalizer :
-    ( {l : Level} →
-      universal-property-coequalizer l
-        ( double-arrow-sequential-diagram A)
-        ( cofork-cocone-sequential-diagram c)) →
+    universal-property-coequalizer
+      ( double-arrow-sequential-diagram A)
+      ( cofork-cocone-sequential-diagram c) →
     universal-property-sequential-colimit c
   universal-property-sequential-colimit-universal-property-coequalizer
     ( up-cofork)
@@ -185,10 +184,9 @@ module _
 
   universal-property-coequalizer-universal-property-sequential-colimit :
     universal-property-sequential-colimit c →
-    ( {l : Level} →
-      universal-property-coequalizer l
-        ( double-arrow-sequential-diagram A)
-        ( cofork-cocone-sequential-diagram c))
+    universal-property-coequalizer
+      ( double-arrow-sequential-diagram A)
+      ( cofork-cocone-sequential-diagram c)
   universal-property-coequalizer-universal-property-sequential-colimit
     ( up-sequential-colimit)
     ( Y) =

--- a/src/synthetic-homotopy-theory/universal-property-suspensions.lagda.md
+++ b/src/synthetic-homotopy-theory/universal-property-suspensions.lagda.md
@@ -56,14 +56,14 @@ module _
     {l : Level} (Z : UU l) → is-equiv (ev-suspension Z)
 ```
 
-### The universal property of the suspension as a pushout
+### The universal property of the suspension at a universe level as a pushout
 
 ```agda
 universal-property-pushout-suspension :
-  (l : Level) {l1 l2 : Level} (X : UU l1) (Y : UU l2)
-  (s : suspension-structure X Y) → UU (lsuc l ⊔ l1 ⊔ l2)
-universal-property-pushout-suspension l X Y s =
-  universal-property-pushout l
+  {l1 l2 : Level} (X : UU l1) (Y : UU l2)
+  (s : suspension-structure X Y) → UUω
+universal-property-pushout-suspension X Y s =
+  universal-property-pushout
     ( terminal-map X)
     ( terminal-map X)
     ( suspension-cocone-suspension-structure s)
@@ -85,10 +85,10 @@ triangle-ev-suspension :
 triangle-ev-suspension (N , S , merid) Z h = refl
 
 is-equiv-ev-suspension :
-  { l1 l2 l3 : Level} {X : UU l1} {Y : UU l2} →
+  { l1 l2 : Level} {X : UU l1} {Y : UU l2} →
   ( s : suspension-structure X Y) →
-  ( up-Y : universal-property-pushout-suspension l3 X Y s) →
-  ( Z : UU l3) → is-equiv (ev-suspension s Z)
+  universal-property-pushout-suspension X Y s →
+  { l3 : Level} (Z : UU l3) → is-equiv (ev-suspension s Z)
 is-equiv-ev-suspension {X = X} s up-Y Z =
   is-equiv-left-map-triangle
     ( ev-suspension s Z)


### PR DESCRIPTION
Refactors all universal properties and induction principles of colimits to quantify over all universe levels. This still leaves some lemmas about pushout cocones in an awkward position, but I leave that for future work.