### PR TITLE
Path-cosplit maps

### DIFF
--- a/src/foundation-core/contractible-maps.lagda.md
+++ b/src/foundation-core/contractible-maps.lagda.md
@@ -18,6 +18,8 @@ open import foundation-core.fibers-of-maps
 open import foundation-core.function-types
 open import foundation-core.homotopies
 open import foundation-core.identity-types
+open import foundation-core.retractions
+open import foundation-core.sections
 ```
 
 </details>
@@ -48,35 +50,43 @@ module _
 
 ```agda
 module _
-  {l1 l2 : Level} {A : UU l1} {B : UU l2} {f : A → B}
+  {l1 l2 : Level} {A : UU l1} {B : UU l2} {f : A → B} (H : is-contr-map f)
   where
 
-  map-inv-is-contr-map : is-contr-map f → B → A
-  map-inv-is-contr-map H y = pr1 (center (H y))
+  map-inv-is-contr-map : B → A
+  map-inv-is-contr-map y = pr1 (center (H y))
 
   is-section-map-inv-is-contr-map :
-    (H : is-contr-map f) → (f ∘ (map-inv-is-contr-map H)) ~ id
-  is-section-map-inv-is-contr-map H y = pr2 (center (H y))
+    is-section f map-inv-is-contr-map
+  is-section-map-inv-is-contr-map y = pr2 (center (H y))
 
   is-retraction-map-inv-is-contr-map :
-    (H : is-contr-map f) → ((map-inv-is-contr-map H) ∘ f) ~ id
-  is-retraction-map-inv-is-contr-map H x =
+    is-retraction f map-inv-is-contr-map
+  is-retraction-map-inv-is-contr-map x =
     ap
-      ( pr1 {B = λ z → (f z) ＝ (f x)})
+      ( pr1 {B = λ z → (f z ＝ f x)})
       ( ( inv
           ( contraction
             ( H (f x))
-            ( ( map-inv-is-contr-map H (f x)) ,
-              ( is-section-map-inv-is-contr-map H (f x))))) ∙
+            ( ( map-inv-is-contr-map (f x)) ,
+              ( is-section-map-inv-is-contr-map (f x))))) ∙
         ( contraction (H (f x)) (x , refl)))
 
+  section-is-contr-map : section f
+  section-is-contr-map =
+    ( map-inv-is-contr-map , is-section-map-inv-is-contr-map)
+
+  retraction-is-contr-map : retraction f
+  retraction-is-contr-map =
+    ( map-inv-is-contr-map , is-retraction-map-inv-is-contr-map)
+
   abstract
-    is-equiv-is-contr-map : is-contr-map f → is-equiv f
-    is-equiv-is-contr-map H =
+    is-equiv-is-contr-map : is-equiv f
+    is-equiv-is-contr-map =
       is-equiv-is-invertible
-        ( map-inv-is-contr-map H)
-        ( is-section-map-inv-is-contr-map H)
-        ( is-retraction-map-inv-is-contr-map H)
+        ( map-inv-is-contr-map)
+        ( is-section-map-inv-is-contr-map)
+        ( is-retraction-map-inv-is-contr-map)
 ```
 
 ### Any coherently invertible map is a contractible map

--- a/src/foundation-core/injective-maps.lagda.md
+++ b/src/foundation-core/injective-maps.lagda.md
@@ -153,3 +153,8 @@ is-injective-is-contr :
   is-contr A → is-injective f
 is-injective-is-contr f H p = eq-is-contr H
 ```
+
+## See also
+
+- [Embeddings](foundation-core.embeddings.md)
+- [Path-cosplit maps](foundation.path-cosplit-maps.md)

--- a/src/foundation.lagda.md
+++ b/src/foundation.lagda.md
@@ -255,6 +255,7 @@ open import foundation.mere-equality public
 open import foundation.mere-equivalences public
 open import foundation.mere-functions public
 open import foundation.mere-logical-equivalences public
+open import foundation.mere-path-cosplit-maps public
 open import foundation.monomorphisms public
 open import foundation.morphisms-arrows public
 open import foundation.morphisms-binary-relations public

--- a/src/foundation.lagda.md
+++ b/src/foundation.lagda.md
@@ -287,6 +287,7 @@ open import foundation.partial-functions public
 open import foundation.partial-sequences public
 open import foundation.partitions public
 open import foundation.path-algebra public
+open import foundation.path-cosplit-maps public
 open import foundation.path-split-maps public
 open import foundation.perfect-images public
 open import foundation.permutations-spans-families-of-types public

--- a/src/foundation/inhabited-types.lagda.md
+++ b/src/foundation/inhabited-types.lagda.md
@@ -195,7 +195,7 @@ pr2 (Σ-Inhabited-Type X Y) =
 ```agda
 map-is-inhabited :
   {l1 l2 : Level} {A : UU l1} {B : UU l2} →
-  (f : (A → B)) → is-inhabited A → is-inhabited B
+  (f : A → B) → is-inhabited A → is-inhabited B
 map-is-inhabited f = map-trunc-Prop f
 ```
 

