### PR TITLE
Reassociated conjugation is the identity

### DIFF
--- a/src/group-theory/abelian-groups.lagda.md
+++ b/src/group-theory/abelian-groups.lagda.md
@@ -601,6 +601,11 @@ module _
   is-identity-conjugation-Ab x y =
     ( ap (add-Ab' A (neg-Ab A x)) (commutative-add-Ab A x y)) ∙
     ( is-retraction-right-subtraction-Ab A x y)
+
+  is-identity-conjugation-assoc-Ab' :
+    (x : type-Ab A) → (add-Ab A x ∘ add-Ab' A (neg-Ab A x)) ~ id
+  is-identity-conjugation-assoc-Ab' x y =
+    inv (associative-add-Ab A x y (neg-Ab A x)) ∙ is-identity-conjugation-Ab x y
 ```
 
 ### Laws for conjugation and addition


### PR DESCRIPTION
There is already a result showing conjugation in an Abelian group is the identity, but I find myself repeatedly needing a differently associated version: `x(yx⁻¹)`, not `(xy)x⁻¹`.