### PR TITLE
Generate the dependency graph before building the website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -430,3 +430,4 @@ SUMMARY.md
 CONTRIBUTORS.md
 MAINTAINERS.md
 /website/css/Agda-highlight.css
+/website/images/agda_dependency_graph.svg

--- a/Makefile
+++ b/Makefile
@@ -145,8 +145,12 @@ CONTRIBUTORS.md: ${AGDAFILES} ${CONTRIBUTORS_FILE} ./scripts/generate_contributo
 website/css/Agda-highlight.css: ./scripts/generate_agda_css.py ./theme/catppuccin.css
 	@python3 ./scripts/generate_agda_css.py
 
+website/images/agda_dependency_graph.svg: ${AGDAFILES}
+	@python3 ./scripts/generate_dependency_graph_rendering.py website/images/agda_dependency_graph svg || true
+
 .PHONY: website-prepare
-website-prepare: agda-html ./SUMMARY.md ./CONTRIBUTORS.md ./MAINTAINERS.md ./website/css/Agda-highlight.css
+website-prepare: agda-html ./SUMMARY.md ./CONTRIBUTORS.md ./MAINTAINERS.md \
+								 ./website/css/Agda-highlight.css ./website/images/agda_dependency_graph.svg
 	@cp $(METAFILES) ./docs/
 	@mkdir -p ./docs/website
 	@cp -r ./website/images ./docs/website/
@@ -157,7 +161,6 @@ website-prepare: agda-html ./SUMMARY.md ./CONTRIBUTORS.md ./MAINTAINERS.md ./web
 .PHONY: website
 website: website-prepare
 	@mdbook build
-	@python3 ./scripts/generate_dependency_graph_rendering.py website/images/agda_dependency_graph svg || true
 
 .PHONY: serve-website
 serve-website: website-prepare


### PR DESCRIPTION
The image was generated after the website was built, so it wasn't put into the right directory for mdbook to pick it up.

The new make rule now also doesn't regenerate the image if no agda files changed.