### PR TITLE
Work on monads and ordinary precategory adjunctions

### DIFF
--- a/src/category-theory/adjunctions-precategories.lagda.md
+++ b/src/category-theory/adjunctions-precategories.lagda.md
@@ -1,0 +1,291 @@
+# Adjunctions between precategories
+
+```agda
+module category-theory.adjunctions-precategories where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import category-theory.functors-precategories
+open import category-theory.natural-transformations-functors-precategories
+open import category-theory.natural-transformations-maps-precategories
+open import category-theory.precategories
+
+open import foundation.action-on-identifications-functions
+open import foundation.dependent-pair-types
+open import foundation.identity-types
+open import foundation.universe-levels
+
+open import foundation-core.cartesian-product-types
+open import foundation-core.commuting-squares-of-maps
+open import foundation-core.equivalences
+open import foundation-core.function-types
+open import foundation-core.homotopies
+open import foundation-core.retractions
+open import foundation-core.sections
+```
+
+</details>
+## Idea
+
+Let `C` and `D` be two
+[precategories](category-theory.precategories.md). Two
+[functors](category-theory.functors-precategories.md) `L : C → D` and
+`R : D → C` constitute an **adjoint pair** if
+
+- for each pair of objects `X` in `C` and `Y` in `D`, there is an
+  [equivalence](foundation-core.equivalences.md)
+  `ϕ X Y : hom (L X) Y ≃ hom X (R Y)` such that
+- for every pair of morhpisms `f : X₂ → X₁` and `g : Y₁ → Y₂` the following
+  square commutes:
+
+```text
+                       ϕ X₁ Y₁
+        hom (L X₁) Y₁ --------> hom X₁ (R Y₁)
+              |                       |
+  g ∘ - ∘ L f |                       | R g ∘ - ∘ f
+              |                       |
+              ∨                       ∨
+        hom (L X₂) Y₂ --------> hom X₂ (R Y₂)
+                       ϕ X₂ Y₂
+```
+
+In this case we say that `L` is **left adjoint** to `R` and `R` is **right
+adjoint** to `L`, and write this as `L ⊣ R`.
+
+## Definition
+
+### The predicate of being an adjoint pair of functors
+```agda
+module _
+  {l1 l2 l3 l4 : Level}
+  (C : Precategory l1 l2)
+  (D : Precategory l3 l4)
+  (L : functor-Precategory C D)
+  (R : functor-Precategory D C)
+  where
+
+  family-of-equivalences-adjoint-pair-Precategory : UU (l1 ⊔ l2 ⊔ l3 ⊔ l4)
+  family-of-equivalences-adjoint-pair-Precategory =
+    (x : obj-Precategory C) (y : obj-Precategory D) →
+    hom-Precategory D (obj-functor-Precategory C D L x) y ≃
+    hom-Precategory C x (obj-functor-Precategory D C R y)
+
+  naturality-family-of-equivalences-adjoint-pair-Precategory :
+    family-of-equivalences-adjoint-pair-Precategory → UU (l1 ⊔ l2 ⊔ l3 ⊔ l4)
+  naturality-family-of-equivalences-adjoint-pair-Precategory e =
+    {x1 x2 : obj-Precategory C} {y1 y2 : obj-Precategory D}
+    (f : hom-Precategory C x2 x1) (g : hom-Precategory D y1 y2) →
+    coherence-square-maps
+      (map-equiv (e x1 y1))
+      (λ h →
+        comp-hom-Precategory D
+          (comp-hom-Precategory D g h)
+          (hom-functor-Precategory C D L f))
+      (λ h →
+        comp-hom-Precategory C
+          (comp-hom-Precategory C
+            (hom-functor-Precategory D C R g)
+            h)
+          f)
+      (map-equiv (e x2 y2))
+
+  is-adjoint-pair-Precategory : UU (l1 ⊔ l2 ⊔ l3 ⊔ l4)
+  is-adjoint-pair-Precategory =
+    Σ family-of-equivalences-adjoint-pair-Precategory
+      (λ e → naturality-family-of-equivalences-adjoint-pair-Precategory e)
+
+  equiv-is-adjoint-pair-Precategory :
+    is-adjoint-pair-Precategory →
+    family-of-equivalences-adjoint-pair-Precategory
+  equiv-is-adjoint-pair-Precategory = pr1
+
+  naturality-equiv-is-adjoint-pair-Precategory :
+    (H : is-adjoint-pair-Precategory) →
+    naturality-family-of-equivalences-adjoint-pair-Precategory
+      (equiv-is-adjoint-pair-Precategory H)
+  naturality-equiv-is-adjoint-pair-Precategory = pr2
+
+  map-equiv-is-adjoint-pair-Precategory :
+    is-adjoint-pair-Precategory →
+    (x : obj-Precategory C) (y : obj-Precategory D) →
+    hom-Precategory D (obj-functor-Precategory C D L x) y →
+    hom-Precategory C x (obj-functor-Precategory D C R y)
+  map-equiv-is-adjoint-pair-Precategory H X Y =
+    map-equiv (equiv-is-adjoint-pair-Precategory H X Y)
+```
+
+## Adjunctions between precategories
+```agda
+module _
+  {l1 l2 l3 l4 : Level}
+  (C : Precategory l1 l2)
+  (D : Precategory l3 l4)
+  where
+
+  Adjunction-Precategory : UU (l1 ⊔ l2 ⊔ l3 ⊔ l4)
+  Adjunction-Precategory =
+    Σ ((functor-Precategory C D) × (functor-Precategory D C))
+      (λ LR → is-adjoint-pair-Precategory C D (pr1 LR) (pr2 LR))
+
+  make-Adjunction-Precategory :
+    (L : functor-Precategory C D) (R : functor-Precategory D C)
+    (a : is-adjoint-pair-Precategory C D L R) →
+    Adjunction-Precategory
+  make-Adjunction-Precategory L R a = (L , R) , a
+```
+
+### Triangle identities
+
+Equivalently, two functors `L` and `R` are an adjoint pair if there is a natural transformation `η : id ⇒ RL` called the **unit** and a natural transformation `ε : LR ⇒ id` called the **counit** satisfying two **triangle identities**:
+
+```text
+εL ∘ Lη = id
+Rε ∘ ηR = id
+```
+Here, we interpret the equality above as a homotopy of natural transformations to avoid associativity issues.
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level}
+  (C : Precategory l1 l2)
+  (D : Precategory l3 l4)
+  (L : functor-Precategory C D)
+  (R : functor-Precategory D C)
+  where
+
+  private
+    LR = comp-functor-Precategory D C D L R
+    RL = comp-functor-Precategory C D C R L
+    idC = id-functor-Precategory C
+    idD = id-functor-Precategory D
+
+  module _
+    (η : natural-transformation-Precategory C C idC RL)
+    (ε : natural-transformation-Precategory D D LR idD)
+    where
+
+    private
+      η₀ = hom-family-natural-transformation-Precategory C C idC RL η
+      ε₀ = hom-family-natural-transformation-Precategory D D LR idD ε
+      L₀ = obj-functor-Precategory C D L
+      L₁ = hom-functor-Precategory C D L
+      R₀ = obj-functor-Precategory D C R
+      R₁ = hom-functor-Precategory D C R
+    
+    has-left-triangle-identity-Precategory : UU (l1 ⊔ l4)
+    has-left-triangle-identity-Precategory =
+      (x : obj-Precategory C) →
+      (comp-hom-Precategory D
+        (ε₀ (L₀ x))
+        (L₁ (η₀ x))) ＝
+      (id-hom-Precategory D)
+
+    has-right-triangle-identity-Precategory : UU (l2 ⊔ l3)
+    has-right-triangle-identity-Precategory =
+      (y : obj-Precategory D) →
+      (comp-hom-Precategory C
+        (R₁ (ε₀ y))
+        (η₀ (R₀ y))) ＝
+      (id-hom-Precategory C)
+
+    module _
+      (lt : has-left-triangle-identity-Precategory)
+      (rt : has-right-triangle-identity-Precategory)
+      where
+
+      module _
+        (x : obj-Precategory C) (y : obj-Precategory D)
+        where
+
+        map-sharp-unit-counit-Precategory :
+          hom-Precategory D (L₀ x) y →
+          hom-Precategory C x (R₀ y)
+        map-sharp-unit-counit-Precategory g =
+          comp-hom-Precategory C (R₁ g) (η₀ x)
+
+        map-flat-unit-counit-Precategory :
+          hom-Precategory C x (R₀ y) →
+          hom-Precategory D (L₀ x) y
+        map-flat-unit-counit-Precategory f =
+          comp-hom-Precategory D (ε₀ y) (L₁ f)
+
+        section-sharp-unit-counit-Precategory :
+          section map-sharp-unit-counit-Precategory
+        pr1 section-sharp-unit-counit-Precategory =
+          map-flat-unit-counit-Precategory
+        pr2 section-sharp-unit-counit-Precategory f =
+          (ap
+            (precomp-hom-Precategory C (η₀ x) _)
+            (preserves-comp-functor-Precategory D C R (ε₀ y) (L₁ f))) ∙
+          (associative-comp-hom-Precategory C (R₁ (ε₀ y)) (R₁ (L₁ f)) (η₀ x)) ∙
+          (ap
+            (postcomp-hom-Precategory C (R₁ (ε₀ y)) _)
+            (naturality-natural-transformation-Precategory C C
+              (id-functor-Precategory C) RL η f)) ∙
+          (inv (associative-comp-hom-Precategory C (R₁ (ε₀ y)) (η₀ (R₀ y)) f)) ∙
+          (ap (precomp-hom-Precategory C f _) (rt y)) ∙
+          (left-unit-law-comp-hom-Precategory C f)
+
+        retraction-sharp-unit-counit-Precategory :
+          retraction map-sharp-unit-counit-Precategory
+        pr1 retraction-sharp-unit-counit-Precategory =
+          map-flat-unit-counit-Precategory
+        pr2 retraction-sharp-unit-counit-Precategory g =
+          (ap
+            (postcomp-hom-Precategory D (ε₀ y) _)
+            (preserves-comp-functor-Precategory C D L (R₁ g) (η₀ x))) ∙
+          (inv
+            (associative-comp-hom-Precategory D
+              (ε₀ y) (L₁ (R₁ g)) (L₁ (η₀ x)))) ∙
+          (ap
+            (precomp-hom-Precategory D (L₁ (η₀ x)) _)
+            (inv
+              (naturality-natural-transformation-Precategory D D
+                LR (id-functor-Precategory D) ε g))) ∙
+          (associative-comp-hom-Precategory D g (ε₀ (L₀ x)) (L₁ (η₀ x))) ∙
+          (ap (postcomp-hom-Precategory D g _) (lt x)) ∙
+          (right-unit-law-comp-hom-Precategory D g)
+
+        is-equiv-sharp-unit-counit-Precategory :
+          is-equiv map-sharp-unit-counit-Precategory
+        pr1 is-equiv-sharp-unit-counit-Precategory =
+          section-sharp-unit-counit-Precategory
+        pr2 is-equiv-sharp-unit-counit-Precategory =
+          retraction-sharp-unit-counit-Precategory
+
+      equiv-family-unit-counit-Precategory :
+        family-of-equivalences-adjoint-pair-Precategory C D L R
+      pr1 (equiv-family-unit-counit-Precategory x y) =
+        map-sharp-unit-counit-Precategory x y
+      pr2 (equiv-family-unit-counit-Precategory x y) =
+        is-equiv-sharp-unit-counit-Precategory x y
+
+      naturality-equiv-family-unit-counit-Precategory :
+        naturality-family-of-equivalences-adjoint-pair-Precategory C D L R
+          equiv-family-unit-counit-Precategory
+      naturality-equiv-family-unit-counit-Precategory {x1} {x2} {y1} {y2} f g h =
+        (ap
+          (precomp-hom-Precategory C (η₀ x2) _)
+          ( (preserves-comp-functor-Precategory D C R
+              (comp-hom-Precategory D g h) (L₁ f)) ∙
+            (ap
+              (precomp-hom-Precategory C (R₁ (L₁ f)) _)
+              (preserves-comp-functor-Precategory D C R g h)))) ∙
+        (associative-comp-hom-Precategory C _ (R₁ (L₁ f)) (η₀ x2)) ∙
+        (ap
+          (postcomp-hom-Precategory C _ _)
+          (naturality-natural-transformation-Precategory C C idC RL η f)) ∙
+        (inv (associative-comp-hom-Precategory C _ (η₀ x1) f)) ∙
+        (ap
+          (precomp-hom-Precategory C f _)
+          (associative-comp-hom-Precategory C _ _ _))
+
+      is-adjoint-pair-unit-counit-Precategory :
+        is-adjoint-pair-Precategory C D L R
+      pr1 is-adjoint-pair-unit-counit-Precategory =
+        equiv-family-unit-counit-Precategory
+      pr2 is-adjoint-pair-unit-counit-Precategory =
+        naturality-equiv-family-unit-counit-Precategory
+```

--- a/src/category-theory/commuting-squares-of-morphisms-in-precategories.lagda.md
+++ b/src/category-theory/commuting-squares-of-morphisms-in-precategories.lagda.md
@@ -10,6 +10,8 @@ module category-theory.commuting-squares-of-morphisms-in-precategories where
 open import category-theory.commuting-squares-of-morphisms-in-set-magmoids
 open import category-theory.precategories
 
+open import foundation.action-on-identifications-functions
+open import foundation.identity-types
 open import foundation.universe-levels
 ```
 
