### PR TITLE
Make GoatCounter ignore the URL query

### DIFF
--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -356,6 +356,11 @@
 
     </div>
 
+    <script>
+        window.goatcounter = {
+            path: location.pathname || '/'
+        };
+    </script>
     <script data-goatcounter="https://agda-unimath.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
 </body>
 


### PR DESCRIPTION
The snippet comes from the [documentation](https://www.goatcounter.com/help/path#using-window-goatcounter-490).

We should probably be able to get the canonical path from mdbook, but I couldn't find how to get the `site-url` into the template, which we would want to avoid hardcoding `/agda-unimath` in too many places.

There's also the issue with `/`, `/index.html` and `/HOME.html` all being the same page with different paths, but I didn't want to put too much effort into coming up with a principled fix.

Fixes #1247