### PR TITLE
Path-cosplittings of locally small types are locally small

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -59,12 +59,12 @@
       "problemMatcher": [],
       // "hide": true,
       "presentation": {
-        "reveal": "silent",
         "revealProblems": "onProblem",
-        "close": true
+        "close": false
       },
       "runOptions": {
-        "runOn": "default"
+        "runOn": "default",
+        "instanceLimit": 99
       }
     }
   ],

--- a/scripts/remove_unused_imports.py
+++ b/scripts/remove_unused_imports.py
@@ -139,5 +139,5 @@ if __name__ == '__main__':
         executor.map(lambda file: process_agda_file(
             file, agda_options, root, temp_dir), sorted_agda_files)
 
-    shutil.rmtree(temp_root)
+    # shutil.rmtree(temp_root)
     sys.exit(status)

--- a/src/foundation/locally-small-types.lagda.md
+++ b/src/foundation/locally-small-types.lagda.md
@@ -8,14 +8,15 @@ module foundation.locally-small-types where
 
 ```agda
 open import foundation.dependent-pair-types
+open import foundation.equivalences
 open import foundation.function-extensionality
 open import foundation.inhabited-subtypes
 open import foundation.subuniverses
 open import foundation.univalence
 open import foundation.universe-levels
 
+open import foundation-core.embeddings
 open import foundation-core.equality-dependent-pair-types
-open import foundation-core.equivalences
 open import foundation-core.function-types
 open import foundation-core.homotopies
 open import foundation-core.identity-types
@@ -31,7 +32,9 @@ open import foundation-core.truncation-levels
 
 ## Idea
 
-A type is said to be **locally small** with respect to a universe `UU l` if its
+A type is said to be
+{{#concept "locally small" Disambiguation="type" Agda=is-locally-small}} with
+respect to a [universe](foundation.universe-levels.md) `UU l` if its
 [identity types](foundation-core.identity-types.md) are
 [small](foundation-core.small-types.md) with respect to that universe.
 
@@ -114,6 +117,28 @@ pr2 (is-locally-small-Prop l A) = is-prop-is-locally-small l A
 ```agda
 is-locally-small' : {l : Level} {A : UU l} → is-locally-small l A
 is-locally-small' x y = is-small'
+```
+
+### Locally small types are closed under embeddings
+
+```agda
+is-locally-small-emb :
+  {l1 l2 l : Level} {A : UU l1} {B : UU l2} →
+  A ↪ B → is-locally-small l B → is-locally-small l A
+is-locally-small-emb f H x y =
+  is-small-equiv
+    ( map-emb f x ＝ map-emb f y)
+    ( equiv-ap-emb f)
+    ( H (map-emb f x) (map-emb f y))
+```
+
+### Locally small types are closed under equivalences
+
+```agda
+is-locally-small-equiv :
+  {l1 l2 l : Level} {A : UU l1} {B : UU l2} →
+  A ≃ B → is-locally-small l B → is-locally-small l A
+is-locally-small-equiv e = is-locally-small-emb (emb-equiv e)
 ```
 
 ### Any small type is locally small

--- a/src/foundation/path-cosplit-maps.lagda.md
+++ b/src/foundation/path-cosplit-maps.lagda.md
@@ -82,7 +82,7 @@ Being `k`-path-cosplitting instead answers the question:
 > At which dimension is the action a
 > [retract](foundation-core.retracts-of-types.md)?
 
-Thus a _-2-path-cosplit map_ is a map equipped with a
+Thus a _`-2`-path-cosplit map_ is a map equipped with a
 [retraction](foundation-core.retractions.md). A _`k+1`-path-cosplit map_ is a
 map whose
 [action on identifications](foundation.action-on-identifications-functions.md)
@@ -94,11 +94,56 @@ induce retracts on higher homotopy groups.
 
 ## Definitions
 
+### The predicate on a map of being path-cosplit
+
 ```agda
 is-path-cosplit :
   {l1 l2 : Level} (k : 𝕋) {A : UU l1} {B : UU l2} → (A → B) → UU (l1 ⊔ l2)
 is-path-cosplit neg-two-𝕋 f = retraction f
 is-path-cosplit (succ-𝕋 k) {A} f = (x y : A) → is-path-cosplit k (ap f {x} {y})
