### PR TITLE
Hom-ring, ℤ, ℚ, etc.

### DIFF
--- a/src/elementary-number-theory/additive-group-of-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/additive-group-of-rational-numbers.lagda.md
@@ -11,6 +11,7 @@ module elementary-number-theory.additive-group-of-rational-numbers where
 ```agda
 open import elementary-number-theory.addition-rational-numbers
 open import elementary-number-theory.difference-rational-numbers
+open import elementary-number-theory.group-of-integers
 open import elementary-number-theory.rational-numbers
 
 open import foundation.dependent-pair-types
@@ -21,6 +22,7 @@ open import foundation.universe-levels
 open import group-theory.abelian-groups
 open import group-theory.commutative-monoids
 open import group-theory.groups
+open import group-theory.homomorphisms-abelian-groups
 open import group-theory.monoids
 open import group-theory.semigroups
 ```
@@ -98,4 +100,11 @@ abstract
 
   left-swap-add-ℚ : (p q r : ℚ) → p +ℚ (q +ℚ r) ＝ q +ℚ (p +ℚ r)
   left-swap-add-ℚ = left-swap-add-Ab abelian-group-add-ℚ
+```
+
+### The inclusion of integers in the rationals is an additive homomorphism
+
+```agda
+hom-add-rational-ℤ : hom-Ab ℤ-Ab abelian-group-add-ℚ
+hom-add-rational-ℤ = (rational-ℤ , λ {x y} → inv (add-rational-ℤ x y))
 ```

--- a/src/elementary-number-theory/positive-integers.lagda.md
+++ b/src/elementary-number-theory/positive-integers.lagda.md
@@ -98,6 +98,9 @@ module _
 ```agda
 one-positive-ℤ : positive-ℤ
 one-positive-ℤ = (one-ℤ , star)
+
+one-ℤ⁺ : ℤ⁺
+one-ℤ⁺ = one-positive-ℤ
 ```
 
 ## Properties

--- a/src/elementary-number-theory/positive-integers.lagda.md
+++ b/src/elementary-number-theory/positive-integers.lagda.md
@@ -156,6 +156,26 @@ is-positive-int-is-nonzero-ℕ (succ-ℕ x) H = star
 
 positive-int-ℕ⁺ : ℕ⁺ → positive-ℤ
 positive-int-ℕ⁺ (n , n≠0) = int-ℕ n , is-positive-int-is-nonzero-ℕ n n≠0
+
+positive-nat-ℤ⁺ : positive-ℤ → ℕ⁺
+positive-nat-ℤ⁺ (inr (inr x) , k>0) = succ-nonzero-ℕ' x
+
+is-section-positive-nat-ℤ⁺ :
+  (k : ℤ⁺) → positive-int-ℕ⁺ (positive-nat-ℤ⁺ k) ＝ k
+is-section-positive-nat-ℤ⁺ (inr (inr k) , k>0) =
+  eq-type-subtype subtype-positive-ℤ refl
+
+is-retraction-positive-nat-ℤ⁺ :
+  (n : ℕ⁺) → positive-nat-ℤ⁺ (positive-int-ℕ⁺ n) ＝ n
+is-retraction-positive-nat-ℤ⁺ (zero-ℕ , n≠0) = ex-falso (n≠0 refl)
+is-retraction-positive-nat-ℤ⁺ (succ-ℕ n , n≠0) = eq-nonzero-ℕ refl
+
+is-equiv-positive-int-ℕ⁺ : is-equiv positive-int-ℕ⁺
+is-equiv-positive-int-ℕ⁺ =
+  is-equiv-is-invertible
+    ( positive-nat-ℤ⁺)
+    ( is-section-positive-nat-ℤ⁺)
+    ( is-retraction-positive-nat-ℤ⁺)
 ```
 
 ### The canonical equivalence between natural numbers and positive integers

--- a/src/elementary-number-theory/ring-of-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/ring-of-rational-numbers.lagda.md
@@ -14,14 +14,19 @@ open import commutative-algebra.commutative-rings
 open import elementary-number-theory.additive-group-of-rational-numbers
 open import elementary-number-theory.multiplication-rational-numbers
 open import elementary-number-theory.multiplicative-monoid-of-rational-numbers
