### PR TITLE
Enable smart punctuation

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -67,6 +67,8 @@ follow-web-links = false
 [output.html]
 default-theme = "light"
 preferred-dark-theme = "Ayu"
+# The following option is renamed to smart-punctuation in mdbook 0.4.38
+curly-quotes = true
 copy-fonts = true
 additional-css = [
   "website/css/Agda.css",


### PR DESCRIPTION
Turns `--` and `---` to ndash and mdash, respectively, and automatically inserts paired quotation marks; see https://rust-lang.github.io/mdBook/format/markdown.html#smart-punctuation.

Note that the option is called `curly-quotes` in the version of mdbook we use. In later versions it's called `smart-punctuation`.