### PR TITLE
Agda version 2.7.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-13, ubuntu-latest]
-        agda: ['2.6.4']
+        agda: ['2.7.0.1']
     steps:
       - name: Checkout our repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-13, ubuntu-latest]
-        agda: ['2.7.0.1']
+        agda: ['2.7.0_1']
     steps:
       - name: Checkout our repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
         with:
           path: master
       - name: Setup Agda
-        uses: wenkokke/setup-agda@v2.1.0
+        uses: wenkokke/setup-agda@v2.5.0
         with:
           agda-version: ${{ matrix.agda }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,9 +42,6 @@ jobs:
         with:
           agda-version: ${{ matrix.agda }}
 
-      - name: Agda version
-        run: agda --version
-
       - uses: actions/cache/restore@v3
         id: cache-agda-formalization
         name: Restore Agda formalization cache
@@ -60,6 +57,7 @@ jobs:
       - name: Typecheck library
         run: |
           cd master
+          agda --version
           make check
 
       - name: Save Agda build cache

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-13, ubuntu-latest]
-        agda: ['2.7.0_1']
+        agda: ['2.7.0']
     steps:
       - name: Checkout our repository
         uses: actions/checkout@v3
@@ -41,6 +41,9 @@ jobs:
         uses: wenkokke/setup-agda@v2.5.0
         with:
           agda-version: ${{ matrix.agda }}
+
+      - name: Agda version
+        run: agda --version
 
       - uses: actions/cache/restore@v3
         id: cache-agda-formalization

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        agda: ['2.7.0_1']
+        agda: ['2.7.0']
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -42,6 +42,9 @@ jobs:
         uses: wenkokke/setup-agda@v2.5.0
         with:
           agda-version: ${{ matrix.agda }}
+
+      - name: Agda version
+        run: agda --version
 
       - uses: actions/cache/restore@v3
         id: cache-agda-formalization

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -43,9 +43,6 @@ jobs:
         with:
           agda-version: ${{ matrix.agda }}
 
-      - name: Agda version
-        run: agda --version
-
       - uses: actions/cache/restore@v3
         id: cache-agda-formalization
         name: Restore Agda formalization cache

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        agda: ['2.6.4']
+        agda: ['2.7.0.1']
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Agda
-        uses: wenkokke/setup-agda@v2.1.0
+        uses: wenkokke/setup-agda@v2.5.0
         with:
           agda-version: ${{ matrix.agda }}
 

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        agda: ['2.7.0.1']
+        agda: ['2.7.0_1']
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/profiling.yaml
+++ b/.github/workflows/profiling.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        agda: ['2.7.0.1']
+        agda: ['2.7.0_1']
 
     steps:
       - name: Checkout our repository
@@ -24,7 +24,7 @@ jobs:
           path: repo
 
       - name: Setup Agda
-        uses: wenkokke/setup-agda@v2.5.0
+        uses:
         with:
           agda-version: ${{ matrix.agda }}
 

--- a/.github/workflows/profiling.yaml
+++ b/.github/workflows/profiling.yaml
@@ -24,7 +24,7 @@ jobs:
           path: repo
 
       - name: Setup Agda
-        uses: wenkokke/setup-agda@v2.1.0
+        uses: wenkokke/setup-agda@v2.5.0
         with:
           agda-version: ${{ matrix.agda }}
 

--- a/.github/workflows/profiling.yaml
+++ b/.github/workflows/profiling.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        agda: ['2.6.4']
+        agda: ['2.7.0.1']
 
     steps:
       - name: Checkout our repository

--- a/.github/workflows/profiling.yaml
+++ b/.github/workflows/profiling.yaml
@@ -28,12 +28,10 @@ jobs:
         with:
           agda-version: ${{ matrix.agda }}
 
-      - name: Agda version
-        run: agda --version
-
       - name: Typecheck library with profiling
         run: |
           cd repo
+          agda --version
           mkdir -p temp
           make check-profile 2> temp/memory-results.txt | tee temp/benchmark-results.txt
 

--- a/.github/workflows/profiling.yaml
+++ b/.github/workflows/profiling.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        agda: ['2.7.0_1']
+        agda: ['2.7.0']
 
     steps:
       - name: Checkout our repository
@@ -24,9 +24,12 @@ jobs:
           path: repo
 
       - name: Setup Agda
-        uses:
+        uses: wenkokke/setup-agda@v2.5.0
         with:
           agda-version: ${{ matrix.agda }}
+
+      - name: Agda version
+        run: agda --version
 
       - name: Typecheck library with profiling
         run: |

