### PR TITLE
Add codensity monads

### DIFF
--- a/src/category-theory.lagda.md
+++ b/src/category-theory.lagda.md
@@ -25,6 +25,7 @@ open import category-theory.category-of-functors public
 open import category-theory.category-of-functors-from-small-to-large-categories public
 open import category-theory.category-of-maps-categories public
 open import category-theory.category-of-maps-from-small-to-large-categories public
+open import category-theory.codensity-monads-on-precategories public
 open import category-theory.commuting-squares-of-morphisms-in-large-precategories public
 open import category-theory.commuting-squares-of-morphisms-in-precategories public
 open import category-theory.commuting-squares-of-morphisms-in-set-magmoids public

--- a/src/category-theory/codensity-monads-on-precategories.lagda.md
+++ b/src/category-theory/codensity-monads-on-precategories.lagda.md
@@ -1,4 +1,4 @@
-# Codensity monads in precategories
+# Codensity monads on precategories
 
 ```agda
 module category-theory.codensity-monads-on-precategories where
@@ -26,7 +26,7 @@ open import foundation.universe-levels
 
 ## Idea
 
-Given an arbitrary functor `F : C → D`, any [right Kan
+Given an arbitrary [functor](category-theory.functors-precategories.md) `F : C → D`, any [right Kan
 extension](category-theory.right-kan-extensions-precategories.md] `R` of `F`
 along itself `F` has a canonical
 [monad](category-theory.monads-on-precategories.md] structure, called the
@@ -509,7 +509,7 @@ module _
         ( _)
         ( _)) ∙
     ( ap
-      ( λ x → comp-natural-transformation-Precategory C D RRRF RF F α x)
+      ( comp-natural-transformation-Precategory C D RRRF RF F α)
       ( eq-htpy-hom-family-natural-transformation-Precategory C D RRRF RF
         ( _)
         ( _)

--- a/src/category-theory/codensity-monads-on-precategories.lagda.md
+++ b/src/category-theory/codensity-monads-on-precategories.lagda.md
@@ -26,11 +26,13 @@ open import foundation.universe-levels
 
 ## Idea
 
-Given an arbitrary [functor](category-theory.functors-precategories.md) `F : C → D`, any [right Kan
+Given an arbitrary [functor](category-theory.functors-precategories.md)
+`F : C → D`, any [right Kan
 extension](category-theory.right-kan-extensions-precategories.md] `R` of `F`
 along itself `F` has a canonical
 [monad](category-theory.monads-on-precategories.md] structure, called the
-{{#concept "codensity monad" Agda=codensity-monad-Precategory}} of `R`.
+{{#concept "codensity monad" Agda=codensity-monad-Precategory WD="codensity monad" WDID=Q97359844}}
+of `R`.
 
 ## Monad structure
 
@@ -88,7 +90,7 @@ module _
     map-inv-is-equiv
       ( KR (comp-functor-Precategory D D D R R))
       ( pr2
-        ( double-right-extension-Precategory C D F
+        ( square-right-extension-Precategory C D F
           ( right-extension-right-kan-extension-Precategory C D D F F Rk)))
 
   abstract
@@ -599,3 +601,8 @@ module _
       ( ( left-unit-law-mul-codensity-monad-Precategory C D F Rk) ,
         ( right-unit-law-mul-codensity-monad-Precategory C D F Rk)))
 ```