+open import elementary-number-theory.rational-numbers
+open import elementary-number-theory.ring-of-integers
 
 open import foundation.coproduct-types
 open import foundation.dependent-pair-types
+open import foundation.homotopies
+open import foundation.identity-types
 open import foundation.unital-binary-operations
 open import foundation.universe-levels
 
 open import group-theory.semigroups
 
+open import ring-theory.homomorphisms-rings
 open import ring-theory.rings
 ```
 
@@ -63,4 +68,22 @@ pr2 ring-ℚ = has-mul-abelian-group-add-ℚ
 commutative-ring-ℚ : Commutative-Ring lzero
 pr1 commutative-ring-ℚ = ring-ℚ
 pr2 commutative-ring-ℚ = commutative-mul-ℚ
+```
+
+### The inclusion of integers in the rationals is the initial ring homomorphism
+
+```agda
+hom-ring-rational-ℤ : hom-Ring ℤ-Ring ring-ℚ
+hom-ring-rational-ℤ =
+  ( hom-add-rational-ℤ) ,
+  ( λ {x y} → inv (mul-rational-ℤ x y)) ,
+  ( refl)
+
+htpy-map-initial-hom-ring-rational-ℤ : map-initial-hom-Ring ring-ℚ ~ rational-ℤ
+htpy-map-initial-hom-ring-rational-ℤ =
+  htpy-initial-hom-Ring ring-ℚ hom-ring-rational-ℤ
+
+eq-initial-hom-ring-rational-ℤ : initial-hom-Ring ring-ℚ ＝ hom-ring-rational-ℤ
+eq-initial-hom-ring-rational-ℤ =
+  contraction-initial-hom-Ring ring-ℚ hom-ring-rational-ℤ
 ```

--- a/src/elementary-number-theory/unit-fractions-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/unit-fractions-rational-numbers.lagda.md
@@ -27,6 +27,7 @@ open import foundation.action-on-identifications-functions
 open import foundation.binary-transport
 open import foundation.dependent-pair-types
 open import foundation.functoriality-dependent-pair-types
+open import foundation.identity-types
 
 open import group-theory.groups
 ```
@@ -117,4 +118,44 @@ smaller-reciprocal-ℚ⁺ q⁺@(q , _) =
           ( rational-ℚ⁺ (positive-rational-ℕ⁺ n⁺ *ℚ⁺ q⁺))
           ( 1<nq)))
     ( bound-archimedean-property-ℚ⁺ q⁺ one-ℚ⁺)
+```
+
+### The reciprocal of `n` is a multiplicative inverse of `n`
+
+```agda
+module _
+  (n : ℕ⁺)
+  where
+
+  left-inverse-law-positive-reciprocal-rational-ℕ⁺ :
+    mul-ℚ⁺
+      ( positive-reciprocal-rational-ℕ⁺ n)
+      ( positive-rational-ℕ⁺ n) ＝
+    one-ℚ⁺
+  left-inverse-law-positive-reciprocal-rational-ℕ⁺ =
+    left-inverse-law-mul-ℚ⁺ (positive-rational-ℕ⁺ n)
+
+  left-inverse-law-reciprocal-rational-ℕ⁺ :
+    mul-ℚ
+      ( reciprocal-rational-ℕ⁺ n)
+      ( rational-ℚ⁺ (positive-rational-ℕ⁺ n)) ＝
+    one-ℚ
+  left-inverse-law-reciprocal-rational-ℕ⁺ =
+    ap rational-ℚ⁺ left-inverse-law-positive-reciprocal-rational-ℕ⁺
+
+  right-inverse-law-positive-reciprocal-rational-ℕ⁺ :
+    mul-ℚ⁺
+      ( positive-rational-ℕ⁺ n)
+      ( positive-reciprocal-rational-ℕ⁺ n) ＝
+    one-ℚ⁺
+  right-inverse-law-positive-reciprocal-rational-ℕ⁺ =
+    right-inverse-law-mul-ℚ⁺ (positive-rational-ℕ⁺ n)
+
+  right-inverse-law-reciprocal-rational-ℕ⁺ :
+    mul-ℚ
+      ( rational-ℚ⁺ (positive-rational-ℕ⁺ n))
+      (reciprocal-rational-ℕ⁺ n) ＝
+    one-ℚ
+  right-inverse-law-reciprocal-rational-ℕ⁺ =
+    ap rational-ℚ⁺ right-inverse-law-positive-reciprocal-rational-ℕ⁺
 ```