--- a/src/foundation/injective-maps.lagda.md
+++ b/src/foundation/injective-maps.lagda.md
@@ -104,3 +104,8 @@ module _
   pr1 (is-injective-Prop H f) = is-injective f
   pr2 (is-injective-Prop H f) = is-prop-is-injective H f
 ```
+
+## See also
+
+- [Embeddings](foundation-core.embeddings.md)
+- [Path-cosplit maps](foundation.path-cosplit-maps.md)

--- a/src/foundation/mere-path-cosplit-maps.lagda.md
+++ b/src/foundation/mere-path-cosplit-maps.lagda.md
@@ -41,7 +41,7 @@ is one such notion, lying somewhere between
 has a converse map, then we have proper inclusions
 
 ```text
-  k-injective maps ⊃ mere k-path-cosplit maps ⊃ k-truncated maps.
+  k-injective maps ⊃ k-path-cosplit maps ⊃ k-truncated maps.
 ```
 
 While `k`-truncatedness answers the question: "at which dimension is the action
@@ -50,7 +50,8 @@ on higher identifications of a function always an
 instead answers the question: "at which dimension is the action merely a
 [retract](foundation-core.retracts-of-types.md)?" Thus a _-2-path-cosplit map_
 is a map that merely is a retract. A mere `k+1`-path-cosplit map is a map whose
-action on identifications is merely `k`-path-cosplit.
+[action on identifications](foundation.action-on-identifications-functions.md)
+is merely `k`-path-cosplit.
 
 We show that mere `k`-path-cosplittness coincides with `k`-truncatedness when
 the codomain is `k`-truncated, but more generally mere `k`-path-cosplitting may
@@ -158,3 +159,7 @@ is-trunc-map-is-mere-path-cosplit-is-trunc-codomain k is-trunc-B is-cosplit-f =
 ## See also
 
 - [Path-cosplit maps](foundation.path-cosplit-maps.md)
+- [Path-split maps](foundation.path-cosplit-maps.md)
+- [Injective maps](foundation-core.injective-maps.md)
+- [Truncated maps](foundation-core.truncated-maps.md)
+- [Embeddings](foundation-core.embeddings.md)

--- a/src/foundation/mere-path-cosplit-maps.lagda.md
+++ b/src/foundation/mere-path-cosplit-maps.lagda.md
@@ -1,0 +1,157 @@
+# Mere path-cosplit maps
+
+```agda
+module foundation.mere-path-cosplit-maps where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.action-on-identifications-functions
+open import foundation.dependent-pair-types
+open import foundation.inhabited-types
+open import foundation.iterated-dependent-product-types
+open import foundation.logical-equivalences
+open import foundation.propositional-truncations
+open import foundation.truncated-maps
+open import foundation.truncation-levels
+open import foundation.universe-levels
+
+open import foundation-core.contractible-maps
+open import foundation-core.contractible-types
+open import foundation-core.equivalences
+open import foundation-core.propositions
+open import foundation-core.retractions
+open import foundation-core.truncated-types
+```
+
+</details>
+
+## Idea
+
+In Homotopy Type Theory, there are multiple nonequivalent ways to state that a
+map is "injective" that are more or less informed by the homotopy structures of
+its domain and codomain. A
+{{#concept "mere path-cosplit map" Disambiguation="between types" Agda=is-mere-path-cosplit}}
+is one such notion, lying somewhere between
+[embeddings](foundation-core.embeddings.md) and
+[injective maps](foundation-core.injective-maps.md). In fact, given an integer
+`k ≥ -2`, if we understand `k`-injective map to mean the `k+2`-dimensional
+[action on identifications](foundation.action-on-higher-identifications-functions.md)
+has a converse map, then we have proper inclusions
+
+```text
+  k-injective maps ⊃ mere k-path-cosplit maps ⊃ k-truncated maps.
+```
+
+While `k`-truncatedness answers the question: "at which dimension is the action
+on higher identifications of a function always an
+[equivalence](foundation-core.equivalences.md)?", mere `k`-path-cosplitting
+instead answers the question: "at which dimension is the action merely a
+[retract](foundation-core.retracts-of-types.md)?" Thus a _-2-path-cosplit map_
+is a map that merely is a retract. A mere `k+1`-path-cosplit map is a map whose
+action on identifications is merely `k`-path-cosplit.
+
+We show that mere `k`-path-cosplittness coincides with `k`-truncatedness when
+the codomain is `k`-truncated, but more generally mere `k`-path-cosplitting may
+only induce mere retracts on higher homotopy groups.
+
+## Definitions
+
+```agda
+is-mere-path-cosplit :
+  {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} → (A → B) → UU (l1 ⊔ l2)
+is-mere-path-cosplit neg-two-𝕋 f = is-inhabited (retraction f)
+is-mere-path-cosplit (succ-𝕋 k) {A} f =
+  (x y : A) → is-mere-path-cosplit k (ap f {x} {y})
+```
+
+## Properties
+
+### Being merely path-cosplit is a property
+
+```agda
+is-prop-is-mere-path-cosplit :
+  {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} (f : A → B) →
+  is-prop (is-mere-path-cosplit k f)
+is-prop-is-mere-path-cosplit neg-two-𝕋 f =
+  is-property-is-inhabited (retraction f)
+is-prop-is-mere-path-cosplit (succ-𝕋 k) f =
+  is-prop-Π (λ x → is-prop-Π λ y → is-prop-is-mere-path-cosplit k (ap f))
+
+is-mere-path-cosplit-Prop :
+  {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} → (A → B) → Prop (l1 ⊔ l2)
+is-mere-path-cosplit-Prop k f = (is-mere-path-cosplit k f , is-prop-is-mere-path-cosplit k f)
+```
+
+### If a map is `k`-truncated then it is merely `k`-path-cosplit
+
+```agda
+is-mere-path-cosplit-is-trunc :
+  {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} {f : A → B} →
+  is-trunc-map k f → is-mere-path-cosplit k f
+is-mere-path-cosplit-is-trunc neg-two-𝕋 is-trunc-f =
+  unit-trunc-Prop (retraction-is-contr-map is-trunc-f)
+is-mere-path-cosplit-is-trunc (succ-𝕋 k) {f = f} is-trunc-f x y =
+  is-mere-path-cosplit-is-trunc k (is-trunc-map-ap-is-trunc-map k f is-trunc-f x y)
+```
+
+### If a map is `k`-path-cosplit then it is merely `k+1`-path-cosplit
+
+```agda
+is-mere-path-cosplit-succ-is-mere-path-cosplit :
+  {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} {f : A → B} →
+  is-mere-path-cosplit k f → is-mere-path-cosplit (succ-𝕋 k) f
+is-mere-path-cosplit-succ-is-mere-path-cosplit neg-two-𝕋 {f = f} is-cosplit-f x y =
+  rec-trunc-Prop
+    ( is-mere-path-cosplit-Prop neg-two-𝕋 (ap f))
+    ( λ r → unit-trunc-Prop (retraction-ap f r))
+    ( is-cosplit-f)
+is-mere-path-cosplit-succ-is-mere-path-cosplit (succ-𝕋 k) is-cosplit-f x y =
+  is-mere-path-cosplit-succ-is-mere-path-cosplit k (is-cosplit-f x y)
+```
+
+### If a type maps into a `k`-truncted type via a merely `k`-path-cosplit map then it is `k`-truncated
+
+```agda
+is-trunc-domain-is-mere-path-cosplit-is-trunc-codomain :
+  {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} {f : A → B} →
+  is-trunc k B → is-mere-path-cosplit k f → is-trunc k A
+is-trunc-domain-is-mere-path-cosplit-is-trunc-codomain neg-two-𝕋
+  {A} {B} {f} is-trunc-B =
+  rec-trunc-Prop
+    ( is-trunc-Prop neg-two-𝕋 A)
+    ( λ r → is-trunc-retract-of (f , r) is-trunc-B)
+is-trunc-domain-is-mere-path-cosplit-is-trunc-codomain
+  (succ-𝕋 k) {A} {B} {f} is-trunc-B is-cosplit-f x y =
+  is-trunc-domain-is-mere-path-cosplit-is-trunc-codomain k
+    ( is-trunc-B (f x) (f y))
+    ( is-cosplit-f x y)
+```
+
+This result generalizes the following statements:
+
+- A type that injects into a set is a set.
+
+- A type that embeds into a `k+1`-truncated type is `k+1`-truncated.
+
+- A type that maps into a `k`-truncated type via a `k`-truncated map is
+  `k`-truncated.
+
+### If the codomain of a mere `k`-path-cosplit map is `k`-truncated then the map is `k`-truncated
+
+```agda
+is-trunc-map-is-mere-path-cosplit-is-trunc-codomain :
+  {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} {f : A → B} →
+  is-trunc k B → is-mere-path-cosplit k f → is-trunc-map k f
+is-trunc-map-is-mere-path-cosplit-is-trunc-codomain k is-trunc-B is-cosplit-f =
+  is-trunc-map-is-trunc-domain-codomain k
+    ( is-trunc-domain-is-mere-path-cosplit-is-trunc-codomain k
+      ( is-trunc-B)
+      ( is-cosplit-f))
+    ( is-trunc-B)
+```
+
+## See also
+
+- [Path-cosplit maps](foundation.path-cosplit-maps.md)

--- a/src/foundation/mere-path-cosplit-maps.lagda.md
+++ b/src/foundation/mere-path-cosplit-maps.lagda.md
@@ -81,7 +81,8 @@ is-prop-is-mere-path-cosplit (succ-𝕋 k) f =
 
 is-mere-path-cosplit-Prop :
   {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} → (A → B) → Prop (l1 ⊔ l2)
-is-mere-path-cosplit-Prop k f = (is-mere-path-cosplit k f , is-prop-is-mere-path-cosplit k f)
+is-mere-path-cosplit-Prop k f =
+  (is-mere-path-cosplit k f , is-prop-is-mere-path-cosplit k f)
 ```
 
 ### If a map is `k`-truncated then it is merely `k`-path-cosplit