+
+## External links
+
+- [Codensity monad](https://ncatlab.org/nlab/show/codensity+monad) at $n$Lab
+- [Codensity monad](https://en.wikipedia.org/wiki/Codensity_monad) at Wikipedia

--- a/src/category-theory/codensity-monads-on-precategories.lagda.md
+++ b/src/category-theory/codensity-monads-on-precategories.lagda.md
@@ -1,0 +1,601 @@
+# Codensity monads in precategories
+
+```agda
+module category-theory.codensity-monads-on-precategories where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import category-theory.algebras-monads-on-precategories
+open import category-theory.functors-precategories
+open import category-theory.monads-on-precategories
+open import category-theory.natural-transformations-functors-precategories
+open import category-theory.precategories
+open import category-theory.right-extensions-precategories
+open import category-theory.right-kan-extensions-precategories
+
+open import foundation.action-on-identifications-functions
+open import foundation.dependent-pair-types
+open import foundation.equivalences
+open import foundation.identity-types
+open import foundation.universe-levels
+```
+
+</details>
+
+## Idea
+
+Given an arbitrary functor `F : C → D`, any [right Kan
+extension](category-theory.right-kan-extensions-precategories.md] `R` of `F`
+along itself `F` has a canonical
+[monad](category-theory.monads-on-precategories.md] structure, called the
+{{#concept "codensity monad" Agda=codensity-monad-Precategory}} of `R`.
+
+## Monad structure
+
+The unit and multiplication of the codensity monads follow from the "existence"
+part of the universal property of the right Kan extension. We use two right
+extensions: the identity map on `D` trivially gives a right extension of `D`
+along itself, and `R²` gives an extension by whiskering and composing the
+natural transformation. By the universal property of `R`, these give natural
+transformations `η : id ⇒ R` and `μ : R² ⇒ R`, respectively. From their
+definition via the universal property, we have two computation rules for these
+natural transformations (where ∙ is whiskering):
+
+1. `α ∘ (η ∙ F) ＝ id_F`; and
+2. `α ∘ (μ ∙ F) = α ∘ (R ∙ α)`.
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level}
+  (C : Precategory l1 l2) (D : Precategory l3 l4)
+  (F : functor-Precategory C D)
+  (Rk : right-kan-extension-Precategory C D D F F)
+  (let R = extension-right-kan-extension-Precategory C D D F F Rk)
+  (let KR = is-right-kan-extension-right-kan-extension-Precategory C D D F F Rk)
+  (let α = natural-transformation-right-kan-extension-Precategory C D D F F Rk)
+  (let RR = comp-functor-Precategory D D D R R)
+  (let RF = comp-functor-Precategory C D D R F)
+  (let RRF = comp-functor-Precategory C D D RR F)
+  where
+
+  unit-codensity-monad-Precategory :
+    natural-transformation-Precategory D D (id-functor-Precategory D) R
+  unit-codensity-monad-Precategory =
+    map-inv-is-equiv
+      ( KR (id-functor-Precategory D))
+      ( pr2 (id-right-extension-Precategory C D F))
+
+  abstract
+    compute-unit-codensity-monad-Precategory :
+      comp-natural-transformation-Precategory C D F RF F
+        ( α)
+        ( right-whisker-natural-transformation-Precategory D D C
+          ( id-functor-Precategory D)
+          ( R)
+          ( unit-codensity-monad-Precategory)
+          ( F)) ＝
+      id-natural-transformation-Precategory C D F
+    compute-unit-codensity-monad-Precategory =
+      is-section-map-inv-is-equiv (KR _) _
+
+  mul-codensity-monad-Precategory :
+    natural-transformation-Precategory D D
+      ( comp-functor-Precategory D D D R R)
+      ( R)
+  mul-codensity-monad-Precategory =
+    map-inv-is-equiv
+      ( KR (comp-functor-Precategory D D D R R))
+      ( pr2
+        ( double-right-extension-Precategory C D F
+          ( right-extension-right-kan-extension-Precategory C D D F F Rk)))
+
+  abstract
+    compute-mul-codensity-monad-Precategory :
+      comp-natural-transformation-Precategory C D RRF RF F
+        ( α)
+        ( right-whisker-natural-transformation-Precategory D D C
+          ( RR)
+          ( R)
+          ( mul-codensity-monad-Precategory)
+          ( F)) ＝
+      comp-natural-transformation-Precategory C D RRF RF F
+        ( α)
+        ( left-whisker-natural-transformation-Precategory C D D
+          ( RF)
+          ( F)
+          ( R)
+          ( α))
+    compute-mul-codensity-monad-Precategory =
+      is-section-map-inv-is-equiv (KR _) _
+```
+
+## Monad laws
+
+Monad laws follow from the "uniqueness" part of the right Kan extension.
+
+### Left unit law
+
+For the left unit law, if `α : R∘F ⇒ F` is the right Kan extension natural
+transformation, we show that the composite
+
+```text
+     (Rμ)F     μF     α
+  R∘F  ⇒  R²∘F ⇒  R∘F  ⇒  R
+```
+
+is equal to `α`; by uniqueness, `μF ∘ RμF = id`.
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level}
+  (C : Precategory l1 l2) (D : Precategory l3 l4)
+  (F : functor-Precategory C D)
+  (Rk : right-kan-extension-Precategory C D D F F)
+  (let R = extension-right-kan-extension-Precategory C D D F F Rk)
+  (let KR = is-right-kan-extension-right-kan-extension-Precategory C D D F F Rk)
+  (let α = natural-transformation-right-kan-extension-Precategory C D D F F Rk)
+  (let RR = comp-functor-Precategory D D D R R)
+  (let RF = comp-functor-Precategory C D D R F)
+  (let RRF = comp-functor-Precategory C D D RR F)
+  where
+
+  precomp-left-unit-law-mul-codensity-monad-Precategory :
+    right-extension-map-Precategory C D D F F (R , α) R
+      ( comp-natural-transformation-Precategory
+        D D R RR R
+        ( mul-codensity-monad-Precategory C D F Rk)
+        ( left-whisker-natural-transformation-Precategory D D D
+          ( id-functor-Precategory D)
+          ( R)
+          ( R)
+          ( unit-codensity-monad-Precategory C D F Rk))) ＝
+    α
+  precomp-left-unit-law-mul-codensity-monad-Precategory =
+    ( inv
+      ( associative-comp-natural-transformation-Precategory C D RF RRF RF F
+        ( _)
+        ( _)
+        ( _))) ∙
+    ( ap
+      ( λ x →
+        comp-natural-transformation-Precategory C D RF RRF F
+          ( x)
+          ( right-whisker-natural-transformation-Precategory D D C R RR
+            ( left-whisker-natural-transformation-Precategory D D D
+              ( id-functor-Precategory D)
+              ( R)
+              ( R)
+              (unit-codensity-monad-Precategory C D F Rk))
+            ( F)))
+      ( compute-mul-codensity-monad-Precategory C D F Rk)) ∙
+    ( associative-comp-natural-transformation-Precategory C D RF RRF RF F
+      ( _)
+      ( _)
+      ( _)) ∙
+    ( ap
+      ( λ x →
+        ( comp-natural-transformation-Precategory C D RF RF F
+          ( α)
+          ( x)))
+      ( inv
+        ( preserves-comp-left-whisker-natural-transformation-Precategory
+          ( C)
+          ( D)
+          ( D)
+          ( F)
+          ( RF)
+          ( F)
+          ( R)
+          ( α)
+          ( right-whisker-natural-transformation-Precategory D D C
+            ( id-functor-Precategory D)
+            ( R)
+            ( unit-codensity-monad-Precategory C D F Rk)
+            ( F))))) ∙
+    ( ap
+      ( λ x →
+        ( comp-natural-transformation-Precategory C D RF RF F
+          ( α)
+          ( left-whisker-natural-transformation-Precategory C D D F F
+            ( R)
+            ( x))))
+      ( compute-unit-codensity-monad-Precategory C D F Rk)) ∙
+    ( ap
+      ( λ x →
+        ( comp-natural-transformation-Precategory C D RF RF F
+          ( α)
+          ( x)))
+      ( preserves-id-left-whisker-natural-transformation-Precategory C D D
+        ( F)
+        ( R))) ∙
+    ( right-unit-law-comp-natural-transformation-Precategory C D RF F α)
+
+  abstract
+    left-unit-law-mul-codensity-monad-Precategory :
+      comp-natural-transformation-Precategory
+        D D R (comp-functor-Precategory D D D R R) R
+        ( mul-codensity-monad-Precategory C D F Rk)
+        ( left-whisker-natural-transformation-Precategory D D D
+          ( id-functor-Precategory D)
+          ( R)
+          ( R)
+          ( unit-codensity-monad-Precategory C D F Rk)) ＝
+      id-natural-transformation-Precategory D D R
+    left-unit-law-mul-codensity-monad-Precategory =
+      ( inv (is-retraction-map-inv-is-equiv (KR R) _)) ∙
+      ( ap
+        ( map-inv-is-equiv (KR R))
+        ( ( precomp-left-unit-law-mul-codensity-monad-Precategory) ∙
+          ( inv
+            ( right-unit-law-comp-natural-transformation-Precategory C D
+              ( RF)
+              ( F)
+              ( α))))) ∙
+      ( is-retraction-map-inv-is-equiv (KR R) _)
+```
+
+### Right unit law
+
+The right unit law is similar; we show that the composite is `α` via:
+
+```text
+      ηRF     μF      α
+   RF  ⇒  R²F  ⇒  RF  ⇒  F
+ α ⇓   Rα ⇓              ∥
+   F   ⇒  RF      ⇒      F
+      ηF          α
+```
+
+The right square (triangle) commutes by "uniqueness" of the right Kan UP; the
+left square commutes by naturality of `η`. The bottom composite is then `id` by
+the UP again.
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level}
+  (C : Precategory l1 l2) (D : Precategory l3 l4)
+  (F : functor-Precategory C D)
+  (Rk : right-kan-extension-Precategory C D D F F)
+  (let R = extension-right-kan-extension-Precategory C D D F F Rk)
+  (let KR = is-right-kan-extension-right-kan-extension-Precategory C D D F F Rk)
+  (let α = natural-transformation-right-kan-extension-Precategory C D D F F Rk)
+  (let RR = comp-functor-Precategory D D D R R)
+  (let RF = comp-functor-Precategory C D D R F)
+  (let RRF = comp-functor-Precategory C D D RR F)
+  where
+
+  precomp-right-unit-law-mul-codensity-monad-Precategory :
+    right-extension-map-Precategory C D D F F (R , α) R
+      ( comp-natural-transformation-Precategory
+        D D R RR R
+        ( mul-codensity-monad-Precategory C D F Rk)
+        ( right-whisker-natural-transformation-Precategory D D D
+          ( id-functor-Precategory D)
+          ( R)
+          ( unit-codensity-monad-Precategory C D F Rk)
+          ( R))) ＝
+    α
+  precomp-right-unit-law-mul-codensity-monad-Precategory =
+    ( inv
+      ( associative-comp-natural-transformation-Precategory C D RF RRF RF F
+        ( _)
+        ( _)
+        ( _))) ∙
+    ( ap
+      ( λ x →
+        ( comp-natural-transformation-Precategory C D RF RRF F
+          ( x)
+          ( right-whisker-natural-transformation-Precategory D D C R RR
+            ( right-whisker-natural-transformation-Precategory D D D
+              ( id-functor-Precategory D)
+              ( R)
+              ( unit-codensity-monad-Precategory C D F Rk)
+              ( R))
+            ( F))))
+      ( is-section-map-inv-is-equiv
+        ( KR (comp-functor-Precategory D D D R R)) _)) ∙
+    ( associative-comp-natural-transformation-Precategory C D RF RRF RF F
+      ( _)
+      ( _)
+      ( _)) ∙
+    ( ap
+      ( λ x → comp-natural-transformation-Precategory C D RF RF F α x)
+      ( eq-htpy-hom-family-natural-transformation-Precategory C D RF RF _ _
+        ( λ x →
+          ( naturality-natural-transformation-Precategory D D
+            (id-functor-Precategory D)
+            ( R)
+            ( unit-codensity-monad-Precategory C D F Rk)
+            ( _))))) ∙
+    ( inv
+      ( associative-comp-natural-transformation-Precategory C D RF F RF F
+        ( _)
+        ( _)
+        ( _))) ∙
+    ( ap
+      ( λ x →
+        ( comp-natural-transformation-Precategory C D RF F F x α))
+      ( compute-unit-codensity-monad-Precategory C D F Rk)) ∙
+    left-unit-law-comp-natural-transformation-Precategory C D RF F α
+
+  abstract
+    right-unit-law-mul-codensity-monad-Precategory :
+      comp-natural-transformation-Precategory
+        D D R (comp-functor-Precategory D D D R R) R
+        ( mul-codensity-monad-Precategory C D F Rk)
+        ( right-whisker-natural-transformation-Precategory D D D
+          ( id-functor-Precategory D)
+          ( R)
+          ( unit-codensity-monad-Precategory C D F Rk)
+          ( R)) ＝
+      id-natural-transformation-Precategory D D R
+    right-unit-law-mul-codensity-monad-Precategory =
+      ( inv (is-retraction-map-inv-is-equiv (KR R) _)) ∙
+      ( ap
+        ( map-inv-is-equiv (KR R))
+        ( ( precomp-right-unit-law-mul-codensity-monad-Precategory) ∙
+          ( inv
+            ( right-unit-law-comp-natural-transformation-Precategory C D
+              ( RF)
+              ( F)
+              ( α))))) ∙
+      ( is-retraction-map-inv-is-equiv (KR R) _)
+```
+
+### Multiplication is associative
+
+Showing that multiplication is associative is similar but longer.
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level}
+  (C : Precategory l1 l2) (D : Precategory l3 l4)
+  (F : functor-Precategory C D)
+  (Rk : right-kan-extension-Precategory C D D F F)
+  (let R = extension-right-kan-extension-Precategory C D D F F Rk)
+  (let KR = is-right-kan-extension-right-kan-extension-Precategory C D D F F Rk)
+  (let α = natural-transformation-right-kan-extension-Precategory C D D F F Rk)
+  (let RR = comp-functor-Precategory D D D R R)
+  (let RF = comp-functor-Precategory C D D R F)
+  (let RRF = comp-functor-Precategory C D D RR F)
+  (let RRR = comp-functor-Precategory D D D R RR)
+  (let RRRF = comp-functor-Precategory C D D RRR F)
+  where
+
+  left-precomp-associative-mul-codensity-monad-Precategory :
+    comp-natural-transformation-Precategory C D RRRF RF F
+      ( α)
+      ( right-whisker-natural-transformation-Precategory D D C
+        ( RRR)
+        ( R)
+        ( comp-natural-transformation-Precategory D D RRR RR R
+          ( mul-codensity-monad-Precategory C D F Rk)
+          ( left-whisker-natural-transformation-Precategory D D D RR R
+            ( R)
+            ( mul-codensity-monad-Precategory C D F Rk)))
+        ( F)) ＝
+    comp-natural-transformation-Precategory C D RRRF RF F
+      ( α)
+      ( left-whisker-natural-transformation-Precategory C D D
+        ( RRF)
+        ( F)
+        ( R)
+        ( comp-natural-transformation-Precategory C D RRF RF F
+          ( α)
+          ( left-whisker-natural-transformation-Precategory C D D
+            ( RF)
+            ( F)
+            ( R)
+            ( α))))
+  left-precomp-associative-mul-codensity-monad-Precategory =
+    ( ap
+      ( λ x → comp-natural-transformation-Precategory C D RRRF RF F α x)
+      ( preserves-comp-right-whisker-natural-transformation-Precategory D D C
+        ( RRR)
+        ( RR)
+        ( R)
+        ( mul-codensity-monad-Precategory C D F Rk)
+        ( left-whisker-natural-transformation-Precategory D D D RR R
+          ( R)
+          ( mul-codensity-monad-Precategory C D F Rk))
+        ( F))) ∙
+    ( inv
+      ( associative-comp-natural-transformation-Precategory C D RRRF RRF RF F
+        ( _)
+        ( _)
+        ( _))) ∙
+    ( ap
+      ( λ x →
+        ( comp-natural-transformation-Precategory C D RRRF RRF F
+          ( x)
+          ( right-whisker-natural-transformation-Precategory D D C
+            ( RRR)
+            ( RR)
+            ( left-whisker-natural-transformation-Precategory D D D RR R
+              ( R)
+              ( mul-codensity-monad-Precategory C D F Rk))
+            ( F))))
+      ( compute-mul-codensity-monad-Precategory C D F Rk)) ∙
+    ( associative-comp-natural-transformation-Precategory C D
+      ( RRRF)
+      ( RRF)
+      ( RF)
+      ( F)
+      ( _)
+      ( _)
+      ( _)) ∙
+    ( ap
+      ( λ x → comp-natural-transformation-Precategory C D RRRF RF F α x)
+      ( inv
+        ( preserves-comp-left-whisker-natural-transformation-Precategory C D D
+          ( RRF)
+          ( RF)
+          ( F)
+          ( R)
+          ( α)
+          ( right-whisker-natural-transformation-Precategory D D C
+            ( RR)
+            ( R)
+            ( mul-codensity-monad-Precategory C D F Rk)
+            ( F))))) ∙
+    ( ap
+      ( λ x → comp-natural-transformation-Precategory C D RRRF RF F
+        ( α)
+        ( left-whisker-natural-transformation-Precategory C D D
+          ( RRF)
+          ( F)
+          ( R)
+          ( x)))
+      ( compute-mul-codensity-monad-Precategory C D F Rk))
+
+  right-precomp-associative-mul-codensity-monad-Precategory :
+    comp-natural-transformation-Precategory C D RRRF RF F
+      ( α)
+      ( right-whisker-natural-transformation-Precategory D D C
+        ( RRR)
+        ( R)
+        ( comp-natural-transformation-Precategory D D RRR RR R
+          ( mul-codensity-monad-Precategory C D F Rk)
+          ( right-whisker-natural-transformation-Precategory D D D RR R
+            ( mul-codensity-monad-Precategory C D F Rk)
+            ( R)))
+        ( F)) ＝
+    comp-natural-transformation-Precategory C D RRRF RF F
+      ( α)
+      ( left-whisker-natural-transformation-Precategory C D D
+        ( RRF)
+        ( F)
+        ( R)
+        ( comp-natural-transformation-Precategory C D RRF RF F
+          ( α)
+          ( left-whisker-natural-transformation-Precategory C D D
+            ( RF)
+            ( F)
+            ( R)
+            ( α))))
+  right-precomp-associative-mul-codensity-monad-Precategory =
+    ( ap
+      ( λ x → comp-natural-transformation-Precategory C D RRRF RF F α x)
+      ( preserves-comp-right-whisker-natural-transformation-Precategory D D C
+        ( RRR)
+        ( RR)
+        ( R)
+        ( mul-codensity-monad-Precategory C D F Rk)
+        ( right-whisker-natural-transformation-Precategory D D D RR R
+          ( mul-codensity-monad-Precategory C D F Rk)
+          ( R))
+        ( F))) ∙
+    ( inv
+      ( associative-comp-natural-transformation-Precategory C D RRRF RRF RF F
+        ( _)
+        ( _)
+        ( _))) ∙
+    ( ap
+      ( λ x →
+        ( comp-natural-transformation-Precategory C D RRRF RRF F
+          ( x)
+          ( right-whisker-natural-transformation-Precategory D D C
+            ( RRR)
+            ( RR)
+            ( right-whisker-natural-transformation-Precategory D D D RR R
+              ( mul-codensity-monad-Precategory C D F Rk)
+              ( R))
+            ( F))))
+      ( compute-mul-codensity-monad-Precategory C D F Rk)) ∙
+    ( associative-comp-natural-transformation-Precategory C D RRRF RRF RF F
+        ( _)
+        ( _)
+        ( _)) ∙
+    ( ap
+      ( λ x → comp-natural-transformation-Precategory C D RRRF RF F α x)
+      ( eq-htpy-hom-family-natural-transformation-Precategory C D RRRF RF
+        ( _)
+        ( _)
+        ( λ x →
+          naturality-natural-transformation-Precategory D D RR R
+            ( mul-codensity-monad-Precategory C D F Rk)
+            ( _)))) ∙
+    ( inv
+      ( associative-comp-natural-transformation-Precategory C D RRRF RRF RF F
+        ( _)
+        ( _)
+        ( _))) ∙
+    ( ap
+      ( λ x →
+        ( comp-natural-transformation-Precategory C D RRRF RRF F
+          ( x)
+          ( left-whisker-natural-transformation-Precategory C D D
+            ( RRF)
+            ( RF)
+            ( R)
+            ( left-whisker-natural-transformation-Precategory C D D
+              ( RF)
+              ( F)
+              ( R)
+              ( α)))))
+      ( compute-mul-codensity-monad-Precategory C D F Rk)) ∙
+    ( associative-comp-natural-transformation-Precategory C D
+      ( RRRF)
+      ( RRF)
+      ( RF)
+      ( F)
+      ( _)
+      ( _)
+      ( _)) ∙
+    ( ap
+      ( λ x → comp-natural-transformation-Precategory C D RRRF RF F α x)
+      ( inv
+        ( preserves-comp-left-whisker-natural-transformation-Precategory C D D
+          ( RRF)
+          ( RF)
+          ( F)
+          ( R)
+          ( α)
+          ( left-whisker-natural-transformation-Precategory C D D
+            ( RF)
+            ( F)
+            ( R)
+            ( α)))))
+
+  abstract
+    associative-mul-codensity-monad-Precategory :
+      comp-natural-transformation-Precategory D D RRR RR R
+        ( mul-codensity-monad-Precategory C D F Rk)
+        ( left-whisker-natural-transformation-Precategory D D D RR R
+          ( R)
+          ( mul-codensity-monad-Precategory C D F Rk)) ＝
+      comp-natural-transformation-Precategory D D RRR RR R
+        ( mul-codensity-monad-Precategory C D F Rk)
+        ( right-whisker-natural-transformation-Precategory D D D RR R
+          ( mul-codensity-monad-Precategory C D F Rk)
+          ( R))
+    associative-mul-codensity-monad-Precategory =
+      ( inv (is-retraction-map-inv-is-equiv (KR RRR) _)) ∙
+      ( ap
+        ( map-inv-is-equiv (KR RRR))
+        ( ( left-precomp-associative-mul-codensity-monad-Precategory) ∙
+          ( inv right-precomp-associative-mul-codensity-monad-Precategory))) ∙
+      ( is-retraction-map-inv-is-equiv (KR RRR) _)
+```
+
+## Definition
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level}
+  (C : Precategory l1 l2) (D : Precategory l3 l4)
+  (F : functor-Precategory C D)
+  (Rk : right-kan-extension-Precategory C D D F F)
+  where
+
+  codensity-monad-Precategory : monad-Precategory D
+  codensity-monad-Precategory =
+    ( extension-right-kan-extension-Precategory C D D F F Rk ,
+      unit-codensity-monad-Precategory C D F Rk) ,
+    ( mul-codensity-monad-Precategory C D F Rk) ,
+    ( ( associative-mul-codensity-monad-Precategory C D F Rk) ,
+      ( ( left-unit-law-mul-codensity-monad-Precategory C D F Rk) ,
+        ( right-unit-law-mul-codensity-monad-Precategory C D F Rk)))
+```

--- a/src/category-theory/natural-transformations-functors-precategories.lagda.md
+++ b/src/category-theory/natural-transformations-functors-precategories.lagda.md
@@ -395,7 +395,14 @@ module _
       ( comp-functor-Precategory E C D F K)
       ( comp-functor-Precategory E C D G K)
   right-whisker-natural-transformation-Precategory F G α K =
-    (λ x → (pr1 α) ((pr1 K) x)) , (λ f → (pr2 α) ((pr1 (pr2 K)) f))
+    ( λ x →
+      hom-family-natural-transformation-Precategory C D F G
+        ( α)
+        ( obj-functor-Precategory E C K x)) ,
+    ( λ f →
+      naturality-natural-transformation-Precategory C D F G
+        ( α)
+        ( hom-functor-Precategory E C K f))
 
   preserves-comp-right-whisker-natural-transformation-Precategory :
     (F G H : functor-Precategory C D)
@@ -455,69 +462,4 @@ module _
       ( comp-functor-Precategory C D E I G)
       ( right-whisker-natural-transformation-Precategory D E C H I β G)
       ( left-whisker-natural-transformation-Precategory C D E F G H α)
-```
-
-## Categorical laws for functor composition
-
-```agda
-module _
-  {l1 l2 l3 l4 : Level} (C : Precategory l1 l2) (D : Precategory l3 l4)
-  (F : functor-Precategory C D)
-  where
-
-  left-unit-law-natural-transformation-comp-functor-Precategory :
-    natural-transformation-Precategory C D
-      ( comp-functor-Precategory C D D (id-functor-Precategory D) F)
-      ( F)
-  pr1 left-unit-law-natural-transformation-comp-functor-Precategory x =
-    id-hom-Precategory D
-  pr2 left-unit-law-natural-transformation-comp-functor-Precategory f =
-    ( right-unit-law-comp-hom-Precategory D _) ∙
-    ( inv (left-unit-law-comp-hom-Precategory D _))
-
-  right-unit-law-natural-transformation-comp-functor-Precategory :
-    natural-transformation-Precategory C D
-      ( comp-functor-Precategory C C D F (id-functor-Precategory C))
-      ( F)
-  pr1 right-unit-law-natural-transformation-comp-functor-Precategory x =
-    id-hom-Precategory D
-  pr2 right-unit-law-natural-transformation-comp-functor-Precategory f =
-    ( right-unit-law-comp-hom-Precategory D _) ∙
-    ( inv (left-unit-law-comp-hom-Precategory D _))
-
-module _
-  {l1 l2 l3 l4 l5 l6 l7 l8 : Level}
-  (A : Precategory l1 l2) (B : Precategory l3 l4)
-  (C : Precategory l5 l6) (D : Precategory l7 l8)
-  (F : functor-Precategory A B) (G : functor-Precategory B C)
-  (H : functor-Precategory C D)
-  where
-
-  associative-natural-transformation-comp-functor-Precategory :
-    natural-transformation-Precategory A D
-      ( comp-functor-Precategory A B D
-        ( comp-functor-Precategory B C D H G)
-        ( F))
-      ( comp-functor-Precategory A C D
-        ( H)
-        ( comp-functor-Precategory A B C G F))
-  pr1 associative-natural-transformation-comp-functor-Precategory x =
-    id-hom-Precategory D
-  pr2 associative-natural-transformation-comp-functor-Precategory f =
-    ( right-unit-law-comp-hom-Precategory D _) ∙
-    ( inv (left-unit-law-comp-hom-Precategory D _))
-
-  associative-natural-transformation-comp-functor-Precategory' :
-    natural-transformation-Precategory A D
-      ( comp-functor-Precategory A C D
-        ( H)
-        ( comp-functor-Precategory A B C G F))
-      ( comp-functor-Precategory A B D
-        ( comp-functor-Precategory B C D H G)
-        ( F))
-  pr1 associative-natural-transformation-comp-functor-Precategory' x =
-    id-hom-Precategory D
-  pr2 associative-natural-transformation-comp-functor-Precategory' f =
-    ( right-unit-law-comp-hom-Precategory D _) ∙
-    ( inv (left-unit-law-comp-hom-Precategory D _))
 ```

--- a/src/category-theory/natural-transformations-functors-precategories.lagda.md
+++ b/src/category-theory/natural-transformations-functors-precategories.lagda.md
@@ -343,6 +343,48 @@ module _
         ( (pr1 α) y)
         ( (pr1 (pr2 F)) f)))
 