--- a/HOME.md
+++ b/HOME.md
@@ -21,7 +21,7 @@ working and learning mathematicians. Our library is designed to work towards
 this goal, and we welcome contributions to the library within any topic in
 mathematics.
 
-The agda-unimath library is compatible with Agda 2.7.0.1 and can be compiled by
+The agda-unimath library is compatible with Agda 2.7.0 and can be compiled by
 running `make check` from the root directory of the repository. Learn more about
 using the library locally in our [installation guide](HOWTO-INSTALL.md).
 

--- a/HOME.md
+++ b/HOME.md
@@ -21,7 +21,7 @@ working and learning mathematicians. Our library is designed to work towards
 this goal, and we welcome contributions to the library within any topic in
 mathematics.
 
-The agda-unimath library is compatible with Agda 2.6.4 and can be compiled by
+The agda-unimath library is compatible with Agda 2.7.0.1 and can be compiled by
 running `make check` from the root directory of the repository. Learn more about
 using the library locally in our [installation guide](HOWTO-INSTALL.md).
 

--- a/HOWTO-INSTALL.md
+++ b/HOWTO-INSTALL.md
@@ -5,7 +5,7 @@
 ### Quick setup
 
 To work or experiment with the agda-unimath library on your machine, you will
-need to have `agda` version 2.7.0.1 installed, and a suitable editor such as
+need to have `agda` version 2.7.0 installed, and a suitable editor such as
 [Emacs](https://www.gnu.org/software/emacs/) or
 [Visual Studio Code](https://code.visualstudio.com/). The following instructions
 will help you on your way right away:
@@ -122,7 +122,7 @@ working branches when necessary.
 
 ## Installing Agda {#installing-agda}
 
-The agda-unimath library is built and verified with Agda 2.7.0.1, and we provide
+The agda-unimath library is built and verified with Agda 2.7.0, and we provide
 two methods for installation: with or without the package manager
 [Nix](https://nixos.org/). Nix streamlines the installation of Agda and its
 dependencies, providing a consistent and reproducible environment for the
@@ -130,7 +130,7 @@ library across different systems.
 
 ### Without Nix
 
-To install Agda 2.7.0.1 without Nix, follow the
+To install Agda 2.7.0 without Nix, follow the
 [installation guide](https://agda.readthedocs.io/en/latest/getting-started/installation.html)
 provided on the Agda documentation page.
 

--- a/HOWTO-INSTALL.md
+++ b/HOWTO-INSTALL.md
@@ -5,7 +5,7 @@
 ### Quick setup
 
 To work or experiment with the agda-unimath library on your machine, you will
-need to have `agda` version 2.6.4 installed, and a suitable editor such as
+need to have `agda` version 2.7.0.1 installed, and a suitable editor such as
 [Emacs](https://www.gnu.org/software/emacs/) or
 [Visual Studio Code](https://code.visualstudio.com/). The following instructions
 will help you on your way right away:
@@ -122,7 +122,7 @@ working branches when necessary.
 
 ## Installing Agda {#installing-agda}
 
-The agda-unimath library is built and verified with Agda 2.6.4, and we provide
+The agda-unimath library is built and verified with Agda 2.7.0.1, and we provide
 two methods for installation: with or without the package manager
 [Nix](https://nixos.org/). Nix streamlines the installation of Agda and its
 dependencies, providing a consistent and reproducible environment for the
@@ -130,7 +130,7 @@ library across different systems.
 
 ### Without Nix
 
-To install Agda 2.6.4 without Nix, follow the
+To install Agda 2.7.0.1 without Nix, follow the
 [installation guide](https://agda.readthedocs.io/en/latest/getting-started/installation.html)
 provided on the Agda documentation page.
 

--- a/agda-unimath.agda-lib
+++ b/agda-unimath.agda-lib
@@ -1,3 +1,3 @@
 name: agda-unimath
 include: src
-flags: --without-K --exact-split --no-import-sorts --auto-inline -WnoWithoutKFlagPrimEraseEquality
+flags: --without-K --exact-split --no-import-sorts --auto-inline --no-require-unique-meta-solutions -WnoWithoutKFlagPrimEraseEquality

--- a/flake.lock
+++ b/flake.lock
@@ -41,16 +41,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1699725108,
-        "narHash": "sha256-NTiPW4jRC+9puakU4Vi8WpFEirhp92kTOSThuZke+FA=",
+        "lastModified": 1736916166,
+        "narHash": "sha256-puPDoVKxkuNmYIGMpMQiK8bEjaACcCksolsG36gdaNQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "911ad1e67f458b6bcf0278fa85e33bb9924fed7e",
+        "rev": "e24b4c09e963677b1beea49d411cd315a024ad3a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -71,12 +71,29 @@
         "type": "github"
       }
     },
+    "nixpkgs-python": {
+      "locked": {
+        "lastModified": 1720535198,
+        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "mdbook-catppuccin": "mdbook-catppuccin",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-mdbook": "nixpkgs-mdbook"
+        "nixpkgs-mdbook": "nixpkgs-mdbook",
+        "nixpkgs-python": "nixpkgs-python"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,8 +3,12 @@
 
   inputs = {
     # Stable 24.11 has Agda 2.7.0.1
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-24.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
     flake-utils.url = "github:numtide/flake-utils";
+    # We aim to support Python 3.8 as long as Ubuntu 20.24 has LTS,
+    # since it ships with that version. Python 3.8 itself is already
+    # EOL, so it was dropped from nixpkgs 24.05
+    nixpkgs-python.url = "github:NixOS/nixpkgs/nixos-23.11";
     # Nixpkgs with tested versions of mdbook crates;
     # may be removed once we backport new mdbook assets to our
     # modified versions
@@ -15,13 +19,14 @@
     };
   };
 
-  outputs = { self, nixpkgs, nixpkgs-mdbook, flake-utils, mdbook-catppuccin }:
+  outputs = { self, nixpkgs, nixpkgs-mdbook, nixpkgs-python, flake-utils, mdbook-catppuccin }:
     flake-utils.lib.eachDefaultSystem
       (system:
         let
           pkgs = nixpkgs.legacyPackages."${system}";
           pkgs-mdbook = nixpkgs-mdbook.legacyPackages."${system}";
-          python = pkgs.python38.withPackages (p: with p; [
+          pkgs-python = nixpkgs-python.legacyPackages."${system}";
+          python = pkgs-python.python38.withPackages (p: with p; [
             # Keep in sync with scripts/requirements.txt
             # pre-commit <- not installed as a Python package but as a binary below
             pybtex

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,8 @@
   description = "agda-unimath";
 
   inputs = {
-    # Unstable is needed for Agda 2.6.4, latest stable 23.05 only has 2.6.3
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    # Stable 24.11 has Agda 2.7.0.1
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-24.11";
     flake-utils.url = "github:numtide/flake-utils";
     # Nixpkgs with tested versions of mdbook crates;
     # may be removed once we backport new mdbook assets to our

--- a/src/reflection/definitions.lagda.md
+++ b/src/reflection/definitions.lagda.md
@@ -34,13 +34,24 @@ The `Definition-Agda` type represents a definition in Agda.
 
 ```agda
 data Definition-Agda : UU lzero where
-  function-Definition-Agda : list Clause-Agda → Definition-Agda
-  data-type-Definition-Agda : ℕ → list Name-Agda → Definition-Agda
+
+  function-Definition-Agda :
+    list Clause-Agda → Definition-Agda
+
+  data-type-Definition-Agda :
+    ℕ → list Name-Agda → Definition-Agda
+
   record-type-Definition-Agda :
     Name-Agda → list (Argument-Agda Name-Agda) → Definition-Agda
-  data-constructor-Definition-Agda : Name-Agda → Definition-Agda
-  postulate-Definition-Agda : Definition-Agda
-  primitive-function-Definition-Agda : Definition-Agda
+
+  data-constructor-Definition-Agda :
+    Name-Agda → Quantity-Argument-Agda → Definition-Agda
+
+  postulate-Definition-Agda :
+    Definition-Agda
+
+  primitive-function-Definition-Agda :
+    Definition-Agda
 ```
 
 ## Bindings

--- a/src/reflection/type-checking-monad.lagda.md
+++ b/src/reflection/type-checking-monad.lagda.md
@@ -161,7 +161,9 @@ postulate
   declare-data :
     Name-Agda → ℕ → Term-Agda → type-Type-Checker unit
   define-data :
-    Name-Agda → list (Name-Agda × Term-Agda) → type-Type-Checker unit
+    Name-Agda →
+    list (Name-Agda × Quantity-Argument-Agda × Term-Agda) →
+    type-Type-Checker unit
 ```
 
 ## Bindings


### PR DESCRIPTION
I think it's about time we consider updating the library to Agda 2.7.0. It's very unfortunate that the newest version is still not hosted with homebrew, but considering it's been over 5 months now and [nothing's happening](https://github.com/Homebrew/homebrew-core/pull/193315), we should consider moving away from depending on it.