### PR TITLE
Fix citation tag configuration for some references

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -152,7 +152,7 @@
   eprintclass = {cs},
 }
 
-@inproceedings{dJKFC23,
+@inproceedings{dJKFX23,
   title       = {Set-{{Theoretic}} and {{Type-Theoretic Ordinals Coincide}}},
   booktitle   = {2023 38th {{Annual ACM}}/{{IEEE Symposium}} on {{Logic}} in {{Computer Science}} ({{LICS}})},
   author      = {de Jong, Tom and Kraus, Nicolai and Forsberg, Fredrik Nordvall and Xu, Chuangjie},

--- a/references.bib
+++ b/references.bib
@@ -39,8 +39,7 @@
 
 @online{BdJR24,
   title       = {Epimorphisms and {{Acyclic Types}} in {{Univalent Mathematics}}},
-  author      = {Buchholtz, Ulrik and {{de}} Jong, Tom and Rijke, Egbert},
-  citeas      = {BdJR24},
+  author      = {Buchholtz, Ulrik and de Jong, Tom and Rijke, Egbert},
   date        = {2024-01-25},
   year        = {2024},
   month       = {01},
@@ -52,10 +51,9 @@
   keywords    = {Computer Science - Logic in Computer Science,Mathematics - Algebraic Topology,Mathematics - Category Theory}
 }
 
-@online{BDR18,
+@online{BvDR18,
   title       = {Higher {{Groups}} in {{Homotopy Type Theory}}},
-  author      = {Buchholtz, Ulrik and {{van}} Doorn, Floris and Rijke, Egbert},
-  citeas      = {BDR18},
+  author      = {Buchholtz, Ulrik and van Doorn, Floris and Rijke, Egbert},
   date        = {2018-02-12},
   year        = {2018},
   month       = {02},
@@ -140,7 +138,7 @@
 
 @article{dJE23,
   title       = {{On Small Types in Univalent Foundations}},
-  author      = {{{de}} Jong, Tom and  Escardó, Martín Hötzel},
+  author      = {de Jong, Tom and  Escardó, Martín Hötzel},
   url         = {https://lmcs.episciences.org/11270},
   doi         = {10.46298/lmcs-19(2:8)2023},
   journal     = {{Logical Methods in Computer Science}},
@@ -152,14 +150,12 @@
   eprint      = {2111.00482},
   eprinttype  = {arxiv},
   eprintclass = {cs},
-  citeas      = {dJE23}
 }
 
 @inproceedings{dJKFC23,
   title       = {Set-{{Theoretic}} and {{Type-Theoretic Ordinals Coincide}}},
   booktitle   = {2023 38th {{Annual ACM}}/{{IEEE Symposium}} on {{Logic}} in {{Computer Science}} ({{LICS}})},
-  author      = {{{de}} Jong, Tom and Kraus, Nicolai and Forsberg, Fredrik Nordvall and Xu, Chuangjie},
-  citeas      = {dJKFC23},
+  author      = {de Jong, Tom and Kraus, Nicolai and Forsberg, Fredrik Nordvall and Xu, Chuangjie},
   date        = {2023-06-26},
   year        = {2023},
   month       = {06},
@@ -475,11 +471,10 @@
   keywords    = {Computer Science - Logic in Computer Science,F.3.1,F.3.1 F.4.1,F.4.1,Mathematics - Category Theory,Mathematics - Logic}
 }
 
-@inproceedings{SDR20,
+@inproceedings{SvDR20,
   title     = {Sequential {{Colimits}} in {{Homotopy Type Theory}}},
   booktitle = {Proceedings of the 35th {{Annual ACM}}/{{IEEE Symposium}} on {{Logic}} in {{Computer Science}}},
-  author    = {Sojakova, Kristina and {{van}} Doorn, Floris and Rijke, Egbert},
-  citeas    = {SDR20},
+  author    = {Sojakova, Kristina and van Doorn, Floris and Rijke, Egbert},
   date      = {2020-07-08},
   year      = {2020},
   month     = {07},

--- a/references.bib
+++ b/references.bib
@@ -138,7 +138,7 @@
 
 @article{dJE23,
   title       = {{On Small Types in Univalent Foundations}},
-  author      = {de Jong, Tom and  Escardó, Martín Hötzel},
+  author      = {de Jong, Tom and Escardó, Martín Hötzel},
   url         = {https://lmcs.episciences.org/11270},
   doi         = {10.46298/lmcs-19(2:8)2023},
   journal     = {{Logical Methods in Computer Science}},

--- a/src/set-theory/cumulative-hierarchy.lagda.md
+++ b/src/set-theory/cumulative-hierarchy.lagda.md
@@ -775,4 +775,4 @@ needed.
 
 ## References
 
-{{#bibliography}} {{#reference UF13}} {{#reference dJKFC23}}
+{{#bibliography}} {{#reference UF13}} {{#reference dJKFX23}}

--- a/src/synthetic-homotopy-theory/cocones-under-sequential-diagrams.lagda.md
+++ b/src/synthetic-homotopy-theory/cocones-under-sequential-diagrams.lagda.md
@@ -383,4 +383,4 @@ module _
 
 ## References
 
-{{#bibliography}} {{#reference SDR20}}
+{{#bibliography}} {{#reference SvDR20}}

--- a/src/synthetic-homotopy-theory/dependent-sequential-diagrams.lagda.md
+++ b/src/synthetic-homotopy-theory/dependent-sequential-diagrams.lagda.md
@@ -165,4 +165,4 @@ module _
 
 ## References
 
-{{#bibliography}} {{#reference SDR20}}
+{{#bibliography}} {{#reference SvDR20}}

--- a/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
+++ b/src/synthetic-homotopy-theory/functoriality-sequential-colimits.lagda.md
@@ -792,4 +792,4 @@ module _
 
 ## References
 
-{{#bibliography}} {{#reference SDR20}}
+{{#bibliography}} {{#reference SvDR20}}

--- a/src/synthetic-homotopy-theory/sequential-diagrams.lagda.md
+++ b/src/synthetic-homotopy-theory/sequential-diagrams.lagda.md
@@ -113,4 +113,4 @@ module _
 
 ## References
 
-{{#bibliography}} {{#reference SDR20}}
+{{#bibliography}} {{#reference SvDR20}}


### PR DESCRIPTION
Fixes and simplifies some citation label configuration. It turns out the system is capable of handling edge cases for capitalization in names, such as "de Jong, Tom" without further input from us.