### PR TITLE
Use classical finite types for convolution reasoning

### DIFF
--- a/src/commutative-algebra/convolution-sequences-commutative-semirings.lagda.md
+++ b/src/commutative-algebra/convolution-sequences-commutative-semirings.lagda.md
@@ -359,22 +359,9 @@ module _
         ( a) ~
       zero-function-Commutative-Semiring R ℕ
     htpy-left-zero-law-convolution-sequence-Commutative-Semiring a n =
-      equational-reasoning
-        sum-finite-Commutative-Semiring
-          ( R)
-          ( finite-type-binary-sum-decomposition-ℕ n)
-          ( λ (i , j , _) →
-            mul-Commutative-Semiring R (zero-Commutative-Semiring R) (a j))
-        ＝
-          sum-finite-Commutative-Semiring
-            ( R)
-            ( finite-type-binary-sum-decomposition-ℕ n)
-            ( λ _ → zero-Commutative-Semiring R)
-          by
-            htpy-sum-finite-Commutative-Semiring R _
-              (λ (i , j , _) → left-zero-law-mul-Commutative-Semiring R _)
-        ＝ zero-Commutative-Semiring R
-          by sum-zero-finite-Commutative-Semiring R _
+      htpy-sum-finite-Commutative-Semiring R _
+        (λ (i , j , _) → left-zero-law-mul-Commutative-Semiring R _) ∙
+      sum-zero-finite-Commutative-Semiring R _
 
     left-zero-law-convolution-sequence-Commutative-Semiring :
       (a : sequence (type-Commutative-Semiring R)) →

--- a/src/commutative-algebra/convolution-sequences-commutative-semirings.lagda.md
+++ b/src/commutative-algebra/convolution-sequences-commutative-semirings.lagda.md
@@ -157,7 +157,7 @@ module _
             by
               eq-sum-finite-sum-count-Commutative-Semiring R
                 ( finite-type-binary-sum-decomposition-ℕ n)
-                ( count-binary-sum-decomposition-ℕ n)
+                ( count-reverse-binary-sum-decomposition-ℕ n)
                 ( _)
         ＝
           add-Commutative-Semiring R

--- a/src/elementary-number-theory/binary-sum-decompositions-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/binary-sum-decompositions-natural-numbers.lagda.md
@@ -11,6 +11,7 @@ open import elementary-number-theory.addition-natural-numbers
 open import elementary-number-theory.equality-natural-numbers
 open import elementary-number-theory.inequality-natural-numbers
 open import elementary-number-theory.natural-numbers
+open import elementary-number-theory.strict-inequality-natural-numbers
 
 open import foundation.action-on-identifications-functions
 open import foundation.automorphisms
@@ -39,6 +40,7 @@ open import foundation.universe-levels
 
 open import logic.complements-decidable-subtypes
 
+open import univalent-combinatorics.classical-finite-types
 open import univalent-combinatorics.counting
 open import univalent-combinatorics.finite-types
 open import univalent-combinatorics.standard-finite-types
@@ -218,13 +220,24 @@ module _
     ( λ (k , k≤n) → eq-pair-eq-fiber (eq-type-Prop (leq-ℕ-Prop k n)))
 
   count-binary-sum-decomposition-ℕ : count (binary-sum-decomposition-ℕ n)
-  count-binary-sum-decomposition-ℕ =
-    succ-ℕ n , equiv-binary-sum-decomposition-leq-ℕ ∘e equiv-fin-succ-leq-ℕ n
+  pr1 count-binary-sum-decomposition-ℕ = succ-ℕ n
+  pr2 count-binary-sum-decomposition-ℕ =
+    equiv-binary-sum-decomposition-leq-ℕ ∘e
+    equiv-le-succ-ℕ-leq-ℕ n ∘e
+    equiv-classical-standard-Fin (succ-ℕ n)
+
+  count-reverse-binary-sum-decomposition-ℕ :
+    count (binary-sum-decomposition-ℕ n)
+  pr1 count-reverse-binary-sum-decomposition-ℕ = succ-ℕ n
+  pr2 count-reverse-binary-sum-decomposition-ℕ =
+    equiv-binary-sum-decomposition-leq-ℕ ∘e
+    equiv-le-succ-ℕ-leq-ℕ n ∘e
+    equiv-classical-standard-Fin-reverse (succ-ℕ n)
 
   finite-type-binary-sum-decomposition-ℕ : Finite-Type lzero
   finite-type-binary-sum-decomposition-ℕ =
