### PR TITLE
Pin macOS version to one with Intel runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS-latest, ubuntu-latest]
+        os: [macOS-13, ubuntu-latest]
         agda: ['2.6.4']
     steps:
       - name: Checkout our repository

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   website:
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         agda: ['2.6.4']


### PR DESCRIPTION
The `macOS-latest` runners are now macOS 14, and GitHub only provides arm64 machines for those. The setup-agda action doesn't have prebuilt binaries of Agda for that, so I'm pinning the macos version to 13.

I also switched the website deployment workflow to run on Ubuntu instead of macos, since the Linux runners are consistently faster for us.