@@ -47,4 +49,29 @@ coherence-square-hom-Precategory :
   UU l2
 coherence-square-hom-Precategory C =
   coherence-square-hom-Set-Magmoid (set-magmoid-Precategory C)
+
+comp-coherence-square-hom-Precategory :
+  {l1 l2 : Level} (C : Precategory l1 l2)
+  {x y z w a b : obj-Precategory C}
+  (topleft : hom-Precategory C x y)
+  (left : hom-Precategory C x z)
+  (middle : hom-Precategory C y w)
+  (bottomleft : hom-Precategory C z w)
+  (topright : hom-Precategory C y a)
+  (right : hom-Precategory C a b)
+  (bottomright : hom-Precategory C w b) →
+  coherence-square-hom-Precategory C topleft left middle bottomleft →
+  coherence-square-hom-Precategory C topright middle right bottomright →
+  coherence-square-hom-Precategory C
+    (comp-hom-Precategory C topright topleft)
+    left
+    right
+    (comp-hom-Precategory C bottomright bottomleft)
+comp-coherence-square-hom-Precategory C
+  topleft left middle bottomleft topright right bottomright commleft commright =
+  associative-comp-hom-Precategory C _ _ _
+  ∙ ap (postcomp-hom-Precategory C bottomright _) commleft
+  ∙ inv (associative-comp-hom-Precategory C _ _ _)
+  ∙ ap (precomp-hom-Precategory C topleft _) commright
+  ∙ associative-comp-hom-Precategory C _ _ _
 ```

--- a/src/category-theory/monads-on-precategories.lagda.md
+++ b/src/category-theory/monads-on-precategories.lagda.md
@@ -7,16 +7,29 @@ module category-theory.monads-on-precategories where
 <details><summary>Imports</summary>
 
 ```agda
