### PR TITLE
Cleanup of finite types

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -51,6 +51,16 @@
   keywords    = {Computer Science - Logic in Computer Science,Mathematics - Algebraic Topology,Mathematics - Category Theory}
 }
 
+@book{BSCS05,
+  title     = {Absztrakt algebrai feladatok},
+  author    = {Bálintné Szendrei, Mária and Czédli, Gábor and Szendrei, Ágnes},
+  url       = {https://interkonyv.hu/konyvek/balintne-szendrei-maria-czedli-gabor-szendrei-agnes-absztrakt-algebrai-feladatok/},
+  year      = {2005},
+  publisher = {Polygon},
+  pagetotal = {523},
+  langid    = {hungarian}
+}
+
 @online{BvDR18,
   title       = {Higher {{Groups}} in {{Homotopy Type Theory}}},
   author      = {Buchholtz, Ulrik and van Doorn, Floris and Rijke, Egbert},
@@ -63,16 +73,6 @@
   abstract    = {We present a development of the theory of higher groups, including infinity groups and connective spectra, in homotopy type theory. An infinity group is simply the loops in a pointed, connected type, where the group structure comes from the structure inherent in the identity types of Martin-L\"of type theory. We investigate ordinary groups from this viewpoint, as well as higher dimensional groups and groups that can be delooped more than once. A major result is the stabilization theorem, which states that if an $n$-type can be delooped $n+2$ times, then it is an infinite loop type. Most of the results have been formalized in the Lean proof assistant.},
   pubstate    = {preprint},
   keywords    = {03B15,Computer Science - Logic in Computer Science,F.4.1,Mathematics - Algebraic Topology,Mathematics - Logic}
-}
-
-@book{BSCS05,
-  title     = {Absztrakt algebrai feladatok},
-  author    = {Bálintné Szendrei, Mária and Czédli, Gábor and Szendrei, Ágnes},
-  url       = {https://interkonyv.hu/konyvek/balintne-szendrei-maria-czedli-gabor-szendrei-agnes-absztrakt-algebrai-feladatok/},
-  year      = {2005},
-  publisher = {Polygon},
-  pagetotal = {523},
-  langid    = {hungarian}
 }
 
 @article{BW23,
@@ -149,7 +149,7 @@
   keywords    = {Computer Science - Logic in Computer Science ; Mathematics - Logic},
   eprint      = {2111.00482},
   eprinttype  = {arxiv},
-  eprintclass = {cs},
+  eprintclass = {cs}
 }
 
 @inproceedings{dJKFX23,
@@ -264,19 +264,19 @@
 }
 
 @inproceedings{KvR19,
-  title       =  {{Path Spaces of Higher Inductive Types in Homotopy Type Theory}},
-  booktitle   =  {Proceedings of the 34th {{Annual ACM}}/{{IEEE Symposium}} on {{Logic}} in {{Computer Science}}},
-  author      =  {Kraus, Nicolai and von Raumer, Jakob},
-  year        =  {2019},
-  publisher   =  {IEEE Press},
-  abstract    =  {The study of equality types is central to homotopy type theory. Characterizing these types is often tricky, and various strategies, such as the encode-decode method, have been developed. We prove a theorem about equality types of coequalizers and pushouts, reminiscent of an induction principle and without any restrictions on the truncation levels. This result makes it possible to reason directly about certain equality types and to streamline existing proofs by eliminating the necessity of auxiliary constructions. To demonstrate this, we give a very short argument for the calculation of the fundamental group of the circle (Licata and Shulman [1]), and for the fact that pushouts preserve embeddings. Further, our development suggests a higher version of the Seifert-van Kampen theorem, and the set-truncation operator maps it to the standard Seifert-van Kampen theorem (due to Favonia and Shulman [2]). We provide a formalization of the main technical results in the proof assistant Lean.},
-  articleno   =  {7},
-  numpages    =  {13},
-  location    =  {Vancouver, Canada},
-  series      =  {LICS '19},
-  eprint      =  {1901.06022},
-  eprinttype  =  {arxiv},
-  eprintclass =  {cs, math},
+  title       = {{Path Spaces of Higher Inductive Types in Homotopy Type Theory}},
+  booktitle   = {Proceedings of the 34th {{Annual ACM}}/{{IEEE Symposium}} on {{Logic}} in {{Computer Science}}},
+  author      = {Kraus, Nicolai and von Raumer, Jakob},
+  year        = {2019},
+  publisher   = {IEEE Press},
+  abstract    = {The study of equality types is central to homotopy type theory. Characterizing these types is often tricky, and various strategies, such as the encode-decode method, have been developed. We prove a theorem about equality types of coequalizers and pushouts, reminiscent of an induction principle and without any restrictions on the truncation levels. This result makes it possible to reason directly about certain equality types and to streamline existing proofs by eliminating the necessity of auxiliary constructions. To demonstrate this, we give a very short argument for the calculation of the fundamental group of the circle (Licata and Shulman [1]), and for the fact that pushouts preserve embeddings. Further, our development suggests a higher version of the Seifert-van Kampen theorem, and the set-truncation operator maps it to the standard Seifert-van Kampen theorem (due to Favonia and Shulman [2]). We provide a formalization of the main technical results in the proof assistant Lean.},
+  articleno   = {7},
+  numpages    = {13},
+  location    = {Vancouver, Canada},
+  series      = {LICS '19},
+  eprint      = {1901.06022},
+  eprinttype  = {arxiv},
+  eprintclass = {cs, math}
 }
 
 @book{May12,
@@ -487,23 +487,6 @@
   keywords    = {Computer Science - Logic in Computer Science,F.3.1,F.3.1 F.4.1,F.4.1,Mathematics - Category Theory,Mathematics - Logic}
 }
 
-@inproceedings{SvDR20,
-  title     = {Sequential {{Colimits}} in {{Homotopy Type Theory}}},
-  booktitle = {Proceedings of the 35th {{Annual ACM}}/{{IEEE Symposium}} on {{Logic}} in {{Computer Science}}},
-  author    = {Sojakova, Kristina and van Doorn, Floris and Rijke, Egbert},
-  date      = {2020-07-08},
-  year      = {2020},
-  month     = {07},
-  series    = {{{LICS}} '20},
-  pages     = {845--858},
-  publisher = {Association for Computing Machinery},
-  location  = {New York, NY, USA},
-  doi       = {10.1145/3373718.3394801},
-  abstract  = {Sequential colimits are an important class of higher inductive types. We present a self-contained and fully formalized proof of the conjecture that in homotopy type theory sequential colimits appropriately commute with Σ-types. This result allows us to give short proofs of a number of useful corollaries, some of which were conjectured in other works: the commutativity of sequential colimits with identity types, with homotopy fibers, loop spaces, and truncations, and the preservation of the properties of truncatedness and connectedness under sequential colimits. Our entire development carries over to (∞, 1)-toposes using Shulman's recent interpretation of homotopy type theory into these structures.},
-  isbn      = {978-1-4503-7104-9},
-  keywords  = {higher inductive types,homotopy type theory,sequential colimits}
-}
-
 @online{Shu14SplittingIdempotents,
   title        = {Splitting {{Idempotents}}},
   author       = {Shulman, Mike},
@@ -539,7 +522,7 @@
   eprint       = {1507.03634},
   eprinttype   = {arxiv},
   eprintclass  = {math},
-  primaryClass = {math.LO},
+  primaryclass = {math.LO},
   journal      = {Logical Methods in Computer Science},
   volume       = {12},
   issue        = {3},
@@ -547,7 +530,6 @@
   publisher    = {Episciences.org},
   issn         = {1860-5974},
   doi          = {10.2168/LMCS-12(3:9)2016},
-  url          = {https://lmcs.episciences.org/2027},
   abstract     = {We study idempotents in intensional Martin-L\"of type theory, and in particular the question of when and whether they split. We show that in the presence of propositional truncation and Voevodsky's univalence axiom, there exist idempotents that do not split; thus in plain MLTT not all idempotents can be proven to split. On the other hand, assuming only function extensionality, an idempotent can be split if and only if its witness of idempotency satisfies one extra coherence condition. Both proofs are inspired by parallel results of Lurie in higher category theory, showing that ideas from higher category theory and homotopy theory can have applications even in ordinary MLTT. Finally, we show that although the witness of idempotency can be recovered from a splitting, the one extra coherence condition cannot in general; and we construct "the type of fully coherent idempotents", by splitting an idempotent on the type of partially coherent ones. Our results have been formally verified in the proof assistant Coq.}
 }
 
@@ -569,6 +551,36 @@
   abstract    = {We combine homotopy type theory with axiomatic cohesion, expressing the latter internally with a version of ‘adjoint logic’ in which the discretization and codiscretization modalities are characterized using a judgemental formalism of ‘crisp variables.’ This yields type theories that we call ‘spatial’ and ‘cohesive,’ in which the types can be viewed as having independent topological and homotopical structure. These type theories can then be used to study formally the process by which topology gives rise to homotopy theory (the ‘fundamental $\infty$-groupoid’ or ‘shape’), disentangling the ‘identifications’ of homotopy type theory from the ‘continuous paths’ of topology. In a further refinement called ‘real-cohesion,’ the shape is determined by continuous maps from the real numbers, as in classical algebraic topology. This enables us to reproduce formally some of the classical applications of homotopy theory to topology. As an example, we prove Brouwer's fixed-point theorem.},
   langid      = {english},
   keywords    = {Mathematics - Algebraic Topology,Mathematics - Category Theory,Mathematics - Logic}
+}
+
+@article{Sto87,
+  title    = {Dedekind finiteness in topoi},
+  journal  = {Journal of Pure and Applied Algebra},
+  volume   = {49},
+  number   = {1},
+  pages    = {219-225},
+  year     = {1987},
+  issn     = {0022-4049},
+  doi      = {10.1016/0022-4049(87)90130-7},
+  author   = {Lawrence Neff Stout},
+  abstract = {A Dedekind finite object in a topos is an object such that any monic endomorphism is an epimorphism. This paper proves the basic properties of Dedekind finiteness and then gives examples which show that the class of Dedekind finite objects is not closed under quotients, subobjects, exponentiation, or finite powerobjects. Examples also show that having no nontrivial epic endomorphisms is distinct from Dedekind finiteness.}
+}
+
+@inproceedings{SvDR20,
+  title     = {Sequential {{Colimits}} in {{Homotopy Type Theory}}},
+  booktitle = {Proceedings of the 35th {{Annual ACM}}/{{IEEE Symposium}} on {{Logic}} in {{Computer Science}}},
+  author    = {Sojakova, Kristina and van Doorn, Floris and Rijke, Egbert},
+  date      = {2020-07-08},
+  year      = {2020},
+  month     = {07},
+  series    = {{{LICS}} '20},
+  pages     = {845--858},
+  publisher = {Association for Computing Machinery},
+  location  = {New York, NY, USA},
+  doi       = {10.1145/3373718.3394801},
+  abstract  = {Sequential colimits are an important class of higher inductive types. We present a self-contained and fully formalized proof of the conjecture that in homotopy type theory sequential colimits appropriately commute with Σ-types. This result allows us to give short proofs of a number of useful corollaries, some of which were conjectured in other works: the commutativity of sequential colimits with identity types, with homotopy fibers, loop spaces, and truncations, and the preservation of the properties of truncatedness and connectedness under sequential colimits. Our entire development carries over to (∞, 1)-toposes using Shulman's recent interpretation of homotopy type theory into these structures.},
+  isbn      = {978-1-4503-7104-9},
+  keywords  = {higher inductive types,homotopy type theory,sequential colimits}
 }
 
 @book{SymmetryBook,

--- a/src/finite-group-theory/finite-groups.lagda.md
+++ b/src/finite-group-theory/finite-groups.lagda.md
@@ -46,6 +46,7 @@ open import univalent-combinatorics.decidable-propositions
 open import univalent-combinatorics.dependent-function-types
 open import univalent-combinatorics.dependent-pair-types
 open import univalent-combinatorics.equality-finite-types
+open import univalent-combinatorics.finite-connected-components
 open import univalent-combinatorics.finite-types
 open import univalent-combinatorics.function-types
 open import univalent-combinatorics.pi-finite-types

--- a/src/finite-group-theory/finite-groups.lagda.md
+++ b/src/finite-group-theory/finite-groups.lagda.md
@@ -46,8 +46,8 @@ open import univalent-combinatorics.decidable-propositions
 open import univalent-combinatorics.dependent-function-types
 open import univalent-combinatorics.dependent-pair-types
 open import univalent-combinatorics.equality-finite-types
-open import univalent-combinatorics.finite-connected-components
 open import univalent-combinatorics.finite-types
+open import univalent-combinatorics.finitely-many-connected-components
 open import univalent-combinatorics.function-types
 open import univalent-combinatorics.pi-finite-types
 open import univalent-combinatorics.standard-finite-types

--- a/src/finite-group-theory/finite-monoids.lagda.md
+++ b/src/finite-group-theory/finite-monoids.lagda.md
@@ -35,6 +35,7 @@ open import univalent-combinatorics.decidable-dependent-pair-types
 open import univalent-combinatorics.dependent-function-types
 open import univalent-combinatorics.dependent-pair-types
 open import univalent-combinatorics.equality-finite-types
+open import univalent-combinatorics.finite-connected-components
 open import univalent-combinatorics.finite-types
 open import univalent-combinatorics.pi-finite-types
 open import univalent-combinatorics.standard-finite-types

--- a/src/finite-group-theory/finite-monoids.lagda.md
+++ b/src/finite-group-theory/finite-monoids.lagda.md
@@ -35,8 +35,8 @@ open import univalent-combinatorics.decidable-dependent-pair-types
 open import univalent-combinatorics.dependent-function-types
 open import univalent-combinatorics.dependent-pair-types
 open import univalent-combinatorics.equality-finite-types
-open import univalent-combinatorics.finite-connected-components
 open import univalent-combinatorics.finite-types
+open import univalent-combinatorics.finitely-many-connected-components
 open import univalent-combinatorics.pi-finite-types
 open import univalent-combinatorics.standard-finite-types
 ```

--- a/src/finite-group-theory/finite-semigroups.lagda.md
+++ b/src/finite-group-theory/finite-semigroups.lagda.md
@@ -26,8 +26,8 @@ open import group-theory.semigroups
 open import univalent-combinatorics.dependent-function-types
 open import univalent-combinatorics.dependent-pair-types
 open import univalent-combinatorics.equality-finite-types
-open import univalent-combinatorics.finite-connected-components
 open import univalent-combinatorics.finite-types
+open import univalent-combinatorics.finitely-many-connected-components
 open import univalent-combinatorics.function-types
 open import univalent-combinatorics.pi-finite-types
 open import univalent-combinatorics.standard-finite-types

--- a/src/finite-group-theory/finite-semigroups.lagda.md
+++ b/src/finite-group-theory/finite-semigroups.lagda.md
@@ -26,6 +26,7 @@ open import group-theory.semigroups
 open import univalent-combinatorics.dependent-function-types
 open import univalent-combinatorics.dependent-pair-types
 open import univalent-combinatorics.equality-finite-types
+open import univalent-combinatorics.finite-connected-components
 open import univalent-combinatorics.finite-types
 open import univalent-combinatorics.function-types
 open import univalent-combinatorics.pi-finite-types

--- a/src/foundation/0-connected-types.lagda.md
+++ b/src/foundation/0-connected-types.lagda.md
@@ -216,7 +216,7 @@ is-0-connected-is-contr X p =
   is-contr-equiv X (inv-equiv (equiv-unit-trunc-Set (X , is-set-is-contr p))) p
 ```
 
-### The image of a function with a 0-connected domain is 0-connected
+### The image of a function with a `0`-connected domain is `0`-connected
 
 ```agda
 abstract

--- a/src/foundation/0-connected-types.lagda.md
+++ b/src/foundation/0-connected-types.lagda.md
@@ -8,10 +8,12 @@ module foundation.0-connected-types where
 
 ```agda
 open import foundation.action-on-identifications-functions
+open import foundation.constant-maps
 open import foundation.contractible-types
 open import foundation.dependent-pair-types
 open import foundation.fiber-inclusions
 open import foundation.functoriality-set-truncation
+open import foundation.images
 open import foundation.inhabited-types
 open import foundation.mere-equality
 open import foundation.propositional-truncations
@@ -179,7 +181,7 @@ is-0-connected-equiv' :
 is-0-connected-equiv' e = is-0-connected-equiv (inv-equiv e)
 ```
 
-### `0-connected` types are closed under cartesian products
+### `0`-connected types are closed under cartesian products
 
 ```agda
 module _
@@ -195,6 +197,14 @@ module _
       ( is-contr-product p1 p2)
 ```
 
+### The unit type is `0`-connected
+
+```agda
+is-0-connected-unit : is-0-connected unit
+is-0-connected-unit =
+  is-contr-equiv' unit equiv-unit-trunc-unit-Set is-contr-unit
+```
+
 ### A contractible type is `0`-connected
 
 ```agda
@@ -203,4 +213,44 @@ is-0-connected-is-contr :
   is-contr X → is-0-connected X
 is-0-connected-is-contr X p =
   is-contr-equiv X (inv-equiv (equiv-unit-trunc-Set (X , is-set-is-contr p))) p
+```
+
+### The image of a function with a 0-connected domain is 0-connected
+
+```agda
+abstract
+  is-0-connected-im-is-0-connected-domain :
+    {l1 l2 : Level} {A : UU l1} {B : UU l2} (f : A → B) →
+    is-0-connected A → is-0-connected (im f)
+  is-0-connected-im-is-0-connected-domain {A = A} {B} f C =
+    apply-universal-property-trunc-Prop
+      ( is-inhabited-is-0-connected C)
+      ( is-contr-Prop _)
+      ( λ a →
+        is-contr-equiv'
+          ( im (map-trunc-Set f))
+          ( equiv-trunc-im-Set f)
+          ( is-contr-im
+            ( trunc-Set B)
+            ( unit-trunc-Set a)
+            ( apply-dependent-universal-property-trunc-Set'
+              ( λ x →
+                set-Prop
+                  ( Id-Prop
+                    ( trunc-Set B)
+                    ( map-trunc-Set f x)
+                    ( map-trunc-Set f (unit-trunc-Set a))))
+              ( λ a' →
+                apply-universal-property-trunc-Prop
+                  ( mere-eq-is-0-connected C a' a)
+                  ( Id-Prop
+                    ( trunc-Set B)
+                    ( map-trunc-Set f (unit-trunc-Set a'))
+                    ( map-trunc-Set f (unit-trunc-Set a)))
+                  ( λ where refl → refl)))))
+
+is-0-connected-im-point' :
+  {l1 : Level} {A : UU l1} (f : unit → A) → is-0-connected (im f)
+is-0-connected-im-point' f =
+  is-0-connected-im-is-0-connected-domain f is-0-connected-unit
 ```

--- a/src/foundation/0-connected-types.lagda.md
+++ b/src/foundation/0-connected-types.lagda.md
@@ -200,9 +200,10 @@ module _
 ### The unit type is `0`-connected
 
 ```agda
-is-0-connected-unit : is-0-connected unit
-is-0-connected-unit =
-  is-contr-equiv' unit equiv-unit-trunc-unit-Set is-contr-unit
+abstract
+  is-0-connected-unit : is-0-connected unit
+  is-0-connected-unit =
+    is-contr-equiv' unit equiv-unit-trunc-unit-Set is-contr-unit
 ```
 
 ### A contractible type is `0`-connected
@@ -249,8 +250,9 @@ abstract
                     ( map-trunc-Set f (unit-trunc-Set a)))
                   ( λ where refl → refl)))))
 
-is-0-connected-im-point' :
-  {l1 : Level} {A : UU l1} (f : unit → A) → is-0-connected (im f)
-is-0-connected-im-point' f =
-  is-0-connected-im-is-0-connected-domain f is-0-connected-unit
+abstract
+  is-0-connected-im-point' :
+    {l1 : Level} {A : UU l1} (f : unit → A) → is-0-connected (im f)
+  is-0-connected-im-point' f =
+    is-0-connected-im-is-0-connected-domain f is-0-connected-unit
 ```

--- a/src/foundation/0-images-of-maps.lagda.md
+++ b/src/foundation/0-images-of-maps.lagda.md
@@ -17,9 +17,15 @@ open import foundation-core.truncation-levels
 
 ## Idea
 
-The 0-image of a map `f : A → B` is the type
-`0-im f := Σ (b : B), type-trunc-Set (fiber f b)`. The map `A → 0-im f` is
-0-connected and the map `0-im f → B` is `0`-truncated.
+The {{#concept "0-image" Disambiguation="of a map of types" Agda=0-im}} of a map
+`f : A → B` is the type
+
+```text
+  0-im f := Σ (b : B), type-trunc-Set (fiber f b).
+```
+
+The map `A → 0-im f` is 0-[connected](foundation.connected-maps.md) and the map
+`0-im f → B` is 0-[truncated](foundation.truncated-maps.md).
 
 ## Definition
 

--- a/src/foundation/constant-maps.lagda.md
+++ b/src/foundation/constant-maps.lagda.md
@@ -16,8 +16,10 @@ open import foundation.dependent-pair-types
 open import foundation.faithful-maps
 open import foundation.function-extensionality
 open import foundation.functoriality-dependent-pair-types
+open import foundation.images
 open import foundation.morphisms-arrows
 open import foundation.postcomposition-functions
+open import foundation.propositional-truncations
 open import foundation.retracts-of-maps
 open import foundation.retracts-of-types
 open import foundation.transposition-identifications-along-equivalences
@@ -30,6 +32,7 @@ open import foundation.whiskering-homotopies-composition
 open import foundation-core.1-types
 open import foundation-core.commuting-squares-of-maps
 open import foundation-core.contractible-maps
+open import foundation-core.contractible-types
 open import foundation-core.embeddings
 open import foundation-core.equivalences
 open import foundation-core.fibers-of-maps
@@ -178,6 +181,23 @@ point-faithful-map :
 pr1 (point-faithful-map A x) = point x
 pr2 (point-faithful-map A x) =
   is-faithful-point-is-1-type (is-1-type-type-1-Type A) x
+```
+
+### The image of a constant map into a set is contractible
+
+```agda
+abstract
+  is-contr-im :
+    {l1 l2 : Level} {A : UU l1} (B : Set l2) {f : A → type-Set B}
+    (a : A) (H : (x : A) → f x ＝ f a) → is-contr (im f)
+  pr1 (is-contr-im B {f} a H) = map-unit-im f a
+  pr2 (is-contr-im B {f} a H) (x , u) =
+    apply-dependent-universal-property-trunc-Prop
+      ( λ v → Id-Prop (im-Set B f) (map-unit-im f a) (x , v))
+      ( u)
+      ( λ where
+        ( a' , refl) →
+          eq-Eq-im f (map-unit-im f a) (map-unit-im f a') (inv (H a')))
 ```
 
 ## See also

--- a/src/foundation/null-homotopic-maps.lagda.md
+++ b/src/foundation/null-homotopic-maps.lagda.md
@@ -15,6 +15,7 @@ open import foundation.functoriality-dependent-pair-types
 open import foundation.fundamental-theorem-of-identity-types
 open import foundation.homotopy-induction
 open import foundation.identity-types
+open import foundation.images
 open import foundation.inhabited-types
 open import foundation.negation
 open import foundation.propositional-truncations
@@ -26,6 +27,7 @@ open import foundation.type-arithmetic-dependent-pair-types
 open import foundation.unit-type
 open import foundation.universal-property-empty-type
 open import foundation.universe-levels
+open import foundation.weakly-constant-maps
 
 open import foundation-core.contractible-types
 open import foundation-core.equivalences
@@ -38,8 +40,8 @@ open import foundation-core.homotopies
 ## Idea
 
 A map `f : A → B` is said to be
-{{#concept "null-homotopic" Disambiguation="map of types" Agda=null-htpy}}, or
-_constant_, if there is an element `y : B` such for every `x : A` we have
+{{#concept "null-homotopic" Disambiguation="map of types" Agda=is-null-homotopic}},
+or _constant_, if there is an element `y : B` such for every `x : A` we have
 `f x ＝ y`. In other words, `f` is null-homotopic if it is
 [homotopic](foundation-core.homotopies.md) to a
 [constant](foundation-core.constant-maps.md) function.
@@ -49,19 +51,19 @@ _constant_, if there is an element `y : B` such for every `x : A` we have
 ### The type of null-homotopies of a map
 
 ```agda
-null-htpy :
+is-null-homotopic :
   {l1 l2 : Level} {A : UU l1} {B : UU l2} → (A → B) → UU (l1 ⊔ l2)
-null-htpy {A = A} {B} f = Σ B (λ y → (x : A) → f x ＝ y)
+is-null-homotopic {A = A} {B} f = Σ B (λ y → (x : A) → f x ＝ y)
 
 module _
-  {l1 l2 : Level} {A : UU l1} {B : UU l2} {f : A → B} (H : null-htpy f)
+  {l1 l2 : Level} {A : UU l1} {B : UU l2} {f : A → B} (H : is-null-homotopic f)
   where
 
-  center-null-htpy : B
-  center-null-htpy = pr1 H
+  center-is-null-homotopic : B
+  center-is-null-homotopic = pr1 H
 
-  contraction-null-htpy : (x : A) → f x ＝ center-null-htpy
-  contraction-null-htpy = pr2 H
+  contraction-is-null-homotopic : (x : A) → f x ＝ center-is-null-homotopic
+  contraction-is-null-homotopic = pr2 H
 ```
 
 ## Properties
@@ -87,47 +89,54 @@ module _
   {l1 l2 : Level} {A : UU l1} {B : UU l2} {f : A → B}
   where
 
-  coherence-htpy-null-htpy :
-    (H K : null-htpy f) (p : center-null-htpy H ＝ center-null-htpy K) →
+  coherence-htpy-is-null-homotopic :
+    (H K : is-null-homotopic f)
+    (p : center-is-null-homotopic H ＝ center-is-null-homotopic K) →
     UU (l1 ⊔ l2)
-  coherence-htpy-null-htpy H K p =
+  coherence-htpy-is-null-homotopic H K p =
     (x : A) →
     coherence-triangle-identifications
-      ( contraction-null-htpy K x)
+      ( contraction-is-null-homotopic K x)
       ( p)
-      ( contraction-null-htpy H x)
+      ( contraction-is-null-homotopic H x)
 
-  htpy-null-htpy : (H K : null-htpy f) → UU (l1 ⊔ l2)
-  htpy-null-htpy H K =
-    Σ ( center-null-htpy H ＝ center-null-htpy K)
-      ( coherence-htpy-null-htpy H K)
+  htpy-is-null-homotopic : (H K : is-null-homotopic f) → UU (l1 ⊔ l2)
+  htpy-is-null-homotopic H K =
+    Σ ( center-is-null-homotopic H ＝ center-is-null-homotopic K)
+      ( coherence-htpy-is-null-homotopic H K)
 
-  refl-htpy-null-htpy : (H : null-htpy f) → htpy-null-htpy H H
-  refl-htpy-null-htpy H = (refl , inv-htpy-right-unit-htpy)
+  refl-htpy-is-null-homotopic :
+    (H : is-null-homotopic f) → htpy-is-null-homotopic H H
+  refl-htpy-is-null-homotopic H = (refl , inv-htpy-right-unit-htpy)
 
-  htpy-eq-null-htpy : (H K : null-htpy f) → H ＝ K → htpy-null-htpy H K
-  htpy-eq-null-htpy H .H refl = refl-htpy-null-htpy H
+  htpy-eq-is-null-homotopic :
+    (H K : is-null-homotopic f) → H ＝ K → htpy-is-null-homotopic H K
+  htpy-eq-is-null-homotopic H .H refl = refl-htpy-is-null-homotopic H
 
-  is-torsorial-htpy-null-htpy :
-    (H : null-htpy f) → is-torsorial (htpy-null-htpy H)
-  is-torsorial-htpy-null-htpy H =
+  is-torsorial-htpy-is-null-homotopic :
+    (H : is-null-homotopic f) → is-torsorial (htpy-is-null-homotopic H)
+  is-torsorial-htpy-is-null-homotopic H =
     is-torsorial-Eq-structure
-      ( is-torsorial-Id (center-null-htpy H))
-      ( center-null-htpy H , refl)
-      ( is-torsorial-htpy' (contraction-null-htpy H ∙h refl-htpy))
+      ( is-torsorial-Id (center-is-null-homotopic H))
+      ( center-is-null-homotopic H , refl)
+      ( is-torsorial-htpy' (contraction-is-null-homotopic H ∙h refl-htpy))
 
-  is-equiv-htpy-eq-null-htpy :
-    (H K : null-htpy f) → is-equiv (htpy-eq-null-htpy H K)
-  is-equiv-htpy-eq-null-htpy H =
-    fundamental-theorem-id (is-torsorial-htpy-null-htpy H) (htpy-eq-null-htpy H)
+  is-equiv-htpy-eq-is-null-homotopic :
+    (H K : is-null-homotopic f) → is-equiv (htpy-eq-is-null-homotopic H K)
+  is-equiv-htpy-eq-is-null-homotopic H =
+    fundamental-theorem-id
+      ( is-torsorial-htpy-is-null-homotopic H)
+      ( htpy-eq-is-null-homotopic H)
 
-  extensionality-htpy-null-htpy :
-    (H K : null-htpy f) → (H ＝ K) ≃ htpy-null-htpy H K
-  extensionality-htpy-null-htpy H K =
-    ( htpy-eq-null-htpy H K , is-equiv-htpy-eq-null-htpy H K)
+  extensionality-htpy-is-null-homotopic :
+    (H K : is-null-homotopic f) → (H ＝ K) ≃ htpy-is-null-homotopic H K
+  extensionality-htpy-is-null-homotopic H K =
+    ( htpy-eq-is-null-homotopic H K , is-equiv-htpy-eq-is-null-homotopic H K)
 
-  eq-htpy-null-htpy : (H K : null-htpy f) → htpy-null-htpy H K → H ＝ K
-  eq-htpy-null-htpy H K = map-inv-is-equiv (is-equiv-htpy-eq-null-htpy H K)
+  eq-htpy-is-null-homotopic :
+    (H K : is-null-homotopic f) → htpy-is-null-homotopic H K → H ＝ K
+  eq-htpy-is-null-homotopic H K =
+    map-inv-is-equiv (is-equiv-htpy-eq-is-null-homotopic H K)
 ```
 
 ### If the domain is empty the type of null-homotopies is equivalent to elements of `B`
@@ -137,8 +146,8 @@ module _
   {l : Level} {B : UU l} {f : empty → B}
   where
 
-  compute-null-htpy-empty-domain : null-htpy f ≃ B
-  compute-null-htpy-empty-domain =
+  compute-is-null-homotopic-empty-domain : is-null-homotopic f ≃ B
+  compute-is-null-homotopic-empty-domain =
     right-unit-law-Σ-is-contr
       ( λ y → dependent-universal-property-empty' (λ x → f x ＝ y))
 ```
@@ -150,10 +159,12 @@ module _
   {l1 l2 : Level} {A : UU l1} {B : UU l2} {f : A → B}
   where
 
-  eq-center-null-htpy-has-element-domain :
-    A → (H K : null-htpy f) → center-null-htpy H ＝ center-null-htpy K
-  eq-center-null-htpy-has-element-domain a H K =
-    inv (contraction-null-htpy H a) ∙ contraction-null-htpy K a
+  eq-center-is-null-homotopic-has-element-domain :
+    A →
+    (H K : is-null-homotopic f) →
+    center-is-null-homotopic H ＝ center-is-null-homotopic K
+  eq-center-is-null-homotopic-has-element-domain a H K =
+    inv (contraction-is-null-homotopic H a) ∙ contraction-is-null-homotopic K a
 ```
 
 ### If the codomain is a set and the domain has an element then being null-homotopic is a property
@@ -165,17 +176,18 @@ module _
   {f : A → B}
   where
 
-  all-elements-equal-null-htpy-has-element-domain-is-set-codomain :
-    all-elements-equal (null-htpy f)
-  all-elements-equal-null-htpy-has-element-domain-is-set-codomain H K =
-    eq-htpy-null-htpy H K
-      ( ( eq-center-null-htpy-has-element-domain a H K) ,
-        ( λ x → eq-is-prop (is-set-B (f x) (center-null-htpy K))))
+  all-elements-equal-is-null-homotopic-has-element-domain-is-set-codomain :
+    all-elements-equal (is-null-homotopic f)
+  all-elements-equal-is-null-homotopic-has-element-domain-is-set-codomain H K =
+    eq-htpy-is-null-homotopic H K
+      ( ( eq-center-is-null-homotopic-has-element-domain a H K) ,
+        ( λ x → eq-is-prop (is-set-B (f x) (center-is-null-homotopic K))))
 
-  is-prop-null-htpy-has-element-domain-is-set-codomain : is-prop (null-htpy f)
-  is-prop-null-htpy-has-element-domain-is-set-codomain =
+  is-prop-is-null-homotopic-has-element-domain-is-set-codomain :
+    is-prop (is-null-homotopic f)
+  is-prop-is-null-homotopic-has-element-domain-is-set-codomain =
     is-prop-all-elements-equal
-      ( all-elements-equal-null-htpy-has-element-domain-is-set-codomain)
+      ( all-elements-equal-is-null-homotopic-has-element-domain-is-set-codomain)
 ```
 
 ### If the codomain is a set and the domain is inhabited then being null-homotopic is a property
@@ -187,25 +199,30 @@ module _
   {f : A → B}
   where
 
-  eq-center-null-htpy-is-inhabited-domain-is-set-codomain :
-    (H K : null-htpy f) → center-null-htpy H ＝ center-null-htpy K
-  eq-center-null-htpy-is-inhabited-domain-is-set-codomain H K =
+  eq-center-is-null-homotopic-is-inhabited-domain-is-set-codomain :
+    (H K : is-null-homotopic f) →
+    center-is-null-homotopic H ＝ center-is-null-homotopic K
+  eq-center-is-null-homotopic-is-inhabited-domain-is-set-codomain H K =
     rec-trunc-Prop
-      ( Id-Prop (B , is-set-B) (center-null-htpy H) (center-null-htpy K))
-      ( λ x → eq-center-null-htpy-has-element-domain x H K)
+      ( Id-Prop
+        ( B , is-set-B)
+        ( center-is-null-homotopic H)
+        ( center-is-null-homotopic K))
+      ( λ x → eq-center-is-null-homotopic-has-element-domain x H K)
       ( a)
 
-  all-elements-equal-null-htpy-is-inhabited-domain-is-set-codomain :
-    all-elements-equal (null-htpy f)
-  all-elements-equal-null-htpy-is-inhabited-domain-is-set-codomain H K =
-    eq-htpy-null-htpy H K
-      ( ( eq-center-null-htpy-is-inhabited-domain-is-set-codomain H K) ,
-        ( λ x → eq-is-prop (is-set-B (f x) (center-null-htpy K))))
+  all-elements-equal-is-null-homotopic-is-inhabited-domain-is-set-codomain :
+    all-elements-equal (is-null-homotopic f)
+  all-elements-equal-is-null-homotopic-is-inhabited-domain-is-set-codomain H K =
+    eq-htpy-is-null-homotopic H K
+      ( ( eq-center-is-null-homotopic-is-inhabited-domain-is-set-codomain H K) ,
+        ( λ x → eq-is-prop (is-set-B (f x) (center-is-null-homotopic K))))
 
-  is-prop-null-htpy-is-inhabited-domain-is-set-codomain : is-prop (null-htpy f)
-  is-prop-null-htpy-is-inhabited-domain-is-set-codomain =
+  is-prop-is-null-homotopic-is-inhabited-domain-is-set-codomain :
+    is-prop (is-null-homotopic f)
+  is-prop-is-null-homotopic-is-inhabited-domain-is-set-codomain =
     is-prop-all-elements-equal
-      ( all-elements-equal-null-htpy-is-inhabited-domain-is-set-codomain)
+      ( all-elements-equal-is-null-homotopic-is-inhabited-domain-is-set-codomain)
 ```
 
 ### Null-homotopic maps from `A` to `B` are in correspondence with elements of `B`
@@ -215,14 +232,30 @@ module _
   {l1 l2 : Level} {A : UU l1} {B : UU l2}
   where
 
-  compute-null-homotopic-map : Σ (A → B) (null-htpy) ≃ B
+  compute-null-homotopic-map : Σ (A → B) (is-null-homotopic) ≃ B
   compute-null-homotopic-map =
     equivalence-reasoning
-      Σ (A → B) (null-htpy)
+      Σ (A → B) (is-null-homotopic)
       ≃ Σ B (λ b → Σ (A → B) (λ f → f ~ const A b)) by equiv-left-swap-Σ
       ≃ B by right-unit-law-Σ-is-contr (λ b → is-torsorial-htpy' (const A b))
+```
+
+### Null-homotopic maps are weakly constant
+
+```agda
+module _
+  {l1 l2 : Level} {A : UU l1} {B : UU l2} {f : A → B}
+  where
+
+  is-weakly-constant-is-null-homotopic :
+    is-null-homotopic f → is-weakly-constant f
+  is-weakly-constant-is-null-homotopic (b , H) x y = H x ∙ inv (H y)
 ```
 
 ## See also
 
 - [Weakly constant maps](foundation.weakly-constant-maps.md)
+
+## External links
+
+- [null homotopy](https://ncatlab.org/nlab/show/null+homotopy) at $n$Lab

--- a/src/foundation/set-presented-types.lagda.md
+++ b/src/foundation/set-presented-types.lagda.md
@@ -7,9 +7,24 @@ module foundation.set-presented-types where
 <details><summary>Imports</summary>
 
 ```agda
+open import foundation.action-on-identifications-functions
+open import foundation.coproduct-types
+open import foundation.dependent-pair-types
+open import foundation.embeddings
+open import foundation.empty-types
+open import foundation.equality-coproduct-types
 open import foundation.equivalences
 open import foundation.existential-quantification
+open import foundation.fibers-of-maps
+open import foundation.functoriality-coproduct-types
+open import foundation.homotopies
+open import foundation.identity-types
+open import foundation.images
+open import foundation.injective-maps
+open import foundation.propositional-truncations
 open import foundation.set-truncations
+open import foundation.subtypes
+open import foundation.surjective-maps
 open import foundation.universe-levels
 
 open import foundation-core.function-types
@@ -27,6 +42,10 @@ A type `A` is said to be
 [set](foundation-core.sets.md) `X` such that the composite
 `X → A → type-trunc-Set A` is an [equivalence](foundation.equivalences.md).
 
+## Definitions
+
+### Set presentations of types
+
 ```agda
 module _
   {l1 l2 : Level} (A : Set l1) (B : UU l2)
@@ -35,4 +54,96 @@ module _
   has-set-presentation-Prop : Prop (l1 ⊔ l2)
   has-set-presentation-Prop =
     ∃ (type-Set A → B) (λ f → is-equiv-Prop (unit-trunc-Set ∘ f))
+
+  has-set-presentation : UU (l1 ⊔ l2)
+  has-set-presentation = type-Prop has-set-presentation-Prop
+
+  is-prop-has-set-presentation : is-prop has-set-presentation
+  is-prop-has-set-presentation = is-prop-type-Prop has-set-presentation-Prop
+```
+
+## Propositions
+
+### Types set presented by coproducts are coproducts
+
+Given a type `B` that is set presented by a coproduct
+
+```text
+              B
+            ∧   \
+         f /     \ η
+          /   ~   ∨
+  (A1 + A2) -----> ║B║₀,
+```
+
+then `B` computes as the coproduct of the images of the restrictions of `f`
+along the left and right inclusion of the coproduct `A1 + A2`
+
+```text
+  B ≃ im (f ∘ inl) + im (f ∘ inr).
+```
+
+```agda
+module _
+  {l1 l2 l3 : Level} {A1 : UU l1} {A2 : UU l2} {B : UU l3}
+  (f : A1 + A2 → B) (e : (A1 + A2) ≃ ║ B ║₀)
+  (H : unit-trunc-Set ∘ f ~ map-equiv e)
+  where
+
+  map-is-coproduct-codomain : (im (f ∘ inl) + im (f ∘ inr)) → B
+  map-is-coproduct-codomain = rec-coproduct pr1 pr1
+
+  triangle-is-coproduct-codomain :
+    ( ( map-is-coproduct-codomain) ∘
+      ( map-coproduct (map-unit-im (f ∘ inl)) (map-unit-im (f ∘ inr)))) ~ f
+  triangle-is-coproduct-codomain (inl x) = refl
+  triangle-is-coproduct-codomain (inr x) = refl
+
+  abstract
+    is-emb-map-is-coproduct-codomain : is-emb map-is-coproduct-codomain
+    is-emb-map-is-coproduct-codomain =
+      is-emb-coproduct
+        ( is-emb-inclusion-subtype (λ b → trunc-Prop _))
+        ( is-emb-inclusion-subtype (λ b → trunc-Prop _))
+        ( λ (b1 , u) (b2 , v) →
+          apply-universal-property-trunc-Prop u
+            ( function-Prop _ empty-Prop)
+            ( λ where
+              ( x , refl) →
+                apply-universal-property-trunc-Prop v
+                  ( function-Prop _ empty-Prop)
+                  ( λ where
+                    ( y , refl) r →
+                      is-empty-eq-coproduct-inl-inr x y
+                        ( is-injective-is-equiv
+                          ( is-equiv-map-equiv e)
+                          ( ( inv (H (inl x))) ∙
+                            ( ap unit-trunc-Set r) ∙
+                            ( H (inr y)))))))
+
+  abstract
+    is-surjective-map-is-coproduct-codomain :
+      is-surjective map-is-coproduct-codomain
+    is-surjective-map-is-coproduct-codomain b =
+      apply-universal-property-trunc-Prop
+        ( apply-effectiveness-unit-trunc-Set
+          ( inv (is-section-map-inv-equiv e (unit-trunc-Set b)) ∙ inv (H a)))
+        ( trunc-Prop (fiber map-is-coproduct-codomain b))
+        ( λ p →
+          unit-trunc-Prop
+            ( ( map-coproduct
+                ( map-unit-im (f ∘ inl))
+                ( map-unit-im (f ∘ inr))
+                ( a)) ,
+              ( triangle-is-coproduct-codomain a ∙ inv p)))
+      where
+      a : A1 + A2
+      a = map-inv-equiv e (unit-trunc-Set b)
+
+  is-coproduct-codomain : (im (f ∘ inl) + im (f ∘ inr)) ≃ B
+  pr1 is-coproduct-codomain = map-is-coproduct-codomain
+  pr2 is-coproduct-codomain =
+    is-equiv-is-emb-is-surjective
+      is-surjective-map-is-coproduct-codomain
+      is-emb-map-is-coproduct-codomain
 ```

--- a/src/foundation/set-truncations.lagda.md
+++ b/src/foundation/set-truncations.lagda.md
@@ -9,16 +9,13 @@ module foundation.set-truncations where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
 open import foundation.effective-maps-equivalence-relations
 open import foundation.equality-coproduct-types
 open import foundation.functoriality-cartesian-product-types
 open import foundation.functoriality-coproduct-types
-open import foundation.images
 open import foundation.mere-equality
 open import foundation.postcomposition-functions
-open import foundation.propositional-truncations
 open import foundation.reflecting-maps-equivalence-relations
 open import foundation.sets
 open import foundation.slice
@@ -39,15 +36,12 @@ open import foundation-core.coproduct-types
 open import foundation-core.embeddings
 open import foundation-core.empty-types
 open import foundation-core.equivalences
-open import foundation-core.fibers-of-maps
 open import foundation-core.function-types
 open import foundation-core.functoriality-dependent-function-types
 open import foundation-core.functoriality-dependent-pair-types
 open import foundation-core.homotopies
 open import foundation-core.identity-types
-open import foundation-core.injective-maps
 open import foundation-core.propositions
-open import foundation-core.subtypes
 open import foundation-core.truncation-levels
 ```
 
@@ -572,93 +566,4 @@ module _
     ( map-product unit-trunc-Set unit-trunc-Set)
   triangle-distributive-trunc-product-Set =
     pr2 (center distributive-trunc-product-Set)
-```
-
-### A computation of the image when the domain and set-truncation of the codomain are equivalent
-
-Given a function on a coproduct
-
-```text
-  f : A1 + A2 → B
-```
-
-such that the set-truncation of the codomain computes to the domain
-
-```text
-              B
-            ∧   \
-         f /     \ η
-          /   ~   ∨
-  (A1 + A2) -----> ║B║₀,
-```
-
-then `B` computes as the coproduct of the images of the restrictions of `f`
-along the left and right inclusion of the coproduct `A1 + A2`
-
-```text
-  B ≃ im (f ∘ inl) + im (f ∘ inr).
-```
-
-```agda
-module _
-  {l1 l2 l3 : Level} {A1 : UU l1} {A2 : UU l2} {B : UU l3}
-  (f : A1 + A2 → B) (e : (A1 + A2) ≃ ║ B ║₀)
-  (H : unit-trunc-Set ∘ f ~ map-equiv e)
-  where
-
-  map-is-coproduct-codomain : (im (f ∘ inl) + im (f ∘ inr)) → B
-  map-is-coproduct-codomain = rec-coproduct pr1 pr1
-
-  triangle-is-coproduct-codomain :
-    ( ( map-is-coproduct-codomain) ∘
-      ( map-coproduct (map-unit-im (f ∘ inl)) (map-unit-im (f ∘ inr)))) ~ f
-  triangle-is-coproduct-codomain (inl x) = refl
-  triangle-is-coproduct-codomain (inr x) = refl
-
-  abstract
-    is-emb-map-is-coproduct-codomain : is-emb map-is-coproduct-codomain
-    is-emb-map-is-coproduct-codomain =
-      is-emb-coproduct
-        ( is-emb-inclusion-subtype (λ b → trunc-Prop _))
-        ( is-emb-inclusion-subtype (λ b → trunc-Prop _))
-        ( λ (b1 , u) (b2 , v) →
-          apply-universal-property-trunc-Prop u
-            ( function-Prop _ empty-Prop)
-            ( λ where
-              ( x , refl) →
-                apply-universal-property-trunc-Prop v
-                  ( function-Prop _ empty-Prop)
-                  ( λ where
-                    ( y , refl) r →
-                      is-empty-eq-coproduct-inl-inr x y
-                        ( is-injective-is-equiv
-                          ( is-equiv-map-equiv e)
-                          ( ( inv (H (inl x))) ∙
-                            ( ap unit-trunc-Set r) ∙
-                            ( H (inr y)))))))
-
-  abstract
-    is-surjective-map-is-coproduct-codomain :
-      is-surjective map-is-coproduct-codomain
-    is-surjective-map-is-coproduct-codomain b =
-      apply-universal-property-trunc-Prop
-        ( apply-effectiveness-unit-trunc-Set
-          ( inv (is-section-map-inv-equiv e (unit-trunc-Set b)) ∙ inv (H a)))
-        ( trunc-Prop (fiber map-is-coproduct-codomain b))
-        ( λ p →
-          unit-trunc-Prop
-            ( ( map-coproduct
-                ( map-unit-im (f ∘ inl))
-                ( map-unit-im (f ∘ inr))
-                ( a)) ,
-              ( triangle-is-coproduct-codomain a ∙ inv p)))
-      where
-      a = map-inv-equiv e (unit-trunc-Set b)
-
-  is-coproduct-codomain : (im (f ∘ inl) + im (f ∘ inr)) ≃ B
-  pr1 is-coproduct-codomain = map-is-coproduct-codomain
-  pr2 is-coproduct-codomain =
-    is-equiv-is-emb-is-surjective
-      is-surjective-map-is-coproduct-codomain
-      is-emb-map-is-coproduct-codomain
 ```

--- a/src/foundation/set-truncations.lagda.md
+++ b/src/foundation/set-truncations.lagda.md
@@ -9,13 +9,16 @@ module foundation.set-truncations where
 <details><summary>Imports</summary>
 
 ```agda
+open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
 open import foundation.effective-maps-equivalence-relations
 open import foundation.equality-coproduct-types
 open import foundation.functoriality-cartesian-product-types
 open import foundation.functoriality-coproduct-types
+open import foundation.images
 open import foundation.mere-equality
 open import foundation.postcomposition-functions
+open import foundation.propositional-truncations
 open import foundation.reflecting-maps-equivalence-relations
 open import foundation.sets
 open import foundation.slice
@@ -36,12 +39,15 @@ open import foundation-core.coproduct-types
 open import foundation-core.embeddings
 open import foundation-core.empty-types
 open import foundation-core.equivalences
+open import foundation-core.fibers-of-maps
 open import foundation-core.function-types
 open import foundation-core.functoriality-dependent-function-types
 open import foundation-core.functoriality-dependent-pair-types
 open import foundation-core.homotopies
 open import foundation-core.identity-types
+open import foundation-core.injective-maps
 open import foundation-core.propositions
+open import foundation-core.subtypes
 open import foundation-core.truncation-levels
 ```
 
@@ -566,4 +572,89 @@ module _
     ( map-product unit-trunc-Set unit-trunc-Set)
   triangle-distributive-trunc-product-Set =
     pr2 (center distributive-trunc-product-Set)
+```
+
+### A computation of the image when the domain and set-truncation of the codomain are equivalent
+
+Given a function on a coproduct
+
+```text
+  f : A1 + A2 → B
+```
+
+such that the set-truncation of the codomain computes to the domain
+
+```text
+              B
+            ∧   \
+         f /     \ η
+          /   ~   ∨
+  (A1 + A2) -----> ║B║₀,
+```
+
+then the coproduct of the images of the restrictions of `f` along the left and
+right inclusion of the coproduct `A1 + A2` computes as `B`
+
+```text
+  im (f ∘ inl) + im (f ∘ inr) ≃ B.
+```
+
+```agda
+module _
+  {l1 l2 l3 : Level} {A1 : UU l1} {A2 : UU l2} {B : UU l3}
+  (f : A1 + A2 → B) (e : (A1 + A2) ≃ ║ B ║₀)
+  (H : unit-trunc-Set ∘ f ~ map-equiv e)
+  where
+
+  map-is-coproduct-codomain : (im (f ∘ inl) + im (f ∘ inr)) → B
+  map-is-coproduct-codomain = rec-coproduct pr1 pr1
+
+  triangle-is-coproduct-codomain :
+    ( ( map-is-coproduct-codomain) ∘
+      ( map-coproduct (map-unit-im (f ∘ inl)) (map-unit-im (f ∘ inr)))) ~ f
+  triangle-is-coproduct-codomain (inl x) = refl
+  triangle-is-coproduct-codomain (inr x) = refl
+
+  abstract
+    is-emb-map-is-coproduct-codomain : is-emb map-is-coproduct-codomain
+    is-emb-map-is-coproduct-codomain =
+      is-emb-coproduct
+        ( is-emb-inclusion-subtype (λ b → trunc-Prop _))
+        ( is-emb-inclusion-subtype (λ b → trunc-Prop _))
+        ( λ (b1 , u) (b2 , v) →
+          apply-universal-property-trunc-Prop u
+            ( function-Prop _ empty-Prop)
+            ( λ where
+              ( x , refl) →
+                apply-universal-property-trunc-Prop v
+                  ( function-Prop _ empty-Prop)
+                  ( λ where
+                    ( y , refl) r →
+                      is-empty-eq-coproduct-inl-inr x y
+                        ( is-injective-is-equiv
+                          ( is-equiv-map-equiv e)
+                          ( ( inv (H (inl x))) ∙
+                            ( ap unit-trunc-Set r) ∙
+                            ( H (inr y)))))))
+
+  is-surjective-map-is-coproduct-codomain :
+    is-surjective map-is-coproduct-codomain
+  is-surjective-map-is-coproduct-codomain b =
+    apply-universal-property-trunc-Prop
+      ( apply-effectiveness-unit-trunc-Set
+        ( inv (is-section-map-inv-equiv e (unit-trunc-Set b)) ∙ inv (H a)))
+      ( trunc-Prop (fiber map-is-coproduct-codomain b))
+      ( λ p →
+        unit-trunc-Prop
+          ( ( map-coproduct (map-unit-im (f ∘ inl)) (map-unit-im (f ∘ inr)) a) ,
+            ( triangle-is-coproduct-codomain a ∙ inv p)))
+    where
+    a = map-inv-equiv e (unit-trunc-Set b)
+
+  is-coproduct-codomain : (im (f ∘ inl) + im (f ∘ inr)) ≃ B
+  pr1 is-coproduct-codomain = map-is-coproduct-codomain
+  pr2 is-coproduct-codomain =
+    is-equiv-is-emb-is-surjective
+      is-surjective-map-is-coproduct-codomain
+      is-emb-map-is-coproduct-codomain
 ```

--- a/src/foundation/set-truncations.lagda.md
+++ b/src/foundation/set-truncations.lagda.md
@@ -592,11 +592,11 @@ such that the set-truncation of the codomain computes to the domain
   (A1 + A2) -----> ║B║₀,
 ```
 
-then the coproduct of the images of the restrictions of `f` along the left and
-right inclusion of the coproduct `A1 + A2` computes as `B`
+then `B` computes as the coproduct of the images of the restrictions of `f`
+along the left and right inclusion of the coproduct `A1 + A2`
 
 ```text
-  im (f ∘ inl) + im (f ∘ inr) ≃ B.
+  B ≃ im (f ∘ inl) + im (f ∘ inr).
 ```
 
 ```agda
@@ -637,19 +637,23 @@ module _
                             ( ap unit-trunc-Set r) ∙
                             ( H (inr y)))))))
 
-  is-surjective-map-is-coproduct-codomain :
-    is-surjective map-is-coproduct-codomain
-  is-surjective-map-is-coproduct-codomain b =
-    apply-universal-property-trunc-Prop
-      ( apply-effectiveness-unit-trunc-Set
-        ( inv (is-section-map-inv-equiv e (unit-trunc-Set b)) ∙ inv (H a)))
-      ( trunc-Prop (fiber map-is-coproduct-codomain b))
-      ( λ p →
-        unit-trunc-Prop
-          ( ( map-coproduct (map-unit-im (f ∘ inl)) (map-unit-im (f ∘ inr)) a) ,
-            ( triangle-is-coproduct-codomain a ∙ inv p)))
-    where
-    a = map-inv-equiv e (unit-trunc-Set b)
+  abstract
+    is-surjective-map-is-coproduct-codomain :
+      is-surjective map-is-coproduct-codomain
+    is-surjective-map-is-coproduct-codomain b =
+      apply-universal-property-trunc-Prop
+        ( apply-effectiveness-unit-trunc-Set
+          ( inv (is-section-map-inv-equiv e (unit-trunc-Set b)) ∙ inv (H a)))
+        ( trunc-Prop (fiber map-is-coproduct-codomain b))
+        ( λ p →
+          unit-trunc-Prop
+            ( ( map-coproduct
+                ( map-unit-im (f ∘ inl))
+                ( map-unit-im (f ∘ inr))
+                ( a)) ,
+              ( triangle-is-coproduct-codomain a ∙ inv p)))
+      where
+      a = map-inv-equiv e (unit-trunc-Set b)
 
   is-coproduct-codomain : (im (f ∘ inl) + im (f ∘ inr)) ≃ B
   pr1 is-coproduct-codomain = map-is-coproduct-codomain

--- a/src/univalent-combinatorics.lagda.md
+++ b/src/univalent-combinatorics.lagda.md
@@ -70,7 +70,7 @@ open import univalent-combinatorics.inhabited-finite-types public
 open import univalent-combinatorics.injective-maps public
 open import univalent-combinatorics.involution-standard-finite-types public
 open import univalent-combinatorics.isotopies-latin-squares public
-open import univalent-combinatorics.kuratowsky-finite-sets public
+open import univalent-combinatorics.kuratowski-finite-sets public
 open import univalent-combinatorics.latin-squares public
 open import univalent-combinatorics.locally-finite-types public
 open import univalent-combinatorics.main-classes-of-latin-hypercubes public

--- a/src/univalent-combinatorics.lagda.md
+++ b/src/univalent-combinatorics.lagda.md
@@ -72,6 +72,7 @@ open import univalent-combinatorics.involution-standard-finite-types public
 open import univalent-combinatorics.isotopies-latin-squares public
 open import univalent-combinatorics.kuratowsky-finite-sets public
 open import univalent-combinatorics.latin-squares public
+open import univalent-combinatorics.locally-finite-types public
 open import univalent-combinatorics.main-classes-of-latin-hypercubes public
 open import univalent-combinatorics.main-classes-of-latin-squares public
 open import univalent-combinatorics.maybe public

--- a/src/univalent-combinatorics.lagda.md
+++ b/src/univalent-combinatorics.lagda.md
@@ -59,7 +59,6 @@ open import univalent-combinatorics.equivalences-standard-finite-types public
 open import univalent-combinatorics.ferrers-diagrams public
 open import univalent-combinatorics.fibers-of-maps public
 open import univalent-combinatorics.finite-choice public
-open import univalent-combinatorics.finite-connected-components public
 open import univalent-combinatorics.finite-presentations public
 open import univalent-combinatorics.finite-types public
 open import univalent-combinatorics.finitely-presented-types public

--- a/src/univalent-combinatorics.lagda.md
+++ b/src/univalent-combinatorics.lagda.md
@@ -61,6 +61,7 @@ open import univalent-combinatorics.fibers-of-maps public
 open import univalent-combinatorics.finite-choice public
 open import univalent-combinatorics.finite-presentations public
 open import univalent-combinatorics.finite-types public
+open import univalent-combinatorics.finitely-many-connected-components public
 open import univalent-combinatorics.finitely-presented-types public
 open import univalent-combinatorics.function-types public
 open import univalent-combinatorics.image-of-maps public

--- a/src/univalent-combinatorics/dedekind-finite-sets.lagda.md
+++ b/src/univalent-combinatorics/dedekind-finite-sets.lagda.md
@@ -19,8 +19,11 @@ open import foundation.universe-levels
 
 ## Idea
 
-Dedekind finite sets are sets `X` with the property that every embedding `X ↪ X`
-is an equivalence.
+{{#concept "Dedekind finite sets" Agda=set-𝔽-Dedekind}} are
+[sets](foundation-core.sets.md) `X` with the
+[property](foundation-core.propositions.md) that every
+[embedding](foundation-core.embeddings.md) `X ↪ X` is an
+[equivalence](foundation-core.equivalences.md).
 
 ## Definition
 
@@ -53,3 +56,23 @@ module _
   is-dedekind-finite-set-𝔽-Dedekind : is-dedekind-finite-set set-𝔽-Dedekind
   is-dedekind-finite-set-𝔽-Dedekind = pr2 X
 ```
+
+## See also
+
+- [Finite types](univalent-combinatorics.finite-types.md)
+- [Kratowsky-finite sets](univalent-combinatorics.kuratowsky-finite-sets.md)
+
+## References
+
+{{#bibliography}} {{#reference Sto87}}
+
+## External links
+
+- [Finiteness in Sheaf Topoi](https://grossack.site/2024/08/19/finiteness-in-sheaf-topoi),
+  blog post by Chris Grossack
+- [`Fin.Dedekind`](https://www.cs.bham.ac.uk/~mhe/TypeTopology/Fin.Dedekind.html)
+  at TypeTopology
+- [finite object#Dedekind finiteness](https://ncatlab.org/nlab/show/finite+object#dedekind_finiteness)
+- [finite set](https://ncatlab.org/nlab/show/finite+set) at $n$Lab
+- [Dedekind-infinite set](https://en.wikipedia.org/wiki/Dedekind-infinite_set)
+  at Wikipedia

--- a/src/univalent-combinatorics/dedekind-finite-sets.lagda.md
+++ b/src/univalent-combinatorics/dedekind-finite-sets.lagda.md
@@ -60,7 +60,7 @@ module _
 ## See also
 
 - [Finite types](univalent-combinatorics.finite-types.md)
-- [Kratowsky-finite sets](univalent-combinatorics.kuratowsky-finite-sets.md)
+- [Kratowsky-finite sets](univalent-combinatorics.kuratowski-finite-sets.md)
 
 ## References
 

--- a/src/univalent-combinatorics/finite-connected-components.lagda.md
+++ b/src/univalent-combinatorics/finite-connected-components.lagda.md
@@ -130,9 +130,10 @@ is-finite-has-finite-connected-components H =
 
 ### Dependent sums of types with finite connectected components
 
-The total space of a family of types with finite connected components has finite
-connected components when the base is 0-connected and its based loop spaces have
-finite connected components.
+The total space of a family of types with finitely many connected components has
+finitely many connected components when the base is `0`-connected and its based
+[loop spaces](synthetic-homotopy-theory.loop-spaces.md) have finitely many
+connected components.
 
 ```agda
 has-finite-connected-components-Σ-is-0-connected :

--- a/src/univalent-combinatorics/finite-connected-components.lagda.md
+++ b/src/univalent-combinatorics/finite-connected-components.lagda.md
@@ -9,29 +9,77 @@ module univalent-combinatorics.finite-connected-components where
 ```agda
 open import elementary-number-theory.natural-numbers
 
+open import foundation.0-connected-types
+open import foundation.action-on-identifications-functions
+open import foundation.contractible-types
+open import foundation.decidable-propositions
+open import foundation.decidable-types
+open import foundation.dependent-identifications
+open import foundation.dependent-pair-types
+open import foundation.equality-dependent-pair-types
+open import foundation.equivalences
+open import foundation.fiber-inclusions
+open import foundation.function-types
+open import foundation.functoriality-set-truncation
+open import foundation.homotopies
+open import foundation.identity-types
+open import foundation.logical-equivalences
+open import foundation.mere-equality
+open import foundation.mere-equivalences
+open import foundation.propositional-extensionality
+open import foundation.propositional-truncations
 open import foundation.propositions
 open import foundation.set-truncations
+open import foundation.sets
+open import foundation.transport-along-identifications
+open import foundation.univalence
 open import foundation.universe-levels
 
+open import univalent-combinatorics.dependent-pair-types
+open import univalent-combinatorics.equality-finite-types
 open import univalent-combinatorics.finite-types
+open import univalent-combinatorics.image-of-maps
+open import univalent-combinatorics.standard-finite-types
 ```
 
 </details>
 
 ## Idea
 
-A type is said to have finitely many connected components if its set truncation
-is a finite type.
+A type is said to have
+{{#concept "finitely many connected components" Agda=has-finitely-many-components}}
+if its [set truncation](foundation.set-truncations.md) is a
+[finite type](univalent-combinatorics.finite-types.md).
 
-## Definition
+## Definitions
+
+### Types with finitely many connected components
 
 ```agda
-has-finitely-many-components-Prop : {l : Level} → UU l → Prop l
-has-finitely-many-components-Prop A = is-finite-Prop (type-trunc-Set A)
+has-finite-connected-components-Prop : {l : Level} → UU l → Prop l
+has-finite-connected-components-Prop A =
+  is-finite-Prop (type-trunc-Set A)
 
-has-finitely-many-components : {l : Level} → UU l → UU l
-has-finitely-many-components A = type-Prop (has-finitely-many-components-Prop A)
+has-finite-connected-components : {l : Level} → UU l → UU l
+has-finite-connected-components A =
+  type-Prop (has-finite-connected-components-Prop A)
 
+number-of-connected-components :
+  {l : Level} {X : UU l} → has-finite-connected-components X → ℕ
+number-of-connected-components H = number-of-elements-is-finite H
+
+mere-equiv-number-of-connected-components :
+  {l : Level} {X : UU l} (H : has-finite-connected-components X) →
+  mere-equiv
+    ( Fin (number-of-connected-components H))
+    ( type-trunc-Set X)
+mere-equiv-number-of-connected-components H =
+  mere-equiv-is-finite H
+```
+
+### Types with connected components of a certain finite cardinality
+
+```agda
 has-cardinality-components-Prop : {l : Level} (k : ℕ) → UU l → Prop l
 has-cardinality-components-Prop k A =
   has-cardinality-Prop k (type-trunc-Set A)
@@ -40,3 +88,198 @@ has-cardinality-components : {l : Level} (k : ℕ) → UU l → UU l
 has-cardinality-components k A =
   type-Prop (has-cardinality-components-Prop k A)
 ```
+
+## Properties
+
+### Having finitely many connected components is invariant under equivalences
+
+```agda
+module _
+  {l1 l2 : Level} {A : UU l1} {B : UU l2} (e : A ≃ B)
+  where
+
+  has-finite-connected-components-equiv :
+    has-finite-connected-components A → has-finite-connected-components B
+  has-finite-connected-components-equiv =
+    is-finite-equiv (equiv-trunc-Set e)
+
+  has-finite-connected-components-equiv' :
+    has-finite-connected-components B → has-finite-connected-components A
+  has-finite-connected-components-equiv' =
+    is-finite-equiv' (equiv-trunc-Set e)
+```
+
+### Any 0-connected type has finitely many connected components
+
+```agda
+has-finite-connected-components-is-0-connected :
+  {l : Level} {A : UU l} →
+  is-0-connected A → has-finite-connected-components A
+has-finite-connected-components-is-0-connected = is-finite-is-contr
+```
+
+### Sets with finite connected components are finite
+
+```agda
+is-finite-has-finite-connected-components :
+  {l : Level} {A : UU l} →
+  is-set A → has-finite-connected-components A → is-finite A
+is-finite-has-finite-connected-components H =
+  is-finite-equiv' (equiv-unit-trunc-Set (_ , H))
+```
+
+### Dependent sums of types with finite connectected components
+
+The total space of a family of types with finite connected components has finite
+connected components when the base is 0-connected and its based loop spaces have
+finite connected components.
+
+```agda
+has-finite-connected-components-Σ-is-0-connected :
+  {l1 l2 : Level} {A : UU l1} {B : A → UU l2} →
+  is-0-connected A →
+  ((a : A) → has-finite-connected-components (a ＝ a)) →
+  ((x : A) → has-finite-connected-components (B x)) →
+  has-finite-connected-components (Σ A B)
+has-finite-connected-components-Σ-is-0-connected {A = A} {B} C H K =
+  apply-universal-property-trunc-Prop
+    ( is-inhabited-is-0-connected C)
+    ( has-finite-connected-components-Prop (Σ A B))
+    ( α)
+  where
+  α : A → has-finite-connected-components (Σ A B)
+  α a =
+    is-finite-codomain
+      ( K a)
+      ( is-surjective-map-trunc-Set
+        ( fiber-inclusion B a)
+        ( is-surjective-fiber-inclusion C a))
+      ( apply-dependent-universal-property-trunc-Set'
+        ( λ x →
+          set-Prop
+            ( Π-Prop
+              ( type-trunc-Set (Σ A B))
+              ( λ y → is-decidable-Prop (Id-Prop (trunc-Set (Σ A B)) x y))))
+        ( β))
+    where
+    β :
+      (x : Σ A B) (v : type-trunc-Set (Σ A B)) →
+      is-decidable (unit-trunc-Set x ＝ v)
+    β (x , y) =
+      apply-dependent-universal-property-trunc-Set'
+        ( λ u →
+          set-Prop
+            ( is-decidable-Prop
+              ( Id-Prop (trunc-Set (Σ A B)) (unit-trunc-Set (x , y)) u)))
+        ( γ)
+      where
+      γ :
+        (v : Σ A B) →
+        is-decidable ((unit-trunc-Set (x , y)) ＝ (unit-trunc-Set v))
+      γ (x' , y') =
+        is-decidable-equiv
+          ( is-effective-unit-trunc-Set
+            ( Σ A B)
+            ( x , y)
+            ( x' , y'))
+          ( apply-universal-property-trunc-Prop
+            ( mere-eq-is-0-connected C a x)
+            ( is-decidable-Prop
+              ( mere-eq-Prop (x , y) (x' , y')))
+              ( δ))
+        where
+        δ : a ＝ x → is-decidable (mere-eq (x , y) (x' , y'))
+        δ refl =
+          apply-universal-property-trunc-Prop
+            ( mere-eq-is-0-connected C a x')
+            ( is-decidable-Prop
+              ( mere-eq-Prop (a , y) (x' , y')))
+            ( ε)
+          where
+          ε : a ＝ x' → is-decidable (mere-eq (x , y) (x' , y'))
+          ε refl =
+            is-decidable-equiv e
+              ( is-decidable-type-trunc-Prop-is-finite
+                ( is-finite-Σ
+                  ( H a)
+                  ( λ ω → is-finite-is-decidable-Prop (P ω) (d ω))))
+            where
+            ℙ :
+              is-contr
+                ( Σ ( hom-Set (trunc-Set (a ＝ a)) (Prop-Set _))
+                    ( λ h →
+                      ( λ a₁ → h (unit-trunc-Set a₁)) ~
+                      ( λ ω₁ →
+                        trunc-Prop (dependent-identification B ω₁ y y'))))
+            ℙ =
+              universal-property-trunc-Set
+                ( a ＝ a)
+                ( Prop-Set _)
+                ( λ ω → trunc-Prop (dependent-identification B ω y y'))
+
+            P : type-trunc-Set (Id a a) → Prop _
+            P = pr1 (center ℙ)
+
+            compute-P :
+              (ω : a ＝ a) →
+              type-Prop (P (unit-trunc-Set ω)) ≃
+              type-trunc-Prop (dependent-identification B ω y y')
+            compute-P ω = equiv-eq (ap pr1 (pr2 (center ℙ) ω))
+
+            d : (t : type-trunc-Set (a ＝ a)) → is-decidable (type-Prop (P t))
+            d =
+              apply-dependent-universal-property-trunc-Set'
+                ( λ t → set-Prop (is-decidable-Prop (P t)))
+                ( λ ω →
+                  is-decidable-equiv'
+                    ( inv-equiv (compute-P ω))
+                    ( is-decidable-equiv'
+                      ( is-effective-unit-trunc-Set (B a) (tr B ω y) y')
+                      ( has-decidable-equality-is-finite
+                        ( K a)
+                        ( unit-trunc-Set (tr B ω y))
+                        ( unit-trunc-Set y'))))
+
+            f : type-hom-Prop
+                ( trunc-Prop (Σ (type-trunc-Set (Id a a)) (type-Prop ∘ P)))
+                ( mere-eq-Prop {A = Σ A B} (a , y) (a , y'))
+            f t =
+              apply-universal-property-trunc-Prop t
+                ( mere-eq-Prop (a , y) (a , y'))
+                  λ (u , v) →
+                  apply-dependent-universal-property-trunc-Set'
+                    ( λ u' →
+                      hom-set-Set
+                        ( set-Prop (P u'))
+                        ( set-Prop
+                          ( mere-eq-Prop (a , y) (a , y'))))
+                    ( λ ω v' →
+                      apply-universal-property-trunc-Prop
+                        ( map-equiv (compute-P ω) v')
+                        ( mere-eq-Prop (a , y) (a , y'))
+                        ( λ p → unit-trunc-Prop (eq-pair-Σ ω p)))
+                    ( u)
+                    ( v)
+            e :
+              mere-eq {A = Σ A B} (a , y) (a , y') ≃
+              type-trunc-Prop (Σ (type-trunc-Set (Id a a)) (type-Prop ∘ P))
+            e =
+              equiv-iff
+                ( mere-eq-Prop (a , y) (a , y'))
+                ( trunc-Prop (Σ (type-trunc-Set (a ＝ a)) (type-Prop ∘ P)))
+                ( λ t →
+                  apply-universal-property-trunc-Prop t
+                    ( trunc-Prop _)
+                    ( ( λ (ω , r) →
+                        unit-trunc-Prop
+                          ( ( unit-trunc-Set ω) ,
+                            ( map-inv-equiv
+                              ( compute-P ω)
+                              ( unit-trunc-Prop r)))) ∘
+                      ( pair-eq-Σ)))
+                ( f)
+```
+
+## See also
+
+- [Kuratowsky finite sets](univalent-combinatorics.kuratowsky-finite-sets.md)

--- a/src/univalent-combinatorics/finite-connected-components.lagda.md
+++ b/src/univalent-combinatorics/finite-connected-components.lagda.md
@@ -77,7 +77,7 @@ mere-equiv-number-of-connected-components H =
   mere-equiv-is-finite H
 ```
 
-### Types with connected components of a certain finite cardinality
+### Types with a finite type of connected components of a specified cardinality
 
 ```agda
 has-cardinality-components-Prop : {l : Level} (k : ℕ) → UU l → Prop l
@@ -118,7 +118,7 @@ has-finite-connected-components-is-0-connected :
 has-finite-connected-components-is-0-connected = is-finite-is-contr
 ```
 
-### Sets with finite connected components are finite
+### Sets with finitely many connected components are finite
 
 ```agda
 is-finite-has-finite-connected-components :
@@ -128,7 +128,7 @@ is-finite-has-finite-connected-components H =
   is-finite-equiv' (equiv-unit-trunc-Set (_ , H))
 ```
 
-### Dependent sums of types with finite connectected components
+### Dependent sums of types with finitely many connected components
 
 The total space of a family of types with finitely many connected components has
 finitely many connected components when the base is `0`-connected and its based

--- a/src/univalent-combinatorics/finite-types.lagda.md
+++ b/src/univalent-combinatorics/finite-types.lagda.md
@@ -50,9 +50,13 @@ open import univalent-combinatorics.standard-finite-types
 
 ## Idea
 
-A type is **finite** if it is
-[merely equivalent](foundation.mere-equivalences.md) to a
+A type is
+{{#concept "finite" Disambiguation="type" Agda=is-finite WD="finite set" WDID=Q272404}}
+if it is [merely equivalent](foundation.mere-equivalences.md) to a
 [standard finite type](univalent-combinatorics.standard-finite-types.md).
+
+**Terminology.** This finiteness condition is also referred to as _Bishop
+finiteness_.
 
 ## Definition
 
@@ -92,7 +96,7 @@ is-finite-type-𝔽 :
 is-finite-type-𝔽 = pr2
 ```
 
-### Types with cardinality `k`
+### Types with finite cardinality `k`
 
 ```agda
 has-cardinality-Prop :
@@ -707,3 +711,14 @@ abstract
           ( p)
           ( pr2 (has-finite-cardinality-is-finite H)))
 ```
+
+## External links
+
+- [Finiteness in Sheaf Topoi](https://grossack.site/2024/08/19/finiteness-in-sheaf-topoi),
+  blog post by Chris Grossack
+- [`Fin.Bishop`](https://www.cs.bham.ac.uk/~mhe/TypeTopology/Fin.Bishop.html) at
+  TypeTopology
+- [finite set](https://ncatlab.org/nlab/show/finite+set) at $n$Lab
+- [finite object](https://ncatlab.org/nlab/show/finite+object) at $n$Lab
+- [Finite set](https://en.wikipedia.org/wiki/Finite_set) at Wikipedia
+- [Finite set](https://www.wikidata.org/wiki/Q272404) at Wikidata

--- a/src/univalent-combinatorics/finite-types.lagda.md
+++ b/src/univalent-combinatorics/finite-types.lagda.md
@@ -56,7 +56,7 @@ if it is [merely equivalent](foundation.mere-equivalences.md) to a
 [standard finite type](univalent-combinatorics.standard-finite-types.md).
 
 **Terminology.** This finiteness condition is also referred to as _Bishop
-finiteness_. (Cf. the external links)
+finiteness_. (Cf. the external links at the bottom of this page)
 
 ## Definition
 

--- a/src/univalent-combinatorics/finite-types.lagda.md
+++ b/src/univalent-combinatorics/finite-types.lagda.md
@@ -56,7 +56,7 @@ if it is [merely equivalent](foundation.mere-equivalences.md) to a
 [standard finite type](univalent-combinatorics.standard-finite-types.md).
 
 **Terminology.** This finiteness condition is also referred to as _Bishop
-finiteness_.
+finiteness_. (Cf. the external links)
 
 ## Definition
 

--- a/src/univalent-combinatorics/finitely-many-connected-components.lagda.md
+++ b/src/univalent-combinatorics/finitely-many-connected-components.lagda.md
@@ -16,6 +16,7 @@ open import foundation.decidable-propositions
 open import foundation.decidable-types
 open import foundation.dependent-identifications
 open import foundation.dependent-pair-types
+open import foundation.empty-types
 open import foundation.equality-dependent-pair-types
 open import foundation.equivalences
 open import foundation.fiber-inclusions
@@ -35,6 +36,7 @@ open import foundation.transport-along-identifications
 open import foundation.univalence
 open import foundation.universe-levels
 
+open import univalent-combinatorics.coproduct-types
 open import univalent-combinatorics.dependent-pair-types
 open import univalent-combinatorics.equality-finite-types
 open import univalent-combinatorics.finite-types
@@ -47,7 +49,7 @@ open import univalent-combinatorics.standard-finite-types
 ## Idea
 
 A type is said to have
-{{#concept "finitely many connected components" Agda=has-finitely-many-components}}
+{{#concept "finitely many connected components"  Disambiguation="of a type" Agda=has-finitely-many-connected-components}}
 if its [set truncation](foundation.set-truncations.md) is a
 [finite type](univalent-combinatorics.finite-types.md).
 
@@ -111,7 +113,16 @@ module _
     is-finite-equiv' (equiv-trunc-Set e)
 ```
 
-### Any 0-connected type has finitely many connected components
+### Empty types have finitely many connected components
+
+```agda
+has-finitely-many-connected-components-is-empty :
+  {l : Level} {A : UU l} → is-empty A → has-finitely-many-connected-components A
+has-finitely-many-connected-components-is-empty f =
+  is-finite-is-empty (is-empty-trunc-Set f)
+```
+
+### Any `0`-connected type has finitely many connected components
 
 ```agda
 has-finitely-many-connected-components-is-0-connected :
@@ -130,12 +141,12 @@ is-finite-has-finitely-many-connected-components H =
   is-finite-equiv' (equiv-unit-trunc-Set (_ , H))
 ```
 
-### Dependent sums of types with finitely many connected components
+### Dependent sums of types with finitely many connected components over a `0`-connected base
 
-The total space of a family of types with finitely many connected components has
-finitely many connected components when the base is `0`-connected and its based
-[loop spaces](synthetic-homotopy-theory.loop-spaces.md) have finitely many
-connected components.
+The total space of a family of types with finitely many connected components
+over a `0`-connected base has finitely many connected components when the based
+[loop spaces](synthetic-homotopy-theory.loop-spaces.md) of the base have
+finitely many connected components.
 
 ```agda
 has-finitely-many-connected-components-Σ-is-0-connected :

--- a/src/univalent-combinatorics/finitely-many-connected-components.lagda.md
+++ b/src/univalent-combinatorics/finitely-many-connected-components.lagda.md
@@ -10,37 +10,17 @@ module univalent-combinatorics.finitely-many-connected-components where
 open import elementary-number-theory.natural-numbers
 
 open import foundation.0-connected-types
-open import foundation.action-on-identifications-functions
-open import foundation.contractible-types
-open import foundation.decidable-propositions
-open import foundation.decidable-types
-open import foundation.dependent-identifications
 open import foundation.dependent-pair-types
 open import foundation.empty-types
-open import foundation.equality-dependent-pair-types
 open import foundation.equivalences
-open import foundation.fiber-inclusions
-open import foundation.function-types
 open import foundation.functoriality-set-truncation
-open import foundation.homotopies
-open import foundation.identity-types
-open import foundation.logical-equivalences
-open import foundation.mere-equality
 open import foundation.mere-equivalences
-open import foundation.propositional-extensionality
-open import foundation.propositional-truncations
 open import foundation.propositions
 open import foundation.set-truncations
 open import foundation.sets
-open import foundation.transport-along-identifications
-open import foundation.univalence
 open import foundation.universe-levels
 
-open import univalent-combinatorics.coproduct-types
-open import univalent-combinatorics.dependent-pair-types
-open import univalent-combinatorics.equality-finite-types
 open import univalent-combinatorics.finite-types
-open import univalent-combinatorics.image-of-maps
 open import univalent-combinatorics.standard-finite-types
 ```
 
@@ -139,159 +119,6 @@ is-finite-has-finitely-many-connected-components :
   is-set A → has-finitely-many-connected-components A → is-finite A
 is-finite-has-finitely-many-connected-components H =
   is-finite-equiv' (equiv-unit-trunc-Set (_ , H))
-```
-
-### Dependent sums of types with finitely many connected components over a `0`-connected base
-
-The total space of a family of types with finitely many connected components
-over a `0`-connected base has finitely many connected components when the based
-[loop spaces](synthetic-homotopy-theory.loop-spaces.md) of the base have
-finitely many connected components.
-
-```agda
-has-finitely-many-connected-components-Σ-is-0-connected :
-  {l1 l2 : Level} {A : UU l1} {B : A → UU l2} →
-  is-0-connected A →
-  ((a : A) → has-finitely-many-connected-components (a ＝ a)) →
-  ((x : A) → has-finitely-many-connected-components (B x)) →
-  has-finitely-many-connected-components (Σ A B)
-has-finitely-many-connected-components-Σ-is-0-connected {A = A} {B} C H K =
-  apply-universal-property-trunc-Prop
-    ( is-inhabited-is-0-connected C)
-    ( has-finitely-many-connected-components-Prop (Σ A B))
-    ( α)
-  where
-  α : A → has-finitely-many-connected-components (Σ A B)
-  α a =
-    is-finite-codomain
-      ( K a)
-      ( is-surjective-map-trunc-Set
-        ( fiber-inclusion B a)
-        ( is-surjective-fiber-inclusion C a))
-      ( apply-dependent-universal-property-trunc-Set'
-        ( λ x →
-          set-Prop
-            ( Π-Prop
-              ( type-trunc-Set (Σ A B))
-              ( λ y → is-decidable-Prop (Id-Prop (trunc-Set (Σ A B)) x y))))
-        ( β))
-    where
-    β :
-      (x : Σ A B) (v : type-trunc-Set (Σ A B)) →
-      is-decidable (unit-trunc-Set x ＝ v)
-    β (x , y) =
-      apply-dependent-universal-property-trunc-Set'
-        ( λ u →
-          set-Prop
-            ( is-decidable-Prop
-              ( Id-Prop (trunc-Set (Σ A B)) (unit-trunc-Set (x , y)) u)))
-        ( γ)
-      where
-      γ :
-        (v : Σ A B) →
-        is-decidable ((unit-trunc-Set (x , y)) ＝ (unit-trunc-Set v))
-      γ (x' , y') =
-        is-decidable-equiv
-          ( is-effective-unit-trunc-Set
-            ( Σ A B)
-            ( x , y)
-            ( x' , y'))
-          ( apply-universal-property-trunc-Prop
-            ( mere-eq-is-0-connected C a x)
-            ( is-decidable-Prop
-              ( mere-eq-Prop (x , y) (x' , y')))
-              ( δ))
-        where
-        δ : a ＝ x → is-decidable (mere-eq (x , y) (x' , y'))
-        δ refl =
-          apply-universal-property-trunc-Prop
-            ( mere-eq-is-0-connected C a x')
-            ( is-decidable-Prop
-              ( mere-eq-Prop (a , y) (x' , y')))
-            ( ε)
-          where
-          ε : a ＝ x' → is-decidable (mere-eq (x , y) (x' , y'))
-          ε refl =
-            is-decidable-equiv e
-              ( is-decidable-type-trunc-Prop-is-finite
-                ( is-finite-Σ
-                  ( H a)
-                  ( λ ω → is-finite-is-decidable-Prop (P ω) (d ω))))
-            where
-            ℙ :
-              is-contr
-                ( Σ ( hom-Set (trunc-Set (a ＝ a)) (Prop-Set _))
-                    ( λ h →
-                      ( λ a₁ → h (unit-trunc-Set a₁)) ~
-                      ( λ ω₁ →
-                        trunc-Prop (dependent-identification B ω₁ y y'))))
-            ℙ =
-              universal-property-trunc-Set
-                ( a ＝ a)
-                ( Prop-Set _)
-                ( λ ω → trunc-Prop (dependent-identification B ω y y'))
-
-            P : type-trunc-Set (Id a a) → Prop _
-            P = pr1 (center ℙ)
-
-            compute-P :
-              (ω : a ＝ a) →
-              type-Prop (P (unit-trunc-Set ω)) ≃
-              type-trunc-Prop (dependent-identification B ω y y')
-            compute-P ω = equiv-eq (ap pr1 (pr2 (center ℙ) ω))
-
-            d : (t : type-trunc-Set (a ＝ a)) → is-decidable (type-Prop (P t))
-            d =
-              apply-dependent-universal-property-trunc-Set'
-                ( λ t → set-Prop (is-decidable-Prop (P t)))
-                ( λ ω →
-                  is-decidable-equiv'
-                    ( inv-equiv (compute-P ω))
-                    ( is-decidable-equiv'
-                      ( is-effective-unit-trunc-Set (B a) (tr B ω y) y')
-                      ( has-decidable-equality-is-finite
-                        ( K a)
-                        ( unit-trunc-Set (tr B ω y))
-                        ( unit-trunc-Set y'))))
-
-            f : type-hom-Prop
-                ( trunc-Prop (Σ (type-trunc-Set (Id a a)) (type-Prop ∘ P)))
-                ( mere-eq-Prop {A = Σ A B} (a , y) (a , y'))
-            f t =
-              apply-universal-property-trunc-Prop t
-                ( mere-eq-Prop (a , y) (a , y'))
-                  λ (u , v) →
-                  apply-dependent-universal-property-trunc-Set'
-                    ( λ u' →
-                      hom-set-Set
-                        ( set-Prop (P u'))
-                        ( set-Prop
-                          ( mere-eq-Prop (a , y) (a , y'))))
-                    ( λ ω v' →
-                      apply-universal-property-trunc-Prop
-                        ( map-equiv (compute-P ω) v')
-                        ( mere-eq-Prop (a , y) (a , y'))
-                        ( λ p → unit-trunc-Prop (eq-pair-Σ ω p)))
-                    ( u)
-                    ( v)
-            e :
-              mere-eq {A = Σ A B} (a , y) (a , y') ≃
-              type-trunc-Prop (Σ (type-trunc-Set (Id a a)) (type-Prop ∘ P))
-            e =
-              equiv-iff
-                ( mere-eq-Prop (a , y) (a , y'))
-                ( trunc-Prop (Σ (type-trunc-Set (a ＝ a)) (type-Prop ∘ P)))
-                ( λ t →
-                  apply-universal-property-trunc-Prop t
-                    ( trunc-Prop _)
-                    ( ( λ (ω , r) →
-                        unit-trunc-Prop
-                          ( ( unit-trunc-Set ω) ,
-                            ( map-inv-equiv
-                              ( compute-P ω)
-                              ( unit-trunc-Prop r)))) ∘
-                      ( pair-eq-Σ)))
-                ( f)
 ```
 
 ## See also

--- a/src/univalent-combinatorics/finitely-many-connected-components.lagda.md
+++ b/src/univalent-combinatorics/finitely-many-connected-components.lagda.md
@@ -80,13 +80,13 @@ mere-equiv-number-of-connected-components H =
 ### Types with a finite type of connected components of a specified cardinality
 
 ```agda
-has-cardinality-components-Prop : {l : Level} (k : ℕ) → UU l → Prop l
-has-cardinality-components-Prop k A =
+has-cardinality-connected-components-Prop : {l : Level} (k : ℕ) → UU l → Prop l
+has-cardinality-connected-components-Prop k A =
   has-cardinality-Prop k (type-trunc-Set A)
 
-has-cardinality-components : {l : Level} (k : ℕ) → UU l → UU l
-has-cardinality-components k A =
-  type-Prop (has-cardinality-components-Prop k A)
+has-cardinality-connected-components : {l : Level} (k : ℕ) → UU l → UU l
+has-cardinality-connected-components k A =
+  type-Prop (has-cardinality-connected-components-Prop k A)
 ```
 
 ## Properties

--- a/src/univalent-combinatorics/finitely-many-connected-components.lagda.md
+++ b/src/univalent-combinatorics/finitely-many-connected-components.lagda.md
@@ -1,7 +1,7 @@
 # Finiteness of the type of connected components
 
 ```agda
-module univalent-combinatorics.finite-connected-components where
+module univalent-combinatorics.finitely-many-connected-components where
 ```
 
 <details><summary>Imports</summary>
@@ -56,20 +56,20 @@ if its [set truncation](foundation.set-truncations.md) is a
 ### Types with finitely many connected components
 
 ```agda
-has-finite-connected-components-Prop : {l : Level} → UU l → Prop l
-has-finite-connected-components-Prop A =
+has-finitely-many-connected-components-Prop : {l : Level} → UU l → Prop l
+has-finitely-many-connected-components-Prop A =
   is-finite-Prop (type-trunc-Set A)
 
-has-finite-connected-components : {l : Level} → UU l → UU l
-has-finite-connected-components A =
-  type-Prop (has-finite-connected-components-Prop A)
+has-finitely-many-connected-components : {l : Level} → UU l → UU l
+has-finitely-many-connected-components A =
+  type-Prop (has-finitely-many-connected-components-Prop A)
 
 number-of-connected-components :
-  {l : Level} {X : UU l} → has-finite-connected-components X → ℕ
+  {l : Level} {X : UU l} → has-finitely-many-connected-components X → ℕ
 number-of-connected-components H = number-of-elements-is-finite H
 
 mere-equiv-number-of-connected-components :
-  {l : Level} {X : UU l} (H : has-finite-connected-components X) →
+  {l : Level} {X : UU l} (H : has-finitely-many-connected-components X) →
   mere-equiv
     ( Fin (number-of-connected-components H))
     ( type-trunc-Set X)
@@ -98,33 +98,33 @@ module _
   {l1 l2 : Level} {A : UU l1} {B : UU l2} (e : A ≃ B)
   where
 
-  has-finite-connected-components-equiv :
-    has-finite-connected-components A → has-finite-connected-components B
-  has-finite-connected-components-equiv =
+  has-finitely-many-connected-components-equiv :
+    has-finitely-many-connected-components A → has-finitely-many-connected-components B
+  has-finitely-many-connected-components-equiv =
     is-finite-equiv (equiv-trunc-Set e)
 
-  has-finite-connected-components-equiv' :
-    has-finite-connected-components B → has-finite-connected-components A
-  has-finite-connected-components-equiv' =
+  has-finitely-many-connected-components-equiv' :
+    has-finitely-many-connected-components B → has-finitely-many-connected-components A
+  has-finitely-many-connected-components-equiv' =
     is-finite-equiv' (equiv-trunc-Set e)
 ```
 
 ### Any 0-connected type has finitely many connected components
 
 ```agda
-has-finite-connected-components-is-0-connected :
+has-finitely-many-connected-components-is-0-connected :
   {l : Level} {A : UU l} →
-  is-0-connected A → has-finite-connected-components A
-has-finite-connected-components-is-0-connected = is-finite-is-contr
+  is-0-connected A → has-finitely-many-connected-components A
+has-finitely-many-connected-components-is-0-connected = is-finite-is-contr
 ```
 
 ### Sets with finitely many connected components are finite
 
 ```agda
-is-finite-has-finite-connected-components :
+is-finite-has-finitely-many-connected-components :
   {l : Level} {A : UU l} →
-  is-set A → has-finite-connected-components A → is-finite A
-is-finite-has-finite-connected-components H =
+  is-set A → has-finitely-many-connected-components A → is-finite A
+is-finite-has-finitely-many-connected-components H =
   is-finite-equiv' (equiv-unit-trunc-Set (_ , H))
 ```
 
@@ -136,19 +136,19 @@ finitely many connected components when the base is `0`-connected and its based
 connected components.
 
 ```agda
-has-finite-connected-components-Σ-is-0-connected :
+has-finitely-many-connected-components-Σ-is-0-connected :
   {l1 l2 : Level} {A : UU l1} {B : A → UU l2} →
   is-0-connected A →
-  ((a : A) → has-finite-connected-components (a ＝ a)) →
-  ((x : A) → has-finite-connected-components (B x)) →
-  has-finite-connected-components (Σ A B)
-has-finite-connected-components-Σ-is-0-connected {A = A} {B} C H K =
+  ((a : A) → has-finitely-many-connected-components (a ＝ a)) →
+  ((x : A) → has-finitely-many-connected-components (B x)) →
+  has-finitely-many-connected-components (Σ A B)
+has-finitely-many-connected-components-Σ-is-0-connected {A = A} {B} C H K =
   apply-universal-property-trunc-Prop
     ( is-inhabited-is-0-connected C)
-    ( has-finite-connected-components-Prop (Σ A B))
+    ( has-finitely-many-connected-components-Prop (Σ A B))
     ( α)
   where
-  α : A → has-finite-connected-components (Σ A B)
+  α : A → has-finitely-many-connected-components (Σ A B)
   α a =
     is-finite-codomain
       ( K a)

--- a/src/univalent-combinatorics/finitely-many-connected-components.lagda.md
+++ b/src/univalent-combinatorics/finitely-many-connected-components.lagda.md
@@ -99,12 +99,14 @@ module _
   where
 
   has-finitely-many-connected-components-equiv :
-    has-finitely-many-connected-components A → has-finitely-many-connected-components B
+    has-finitely-many-connected-components A →
+    has-finitely-many-connected-components B
   has-finitely-many-connected-components-equiv =
     is-finite-equiv (equiv-trunc-Set e)
 
   has-finitely-many-connected-components-equiv' :
-    has-finitely-many-connected-components B → has-finitely-many-connected-components A
+    has-finitely-many-connected-components B →
+    has-finitely-many-connected-components A
   has-finitely-many-connected-components-equiv' =
     is-finite-equiv' (equiv-trunc-Set e)
 ```

--- a/src/univalent-combinatorics/finitely-many-connected-components.lagda.md
+++ b/src/univalent-combinatorics/finitely-many-connected-components.lagda.md
@@ -285,4 +285,4 @@ has-finitely-many-connected-components-Σ-is-0-connected {A = A} {B} C H K =
 
 ## See also
 
-- [Kuratowsky finite sets](univalent-combinatorics.kuratowsky-finite-sets.md)
+- [Kuratowski finite sets](univalent-combinatorics.kuratowski-finite-sets.md)

--- a/src/univalent-combinatorics/finitely-presented-types.lagda.md
+++ b/src/univalent-combinatorics/finitely-presented-types.lagda.md
@@ -104,8 +104,12 @@ all-elements-equal-is-finitely-presented {l1} {A} (pair k K) (pair l L) =
   eq-type-subtype
     ( λ n → has-set-presentation-Prop (Fin-Set n) A)
     ( eq-cardinality
-      ( has-cardinality-connected-components-has-presentation-of-cardinality k K)
-      ( has-cardinality-connected-components-has-presentation-of-cardinality l L))
+      ( has-cardinality-connected-components-has-presentation-of-cardinality
+        ( k)
+        ( K))
+      ( has-cardinality-connected-components-has-presentation-of-cardinality
+        ( l)
+        ( L)))
 
 is-prop-is-finitely-presented :
   {l1 : Level} {A : UU l1} → is-prop (is-finitely-presented A)

--- a/src/univalent-combinatorics/finitely-presented-types.lagda.md
+++ b/src/univalent-combinatorics/finitely-presented-types.lagda.md
@@ -21,8 +21,8 @@ open import foundation.subtypes
 open import foundation.universe-levels
 
 open import univalent-combinatorics.finite-choice
-open import univalent-combinatorics.finite-connected-components
 open import univalent-combinatorics.finite-types
+open import univalent-combinatorics.finitely-many-connected-components
 open import univalent-combinatorics.standard-finite-types
 ```
 

--- a/src/univalent-combinatorics/finitely-presented-types.lagda.md
+++ b/src/univalent-combinatorics/finitely-presented-types.lagda.md
@@ -61,10 +61,10 @@ is-finitely-presented A =
 ### A type has finitely many connected components if and only if it has a finite presentation
 
 ```agda
-has-presentation-of-cardinality-has-cardinality-components :
-  {l : Level} (k : ℕ) {A : UU l} → has-cardinality-components k A →
+has-presentation-of-cardinality-has-cardinality-connected-components :
+  {l : Level} (k : ℕ) {A : UU l} → has-cardinality-connected-components k A →
   has-presentation-of-cardinality k A
-has-presentation-of-cardinality-has-cardinality-components {l} k {A} H =
+has-presentation-of-cardinality-has-cardinality-connected-components k {A} H =
   apply-universal-property-trunc-Prop H
     ( has-presentation-of-cardinality-Prop k A)
     ( λ e →
@@ -86,12 +86,12 @@ has-presentation-of-cardinality-has-cardinality-components {l} k {A} H =
     type-trunc-Prop ((x : Fin k) → fiber unit-trunc-Set (map-equiv e x))
   P2 e = finite-choice-Fin k (P1 e)
 
-has-cardinality-components-has-presentation-of-cardinality :
+has-cardinality-connected-components-has-presentation-of-cardinality :
   {l : Level} (k : ℕ) {A : UU l} → has-presentation-of-cardinality k A →
-  has-cardinality-components k A
-has-cardinality-components-has-presentation-of-cardinality {l} k {A} H =
+  has-cardinality-connected-components k A
+has-cardinality-connected-components-has-presentation-of-cardinality k {A} H =
   apply-universal-property-trunc-Prop H
-    ( has-cardinality-components-Prop k A)
+    ( has-cardinality-connected-components-Prop k A)
     ( λ (f , E) → unit-trunc-Prop (unit-trunc-Set ∘ f , E))
 ```
 
@@ -104,8 +104,8 @@ all-elements-equal-is-finitely-presented {l1} {A} (pair k K) (pair l L) =
   eq-type-subtype
     ( λ n → has-set-presentation-Prop (Fin-Set n) A)
     ( eq-cardinality
-      ( has-cardinality-components-has-presentation-of-cardinality k K)
-      ( has-cardinality-components-has-presentation-of-cardinality l L))
+      ( has-cardinality-connected-components-has-presentation-of-cardinality k K)
+      ( has-cardinality-connected-components-has-presentation-of-cardinality l L))
 
 is-prop-is-finitely-presented :
   {l1 : Level} {A : UU l1} → is-prop (is-finitely-presented A)

--- a/src/univalent-combinatorics/kuratowski-finite-sets.lagda.md
+++ b/src/univalent-combinatorics/kuratowski-finite-sets.lagda.md
@@ -1,7 +1,7 @@
-# Kuratowsky finite sets
+# Kuratowski finite sets
 
 ```agda
-module univalent-combinatorics.kuratowsky-finite-sets where
+module univalent-combinatorics.kuratowski-finite-sets where
 ```
 
 <details><summary>Imports</summary>
@@ -28,64 +28,64 @@ open import univalent-combinatorics.standard-finite-types
 
 ## Idea
 
-A {{#concept "Kuratowsky finite set" agda=𝔽-Kuratowsky}} is a
+A {{#concept "Kuratowski finite set" agda=𝔽-Kuratowski}} is a
 [set](foundation-core.sets.md) `X` for which there exists a
 [surjection](foundation.surjective-maps.md) into `X` from a standard finite
-type. In other words, the Kuratowsky finite set are the
+type. In other words, the Kuratowski finite set are the
 [set-quotient](foundation.set-quotients.md) of a
 [standard finite type](univalent-combinatorics.standard-finite-types.md).
 
 ## Definition
 
 ```agda
-is-kuratowsky-finite-set-Prop : {l : Level} → Set l → Prop l
-is-kuratowsky-finite-set-Prop X =
+is-kuratowski-finite-set-Prop : {l : Level} → Set l → Prop l
+is-kuratowski-finite-set-Prop X =
   exists-structure-Prop ℕ (λ n → Fin n ↠ type-Set X)
 
-is-kuratowsky-finite-set : {l : Level} → Set l → UU l
-is-kuratowsky-finite-set X = type-Prop (is-kuratowsky-finite-set-Prop X)
+is-kuratowski-finite-set : {l : Level} → Set l → UU l
+is-kuratowski-finite-set X = type-Prop (is-kuratowski-finite-set-Prop X)
 
-𝔽-Kuratowsky : (l : Level) → UU (lsuc l)
-𝔽-Kuratowsky l = Σ (Set l) is-kuratowsky-finite-set
+𝔽-Kuratowski : (l : Level) → UU (lsuc l)
+𝔽-Kuratowski l = Σ (Set l) is-kuratowski-finite-set
 
 module _
-  {l : Level} (X : 𝔽-Kuratowsky l)
+  {l : Level} (X : 𝔽-Kuratowski l)
   where
 
-  set-𝔽-Kuratowsky : Set l
-  set-𝔽-Kuratowsky = pr1 X
+  set-𝔽-Kuratowski : Set l
+  set-𝔽-Kuratowski = pr1 X
 
-  type-𝔽-Kuratowsky : UU l
-  type-𝔽-Kuratowsky = type-Set set-𝔽-Kuratowsky
+  type-𝔽-Kuratowski : UU l
+  type-𝔽-Kuratowski = type-Set set-𝔽-Kuratowski
 
-  is-set-type-𝔽-Kuratowsky : is-set type-𝔽-Kuratowsky
-  is-set-type-𝔽-Kuratowsky = is-set-type-Set set-𝔽-Kuratowsky
+  is-set-type-𝔽-Kuratowski : is-set type-𝔽-Kuratowski
+  is-set-type-𝔽-Kuratowski = is-set-type-Set set-𝔽-Kuratowski
 
-  is-kuratowsky-finite-set-𝔽-Kuratowsky :
-    is-kuratowsky-finite-set set-𝔽-Kuratowsky
-  is-kuratowsky-finite-set-𝔽-Kuratowsky = pr2 X
+  is-kuratowski-finite-set-𝔽-Kuratowski :
+    is-kuratowski-finite-set set-𝔽-Kuratowski
+  is-kuratowski-finite-set-𝔽-Kuratowski = pr2 X
 ```
 
 ## Properties
 
-### A Kuratowsky finite set is finite if and only if it has decidable equality
+### A Kuratowski finite set is finite if and only if it has decidable equality
 
 ```agda
-is-finite-has-decidable-equality-type-𝔽-Kuratowsky :
-  {l : Level} (X : 𝔽-Kuratowsky l) →
-  has-decidable-equality (type-𝔽-Kuratowsky X) →
-  is-finite (type-𝔽-Kuratowsky X)
-is-finite-has-decidable-equality-type-𝔽-Kuratowsky X H =
+is-finite-has-decidable-equality-type-𝔽-Kuratowski :
+  {l : Level} (X : 𝔽-Kuratowski l) →
+  has-decidable-equality (type-𝔽-Kuratowski X) →
+  is-finite (type-𝔽-Kuratowski X)
+is-finite-has-decidable-equality-type-𝔽-Kuratowski X H =
   apply-universal-property-trunc-Prop
-    ( is-kuratowsky-finite-set-𝔽-Kuratowsky X)
-    ( is-finite-Prop (type-𝔽-Kuratowsky X))
+    ( is-kuratowski-finite-set-𝔽-Kuratowski X)
+    ( is-finite-Prop (type-𝔽-Kuratowski X))
     ( λ (n , f , s) → is-finite-codomain (is-finite-Fin n) s H)
 
-has-decidable-equality-is-finite-type-𝔽-Kuratowsky :
-  {l : Level} (X : 𝔽-Kuratowsky l) →
-  is-finite (type-𝔽-Kuratowsky X) →
-  has-decidable-equality (type-𝔽-Kuratowsky X)
-has-decidable-equality-is-finite-type-𝔽-Kuratowsky X =
+has-decidable-equality-is-finite-type-𝔽-Kuratowski :
+  {l : Level} (X : 𝔽-Kuratowski l) →
+  is-finite (type-𝔽-Kuratowski X) →
+  has-decidable-equality (type-𝔽-Kuratowski X)
+has-decidable-equality-is-finite-type-𝔽-Kuratowski X =
   has-decidable-equality-is-finite
 ```
 

--- a/src/univalent-combinatorics/kuratowsky-finite-sets.lagda.md
+++ b/src/univalent-combinatorics/kuratowsky-finite-sets.lagda.md
@@ -28,9 +28,12 @@ open import univalent-combinatorics.standard-finite-types
 
 ## Idea
 
-A Kuratowsky finite type is a set `X` for which there exists a surjection into
-`X` from a standard finite type. In other words, the Kuratowsky finite types are
-the set-quotient of a standard finite type.
+A {{#concept "Kuratowsky finite set" agda=𝔽-Kuratowsky}} is a
+[set](foundation-core.sets.md) `X` for which there exists a
+[surjection](foundation.surjective-maps.md) into `X` from a standard finite
+type. In other words, the Kuratowsky finite set are the
+[set-quotient](foundation.set-quotients.md) of a
+[standard finite type](univalent-combinatorics.standard-finite-types.md).
 
 ## Definition
 
@@ -82,6 +85,21 @@ has-decidable-equality-is-finite-type-𝔽-Kuratowsky :
   {l : Level} (X : 𝔽-Kuratowsky l) →
   is-finite (type-𝔽-Kuratowsky X) →
   has-decidable-equality (type-𝔽-Kuratowsky X)
-has-decidable-equality-is-finite-type-𝔽-Kuratowsky X H =
-  has-decidable-equality-is-finite H
+has-decidable-equality-is-finite-type-𝔽-Kuratowsky X =
+  has-decidable-equality-is-finite
 ```
+
+## See also
+
+- [Finite types](univalent-combinatorics.finite-types.md)
+- [Dedekind-finite sets](univalent-combinatorics.dedekind-finite-sets.md)
+
+## External links
+
+- [Finiteness in Sheaf Topoi](https://grossack.site/2024/08/19/finiteness-in-sheaf-topoi),
+  blog post by Chris Grossack
+- [`Fin.Kuratowski`](https://www.cs.bham.ac.uk/~mhe/TypeTopology/Fin.Kuratowski.html)
+  at TypeTopology
+- [finite set](https://ncatlab.org/nlab/show/finite+set) at $n$Lab
+- [finite object](https://ncatlab.org/nlab/show/finite+object) at $n$Lab
+- [Finite set](https://en.wikipedia.org/wiki/Finite_set) at Wikipedia

--- a/src/univalent-combinatorics/locally-finite-types.lagda.md
+++ b/src/univalent-combinatorics/locally-finite-types.lagda.md
@@ -82,7 +82,7 @@ A type is
 its [identity types](foundation-core.identity-types.md) are
 [finite](univalent-combinatorics.finite-types.md).
 
-## Definition
+## Definitions
 
 ### Locally finite types
 
@@ -90,7 +90,7 @@ its [identity types](foundation-core.identity-types.md) are
 is-locally-finite-Prop :
   {l : Level} → UU l → Prop l
 is-locally-finite-Prop A =
-  Π-Prop A (λ x → Π-Prop A (λ y → is-finite-Prop (Id x y)))
+  Π-Prop A (λ x → Π-Prop A (λ y → is-finite-Prop (x ＝ y)))
 
 is-locally-finite : {l : Level} → UU l → UU l
 is-locally-finite A = type-Prop (is-locally-finite-Prop A)
@@ -165,7 +165,7 @@ is-locally-finite-empty : is-locally-finite empty
 is-locally-finite-empty = is-locally-finite-is-empty id
 ```
 
-### The dependent product of locally finite types
+### Cartesian products of locally finite types
 
 ```agda
 is-locally-finite-product :
@@ -175,7 +175,11 @@ is-locally-finite-product f g x y =
   is-finite-equiv
     ( equiv-eq-pair x y)
     ( is-finite-product (f (pr1 x) (pr1 y)) (g (pr2 x) (pr2 y)))
+```
 
+### Finite products of locally finite types are locally finite
+
+```agda
 is-locally-finite-Π-Fin :
   {l1 : Level} (k : ℕ) {B : Fin k → UU l1} →
   ((x : Fin k) → is-locally-finite (B x)) →
@@ -213,7 +217,8 @@ is-locally-finite-Π {l1} {l2} {A} {B} f g =
 ```agda
 is-locally-finite-Σ :
   {l1 l2 : Level} {A : UU l1} {B : A → UU l2} →
-  is-locally-finite A → ((x : A) → is-locally-finite (B x)) →
+  is-locally-finite A →
+  ((x : A) → is-locally-finite (B x)) →
   is-locally-finite (Σ A B)
 is-locally-finite-Σ {B = B} H K (x , y) (x' , y') =
   is-finite-equiv'

--- a/src/univalent-combinatorics/locally-finite-types.lagda.md
+++ b/src/univalent-combinatorics/locally-finite-types.lagda.md
@@ -1,0 +1,222 @@
+# Locally finite types
+
+```agda
+module univalent-combinatorics.locally-finite-types where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import elementary-number-theory.natural-numbers
+
+open import foundation.0-connected-types
+open import foundation.1-types
+open import foundation.action-on-identifications-functions
+open import foundation.cartesian-product-types
+open import foundation.constant-maps
+open import foundation.contractible-types
+open import foundation.coproduct-types
+open import foundation.decidable-equality
+open import foundation.decidable-propositions
+open import foundation.decidable-types
+open import foundation.dependent-universal-property-equivalences
+open import foundation.embeddings
+open import foundation.empty-types
+open import foundation.equality-cartesian-product-types
+open import foundation.equality-coproduct-types
+open import foundation.equality-dependent-pair-types
+open import foundation.equivalences
+open import foundation.fiber-inclusions
+open import foundation.fibers-of-maps
+open import foundation.function-extensionality
+open import foundation.function-types
+open import foundation.functoriality-coproduct-types
+open import foundation.functoriality-dependent-pair-types
+open import foundation.functoriality-set-truncation
+open import foundation.homotopies
+open import foundation.identity-types
+open import foundation.injective-maps
+open import foundation.logical-equivalences
+open import foundation.maybe
+open import foundation.mere-equality
+open import foundation.mere-equivalences
+open import foundation.propositional-extensionality
+open import foundation.propositional-truncations
+open import foundation.propositions
+open import foundation.set-truncations
+open import foundation.sets
+open import foundation.subtypes
+open import foundation.surjective-maps
+open import foundation.transport-along-identifications
+open import foundation.truncated-types
+open import foundation.truncation-levels
+open import foundation.type-arithmetic-coproduct-types
+open import foundation.unit-type
+open import foundation.univalence
+open import foundation.universal-property-coproduct-types
+open import foundation.universal-property-empty-type
+open import foundation.universal-property-unit-type
+open import foundation.universe-levels
+open import foundation.whiskering-homotopies-composition
+
+open import univalent-combinatorics.cartesian-product-types
+open import univalent-combinatorics.coproduct-types
+open import univalent-combinatorics.counting
+open import univalent-combinatorics.dependent-function-types
+open import univalent-combinatorics.dependent-pair-types
+open import univalent-combinatorics.distributivity-of-set-truncation-over-finite-products
+open import univalent-combinatorics.equality-finite-types
+open import univalent-combinatorics.finite-types
+open import univalent-combinatorics.finitely-presented-types
+open import univalent-combinatorics.function-types
+open import univalent-combinatorics.image-of-maps
+open import univalent-combinatorics.standard-finite-types
+```
+
+</details>
+
+## Idea
+
+A type is
+{{#concept "locally finite" Disambiguation="type" Agda=is-locally-finite}} if
+its [identity types](foundation-core.identity-types.md) are
+[finite](univalent-combinatorics.finite-types.md).
+
+## Definition
+
+### Locally finite types
+
+```agda
+is-locally-finite-Prop :
+  {l : Level} → UU l → Prop l
+is-locally-finite-Prop A =
+  Π-Prop A (λ x → Π-Prop A (λ y → is-finite-Prop (Id x y)))
+
+is-locally-finite : {l : Level} → UU l → UU l
+is-locally-finite A = type-Prop (is-locally-finite-Prop A)
+
+is-prop-is-locally-finite :
+  {l : Level} (A : UU l) → is-prop (is-locally-finite A)
+is-prop-is-locally-finite A = is-prop-type-Prop (is-locally-finite-Prop A)
+```
+
+## Properties
+
+### Locally finite types are closed under equivalences
+
+```agda
+is-locally-finite-equiv :
+  {l1 l2 : Level} {A : UU l1} {B : UU l2} (e : A ≃ B) →
+  is-locally-finite B → is-locally-finite A
+is-locally-finite-equiv e f x y =
+  is-finite-equiv' (equiv-ap e x y) (f (map-equiv e x) (map-equiv e y))
+
+is-locally-finite-equiv' :
+  {l1 l2 : Level} {A : UU l1} {B : UU l2} (e : A ≃ B) →
+  is-locally-finite A → is-locally-finite B
+is-locally-finite-equiv' e = is-locally-finite-equiv (inv-equiv e)
+```
+
+### Locally finite types are 1-types
+
+```agda
+is-1-type-is-locally-finite :
+  {l1 : Level} {A : UU l1} →
+  is-locally-finite A → is-1-type A
+is-1-type-is-locally-finite H x y = is-set-is-finite (H x y)
+```
+
+### Types with decidable equality are locally finite
+
+```agda
+is-locally-finite-has-decidable-equality :
+  {l1 : Level} {A : UU l1} → has-decidable-equality A → is-locally-finite A
+is-locally-finite-has-decidable-equality d x y = is-finite-eq d
+```
+
+### Any proposition is locally finite
+
+```agda
+is-locally-finite-is-prop :
+  {l1 : Level} {A : UU l1} → is-prop A → is-locally-finite A
+is-locally-finite-is-prop H x y = is-finite-is-contr (H x y)
+```
+
+### Any contractible type is locally finite
+
+```agda
+is-locally-finite-is-contr :
+  {l1 : Level} {A : UU l1} → is-contr A → is-locally-finite A
+is-locally-finite-is-contr H =
+  is-locally-finite-is-prop (is-prop-is-contr H)
+
+is-locally-finite-unit : is-locally-finite unit
+is-locally-finite-unit = is-locally-finite-is-contr is-contr-unit
+```
+
+### Any empty type is locally finite
+
+```agda
+is-locally-finite-is-empty :
+  {l1 : Level} {A : UU l1} → is-empty A → is-locally-finite A
+is-locally-finite-is-empty H = is-locally-finite-is-prop (λ x → ex-falso (H x))
+
+is-locally-finite-empty : is-locally-finite empty
+is-locally-finite-empty = is-locally-finite-is-empty id
+```
+
+### The dependent product of locally finite types
+
+```agda
+is-locally-finite-product :
+  {l1 l2 : Level} {A : UU l1} {B : UU l2} →
+  is-locally-finite A → is-locally-finite B → is-locally-finite (A × B)
+is-locally-finite-product f g x y =
+  is-finite-equiv
+    ( equiv-eq-pair x y)
+    ( is-finite-product (f (pr1 x) (pr1 y)) (g (pr2 x) (pr2 y)))
+
+is-locally-finite-Π-Fin :
+  {l1 : Level} (k : ℕ) {B : Fin k → UU l1} →
+  ((x : Fin k) → is-locally-finite (B x)) →
+  is-locally-finite ((x : Fin k) → B x)
+is-locally-finite-Π-Fin {l1} zero-ℕ {B} f =
+  is-locally-finite-is-contr (dependent-universal-property-empty' B)
+is-locally-finite-Π-Fin {l1} (succ-ℕ k) {B} f =
+  is-locally-finite-equiv
+    ( equiv-dependent-universal-property-coproduct B)
+    ( is-locally-finite-product
+      ( is-locally-finite-Π-Fin k (λ x → f (inl x)))
+      ( is-locally-finite-equiv
+        ( equiv-dependent-universal-property-unit (B ∘ inr))
+        ( f (inr star))))
+
+is-locally-finite-Π-count :
+  {l1 l2 : Level} {A : UU l1} {B : A → UU l2} → count A →
+  ((x : A) → is-locally-finite (B x)) → is-locally-finite ((x : A) → B x)
+is-locally-finite-Π-count {l1} {l2} {A} {B} (k , e) g =
+  is-locally-finite-equiv
+    ( equiv-precomp-Π e B)
+    ( is-locally-finite-Π-Fin k (λ x → g (map-equiv e x)))
+
+is-locally-finite-Π :
+  {l1 l2 : Level} {A : UU l1} {B : A → UU l2} → is-finite A →
+  ((x : A) → is-locally-finite (B x)) → is-locally-finite ((x : A) → B x)
+is-locally-finite-Π {l1} {l2} {A} {B} f g =
+  apply-universal-property-trunc-Prop f
+    ( is-locally-finite-Prop ((x : A) → B x))
+    ( λ e → is-locally-finite-Π-count e g)
+```
+
+### The dependent sum of locally finite types
+
+```agda
+is-locally-finite-Σ :
+  {l1 l2 : Level} {A : UU l1} {B : A → UU l2} →
+  is-locally-finite A → ((x : A) → is-locally-finite (B x)) →
+  is-locally-finite (Σ A B)
+is-locally-finite-Σ {B = B} H K (x , y) (x' , y') =
+  is-finite-equiv'
+    ( equiv-pair-eq-Σ (x , y) (x' , y'))
+    ( is-finite-Σ (H x x') (λ p → K x' (tr B p y) y'))
+```

--- a/src/univalent-combinatorics/locally-finite-types.lagda.md
+++ b/src/univalent-combinatorics/locally-finite-types.lagda.md
@@ -117,7 +117,7 @@ is-locally-finite-equiv' :
 is-locally-finite-equiv' e = is-locally-finite-equiv (inv-equiv e)
 ```
 
-### Locally finite types are 1-types
+### Locally finite types are `1`-types
 
 ```agda
 is-1-type-is-locally-finite :

--- a/src/univalent-combinatorics/pi-finite-types.lagda.md
+++ b/src/univalent-combinatorics/pi-finite-types.lagda.md
@@ -26,6 +26,7 @@ open import foundation.identity-types
 open import foundation.maybe
 open import foundation.propositional-truncations
 open import foundation.propositions
+open import foundation.set-presented-types
 open import foundation.set-truncations
 open import foundation.sets
 open import foundation.subtypes
@@ -423,7 +424,7 @@ abstract
       ( is-empty-is-empty-trunc-Set (map-inv-equiv e) ∘ pr1)
   has-finitely-many-connected-components-Σ' (succ-ℕ k) {A} {B} e H K =
     apply-universal-property-trunc-Prop
-      ( has-presentation-of-cardinality-has-cardinality-components
+      ( has-presentation-of-cardinality-has-cardinality-connected-components
         ( succ-ℕ k)
         ( unit-trunc-Prop e))
       ( has-finitely-many-connected-components-Prop (Σ A B))

--- a/src/univalent-combinatorics/pi-finite-types.lagda.md
+++ b/src/univalent-combinatorics/pi-finite-types.lagda.md
@@ -10,61 +10,39 @@ module univalent-combinatorics.pi-finite-types where
 open import elementary-number-theory.natural-numbers
 
 open import foundation.0-connected-types
-open import foundation.action-on-identifications-functions
-open import foundation.cartesian-product-types
-open import foundation.constant-maps
 open import foundation.contractible-types
 open import foundation.coproduct-types
-open import foundation.decidable-equality
-open import foundation.decidable-propositions
-open import foundation.decidable-types
-open import foundation.dependent-universal-property-equivalences
 open import foundation.embeddings
 open import foundation.empty-types
-open import foundation.equality-cartesian-product-types
 open import foundation.equality-coproduct-types
 open import foundation.equality-dependent-pair-types
 open import foundation.equivalences
-open import foundation.fiber-inclusions
-open import foundation.fibers-of-maps
 open import foundation.function-extensionality
 open import foundation.function-types
-open import foundation.functoriality-coproduct-types
 open import foundation.functoriality-dependent-pair-types
 open import foundation.functoriality-set-truncation
 open import foundation.homotopies
 open import foundation.identity-types
-open import foundation.injective-maps
-open import foundation.logical-equivalences
 open import foundation.maybe
-open import foundation.mere-equality
-open import foundation.mere-equivalences
-open import foundation.propositional-extensionality
 open import foundation.propositional-truncations
 open import foundation.propositions
 open import foundation.set-truncations
 open import foundation.sets
 open import foundation.subtypes
 open import foundation.surjective-maps
-open import foundation.transport-along-identifications
 open import foundation.truncated-types
 open import foundation.truncation-levels
 open import foundation.type-arithmetic-coproduct-types
 open import foundation.unit-type
-open import foundation.univalence
-open import foundation.universal-property-coproduct-types
-open import foundation.universal-property-empty-type
-open import foundation.universal-property-unit-type
 open import foundation.universe-levels
 open import foundation.whiskering-homotopies-composition
 
-open import univalent-combinatorics.cartesian-product-types
 open import univalent-combinatorics.coproduct-types
 open import univalent-combinatorics.counting
 open import univalent-combinatorics.dependent-function-types
 open import univalent-combinatorics.dependent-pair-types
 open import univalent-combinatorics.distributivity-of-set-truncation-over-finite-products
-open import univalent-combinatorics.equality-finite-types
+open import univalent-combinatorics.finite-connected-components
 open import univalent-combinatorics.finite-types
 open import univalent-combinatorics.finitely-presented-types
 open import univalent-combinatorics.function-types
@@ -76,26 +54,13 @@ open import univalent-combinatorics.standard-finite-types
 
 ## Idea
 
-A type is `π_n`-finite if it has finitely many connected components and all of
-its homotopy groups up to level `n` at all base points are finite.
+A type is
+{{#concept "`πₙ`-finite" Disambiguation="type" Agda=is-π-finite Agda=π-Finite}}
+if it has [finitely](univalent-combinatorics.finite-types.md) many
+[connected components](foundation.connected-components.md) and all of its
+homotopy groups up to level `n` at all base points are finite.
 
 ## Definition
-
-### Locally finite types
-
-```agda
-is-locally-finite-Prop :
-  {l : Level} → UU l → Prop l
-is-locally-finite-Prop A =
-  Π-Prop A (λ x → Π-Prop A (λ y → is-finite-Prop (Id x y)))
-
-is-locally-finite : {l : Level} → UU l → UU l
-is-locally-finite A = type-Prop (is-locally-finite-Prop A)
-
-is-prop-is-locally-finite :
-  {l : Level} (A : UU l) → is-prop (is-locally-finite A)
-is-prop-is-locally-finite A = is-prop-type-Prop (is-locally-finite-Prop A)
-```
 
 ### Truncated π-finite types
 
@@ -104,37 +69,13 @@ is-truncated-π-finite-Prop : {l : Level} (k : ℕ) → UU l → Prop l
 is-truncated-π-finite-Prop zero-ℕ X = is-finite-Prop X
 is-truncated-π-finite-Prop (succ-ℕ k) X =
   product-Prop
-    ( is-finite-Prop (type-trunc-Set X))
+    ( has-finite-connected-components-Prop X)
     ( Π-Prop X
       ( λ x → Π-Prop X (λ y → is-truncated-π-finite-Prop k (Id x y))))
 
 is-truncated-π-finite : {l : Level} (k : ℕ) → UU l → UU l
 is-truncated-π-finite k A =
   type-Prop (is-truncated-π-finite-Prop k A)
-```
-
-### Types with finitely many connected components
-
-```agda
-has-finite-connected-components-Prop : {l : Level} → UU l → Prop l
-has-finite-connected-components-Prop A =
-  is-finite-Prop (type-trunc-Set A)
-
-has-finite-connected-components : {l : Level} → UU l → UU l
-has-finite-connected-components A =
-  type-Prop (has-finite-connected-components-Prop A)
-
-number-of-connected-components :
-  {l : Level} {X : UU l} → has-finite-connected-components X → ℕ
-number-of-connected-components H = number-of-elements-is-finite H
-
-mere-equiv-number-of-connected-components :
-  {l : Level} {X : UU l} (H : has-finite-connected-components X) →
-  mere-equiv
-    ( Fin (number-of-connected-components H))
-    ( type-trunc-Set X)
-mere-equiv-number-of-connected-components H =
-  mere-equiv-is-finite H
 ```
 
 ### π-finite types
@@ -166,63 +107,15 @@ is-π-finite-type-π-Finite :
   {l : Level} (k : ℕ) (A : π-Finite l k) →
   is-π-finite k (type-π-Finite {l} k A)
 is-π-finite-type-π-Finite k = pr2
+
+has-finite-connected-components-is-π-finite :
+  {l : Level} (k : ℕ) {A : UU l} →
+  is-π-finite k A → has-finite-connected-components A
+has-finite-connected-components-is-π-finite zero-ℕ H = H
+has-finite-connected-components-is-π-finite (succ-ℕ k) H = pr1 H
 ```
 
 ## Properties
-
-### Locally finite types are closed under equivalences
-
-```agda
-is-locally-finite-equiv :
-  {l1 l2 : Level} {A : UU l1} {B : UU l2} (e : A ≃ B) →
-  is-locally-finite B → is-locally-finite A
-is-locally-finite-equiv e f x y =
-  is-finite-equiv' (equiv-ap e x y) (f (map-equiv e x) (map-equiv e y))
-
-is-locally-finite-equiv' :
-  {l1 l2 : Level} {A : UU l1} {B : UU l2} (e : A ≃ B) →
-  is-locally-finite A → is-locally-finite B
-is-locally-finite-equiv' e = is-locally-finite-equiv (inv-equiv e)
-```
-
-### Types with decidable equality are locally finite
-
-```agda
-is-locally-finite-has-decidable-equality :
-  {l1 : Level} {A : UU l1} → has-decidable-equality A → is-locally-finite A
-is-locally-finite-has-decidable-equality d x y = is-finite-eq d
-```
-
-### Any proposition is locally finite
-
-```agda
-is-locally-finite-is-prop :
-  {l1 : Level} {A : UU l1} → is-prop A → is-locally-finite A
-is-locally-finite-is-prop H x y = is-finite-is-contr (H x y)
-```
-
-### Any contractible type is locally finite
-
-```agda
-is-locally-finite-is-contr :
-  {l1 : Level} {A : UU l1} → is-contr A → is-locally-finite A
-is-locally-finite-is-contr H =
-  is-locally-finite-is-prop (is-prop-is-contr H)
-
-is-locally-finite-unit : is-locally-finite unit
-is-locally-finite-unit = is-locally-finite-is-contr is-contr-unit
-```
-
-### Any empty type is locally finite
-
-```agda
-is-locally-finite-is-empty :
-  {l1 : Level} {A : UU l1} → is-empty A → is-locally-finite A
-is-locally-finite-is-empty H = is-locally-finite-is-prop (λ x → ex-falso (H x))
-
-is-locally-finite-empty : is-locally-finite empty
-is-locally-finite-empty = is-locally-finite-is-empty id
-```
 
 ### π-finite types are closed under equivalences
 
@@ -387,25 +280,15 @@ pr1 (π-finite-𝔽 k A) = type-𝔽 A
 pr2 (π-finite-𝔽 k A) = is-π-finite-is-finite k (is-finite-type-𝔽 A)
 ```
 
-### Any 0-connected type has finitely many connected components
-
-```agda
-has-finite-connected-components-is-0-connected :
-  {l : Level} {A : UU l} →
-  is-0-connected A → has-finite-connected-components A
-has-finite-connected-components-is-0-connected C =
-  is-finite-is-contr C
-```
-
 ### The type of all `n`-element types in `UU l` is π-finite
 
 ```agda
 is-π-finite-UU-Fin :
   {l : Level} (k n : ℕ) → is-π-finite k (UU-Fin l n)
 is-π-finite-UU-Fin zero-ℕ n =
-  has-finite-connected-components-is-0-connected
-    ( is-0-connected-UU-Fin n)
-pr1 (is-π-finite-UU-Fin (succ-ℕ k) n) = is-π-finite-UU-Fin zero-ℕ n
+  has-finite-connected-components-is-0-connected (is-0-connected-UU-Fin n)
+pr1 (is-π-finite-UU-Fin (succ-ℕ k) n) =
+  is-π-finite-UU-Fin zero-ℕ n
 pr2 (is-π-finite-UU-Fin (succ-ℕ k) n) x y =
   is-π-finite-equiv k
     ( equiv-equiv-eq-UU-Fin n x y)
@@ -413,19 +296,11 @@ pr2 (is-π-finite-UU-Fin (succ-ℕ k) n) x y =
       ( is-finite-≃
         ( is-finite-has-finite-cardinality (n , (pr2 x)))
         ( is-finite-has-finite-cardinality (n , (pr2 y)))))
+```
 
-is-finite-has-finite-connected-components :
-  {l : Level} {A : UU l} →
-  is-set A → has-finite-connected-components A → is-finite A
-is-finite-has-finite-connected-components H =
-  is-finite-equiv' (equiv-unit-trunc-Set (_ , H))
+### πₙ₊₁-finite types are πₙ-finite
 
-has-finite-connected-components-is-π-finite :
-  {l : Level} (k : ℕ) {A : UU l} →
-  is-π-finite k A → has-finite-connected-components A
-has-finite-connected-components-is-π-finite zero-ℕ H = H
-has-finite-connected-components-is-π-finite (succ-ℕ k) H = pr1 H
-
+```agda
 is-π-finite-is-π-finite-succ-ℕ :
   {l : Level} (k : ℕ) {A : UU l} →
   is-π-finite (succ-ℕ k) A → is-π-finite k A
@@ -435,7 +310,11 @@ pr1 (is-π-finite-is-π-finite-succ-ℕ (succ-ℕ k) H) =
   has-finite-connected-components-is-π-finite (succ-ℕ (succ-ℕ k)) H
 pr2 (is-π-finite-is-π-finite-succ-ℕ (succ-ℕ k) H) x y =
   is-π-finite-is-π-finite-succ-ℕ k (pr2 H x y)
+```
 
+### πₙ₊₁-finite types are π₁-finite
+
+```agda
 is-π-finite-one-is-π-finite-succ-ℕ :
   {l : Level} (k : ℕ) {A : UU l} →
   is-π-finite (succ-ℕ k) A → is-π-finite 1 A
@@ -443,7 +322,11 @@ is-π-finite-one-is-π-finite-succ-ℕ zero-ℕ H = H
 is-π-finite-one-is-π-finite-succ-ℕ (succ-ℕ k) H =
   is-π-finite-one-is-π-finite-succ-ℕ k
     ( is-π-finite-is-π-finite-succ-ℕ (succ-ℕ k) H)
+```
 
+### πₙ-finite sets are finite
+
+```agda
 is-finite-is-π-finite :
   {l : Level} (k : ℕ) {A : UU l} → is-set A →
   is-π-finite k A → is-finite A
@@ -451,7 +334,11 @@ is-finite-is-π-finite k H K =
   is-finite-equiv'
     ( equiv-unit-trunc-Set (_ , H))
     ( has-finite-connected-components-is-π-finite k K)
+```
 
+### πₙ-finite n-truncated types are truncated πₙ-finite
+
+```agda
 is-truncated-π-finite-is-π-finite :
   {l : Level} (k : ℕ) {A : UU l} → is-trunc (truncation-level-ℕ k) A →
   is-π-finite k A → is-truncated-π-finite k A
@@ -460,7 +347,11 @@ is-truncated-π-finite-is-π-finite zero-ℕ H K =
 pr1 (is-truncated-π-finite-is-π-finite (succ-ℕ k) H K) = pr1 K
 pr2 (is-truncated-π-finite-is-π-finite (succ-ℕ k) H K) x y =
   is-truncated-π-finite-is-π-finite k (H x y) (pr2 K x y)
+```
 
+### truncated πₙ-finite types are πₙ-finite
+
+```agda
 is-π-finite-is-truncated-π-finite :
   {l : Level} (k : ℕ) {A : UU l} →
   is-truncated-π-finite k A → is-π-finite k A
@@ -473,52 +364,7 @@ pr2 (is-π-finite-is-truncated-π-finite (succ-ℕ k) H) x y =
   is-π-finite-is-truncated-π-finite k (pr2 H x y)
 ```
 
-### Proposition 1.5
-
-#### The dependent product of locally finite types
-
-```agda
-is-locally-finite-product :
-  {l1 l2 : Level} {A : UU l1} {B : UU l2} →
-  is-locally-finite A → is-locally-finite B → is-locally-finite (A × B)
-is-locally-finite-product f g x y =
-  is-finite-equiv
-    ( equiv-eq-pair x y)
-    ( is-finite-product (f (pr1 x) (pr1 y)) (g (pr2 x) (pr2 y)))
-
-is-locally-finite-Π-Fin :
-  {l1 : Level} (k : ℕ) {B : Fin k → UU l1} →
-  ((x : Fin k) → is-locally-finite (B x)) →
-  is-locally-finite ((x : Fin k) → B x)
-is-locally-finite-Π-Fin {l1} zero-ℕ {B} f =
-  is-locally-finite-is-contr (dependent-universal-property-empty' B)
-is-locally-finite-Π-Fin {l1} (succ-ℕ k) {B} f =
-  is-locally-finite-equiv
-    ( equiv-dependent-universal-property-coproduct B)
-    ( is-locally-finite-product
-      ( is-locally-finite-Π-Fin k (λ x → f (inl x)))
-      ( is-locally-finite-equiv
-        ( equiv-dependent-universal-property-unit (B ∘ inr))
-        ( f (inr star))))
-
-is-locally-finite-Π-count :
-  {l1 l2 : Level} {A : UU l1} {B : A → UU l2} → count A →
-  ((x : A) → is-locally-finite (B x)) → is-locally-finite ((x : A) → B x)
-is-locally-finite-Π-count {l1} {l2} {A} {B} (k , e) g =
-  is-locally-finite-equiv
-    ( equiv-precomp-Π e B)
-    ( is-locally-finite-Π-Fin k (λ x → g (map-equiv e x)))
-
-is-locally-finite-Π :
-  {l1 l2 : Level} {A : UU l1} {B : A → UU l2} → is-finite A →
-  ((x : A) → is-locally-finite (B x)) → is-locally-finite ((x : A) → B x)
-is-locally-finite-Π {l1} {l2} {A} {B} f g =
-  apply-universal-property-trunc-Prop f
-    ( is-locally-finite-Prop ((x : A) → B x))
-    ( λ e → is-locally-finite-Π-count e g)
-```
-
-#### Finite products of π-finite types
+### Finite products of π-finite types are π-finite
 
 ```agda
 is-π-finite-Π :
@@ -546,278 +392,32 @@ pr2 (π-Finite-Π k A B) =
     ( λ x → is-π-finite-type-π-Finite k (B x))
 ```
 
-### Proposition 1.6
-
-```agda
-is-locally-finite-Σ :
-  {l1 l2 : Level} {A : UU l1} {B : A → UU l2} →
-  is-locally-finite A → ((x : A) → is-locally-finite (B x)) →
-  is-locally-finite (Σ A B)
-is-locally-finite-Σ {B = B} H K (x , y) (x' , y') =
-  is-finite-equiv'
-    ( equiv-pair-eq-Σ (x , y) (x' , y'))
-    ( is-finite-Σ (H x x') (λ p → K x' (tr B p y) y'))
-```
-
 ### Proposition 1.7
 
 ```agda
-has-finite-connected-components-Σ-is-0-connected :
+has-finite-connected-components-Σ-is-0-connected' :
   {l1 l2 : Level} {A : UU l1} {B : A → UU l2} →
   is-0-connected A → is-π-finite 1 A →
   ((x : A) → has-finite-connected-components (B x)) →
   has-finite-connected-components (Σ A B)
-has-finite-connected-components-Σ-is-0-connected {A = A} {B} C H K =
-  apply-universal-property-trunc-Prop
-    ( is-inhabited-is-0-connected C)
-    ( is-π-finite-Prop zero-ℕ (Σ A B))
-    ( α)
-  where
-  α : A → is-π-finite zero-ℕ (Σ A B)
-  α a =
-    is-finite-codomain
-      ( K a)
-      ( is-surjective-map-trunc-Set
-        ( fiber-inclusion B a)
-        ( is-surjective-fiber-inclusion C a))
-      ( apply-dependent-universal-property-trunc-Set'
-        ( λ x →
-          set-Prop
-            ( Π-Prop
-              ( type-trunc-Set (Σ A B))
-              ( λ y → is-decidable-Prop (Id-Prop (trunc-Set (Σ A B)) x y))))
-        ( β))
-    where
-    β : (x : Σ A B) (v : type-trunc-Set (Σ A B)) →
-        is-decidable (Id (unit-trunc-Set x) v)
-    β (x , y) =
-      apply-dependent-universal-property-trunc-Set'
-        ( λ u →
-          set-Prop
-            ( is-decidable-Prop
-              ( Id-Prop (trunc-Set (Σ A B)) (unit-trunc-Set (x , y)) u)))
-        ( γ)
-      where
-      γ : (v : Σ A B) →
-          is-decidable (Id (unit-trunc-Set (x , y)) (unit-trunc-Set v))
-      γ (x' , y') =
-        is-decidable-equiv
-          ( is-effective-unit-trunc-Set
-            ( Σ A B)
-            ( x , y)
-            ( x' , y'))
-          ( apply-universal-property-trunc-Prop
-            ( mere-eq-is-0-connected C a x)
-            ( is-decidable-Prop
-              ( mere-eq-Prop (x , y) (x' , y')))
-              ( δ))
-        where
-        δ : Id a x → is-decidable (mere-eq (x , y) (x' , y'))
-        δ refl =
-          apply-universal-property-trunc-Prop
-            ( mere-eq-is-0-connected C a x')
-            ( is-decidable-Prop
-              ( mere-eq-Prop (a , y) (x' , y')))
-            ( ε)
-          where
-          ε : Id a x' → is-decidable (mere-eq (x , y) (x' , y'))
-          ε refl =
-            is-decidable-equiv e
-              ( is-decidable-type-trunc-Prop-is-finite
-                ( is-finite-Σ
-                  ( pr2 H a a)
-                  ( λ ω → is-finite-is-decidable-Prop (P ω) (d ω))))
-            where
-            ℙ : is-contr
-                ( Σ ( hom-Set (trunc-Set (Id a a)) (Prop-Set _))
-                    ( λ h →
-                      ( λ a₁ → h (unit-trunc-Set a₁)) ~
-                      ( λ ω₁ → trunc-Prop (Id (tr B ω₁ y) y'))))
-            ℙ = universal-property-trunc-Set
-                ( Id a a)
-                ( Prop-Set _)
-                ( λ ω → trunc-Prop (Id (tr B ω y) y'))
-            P : type-trunc-Set (Id a a) → Prop _
-            P = pr1 (center ℙ)
-            compute-P :
-              ( ω : Id a a) →
-              type-Prop (P (unit-trunc-Set ω)) ≃
-              type-trunc-Prop (Id (tr B ω y) y')
-            compute-P ω = equiv-eq (ap pr1 (pr2 (center ℙ) ω))
-            d : (t : type-trunc-Set (Id a a)) → is-decidable (type-Prop (P t))
-            d = apply-dependent-universal-property-trunc-Set'
-                ( λ t → set-Prop (is-decidable-Prop (P t)))
-                ( λ ω →
-                  is-decidable-equiv'
-                    ( inv-equiv (compute-P ω))
-                    ( is-decidable-equiv'
-                      ( is-effective-unit-trunc-Set (B a) (tr B ω y) y')
-                      ( has-decidable-equality-is-finite
-                        ( K a)
-                        ( unit-trunc-Set (tr B ω y))
-                        ( unit-trunc-Set y'))))
-            f : type-hom-Prop
-                ( trunc-Prop (Σ (type-trunc-Set (Id a a)) (type-Prop ∘ P)))
-                ( mere-eq-Prop {A = Σ A B} (a , y) (a , y'))
-            f t = apply-universal-property-trunc-Prop t
-                    ( mere-eq-Prop (a , y) (a , y'))
-                      λ (u , v) →
-                      apply-dependent-universal-property-trunc-Set'
-                        ( λ u' →
-                          hom-set-Set
-                            ( set-Prop (P u'))
-                            ( set-Prop
-                              ( mere-eq-Prop (a , y) (a , y'))))
-                        ( λ ω v' →
-                          apply-universal-property-trunc-Prop
-                            ( map-equiv (compute-P ω) v')
-                            ( mere-eq-Prop (a , y) (a , y'))
-                            ( λ p → unit-trunc-Prop (eq-pair-Σ ω p)))
-                        ( u)
-                        ( v)
-            e : mere-eq {A = Σ A B} (a , y) (a , y') ≃
-                type-trunc-Prop (Σ (type-trunc-Set (Id a a)) (type-Prop ∘ P))
-            e = equiv-iff
-                  ( mere-eq-Prop (a , y) (a , y'))
-                  ( trunc-Prop (Σ (type-trunc-Set (Id a a)) (type-Prop ∘ P)))
-                  ( λ t →
-                    apply-universal-property-trunc-Prop t
-                      ( trunc-Prop _)
-                      ( ( λ ( ω , r) →
-                          unit-trunc-Prop
-                            ( ( unit-trunc-Set ω) ,
-                              ( map-inv-equiv
-                                ( compute-P ω)
-                                ( unit-trunc-Prop r)))) ∘
-                        ( pair-eq-Σ)))
-                  ( f)
+has-finite-connected-components-Σ-is-0-connected' C H =
+  has-finite-connected-components-Σ-is-0-connected C (λ a → pr2 H a a)
 ```
 
-### Proposition 1.8
+### Dependent sums of π-finite types
 
 ```agda
-module _
-  {l1 l2 l3 : Level} {A1 : UU l1} {A2 : UU l2} {B : UU l3}
-  (f : A1 + A2 → B) (e : (A1 + A2) ≃ type-trunc-Set B)
-  (H : (unit-trunc-Set ∘ f) ~ map-equiv e)
-  where
-
-  map-is-coproduct-codomain : (im (f ∘ inl) + im (f ∘ inr)) → B
-  map-is-coproduct-codomain = rec-coproduct pr1 pr1
-
-  triangle-is-coproduct-codomain :
-    ( ( map-is-coproduct-codomain) ∘
-      ( map-coproduct (map-unit-im (f ∘ inl)) (map-unit-im (f ∘ inr)))) ~ f
-  triangle-is-coproduct-codomain (inl x) = refl
-  triangle-is-coproduct-codomain (inr x) = refl
-
-  abstract
-    is-emb-map-is-coproduct-codomain : is-emb map-is-coproduct-codomain
-    is-emb-map-is-coproduct-codomain =
-      is-emb-coproduct
-        ( is-emb-inclusion-subtype (λ b → trunc-Prop _))
-        ( is-emb-inclusion-subtype (λ b → trunc-Prop _))
-        ( λ (b1 , u) (b2 , v) →
-          apply-universal-property-trunc-Prop u
-            ( function-Prop _ empty-Prop)
-            ( λ where
-              ( x , refl) →
-                apply-universal-property-trunc-Prop v
-                  ( function-Prop _ empty-Prop)
-                  ( λ where
-                    ( y , refl) r →
-                      is-empty-eq-coproduct-inl-inr x y
-                        ( is-injective-is-equiv
-                          ( is-equiv-map-equiv e)
-                          ( ( inv (H (inl x))) ∙
-                            ( ap unit-trunc-Set r) ∙
-                            ( H (inr y)))))))
-
-  is-surjective-map-is-coproduct-codomain :
-    is-surjective map-is-coproduct-codomain
-  is-surjective-map-is-coproduct-codomain b =
-    apply-universal-property-trunc-Prop
-      ( apply-effectiveness-unit-trunc-Set
-        ( inv (is-section-map-inv-equiv e (unit-trunc-Set b)) ∙ inv (H a)))
-      ( trunc-Prop (fiber map-is-coproduct-codomain b))
-      ( λ p →
-        unit-trunc-Prop
-          ( ( map-coproduct (map-unit-im (f ∘ inl)) (map-unit-im (f ∘ inr)) a) ,
-            ( triangle-is-coproduct-codomain a ∙ inv p)))
-    where
-    a = map-inv-equiv e (unit-trunc-Set b)
-
-  is-coproduct-codomain : (im (f ∘ inl) + im (f ∘ inr)) ≃ B
-  pr1 is-coproduct-codomain = map-is-coproduct-codomain
-  pr2 is-coproduct-codomain =
-    is-equiv-is-emb-is-surjective
-      is-surjective-map-is-coproduct-codomain
-      is-emb-map-is-coproduct-codomain
-
-is-0-connected-unit : is-0-connected unit
-is-0-connected-unit =
-  is-contr-equiv' unit equiv-unit-trunc-unit-Set is-contr-unit
-
-abstract
-  is-contr-im :
-    {l1 l2 : Level} {A : UU l1} (B : Set l2) {f : A → type-Set B}
-    (a : A) (H : f ~ const A (f a)) → is-contr (im f)
-  pr1 (is-contr-im B {f} a H) = map-unit-im f a
-  pr2 (is-contr-im B {f} a H) (x , u) =
-    apply-dependent-universal-property-trunc-Prop
-      ( λ v → Id-Prop (im-Set B f) (map-unit-im f a) (x , v))
-      ( u)
-      ( λ where
-        ( a' , refl) →
-          eq-Eq-im f (map-unit-im f a) (map-unit-im f a') (inv (H a')))
-
-abstract
-  is-0-connected-im :
-    {l1 l2 : Level} {A : UU l1} {B : UU l2} (f : A → B) →
-    is-0-connected A → is-0-connected (im f)
-  is-0-connected-im {l1} {l2} {A} {B} f C =
-    apply-universal-property-trunc-Prop
-      ( is-inhabited-is-0-connected C)
-      ( is-contr-Prop _)
-      ( λ a →
-        is-contr-equiv'
-          ( im (map-trunc-Set f))
-          ( equiv-trunc-im-Set f)
-          ( is-contr-im
-            ( trunc-Set B)
-            ( unit-trunc-Set a)
-            ( apply-dependent-universal-property-trunc-Set'
-              ( λ x →
-                set-Prop
-                  ( Id-Prop
-                    ( trunc-Set B)
-                    ( map-trunc-Set f x)
-                    ( map-trunc-Set f (unit-trunc-Set a))))
-              ( λ a' →
-                apply-universal-property-trunc-Prop
-                  ( mere-eq-is-0-connected C a' a)
-                  ( Id-Prop
-                    ( trunc-Set B)
-                    ( map-trunc-Set f (unit-trunc-Set a'))
-                    ( map-trunc-Set f (unit-trunc-Set a)))
-                  ( λ where refl → refl)))))
-
-is-0-connected-im-unit :
-  {l1 : Level} {A : UU l1} (f : unit → A) → is-0-connected (im f)
-is-0-connected-im-unit f =
-  is-0-connected-im f is-0-connected-unit
-
 abstract
   has-finite-connected-components-Σ' :
-    {l1 l2 : Level} {A : UU l1} {B : A → UU l2} →
-    (k : ℕ) → (Fin k ≃ (type-trunc-Set A)) →
-    ((x y : A) → has-finite-connected-components (Id x y)) →
+    {l1 l2 : Level} (k : ℕ) {A : UU l1} {B : A → UU l2} →
+    (Fin k ≃ type-trunc-Set A) →
+    ((x y : A) → has-finite-connected-components (x ＝ y)) →
     ((x : A) → has-finite-connected-components (B x)) →
     has-finite-connected-components (Σ A B)
   has-finite-connected-components-Σ' zero-ℕ e H K =
     is-π-finite-is-empty zero-ℕ
       ( is-empty-is-empty-trunc-Set (map-inv-equiv e) ∘ pr1)
-  has-finite-connected-components-Σ' {l1} {l2} {A} {B} (succ-ℕ k) e H K =
+  has-finite-connected-components-Σ' (succ-ℕ k) {A} {B} e H K =
     apply-universal-property-trunc-Prop
       ( has-presentation-of-cardinality-has-cardinality-components
         ( succ-ℕ k)
@@ -844,10 +444,14 @@ abstract
                       ( pr1 , is-emb-inclusion-subtype ( λ u → trunc-Prop _))))
                   ( H (pr1 x) (pr1 y)))
               ( λ x → K (pr1 x)))
-            ( has-finite-connected-components-Σ-is-0-connected
-              ( is-0-connected-im (f ∘ inr) is-0-connected-unit)
+            ( has-finite-connected-components-Σ-is-0-connected'
+              ( is-0-connected-im-is-0-connected-domain
+                ( f ∘ inr)
+                ( is-0-connected-unit))
               ( ( is-finite-is-contr
-                  ( is-0-connected-im (f ∘ inr) is-0-connected-unit)) ,
+                  ( is-0-connected-im-is-0-connected-domain
+                    ( f ∘ inr)
+                    ( is-0-connected-unit))) ,
                 ( λ x y →
                   is-π-finite-equiv zero-ℕ
                     ( equiv-Eq-eq-im (f ∘ inr) x y)
@@ -856,23 +460,27 @@ abstract
       where
       g : ((Σ (im (f ∘ inl)) (B ∘ pr1)) + (Σ (im (f ∘ inr)) (B ∘ pr1))) ≃
           Σ A B
-      g = ( equiv-Σ B
-            ( is-coproduct-codomain f
-              ( unit-trunc-Set ∘ f , Eηf)
-              ( refl-htpy))
-            ( λ { (inl x) → id-equiv ; (inr x) → id-equiv})) ∘e
-          ( inv-equiv
-            ( right-distributive-Σ-coproduct
-              ( im (f ∘ inl))
-              ( im (f ∘ inr))
-              ( rec-coproduct (B ∘ pr1) (B ∘ pr1))))
+      g =
+        ( equiv-Σ B
+          ( is-coproduct-codomain f
+            ( unit-trunc-Set ∘ f , Eηf)
+            ( refl-htpy))
+          ( λ { (inl x) → id-equiv ; (inr x) → id-equiv})) ∘e
+        ( inv-equiv
+          ( right-distributive-Σ-coproduct
+            ( im (f ∘ inl))
+            ( im (f ∘ inr))
+            ( rec-coproduct (B ∘ pr1) (B ∘ pr1))))
+
       i : Fin k → type-trunc-Set (im (f ∘ inl))
       i = unit-trunc-Set ∘ map-unit-im (f ∘ inl)
+
       is-surjective-i : is-surjective i
       is-surjective-i =
         is-surjective-comp
           ( is-surjective-unit-trunc-Set (im (f ∘ inl)))
           ( is-surjective-map-unit-im (f ∘ inl))
+
       is-emb-i : is-emb i
       is-emb-i =
         is-emb-top-map-triangle
@@ -887,14 +495,16 @@ abstract
             ( inl)
             ( is-emb-is-equiv Eηf)
             ( is-emb-inl (Fin k) unit))
+
       h : Fin k ≃ type-trunc-Set (im (f ∘ inl))
       h = i , (is-equiv-is-emb-is-surjective is-surjective-i is-emb-i)
 
 has-finite-connected-components-Σ :
-  {l1 l2 : Level} {A : UU l1} {B : A → UU l2} → is-π-finite 1 A →
+  {l1 l2 : Level} {A : UU l1} {B : A → UU l2} →
+  is-π-finite 1 A →
   ((x : A) → has-finite-connected-components (B x)) →
   has-finite-connected-components (Σ A B)
-has-finite-connected-components-Σ {l1} {l2} {A} {B} H K =
+has-finite-connected-components-Σ {A = A} {B} H K =
   apply-universal-property-trunc-Prop
     ( pr1 H)
     ( has-finite-connected-components-Prop (Σ A B))
@@ -905,7 +515,7 @@ abstract
     {l1 l2 : Level} (k : ℕ) {A : UU l1} {B : A → UU l2} →
     is-π-finite (succ-ℕ k) A → ((x : A) → is-π-finite k (B x)) →
     is-π-finite k (Σ A B)
-  is-π-finite-Σ zero-ℕ {A} {B} H K = has-finite-connected-components-Σ H K
+  is-π-finite-Σ zero-ℕ {A} {B} = has-finite-connected-components-Σ
   pr1 (is-π-finite-Σ (succ-ℕ k) H K) =
     has-finite-connected-components-Σ
       ( is-π-finite-one-is-π-finite-succ-ℕ (succ-ℕ k) H)
@@ -929,3 +539,7 @@ pr2 (π-Finite-Σ k A B) =
     ( is-π-finite-type-π-Finite (succ-ℕ k) A)
     ( λ x → is-π-finite-type-π-Finite k (B x))
 ```
+
+## External links
+
+- [pi-finite type](https://ncatlab.org/nlab/show/pi-finite+type) at $n$Lab

--- a/src/univalent-combinatorics/pi-finite-types.lagda.md
+++ b/src/univalent-combinatorics/pi-finite-types.lagda.md
@@ -394,18 +394,6 @@ pr2 (π-Finite-Π k A B) =
     ( λ x → is-π-finite-type-π-Finite k (B x))
 ```
 
-### Proposition 1.7
-
-```agda
-has-finitely-many-connected-components-Σ-is-0-connected' :
-  {l1 l2 : Level} {A : UU l1} {B : A → UU l2} →
-  is-0-connected A → is-π-finite 1 A →
-  ((x : A) → has-finitely-many-connected-components (B x)) →
-  has-finitely-many-connected-components (Σ A B)
-has-finitely-many-connected-components-Σ-is-0-connected' C H =
-  has-finitely-many-connected-components-Σ-is-0-connected C (λ a → pr2 H a a)
-```
-
 ### Dependent sums of π-finite types
 
 The dependent sum of a family of πₙ-finite types over a πₙ₊₁-finite base is
@@ -449,18 +437,14 @@ abstract
                       ( pr1 , is-emb-inclusion-subtype ( λ u → trunc-Prop _))))
                   ( H (pr1 x) (pr1 y)))
               ( λ x → K (pr1 x)))
-            ( has-finitely-many-connected-components-Σ-is-0-connected'
+            ( has-finitely-many-connected-components-Σ-is-0-connected
               ( is-0-connected-im-is-0-connected-domain
                 ( f ∘ inr)
                 ( is-0-connected-unit))
-              ( ( is-finite-is-contr
-                  ( is-0-connected-im-is-0-connected-domain
-                    ( f ∘ inr)
-                    ( is-0-connected-unit))) ,
-                ( λ x y →
+              ( ( λ a →
                   is-π-finite-equiv zero-ℕ
-                    ( equiv-Eq-eq-im (f ∘ inr) x y)
-                    ( H (pr1 x) (pr1 y))))
+                    ( equiv-Eq-eq-im (f ∘ inr) a a)
+                    ( H (pr1 a) (pr1 a))))
               ( λ x → K (pr1 x)))))
       where
       g : ((Σ (im (f ∘ inl)) (B ∘ pr1)) + (Σ (im (f ∘ inr)) (B ∘ pr1))) ≃

--- a/src/univalent-combinatorics/pi-finite-types.lagda.md
+++ b/src/univalent-combinatorics/pi-finite-types.lagda.md
@@ -10,20 +10,30 @@ module univalent-combinatorics.pi-finite-types where
 open import elementary-number-theory.natural-numbers
 
 open import foundation.0-connected-types
+open import foundation.action-on-identifications-functions
 open import foundation.contractible-types
 open import foundation.coproduct-types
+open import foundation.decidable-propositions
+open import foundation.decidable-types
+open import foundation.dependent-identifications
+open import foundation.dependent-pair-types
 open import foundation.embeddings
 open import foundation.empty-types
 open import foundation.equality-coproduct-types
 open import foundation.equality-dependent-pair-types
 open import foundation.equivalences
+open import foundation.fiber-inclusions
 open import foundation.function-extensionality
 open import foundation.function-types
 open import foundation.functoriality-dependent-pair-types
 open import foundation.functoriality-set-truncation
 open import foundation.homotopies
 open import foundation.identity-types
+open import foundation.logical-equivalences
 open import foundation.maybe
+open import foundation.mere-equality
+open import foundation.mere-equivalences
+open import foundation.propositional-extensionality
 open import foundation.propositional-truncations
 open import foundation.propositions
 open import foundation.set-presented-types
@@ -31,10 +41,12 @@ open import foundation.set-truncations
 open import foundation.sets
 open import foundation.subtypes
 open import foundation.surjective-maps
+open import foundation.transport-along-identifications
 open import foundation.truncated-types
 open import foundation.truncation-levels
 open import foundation.type-arithmetic-coproduct-types
 open import foundation.unit-type
+open import foundation.univalence
 open import foundation.universe-levels
 open import foundation.whiskering-homotopies-composition
 
@@ -43,6 +55,7 @@ open import univalent-combinatorics.counting
 open import univalent-combinatorics.dependent-function-types
 open import univalent-combinatorics.dependent-pair-types
 open import univalent-combinatorics.distributivity-of-set-truncation-over-finite-products
+open import univalent-combinatorics.equality-finite-types
 open import univalent-combinatorics.finite-types
 open import univalent-combinatorics.finitely-many-connected-components
 open import univalent-combinatorics.finitely-presented-types
@@ -392,6 +405,159 @@ pr2 (π-Finite-Π k A B) =
   is-π-finite-Π k
     ( is-finite-type-𝔽 A)
     ( λ x → is-π-finite-type-π-Finite k (B x))
+```
+
+### Dependent sums of types with finitely many connected components over a `0`-connected base
+
+The total space of a family of types with finitely many connected components
+over a `0`-connected base has finitely many connected components when the based
+[loop spaces](synthetic-homotopy-theory.loop-spaces.md) of the base have
+finitely many connected components.
+
+```agda
+has-finitely-many-connected-components-Σ-is-0-connected :
+  {l1 l2 : Level} {A : UU l1} {B : A → UU l2} →
+  is-0-connected A →
+  ((a : A) → has-finitely-many-connected-components (a ＝ a)) →
+  ((x : A) → has-finitely-many-connected-components (B x)) →
+  has-finitely-many-connected-components (Σ A B)
+has-finitely-many-connected-components-Σ-is-0-connected {A = A} {B} C H K =
+  apply-universal-property-trunc-Prop
+    ( is-inhabited-is-0-connected C)
+    ( has-finitely-many-connected-components-Prop (Σ A B))
+    ( α)
+  where
+  α : A → has-finitely-many-connected-components (Σ A B)
+  α a =
+    is-finite-codomain
+      ( K a)
+      ( is-surjective-map-trunc-Set
+        ( fiber-inclusion B a)
+        ( is-surjective-fiber-inclusion C a))
+      ( apply-dependent-universal-property-trunc-Set'
+        ( λ x →
+          set-Prop
+            ( Π-Prop
+              ( type-trunc-Set (Σ A B))
+              ( λ y → is-decidable-Prop (Id-Prop (trunc-Set (Σ A B)) x y))))
+        ( β))
+    where
+    β :
+      (x : Σ A B) (v : type-trunc-Set (Σ A B)) →
+      is-decidable (unit-trunc-Set x ＝ v)
+    β (x , y) =
+      apply-dependent-universal-property-trunc-Set'
+        ( λ u →
+          set-Prop
+            ( is-decidable-Prop
+              ( Id-Prop (trunc-Set (Σ A B)) (unit-trunc-Set (x , y)) u)))
+        ( γ)
+      where
+      γ :
+        (v : Σ A B) →
+        is-decidable ((unit-trunc-Set (x , y)) ＝ (unit-trunc-Set v))
+      γ (x' , y') =
+        is-decidable-equiv
+          ( is-effective-unit-trunc-Set
+            ( Σ A B)
+            ( x , y)
+            ( x' , y'))
+          ( apply-universal-property-trunc-Prop
+            ( mere-eq-is-0-connected C a x)
+            ( is-decidable-Prop
+              ( mere-eq-Prop (x , y) (x' , y')))
+              ( δ))
+        where
+        δ : a ＝ x → is-decidable (mere-eq (x , y) (x' , y'))
+        δ refl =
+          apply-universal-property-trunc-Prop
+            ( mere-eq-is-0-connected C a x')
+            ( is-decidable-Prop
+              ( mere-eq-Prop (a , y) (x' , y')))
+            ( ε)
+          where
+          ε : a ＝ x' → is-decidable (mere-eq (x , y) (x' , y'))
+          ε refl =
+            is-decidable-equiv e
+              ( is-decidable-type-trunc-Prop-is-finite
+                ( is-finite-Σ
+                  ( H a)
+                  ( λ ω → is-finite-is-decidable-Prop (P ω) (d ω))))
+            where
+            ℙ :
+              is-contr
+                ( Σ ( hom-Set (trunc-Set (a ＝ a)) (Prop-Set _))
+                    ( λ h →
+                      ( λ a₁ → h (unit-trunc-Set a₁)) ~
+                      ( λ ω₁ →
+                        trunc-Prop (dependent-identification B ω₁ y y'))))
+            ℙ =
+              universal-property-trunc-Set
+                ( a ＝ a)
+                ( Prop-Set _)
+                ( λ ω → trunc-Prop (dependent-identification B ω y y'))
+
+            P : type-trunc-Set (Id a a) → Prop _
+            P = pr1 (center ℙ)
+
+            compute-P :
+              (ω : a ＝ a) →
+              type-Prop (P (unit-trunc-Set ω)) ≃
+              type-trunc-Prop (dependent-identification B ω y y')
+            compute-P ω = equiv-eq (ap pr1 (pr2 (center ℙ) ω))
+
+            d : (t : type-trunc-Set (a ＝ a)) → is-decidable (type-Prop (P t))
+            d =
+              apply-dependent-universal-property-trunc-Set'
+                ( λ t → set-Prop (is-decidable-Prop (P t)))
+                ( λ ω →
+                  is-decidable-equiv'
+                    ( inv-equiv (compute-P ω))
+                    ( is-decidable-equiv'
+                      ( is-effective-unit-trunc-Set (B a) (tr B ω y) y')
+                      ( has-decidable-equality-is-finite
+                        ( K a)
+                        ( unit-trunc-Set (tr B ω y))
+                        ( unit-trunc-Set y'))))
+
+            f : type-hom-Prop
+                ( trunc-Prop (Σ (type-trunc-Set (Id a a)) (type-Prop ∘ P)))
+                ( mere-eq-Prop {A = Σ A B} (a , y) (a , y'))
+            f t =
+              apply-universal-property-trunc-Prop t
+                ( mere-eq-Prop (a , y) (a , y'))
+                  λ (u , v) →
+                  apply-dependent-universal-property-trunc-Set'
+                    ( λ u' →
+                      hom-set-Set
+                        ( set-Prop (P u'))
+                        ( set-Prop
+                          ( mere-eq-Prop (a , y) (a , y'))))
+                    ( λ ω v' →
+                      apply-universal-property-trunc-Prop
+                        ( map-equiv (compute-P ω) v')
+                        ( mere-eq-Prop (a , y) (a , y'))
+                        ( λ p → unit-trunc-Prop (eq-pair-Σ ω p)))
+                    ( u)
+                    ( v)
+            e :
+              mere-eq {A = Σ A B} (a , y) (a , y') ≃
+              type-trunc-Prop (Σ (type-trunc-Set (Id a a)) (type-Prop ∘ P))
+            e =
+              equiv-iff
+                ( mere-eq-Prop (a , y) (a , y'))
+                ( trunc-Prop (Σ (type-trunc-Set (a ＝ a)) (type-Prop ∘ P)))
+                ( λ t →
+                  apply-universal-property-trunc-Prop t
+                    ( trunc-Prop _)
+                    ( ( λ (ω , r) →
+                        unit-trunc-Prop
+                          ( ( unit-trunc-Set ω) ,
+                            ( map-inv-equiv
+                              ( compute-P ω)
+                              ( unit-trunc-Prop r)))) ∘
+                      ( pair-eq-Σ)))
+                ( f)
 ```
 
 ### Dependent sums of types with finitely many connected components

--- a/src/univalent-combinatorics/pi-finite-types.lagda.md
+++ b/src/univalent-combinatorics/pi-finite-types.lagda.md
@@ -71,7 +71,7 @@ is-truncated-π-finite-Prop (succ-ℕ k) X =
   product-Prop
     ( has-finite-connected-components-Prop X)
     ( Π-Prop X
-      ( λ x → Π-Prop X (λ y → is-truncated-π-finite-Prop k (Id x y))))
+      ( λ x → Π-Prop X (λ y → is-truncated-π-finite-Prop k (x ＝ y))))
 
 is-truncated-π-finite : {l : Level} (k : ℕ) → UU l → UU l
 is-truncated-π-finite k A =
@@ -86,7 +86,7 @@ is-π-finite-Prop zero-ℕ X = has-finite-connected-components-Prop X
 is-π-finite-Prop (succ-ℕ k) X =
   product-Prop
     ( is-π-finite-Prop zero-ℕ X)
-    ( Π-Prop X (λ x → Π-Prop X (λ y → is-π-finite-Prop k (Id x y))))
+    ( Π-Prop X (λ x → Π-Prop X (λ y → is-π-finite-Prop k (x ＝ y))))
 
 is-π-finite : {l : Level} (k : ℕ) → UU l → UU l
 is-π-finite k X = type-Prop (is-π-finite-Prop k X)
@@ -406,6 +406,9 @@ has-finite-connected-components-Σ-is-0-connected' C H =
 
 ### Dependent sums of π-finite types
 
+The dependent sum of a family of πₙ-finite types over a πₙ₊₁-finite base is
+πₙ-finite.
+
 ```agda
 abstract
   has-finite-connected-components-Σ' :
@@ -515,7 +518,8 @@ abstract
     {l1 l2 : Level} (k : ℕ) {A : UU l1} {B : A → UU l2} →
     is-π-finite (succ-ℕ k) A → ((x : A) → is-π-finite k (B x)) →
     is-π-finite k (Σ A B)
-  is-π-finite-Σ zero-ℕ {A} {B} = has-finite-connected-components-Σ
+  is-π-finite-Σ zero-ℕ =
+    has-finite-connected-components-Σ
   pr1 (is-π-finite-Σ (succ-ℕ k) H K) =
     has-finite-connected-components-Σ
       ( is-π-finite-one-is-π-finite-succ-ℕ (succ-ℕ k) H)

--- a/src/univalent-combinatorics/pi-finite-types.lagda.md
+++ b/src/univalent-combinatorics/pi-finite-types.lagda.md
@@ -42,8 +42,8 @@ open import univalent-combinatorics.counting
 open import univalent-combinatorics.dependent-function-types
 open import univalent-combinatorics.dependent-pair-types
 open import univalent-combinatorics.distributivity-of-set-truncation-over-finite-products
-open import univalent-combinatorics.finite-connected-components
 open import univalent-combinatorics.finite-types
+open import univalent-combinatorics.finitely-many-connected-components
 open import univalent-combinatorics.finitely-presented-types
 open import univalent-combinatorics.function-types
 open import univalent-combinatorics.image-of-maps
@@ -69,7 +69,7 @@ is-truncated-π-finite-Prop : {l : Level} (k : ℕ) → UU l → Prop l
 is-truncated-π-finite-Prop zero-ℕ X = is-finite-Prop X
 is-truncated-π-finite-Prop (succ-ℕ k) X =
   product-Prop
-    ( has-finite-connected-components-Prop X)
+    ( has-finitely-many-connected-components-Prop X)
     ( Π-Prop X
       ( λ x → Π-Prop X (λ y → is-truncated-π-finite-Prop k (x ＝ y))))
 
@@ -82,7 +82,7 @@ is-truncated-π-finite k A =
 
 ```agda
 is-π-finite-Prop : {l : Level} (k : ℕ) → UU l → Prop l
-is-π-finite-Prop zero-ℕ X = has-finite-connected-components-Prop X
+is-π-finite-Prop zero-ℕ X = has-finitely-many-connected-components-Prop X
 is-π-finite-Prop (succ-ℕ k) X =
   product-Prop
     ( is-π-finite-Prop zero-ℕ X)
@@ -108,11 +108,11 @@ is-π-finite-type-π-Finite :
   is-π-finite k (type-π-Finite {l} k A)
 is-π-finite-type-π-Finite k = pr2
 
-has-finite-connected-components-is-π-finite :
+has-finitely-many-connected-components-is-π-finite :
   {l : Level} (k : ℕ) {A : UU l} →
-  is-π-finite k A → has-finite-connected-components A
-has-finite-connected-components-is-π-finite zero-ℕ H = H
-has-finite-connected-components-is-π-finite (succ-ℕ k) H = pr1 H
+  is-π-finite k A → has-finitely-many-connected-components A
+has-finitely-many-connected-components-is-π-finite zero-ℕ H = H
+has-finitely-many-connected-components-is-π-finite (succ-ℕ k) H = pr1 H
 ```
 
 ## Properties
@@ -286,7 +286,8 @@ pr2 (π-finite-𝔽 k A) = is-π-finite-is-finite k (is-finite-type-𝔽 A)
 is-π-finite-UU-Fin :
   {l : Level} (k n : ℕ) → is-π-finite k (UU-Fin l n)
 is-π-finite-UU-Fin zero-ℕ n =
-  has-finite-connected-components-is-0-connected (is-0-connected-UU-Fin n)
+  has-finitely-many-connected-components-is-0-connected
+    ( is-0-connected-UU-Fin n)
 pr1 (is-π-finite-UU-Fin (succ-ℕ k) n) =
   is-π-finite-UU-Fin zero-ℕ n
 pr2 (is-π-finite-UU-Fin (succ-ℕ k) n) x y =
@@ -305,9 +306,9 @@ is-π-finite-is-π-finite-succ-ℕ :
   {l : Level} (k : ℕ) {A : UU l} →
   is-π-finite (succ-ℕ k) A → is-π-finite k A
 is-π-finite-is-π-finite-succ-ℕ zero-ℕ H =
-  has-finite-connected-components-is-π-finite 1 H
+  has-finitely-many-connected-components-is-π-finite 1 H
 pr1 (is-π-finite-is-π-finite-succ-ℕ (succ-ℕ k) H) =
-  has-finite-connected-components-is-π-finite (succ-ℕ (succ-ℕ k)) H
+  has-finitely-many-connected-components-is-π-finite (succ-ℕ (succ-ℕ k)) H
 pr2 (is-π-finite-is-π-finite-succ-ℕ (succ-ℕ k) H) x y =
   is-π-finite-is-π-finite-succ-ℕ k (pr2 H x y)
 ```
@@ -333,7 +334,7 @@ is-finite-is-π-finite :
 is-finite-is-π-finite k H K =
   is-finite-equiv'
     ( equiv-unit-trunc-Set (_ , H))
-    ( has-finite-connected-components-is-π-finite k K)
+    ( has-finitely-many-connected-components-is-π-finite k K)
 ```
 
 ### πₙ-finite n-truncated types are truncated πₙ-finite
@@ -395,13 +396,13 @@ pr2 (π-Finite-Π k A B) =
 ### Proposition 1.7
 
 ```agda
-has-finite-connected-components-Σ-is-0-connected' :
+has-finitely-many-connected-components-Σ-is-0-connected' :
   {l1 l2 : Level} {A : UU l1} {B : A → UU l2} →
   is-0-connected A → is-π-finite 1 A →
-  ((x : A) → has-finite-connected-components (B x)) →
-  has-finite-connected-components (Σ A B)
-has-finite-connected-components-Σ-is-0-connected' C H =
-  has-finite-connected-components-Σ-is-0-connected C (λ a → pr2 H a a)
+  ((x : A) → has-finitely-many-connected-components (B x)) →
+  has-finitely-many-connected-components (Σ A B)
+has-finitely-many-connected-components-Σ-is-0-connected' C H =
+  has-finitely-many-connected-components-Σ-is-0-connected C (λ a → pr2 H a a)
 ```
 
 ### Dependent sums of π-finite types
@@ -411,25 +412,25 @@ The dependent sum of a family of πₙ-finite types over a πₙ₊₁-finite ba
 
 ```agda
 abstract
-  has-finite-connected-components-Σ' :
+  has-finitely-many-connected-components-Σ' :
     {l1 l2 : Level} (k : ℕ) {A : UU l1} {B : A → UU l2} →
     (Fin k ≃ type-trunc-Set A) →
-    ((x y : A) → has-finite-connected-components (x ＝ y)) →
-    ((x : A) → has-finite-connected-components (B x)) →
-    has-finite-connected-components (Σ A B)
-  has-finite-connected-components-Σ' zero-ℕ e H K =
+    ((x y : A) → has-finitely-many-connected-components (x ＝ y)) →
+    ((x : A) → has-finitely-many-connected-components (B x)) →
+    has-finitely-many-connected-components (Σ A B)
+  has-finitely-many-connected-components-Σ' zero-ℕ e H K =
     is-π-finite-is-empty zero-ℕ
       ( is-empty-is-empty-trunc-Set (map-inv-equiv e) ∘ pr1)
-  has-finite-connected-components-Σ' (succ-ℕ k) {A} {B} e H K =
+  has-finitely-many-connected-components-Σ' (succ-ℕ k) {A} {B} e H K =
     apply-universal-property-trunc-Prop
       ( has-presentation-of-cardinality-has-cardinality-components
         ( succ-ℕ k)
         ( unit-trunc-Prop e))
-      ( has-finite-connected-components-Prop (Σ A B))
+      ( has-finitely-many-connected-components-Prop (Σ A B))
       ( α)
     where
     α : Σ (Fin (succ-ℕ k) → A) (λ f → is-equiv (unit-trunc-Set ∘ f)) →
-        has-finite-connected-components (Σ A B)
+        has-finitely-many-connected-components (Σ A B)
     α (f , Eηf) =
       is-finite-equiv
         ( equiv-trunc-Set g)
@@ -438,7 +439,7 @@ abstract
             ( Σ (im (f ∘ inl)) (B ∘ pr1))
             ( Σ (im (f ∘ inr)) (B ∘ pr1)))
           ( is-finite-coproduct
-            ( has-finite-connected-components-Σ' k
+            ( has-finitely-many-connected-components-Σ' k
               ( h)
               ( λ x y →
                 is-finite-equiv'
@@ -447,7 +448,7 @@ abstract
                       ( pr1 , is-emb-inclusion-subtype ( λ u → trunc-Prop _))))
                   ( H (pr1 x) (pr1 y)))
               ( λ x → K (pr1 x)))
-            ( has-finite-connected-components-Σ-is-0-connected'
+            ( has-finitely-many-connected-components-Σ-is-0-connected'
               ( is-0-connected-im-is-0-connected-domain
                 ( f ∘ inr)
                 ( is-0-connected-unit))
@@ -502,16 +503,17 @@ abstract
       h : Fin k ≃ type-trunc-Set (im (f ∘ inl))
       h = i , (is-equiv-is-emb-is-surjective is-surjective-i is-emb-i)
 
-has-finite-connected-components-Σ :
+has-finitely-many-connected-components-Σ :
   {l1 l2 : Level} {A : UU l1} {B : A → UU l2} →
   is-π-finite 1 A →
-  ((x : A) → has-finite-connected-components (B x)) →
-  has-finite-connected-components (Σ A B)
-has-finite-connected-components-Σ {A = A} {B} H K =
+  ((x : A) → has-finitely-many-connected-components (B x)) →
+  has-finitely-many-connected-components (Σ A B)
+has-finitely-many-connected-components-Σ {A = A} {B} H K =
   apply-universal-property-trunc-Prop
     ( pr1 H)
-    ( has-finite-connected-components-Prop (Σ A B))
-    ( λ (k , e) → has-finite-connected-components-Σ' k e (λ x y → pr2 H x y) K)
+    ( has-finitely-many-connected-components-Prop (Σ A B))
+    ( λ (k , e) →
+      has-finitely-many-connected-components-Σ' k e (λ x y → pr2 H x y) K)
 
 abstract
   is-π-finite-Σ :
@@ -519,12 +521,12 @@ abstract
     is-π-finite (succ-ℕ k) A → ((x : A) → is-π-finite k (B x)) →
     is-π-finite k (Σ A B)
   is-π-finite-Σ zero-ℕ =
-    has-finite-connected-components-Σ
+    has-finitely-many-connected-components-Σ
   pr1 (is-π-finite-Σ (succ-ℕ k) H K) =
-    has-finite-connected-components-Σ
+    has-finitely-many-connected-components-Σ
       ( is-π-finite-one-is-π-finite-succ-ℕ (succ-ℕ k) H)
       ( λ x →
-        has-finite-connected-components-is-π-finite (succ-ℕ k) (K x))
+        has-finitely-many-connected-components-is-π-finite (succ-ℕ k) (K x))
   pr2 (is-π-finite-Σ (succ-ℕ k) H K) (x , u) (y , v) =
     is-π-finite-equiv k
       ( equiv-pair-eq-Σ (x , u) (y , v))

--- a/src/univalent-combinatorics/pi-finite-types.lagda.md
+++ b/src/univalent-combinatorics/pi-finite-types.lagda.md
@@ -178,8 +178,7 @@ pr2 (is-π-finite-is-contr (succ-ℕ k) H) x y =
 ### The unit type is π-finite
 
 ```agda
-is-π-finite-unit :
-  (k : ℕ) → is-π-finite k unit
+is-π-finite-unit : (k : ℕ) → is-π-finite k unit
 is-π-finite-unit k = is-π-finite-is-contr k is-contr-unit
 
 unit-π-Finite : (k : ℕ) → π-Finite lzero k
@@ -220,7 +219,8 @@ pr2 (is-π-finite-coproduct (succ-ℕ k) H K) (inr x) (inr y) =
 coproduct-π-Finite :
   {l1 l2 : Level} (k : ℕ) →
   π-Finite l1 k → π-Finite l2 k → π-Finite (l1 ⊔ l2) k
-pr1 (coproduct-π-Finite k A B) = (type-π-Finite k A + type-π-Finite k B)
+pr1 (coproduct-π-Finite k A B) =
+  (type-π-Finite k A + type-π-Finite k B)
 pr2 (coproduct-π-Finite k A B) =
   is-π-finite-coproduct k
     ( is-π-finite-type-π-Finite k A)
@@ -394,10 +394,7 @@ pr2 (π-Finite-Π k A B) =
     ( λ x → is-π-finite-type-π-Finite k (B x))
 ```
 
-### Dependent sums of π-finite types
-
-The dependent sum of a family of πₙ-finite types over a πₙ₊₁-finite base is
-πₙ-finite.
+### Dependent sums of types with finitely many connected components
 
 ```agda
 abstract
@@ -408,7 +405,7 @@ abstract
     ((x : A) → has-finitely-many-connected-components (B x)) →
     has-finitely-many-connected-components (Σ A B)
   has-finitely-many-connected-components-Σ' zero-ℕ e H K =
-    is-π-finite-is-empty zero-ℕ
+    has-finitely-many-connected-components-is-empty
       ( is-empty-is-empty-trunc-Set (map-inv-equiv e) ∘ pr1)
   has-finitely-many-connected-components-Σ' (succ-ℕ k) {A} {B} e H K =
     apply-universal-property-trunc-Prop
@@ -442,7 +439,7 @@ abstract
                 ( f ∘ inr)
                 ( is-0-connected-unit))
               ( ( λ a →
-                  is-π-finite-equiv zero-ℕ
+                  has-finitely-many-connected-components-equiv'
                     ( equiv-Eq-eq-im (f ∘ inr) a a)
                     ( H (pr1 a) (pr1 a))))
               ( λ x → K (pr1 x)))))
@@ -487,7 +484,14 @@ abstract
 
       h : Fin k ≃ type-trunc-Set (im (f ∘ inl))
       h = i , (is-equiv-is-emb-is-surjective is-surjective-i is-emb-i)
+```
 
+### Dependent sums of π-finite types
+
+The dependent sum of a family of πₙ-finite types over a πₙ₊₁-finite base is
+πₙ-finite.
+
+```agda
 has-finitely-many-connected-components-Σ :
   {l1 l2 : Level} {A : UU l1} {B : A → UU l2} →
   is-π-finite 1 A →


### PR DESCRIPTION
So uhh, I felt a little inspired while reading Chris Grossack's blog post on [Finiteness in Sheaf Topoi](https://grossack.site/2024/08/19/finiteness-in-sheaf-topoi) this evening, and decided to have a look around and see if I could add any small definitions or external links to the library. Then things kind of derailed when I stumbled upon our file on pi-finite types. Turns out this file entangled three concepts (pi-finite types, locally finite types, and types with finite connected components). So I, uh..., unentangled it! 😬 I hope I'm not stepping on your toes, @EgbertRijke, I really did not intend to.