+  preserves-comp-left-whisker-natural-transformation-Precategory :
+    (F G H : functor-Precategory C D)
+    (I : functor-Precategory D E)
+    (β : natural-transformation-Precategory C D G H)
+    (α : natural-transformation-Precategory C D F G) →
+    left-whisker-natural-transformation-Precategory
+      ( F)
+      ( H)
+      ( I)
+      ( comp-natural-transformation-Precategory C D F G H β α) ＝
+    comp-natural-transformation-Precategory
+      ( C)
+      ( E)
+      ( comp-functor-Precategory C D E I F)
+      ( comp-functor-Precategory C D E I G)
+      ( comp-functor-Precategory C D E I H)
+      ( left-whisker-natural-transformation-Precategory G H I β)
+      ( left-whisker-natural-transformation-Precategory F G I α)
+  preserves-comp-left-whisker-natural-transformation-Precategory F G H I β α =
+    eq-htpy-hom-family-natural-transformation-Precategory C E
+      ( comp-functor-Precategory C D E I F)
+      ( comp-functor-Precategory C D E I H)
+      ( _)
+      ( _)
+      ( λ x → preserves-comp-functor-Precategory D E I _ _)
+
+  preserves-id-left-whisker-natural-transformation-Precategory :
+    (F : functor-Precategory C D)
+    (H : functor-Precategory D E) →
+    left-whisker-natural-transformation-Precategory F F
+      ( H)
+      ( id-natural-transformation-Precategory C D F) ＝
+    id-natural-transformation-Precategory C E
+      ( comp-functor-Precategory C D E H F)
+  preserves-id-left-whisker-natural-transformation-Precategory F H =
+    eq-htpy-hom-family-natural-transformation-Precategory C E
+      ( comp-functor-Precategory C D E H F)
+      ( comp-functor-Precategory C D E H F)
+      ( _)
+      ( _)
+      ( λ x → preserves-id-functor-Precategory D E H _)
+
   right-whisker-natural-transformation-Precategory :
     (F G : functor-Precategory C D)
     (α : natural-transformation-Precategory C D F G)