+open import category-theory.adjunctions-precategories
+open import category-theory.commuting-squares-of-morphisms-in-precategories
 open import category-theory.functors-precategories
 open import category-theory.natural-transformations-functors-precategories
+open import category-theory.natural-transformations-maps-precategories
 open import category-theory.pointed-endofunctors-precategories
 open import category-theory.precategories
 
+open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
+open import foundation.equality-cartesian-product-types
 open import foundation.identity-types
+open import foundation.sets
 open import foundation.universe-levels
 
 open import foundation-core.cartesian-product-types
+open import foundation-core.commuting-squares-of-maps
+open import foundation-core.equality-dependent-pair-types
+open import foundation-core.equivalences
+open import foundation-core.function-types
+open import foundation-core.homotopies
+open import foundation-core.propositions
+open import foundation-core.transport-along-identifications
 ```
 
 </details>
@@ -106,6 +119,45 @@ module _
           ( functor-pointed-endofunctor-Precategory C T)
           ( μ)
           ( functor-pointed-endofunctor-Precategory C T))
+
+  associative-mul-hom-family-pointed-endofunctor-Precategory : UU (l1 ⊔ l2)
+  associative-mul-hom-family-pointed-endofunctor-Precategory =
+    (λ x →
+      (comp-hom-Precategory C
+        (hom-family-natural-transformation-Precategory C C
+          (comp-functor-Precategory C C C
+            (functor-pointed-endofunctor-Precategory C T)
+            (functor-pointed-endofunctor-Precategory C T))
+          (functor-pointed-endofunctor-Precategory C T)
+          μ
+          x)
+        (hom-functor-Precategory C C
+          (functor-pointed-endofunctor-Precategory C T)
+          (hom-family-natural-transformation-Precategory C C
+            (comp-functor-Precategory C C C
+              (functor-pointed-endofunctor-Precategory C T)
+              (functor-pointed-endofunctor-Precategory C T))
+            (functor-pointed-endofunctor-Precategory C T)
+            μ
+            x)))) ~
+    (λ x →
+      (comp-hom-Precategory C
+        (hom-family-natural-transformation-Precategory C C
+          (comp-functor-Precategory C C C
+            (functor-pointed-endofunctor-Precategory C T)
+            (functor-pointed-endofunctor-Precategory C T))
+          (functor-pointed-endofunctor-Precategory C T)
+          μ
+          x)
+        (hom-family-natural-transformation-Precategory C C
+          (comp-functor-Precategory C C C
+            (functor-pointed-endofunctor-Precategory C T)
+            (functor-pointed-endofunctor-Precategory C T))
+          (functor-pointed-endofunctor-Precategory C T)
+          μ
+          (obj-functor-Precategory C C
+            (functor-pointed-endofunctor-Precategory C T)
+            x))))
 ```
 
 ### The left unit law on a multiplication on a pointed endofunctor