@@ -93,7 +94,8 @@ is-mere-path-cosplit-is-trunc :
 is-mere-path-cosplit-is-trunc neg-two-𝕋 is-trunc-f =
   unit-trunc-Prop (retraction-is-contr-map is-trunc-f)
 is-mere-path-cosplit-is-trunc (succ-𝕋 k) {f = f} is-trunc-f x y =
-  is-mere-path-cosplit-is-trunc k (is-trunc-map-ap-is-trunc-map k f is-trunc-f x y)
+  is-mere-path-cosplit-is-trunc k
+    ( is-trunc-map-ap-is-trunc-map k f is-trunc-f x y)
 ```
 
 ### If a map is `k`-path-cosplit then it is merely `k+1`-path-cosplit
@@ -102,7 +104,8 @@ is-mere-path-cosplit-is-trunc (succ-𝕋 k) {f = f} is-trunc-f x y =
 is-mere-path-cosplit-succ-is-mere-path-cosplit :
   {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} {f : A → B} →
   is-mere-path-cosplit k f → is-mere-path-cosplit (succ-𝕋 k) f
-is-mere-path-cosplit-succ-is-mere-path-cosplit neg-two-𝕋 {f = f} is-cosplit-f x y =
+is-mere-path-cosplit-succ-is-mere-path-cosplit
+  neg-two-𝕋 {f = f} is-cosplit-f x y =
   rec-trunc-Prop
     ( is-mere-path-cosplit-Prop neg-two-𝕋 (ap f))
     ( λ r → unit-trunc-Prop (retraction-ap f r))

--- a/src/foundation/mere-path-cosplit-maps.lagda.md
+++ b/src/foundation/mere-path-cosplit-maps.lagda.md
@@ -44,12 +44,18 @@ has a converse map, then we have proper inclusions
   k-injective maps ⊃ k-path-cosplit maps ⊃ k-truncated maps.
 ```
 
