### PR TITLE
Arithmetically located Dedekind cuts

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -890,3 +890,15 @@ archivePrefix = {arXiv},
   pubstate    = {preprint},
   keywords    = {Mathematics - Algebraic Topology,Mathematics - Category Theory}
 }
+
+@article{TaylorP:dedras,
+  author = {Bauer, Andrej and Taylor, Paul},
+  title = {The {D}edekind Reals in Abstract {S}tone Duality},
+  journal = {Mathematical Structures in Computer Science},
+  publisher = {Cambridge University Press},
+  year = 2009,
+  volume = 19,
+  pages = {757--838},
+  doi = {10.1017/S0960129509007695},
+  url = {PaulTaylor.EU/ASD/dedras/},
+  amsclass = {03F60, 06E15, 18C20, 26E40, 54D45, 65G40}}

--- a/src/elementary-number-theory/strict-inequality-integer-fractions.lagda.md
+++ b/src/elementary-number-theory/strict-inequality-integer-fractions.lagda.md
@@ -157,41 +157,42 @@ module _
   (p q r : fraction-ℤ)
   where
 
-  concatenate-le-leq-fraction-ℤ :
-    le-fraction-ℤ p q →
-    leq-fraction-ℤ q r →
-    le-fraction-ℤ p r
-  concatenate-le-leq-fraction-ℤ H H' =
-    is-positive-right-factor-mul-ℤ
-      ( is-positive-eq-ℤ
-        ( lemma-add-cross-mul-diff-fraction-ℤ p q r)
-        ( is-positive-add-nonnegative-positive-ℤ
-          ( is-nonnegative-mul-ℤ
-            ( is-nonnegative-is-positive-ℤ
-              ( is-positive-denominator-fraction-ℤ p))
-            ( H'))
-          ( is-positive-mul-ℤ
-            ( is-positive-denominator-fraction-ℤ r)
-            ( H))))
-      ( is-positive-denominator-fraction-ℤ q)
+  abstract
+    concatenate-le-leq-fraction-ℤ :
+      le-fraction-ℤ p q →
+      leq-fraction-ℤ q r →
+      le-fraction-ℤ p r
+    concatenate-le-leq-fraction-ℤ H H' =
+      is-positive-right-factor-mul-ℤ
+        ( is-positive-eq-ℤ
+          ( lemma-add-cross-mul-diff-fraction-ℤ p q r)
+          ( is-positive-add-nonnegative-positive-ℤ
+            ( is-nonnegative-mul-ℤ
+              ( is-nonnegative-is-positive-ℤ
+                ( is-positive-denominator-fraction-ℤ p))
+              ( H'))
+            ( is-positive-mul-ℤ
+              ( is-positive-denominator-fraction-ℤ r)
+              ( H))))
+        ( is-positive-denominator-fraction-ℤ q)
 
-  concatenate-leq-le-fraction-ℤ :
-    leq-fraction-ℤ p q →
-    le-fraction-ℤ q r →
-    le-fraction-ℤ p r
-  concatenate-leq-le-fraction-ℤ H H' =
-    is-positive-right-factor-mul-ℤ
-      ( is-positive-eq-ℤ
-        ( lemma-add-cross-mul-diff-fraction-ℤ p q r)
-        ( is-positive-add-positive-nonnegative-ℤ
-          ( is-positive-mul-ℤ
-            ( is-positive-denominator-fraction-ℤ p)
-            ( H'))
-          ( is-nonnegative-mul-ℤ
-            ( is-nonnegative-is-positive-ℤ
-              ( is-positive-denominator-fraction-ℤ r))
-            ( H))))
-      ( is-positive-denominator-fraction-ℤ q)
+    concatenate-leq-le-fraction-ℤ :
+      leq-fraction-ℤ p q →
+      le-fraction-ℤ q r →
+      le-fraction-ℤ p r
+    concatenate-leq-le-fraction-ℤ H H' =
+      is-positive-right-factor-mul-ℤ
+        ( is-positive-eq-ℤ
+          ( lemma-add-cross-mul-diff-fraction-ℤ p q r)
+          ( is-positive-add-positive-nonnegative-ℤ
+            ( is-positive-mul-ℤ
+              ( is-positive-denominator-fraction-ℤ p)
+              ( H'))
+            ( is-nonnegative-mul-ℤ
+              ( is-nonnegative-is-positive-ℤ
+                ( is-positive-denominator-fraction-ℤ r))
+              ( H))))
+        ( is-positive-denominator-fraction-ℤ q)
 ```
 
 ### Chaining rules for similarity and strict inequality on the integer fractions

--- a/src/elementary-number-theory/strict-inequality-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/strict-inequality-rational-numbers.lagda.md
@@ -236,26 +236,29 @@ module _
   (x y : ℚ)
   where
 
-  iff-translate-diff-le-zero-ℚ : le-ℚ zero-ℚ (y -ℚ x) ↔ le-ℚ x y
-  iff-translate-diff-le-zero-ℚ =
-    logical-equivalence-reasoning
-      le-ℚ zero-ℚ (y -ℚ x)
-      ↔ le-fraction-ℤ
-        ( zero-fraction-ℤ)
-        ( add-fraction-ℤ (fraction-ℚ y) (neg-fraction-ℤ (fraction-ℚ x)))
-        by
-          inv-iff
-            ( iff-le-right-rational-fraction-ℤ
-              ( zero-ℚ)
-              ( add-fraction-ℤ (fraction-ℚ y) (neg-fraction-ℤ (fraction-ℚ x))))
-      ↔ le-ℚ x y
-        by
-          inv-tr
-            ( _↔ le-ℚ x y)
-            ( eq-translate-diff-le-zero-fraction-ℤ
-              ( fraction-ℚ x)
-              ( fraction-ℚ y))
-            ( id-iff)
+  abstract
+    iff-translate-diff-le-zero-ℚ : le-ℚ zero-ℚ (y -ℚ x) ↔ le-ℚ x y
+    iff-translate-diff-le-zero-ℚ =
+      logical-equivalence-reasoning
+        le-ℚ zero-ℚ (y -ℚ x)
+        ↔ le-fraction-ℤ
+          ( zero-fraction-ℤ)
+          ( add-fraction-ℤ (fraction-ℚ y) (neg-fraction-ℤ (fraction-ℚ x)))
+          by
+            inv-iff
+              ( iff-le-right-rational-fraction-ℤ
+                ( zero-ℚ)
+                ( add-fraction-ℤ
+                  ( fraction-ℚ y)
+                  ( neg-fraction-ℤ (fraction-ℚ x))))
+        ↔ le-ℚ x y
+          by
+            inv-tr
+              ( _↔ le-ℚ x y)
+              ( eq-translate-diff-le-zero-fraction-ℤ
+                ( fraction-ℚ x)
+                ( fraction-ℚ y))
+              ( id-iff)
 ```
 
 ### Strict inequality on the rational numbers is invariant by translation
@@ -265,34 +268,35 @@ module _
   (z x y : ℚ)
   where
 
-  iff-translate-left-le-ℚ : le-ℚ (z +ℚ x) (z +ℚ y) ↔ le-ℚ x y
-  iff-translate-left-le-ℚ =
-    logical-equivalence-reasoning
-      le-ℚ (z +ℚ x) (z +ℚ y)
-      ↔ le-ℚ zero-ℚ ((z +ℚ y) -ℚ (z +ℚ x))
-        by (inv-iff (iff-translate-diff-le-zero-ℚ (z +ℚ x) (z +ℚ y)))
-      ↔ le-ℚ zero-ℚ (y -ℚ x)
-        by
-          ( inv-tr
-            ( _↔ le-ℚ zero-ℚ (y -ℚ x))
-            ( ap (le-ℚ zero-ℚ) (left-translation-diff-ℚ y x z))
-            ( id-iff))
-      ↔ le-ℚ x y
-        by (iff-translate-diff-le-zero-ℚ x y)
+  abstract
+    iff-translate-left-le-ℚ : le-ℚ (z +ℚ x) (z +ℚ y) ↔ le-ℚ x y
+    iff-translate-left-le-ℚ =
+      logical-equivalence-reasoning
+        le-ℚ (z +ℚ x) (z +ℚ y)
+        ↔ le-ℚ zero-ℚ ((z +ℚ y) -ℚ (z +ℚ x))
+          by (inv-iff (iff-translate-diff-le-zero-ℚ (z +ℚ x) (z +ℚ y)))
+        ↔ le-ℚ zero-ℚ (y -ℚ x)
+          by
+            ( inv-tr
+              ( _↔ le-ℚ zero-ℚ (y -ℚ x))
+              ( ap (le-ℚ zero-ℚ) (left-translation-diff-ℚ y x z))
+              ( id-iff))
+        ↔ le-ℚ x y
+          by (iff-translate-diff-le-zero-ℚ x y)
 
-  iff-translate-right-le-ℚ : le-ℚ (x +ℚ z) (y +ℚ z) ↔ le-ℚ x y
-  iff-translate-right-le-ℚ =
-    logical-equivalence-reasoning
-      le-ℚ (x +ℚ z) (y +ℚ z)
-      ↔ le-ℚ zero-ℚ ((y +ℚ z) -ℚ (x +ℚ z))
-        by (inv-iff (iff-translate-diff-le-zero-ℚ (x +ℚ z) (y +ℚ z)))
-      ↔ le-ℚ zero-ℚ (y -ℚ x)
-        by
-          ( inv-tr
-            ( _↔ le-ℚ zero-ℚ (y -ℚ x))
-            ( ap (le-ℚ zero-ℚ) (right-translation-diff-ℚ y x z))
-            ( id-iff))
-      ↔ le-ℚ x y by (iff-translate-diff-le-zero-ℚ x y)
+    iff-translate-right-le-ℚ : le-ℚ (x +ℚ z) (y +ℚ z) ↔ le-ℚ x y
+    iff-translate-right-le-ℚ =
+      logical-equivalence-reasoning
+        le-ℚ (x +ℚ z) (y +ℚ z)
+        ↔ le-ℚ zero-ℚ ((y +ℚ z) -ℚ (x +ℚ z))
+          by (inv-iff (iff-translate-diff-le-zero-ℚ (x +ℚ z) (y +ℚ z)))
+        ↔ le-ℚ zero-ℚ (y -ℚ x)
+          by
+            ( inv-tr
+              ( _↔ le-ℚ zero-ℚ (y -ℚ x))
+              ( ap (le-ℚ zero-ℚ) (right-translation-diff-ℚ y x z))
+              ( id-iff))
+        ↔ le-ℚ x y by (iff-translate-diff-le-zero-ℚ x y)
 
   preserves-le-left-add-ℚ : le-ℚ x y → le-ℚ (x +ℚ z) (y +ℚ z)
   preserves-le-left-add-ℚ = backward-implication iff-translate-right-le-ℚ

--- a/src/real-numbers.lagda.md
+++ b/src/real-numbers.lagda.md
@@ -5,6 +5,7 @@
 ```agda
 module real-numbers where
 
+open import real-numbers.arithmetically-located-cuts public
 open import real-numbers.dedekind-real-numbers public
 open import real-numbers.metric-space-of-real-numbers public
 open import real-numbers.rational-real-numbers public

--- a/src/real-numbers/arithmetically-located-cuts.lagda.md
+++ b/src/real-numbers/arithmetically-located-cuts.lagda.md
@@ -1,0 +1,101 @@
+# Arithmetically located cuts
+
+```agda
+module real-numbers.arithmetically-located-cuts where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import elementary-number-theory.addition-rational-numbers
+open import elementary-number-theory.additive-group-of-rational-numbers
+open import elementary-number-theory.difference-rational-numbers
+open import elementary-number-theory.inequality-rational-numbers
+open import elementary-number-theory.positive-rational-numbers
+open import elementary-number-theory.rational-numbers
+open import elementary-number-theory.strict-inequality-rational-numbers
+
+open import foundation.cartesian-product-types
+open import foundation.conjunction
+open import foundation.coproduct-types
+open import foundation.dependent-pair-types
+open import foundation.disjunction
+open import foundation.existential-quantification
+open import foundation.identity-types
+open import foundation.logical-equivalences
+open import foundation.raising-universe-levels
+open import foundation.subtypes
+open import foundation.transport-along-identifications
+open import foundation.universe-levels
+
+open import group-theory.abelian-groups
+```
+
+</details>
+
+## Definition
+
+```agda
+module _
+  {l : Level}
+  (L : subtype l ℚ)
+  (U : subtype l ℚ)
+  where
+
+  is-arithmetically-located : UU l
+  is-arithmetically-located =
+    (ε : ℚ) →
+    is-positive-ℚ ε →
+    exists (ℚ × ℚ) (λ (p , q) → le-ℚ-Prop p q ∧ le-ℚ-Prop q (p +ℚ ε) ∧ L p ∧ U q)
+```
+### Arithmetically located cuts are located
+
+If a cut is arithmetically located and closed under strict inequality on the rational numbers, it is also located.
+
+```agda
+module _
+  {l : Level}
+  (L : subtype l ℚ)
+  (U : subtype l ℚ)
+  where
+
+  arithmetically-located-and-closed-location :
+    is-arithmetically-located L U →
+    ((p q : ℚ) → le-ℚ p q → is-in-subtype L q → is-in-subtype L p) →
+    ((p q : ℚ) → le-ℚ p q → is-in-subtype U p → is-in-subtype U q) →
+    (p q : ℚ) → le-ℚ p q → type-disjunction-Prop (L p) (U q)
+  arithmetically-located-and-closed-location AL lower-closed upper-closed p q p<q =
+    elim-exists
+      (L p ∨ U q)
+      (λ (p' , q') (p'<q' , q'<p'+ε , p'-in-l , q'-in-u) →
+        rec-coproduct
+          (λ p<p' → inl-disjunction (lower-closed p p' p<p' p'-in-l))
+          (λ p'≤p → inr-disjunction
+            ( upper-closed
+              ( q')
+              ( q)
+              ( concatenate-le-leq-ℚ
+                ( q')
+                ( p' +ℚ (q -ℚ p))
+                ( q)
+                ( q'<p'+ε)
+                ( tr
+                  ( leq-ℚ (p' +ℚ q -ℚ p))
+                  ( equational-reasoning
+                    p +ℚ (q -ℚ p)
+                    ＝ (p +ℚ q) -ℚ p
+                      by inv (associative-add-ℚ p q (neg-ℚ p))
+                    ＝ q
+                      by is-identity-conjugation-Ab abelian-group-add-ℚ p q)
+                  ( backward-implication
+                    ( iff-translate-right-leq-ℚ (q -ℚ p) p' p)
+                    ( p'≤p))))
+              ( q'-in-u)))
+          (decide-le-leq-ℚ p p'))
+      ( AL
+        ( q -ℚ p)
+        ( is-positive-le-zero-ℚ
+          ( q -ℚ p) (backward-implication (iff-translate-diff-le-zero-ℚ p q) p<q)))
+```
+
+### The cuts of Dedekind real numbers are arithmetically located

--- a/src/real-numbers/arithmetically-located-cuts.lagda.md
+++ b/src/real-numbers/arithmetically-located-cuts.lagda.md
@@ -35,6 +35,11 @@ open import group-theory.abelian-groups
 
 ## Definition
 
+A cut `(L, U)` is arithmetically located if for any positive `ε : ℚ`, there
+exist `p, q : ℚ` such that `0 < q - p < ε`, `p ∈ L`, and `q ∈ U`.  Intuitively,
+when `L , U` represent the Dedekind cuts of a real number `x`, `p` and `q` are
+rational approximations of `x` to within `ε`.
+
 ```agda
 module _
   {l : Level}
@@ -46,11 +51,15 @@ module _
   is-arithmetically-located =
     (ε : ℚ) →
     is-positive-ℚ ε →
-    exists (ℚ × ℚ) (λ (p , q) → le-ℚ-Prop p q ∧ le-ℚ-Prop q (p +ℚ ε) ∧ L p ∧ U q)
+    exists
+      ( ℚ × ℚ)
+      ( λ (p , q) → le-ℚ-Prop p q ∧ le-ℚ-Prop q (p +ℚ ε) ∧ L p ∧ U q)
 ```
+
 ### Arithmetically located cuts are located
 
-If a cut is arithmetically located and closed under strict inequality on the rational numbers, it is also located.
+If a cut is arithmetically located and closed under strict inequality on the
+rational numbers, it is also located.
 
 ```agda
 module _
@@ -59,41 +68,49 @@ module _
   (U : subtype l ℚ)
   where
 
-  arithmetically-located-and-closed-location :
-    is-arithmetically-located L U →
-    ((p q : ℚ) → le-ℚ p q → is-in-subtype L q → is-in-subtype L p) →
-    ((p q : ℚ) → le-ℚ p q → is-in-subtype U p → is-in-subtype U q) →
-    (p q : ℚ) → le-ℚ p q → type-disjunction-Prop (L p) (U q)
-  arithmetically-located-and-closed-location AL lower-closed upper-closed p q p<q =
-    elim-exists
-      (L p ∨ U q)
-      (λ (p' , q') (p'<q' , q'<p'+ε , p'-in-l , q'-in-u) →
-        rec-coproduct
-          (λ p<p' → inl-disjunction (lower-closed p p' p<p' p'-in-l))
-          (λ p'≤p → inr-disjunction
-            ( upper-closed
-              ( q')
-              ( q)
-              ( concatenate-le-leq-ℚ
+  abstract
+    arithmetically-located-and-closed-located :
+      is-arithmetically-located L U →
+      ((p q : ℚ) → le-ℚ p q → is-in-subtype L q → is-in-subtype L p) →
+      ((p q : ℚ) → le-ℚ p q → is-in-subtype U p → is-in-subtype U q) →
+      (p q : ℚ) → le-ℚ p q → type-disjunction-Prop (L p) (U q)
+    arithmetically-located-and-closed-located
+      arithmetically-located lower-closed upper-closed p q p<q =
+      elim-exists
+        (L p ∨ U q)
+        (λ (p' , q') (p'<q' , q'<p'+ε , p'-in-l , q'-in-u) →
+          rec-coproduct
+            (λ p<p' → inl-disjunction (lower-closed p p' p<p' p'-in-l))
+            (λ p'≤p → inr-disjunction
+              ( upper-closed
                 ( q')
-                ( p' +ℚ (q -ℚ p))
                 ( q)
-                ( q'<p'+ε)
-                ( tr
-                  ( leq-ℚ (p' +ℚ q -ℚ p))
-                  ( equational-reasoning
-                    p +ℚ (q -ℚ p)
-                    ＝ (p +ℚ q) -ℚ p
-                      by inv (associative-add-ℚ p q (neg-ℚ p))
-                    ＝ q
-                      by is-identity-conjugation-Ab abelian-group-add-ℚ p q)
-                  ( backward-implication
-                    ( iff-translate-right-leq-ℚ (q -ℚ p) p' p)
-                    ( p'≤p))))
-              ( q'-in-u)))
-          (decide-le-leq-ℚ p p'))
-      ( AL
-        ( q -ℚ p)
-        ( is-positive-le-zero-ℚ
-          ( q -ℚ p) (backward-implication (iff-translate-diff-le-zero-ℚ p q) p<q)))
+                ( concatenate-le-leq-ℚ
+                  ( q')
+                  ( p' +ℚ (q -ℚ p))
+                  ( q)
+                  ( q'<p'+ε)
+                  ( tr
+                    ( leq-ℚ (p' +ℚ q -ℚ p))
+                    ( equational-reasoning
+                      p +ℚ (q -ℚ p)
+                      ＝ (p +ℚ q) -ℚ p
+                        by inv (associative-add-ℚ p q (neg-ℚ p))
+                      ＝ q
+                        by is-identity-conjugation-Ab abelian-group-add-ℚ p q)
+                    ( backward-implication
+                      ( iff-translate-right-leq-ℚ (q -ℚ p) p' p)
+                      ( p'≤p))))
+                ( q'-in-u)))
+            (decide-le-leq-ℚ p p'))
+        ( arithmetically-located
+          ( q -ℚ p)
+          ( is-positive-le-zero-ℚ
+            ( q -ℚ p)
+            ( backward-implication (iff-translate-diff-le-zero-ℚ p q) p<q)))
 ```
+## References
+
+This page follows parts of Section 11 in {{#cite TaylorP:dedras}}.
+
+{{#bibliography}}

--- a/src/real-numbers/arithmetically-located-cuts.lagda.md
+++ b/src/real-numbers/arithmetically-located-cuts.lagda.md
@@ -97,5 +97,3 @@ module _
         ( is-positive-le-zero-ℚ
           ( q -ℚ p) (backward-implication (iff-translate-diff-le-zero-ℚ p q) p<q)))
 ```
-
-### The cuts of Dedekind real numbers are arithmetically located


### PR DESCRIPTION
We define what it means for a cut to be arithmetically located, and show that a cut that is arithmetically located and closed under the ordering of the rationals is located.

Reviewing the goal of addition on the reals, the strategy is:

* the Archimedean property of the rationals is necessary to show Dedekind cuts are arithmetically located
* that allows us to approximate two reals `x` and `y` within `epsilon/2`
* the sums of the lower and upper bounds on `x` and `y` are within `epsilon`
* the sum is arithmetically located
* the sum is located and therefore a valid Dedekind cut

This seems to take forever to compile -- `make pre-commit` took almost five minutes despite only compiling this one file -- but I have optimistically attempted marking more properties of the rationals `abstract` in the hope that will help.  Any other advice for improving compilation times would be strongly appreciated.

I also keep failing to find a pre-proven identity that shows that `a + (b - a)` is the identity in an Abelian group.  There are lots of other identities that are just slightly different, with a different ordering or parenthesization, but it seems like that probably exists and I'm just not seeing it?