--- a/src/elementary-number-theory/unit-fractions-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/unit-fractions-rational-numbers.lagda.md
@@ -14,8 +14,8 @@ open import elementary-number-theory.inequality-integers
 open import elementary-number-theory.inequality-rational-numbers
 open import elementary-number-theory.integer-fractions
 open import elementary-number-theory.integers
-open import elementary-number-theory.multiplication-integers
 open import elementary-number-theory.multiplication-integer-fractions
+open import elementary-number-theory.multiplication-integers
 open import elementary-number-theory.multiplication-rational-numbers
 open import elementary-number-theory.multiplicative-group-of-positive-rational-numbers
 open import elementary-number-theory.natural-numbers

--- a/src/elementary-number-theory/unit-fractions-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/unit-fractions-rational-numbers.lagda.md
@@ -12,12 +12,15 @@ module elementary-number-theory.unit-fractions-rational-numbers where
 open import elementary-number-theory.archimedean-property-positive-rational-numbers
 open import elementary-number-theory.inequality-integers
 open import elementary-number-theory.inequality-rational-numbers
+open import elementary-number-theory.integer-fractions
 open import elementary-number-theory.integers
 open import elementary-number-theory.multiplication-integers
+open import elementary-number-theory.multiplication-integer-fractions
 open import elementary-number-theory.multiplication-rational-numbers
 open import elementary-number-theory.multiplicative-group-of-positive-rational-numbers
 open import elementary-number-theory.natural-numbers
 open import elementary-number-theory.nonzero-natural-numbers
+open import elementary-number-theory.positive-integers
 open import elementary-number-theory.positive-rational-numbers
 open import elementary-number-theory.rational-numbers
 open import elementary-number-theory.strict-inequality-integers
@@ -61,6 +64,20 @@ reciprocal-rational-succ-ℕ n =
   reciprocal-rational-ℕ⁺ (succ-nonzero-ℕ' n)
 ```
 
+### Reciprocals of positive integers
+
+```agda
+positive-reciprocal-rational-ℤ⁺ : ℤ⁺ → ℚ⁺
+positive-reciprocal-rational-ℤ⁺ k =
+  positive-reciprocal-rational-ℕ⁺ (positive-nat-ℤ⁺ k)
+
+reciprocal-rational-ℤ⁺ : ℤ⁺ → ℚ
+reciprocal-rational-ℤ⁺ k =
+  reciprocal-rational-ℕ⁺ (positive-nat-ℤ⁺ k)
+```
+
+## Properties
+
 ### If `m ≤ n`, the reciprocal of `n` is less than or equal to the reciprocal of `n`
 
 ```agda
@@ -92,8 +109,6 @@ abstract
       ( left-unit-law-mul-ℤ (int-ℕ n))
       ( le-natural-le-ℤ m n m<n)
 ```
-
-## Properties
 
 ### For every positive rational number, there is a smaller unit fraction
 
@@ -154,7 +169,7 @@ module _
   right-inverse-law-reciprocal-rational-ℕ⁺ :
     mul-ℚ
       ( rational-ℚ⁺ (positive-rational-ℕ⁺ n))
-      (reciprocal-rational-ℕ⁺ n) ＝
+      ( reciprocal-rational-ℕ⁺ n) ＝
     one-ℚ
   right-inverse-law-reciprocal-rational-ℕ⁺ =
     ap rational-ℚ⁺ right-inverse-law-positive-reciprocal-rational-ℕ⁺


### PR DESCRIPTION
This PR aims to fill some gaps in ring-theory relations between ℤ and ℚ:

- `rational-ℤ` is the initial ring homomorphism `ℤ → ℚ`;
- elements of `ℤ⁺` are invertible in `ℚ`.