-While `k`-truncatedness answers the question: "at which dimension is the action
-on higher identifications of a function always an
-[equivalence](foundation-core.equivalences.md)?", mere `k`-path-cosplitting
-instead answers the question: "at which dimension is the action merely a
-[retract](foundation-core.retracts-of-types.md)?" Thus a _-2-path-cosplit map_
-is a map that merely is a retract. A mere `k+1`-path-cosplit map is a map whose
+While `k`-truncatedness answers the question:
+
+> At which dimension is the action on higher identifications of a function
+> always an [equivalence](foundation-core.equivalences.md)?
+
+Mere `k`-path-cosplitting instead answers the question:
+
+> At which dimension is the action merely a
+> [retract](foundation-core.retracts-of-types.md)?
+
+Thus a _merely `-2`-path-cosplit map_ is a map that merely is a retract. A
+_merely `k+1`-path-cosplit map_ is a map whose
 [action on identifications](foundation.action-on-identifications-functions.md)
 is merely `k`-path-cosplit.
 

--- a/src/foundation/path-cosplit-maps.lagda.md
+++ b/src/foundation/path-cosplit-maps.lagda.md
@@ -12,9 +12,9 @@ open import foundation.dependent-pair-types
 open import foundation.inhabited-types
 open import foundation.iterated-dependent-product-types
 open import foundation.logical-equivalences
+open import foundation.mere-path-cosplit-maps
 open import foundation.propositional-truncations
 open import foundation.truncated-maps
-open import foundation.mere-path-cosplit-maps
 open import foundation.truncation-levels
 open import foundation.universe-levels
 

