### PR TITLE
Incidence algebras

### DIFF
--- a/src/order-theory.lagda.md
+++ b/src/order-theory.lagda.md
@@ -49,6 +49,7 @@ open import order-theory.homomorphisms-meet-semilattices public
 open import order-theory.homomorphisms-meet-sup-lattices public
 open import order-theory.homomorphisms-sup-lattices public
 open import order-theory.ideals-preorders public
+open import order-theory.incidence-algebras public
 open import order-theory.inhabited-finite-total-orders public
 open import order-theory.interval-subposets public
 open import order-theory.join-semilattices public

--- a/src/order-theory/incidence-algebras.lagda.md
+++ b/src/order-theory/incidence-algebras.lagda.md
@@ -27,9 +27,10 @@ open import order-theory.posets
 For a [locally finite poset](order-theory.locally-finite-posets.md) 'P' and
 [commutative ring](commutative-algebra.commutative-rings.md) 'R', there is a
 canonical 'R'-associative algebra whose undderlying 'R'-module are the set-maps
-from the nonempty intervals of 'P' to 'R' (which we constructify as the
-inhabited intervals), and whose multiplication is given by a "convolution" of
-maps. This is the **incidence algebra** of 'P' over 'R'.
+from the nonempty [intervals](order-theory.interval-subposets.md) of 'P' to 'R'
+(which we constructify as the inhabited intervals), and whose multiplication is
+given by a "convolution" of maps. This is the **incidence algebra** of 'P' over
+'R'.
 
 ## Definition
 
@@ -39,16 +40,8 @@ module _
   (x y : type-Poset P) (R : Commutative-Ring l3)
   where
 
-  is-inhabited-interval : UU (l1 ⊔ l2)
-  is-inhabited-interval =
-    is-inhabited (type-Poset (poset-interval-Subposet P x y))
-
-  inhabited-intervals : UU (l1 ⊔ l2)
-  inhabited-intervals =
-    Σ (type-Poset P × type-Poset P) (λ (p , q) → is-inhabited-interval)
-
-  interval-maps : UU (l1 ⊔ l2 ⊔ l3)
-  interval-maps = inhabited-intervals → type-Commutative-Ring R
+  interval-map : UU (l1 ⊔ l2 ⊔ l3)
+  interval-map = inhabited-interval P x y → type-Commutative-Ring R
 ```
 
 WIP: complete this definition after _R-modules_ have been defined. Defining

--- a/src/order-theory/incidence-algebras.lagda.md
+++ b/src/order-theory/incidence-algebras.lagda.md
@@ -24,8 +24,8 @@ open import order-theory.posets
 
 ## Idea
 
-For a [locally finite poset](order-theory.locally-finite-posets) 'P' and
-[commutative ring](commutative-algebra.commutative-rings) 'R', there is a
+For a [locally finite poset](order-theory.locally-finite-posets.md) 'P' and
+[commutative ring](commutative-algebra.commutative-rings.md) 'R', there is a
 canonical 'R'-associative algebra whose undderlying 'R'-module are the set-maps
 from the nonempty intervals of 'P' to 'R' (which we constructify as the
 inhabited intervals), and whose multiplication is given by a "convolution" of

--- a/src/order-theory/incidence-algebras.lagda.md
+++ b/src/order-theory/incidence-algebras.lagda.md
@@ -40,13 +40,17 @@ module _
   where
 
   is-inhabited-interval : UU (l1 ⊔ l2)
-  is-inhabited-interval = is-inhabited (type-Poset (poset-interval-Subposet P x y))
+  is-inhabited-interval =
+    is-inhabited (type-Poset (poset-interval-Subposet P x y))
 
   inhabited-intervals : UU (l1 ⊔ l2)
-  inhabited-intervals = Σ (type-Poset P × type-Poset P) (λ (p , q) → is-inhabited-interval)
+  inhabited-intervals =
+    Σ (type-Poset P × type-Poset P) (λ (p , q) → is-inhabited-interval)
 
   interval-maps : UU (l1 ⊔ l2 ⊔ l3)
   interval-maps = inhabited-intervals → type-Commutative-Ring R
 ```
 