@@ -354,6 +396,27 @@ module _
       ( comp-functor-Precategory E C D G K)
   right-whisker-natural-transformation-Precategory F G α K =
     (λ x → (pr1 α) ((pr1 K) x)) , (λ f → (pr2 α) ((pr1 (pr2 K)) f))
+
+  preserves-comp-right-whisker-natural-transformation-Precategory :
+    (F G H : functor-Precategory C D)
+    (β : natural-transformation-Precategory C D G H)
+    (α : natural-transformation-Precategory C D F G)
+    (I : functor-Precategory E C) →
+    right-whisker-natural-transformation-Precategory
+      ( F)
+      ( H)
+      ( comp-natural-transformation-Precategory C D F G H β α)
+      ( I) ＝
+    comp-natural-transformation-Precategory
+      ( E)
+      ( D)
+      ( comp-functor-Precategory E C D F I)
+      ( comp-functor-Precategory E C D G I)
+      ( comp-functor-Precategory E C D H I)
+      ( right-whisker-natural-transformation-Precategory G H β I)
+      ( right-whisker-natural-transformation-Precategory F G α I)
+  preserves-comp-right-whisker-natural-transformation-Precategory F G H β α I =
+    refl
 ```
 
 ## Horizontal composition
@@ -392,4 +455,69 @@ module _
       ( comp-functor-Precategory C D E I G)
       ( right-whisker-natural-transformation-Precategory D E C H I β G)
       ( left-whisker-natural-transformation-Precategory C D E F G H α)
+```
+
+## Categorical laws for functor composition
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level} (C : Precategory l1 l2) (D : Precategory l3 l4)
+  (F : functor-Precategory C D)
+  where
+
+  left-unit-law-natural-transformation-comp-functor-Precategory :
+    natural-transformation-Precategory C D
+      ( comp-functor-Precategory C D D (id-functor-Precategory D) F)
+      ( F)
+  pr1 left-unit-law-natural-transformation-comp-functor-Precategory x =
+    id-hom-Precategory D
+  pr2 left-unit-law-natural-transformation-comp-functor-Precategory f =
+    ( right-unit-law-comp-hom-Precategory D _) ∙
+    ( inv (left-unit-law-comp-hom-Precategory D _))
+
+  right-unit-law-natural-transformation-comp-functor-Precategory :
+    natural-transformation-Precategory C D
+      ( comp-functor-Precategory C C D F (id-functor-Precategory C))
+      ( F)
+  pr1 right-unit-law-natural-transformation-comp-functor-Precategory x =
+    id-hom-Precategory D
+  pr2 right-unit-law-natural-transformation-comp-functor-Precategory f =
+    ( right-unit-law-comp-hom-Precategory D _) ∙
+    ( inv (left-unit-law-comp-hom-Precategory D _))
+
+module _
+  {l1 l2 l3 l4 l5 l6 l7 l8 : Level}
+  (A : Precategory l1 l2) (B : Precategory l3 l4)
+  (C : Precategory l5 l6) (D : Precategory l7 l8)
+  (F : functor-Precategory A B) (G : functor-Precategory B C)
+  (H : functor-Precategory C D)
+  where
+
+  associative-natural-transformation-comp-functor-Precategory :
+    natural-transformation-Precategory A D
+      ( comp-functor-Precategory A B D
+        ( comp-functor-Precategory B C D H G)
+        ( F))
+      ( comp-functor-Precategory A C D
+        ( H)
+        ( comp-functor-Precategory A B C G F))
+  pr1 associative-natural-transformation-comp-functor-Precategory x =
+    id-hom-Precategory D
+  pr2 associative-natural-transformation-comp-functor-Precategory f =
+    ( right-unit-law-comp-hom-Precategory D _) ∙
+    ( inv (left-unit-law-comp-hom-Precategory D _))
+
+  associative-natural-transformation-comp-functor-Precategory' :
+    natural-transformation-Precategory A D
+      ( comp-functor-Precategory A C D
+        ( H)
+        ( comp-functor-Precategory A B C G F))
+      ( comp-functor-Precategory A B D
+        ( comp-functor-Precategory B C D H G)
+        ( F))
+  pr1 associative-natural-transformation-comp-functor-Precategory' x =
+    id-hom-Precategory D
+  pr2 associative-natural-transformation-comp-functor-Precategory' f =
+    ( right-unit-law-comp-hom-Precategory D _) ∙
+    ( inv (left-unit-law-comp-hom-Precategory D _))
 ```

--- a/src/category-theory/right-extensions-precategories.lagda.md
+++ b/src/category-theory/right-extensions-precategories.lagda.md
@@ -282,13 +282,13 @@ module _
           ( extension-right-extension-Precategory C D D F F R)
           ( extension-right-extension-Precategory C D D F F R))
         ( F))
-      (comp-functor-Precategory C D D
+      ( comp-functor-Precategory C D D
         ( extension-right-extension-Precategory C D D F F R)
         ( F))
       ( F)
       ( natural-transformation-right-extension-Precategory C D D F F R)
       ( left-whisker-natural-transformation-Precategory C D D
-        (comp-functor-Precategory C D D
+        ( comp-functor-Precategory C D D
           ( extension-right-extension-Precategory C D D F F R)
           ( F))
         ( F)

--- a/src/category-theory/right-extensions-precategories.lagda.md
+++ b/src/category-theory/right-extensions-precategories.lagda.md
@@ -268,14 +268,14 @@ module _
   pr2 id-right-extension-Precategory =
     id-natural-transformation-Precategory C D F
 
-  double-right-extension-Precategory :
+  square-right-extension-Precategory :
     (R : right-extension-Precategory C D D F F) →
     right-extension-Precategory C D D F F
-  pr1 (double-right-extension-Precategory R) =
+  pr1 (square-right-extension-Precategory R) =
     comp-functor-Precategory D D D
       ( extension-right-extension-Precategory C D D F F R)
       ( extension-right-extension-Precategory C D D F F R)
-  pr2 (double-right-extension-Precategory R) =
+  pr2 (square-right-extension-Precategory R) =
     comp-natural-transformation-Precategory C D
       ( comp-functor-Precategory C D D
         ( comp-functor-Precategory D D D

--- a/src/category-theory/right-extensions-precategories.lagda.md
+++ b/src/category-theory/right-extensions-precategories.lagda.md
@@ -248,3 +248,50 @@ module _
   eq-htpy-right-extension-Precategory R S =
     map-inv-equiv (equiv-htpy-eq-right-extension-Precategory R S)
 ```