--- a/src/foundation/path-cosplit-maps.lagda.md
+++ b/src/foundation/path-cosplit-maps.lagda.md
@@ -45,13 +45,19 @@ has a converse map, then we have proper inclusions
   k-injective maps ⊃ k-path-cosplit maps ⊃ k-truncated maps.
 ```
 
-While `k`-truncatedness answers the question: "at which dimension is the action
-on higher identifications of a function always an
-[equivalence](foundation-core.equivalences.md)?", `k`-path-cosplitting instead
-answers the question: "at which dimension is the action a
-[retract](foundation-core.retracts-of-types.md)?" Thus a _-2-path-cosplit map_
-is a map equipped with a [retraction](foundation-core.retractions.md). A
-`k+1`-path-cosplit map is a map whose
+While `k`-truncatedness answers the question:
+
+> At which dimension is the action on higher identifications of a function
+> always an [equivalence](foundation-core.equivalences.md)?
+
+Being `k`-path-cosplitting instead answers the question:
+
+> At which dimension is the action a
+> [retract](foundation-core.retracts-of-types.md)?
+
+Thus a _-2-path-cosplit map_ is a map equipped with a
+[retraction](foundation-core.retractions.md). A _`k+1`-path-cosplit map_ is a
+map whose
 [action on identifications](foundation.action-on-identifications-functions.md)
 is `k`-path-cosplit.
 

--- a/src/foundation/path-cosplit-maps.lagda.md
+++ b/src/foundation/path-cosplit-maps.lagda.md
@@ -1,0 +1,131 @@
+# Path-cosplit maps
+
+```agda
+module foundation.path-cosplit-maps where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.action-on-identifications-functions
+open import foundation.dependent-pair-types
+open import foundation.inhabited-types
+open import foundation.iterated-dependent-product-types
+open import foundation.logical-equivalences
+open import foundation.propositional-truncations
+open import foundation.truncation-levels
+open import foundation.universe-levels
+
+open import foundation-core.contractible-maps
+open import foundation-core.contractible-types
+open import foundation-core.equivalences
+open import foundation-core.propositions
+open import foundation-core.retractions
+open import foundation-core.truncated-maps
+open import foundation-core.truncated-types
+```
+
+</details>
+
+## Idea
+
+In Homotopy Type Theory, there are multiple nonequivalent ways to state that a
+map is "injective" that are more or less informed by the homotopy structures of
+its domain and codomain. A _path-cosplit map_ is one such notion, lying
+somewhere between [embeddings](foundation-core.embeddings.md) and
+[injective maps](foundation-core.injective-maps.md). In fact, if we understand
+`k`-injective map to mean the `k`-dimensional action on identifications has a
+converse, then we have proper inclusions
+
+```text
+  k-injective maps ⊂ k-path-cosplit maps ⊂ k-truncated maps
+```
+
+In essence, we can ask two independent questions about a function `f : A → B`:
+at which dimension is its (iterated)
+[action on identifications](foundation.action-on-identifications-functions.md)
+an equivalence, but also, before that, at which level is it a retract? While
+`k`-truncation answers the first question, `k`-path-cosplitting answers the
+second.
+
+Thus a -2-path-cosplit map is a map that merely is a retract. A
+`k+1`-path-cosplit map is a map whose action on identifications is
+`k`-path-cosplit.
+
+## Definitions
+
+```agda
+is-path-cosplit :
+  {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} → (A → B) → UU (l1 ⊔ l2)
+is-path-cosplit neg-two-𝕋 f = is-inhabited (retraction f)
+is-path-cosplit (succ-𝕋 k) {A} f = (x y : A) → is-path-cosplit k (ap f {x} {y})
+```
+
+## Properties
+
+### Being path-cosplit is a property
+
+```agda
+is-prop-is-path-cosplit :
+  {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} (f : A → B) →
+  is-prop (is-path-cosplit k f)
+is-prop-is-path-cosplit neg-two-𝕋 f =
+  is-property-is-inhabited (retraction f)
+is-prop-is-path-cosplit (succ-𝕋 k) f =
+  is-prop-Π (λ x → is-prop-Π λ y → is-prop-is-path-cosplit k (ap f))
+
+is-path-cosplit-Prop :
+  {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} → (A → B) → Prop (l1 ⊔ l2)
+is-path-cosplit-Prop k f = (is-path-cosplit k f , is-prop-is-path-cosplit k f)
+```
+
+### If a map is `k`-truncated then it is `k`-path-cosplit
+
+```agda
+is-path-cosplit-is-trunc :
+  {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} {f : A → B} →
+  is-trunc-map k f → is-path-cosplit k f
+is-path-cosplit-is-trunc neg-two-𝕋 is-trunc-f =
+  unit-trunc-Prop (retraction-is-contr-map is-trunc-f)
+is-path-cosplit-is-trunc (succ-𝕋 k) {f = f} is-trunc-f x y =
+  is-path-cosplit-is-trunc k (is-trunc-map-ap-is-trunc-map k f is-trunc-f x y)
+```
+
+### If a map is `k`-path-cosplit then it is `k+1`-path-cosplit
+
+```agda
+is-path-cosplit-succ-is-path-cosplit :
+  {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} {f : A → B} →
+  is-path-cosplit k f → is-path-cosplit (succ-𝕋 k) f
+is-path-cosplit-succ-is-path-cosplit neg-two-𝕋 {f = f} is-cosplit-f x y =
+  rec-trunc-Prop
+    ( is-path-cosplit-Prop neg-two-𝕋 (ap f))
+    ( λ r → unit-trunc-Prop (retraction-ap f r))
+    ( is-cosplit-f)
+is-path-cosplit-succ-is-path-cosplit (succ-𝕋 k) is-cosplit-f x y =
+  is-path-cosplit-succ-is-path-cosplit k (is-cosplit-f x y)
+```
+
+### If a type maps into a `k`-truncted type via a `k`-path-cosplit map then it is `k`-truncated
+
+```agda
+is-trunc-domain-is-path-cosplit-is-trunc-codomain :
+  {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} {f : A → B} →
+  is-trunc k B → is-path-cosplit k f → is-trunc k A
+is-trunc-domain-is-path-cosplit-is-trunc-codomain neg-two-𝕋
+  {A} {B} {f} is-trunc-B =
+  rec-trunc-Prop
+    ( is-trunc-Prop neg-two-𝕋 A)
+    ( λ r → is-trunc-retract-of (f , r) is-trunc-B)
+is-trunc-domain-is-path-cosplit-is-trunc-codomain
+  (succ-𝕋 k) {A} {B} {f} is-trunc-B is-cosplit-f x y =
+  is-trunc-domain-is-path-cosplit-is-trunc-codomain k
+    ( is-trunc-B (f x) (f y))
+    ( is-cosplit-f x y)
+```
+
+This result generalizes both of the following statements:
+
+- A type that injects into a set is a set.
+
+- A type that embeds into a `k+1`-truncated type is `k+1`-truncated.

--- a/src/foundation/path-cosplit-maps.lagda.md
+++ b/src/foundation/path-cosplit-maps.lagda.md
@@ -31,26 +31,26 @@ open import foundation-core.truncated-types
 
 In Homotopy Type Theory, there are multiple nonequivalent ways to state that a
 map is "injective" that are more or less informed by the homotopy structures of
-its domain and codomain. A _path-cosplit map_ is one such notion, lying
-somewhere between [embeddings](foundation-core.embeddings.md) and
+its domain and codomain. A
+{{#concept "path-cosplit map" Disambiguation="between types" Agda=is-path-cosplit}}
+is one such notion, lying somewhere between
+[embeddings](foundation-core.embeddings.md) and
 [injective maps](foundation-core.injective-maps.md). In fact, if we understand
-`k`-injective map to mean the `k`-dimensional action on identifications has a
-converse, then we have proper inclusions
+`k`-injective map to mean the `k`-dimensional
+[action on identifications](foundation.action-on-identifications-functions.md)
+has a converse map, then we have proper inclusions
 
 ```text