-WIP: complete this definition after _R-modules_ have been defined
+WIP: complete this definition after _R-modules_ have been defined. Defining
+convolution of maps would be aided as well with a lemma on 'unordered' addition
+in abelian groups over finite sets.

--- a/src/order-theory/incidence-algebras.lagda.md
+++ b/src/order-theory/incidence-algebras.lagda.md
@@ -1,0 +1,42 @@
+# Incidence algebras
+
+```agda
+module order-theory.incidence-algebras where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import commutative-algebra.commutative-rings
+open import commutative-algebra.function-commutative-rings
+
+open import foundation.dependent-pair-types
+open import foundation.inhabited-types
+open import foundation.universe-levels
+
+open import order-theory.interval-subposets
+open import order-theory.locally-finite-posets
+open import order-theory.posets
+```
+
+</details>
+
+## Idea
+
+For a [locally finite poset](order-theory.locally-finite-posets) 'P' and
+[commutative ring](commutative-algebra.commutative-rings) 'R', there is a
+canonical 'R'-associative algebra whose undderlying 'R'-module are the set-maps
+from 'P' to 'R', and whose multiplication is given by a "convolution" of maps.
+This is the **incidence algebra** of 'P' over 'R'.
+
+## Definition
+
+```agda
+module _
+  {l1 l2 l3 : Level} (P : Poset l1 l2) (loc-fin : is-locally-finite-Poset P)
+  (x y : type-Poset P) (R : Commutative-Ring l3)
+  where
+
+  interval-maps : UU _
+  interval-maps = {! !} → type-Commutative-Ring R
+```

--- a/src/order-theory/incidence-algebras.lagda.md
+++ b/src/order-theory/incidence-algebras.lagda.md
@@ -8,11 +8,12 @@ module order-theory.incidence-algebras where
 
 ```agda
 open import commutative-algebra.commutative-rings
-open import commutative-algebra.function-commutative-rings
 
 open import foundation.dependent-pair-types
 open import foundation.inhabited-types
 open import foundation.universe-levels
+
+open import foundation-core.cartesian-product-types
 
 open import order-theory.interval-subposets
 open import order-theory.locally-finite-posets
@@ -26,8 +27,9 @@ open import order-theory.posets
 For a [locally finite poset](order-theory.locally-finite-posets) 'P' and
 [commutative ring](commutative-algebra.commutative-rings) 'R', there is a
 canonical 'R'-associative algebra whose undderlying 'R'-module are the set-maps
-from 'P' to 'R', and whose multiplication is given by a "convolution" of maps.
-This is the **incidence algebra** of 'P' over 'R'.
+from the nonempty intervals of 'P' to 'R' (which we constructify as the
+inhabited intervals), and whose multiplication is given by a "convolution" of
+maps. This is the **incidence algebra** of 'P' over 'R'.
 
 ## Definition
 
@@ -37,6 +39,14 @@ module _
   (x y : type-Poset P) (R : Commutative-Ring l3)
   where
 
-  interval-maps : UU _
-  interval-maps = {! !} → type-Commutative-Ring R
+  is-inhabited-interval : UU (l1 ⊔ l2)
+  is-inhabited-interval = is-inhabited (type-Poset (poset-interval-Subposet P x y))
+
+  inhabited-intervals : UU (l1 ⊔ l2)
+  inhabited-intervals = Σ (type-Poset P × type-Poset P) (λ (p , q) → is-inhabited-interval)
+
+  interval-maps : UU (l1 ⊔ l2 ⊔ l3)
+  interval-maps = inhabited-intervals → type-Commutative-Ring R
 ```
+
+WIP: complete this definition after _R-modules_ have been defined

--- a/src/order-theory/incidence-algebras.lagda.md
+++ b/src/order-theory/incidence-algebras.lagda.md
@@ -26,7 +26,7 @@ open import order-theory.posets
 
 For a [locally finite poset](order-theory.locally-finite-posets.md) 'P' and
 [commutative ring](commutative-algebra.commutative-rings.md) 'R', there is a