+
+### Self-extensions
+
+In the case of extending a functor along itself, we have distinguished right
+extensions: the identity map gives a right extension (with the identity natural
+transformation) and we can iterate any right extension `R` to get a right
+extension `R²`.
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level}
+  (C : Precategory l1 l2) (D : Precategory l3 l4)
+  (F : functor-Precategory C D)
+  where
+
+  id-right-extension-Precategory : right-extension-Precategory C D D F F
+  pr1 id-right-extension-Precategory = id-functor-Precategory D
+  pr2 id-right-extension-Precategory =
+    id-natural-transformation-Precategory C D F
+
+  double-right-extension-Precategory :
+    (R : right-extension-Precategory C D D F F) →
+    right-extension-Precategory C D D F F
+  pr1 (double-right-extension-Precategory R) =
+    comp-functor-Precategory D D D
+      ( extension-right-extension-Precategory C D D F F R)
+      ( extension-right-extension-Precategory C D D F F R)
+  pr2 (double-right-extension-Precategory R) =
+    comp-natural-transformation-Precategory C D
+      ( comp-functor-Precategory C D D
+        ( comp-functor-Precategory D D D
+          ( extension-right-extension-Precategory C D D F F R)
+          ( extension-right-extension-Precategory C D D F F R))
+        ( F))
+      (comp-functor-Precategory C D D
+        ( extension-right-extension-Precategory C D D F F R)
+        ( F))
+      ( F)
+      ( natural-transformation-right-extension-Precategory C D D F F R)
+      ( left-whisker-natural-transformation-Precategory C D D
+        (comp-functor-Precategory C D D
+          ( extension-right-extension-Precategory C D D F F R)
+          ( F))
+        ( F)
+        ( extension-right-extension-Precategory C D D F F R)
+        ( natural-transformation-right-extension-Precategory C D D F F R))
+```


### PR DESCRIPTION
This adds codensity monads, showing that any right Kan extension of a functor along itself carries a canonical monad structure induced by the universal property of the right Kan extension. 

There are also a few added lemmas about natural transformations and whiskering.