-  k-injective maps ⊂ k-path-cosplit maps ⊂ k-truncated maps
+  k-injective maps ⊃ k-path-cosplit maps ⊃ k-truncated maps.
 ```
 
-In essence, we can ask two independent questions about a function `f : A → B`:
-at which dimension is its (iterated)
-[action on identifications](foundation.action-on-identifications-functions.md)
-an equivalence, but also, before that, at which level is it a retract? While
-`k`-truncation answers the first question, `k`-path-cosplitting answers the
-second.
-
-Thus a -2-path-cosplit map is a map that merely is a retract. A
-`k+1`-path-cosplit map is a map whose action on identifications is
-`k`-path-cosplit.
+While a `k`-truncated map answers the question: "at which dimension is the
+[action on higher identifications](foundation.action-on-higher-identifications-functions.md)
+of a function always an [equivalence](foundation-core.equivalences.md)?",
+`k`-path-cosplitting instead answers the question: "at which dimension is the
+action a [retract](foundation-core.retracts-of-types.md)?" Thus a
+_-2-path-cosplit map_ is a map that merely is a retract. A `k+1`-path-cosplit
+map is a map whose action on identifications is `k`-path-cosplit.
 
 ## Definitions
 

--- a/src/foundation/path-cosplit-maps.lagda.md
+++ b/src/foundation/path-cosplit-maps.lagda.md
@@ -13,6 +13,7 @@ open import foundation.inhabited-types
 open import foundation.iterated-dependent-product-types
 open import foundation.logical-equivalences
 open import foundation.propositional-truncations
+open import foundation.truncated-maps
 open import foundation.truncation-levels
 open import foundation.universe-levels
 
@@ -21,7 +22,6 @@ open import foundation-core.contractible-types
 open import foundation-core.equivalences
 open import foundation-core.propositions
 open import foundation-core.retractions
-open import foundation-core.truncated-maps
 open import foundation-core.truncated-types
 ```
 
@@ -124,8 +124,25 @@ is-trunc-domain-is-path-cosplit-is-trunc-codomain
     ( is-cosplit-f x y)
 ```
 
-This result generalizes both of the following statements:
+This result generalizes the following statements:
 
 - A type that injects into a set is a set.
 
 - A type that embeds into a `k+1`-truncated type is `k+1`-truncated.
+
+- A type that maps into a `k`-truncated type via a `k`-truncated map is
+  `k`-truncated.
+
+### If the codomain of a `k`-path-cosplit map is `k`-truncated then the map is `k`-truncated
+
+```agda
+is-trunc-map-is-path-cosplit-is-trunc-codomain :
+  {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} {f : A → B} →
+  is-trunc k B → is-path-cosplit k f → is-trunc-map k f
+is-trunc-map-is-path-cosplit-is-trunc-codomain k is-trunc-B is-cosplit-f =
+  is-trunc-map-is-trunc-domain-codomain k
+    ( is-trunc-domain-is-path-cosplit-is-trunc-codomain k
+      ( is-trunc-B)
+      ( is-cosplit-f))
+    ( is-trunc-B)
+```

--- a/src/foundation/path-cosplit-maps.lagda.md
+++ b/src/foundation/path-cosplit-maps.lagda.md
@@ -52,6 +52,10 @@ action a [retract](foundation-core.retracts-of-types.md)?" Thus a
 _-2-path-cosplit map_ is a map that merely is a retract. A `k+1`-path-cosplit
 map is a map whose action on identifications is `k`-path-cosplit.
 
+We show that `k`-path-cosplittness coincides with `k`-truncatedness when the
+codomain is `k`-truncated, but more generally `k`-path-cosplitting may only
+induce mere retracts on higher homotopy groups.
+
 ## Definitions
 
 ```agda