-    binary-sum-decomposition-ℕ n ,
-    is-finite-count count-binary-sum-decomposition-ℕ
+    ( binary-sum-decomposition-ℕ n ,
+      is-finite-count count-binary-sum-decomposition-ℕ)
 ```
 
 ### Permuting components in a triple of sums

--- a/src/univalent-combinatorics/classical-finite-types.lagda.md
+++ b/src/univalent-combinatorics/classical-finite-types.lagda.md
@@ -12,8 +12,17 @@ open import elementary-number-theory.modular-arithmetic-standard-finite-types
 open import elementary-number-theory.natural-numbers
 open import elementary-number-theory.strict-inequality-natural-numbers
 
+open import foundation.action-on-identifications-functions
+open import foundation.coproduct-types
 open import foundation.dependent-pair-types
+open import foundation.equality-dependent-pair-types
+open import foundation.equivalences
+open import foundation.function-types
 open import foundation.identity-types
+open import foundation.propositions
+open import foundation.retractions
+open import foundation.sections
+open import foundation.unit-type
 open import foundation.universe-levels
 
 open import univalent-combinatorics.standard-finite-types
@@ -111,3 +120,74 @@ is-retraction-classical-standard-Fin {succ-ℕ k} (pair x p) =
       ( p)
       ( cong-nat-mod-succ-ℕ k x))
 ```
+
+#### The standard equivalence
+
+```agda
+equiv-classical-standard-Fin : (n : ℕ) → Fin n ≃ classical-Fin n
+pr1 (equiv-classical-standard-Fin n) = classical-standard-Fin n
+pr2 (equiv-classical-standard-Fin n) =
+  is-equiv-is-invertible
+    ( standard-classical-Fin n)
+    ( is-retraction-classical-standard-Fin {n})
+    ( is-section-classical-standard-Fin {n})
+```
+
+### The reverse equivalence
+
+The equivalence based on `nat-Fin-reverse` is occasionally useful.
+
+#### We define the reversed maps back and forth between the standard finite sets and the bounded natural numbers
+
+```agda
+classical-standard-Fin-reverse : (n : ℕ) (k : Fin n) → classical-Fin n
+classical-standard-Fin-reverse (succ-ℕ n) (inr star) = zero-ℕ , star
+classical-standard-Fin-reverse (succ-ℕ n) (inl k) =
+  ind-Σ (λ m m<n → (succ-ℕ m , m<n)) (classical-standard-Fin-reverse n k)
+
+standard-classical-Fin-reverse : (n : ℕ) → Σ ℕ (λ k → le-ℕ k n) → Fin n
+standard-classical-Fin-reverse (succ-ℕ n) (zero-ℕ , star) = inr star
+standard-classical-Fin-reverse (succ-ℕ n) (succ-ℕ k , H) =
+  inl (standard-classical-Fin-reverse n (k , H))
+```
+
+#### We show that these maps are mutual inverses
+
+```agda
+is-section-classical-standard-Fin-reverse :
+  (n : ℕ) →
+  is-section
+    ( classical-standard-Fin-reverse n)
+    ( standard-classical-Fin-reverse n)
+is-section-classical-standard-Fin-reverse (succ-ℕ n) (zero-ℕ , k<n) = refl
+is-section-classical-standard-Fin-reverse (succ-ℕ n) (succ-ℕ k , k<n) =
+  eq-pair-Σ
+    ( ap (succ-ℕ ∘ pr1) (is-section-classical-standard-Fin-reverse n (k , k<n)))
+    ( eq-type-Prop (le-ℕ-Prop k n))
+
+is-retraction-classical-standard-Fin-reverse :
+  (n : ℕ) →
+  is-retraction
+    ( classical-standard-Fin-reverse n)
+    ( standard-classical-Fin-reverse n)
+is-retraction-classical-standard-Fin-reverse (succ-ℕ n) (inl x) =
+  ap inl (is-retraction-classical-standard-Fin-reverse n x)
+is-retraction-classical-standard-Fin-reverse (succ-ℕ n) (inr star) = refl
+```
+
+#### The reversed equivalence
+
+```agda
+equiv-classical-standard-Fin-reverse : (n : ℕ) → Fin n ≃ classical-Fin n
+pr1 (equiv-classical-standard-Fin-reverse n) = classical-standard-Fin-reverse n
+pr2 (equiv-classical-standard-Fin-reverse n) =
+  is-equiv-is-invertible
+    ( standard-classical-Fin-reverse n)
+    ( is-section-classical-standard-Fin-reverse n)
+    ( is-retraction-classical-standard-Fin-reverse n)
+```
+
+## See also
+
+- [Standard finite types](univalent-combinatorics.classical-finite-types.md), an
+  inductively constructed set of `n` distinct elements

