### PR TITLE
fix typo in binary-relations.lagda.md

### DIFF
--- a/src/foundation/binary-relations.lagda.md
+++ b/src/foundation/binary-relations.lagda.md
@@ -172,7 +172,7 @@ module _
 ### The predicate of being an irreflexive relation
 
 A relation `R` on a type `A` is said to be **irreflexive** if it comes equipped
-with a function `(x : A) → ¬ (R x y)`.
+with a function `(x : A) → ¬ (R x x)`.
 
 ```agda
 module _


### PR DESCRIPTION
It said before that a relation is irreflexive if there exists a function (x : A) -> neg (R x y).
Should be R x x