--- a/src/foundation/path-cosplit-maps.lagda.md
+++ b/src/foundation/path-cosplit-maps.lagda.md
@@ -35,53 +35,38 @@ its domain and codomain. A
 {{#concept "path-cosplit map" Disambiguation="between types" Agda=is-path-cosplit}}
 is one such notion, lying somewhere between
 [embeddings](foundation-core.embeddings.md) and
-[injective maps](foundation-core.injective-maps.md). In fact, if we understand
-`k`-injective map to mean the `k`-dimensional
-[action on identifications](foundation.action-on-identifications-functions.md)
+[injective maps](foundation-core.injective-maps.md). In fact, given an integer
+`k ≥ -2`, if we understand `k`-injective map to mean the `k+2`-dimensional
+[action on identifications](foundation.action-on-higher-identifications-functions.md)
 has a converse map, then we have proper inclusions
 
 ```text
   k-injective maps ⊃ k-path-cosplit maps ⊃ k-truncated maps.
 ```
 
-While a `k`-truncated map answers the question: "at which dimension is the
-[action on higher identifications](foundation.action-on-higher-identifications-functions.md)
-of a function always an [equivalence](foundation-core.equivalences.md)?",
-`k`-path-cosplitting instead answers the question: "at which dimension is the
-action a [retract](foundation-core.retracts-of-types.md)?" Thus a
-_-2-path-cosplit map_ is a map that merely is a retract. A `k+1`-path-cosplit
-map is a map whose action on identifications is `k`-path-cosplit.
+While `k`-truncatedness answers the question: "at which dimension is the action
+on higher identifications of a function always an
+[equivalence](foundation-core.equivalences.md)?", `k`-path-cosplitting instead
+answers the question: "at which dimension is the action a
+[retract](foundation-core.retracts-of-types.md)?" Thus a _-2-path-cosplit map_
+is a map equipped with a [retraction](foundation-core.retractions.md). A
+`k+1`-path-cosplit map is a map whose action on identifications is
+`k`-path-cosplit.
 
 We show that `k`-path-cosplittness coincides with `k`-truncatedness when the
 codomain is `k`-truncated, but more generally `k`-path-cosplitting may only
-induce mere retracts on higher homotopy groups.
+induce retracts on higher homotopy groups.
 
 ## Definitions
 
 ```agda
 is-path-cosplit :
   {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} → (A → B) → UU (l1 ⊔ l2)
-is-path-cosplit neg-two-𝕋 f = is-inhabited (retraction f)
+is-path-cosplit neg-two-𝕋 f = retraction f
 is-path-cosplit (succ-𝕋 k) {A} f = (x y : A) → is-path-cosplit k (ap f {x} {y})
 ```
 
 ## Properties
-
-### Being path-cosplit is a property
-
-```agda
-is-prop-is-path-cosplit :
-  {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} (f : A → B) →
-  is-prop (is-path-cosplit k f)
-is-prop-is-path-cosplit neg-two-𝕋 f =
-  is-property-is-inhabited (retraction f)
-is-prop-is-path-cosplit (succ-𝕋 k) f =
-  is-prop-Π (λ x → is-prop-Π λ y → is-prop-is-path-cosplit k (ap f))
-
-is-path-cosplit-Prop :
-  {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} → (A → B) → Prop (l1 ⊔ l2)
-is-path-cosplit-Prop k f = (is-path-cosplit k f , is-prop-is-path-cosplit k f)
-```
 
 ### If a map is `k`-truncated then it is `k`-path-cosplit
 
@@ -90,7 +75,7 @@ is-path-cosplit-is-trunc :
   {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} {f : A → B} →
   is-trunc-map k f → is-path-cosplit k f
 is-path-cosplit-is-trunc neg-two-𝕋 is-trunc-f =
-  unit-trunc-Prop (retraction-is-contr-map is-trunc-f)
+  retraction-is-contr-map is-trunc-f
 is-path-cosplit-is-trunc (succ-𝕋 k) {f = f} is-trunc-f x y =
   is-path-cosplit-is-trunc k (is-trunc-map-ap-is-trunc-map k f is-trunc-f x y)
 ```
@@ -102,10 +87,7 @@ is-path-cosplit-succ-is-path-cosplit :
   {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} {f : A → B} →
   is-path-cosplit k f → is-path-cosplit (succ-𝕋 k) f
 is-path-cosplit-succ-is-path-cosplit neg-two-𝕋 {f = f} is-cosplit-f x y =
-  rec-trunc-Prop
-    ( is-path-cosplit-Prop neg-two-𝕋 (ap f))
-    ( λ r → unit-trunc-Prop (retraction-ap f r))
-    ( is-cosplit-f)
+  retraction-ap f is-cosplit-f
 is-path-cosplit-succ-is-path-cosplit (succ-𝕋 k) is-cosplit-f x y =
   is-path-cosplit-succ-is-path-cosplit k (is-cosplit-f x y)
 ```
@@ -117,10 +99,8 @@ is-trunc-domain-is-path-cosplit-is-trunc-codomain :
   {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} {f : A → B} →
   is-trunc k B → is-path-cosplit k f → is-trunc k A
 is-trunc-domain-is-path-cosplit-is-trunc-codomain neg-two-𝕋
-  {A} {B} {f} is-trunc-B =
-  rec-trunc-Prop
-    ( is-trunc-Prop neg-two-𝕋 A)
-    ( λ r → is-trunc-retract-of (f , r) is-trunc-B)
+  {A} {B} {f} is-trunc-B is-cosplit-f =
+  is-trunc-retract-of (f , is-cosplit-f) is-trunc-B
 is-trunc-domain-is-path-cosplit-is-trunc-codomain
   (succ-𝕋 k) {A} {B} {f} is-trunc-B is-cosplit-f x y =
   is-trunc-domain-is-path-cosplit-is-trunc-codomain k
@@ -150,3 +130,7 @@ is-trunc-map-is-path-cosplit-is-trunc-codomain k is-trunc-B is-cosplit-f =
       ( is-cosplit-f))
     ( is-trunc-B)
 ```
+
+## See also
+
+- [Mere path-cosplit maps](foundation.mere-path-cosplit-maps.md)

--- a/src/foundation/path-cosplit-maps.lagda.md
+++ b/src/foundation/path-cosplit-maps.lagda.md
@@ -51,8 +51,9 @@ on higher identifications of a function always an
 answers the question: "at which dimension is the action a
 [retract](foundation-core.retracts-of-types.md)?" Thus a _-2-path-cosplit map_
 is a map equipped with a [retraction](foundation-core.retractions.md). A
-`k+1`-path-cosplit map is a map whose action on identifications is
-`k`-path-cosplit.
+`k+1`-path-cosplit map is a map whose
+[action on identifications](foundation.action-on-identifications-functions.md)
+is `k`-path-cosplit.
 
 We show that `k`-path-cosplittness coincides with `k`-truncatedness when the
 codomain is `k`-truncated, but more generally `k`-path-cosplitting may only
@@ -147,3 +148,7 @@ is-trunc-map-is-path-cosplit-is-trunc-codomain k is-trunc-B is-cosplit-f =
 ## See also
 
 - [Mere path-cosplit maps](foundation.mere-path-cosplit-maps.md)
+- [Path-split maps](foundation.path-cosplit-maps.md)
+- [Injective maps](foundation-core.injective-maps.md)
+- [Truncated maps](foundation-core.truncated-maps.md)
+- [Embeddings](foundation-core.embeddings.md)

--- a/src/foundation/path-cosplit-maps.lagda.md
+++ b/src/foundation/path-cosplit-maps.lagda.md
@@ -14,6 +14,7 @@ open import foundation.iterated-dependent-product-types
 open import foundation.logical-equivalences
 open import foundation.propositional-truncations
 open import foundation.truncated-maps
+open import foundation.mere-path-cosplit-maps
 open import foundation.truncation-levels
 open import foundation.universe-levels
 
@@ -67,6 +68,18 @@ is-path-cosplit (succ-𝕋 k) {A} f = (x y : A) → is-path-cosplit k (ap f {x} 
 ```
 
 ## Properties
+
+### If a map is `k`-path-cosplit it is merely `k`-path-cosplit
+
+```agda
+is-mere-path-cosplit-is-path-cosplit :
+  {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} {f : A → B} →
+  is-path-cosplit k f → is-mere-path-cosplit k f
+is-mere-path-cosplit-is-path-cosplit neg-two-𝕋 is-cosplit-f =
+  unit-trunc-Prop is-cosplit-f
+is-mere-path-cosplit-is-path-cosplit (succ-𝕋 k) is-cosplit-f x y =
+  is-mere-path-cosplit-is-path-cosplit k (is-cosplit-f x y)
+```
 
 ### If a map is `k`-truncated then it is `k`-path-cosplit
 

--- a/src/foundation/path-split-maps.lagda.md
+++ b/src/foundation/path-split-maps.lagda.md
@@ -68,7 +68,7 @@ module _
 
   equiv-is-equiv-is-path-split : (f : A → B) → is-path-split f ≃ is-equiv f
   equiv-is-equiv-is-path-split f =
-    pair (is-equiv-is-path-split f) (is-equiv-is-equiv-is-path-split f)
+    ( is-equiv-is-path-split f , is-equiv-is-equiv-is-path-split f)
 ```
 
 ## See also


### PR DESCRIPTION
A (mere) `k`-path-cosplit map is defined inductively
- A (mere) `-2`-path-cosplit map is a map that is (merely) a retract
- A (mere) `k+1`-path-cosplit map is a map whose action on identifications is (merely) `k`-path-cosplit.

We show
- Mere `k`-path-cosplitting is a property
- `k`-truncated maps are `k`-path-cosplit
- (merely) `k`-path-cosplit maps are (merely) `k+1`-path-cosplit
- types that map into `k`-truncated types via (mere) `k`-path-cosplit maps are `k`-truncated
- (mere) `k`-path-cosplit maps into `k`-truncated types are `k`-truncated.