### PR TITLE
total metric spaces

### DIFF
--- a/src/metric-spaces.lagda.md
+++ b/src/metric-spaces.lagda.md
@@ -90,6 +90,7 @@ open import metric-spaces.short-functions-metric-spaces public
 open import metric-spaces.short-functions-premetric-spaces public
 open import metric-spaces.subspaces-metric-spaces public
 open import metric-spaces.symmetric-premetric-structures public
+open import metric-spaces.total-metric-spaces public
 open import metric-spaces.triangular-premetric-structures public
 open import metric-spaces.uniformly-continuous-functions-metric-spaces public
 open import metric-spaces.uniformly-continuous-functions-premetric-spaces public

--- a/src/metric-spaces/total-metric-spaces.lagda.md
+++ b/src/metric-spaces/total-metric-spaces.lagda.md
@@ -1,0 +1,48 @@
+# Total metric spaces
+
+```agda
+module metric-spaces.total-metric-spaces where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.inhabited-subtypes
+open import foundation.propositions
+open import foundation.universe-levels
+
+open import metric-spaces.metric-spaces
+```
+
+</details>
+
+## Idea
+
+A [metric space](metric-spaces.metric-spaces.md) is
+{{#concept "total" Disambiguation="metric space" Agda=is-total-Metric-Space}} if
+all elements are at bounded distance.
+
+## Definitions
+
+### The property of being a total metric space
+
+```agda
+module _
+  {l1 l2 : Level} (A : Metric-Space l1 l2)
+  where
+
+  is-total-prop-Metric-Space : Prop (l1 ⊔ l2)
+  is-total-prop-Metric-Space =
+    Π-Prop
+      ( type-Metric-Space A)
+      ( λ x →
+        Π-Prop
+          ( type-Metric-Space A)
+          ( λ y →
+            is-inhabited-subtype-Prop
+              ( λ d → structure-Metric-Space A d x y)))
+
+  is-total-Metric-Space : UU (l1 ⊔ l2)
+  is-total-Metric-Space =
+    type-Prop is-total-prop-Metric-Space
+```


### PR DESCRIPTION
Some work on **total metric spaces**: metric spaces such that all elements are at bounded distance.
I think it's related to **distance functions**:
-  the existence of a distance function will make a metric space total;
-  maybe there's some kind of converse, where we can use the inhabitedness of the set of upper bound on the distance to define some (lower|upper|)real that would effectively act as a distance? 

I think we'll need this as an hypothesis for [Banach fixed point theorem](https://en.wikipedia.org/wiki/Banach_fixed-point_theorem) (or at least, the proof I have in mind uses it) so that's certainly a concept we might want to add at some point.