--- a/src/univalent-combinatorics/standard-finite-types.lagda.md
+++ b/src/univalent-combinatorics/standard-finite-types.lagda.md
@@ -496,38 +496,7 @@ is-preunivalent-Fin =
   is-preunivalent-retraction-equiv-tr-Set Fin-Set retraction-equiv-tr-Fin
 ```
 
-### `Fin n` is equivalent to the set of natural numbers less than `n`
+## See also
 
-```agda
-nat-le-Fin-reverse : (n : ℕ) (k : Fin n) → Σ ℕ (λ m → le-ℕ m n)
-nat-le-Fin-reverse (succ-ℕ n) (inr star) = zero-ℕ , star
-nat-le-Fin-reverse (succ-ℕ n) (inl k) =
-  ind-Σ (λ m m<n → succ-ℕ m , m<n) (nat-le-Fin-reverse n k)
-
-fin-reverse-le-ℕ : (n : ℕ) → Σ ℕ (λ k → le-ℕ k n) → Fin n
-fin-reverse-le-ℕ (succ-ℕ n) (zero-ℕ , star) = inr star
-fin-reverse-le-ℕ (succ-ℕ n) (succ-ℕ k , H) = inl (fin-reverse-le-ℕ n (k , H))
-
-is-section-fin-reverse-le-ℕ :
-  (n : ℕ) → is-section (nat-le-Fin-reverse n) (fin-reverse-le-ℕ n)
-is-section-fin-reverse-le-ℕ (succ-ℕ n) (zero-ℕ , k<n) = refl
-is-section-fin-reverse-le-ℕ (succ-ℕ n) (succ-ℕ k , k<n) =
-  eq-pair-Σ
-    ( ap (succ-ℕ ∘ pr1) (is-section-fin-reverse-le-ℕ n (k , k<n)))
-    ( eq-type-Prop (le-ℕ-Prop k n))
-
-is-retraction-fin-reverse-le-ℕ :
-  (n : ℕ) → is-retraction (nat-le-Fin-reverse n) (fin-reverse-le-ℕ n)
-is-retraction-fin-reverse-le-ℕ (succ-ℕ n) (inl x) =
-  ap inl (is-retraction-fin-reverse-le-ℕ n x)
-is-retraction-fin-reverse-le-ℕ (succ-ℕ n) (inr star) = refl
-
-equiv-fin-le-ℕ : (n : ℕ) → Fin n ≃ Σ ℕ (λ m → le-ℕ m n)
-equiv-fin-le-ℕ n =
-  nat-le-Fin-reverse n ,
-  ( fin-reverse-le-ℕ n , is-section-fin-reverse-le-ℕ n) ,
-  ( fin-reverse-le-ℕ n , is-retraction-fin-reverse-le-ℕ n)
-
-equiv-fin-succ-leq-ℕ : (n : ℕ) → Fin (succ-ℕ n) ≃ Σ ℕ (λ m → leq-ℕ m n)
-equiv-fin-succ-leq-ℕ n = equiv-le-succ-ℕ-leq-ℕ n ∘e equiv-fin-le-ℕ (succ-ℕ n)
-```
+- [Classical finite types](univalent-combinatorics.classical-finite-types.md),
+  the set of natural numbers less than `n`


### PR DESCRIPTION
As pointed out by @malarbol, variations on the needed equivalences between `Fin n` and the type of natural numbers less than `n` already existed in `classical-finite-types`, which I hadn't picked up on.