@@ -133,6 +185,26 @@ module _
         ( pointing-pointed-endofunctor-Precategory C T)) ＝
     id-natural-transformation-Precategory C C
       ( functor-pointed-endofunctor-Precategory C T)
+
+  left-unit-law-mul-hom-family-pointed-endofunctor-Precategory : UU (l1 ⊔ l2)
+  left-unit-law-mul-hom-family-pointed-endofunctor-Precategory =
+    (λ x →
+      comp-hom-Precategory C
+        (hom-family-natural-transformation-Precategory C C
+          (comp-functor-Precategory C C C
+            (functor-pointed-endofunctor-Precategory C T)
+            (functor-pointed-endofunctor-Precategory C T))
+          (functor-pointed-endofunctor-Precategory C T)
+          μ
+          x)
+        (hom-functor-Precategory C C
+          (functor-pointed-endofunctor-Precategory C T)
+          (hom-family-natural-transformation-Precategory C C
+            (id-functor-Precategory C)
+            (functor-pointed-endofunctor-Precategory C T)
+            (pointing-pointed-endofunctor-Precategory C T)
+            x))) ~
+    (λ x → id-hom-Precategory C)
 ```
 
 ### The right unit law on a multiplication on a pointed endofunctor
@@ -160,6 +232,25 @@ module _
         ( functor-pointed-endofunctor-Precategory C T)) ＝
     id-natural-transformation-Precategory C C
       ( functor-pointed-endofunctor-Precategory C T)
+
+  right-unit-law-mul-hom-family-pointed-endofunctor-Precategory : UU (l1 ⊔ l2)
+  right-unit-law-mul-hom-family-pointed-endofunctor-Precategory =
+    (λ x →
+      comp-hom-Precategory C
+        (hom-family-natural-transformation-Precategory C C
+          (comp-functor-Precategory C C C
+            (functor-pointed-endofunctor-Precategory C T)
+            (functor-pointed-endofunctor-Precategory C T))
+          (functor-pointed-endofunctor-Precategory C T)
+          μ
+          x)
+        (hom-family-natural-transformation-Precategory C C
+          (id-functor-Precategory C)
+          (functor-pointed-endofunctor-Precategory C T)
+          (pointing-pointed-endofunctor-Precategory C T)
+          (obj-functor-Precategory C C
+            (functor-pointed-endofunctor-Precategory C T) x))) ~
+    (λ x → id-hom-Precategory C)
 ```
 
 ### The structure of a monad on a pointed endofunctor on a precategory
@@ -301,6 +392,20 @@ module _
     associative-mul-monad-Precategory =
       pr1 (pr2 (pr2 T))
 
+    associative-mul-hom-family-monad-Precategory :
+      associative-mul-hom-family-pointed-endofunctor-Precategory C
+        (pointed-endofunctor-monad-Precategory)
+        (mul-monad-Precategory)
+    associative-mul-hom-family-monad-Precategory =
+      htpy-eq-hom-family-natural-transformation-Precategory C C
+        (comp-functor-Precategory C C C
+          endofunctor-monad-Precategory
+          (comp-functor-Precategory C C C
+            endofunctor-monad-Precategory
+            endofunctor-monad-Precategory))
+        endofunctor-monad-Precategory
+        associative-mul-monad-Precategory
+
     left-unit-law-mul-monad-Precategory :
       left-unit-law-mul-pointed-endofunctor-Precategory C
         ( pointed-endofunctor-monad-Precategory)
@@ -308,10 +413,437 @@ module _
     left-unit-law-mul-monad-Precategory =
       pr1 (pr2 (pr2 (pr2 T)))
 
+    left-unit-law-mul-hom-family-monad-Precategory :
+      left-unit-law-mul-hom-family-pointed-endofunctor-Precategory C
+        (pointed-endofunctor-monad-Precategory)
+        (mul-monad-Precategory)
+    left-unit-law-mul-hom-family-monad-Precategory =
+      htpy-eq-hom-family-natural-transformation-Precategory C C
+        endofunctor-monad-Precategory endofunctor-monad-Precategory
+        left-unit-law-mul-monad-Precategory
+
     right-unit-law-mul-monad-Precategory :
       right-unit-law-mul-pointed-endofunctor-Precategory C
         ( pointed-endofunctor-monad-Precategory)
         ( mul-monad-Precategory)
     right-unit-law-mul-monad-Precategory =
       pr2 (pr2 (pr2 (pr2 T)))