-canonical 'R'-associative algebra whose undderlying 'R'-module are the set-maps
+canonical 'R'-associative algebra whose underlying 'R'-module are the set-maps
 from the nonempty [intervals](order-theory.interval-subposets.md) of 'P' to 'R'
 (which we constructify as the inhabited intervals), and whose multiplication is
 given by a "convolution" of maps. This is the **incidence algebra** of 'P' over

--- a/src/order-theory/incidence-algebras.lagda.md
+++ b/src/order-theory/incidence-algebras.lagda.md
@@ -41,7 +41,7 @@ module _
   where
 
   interval-map : UU (l1 ⊔ l2 ⊔ l3)
-  interval-map = inhabited-interval P x y → type-Commutative-Ring R
+  interval-map = inhabited-interval P → type-Commutative-Ring R
 ```
 
 WIP: complete this definition after _R-modules_ have been defined. Defining

--- a/src/order-theory/interval-subposets.lagda.md
+++ b/src/order-theory/interval-subposets.lagda.md
@@ -52,7 +52,7 @@ module _
   is-inhabited-interval =
     is-inhabited (type-Poset (poset-interval-Subposet X x y))
 
-dule _
+module _
   {l1 l2 : Level} (X : Poset l1 l2)
   where
   

--- a/src/order-theory/interval-subposets.lagda.md
+++ b/src/order-theory/interval-subposets.lagda.md
@@ -55,8 +55,8 @@ module _
 module _
   {l1 l2 : Level} (X : Poset l1 l2)
   where
-  
+
   inhabited-interval : UU (l1 ⊔ l2)
   inhabited-interval =
-    Σ (type-Poset X × type-Poset X) (λ (p , q) → is-inhabited-interval)
+    Σ (type-Poset X × type-Poset X) λ (p , q) → (is-inhabited-interval X p q)
 ```

--- a/src/order-theory/interval-subposets.lagda.md
+++ b/src/order-theory/interval-subposets.lagda.md
@@ -7,8 +7,12 @@ module order-theory.interval-subposets where
 <details><summary>Imports</summary>
 
 ```agda
+open import foundation.dependent-pair-types
+open import foundation.inhabited-types
 open import foundation.propositions
 open import foundation.universe-levels
+
+open import foundation-core.cartesian-product-types
 
 open import order-theory.posets
 open import order-theory.subposets
@@ -35,4 +39,20 @@ module _
 
   poset-interval-Subposet : Poset (l1 ⊔ l2) l2
   poset-interval-Subposet = poset-Subposet X is-in-interval-Poset
+```
+
+### The predicate of an interval being inhabited
+
+```agda
+module _
+  {l1 l2 : Level} (X : Poset l1 l2) (x y : type-Poset X)
+  where
+
+  is-inhabited-interval : UU (l1 ⊔ l2)
+  is-inhabited-interval =
+    is-inhabited (type-Poset (poset-interval-Subposet X x y))
+
+  inhabited-interval : UU (l1 ⊔ l2)
+  inhabited-interval =
+    Σ (type-Poset X × type-Poset X) (λ (p , q) → is-inhabited-interval)
 ```

--- a/src/order-theory/interval-subposets.lagda.md
+++ b/src/order-theory/interval-subposets.lagda.md
@@ -52,6 +52,10 @@ module _
   is-inhabited-interval =
     is-inhabited (type-Poset (poset-interval-Subposet X x y))
 
+dule _
+  {l1 l2 : Level} (X : Poset l1 l2)
+  where
+  
   inhabited-interval : UU (l1 ⊔ l2)
   inhabited-interval =
     Σ (type-Poset X × type-Poset X) (λ (p , q) → is-inhabited-interval)


### PR DESCRIPTION
Very preliminary work on defining the incidence algebra of a locally finite poset, as towards defining more sophisticated objects such as Möbius inversion. Work stalled pending infrastructure in the commutative algebra library for "unordered" addition indexed by finite sets and for some module theory, but want to get this file with a thumbtack in the upstream before turning that way.