+```
+
+### The type of path-cosplit maps between two types
+
+```agda
+path-cosplit-map :
+  {l1 l2 : Level} → 𝕋 → UU l1 → UU l2 → UU (l1 ⊔ l2)
+path-cosplit-map k A B = Σ (A → B) (is-path-cosplit k)
+
+module _
+  {l1 l2 : Level} {k : 𝕋} {A : UU l1} {B : UU l2} (f : path-cosplit-map k A B)
+  where
+
+  map-path-cosplit-map : A → B
+  map-path-cosplit-map = pr1 f
+
+  is-path-cosplit-path-cosplit-map : is-path-cosplit k map-path-cosplit-map
+  is-path-cosplit-path-cosplit-map = pr2 f
+```
+
+### The type of path-cosplittings of a type
+
+```agda
+path-cosplitting :
+  (l1 : Level) {l2 : Level} → 𝕋 → UU l2 → UU (lsuc l1 ⊔ l2)
+path-cosplitting l1 k B = Σ (UU l1) (λ A → path-cosplit-map k A B)
+
+module _
+  {l1 l2 : Level} {k : 𝕋} {B : UU l2} (H : path-cosplitting l1 k B)
+  where
+
+  type-path-cosplitting : UU l1
+  type-path-cosplitting = pr1 H
+
+  path-cosplit-map-path-cosplitting : path-cosplit-map k type-path-cosplitting B
+  path-cosplit-map-path-cosplitting = pr2 H
+
+  map-path-cosplitting : type-path-cosplitting → B
+  map-path-cosplitting = map-path-cosplit-map path-cosplit-map-path-cosplitting
+
+  is-path-cosplit-map-path-cosplitting : is-path-cosplit k map-path-cosplitting
+  is-path-cosplit-map-path-cosplitting =
+    is-path-cosplit-path-cosplit-map path-cosplit-map-path-cosplitting
 ```
 
 ## Properties
@@ -219,7 +264,7 @@ is-trunc-map-is-path-cosplit-is-trunc-codomain k is-trunc-B is-cosplit-f =
     ( is-trunc-B)
 ```
 
-### If the domain is `k+r+2`-truncated, the type of `k`-path-cosplittings is `r`-truncated
+### If the domain is `k+r+2`-truncated, the type of `k`-path-cosplittings of `f` is `r`-truncated
 
 ```agda
 is-trunc-is-path-cosplit-is-trunc-succ-domain :
@@ -234,7 +279,7 @@ is-trunc-is-path-cosplit-is-trunc-succ-domain {k = succ-𝕋 k} {r} is-trunc-A =
         ( λ y → is-trunc-is-path-cosplit-is-trunc-succ-domain (is-trunc-A x y)))
 ```
 
-### If the domain is `k+1`-truncated then `k`-path-cosplittings are unique
+### If the domain is `k+1`-truncated then `k`-path-cosplittings of `f` are unique
 
 ```agda
 is-prop-is-path-cosplit-is-trunc-succ-domain :
@@ -249,7 +294,7 @@ is-prop-is-path-cosplit-is-trunc-succ-domain {k = succ-𝕋 k} is-trunc-A =
         ( λ y → is-prop-is-path-cosplit-is-trunc-succ-domain (is-trunc-A x y)))
 ```
 
-### If the domain is `k`-truncated then there is a unique `k`-path-cosplitting
+### If the domain is `k`-truncated then there is a unique `k`-path-cosplitting of `f`
 
 ```agda
 is-contr-is-path-cosplit-is-trunc-domain :
@@ -546,8 +591,6 @@ is-path-cosplit-map-coproduct {k = succ-𝕋 k} =
 
 ## See also
 
+- In [Split-idempotent maps](foundation.split-idempotent-maps.md) we show that
+  locally small types are closed under `-1`-path-cosplit maps.
 - [Mere path-cosplit maps](foundation.mere-path-cosplit-maps.md)
-- [Path-split maps](foundation.path-cosplit-maps.md)
-- [Injective maps](foundation-core.injective-maps.md)
-- [Truncated maps](foundation-core.truncated-maps.md)
-- [Embeddings](foundation-core.embeddings.md)

--- a/src/foundation/split-idempotent-maps.lagda.md
+++ b/src/foundation/split-idempotent-maps.lagda.md
@@ -21,11 +21,13 @@ open import foundation.homotopy-algebra
 open import foundation.homotopy-induction
 open import foundation.idempotent-maps
 open import foundation.inverse-sequential-diagrams
-open import foundation.path-algebra
+open import foundation.locally-small-types
+open import foundation.path-cosplit-maps
 open import foundation.quasicoherently-idempotent-maps
 open import foundation.retracts-of-types
 open import foundation.sequential-limits
 open import foundation.structure-identity-principle
+open import foundation.truncation-levels
 open import foundation.type-arithmetic-dependent-pair-types
 open import foundation.univalence
 open import foundation.universe-levels
@@ -79,7 +81,7 @@ One important fact about split idempotent maps is that every
 [quasicoherently idempotent map](foundation.quasicoherently-idempotent-maps.md)
 splits, and conversely, every split idempotent map is quasicoherently
 idempotent. In fact, the type of proofs of split idempotence for an endomap `f`
-is a retract of the type of proofs of quasicoherent idempotence.
+is a retract of the type of proofs of quasicoherent idempotence. {{#cite Shu17}}
 
 ## Definitions
 
@@ -999,11 +1001,12 @@ Note, in particular, that the left-hand square is the inductive hypothesis.
               ( ap f (I (a (second-succ-ℕ n))))) ∙
           ( ap
             ( ξ n ∙_)
-            ( ap
-              ( ap (f ∘ f) (α (succ-ℕ n)) ∙_)
-              ( coh-is-quasicoherently-idempotent H
-                ( a (succ-ℕ (succ-ℕ n)))) ∙
-            ( inv (nat-htpy I (α (succ-ℕ n)))))) ∙
+            ( ( ap
+                ( ap (f ∘ f) (α (succ-ℕ n)) ∙_)
+                ( coh-is-quasicoherently-idempotent
+                  ( H)
+                  ( a (succ-ℕ (succ-ℕ n))))) ∙
+              ( inv (nat-htpy I (α (succ-ℕ n)))))) ∙
           ( inv (assoc (ξ n) (I (a (succ-ℕ n))) (ap f (α (succ-ℕ n)))))))
       where
         ξ :
@@ -1197,6 +1200,23 @@ module _
   is-small-retract is-small-A r =
     is-small-retract'
       ( comp-retract (retract-equiv (equiv-is-small is-small-A)) r)
+```
+
+### Locally small types are closed under path cosplittings
+
+```agda
+module _
+  {l1 l2 l3 : Level} {A : UU l1} {B : UU l2}
+  where
+
+  is-locally-small-path-cosplitting :
+    is-locally-small l3 A →
+    path-cosplit-map neg-one-𝕋 B A →
+    is-locally-small l3 B
+  is-locally-small-path-cosplitting H r x y =
+    is-small-retract
+      ( H (map-path-cosplit-map r x) (map-path-cosplit-map r y))
+      ( ap (map-path-cosplit-map r) , is-path-cosplit-path-cosplit-map r x y)
 ```
 
 ## References