+
+    right-unit-law-mul-hom-family-monad-Precategory :
+      right-unit-law-mul-hom-family-pointed-endofunctor-Precategory C
+        (pointed-endofunctor-monad-Precategory)
+        (mul-monad-Precategory)
+    right-unit-law-mul-hom-family-monad-Precategory =
+      htpy-eq-hom-family-natural-transformation-Precategory C C
+        endofunctor-monad-Precategory endofunctor-monad-Precategory
+        right-unit-law-mul-monad-Precategory
+```
+
+## Algebras over a monad
+
+```agda
+module _
+  {l1 l2 : Level} (C : Precategory l1 l2)
+  (T : monad-Precategory C)
+  where
+
+  module _
+    {A : obj-Precategory C}
+    (a : hom-Precategory C (obj-endofunctor-monad-Precategory C T A) A)
+    where
+
+    has-unit-law-monad-algebra-Precategory : UU l2
+    has-unit-law-monad-algebra-Precategory =
+        comp-hom-Precategory C a (hom-unit-monad-Precategory C T A) ＝
+        id-hom-Precategory C
+
+    has-mul-law-monad-algebra-Precategory : UU l2
+    has-mul-law-monad-algebra-Precategory =
+        comp-hom-Precategory C a (hom-endofunctor-monad-Precategory C T a) ＝
+        comp-hom-Precategory C a (hom-mul-monad-Precategory C T A)
+
+    is-monad-algebra-Precategory : UU l2
+    is-monad-algebra-Precategory =
+        has-unit-law-monad-algebra-Precategory ×
+        has-mul-law-monad-algebra-Precategory
+
+  monad-algebra-Precategory : UU (l1 ⊔ l2)
+  monad-algebra-Precategory =
+    Σ (obj-Precategory C)
+      (λ A →
+      Σ (hom-Precategory C (obj-endofunctor-monad-Precategory C T A) A)
+        (λ a -> is-monad-algebra-Precategory a))
+
+  obj-monad-algebra-Precategory : monad-algebra-Precategory → obj-Precategory C
+  obj-monad-algebra-Precategory = pr1
+
+  hom-monad-algebra-Precategory : (f : monad-algebra-Precategory) →
+    hom-Precategory C
+      (obj-endofunctor-monad-Precategory C T (obj-monad-algebra-Precategory f))
+      (obj-monad-algebra-Precategory f)
+  hom-monad-algebra-Precategory f = pr1 (pr2 f)
+
+  comm-monad-algebra-Precategory : (f : monad-algebra-Precategory) →
+    is-monad-algebra-Precategory (hom-monad-algebra-Precategory f)
+  comm-monad-algebra-Precategory f = pr2 (pr2 f)
+
+  unit-law-monad-algebra-Precategory : (f : monad-algebra-Precategory) →
+    has-unit-law-monad-algebra-Precategory (hom-monad-algebra-Precategory f)
+  unit-law-monad-algebra-Precategory f = pr1 (pr2 (pr2 f))
+
+  mul-law-monad-algebra-Precategory : (f : monad-algebra-Precategory) →
+    has-mul-law-monad-algebra-Precategory (hom-monad-algebra-Precategory f)
+  mul-law-monad-algebra-Precategory f = pr2 (pr2 (pr2 f))
+
+  monad-algebra-morphism-Precategory : (f g : monad-algebra-Precategory) → UU l2
+  monad-algebra-morphism-Precategory f g =
+    Σ (hom-Precategory C
+        (obj-monad-algebra-Precategory f)
+        (obj-monad-algebra-Precategory g))
+      (λ h →
+        coherence-square-hom-Precategory C
+          (hom-endofunctor-monad-Precategory C T h)
+          (hom-monad-algebra-Precategory f)
+          (hom-monad-algebra-Precategory g)
+          h)
+
+  hom-monad-algebra-morphism-Precategory :
+    (f g : monad-algebra-Precategory)
+    (h : monad-algebra-morphism-Precategory f g) →
+    hom-Precategory C
+      (obj-monad-algebra-Precategory f)
+      (obj-monad-algebra-Precategory g)
+  hom-monad-algebra-morphism-Precategory f g h = pr1 h
+
+  top-hom-monad-algebra-morphism-Precategory :
+    (f g : monad-algebra-Precategory)
+    (h : monad-algebra-morphism-Precategory f g) →
+    hom-Precategory C
+      (obj-endofunctor-monad-Precategory C T (obj-monad-algebra-Precategory f))
+      (obj-endofunctor-monad-Precategory C T (obj-monad-algebra-Precategory g))
+  top-hom-monad-algebra-morphism-Precategory f g h =
+    hom-endofunctor-monad-Precategory C T
+      (hom-monad-algebra-morphism-Precategory f g h)
+
+  comm-hom-monad-algebra-morphism-Precategory :
+    (f g : monad-algebra-Precategory)
+    (h : monad-algebra-morphism-Precategory f g) →
+    coherence-square-hom-Precategory C
+      (top-hom-monad-algebra-morphism-Precategory f g h)
+      (hom-monad-algebra-Precategory f)
+      (hom-monad-algebra-Precategory g)
+      (hom-monad-algebra-morphism-Precategory f g h)
+  comm-hom-monad-algebra-morphism-Precategory f g h = pr2 h
+
+  comp-monad-algebra-morphism-Precategory :
+    (a b c : monad-algebra-Precategory)
+    (g : monad-algebra-morphism-Precategory b c) →
+    (f : monad-algebra-morphism-Precategory a b) →
+    monad-algebra-morphism-Precategory a c
+  comp-monad-algebra-morphism-Precategory a b c g f =
+    (comp-hom-Precategory C
+      (hom-monad-algebra-morphism-Precategory b c g)
+      (hom-monad-algebra-morphism-Precategory a b f)) ,
+    (comp-coherence-square-hom-Precategory C
+      (top-hom-monad-algebra-morphism-Precategory a b f)
+      (hom-monad-algebra-Precategory a)
+      (hom-monad-algebra-Precategory b)
+      (hom-monad-algebra-morphism-Precategory a b f)
+      (top-hom-monad-algebra-morphism-Precategory b c g)
+      (hom-monad-algebra-Precategory c)
+      (hom-monad-algebra-morphism-Precategory b c g)
+      (comm-hom-monad-algebra-morphism-Precategory a b f)
+      (comm-hom-monad-algebra-morphism-Precategory b c g)) ∙
+    (ap
+      (postcomp-hom-Precategory C (hom-monad-algebra-Precategory c) _)
+      (inv (preserves-comp-endofunctor-monad-Precategory C T _ _)))
+
+  is-set-monad-algebra-morphism-Precategory :
+    (f g : monad-algebra-Precategory) →
+    is-set (monad-algebra-morphism-Precategory f g)
+  is-set-monad-algebra-morphism-Precategory f g =
+    is-set-Σ
+      (is-set-hom-Precategory C _ _)
+      (λ hk → is-set-is-prop (is-set-hom-Precategory C _ _ _ _))
+```
+
+## The Kleisli precategory of a monad
+
+This is the precategory of free `T`-algebras and their morphisms; we view it as the precategory with the same objects as `C` but different types of morphisms. It comes with functors to and from `C`.
+
+```agda
+module _
+  {l1 l2 : Level} {C : Precategory l1 l2}
+  (T : monad-Precategory C)
+  where
+
+  private
+    Tf = endofunctor-monad-Precategory C T
+    μ = hom-mul-monad-Precategory C T
+    η = hom-unit-monad-Precategory C T
+    T₀ = obj-endofunctor-monad-Precategory C T
+    T₁ = hom-endofunctor-monad-Precategory C T
+
+  kleisli-monad-Precategory : Precategory l1 l2
+  kleisli-monad-Precategory =
+    make-Precategory
+      (obj-Precategory C)
+      (λ x y → hom-set-Precategory C x (T₀ y))
+      (λ g f → comp-hom-Precategory C (comp-hom-Precategory C (μ _) (T₁ g)) f)
+      (λ x → hom-unit-monad-Precategory C T x)
+      (λ h g f →
+        (ap
+          (precomp-hom-Precategory C f _)
+          ( (ap
+              (postcomp-hom-Precategory C (μ _) _)
+              ( (preserves-comp-endofunctor-monad-Precategory C T _ g) ∙
+                (ap
+                  (precomp-hom-Precategory C (T₁ g) _)
+                  (preserves-comp-endofunctor-monad-Precategory C T _ _)) ∙
+                (associative-comp-hom-Precategory C _ _ _))) ∙
+            (inv (associative-comp-hom-Precategory C _ _ _)) ∙
+            (ap
+              (precomp-hom-Precategory C _ _)
+              (associative-mul-hom-family-monad-Precategory C T _)) ∙
+            (associative-comp-hom-Precategory C _ _ _) ∙
+            (ap
+              (postcomp-hom-Precategory C (μ _) _)
+              ( (inv (associative-comp-hom-Precategory C _ _ _)) ∙
+                (ap
+                  (precomp-hom-Precategory C (T₁ g) _)
+                  (inv (naturality-mul-monad-Precategory C T h))) ∙
+                (associative-comp-hom-Precategory C _ _ _))) ∙
+            (inv (associative-comp-hom-Precategory C _ _ _))) ∙
+        (associative-comp-hom-Precategory C _ _ _)))
+      (λ f →
+        (ap
+          (precomp-hom-Precategory C _ _)
+          (left-unit-law-mul-hom-family-monad-Precategory C T _)) ∙
+        (left-unit-law-comp-hom-Precategory C f))
+      (λ f →
+        (associative-comp-hom-Precategory C _ _ _) ∙
+        (ap
+          (postcomp-hom-Precategory C _ _)
+          (naturality-unit-monad-Precategory C T f)) ∙
+        (inv (associative-comp-hom-Precategory C _ _ _)) ∙
+        (ap
+          (precomp-hom-Precategory C f _)
+          (right-unit-law-mul-hom-family-monad-Precategory C T _)) ∙
+        (left-unit-law-comp-hom-Precategory C f))
+
+  functor-to-kleisli-monad-Precategory :
+    functor-Precategory C kleisli-monad-Precategory
+  functor-to-kleisli-monad-Precategory =
+    id ,
+    (λ {x} {y} f →
+      comp-hom-Precategory C (T₁ f) (hom-unit-monad-Precategory C T x)) ,
+    (λ {x} {y} {z} g f →
+      (ap
+        (precomp-hom-Precategory C (η x) _)
+        ( (preserves-comp-endofunctor-monad-Precategory C T g f) ∙
+          (ap
+            (precomp-hom-Precategory C (T₁ f) _)
+            ( (inv (left-unit-law-comp-hom-Precategory C _)) ∙
+              (ap
+                (precomp-hom-Precategory C (T₁ g) _)
+                (inv (left-unit-law-mul-hom-family-monad-Precategory C T z))) ∙
+              (associative-comp-hom-Precategory C _ _ _) ∙
+              (ap
+                (postcomp-hom-Precategory C (μ z) _)
+                ( (inv
+                    (preserves-comp-endofunctor-monad-Precategory C T
+                      (η z) g)) ∙
+                  (ap
+                    T₁
+                    (inv (naturality-unit-monad-Precategory C T g))))))))) ∙
+      (associative-comp-hom-Precategory C _ _ _)) ,
+    (λ x →
+      (ap
+        (precomp-hom-Precategory C _ _)
+        (preserves-id-endofunctor-monad-Precategory C T x)) ∙
+      (left-unit-law-comp-hom-Precategory C _))
+
+  functor-from-kleisli-monad-Precategory :
+    functor-Precategory kleisli-monad-Precategory C
+  functor-from-kleisli-monad-Precategory =
+    T₀ ,
+    (λ {x} {y} f →
+      comp-hom-Precategory C (hom-mul-monad-Precategory C T y) (T₁ f)) ,
+    (λ {x} {y} {z} g f →
+      (ap
+        (postcomp-hom-Precategory C (μ z) _)
+        ( (preserves-comp-endofunctor-monad-Precategory C T _ f) ∙
+          (ap
+            (precomp-hom-Precategory C (T₁ f) _)
+            (preserves-comp-endofunctor-monad-Precategory C T (μ z) (T₁ g))) ∙
+          (associative-comp-hom-Precategory C _ _ _))) ∙
+      (inv (associative-comp-hom-Precategory C _ _ _)) ∙
+      (ap
+        (precomp-hom-Precategory C _ _)
+        (associative-mul-hom-family-monad-Precategory C T z)) ∙
+      (associative-comp-hom-Precategory C _ _ _) ∙
+      (ap
+        (postcomp-hom-Precategory C (μ z) _)
+        ( (inv (associative-comp-hom-Precategory C _ _ _)) ∙
+          (ap
+            (precomp-hom-Precategory C (T₁ f) _)
+            (inv (naturality-mul-monad-Precategory C T g))) ∙
+          (associative-comp-hom-Precategory C _ _ _))) ∙
+      (inv (associative-comp-hom-Precategory C _ _ _))) ,
+    (left-unit-law-mul-hom-family-monad-Precategory C T)
+```
+
+## The Eilenberg-Moore precategory of a monad
+
+The Eilenberg-Moore category `EM(T)` consists of all `T`-algebras and
+`T`-algebra morphisms. It comes with an adjunction `C : ⇄ EM(T)`.
+
+```agda
+module _
+  {l1 l2 : Level} (C : Precategory l1 l2)
+  (T : monad-Precategory C)
+  where
+
+  private
+    Tf = endofunctor-monad-Precategory C T
+    T₁ = hom-endofunctor-monad-Precategory C T
+    T₀ = obj-endofunctor-monad-Precategory C T
+
+  em-monad-Precategory : Precategory (l1 ⊔ l2) l2
+  em-monad-Precategory = make-Precategory
+    (monad-algebra-Precategory C T)
+    (λ f g →
+      (monad-algebra-morphism-Precategory C T f g) ,
+      (is-set-monad-algebra-morphism-Precategory C T f g))
+    (λ {a} {b} {c} g f → comp-monad-algebra-morphism-Precategory C T a b c g f)
+    (λ x →
+      (id-hom-Precategory C) ,
+      (left-unit-law-comp-hom-Precategory C
+        (hom-monad-algebra-Precategory C T x)) ∙
+      (inv
+        (right-unit-law-comp-hom-Precategory C
+          (hom-monad-algebra-Precategory C T x))) ∙
+      (ap
+        (postcomp-hom-Precategory C _ _)
+        (inv (preserves-id-endofunctor-monad-Precategory C T _))))
+    (λ h g f →
+      eq-pair-Σ
+        (associative-comp-hom-Precategory C _ _ _)
+        (eq-is-prop (is-set-hom-Precategory C _ _ _ _)))
+    (λ {a} {b} f →
+      eq-pair-Σ
+        (left-unit-law-comp-hom-Precategory C
+          (hom-monad-algebra-morphism-Precategory C T a b f))
+        (eq-is-prop (is-set-hom-Precategory C _ _ _ _)))
+    λ {a} {b} f →
+      eq-pair-Σ
+        (right-unit-law-comp-hom-Precategory C
+          (hom-monad-algebra-morphism-Precategory C T a b f))
+        (eq-is-prop (is-set-hom-Precategory C _ _ _ _))
+
+  obj-functor-to-em-monad-Precategory :
+    obj-Precategory C → obj-Precategory em-monad-Precategory
+  obj-functor-to-em-monad-Precategory x =
+    (obj-endofunctor-monad-Precategory C T x) ,
+    ((hom-mul-monad-Precategory C T x) ,
+      right-unit-law-mul-hom-family-monad-Precategory C T x ,
+      associative-mul-hom-family-monad-Precategory C T x)
+
+  hom-functor-to-em-monad-Precategory : {x y : obj-Precategory C}
+    (f : hom-Precategory C x y) →
+    hom-Precategory em-monad-Precategory
+      (obj-functor-to-em-monad-Precategory x)
+      (obj-functor-to-em-monad-Precategory y)
+  hom-functor-to-em-monad-Precategory f =
+    (T₁ f) , naturality-mul-monad-Precategory C T f
+
+  functor-to-em-monad-Precategory : functor-Precategory C em-monad-Precategory
+  functor-to-em-monad-Precategory =
+    obj-functor-to-em-monad-Precategory ,
+    hom-functor-to-em-monad-Precategory ,
+    (λ g f →
+      eq-pair-Σ
+        (preserves-comp-endofunctor-monad-Precategory C T g f)
+        (eq-is-prop (is-set-hom-Precategory C _ _ _ _))) ,
+    (λ x →
+      eq-pair-Σ
+        (preserves-id-endofunctor-monad-Precategory C T x)
+        (eq-is-prop (is-set-hom-Precategory C _ _ _ _)))
+
+  functor-from-em-monad-Precategory : functor-Precategory em-monad-Precategory C
+  functor-from-em-monad-Precategory =
+    (obj-monad-algebra-Precategory C T) ,
+    (λ {x} {y} f → hom-monad-algebra-morphism-Precategory C T x y f) ,
+    (λ g f → refl) ,
+    (λ x → refl)
+
+  -- The unit x → Tx is exactly the unit of the monad
+  unit-em-monad-Precategory :
+    natural-transformation-Precategory C C
+      (id-functor-Precategory C)
+      (comp-functor-Precategory C em-monad-Precategory C
+        functor-from-em-monad-Precategory
+        functor-to-em-monad-Precategory)
+  unit-em-monad-Precategory = unit-monad-Precategory C T
+
+  -- The counit is the vertical map given by the structure map of the algebra
+  --       μ
+  --   T²x → Tx
+  -- Ta ↓    ↓ a
+  --   Tx  → x
+  --       a
+  counit-em-monad-Precategory :
+    natural-transformation-Precategory em-monad-Precategory em-monad-Precategory
+      (comp-functor-Precategory em-monad-Precategory C em-monad-Precategory
+        functor-to-em-monad-Precategory functor-from-em-monad-Precategory)
+      (id-functor-Precategory em-monad-Precategory)
+  counit-em-monad-Precategory =
+    (λ x →
+      (hom-monad-algebra-Precategory C T x) ,
+      inv (mul-law-monad-algebra-Precategory C T x)) ,
+    (λ {x} {y} f → eq-pair-Σ
+      (comm-hom-monad-algebra-morphism-Precategory C T x y f)
+      (eq-is-prop (is-set-hom-Precategory C _ _ _ _)))
+
+  private
+    LR =
+      comp-functor-Precategory em-monad-Precategory C em-monad-Precategory
+        functor-to-em-monad-Precategory functor-from-em-monad-Precategory
+    RL =
+      comp-functor-Precategory C em-monad-Precategory C
+        functor-from-em-monad-Precategory functor-to-em-monad-Precategory
+
+  left-triangle-em-monad-Precategory :
+    has-left-triangle-identity-Precategory C em-monad-Precategory
+      functor-to-em-monad-Precategory
+      functor-from-em-monad-Precategory
+      unit-em-monad-Precategory
+      counit-em-monad-Precategory
+  left-triangle-em-monad-Precategory x =
+    eq-pair-Σ
+      (left-unit-law-mul-hom-family-monad-Precategory C T x)
+      (eq-is-prop (is-set-hom-Precategory C _ _ _ _))
+
+  right-triangle-em-monad-Precategory :
+    has-right-triangle-identity-Precategory C em-monad-Precategory
+      functor-to-em-monad-Precategory
+      functor-from-em-monad-Precategory
+      unit-em-monad-Precategory
+      counit-em-monad-Precategory
+  right-triangle-em-monad-Precategory x =
+    unit-law-monad-algebra-Precategory C T x
+
+  adjunction-em-monad-Precategory :
+    Adjunction-Precategory C em-monad-Precategory
+  adjunction-em-monad-Precategory =
+    make-Adjunction-Precategory C em-monad-Precategory
+      functor-to-em-monad-Precategory
+      functor-from-em-monad-Precategory
+      (is-adjoint-pair-unit-counit-Precategory C em-monad-Precategory
+        functor-to-em-monad-Precategory
+        functor-from-em-monad-Precategory
+        unit-em-monad-Precategory
+        counit-em-monad-Precategory
+        left-triangle-em-monad-Precategory
+        right-triangle-em-monad-Precategory)
 ```

--- a/src/category-theory/natural-transformations-functors-precategories.lagda.md
+++ b/src/category-theory/natural-transformations-functors-precategories.lagda.md
@@ -222,6 +222,17 @@ module _
     eq-htpy-hom-family-natural-transformation-map-Precategory C D
       ( map-functor-Precategory C D F)
       ( map-functor-Precategory C D G)
+
+  -- Agda seems to be able to infer α and β without issue
+  htpy-eq-hom-family-natural-transformation-Precategory :
+    {α β : natural-transformation-Precategory C D F G} →
+    α ＝ β →
+    ( hom-family-natural-transformation-Precategory C D F G α ~
+      hom-family-natural-transformation-Precategory C D F G β)
+  htpy-eq-hom-family-natural-transformation-Precategory =
+    htpy-eq-hom-family-natural-transformation-map-Precategory C D
+      ( map-functor-Precategory C D F)
+      ( map-functor-Precategory C D G)
 ```
 
 ### Categorical laws for natural transformations

--- a/src/category-theory/natural-transformations-maps-precategories.lagda.md
+++ b/src/category-theory/natural-transformations-maps-precategories.lagda.md
@@ -267,6 +267,14 @@ module _
     α ＝ β
   eq-htpy-hom-family-natural-transformation-map-Precategory α β =
     map-inv-equiv (extensionality-natural-transformation-map-Precategory α β)
+
+  htpy-eq-hom-family-natural-transformation-map-Precategory :
+    {α β : natural-transformation-map-Precategory C D F G} →
+    α ＝ β →
+    ( hom-family-natural-transformation-map-Precategory C D F G α ~
+      hom-family-natural-transformation-map-Precategory C D F G β)
+  htpy-eq-hom-family-natural-transformation-map-Precategory {α} {β} =
+    map-equiv (extensionality-natural-transformation-map-Precategory α β)
 ```
 
 ### Categorical laws for natural transformations


### PR DESCRIPTION
This adds definitions and results about monad algebras to `category-theory.monads-on-precategories`, mainly the Kleisli and Eilenberg-Moore precategories. It also adds adjunctions between ordinary precategories, copying the definitions for large precategories (with sigma types instead of records) and showing that this is implied by the triangle identities.