--- a/src/foundation/split-idempotent-maps.lagda.md
+++ b/src/foundation/split-idempotent-maps.lagda.md
@@ -942,11 +942,11 @@ For the inductive step we fill the following diagram as prescribed, in the
 notation of {{#cite Shu17}}:
 
 ```text
-              ξₙ₊₁               I aₙ₊₁             f (αₙ₊₁)⁻¹
-    f a₀ ------------> f (f aₙ₊₁) ---> f aₙ₊₁ --------------------> f (f aₙ₊₂)
-     |                    |                  [nat-htpy]  ___refl___/   |
-  (I⁻¹ a₀)    [Ξₙ]        |       I (f aₙ₊₂)            /         (f ∘ f)(αₙ₊₂)
-     ∨                    ∨         ------>           /                ∨
+              ξₙ₊₁                   I aₙ₊₁
+    f a₀ ------------> f (f aₙ₊₁) -----------> f aₙ₊₁
+     |                    |      [nat-htpy]      |
+  (I⁻¹ a₀)    [Ξₙ]        |       I (f aₙ₊₂)     | f (αₙ₊₁)⁻¹
+     ∨                    ∨         ------>      ∨
   f (f a₀) --------> f (f (f aₙ₊₂))   [J]   f (f aₙ₊₂) ----------> f (f (f aₙ₊₃))
      (f (ξₙ ∙ I aₙ₊₁ ∙ f αₙ₊₁))     ------>           (f ∘ f) (αₙ₊₂)
                                   f (I aₙ₊₂)

--- a/src/foundation/split-idempotent-maps.lagda.md
+++ b/src/foundation/split-idempotent-maps.lagda.md
@@ -942,14 +942,14 @@ For the inductive step we fill the following diagram as prescribed, in the
 notation of {{#cite Shu17}}:
 
 ```text
-              ξₙ₊₁                   I aₙ₊₁
-    f a₀ ------------> f (f aₙ₊₁) -----------> f aₙ₊₁
-     |                    |      [nat-htpy]      |
-  (I⁻¹ a₀)    [Ξₙ]        |       I (f aₙ₊₂)     | f (αₙ₊₁)⁻¹
-     ∨                    ∨         ------>      ∨
-  f (f a₀) --------> f (f (f aₙ₊₂))   [J]   f (f aₙ₊₂) ----------> f (f (f aₙ₊₃))
-     (f (ξₙ ∙ I aₙ₊₁ ∙ f αₙ₊₁))     ------>           (f ∘ f) (αₙ₊₂)
-                                  f (I aₙ₊₂)
+                  ξₙ₊₁                   I aₙ₊₁
+        f a₀ ------------> f (f aₙ₊₁) -------------> f aₙ₊₁
+         |                     |       [nat-htpy]      |
+  I⁻¹ a₀ |        [Ξₙ]         |                       | f (αₙ₊₁)⁻¹
+         ∨                     ∨        -------->      ∨
+      f (f a₀) --------> f (f (f aₙ₊₂))    [J]    f (f aₙ₊₂) ----> f (f (f aₙ₊₃))
+         (f (ξₙ ∙ I aₙ₊₁ ∙ f αₙ₊₁))     -------->          f (f αₙ₊₂)
+                                        f (I aₙ₊₂)
 ```
 
 where the symbols translate to code as follows:


### PR DESCRIPTION
Shows that locally small types are closed under path-cosplittings.