### PR TITLE
Make rational arithmetic opaque

### DIFF
--- a/src/elementary-number-theory/absolute-value-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/absolute-value-rational-numbers.lagda.md
@@ -43,7 +43,9 @@ its negation.
 rational-abs-ℚ : ℚ → ℚ
 rational-abs-ℚ q = max-ℚ q (neg-ℚ q)
 
-abstract
+opaque
+  unfolding neg-ℚ
+
   is-nonnegative-rational-abs-ℚ : (q : ℚ) → is-nonnegative-ℚ (rational-abs-ℚ q)
   is-nonnegative-rational-abs-ℚ q =
     rec-coproduct
@@ -88,7 +90,9 @@ abstract
 ### The absolute value of a nonnegative rational number is the number itself
 
 ```agda
-abstract
+opaque
+  unfolding neg-ℚ
+
   abs-rational-ℚ⁰⁺ : (q : ℚ⁰⁺) → abs-ℚ (rational-ℚ⁰⁺ q) ＝ q
   abs-rational-ℚ⁰⁺ (q , nonneg-q) =
     eq-ℚ⁰⁺
@@ -144,7 +148,9 @@ abstract
 ### The absolute value of `q` is zero iff `q` is zero
 
 ```agda
-abstract
+opaque
+  unfolding neg-ℚ
+
   eq-zero-eq-abs-zero-ℚ : (q : ℚ) → abs-ℚ q ＝ zero-ℚ⁰⁺ → q ＝ zero-ℚ
   eq-zero-eq-abs-zero-ℚ q abs=0 =
     rec-coproduct
@@ -207,7 +213,9 @@ abstract
 ### `|ab| = |a||b|`
 
 ```agda
-abstract
+opaque
+  unfolding neg-ℚ
+
   abs-left-mul-nonnegative-ℚ :
     (q : ℚ) (p : ℚ⁰⁺) → abs-ℚ (rational-ℚ⁰⁺ p *ℚ q) ＝ p *ℚ⁰⁺ abs-ℚ q
   abs-left-mul-nonnegative-ℚ q p⁰⁺@(p , nonneg-p) with linear-leq-ℚ zero-ℚ q

--- a/src/elementary-number-theory/addition-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/addition-rational-numbers.lagda.md
@@ -153,6 +153,7 @@ abstract
 ```agda
 opaque
   unfolding add-ℚ
+  unfolding neg-ℚ
 
   left-inverse-law-add-ℚ : (x : ℚ) → (neg-ℚ x) +ℚ x ＝ zero-ℚ
   left-inverse-law-add-ℚ x =
@@ -191,6 +192,7 @@ abstract
 ```agda
 opaque
   unfolding add-ℚ
+  unfolding neg-ℚ
 
   distributive-neg-add-ℚ :
     (x y : ℚ) → neg-ℚ (x +ℚ y) ＝ neg-ℚ x +ℚ neg-ℚ y
@@ -207,6 +209,7 @@ opaque
 ```agda
 opaque
   unfolding add-ℚ
+  unfolding neg-ℚ
 
   is-retraction-pred-ℚ : is-retraction succ-ℚ pred-ℚ
   is-retraction-pred-ℚ x =

--- a/src/elementary-number-theory/addition-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/addition-rational-numbers.lagda.md
@@ -95,6 +95,7 @@ opaque
 ```agda
 opaque
   unfolding add-ℚ
+  unfolding rational-fraction-ℤ
 
   associative-add-ℚ :
     (x y z : ℚ) →
@@ -256,6 +257,7 @@ pr2 equiv-pred-ℚ = is-equiv-pred-ℚ
 ```agda
 opaque
   unfolding add-ℚ
+  unfolding rational-fraction-ℤ
 
   add-rational-fraction-ℤ :
     (x y : fraction-ℤ) →

--- a/src/elementary-number-theory/addition-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/addition-rational-numbers.lagda.md
@@ -40,8 +40,9 @@ basic properties.
 ## Definition
 
 ```agda
-add-ℚ : ℚ → ℚ → ℚ
-add-ℚ (x , p) (y , q) = rational-fraction-ℤ (add-fraction-ℤ x y)
+opaque
+  add-ℚ : ℚ → ℚ → ℚ
+  add-ℚ (x , p) (y , q) = rational-fraction-ℤ (add-fraction-ℤ x y)
 
 add-ℚ' : ℚ → ℚ → ℚ
 add-ℚ' x y = add-ℚ y x
@@ -69,7 +70,9 @@ pred-ℚ = add-ℚ neg-one-ℚ
 ### Unit laws
 
 ```agda
-abstract
+opaque
+  unfolding add-ℚ
+
   left-unit-law-add-ℚ : (x : ℚ) → zero-ℚ +ℚ x ＝ x
   left-unit-law-add-ℚ (x , p) =
     eq-ℚ-sim-fraction-ℤ
@@ -90,7 +93,9 @@ abstract
 ### Addition is associative
 
 ```agda
-abstract
+opaque
+  unfolding add-ℚ
+
   associative-add-ℚ :
     (x y z : ℚ) →
     (x +ℚ y) +ℚ z ＝ x +ℚ (y +ℚ z)
@@ -117,7 +122,9 @@ abstract
 ### Addition is commutative
 
 ```agda
-abstract
+opaque
+  unfolding add-ℚ
+
   commutative-add-ℚ :
     (x y : ℚ) →
     x +ℚ y ＝ y +ℚ x
@@ -144,7 +151,9 @@ abstract
 ### The negative of a rational number is its additive inverse
 
 ```agda
-abstract
+opaque
+  unfolding add-ℚ
+
   left-inverse-law-add-ℚ : (x : ℚ) → (neg-ℚ x) +ℚ x ＝ zero-ℚ
   left-inverse-law-add-ℚ x =
     ( eq-ℚ-sim-fraction-ℤ
@@ -180,7 +189,9 @@ abstract
 ### The negatives of rational numbers distribute over addition
 
 ```agda
-abstract
+opaque
+  unfolding add-ℚ
+
   distributive-neg-add-ℚ :
     (x y : ℚ) → neg-ℚ (x +ℚ y) ＝ neg-ℚ x +ℚ neg-ℚ y
   distributive-neg-add-ℚ (x , dxp) (y , dyp) =
@@ -194,7 +205,9 @@ abstract
 ### The successor and predecessor functions on ℚ are mutual inverses
 
 ```agda
-abstract
+opaque
+  unfolding add-ℚ
+
   is-retraction-pred-ℚ : is-retraction succ-ℚ pred-ℚ
   is-retraction-pred-ℚ x =
     equational-reasoning
@@ -238,7 +251,9 @@ pr2 equiv-pred-ℚ = is-equiv-pred-ℚ
 ### The inclusion of integer fractions preserves addition
 
 ```agda
-abstract
+opaque
+  unfolding add-ℚ
+
   add-rational-fraction-ℤ :
     (x y : fraction-ℤ) →
     rational-fraction-ℤ x +ℚ rational-fraction-ℤ y ＝

--- a/src/elementary-number-theory/difference-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/difference-rational-numbers.lagda.md
@@ -75,7 +75,9 @@ abstract
 ### The difference of a rational number with zero is itself
 
 ```agda
-abstract
+opaque
+  unfolding neg-ℚ
+
   right-zero-law-diff-ℚ : (x : ℚ) → x -ℚ zero-ℚ ＝ x
   right-zero-law-diff-ℚ = right-unit-law-add-ℚ
 ```

--- a/src/elementary-number-theory/distance-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/distance-rational-numbers.lagda.md
@@ -80,7 +80,9 @@ abstract
 ### Zero laws
 
 ```agda
-abstract
+opaque
+  unfolding neg-ℚ
+
   right-zero-law-dist-ℚ : (q : ℚ) → dist-ℚ q zero-ℚ ＝ abs-ℚ q
   right-zero-law-dist-ℚ q = ap abs-ℚ (right-unit-law-add-ℚ _)
 

--- a/src/elementary-number-theory/inequality-arithmetic-geometric-means-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/inequality-arithmetic-geometric-means-rational-numbers.lagda.md
@@ -41,7 +41,10 @@ numbers.
 ### Proof
 
 ```agda
-abstract
+opaque
+  unfolding mul-ℚ
+  unfolding neg-ℚ
+
   eq-square-sum-minus-four-mul-ℚ-square-diff :
     (x y : ℚ) →
     square-ℚ (x +ℚ y) -ℚ rational-ℕ 4 *ℚ (x *ℚ y) ＝ square-ℚ (x -ℚ y)

--- a/src/elementary-number-theory/inequality-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/inequality-rational-numbers.lagda.md
@@ -203,6 +203,7 @@ module _
 
   opaque
     unfolding leq-ℚ-Prop
+    unfolding rational-fraction-ℤ
 
     preserves-leq-rational-fraction-ℤ :
       leq-fraction-ℤ p q → leq-ℚ (rational-fraction-ℤ p) (rational-fraction-ℤ q)
@@ -221,6 +222,7 @@ module _
 
   opaque
     unfolding leq-ℚ-Prop
+    unfolding rational-fraction-ℤ
 
     preserves-leq-right-rational-fraction-ℤ :
       leq-fraction-ℤ (fraction-ℚ x) p → leq-ℚ x (rational-fraction-ℤ p)
@@ -253,6 +255,7 @@ module _
 
   opaque
     unfolding leq-ℚ-Prop
+    unfolding rational-fraction-ℤ
 
     preserves-leq-left-rational-fraction-ℤ :
       leq-fraction-ℤ p (fraction-ℚ x) → leq-ℚ (rational-fraction-ℤ p) x

--- a/src/elementary-number-theory/inequality-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/inequality-rational-numbers.lagda.md
@@ -265,7 +265,9 @@ module _
   (x y : ℚ)
   where
 
-  abstract
+  opaque
+    unfolding add-ℚ
+
     iff-translate-diff-leq-zero-ℚ : leq-ℚ zero-ℚ (y -ℚ x) ↔ leq-ℚ x y
     iff-translate-diff-leq-zero-ℚ =
       logical-equivalence-reasoning

--- a/src/elementary-number-theory/inequality-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/inequality-rational-numbers.lagda.md
@@ -69,8 +69,9 @@ is [less than or equal](elementary-number-theory.inequality-integers.md) to
 ### Inequality on the rational numbers
 
 ```agda
-leq-ℚ-Prop : ℚ → ℚ → Prop lzero
-leq-ℚ-Prop (x , px) (y , py) = leq-fraction-ℤ-Prop x y
+opaque
+  leq-ℚ-Prop : ℚ → ℚ → Prop lzero
+  leq-ℚ-Prop (x , px) (y , py) = leq-fraction-ℤ-Prop x y
 
 leq-ℚ : ℚ → ℚ → UU lzero
 leq-ℚ x y = type-Prop (leq-ℚ-Prop x y)
@@ -87,16 +88,22 @@ _≤-ℚ_ = leq-ℚ
 ### Zero is less than one
 
 ```agda
-leq-zero-one-ℚ : leq-ℚ zero-ℚ one-ℚ
-leq-zero-one-ℚ = leq-zero-one-ℤ
+opaque
+  unfolding leq-ℚ-Prop
+
+  leq-zero-one-ℚ : leq-ℚ zero-ℚ one-ℚ
+  leq-zero-one-ℚ = leq-zero-one-ℤ
 ```
 
 ### Inequality on the rational numbers is decidable
 
 ```agda
-is-decidable-leq-ℚ : (x y : ℚ) → (leq-ℚ x y) + ¬ (leq-ℚ x y)
-is-decidable-leq-ℚ x y =
-  is-decidable-leq-fraction-ℤ (fraction-ℚ x) (fraction-ℚ y)
+opaque
+  unfolding leq-ℚ-Prop
+
+  is-decidable-leq-ℚ : (x y : ℚ) → (leq-ℚ x y) + ¬ (leq-ℚ x y)
+  is-decidable-leq-ℚ x y =
+    is-decidable-leq-fraction-ℤ (fraction-ℚ x) (fraction-ℚ y)
 
 leq-ℚ-Decidable-Prop : (x y : ℚ) → Decidable-Prop lzero
 leq-ℚ-Decidable-Prop x y =
@@ -108,18 +115,24 @@ leq-ℚ-Decidable-Prop x y =
 ### Inequality on the rational numbers is reflexive
 
 ```agda
-refl-leq-ℚ : (x : ℚ) → leq-ℚ x x
-refl-leq-ℚ x =
-  refl-leq-ℤ (numerator-ℚ x *ℤ denominator-ℚ x)
+opaque
+  unfolding leq-ℚ-Prop
 
-leq-eq-ℚ : (x y : ℚ) → x ＝ y → leq-ℚ x y
-leq-eq-ℚ x y x=y = tr (leq-ℚ x) x=y (refl-leq-ℚ x)
+  refl-leq-ℚ : (x : ℚ) → leq-ℚ x x
+  refl-leq-ℚ x =
+    refl-leq-ℤ (numerator-ℚ x *ℤ denominator-ℚ x)
+
+abstract
+  leq-eq-ℚ : (x y : ℚ) → x ＝ y → leq-ℚ x y
+  leq-eq-ℚ x y x=y = tr (leq-ℚ x) x=y (refl-leq-ℚ x)
 ```
 
 ### Inequality on the rational numbers is antisymmetric
 
 ```agda
-abstract
+opaque
+  unfolding leq-ℚ-Prop
+
   antisymmetric-leq-ℚ : (x y : ℚ) → leq-ℚ x y → leq-ℚ y x → x ＝ y
   antisymmetric-leq-ℚ x y H H' =
     ( inv (is-retraction-rational-fraction-ℚ x)) ∙
@@ -137,7 +150,9 @@ abstract
 ### Inequality on the rational numbers is linear
 
 ```agda
-abstract
+opaque
+  unfolding leq-ℚ-Prop
+
   linear-leq-ℚ : (x y : ℚ) → (leq-ℚ x y) + (leq-ℚ y x)
   linear-leq-ℚ x y =
     map-coproduct
@@ -157,7 +172,9 @@ module _
   (x y z : ℚ)
   where
 
-  abstract
+  opaque
+    unfolding leq-ℚ-Prop
+
     transitive-leq-ℚ : leq-ℚ y z → leq-ℚ x y → leq-ℚ x z
     transitive-leq-ℚ =
       transitive-leq-fraction-ℤ
@@ -184,7 +201,9 @@ module _
   (p q : fraction-ℤ)
   where
 
-  abstract
+  opaque
+    unfolding leq-ℚ-Prop
+
     preserves-leq-rational-fraction-ℤ :
       leq-fraction-ℤ p q → leq-ℚ (rational-fraction-ℤ p) (rational-fraction-ℤ q)
     preserves-leq-rational-fraction-ℤ =
@@ -200,7 +219,9 @@ module _
   (x : ℚ) (p : fraction-ℤ)
   where
 
-  abstract
+  opaque
+    unfolding leq-ℚ-Prop
+
     preserves-leq-right-rational-fraction-ℤ :
       leq-fraction-ℤ (fraction-ℚ x) p → leq-ℚ x (rational-fraction-ℤ p)
     preserves-leq-right-rational-fraction-ℤ H =
@@ -230,7 +251,9 @@ module _
     preserves-leq-right-rational-fraction-ℤ
   pr2 iff-leq-right-rational-fraction-ℤ = reflects-leq-right-rational-fraction-ℤ
 
-  abstract
+  opaque
+    unfolding leq-ℚ-Prop
+
     preserves-leq-left-rational-fraction-ℤ :
       leq-fraction-ℤ p (fraction-ℚ x) → leq-ℚ (rational-fraction-ℤ p) x
     preserves-leq-left-rational-fraction-ℤ =
@@ -267,6 +290,8 @@ module _
 
   opaque
     unfolding add-ℚ
+    unfolding leq-ℚ-Prop
+    unfolding neg-ℚ
 
     iff-translate-diff-leq-zero-ℚ : leq-ℚ zero-ℚ (y -ℚ x) ↔ leq-ℚ x y
     iff-translate-diff-leq-zero-ℚ =
@@ -353,22 +378,27 @@ pr2 (left-add-hom-leq-ℚ z) = preserves-leq-right-add-ℚ z
 ### Addition on the rational numbers preserves inequality
 
 ```agda
-preserves-leq-add-ℚ :
-  {a b c d : ℚ} → leq-ℚ a b → leq-ℚ c d → leq-ℚ (a +ℚ c) (b +ℚ d)
-preserves-leq-add-ℚ {a} {b} {c} {d} H K =
-  transitive-leq-ℚ
-    ( a +ℚ c)
-    ( b +ℚ c)
-    ( b +ℚ d)
-    ( preserves-leq-right-add-ℚ b c d K)
-    ( preserves-leq-left-add-ℚ c a b H)
+abstract
+  preserves-leq-add-ℚ :
+    {a b c d : ℚ} → leq-ℚ a b → leq-ℚ c d → leq-ℚ (a +ℚ c) (b +ℚ d)
+  preserves-leq-add-ℚ {a} {b} {c} {d} H K =
+    transitive-leq-ℚ
+      ( a +ℚ c)
+      ( b +ℚ c)
+      ( b +ℚ d)
+      ( preserves-leq-right-add-ℚ b c d K)
+      ( preserves-leq-left-add-ℚ c a b H)
 ```
 
 ### Negation of rational numbers reverses inequality
 
 ```agda
-neg-leq-ℚ : (x y : ℚ) → leq-ℚ x y → leq-ℚ (neg-ℚ y) (neg-ℚ x)
-neg-leq-ℚ x y = neg-leq-fraction-ℤ (fraction-ℚ x) (fraction-ℚ y)
+opaque
+  unfolding leq-ℚ-Prop
+  unfolding neg-ℚ
+
+  neg-leq-ℚ : (x y : ℚ) → leq-ℚ x y → leq-ℚ (neg-ℚ y) (neg-ℚ x)
+  neg-leq-ℚ x y = neg-leq-fraction-ℤ (fraction-ℚ x) (fraction-ℚ y)
 ```
 
 ### Transposing additions on inequalities of rational numbers

--- a/src/elementary-number-theory/multiplication-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/multiplication-rational-numbers.lagda.md
@@ -152,6 +152,7 @@ opaque
 ```agda
 opaque
   unfolding mul-ℚ
+  unfolding neg-ℚ
 
   left-neg-unit-law-mul-ℚ : (x : ℚ) → neg-one-ℚ *ℚ x ＝ neg-ℚ x
   left-neg-unit-law-mul-ℚ x =

--- a/src/elementary-number-theory/multiplication-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/multiplication-rational-numbers.lagda.md
@@ -99,6 +99,7 @@ module _
 ```agda
 opaque
   unfolding mul-ℚ
+  unfolding rational-fraction-ℤ
 
   decide-is-zero-factor-is-zero-mul-ℚ :
     (x y : ℚ) → is-zero-ℚ (x *ℚ y) → (is-zero-ℚ x) + (is-zero-ℚ y)
@@ -180,6 +181,7 @@ opaque
 ```agda
 opaque
   unfolding mul-ℚ
+  unfolding rational-fraction-ℤ
 
   associative-mul-ℚ :
     (x y z : ℚ) → (x *ℚ y) *ℚ z ＝ x *ℚ (y *ℚ z)
@@ -280,8 +282,9 @@ abstract
 
 ```agda
 opaque
-  unfolding mul-ℚ
   unfolding add-ℚ
+  unfolding mul-ℚ
+  unfolding rational-fraction-ℤ
 
   left-distributive-mul-add-ℚ :
     (x y z : ℚ) → x *ℚ (y +ℚ z) ＝ (x *ℚ y) +ℚ (x *ℚ z)
@@ -356,6 +359,7 @@ abstract
 ```agda
 opaque
   unfolding mul-ℚ
+  unfolding rational-fraction-ℤ
 
   mul-rational-fraction-ℤ :
     (x y : fraction-ℤ) →

--- a/src/elementary-number-theory/multiplication-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/multiplication-rational-numbers.lagda.md
@@ -46,8 +46,9 @@ rational numbers.
 ## Definition
 
 ```agda
-mul-ℚ : ℚ → ℚ → ℚ
-mul-ℚ (x , p) (y , q) = rational-fraction-ℤ (mul-fraction-ℤ x y)
+opaque
+  mul-ℚ : ℚ → ℚ → ℚ
+  mul-ℚ (x , p) (y , q) = rational-fraction-ℤ (mul-fraction-ℤ x y)
 
 mul-ℚ' : ℚ → ℚ → ℚ
 mul-ℚ' x y = mul-ℚ y x
@@ -69,7 +70,9 @@ module _
   (x : ℚ)
   where
 
-  abstract
+  opaque
+    unfolding mul-ℚ
+
     left-zero-law-mul-ℚ : zero-ℚ *ℚ x ＝ zero-ℚ
     left-zero-law-mul-ℚ =
       ( eq-ℚ-sim-fraction-ℤ
@@ -94,34 +97,39 @@ module _
 ### If the product of two rational numbers is zero, the left or right factor is zero
 
 ```agda
-decide-is-zero-factor-is-zero-mul-ℚ :
-  (x y : ℚ) → is-zero-ℚ (x *ℚ y) → (is-zero-ℚ x) + (is-zero-ℚ y)
-decide-is-zero-factor-is-zero-mul-ℚ x y H =
-  rec-coproduct
-    ( inl ∘ is-zero-is-zero-numerator-ℚ x)
-    ( inr ∘ is-zero-is-zero-numerator-ℚ y)
-    ( is-zero-is-zero-mul-ℤ
-      ( numerator-ℚ x)
-      ( numerator-ℚ y)
-      ( ( inv
-          ( eq-reduce-numerator-fraction-ℤ
-            ( mul-fraction-ℤ (fraction-ℚ x) (fraction-ℚ y)))) ∙
-        ( ap
-          ( mul-ℤ'
-            ( gcd-ℤ
-              ( numerator-ℚ x *ℤ numerator-ℚ y)
-              ( denominator-ℚ x *ℤ denominator-ℚ y)))
-          ( ( is-zero-numerator-is-zero-ℚ (x *ℚ y) H) ∙
-            ( left-zero-law-mul-ℤ
+opaque
+  unfolding mul-ℚ
+
+  decide-is-zero-factor-is-zero-mul-ℚ :
+    (x y : ℚ) → is-zero-ℚ (x *ℚ y) → (is-zero-ℚ x) + (is-zero-ℚ y)
+  decide-is-zero-factor-is-zero-mul-ℚ x y H =
+    rec-coproduct
+      ( inl ∘ is-zero-is-zero-numerator-ℚ x)
+      ( inr ∘ is-zero-is-zero-numerator-ℚ y)
+      ( is-zero-is-zero-mul-ℤ
+        ( numerator-ℚ x)
+        ( numerator-ℚ y)
+        ( ( inv
+            ( eq-reduce-numerator-fraction-ℤ
+              ( mul-fraction-ℤ (fraction-ℚ x) (fraction-ℚ y)))) ∙
+          ( ap
+            ( mul-ℤ'
               ( gcd-ℤ
-                (numerator-ℚ x *ℤ numerator-ℚ y)
-                (denominator-ℚ x *ℤ denominator-ℚ y)))))))
+                ( numerator-ℚ x *ℤ numerator-ℚ y)
+                ( denominator-ℚ x *ℤ denominator-ℚ y)))
+            ( ( is-zero-numerator-is-zero-ℚ (x *ℚ y) H) ∙
+              ( left-zero-law-mul-ℤ
+                ( gcd-ℤ
+                  (numerator-ℚ x *ℤ numerator-ℚ y)
+                  (denominator-ℚ x *ℤ denominator-ℚ y)))))))
 ```
 
 ### Unit laws for multiplication on rational numbers
 
 ```agda
-abstract
+opaque
+  unfolding mul-ℚ
+
   left-unit-law-mul-ℚ : (x : ℚ) → one-ℚ *ℚ x ＝ x
   left-unit-law-mul-ℚ x =
     ( eq-ℚ-sim-fraction-ℤ
@@ -142,7 +150,9 @@ abstract
 ### Multiplication of a rational number by `-1` is equal to the negative
 
 ```agda
-abstract
+opaque
+  unfolding mul-ℚ
+
   left-neg-unit-law-mul-ℚ : (x : ℚ) → neg-one-ℚ *ℚ x ＝ neg-ℚ x
   left-neg-unit-law-mul-ℚ x =
     ( eq-ℚ-sim-fraction-ℤ
@@ -167,7 +177,9 @@ abstract
 ### Multiplication of rational numbers is associative
 
 ```agda
-abstract
+opaque
+  unfolding mul-ℚ
+
   associative-mul-ℚ :
     (x y z : ℚ) → (x *ℚ y) *ℚ z ＝ x *ℚ (y *ℚ z)
   associative-mul-ℚ x y z =
@@ -206,7 +218,9 @@ abstract
 ### Multiplication of rational numbers is commutative
 
 ```agda
-abstract
+opaque
+  unfolding mul-ℚ
+
   commutative-mul-ℚ : (x y : ℚ) → x *ℚ y ＝ y *ℚ x
   commutative-mul-ℚ x y =
     eq-ℚ-sim-fraction-ℤ
@@ -264,7 +278,10 @@ abstract
 ### Multiplication on rational numbers distributes over addition
 
 ```agda
-abstract
+opaque
+  unfolding mul-ℚ
+  unfolding add-ℚ
+
   left-distributive-mul-add-ℚ :
     (x y z : ℚ) → x *ℚ (y +ℚ z) ＝ (x *ℚ y) +ℚ (x *ℚ z)
   left-distributive-mul-add-ℚ x y z =
@@ -336,7 +353,9 @@ abstract
 ### The inclusion of integer fractions preserves multiplication
 
 ```agda
-abstract
+opaque
+  unfolding mul-ℚ
+
   mul-rational-fraction-ℤ :
     (x y : fraction-ℤ) →
     rational-fraction-ℤ x *ℚ rational-fraction-ℤ y ＝

--- a/src/elementary-number-theory/multiplicative-group-of-positive-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/multiplicative-group-of-positive-rational-numbers.lagda.md
@@ -10,12 +10,14 @@ module elementary-number-theory.multiplicative-group-of-positive-rational-number
 
 ```agda
 open import elementary-number-theory.inequality-integers
+open import elementary-number-theory.inequality-rational-numbers
 open import elementary-number-theory.multiplication-integers
 open import elementary-number-theory.multiplication-rational-numbers
 open import elementary-number-theory.multiplicative-monoid-of-rational-numbers
 open import elementary-number-theory.positive-rational-numbers
 open import elementary-number-theory.rational-numbers
 open import elementary-number-theory.strict-inequality-integers
+open import elementary-number-theory.strict-inequality-rational-numbers
 
 open import foundation.binary-transport
 open import foundation.cartesian-product-types
@@ -91,7 +93,9 @@ pr2 abelian-group-mul-ℚ⁺ = commutative-mul-ℚ⁺
 ### Inversion reverses inequality on the positive rational numbers
 
 ```agda
-abstract
+opaque
+  unfolding leq-ℚ-Prop
+
   inv-leq-ℚ⁺ : (x y : ℚ⁺) → leq-ℚ⁺ (inv-ℚ⁺ x) (inv-ℚ⁺ y) → leq-ℚ⁺ y x
   inv-leq-ℚ⁺ x y =
     binary-tr
@@ -107,7 +111,9 @@ abstract
 ### Inversion reverses strict inequality on the positive rational numbers
 
 ```agda
-abstract
+opaque
+  unfolding le-ℚ-Prop
+
   inv-le-ℚ⁺ : (x y : ℚ⁺) → le-ℚ⁺ (inv-ℚ⁺ x) (inv-ℚ⁺ y) → le-ℚ⁺ y x
   inv-le-ℚ⁺ x y =
     binary-tr

--- a/src/elementary-number-theory/multiplicative-group-of-positive-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/multiplicative-group-of-positive-rational-numbers.lagda.md
@@ -46,9 +46,33 @@ is a [commutative group](group-theory.abelian-groups.md).
 ### The positive inverse of a positive rational number
 
 ```agda
-inv-ℚ⁺ : ℚ⁺ → ℚ⁺
-pr1 (inv-ℚ⁺ (x , P)) = inv-is-positive-ℚ x P
-pr2 (inv-ℚ⁺ (x , P)) = is-positive-denominator-ℚ x
+opaque
+  unfolding inv-is-positive-ℚ
+
+  inv-ℚ⁺ : ℚ⁺ → ℚ⁺
+  pr1 (inv-ℚ⁺ (x , P)) = inv-is-positive-ℚ x P
+  pr2 (inv-ℚ⁺ (x , P)) = is-positive-denominator-ℚ x
+```
+
+### Inverse laws in the multiplicative group of positive rational numbers
+
+```agda
+opaque
+  unfolding inv-ℚ⁺
+
+  left-inverse-law-mul-ℚ⁺ : (x : ℚ⁺) → (inv-ℚ⁺ x) *ℚ⁺ x ＝ one-ℚ⁺
+  left-inverse-law-mul-ℚ⁺ x =
+    eq-ℚ⁺
+      ( left-inverse-law-mul-is-positive-ℚ
+        ( rational-ℚ⁺ x)
+        ( is-positive-rational-ℚ⁺ x))
+
+  right-inverse-law-mul-ℚ⁺ : (x : ℚ⁺) → x *ℚ⁺ (inv-ℚ⁺ x) ＝ one-ℚ⁺
+  right-inverse-law-mul-ℚ⁺ x =
+    eq-ℚ⁺
+      ( right-inverse-law-mul-is-positive-ℚ
+        ( rational-ℚ⁺ x)
+        ( is-positive-rational-ℚ⁺ x))
 ```
 
 ### The multiplicative group of positive rational numbers
@@ -58,26 +82,8 @@ group-mul-ℚ⁺ : Group lzero
 pr1 group-mul-ℚ⁺ = semigroup-mul-ℚ⁺
 pr1 (pr2 group-mul-ℚ⁺) = is-unital-Monoid monoid-mul-ℚ⁺
 pr1 (pr2 (pr2 group-mul-ℚ⁺)) = inv-ℚ⁺
-pr1 (pr2 (pr2 (pr2 group-mul-ℚ⁺))) x =
-  eq-ℚ⁺
-    ( left-inverse-law-mul-is-positive-ℚ
-      ( rational-ℚ⁺ x)
-      ( is-positive-rational-ℚ⁺ x))
-pr2 (pr2 (pr2 (pr2 group-mul-ℚ⁺))) x =
-  eq-ℚ⁺
-    ( right-inverse-law-mul-is-positive-ℚ
-      ( rational-ℚ⁺ x)
-      ( is-positive-rational-ℚ⁺ x))
-```
-
-### Inverse laws in the multiplicative group of positive rational numbers
-
-```agda
-left-inverse-law-mul-ℚ⁺ : (x : ℚ⁺) → (inv-ℚ⁺ x) *ℚ⁺ x ＝ one-ℚ⁺
-left-inverse-law-mul-ℚ⁺ = left-inverse-law-mul-Group group-mul-ℚ⁺
-
-right-inverse-law-mul-ℚ⁺ : (x : ℚ⁺) → x *ℚ⁺ (inv-ℚ⁺ x) ＝ one-ℚ⁺
-right-inverse-law-mul-ℚ⁺ = right-inverse-law-mul-Group group-mul-ℚ⁺
+pr1 (pr2 (pr2 (pr2 group-mul-ℚ⁺))) = left-inverse-law-mul-ℚ⁺
+pr2 (pr2 (pr2 (pr2 group-mul-ℚ⁺))) = right-inverse-law-mul-ℚ⁺
 ```
 
 ## Properties
@@ -94,6 +100,7 @@ pr2 abelian-group-mul-ℚ⁺ = commutative-mul-ℚ⁺
 
 ```agda
 opaque
+  unfolding inv-ℚ⁺
   unfolding leq-ℚ-Prop
 
   inv-leq-ℚ⁺ : (x y : ℚ⁺) → leq-ℚ⁺ (inv-ℚ⁺ x) (inv-ℚ⁺ y) → leq-ℚ⁺ y x
@@ -112,6 +119,7 @@ opaque
 
 ```agda
 opaque
+  unfolding inv-ℚ⁺
   unfolding le-ℚ-Prop
 
   inv-le-ℚ⁺ : (x y : ℚ⁺) → le-ℚ⁺ (inv-ℚ⁺ x) (inv-ℚ⁺ y) → le-ℚ⁺ y x

--- a/src/elementary-number-theory/negative-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/negative-rational-numbers.lagda.md
@@ -153,6 +153,7 @@ negative-rational-negative-ℤ (x , x-is-neg) =
 ```agda
 opaque
   unfolding neg-ℚ
+  unfolding rational-fraction-ℤ
 
   is-negative-rational-fraction-ℤ :
     {x : fraction-ℤ} (P : is-negative-fraction-ℤ x) →
@@ -224,6 +225,7 @@ abstract
 ```agda
 opaque
   unfolding mul-ℚ
+  unfolding rational-fraction-ℤ
 
   is-positive-mul-negative-ℚ :
     {x y : ℚ} → is-negative-ℚ x → is-negative-ℚ y → is-positive-ℚ (x *ℚ y)

--- a/src/elementary-number-theory/negative-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/negative-rational-numbers.lagda.md
@@ -95,14 +95,17 @@ module _
   is-negative-rational-ℚ⁻ : is-negative-ℚ rational-ℚ⁻
   is-negative-rational-ℚ⁻ = pr2 x
 
-  is-negative-fraction-ℚ⁻ : is-negative-fraction-ℤ fraction-ℚ⁻
-  is-negative-fraction-ℚ⁻ =
-    tr
-      ( is-negative-fraction-ℤ)
-      ( neg-neg-fraction-ℤ fraction-ℚ⁻)
-      ( is-negative-neg-positive-fraction-ℤ
-        ( neg-fraction-ℤ fraction-ℚ⁻)
-        ( is-negative-rational-ℚ⁻))
+  opaque
+    unfolding neg-ℚ
+
+    is-negative-fraction-ℚ⁻ : is-negative-fraction-ℤ fraction-ℚ⁻
+    is-negative-fraction-ℚ⁻ =
+      tr
+        ( is-negative-fraction-ℤ)
+        ( neg-neg-fraction-ℤ fraction-ℚ⁻)
+        ( is-negative-neg-positive-fraction-ℤ
+          ( neg-fraction-ℤ fraction-ℚ⁻)
+          ( is-negative-rational-ℚ⁻))
 
   is-negative-numerator-ℚ⁻ : is-negative-ℤ numerator-ℚ⁻
   is-negative-numerator-ℚ⁻ = is-negative-fraction-ℚ⁻
@@ -133,7 +136,9 @@ is-set-ℚ⁻ = is-set-type-subtype is-negative-prop-ℚ is-set-ℚ
 ### The rational image of a negative integer is negative
 
 ```agda
-abstract
+opaque
+  unfolding neg-ℚ
+
   is-negative-rational-ℤ :
     (x : ℤ) → is-negative-ℤ x → is-negative-ℚ (rational-ℤ x)
   is-negative-rational-ℤ _ = is-positive-neg-is-negative-ℤ
@@ -146,7 +151,9 @@ negative-rational-negative-ℤ (x , x-is-neg) =
 ### The rational image of a negative integer fraction is negative
 
 ```agda
-abstract
+opaque
+  unfolding neg-ℚ
+
   is-negative-rational-fraction-ℤ :
     {x : fraction-ℤ} (P : is-negative-fraction-ℤ x) →
     is-negative-ℚ (rational-fraction-ℤ x)
@@ -161,7 +168,9 @@ module _
   (x : ℚ)
   where
 
-  abstract
+  opaque
+    unfolding neg-ℚ
+
     le-zero-is-negative-ℚ : is-negative-ℚ x → le-ℚ x zero-ℚ
     le-zero-is-negative-ℚ x-is-neg =
       tr
@@ -213,7 +222,9 @@ abstract
 ### The product of two negative rational numbers is positive
 
 ```agda
-abstract
+opaque
+  unfolding mul-ℚ
+
   is-positive-mul-negative-ℚ :
     {x y : ℚ} → is-negative-ℚ x → is-negative-ℚ y → is-positive-ℚ (x *ℚ y)
   is-positive-mul-negative-ℚ {x} {y} P Q =

--- a/src/elementary-number-theory/nonnegative-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/nonnegative-rational-numbers.lagda.md
@@ -160,7 +160,9 @@ nonnegative-rational-nonnegative-ℤ (x , x-is-neg) =
 ### The rational image of a nonnegative integer fraction is nonnegative
 
 ```agda
-abstract
+opaque
+  unfolding rational-fraction-ℤ
+
   is-nonnegative-rational-fraction-ℤ :
     {x : fraction-ℤ} (P : is-nonnegative-fraction-ℤ x) →
     is-nonnegative-ℚ (rational-fraction-ℤ x)

--- a/src/elementary-number-theory/nonnegative-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/nonnegative-rational-numbers.lagda.md
@@ -178,7 +178,9 @@ module _
   (x : ℚ)
   where
 
-  abstract
+  opaque
+    unfolding leq-ℚ-Prop
+
     leq-zero-is-nonnegative-ℚ : is-nonnegative-ℚ x → leq-ℚ zero-ℚ x
     leq-zero-is-nonnegative-ℚ =
       is-nonnegative-eq-ℤ (inv (cross-mul-diff-zero-fraction-ℤ (fraction-ℚ x)))
@@ -216,7 +218,9 @@ positive-succ-ℚ⁰⁺ (q , H) = (succ-ℚ q , is-positive-succ-is-nonnegative-
 ### The product of two nonnegative rational numbers is nonnegative
 
 ```agda
-abstract
+opaque
+  unfolding mul-ℚ
+
   is-nonnegative-mul-nonnegative-ℚ :
     {x y : ℚ} → is-nonnegative-ℚ x → is-nonnegative-ℚ y →
     is-nonnegative-ℚ (x *ℚ y)
@@ -232,7 +236,10 @@ abstract
 ### Multiplication by a nonnegative rational number preserves inequality
 
 ```agda
-abstract
+opaque
+  unfolding leq-ℚ-Prop
+  unfolding mul-ℚ
+
   preserves-leq-right-mul-ℚ⁰⁺ :
     (p : ℚ⁰⁺) (q r : ℚ) → leq-ℚ q r →
     leq-ℚ (q *ℚ rational-ℚ⁰⁺ p) (r *ℚ rational-ℚ⁰⁺ p)
@@ -269,7 +276,9 @@ abstract
 ### Addition on nonnegative rational numbers
 
 ```agda
-abstract
+opaque
+  unfolding add-ℚ
+
   is-nonnegative-add-ℚ :
     (p q : ℚ) → is-nonnegative-ℚ p → is-nonnegative-ℚ q →
     is-nonnegative-ℚ (p +ℚ q)
@@ -293,7 +302,9 @@ _+ℚ⁰⁺_ = add-ℚ⁰⁺
 ### Multiplication on nonnegative rational numbers
 
 ```agda
-abstract
+opaque
+  unfolding mul-ℚ
+
   is-nonnegative-mul-ℚ :
     (p q : ℚ) → is-nonnegative-ℚ p → is-nonnegative-ℚ q →
     is-nonnegative-ℚ (p *ℚ q)

--- a/src/elementary-number-theory/nonzero-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/nonzero-rational-numbers.lagda.md
@@ -112,7 +112,9 @@ one-nonzero-ℚ = (one-ℚ , is-nonzero-one-ℚ)
 ### The negative of a nonzero rational number is nonzero
 
 ```agda
-abstract
+opaque
+  unfolding neg-ℚ
+
   is-nonzero-neg-ℚ : {x : ℚ} → is-nonzero-ℚ x → is-nonzero-ℚ (neg-ℚ x)
   is-nonzero-neg-ℚ {x} H =
     is-nonzero-is-nonzero-numerator-ℚ

--- a/src/elementary-number-theory/positive-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/positive-rational-numbers.lagda.md
@@ -43,6 +43,7 @@ open import foundation.cartesian-product-types
 open import foundation.coproduct-types
 open import foundation.dependent-pair-types
 open import foundation.empty-types
+open import foundation.action-on-identifications-binary-functions
 open import foundation.equivalences
 open import foundation.existential-quantification
 open import foundation.function-types
@@ -307,7 +308,9 @@ nonzero-ℚ⁺ (x , P) = (x , is-nonzero-is-positive-ℚ P)
 ### The sum of two positive rational numbers is positive
 
 ```agda
-abstract
+opaque
+  unfolding add-ℚ
+
   is-positive-add-ℚ :
     {x y : ℚ} → is-positive-ℚ x → is-positive-ℚ y → is-positive-ℚ (x +ℚ y)
   is-positive-add-ℚ {x} {y} P Q =
@@ -342,6 +345,10 @@ add-ℚ⁺' x y = add-ℚ⁺ y x
 
 infixl 35 _+ℚ⁺_
 _+ℚ⁺_ = add-ℚ⁺
+
+ap-add-ℚ⁺ :
+  {x y x' y' : ℚ⁺} → x ＝ x' → y ＝ y' → x +ℚ⁺ y ＝ x' +ℚ⁺ y'
+ap-add-ℚ⁺ p q = ap-binary add-ℚ⁺ p q
 ```
 
 ### The positive sum of positive rational numbers is associative
@@ -377,7 +384,9 @@ interchange-law-add-add-ℚ⁺ x y u v =
 ### The product of two positive rational numbers is positive
 
 ```agda
-abstract
+opaque
+  unfolding mul-ℚ
+
   is-positive-mul-ℚ :
     {x y : ℚ} → is-positive-ℚ x → is-positive-ℚ y → is-positive-ℚ (x *ℚ y)
   is-positive-mul-ℚ {x} {y} P Q =
@@ -469,7 +478,9 @@ module _
       ( P)
       ( is-reduced-fraction-ℚ x)
 
-  abstract
+  opaque
+    unfolding mul-ℚ
+
     left-inverse-law-mul-is-positive-ℚ : inv-is-positive-ℚ *ℚ x ＝ one-ℚ
     left-inverse-law-mul-is-positive-ℚ =
       ( eq-ℚ-sim-fraction-ℤ
@@ -720,7 +731,9 @@ module _
 ### Multiplication by a positive rational number preserves strict inequality
 
 ```agda
-abstract
+opaque
+  unfolding mul-ℚ
+
   preserves-le-left-mul-ℚ⁺ :
     (p : ℚ⁺) (q r : ℚ) →
     le-ℚ q r →
@@ -758,37 +771,41 @@ abstract
 ### Multiplication by a positive rational number preserves inequality
 
 ```agda
-preserves-leq-left-mul-ℚ⁺ :
-  (p : ℚ⁺) (q r : ℚ) → leq-ℚ q r →
-  leq-ℚ (rational-ℚ⁺ p *ℚ q) (rational-ℚ⁺ p *ℚ r)
-preserves-leq-left-mul-ℚ⁺
-  p⁺@((p@(p-num , p-denom , p-denom-pos) , _) , p-num-pos)
-  q@((q-num , q-denom , _) , _)
-  r@((r-num , r-denom , _) , _)
-  q≤r =
-    preserves-leq-rational-fraction-ℤ
-      ( mul-fraction-ℤ p (fraction-ℚ q))
-      ( mul-fraction-ℤ p (fraction-ℚ r))
-      ( binary-tr
-        ( leq-ℤ)
-        ( interchange-law-mul-mul-ℤ _ _ _ _)
-        ( interchange-law-mul-mul-ℤ _ _ _ _)
-        ( preserves-leq-right-mul-nonnegative-ℤ
-          ( nonnegative-positive-ℤ
-            ( mul-positive-ℤ (p-num , p-num-pos) (p-denom , p-denom-pos)))
-          ( q-num *ℤ r-denom)
-          ( r-num *ℤ q-denom)
-          ( q≤r)))
+opaque
+  unfolding mul-ℚ
 
-preserves-leq-right-mul-ℚ⁺ :
-  (p : ℚ⁺) (q r : ℚ) → leq-ℚ q r →
-  leq-ℚ (q *ℚ rational-ℚ⁺ p) (r *ℚ rational-ℚ⁺ p)
-preserves-leq-right-mul-ℚ⁺ p q r q≤r =
-  binary-tr
-    ( leq-ℚ)
-    ( commutative-mul-ℚ (rational-ℚ⁺ p) q)
-    ( commutative-mul-ℚ (rational-ℚ⁺ p) r)
-    ( preserves-leq-left-mul-ℚ⁺ p q r q≤r)
+  preserves-leq-left-mul-ℚ⁺ :
+    (p : ℚ⁺) (q r : ℚ) → leq-ℚ q r →
+    leq-ℚ (rational-ℚ⁺ p *ℚ q) (rational-ℚ⁺ p *ℚ r)
+  preserves-leq-left-mul-ℚ⁺
+    p⁺@((p@(p-num , p-denom , p-denom-pos) , _) , p-num-pos)
+    q@((q-num , q-denom , _) , _)
+    r@((r-num , r-denom , _) , _)
+    q≤r =
+      preserves-leq-rational-fraction-ℤ
+        ( mul-fraction-ℤ p (fraction-ℚ q))
+        ( mul-fraction-ℤ p (fraction-ℚ r))
+        ( binary-tr
+          ( leq-ℤ)
+          ( interchange-law-mul-mul-ℤ _ _ _ _)
+          ( interchange-law-mul-mul-ℤ _ _ _ _)
+          ( preserves-leq-right-mul-nonnegative-ℤ
+            ( nonnegative-positive-ℤ
+              ( mul-positive-ℤ (p-num , p-num-pos) (p-denom , p-denom-pos)))
+            ( q-num *ℤ r-denom)
+            ( r-num *ℤ q-denom)
+            ( q≤r)))
+
+abstract
+  preserves-leq-right-mul-ℚ⁺ :
+    (p : ℚ⁺) (q r : ℚ) → leq-ℚ q r →
+    leq-ℚ (q *ℚ rational-ℚ⁺ p) (r *ℚ rational-ℚ⁺ p)
+  preserves-leq-right-mul-ℚ⁺ p q r q≤r =
+    binary-tr
+      ( leq-ℚ)
+      ( commutative-mul-ℚ (rational-ℚ⁺ p) q)
+      ( commutative-mul-ℚ (rational-ℚ⁺ p) r)
+      ( preserves-leq-left-mul-ℚ⁺ p q r q≤r)
 ```
 
 ### Multiplication of a positive rational by another positive rational less than 1 is a strictly deflationary map
@@ -969,27 +986,28 @@ module _
 ### Addition with a positive rational number is an increasing map
 
 ```agda
-le-left-add-rational-ℚ⁺ : (x : ℚ) (d : ℚ⁺) → le-ℚ x ((rational-ℚ⁺ d) +ℚ x)
-le-left-add-rational-ℚ⁺ x d =
-  concatenate-leq-le-ℚ
-    ( x)
-    ( zero-ℚ +ℚ x)
-    ( (rational-ℚ⁺ d) +ℚ x)
-    ( inv-tr (leq-ℚ x) (left-unit-law-add-ℚ x) (refl-leq-ℚ x))
-    ( preserves-le-left-add-ℚ
+abstract
+  le-left-add-rational-ℚ⁺ : (x : ℚ) (d : ℚ⁺) → le-ℚ x ((rational-ℚ⁺ d) +ℚ x)
+  le-left-add-rational-ℚ⁺ x d =
+    concatenate-leq-le-ℚ
       ( x)
-      ( zero-ℚ)
-      ( rational-ℚ⁺ d)
-      ( le-zero-is-positive-ℚ
+      ( zero-ℚ +ℚ x)
+      ( (rational-ℚ⁺ d) +ℚ x)
+      ( inv-tr (leq-ℚ x) (left-unit-law-add-ℚ x) (refl-leq-ℚ x))
+      ( preserves-le-left-add-ℚ
+        ( x)
+        ( zero-ℚ)
         ( rational-ℚ⁺ d)
-        ( is-positive-rational-ℚ⁺ d)))
+        ( le-zero-is-positive-ℚ
+          ( rational-ℚ⁺ d)
+          ( is-positive-rational-ℚ⁺ d)))
 
-le-right-add-rational-ℚ⁺ : (x : ℚ) (d : ℚ⁺) → le-ℚ x (x +ℚ (rational-ℚ⁺ d))
-le-right-add-rational-ℚ⁺ x d =
-  inv-tr
-    ( le-ℚ x)
-    ( commutative-add-ℚ x (rational-ℚ⁺ d))
-    ( le-left-add-rational-ℚ⁺ x d)
+  le-right-add-rational-ℚ⁺ : (x : ℚ) (d : ℚ⁺) → le-ℚ x (x +ℚ (rational-ℚ⁺ d))
+  le-right-add-rational-ℚ⁺ x d =
+    inv-tr
+      ( le-ℚ x)
+      ( commutative-add-ℚ x (rational-ℚ⁺ d))
+      ( le-left-add-rational-ℚ⁺ x d)
 ```
 
 ### Subtraction by a positive rational number is a strictly deflationary map

--- a/src/elementary-number-theory/positive-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/positive-rational-numbers.lagda.md
@@ -196,7 +196,9 @@ positive-rational-ℕ⁺ n = positive-rational-positive-ℤ (positive-int-ℕ⁺
 ### The rational image of a positive integer fraction is positive
 
 ```agda
-abstract
+opaque
+  unfolding rational-fraction-ℤ
+
   is-positive-rational-fraction-ℤ :
     {x : fraction-ℤ} (P : is-positive-fraction-ℤ x) →
     is-positive-ℚ (rational-fraction-ℤ x)
@@ -477,16 +479,16 @@ module _
   (x : ℚ) (P : is-positive-ℚ x)
   where
 
-  inv-is-positive-ℚ : ℚ
-  pr1 inv-is-positive-ℚ = inv-is-positive-fraction-ℤ (fraction-ℚ x) P
-  pr2 inv-is-positive-ℚ =
-    is-reduced-inv-is-positive-fraction-ℤ
-      ( fraction-ℚ x)
-      ( P)
-      ( is-reduced-fraction-ℚ x)
-
   opaque
     unfolding mul-ℚ
+
+    inv-is-positive-ℚ : ℚ
+    pr1 inv-is-positive-ℚ = inv-is-positive-fraction-ℤ (fraction-ℚ x) P
+    pr2 inv-is-positive-ℚ =
+      is-reduced-inv-is-positive-fraction-ℤ
+        ( fraction-ℚ x)
+        ( P)
+        ( is-reduced-fraction-ℚ x)
 
     left-inverse-law-mul-is-positive-ℚ : inv-is-positive-ℚ *ℚ x ＝ one-ℚ
     left-inverse-law-mul-is-positive-ℚ =

--- a/src/elementary-number-theory/positive-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/positive-rational-numbers.lagda.md
@@ -36,6 +36,7 @@ open import elementary-number-theory.reduced-integer-fractions
 open import elementary-number-theory.strict-inequality-integers
 open import elementary-number-theory.strict-inequality-rational-numbers
 
+open import foundation.action-on-identifications-binary-functions
 open import foundation.action-on-identifications-functions
 open import foundation.binary-relations
 open import foundation.binary-transport
@@ -43,7 +44,6 @@ open import foundation.cartesian-product-types
 open import foundation.coproduct-types
 open import foundation.dependent-pair-types
 open import foundation.empty-types
-open import foundation.action-on-identifications-binary-functions
 open import foundation.equivalences
 open import foundation.existential-quantification
 open import foundation.function-types
@@ -210,7 +210,9 @@ module _
   (x : ℚ)
   where
 
-  abstract
+  opaque
+    unfolding le-ℚ-Prop
+
     le-zero-is-positive-ℚ : is-positive-ℚ x → le-ℚ zero-ℚ x
     le-zero-is-positive-ℚ =
       is-positive-eq-ℤ (inv (cross-mul-diff-zero-fraction-ℤ (fraction-ℚ x)))
@@ -264,21 +266,26 @@ module _
 ### A nonzero rational number or its negative is positive
 
 ```agda
-decide-is-negative-is-positive-is-nonzero-ℚ :
-  {x : ℚ} → is-nonzero-ℚ x → is-positive-ℚ (neg-ℚ x) + is-positive-ℚ x
-decide-is-negative-is-positive-is-nonzero-ℚ {x} H =
-  rec-coproduct
-    ( inl ∘ is-positive-neg-is-negative-ℤ)
-    ( inr)
-    ( decide-sign-nonzero-ℤ
-      { numerator-ℚ x}
-      (is-nonzero-numerator-is-nonzero-ℚ x H))
+opaque
+  unfolding neg-ℚ
+
+  decide-is-negative-is-positive-is-nonzero-ℚ :
+    {x : ℚ} → is-nonzero-ℚ x → is-positive-ℚ (neg-ℚ x) + is-positive-ℚ x
+  decide-is-negative-is-positive-is-nonzero-ℚ {x} H =
+    rec-coproduct
+      ( inl ∘ is-positive-neg-is-negative-ℤ)
+      ( inr)
+      ( decide-sign-nonzero-ℤ
+        { numerator-ℚ x}
+        ( is-nonzero-numerator-is-nonzero-ℚ x H))
 ```
 
 ### A rational and its negative are not both positive
 
 ```agda
-abstract
+opaque
+  unfolding neg-ℚ
+
   not-is-negative-is-positive-ℚ :
     (x : ℚ) → ¬ (is-positive-ℚ (neg-ℚ x) × is-positive-ℚ x)
   not-is-negative-is-positive-ℚ x (N , P) =
@@ -732,6 +739,7 @@ module _
 
 ```agda
 opaque
+  unfolding le-ℚ-Prop
   unfolding mul-ℚ
 
   preserves-le-left-mul-ℚ⁺ :
@@ -772,6 +780,7 @@ opaque
 
 ```agda
 opaque
+  unfolding leq-ℚ-Prop
   unfolding mul-ℚ
 
   preserves-leq-left-mul-ℚ⁺ :
@@ -811,37 +820,38 @@ abstract
 ### Multiplication of a positive rational by another positive rational less than 1 is a strictly deflationary map
 
 ```agda
-le-left-mul-less-than-one-ℚ⁺ :
-  (p : ℚ⁺) → le-ℚ⁺ p one-ℚ⁺ → (q : ℚ⁺) → le-ℚ⁺ (p *ℚ⁺ q) q
-le-left-mul-less-than-one-ℚ⁺ p p<1 q =
-  tr
-    ( le-ℚ⁺ ( p *ℚ⁺ q))
-    ( left-unit-law-mul-ℚ⁺ q)
-    ( preserves-le-right-mul-ℚ⁺ q (rational-ℚ⁺ p) one-ℚ p<1)
+abstract
+  le-left-mul-less-than-one-ℚ⁺ :
+    (p : ℚ⁺) → le-ℚ⁺ p one-ℚ⁺ → (q : ℚ⁺) → le-ℚ⁺ (p *ℚ⁺ q) q
+  le-left-mul-less-than-one-ℚ⁺ p p<1 q =
+    tr
+      ( le-ℚ⁺ ( p *ℚ⁺ q))
+      ( left-unit-law-mul-ℚ⁺ q)
+      ( preserves-le-right-mul-ℚ⁺ q (rational-ℚ⁺ p) one-ℚ p<1)
 
-le-right-mul-less-than-one-ℚ⁺ :
-  (p : ℚ⁺) → le-ℚ⁺ p one-ℚ⁺ → (q : ℚ⁺) → le-ℚ⁺ (q *ℚ⁺ p) q
-le-right-mul-less-than-one-ℚ⁺ p p<1 q =
-  tr
-    ( λ r → le-ℚ⁺ r q)
-    ( commutative-mul-ℚ⁺ p q)
-    ( le-left-mul-less-than-one-ℚ⁺ p p<1 q)
+  le-right-mul-less-than-one-ℚ⁺ :
+    (p : ℚ⁺) → le-ℚ⁺ p one-ℚ⁺ → (q : ℚ⁺) → le-ℚ⁺ (q *ℚ⁺ p) q
+  le-right-mul-less-than-one-ℚ⁺ p p<1 q =
+    tr
+      ( λ r → le-ℚ⁺ r q)
+      ( commutative-mul-ℚ⁺ p q)
+      ( le-left-mul-less-than-one-ℚ⁺ p p<1 q)
 ```
 
 ### The positive mediant between zero and a positive rational number
 
 ```agda
-mediant-zero-ℚ⁺ : ℚ⁺ → ℚ⁺
-mediant-zero-ℚ⁺ x =
-  ( mediant-ℚ zero-ℚ (rational-ℚ⁺ x) ,
-    is-positive-le-zero-ℚ
-      ( mediant-ℚ zero-ℚ (rational-ℚ⁺ x))
-      ( le-left-mediant-ℚ
-        ( zero-ℚ)
-        ( rational-ℚ⁺ x)
-        ( le-zero-is-positive-ℚ (rational-ℚ⁺ x) (is-positive-rational-ℚ⁺ x))))
+opaque
+  mediant-zero-ℚ⁺ : ℚ⁺ → ℚ⁺
+  mediant-zero-ℚ⁺ x =
+    ( mediant-ℚ zero-ℚ (rational-ℚ⁺ x) ,
+      is-positive-le-zero-ℚ
+        ( mediant-ℚ zero-ℚ (rational-ℚ⁺ x))
+        ( le-left-mediant-ℚ
+          ( zero-ℚ)
+          ( rational-ℚ⁺ x)
+          ( le-zero-is-positive-ℚ (rational-ℚ⁺ x) (is-positive-rational-ℚ⁺ x))))
 
-abstract
   le-mediant-zero-ℚ⁺ : (x : ℚ⁺) → le-ℚ⁺ (mediant-zero-ℚ⁺ x) x
   le-mediant-zero-ℚ⁺ x =
     le-right-mediant-ℚ
@@ -910,23 +920,24 @@ module _
   mediant-zero-min-ℚ⁺ : ℚ⁺
   mediant-zero-min-ℚ⁺ = mediant-zero-ℚ⁺ (min-ℚ⁺ x y)
 
-  le-left-mediant-zero-min-ℚ⁺ : le-ℚ⁺ mediant-zero-min-ℚ⁺ x
-  le-left-mediant-zero-min-ℚ⁺ =
-    concatenate-le-leq-ℚ
-      ( rational-ℚ⁺ mediant-zero-min-ℚ⁺)
-      ( rational-ℚ⁺ (min-ℚ⁺ x y))
-      ( rational-ℚ⁺ x)
-      ( le-mediant-zero-ℚ⁺ (min-ℚ⁺ x y))
-      ( leq-left-min-ℚ⁺ x y)
+  abstract
+    le-left-mediant-zero-min-ℚ⁺ : le-ℚ⁺ mediant-zero-min-ℚ⁺ x
+    le-left-mediant-zero-min-ℚ⁺ =
+      concatenate-le-leq-ℚ
+        ( rational-ℚ⁺ mediant-zero-min-ℚ⁺)
+        ( rational-ℚ⁺ (min-ℚ⁺ x y))
+        ( rational-ℚ⁺ x)
+        ( le-mediant-zero-ℚ⁺ (min-ℚ⁺ x y))
+        ( leq-left-min-ℚ⁺ x y)
 
-  le-right-mediant-zero-min-ℚ⁺ : le-ℚ⁺ mediant-zero-min-ℚ⁺ y
-  le-right-mediant-zero-min-ℚ⁺ =
-    concatenate-le-leq-ℚ
-      ( rational-ℚ⁺ mediant-zero-min-ℚ⁺)
-      ( rational-ℚ⁺ (min-ℚ⁺ x y))
-      ( rational-ℚ⁺ y)
-      ( le-mediant-zero-ℚ⁺ (min-ℚ⁺ x y))
-      ( leq-right-min-ℚ⁺ x y)
+    le-right-mediant-zero-min-ℚ⁺ : le-ℚ⁺ mediant-zero-min-ℚ⁺ y
+    le-right-mediant-zero-min-ℚ⁺ =
+      concatenate-le-leq-ℚ
+        ( rational-ℚ⁺ mediant-zero-min-ℚ⁺)
+        ( rational-ℚ⁺ (min-ℚ⁺ x y))
+        ( rational-ℚ⁺ y)
+        ( le-mediant-zero-ℚ⁺ (min-ℚ⁺ x y))
+        ( leq-right-min-ℚ⁺ x y)
 ```
 
 ### Any positive rational number `p` has a `q` with `q + q < p`

--- a/src/elementary-number-theory/rational-numbers.lagda.md
+++ b/src/elementary-number-theory/rational-numbers.lagda.md
@@ -93,9 +93,10 @@ module _
 ### Inclusion of fractions
 
 ```agda
-rational-fraction-ℤ : fraction-ℤ → ℚ
-pr1 (rational-fraction-ℤ x) = reduce-fraction-ℤ x
-pr2 (rational-fraction-ℤ x) = is-reduced-reduce-fraction-ℤ x
+opaque
+  rational-fraction-ℤ : fraction-ℤ → ℚ
+  pr1 (rational-fraction-ℤ x) = reduce-fraction-ℤ x
+  pr2 (rational-fraction-ℤ x) = is-reduced-reduce-fraction-ℤ x
 ```
 
 ### Inclusion of the integers
@@ -165,7 +166,9 @@ opaque
 ### The rational images of two similar integer fractions are equal
 
 ```agda
-abstract
+opaque
+  unfolding rational-fraction-ℤ
+
   eq-ℚ-sim-fraction-ℤ :
     (x y : fraction-ℤ) → (H : sim-fraction-ℤ x y) →
     rational-fraction-ℤ x ＝ rational-fraction-ℤ y
@@ -194,7 +197,9 @@ pr2 ℚ-Set = is-set-ℚ
 ### The rationals are a retract of the integer fractions
 
 ```agda
-abstract
+opaque
+  unfolding rational-fraction-ℤ
+
   is-retraction-rational-fraction-ℚ :
     (x : ℚ) → rational-fraction-ℤ (fraction-ℚ x) ＝ x
   is-retraction-rational-fraction-ℚ ((m , n , n-pos) , p) =
@@ -293,6 +298,7 @@ opaque
 ```agda
 opaque
   unfolding neg-ℚ
+  unfolding rational-fraction-ℤ
 
   preserves-neg-rational-fraction-ℤ :
     (x : fraction-ℤ) →

--- a/src/elementary-number-theory/rational-numbers.lagda.md
+++ b/src/elementary-number-theory/rational-numbers.lagda.md
@@ -142,20 +142,22 @@ is-one-ℚ x = (x ＝ one-ℚ)
 ### The negative of a rational number
 
 ```agda
-neg-ℚ : ℚ → ℚ
-pr1 (neg-ℚ (x , H)) = neg-fraction-ℤ x
-pr2 (neg-ℚ (x , H)) = is-reduced-neg-fraction-ℤ x H
+opaque
+  neg-ℚ : ℚ → ℚ
+  pr1 (neg-ℚ (x , H)) = neg-fraction-ℤ x
+  pr2 (neg-ℚ (x , H)) = is-reduced-neg-fraction-ℤ x H
 ```
 
 ### The mediant of two rationals
 
 ```agda
-mediant-ℚ : ℚ → ℚ → ℚ
-mediant-ℚ x y =
-  rational-fraction-ℤ
-    ( mediant-fraction-ℤ
-      ( fraction-ℚ x)
-      ( fraction-ℚ y))
+opaque
+  mediant-ℚ : ℚ → ℚ → ℚ
+  mediant-ℚ x y =
+    rational-fraction-ℤ
+      ( mediant-fraction-ℤ
+        ( fraction-ℚ x)
+        ( fraction-ℚ y))
 ```
 
 ## Properties
@@ -277,7 +279,9 @@ module _
 ### The rational image of the negative of an integer is the rational negative of its image
 
 ```agda
-abstract
+opaque
+  unfolding neg-ℚ
+
   preserves-neg-rational-ℤ :
     (k : ℤ) → rational-ℤ (neg-ℤ k) ＝ neg-ℚ (rational-ℤ k)
   preserves-neg-rational-ℤ k =
@@ -287,7 +291,9 @@ abstract
 ### The reduced fraction of the negative of an integer fraction is the negative of the reduced fraction
 
 ```agda
-abstract
+opaque
+  unfolding neg-ℚ
+
   preserves-neg-rational-fraction-ℤ :
     (x : fraction-ℤ) →
     rational-fraction-ℤ (neg-fraction-ℤ x) ＝ neg-ℚ (rational-fraction-ℤ x)
@@ -305,7 +311,9 @@ abstract
 ### The negative function on the rational numbers is an involution
 
 ```agda
-abstract
+opaque
+  unfolding neg-ℚ
+
   neg-neg-ℚ : (x : ℚ) → neg-ℚ (neg-ℚ x) ＝ x
   neg-neg-ℚ x = eq-ℚ (neg-ℚ (neg-ℚ x)) x (neg-neg-ℤ (numerator-ℚ x)) refl
 ```

--- a/src/elementary-number-theory/strict-inequality-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/strict-inequality-rational-numbers.lagda.md
@@ -243,7 +243,9 @@ module _
   (x y : ℚ)
   where
 
-  abstract
+  opaque
+    unfolding add-ℚ
+
     iff-translate-diff-le-zero-ℚ : le-ℚ zero-ℚ (y -ℚ x) ↔ le-ℚ x y
     iff-translate-diff-le-zero-ℚ =
       logical-equivalence-reasoning

--- a/src/elementary-number-theory/strict-inequality-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/strict-inequality-rational-numbers.lagda.md
@@ -73,8 +73,9 @@ is [strictly less](elementary-number-theory.strict-inequality-integers.md) than
 ### The standard strict inequality on the rational numbers
 
 ```agda
-le-ℚ-Prop : ℚ → ℚ → Prop lzero
-le-ℚ-Prop (x , px) (y , py) = le-fraction-ℤ-Prop x y
+opaque
+  le-ℚ-Prop : ℚ → ℚ → Prop lzero
+  le-ℚ-Prop (x , px) (y , py) = le-fraction-ℤ-Prop x y
 
 le-ℚ : ℚ → ℚ → UU lzero
 le-ℚ x y = type-Prop (le-ℚ-Prop x y)
@@ -88,9 +89,12 @@ is-prop-le-ℚ x y = is-prop-type-Prop (le-ℚ-Prop x y)
 ### Strict inequality on the rational numbers is decidable
 
 ```agda
-is-decidable-le-ℚ : (x y : ℚ) → (le-ℚ x y) + ¬ (le-ℚ x y)
-is-decidable-le-ℚ x y =
-  is-decidable-le-fraction-ℤ (fraction-ℚ x) (fraction-ℚ y)
+opaque
+  unfolding le-ℚ-Prop
+
+  is-decidable-le-ℚ : (x y : ℚ) → (le-ℚ x y) + ¬ (le-ℚ x y)
+  is-decidable-le-ℚ x y =
+    is-decidable-le-fraction-ℤ (fraction-ℚ x) (fraction-ℚ y)
 
 le-ℚ-Decidable-Prop : (x y : ℚ) → Decidable-Prop lzero
 le-ℚ-Decidable-Prop x y =
@@ -102,18 +106,25 @@ le-ℚ-Decidable-Prop x y =
 ### Strict inequality on the rational numbers implies inequality
 
 ```agda
-leq-le-ℚ : {x y : ℚ} → le-ℚ x y → leq-ℚ x y
-leq-le-ℚ {x} {y} = leq-le-fraction-ℤ {fraction-ℚ x} {fraction-ℚ y}
+opaque
+  unfolding le-ℚ-Prop
+  unfolding leq-ℚ-Prop
+
+  leq-le-ℚ : {x y : ℚ} → le-ℚ x y → leq-ℚ x y
+  leq-le-ℚ {x} {y} = leq-le-fraction-ℤ {fraction-ℚ x} {fraction-ℚ y}
 ```
 
 ### Strict inequality on the rationals is asymmetric
 
 ```agda
-asymmetric-le-ℚ : (x y : ℚ) → le-ℚ x y → ¬ (le-ℚ y x)
-asymmetric-le-ℚ x y =
-  asymmetric-le-fraction-ℤ
-    ( fraction-ℚ x)
-    ( fraction-ℚ y)
+opaque
+  unfolding le-ℚ-Prop
+
+  asymmetric-le-ℚ : (x y : ℚ) → le-ℚ x y → ¬ (le-ℚ y x)
+  asymmetric-le-ℚ x y =
+    asymmetric-le-fraction-ℤ
+      ( fraction-ℚ x)
+      ( fraction-ℚ y)
 
 irreflexive-le-ℚ : (x : ℚ) → ¬ (le-ℚ x x)
 irreflexive-le-ℚ =
@@ -127,7 +138,9 @@ module _
   (x y z : ℚ)
   where
 
-  abstract
+  opaque
+    unfolding le-ℚ-Prop
+
     transitive-le-ℚ : le-ℚ y z → le-ℚ x y → le-ℚ x z
     transitive-le-ℚ =
       transitive-le-fraction-ℤ
@@ -143,19 +156,23 @@ module _
   (x y z : ℚ)
   where
 
-  concatenate-le-leq-ℚ : le-ℚ x y → leq-ℚ y z → le-ℚ x z
-  concatenate-le-leq-ℚ =
-    concatenate-le-leq-fraction-ℤ
-      ( fraction-ℚ x)
-      ( fraction-ℚ y)
-      ( fraction-ℚ z)
+  opaque
+    unfolding le-ℚ-Prop
+    unfolding leq-ℚ-Prop
 
-  concatenate-leq-le-ℚ : leq-ℚ x y → le-ℚ y z → le-ℚ x z
-  concatenate-leq-le-ℚ =
-    concatenate-leq-le-fraction-ℤ
-      ( fraction-ℚ x)
-      ( fraction-ℚ y)
-      ( fraction-ℚ z)
+    concatenate-le-leq-ℚ : le-ℚ x y → leq-ℚ y z → le-ℚ x z
+    concatenate-le-leq-ℚ =
+      concatenate-le-leq-fraction-ℤ
+        ( fraction-ℚ x)
+        ( fraction-ℚ y)
+        ( fraction-ℚ z)
+
+    concatenate-leq-le-ℚ : leq-ℚ x y → le-ℚ y z → le-ℚ x z
+    concatenate-leq-le-ℚ =
+      concatenate-leq-le-fraction-ℤ
+        ( fraction-ℚ x)
+        ( fraction-ℚ y)
+        ( fraction-ℚ z)
 ```
 
 ### The canonical map from integer fractions to the rational numbers preserves strict inequality
@@ -165,7 +182,9 @@ module _
   (p q : fraction-ℤ)
   where
 
-  abstract
+  opaque
+    unfolding le-ℚ-Prop
+
     preserves-le-rational-fraction-ℤ :
       le-fraction-ℤ p q → le-ℚ (rational-fraction-ℤ p) (rational-fraction-ℤ q)
     preserves-le-rational-fraction-ℤ =
@@ -181,54 +200,59 @@ module _
   (x : ℚ) (p : fraction-ℤ)
   where
 
-  preserves-le-right-rational-fraction-ℤ :
-    le-fraction-ℤ (fraction-ℚ x) p → le-ℚ x (rational-fraction-ℤ p)
-  preserves-le-right-rational-fraction-ℤ H =
-    concatenate-le-sim-fraction-ℤ
-      ( fraction-ℚ x)
-      ( p)
-      ( fraction-ℚ ( rational-fraction-ℤ p))
-      ( H)
-      ( sim-reduced-fraction-ℤ p)
-
-  reflects-le-right-rational-fraction-ℤ :
-    le-ℚ x (rational-fraction-ℤ p) → le-fraction-ℤ (fraction-ℚ x) p
-  reflects-le-right-rational-fraction-ℤ H =
-    concatenate-le-sim-fraction-ℤ
-      ( fraction-ℚ x)
-      ( reduce-fraction-ℤ p)
-      ( p)
-      ( H)
-      ( symmetric-sim-fraction-ℤ
+  opaque
+    unfolding le-ℚ-Prop
+    preserves-le-right-rational-fraction-ℤ :
+      le-fraction-ℤ (fraction-ℚ x) p → le-ℚ x (rational-fraction-ℤ p)
+    preserves-le-right-rational-fraction-ℤ H =
+      concatenate-le-sim-fraction-ℤ
+        ( fraction-ℚ x)
         ( p)
+        ( fraction-ℚ ( rational-fraction-ℤ p))
+        ( H)
+        ( sim-reduced-fraction-ℤ p)
+
+    reflects-le-right-rational-fraction-ℤ :
+      le-ℚ x (rational-fraction-ℤ p) → le-fraction-ℤ (fraction-ℚ x) p
+    reflects-le-right-rational-fraction-ℤ H =
+      concatenate-le-sim-fraction-ℤ
+        ( fraction-ℚ x)
         ( reduce-fraction-ℤ p)
-        ( sim-reduced-fraction-ℤ p))
+        ( p)
+        ( H)
+        ( symmetric-sim-fraction-ℤ
+          ( p)
+          ( reduce-fraction-ℤ p)
+          ( sim-reduced-fraction-ℤ p))
 
   iff-le-right-rational-fraction-ℤ :
     le-fraction-ℤ (fraction-ℚ x) p ↔ le-ℚ x (rational-fraction-ℤ p)
   pr1 iff-le-right-rational-fraction-ℤ = preserves-le-right-rational-fraction-ℤ
   pr2 iff-le-right-rational-fraction-ℤ = reflects-le-right-rational-fraction-ℤ
 
-  preserves-le-left-rational-fraction-ℤ :
-    le-fraction-ℤ p (fraction-ℚ x) → le-ℚ (rational-fraction-ℤ p) x
-  preserves-le-left-rational-fraction-ℤ =
-    concatenate-sim-le-fraction-ℤ
-      ( fraction-ℚ ( rational-fraction-ℤ p))
-      ( p)
-      ( fraction-ℚ x)
-      ( symmetric-sim-fraction-ℤ
-        ( p)
-        ( fraction-ℚ ( rational-fraction-ℤ p))
-        ( sim-reduced-fraction-ℤ p))
+  opaque
+    unfolding le-ℚ-Prop
 
-  reflects-le-left-rational-fraction-ℤ :
-    le-ℚ (rational-fraction-ℤ p) x → le-fraction-ℤ p (fraction-ℚ x)
-  reflects-le-left-rational-fraction-ℤ =
-    concatenate-sim-le-fraction-ℤ
-      ( p)
-      ( reduce-fraction-ℤ p)
-      ( fraction-ℚ x)
-      ( sim-reduced-fraction-ℤ p)
+    preserves-le-left-rational-fraction-ℤ :
+      le-fraction-ℤ p (fraction-ℚ x) → le-ℚ (rational-fraction-ℤ p) x
+    preserves-le-left-rational-fraction-ℤ =
+      concatenate-sim-le-fraction-ℤ
+        ( fraction-ℚ ( rational-fraction-ℤ p))
+        ( p)
+        ( fraction-ℚ x)
+        ( symmetric-sim-fraction-ℤ
+          ( p)
+          ( fraction-ℚ ( rational-fraction-ℤ p))
+          ( sim-reduced-fraction-ℤ p))
+
+    reflects-le-left-rational-fraction-ℤ :
+      le-ℚ (rational-fraction-ℤ p) x → le-fraction-ℤ p (fraction-ℚ x)
+    reflects-le-left-rational-fraction-ℤ =
+      concatenate-sim-le-fraction-ℤ
+        ( p)
+        ( reduce-fraction-ℤ p)
+        ( fraction-ℚ x)
+        ( sim-reduced-fraction-ℤ p)
 
   iff-le-left-rational-fraction-ℤ :
     le-fraction-ℤ p (fraction-ℚ x) ↔ le-ℚ (rational-fraction-ℤ p) x
@@ -245,6 +269,8 @@ module _
 
   opaque
     unfolding add-ℚ
+    unfolding le-ℚ-Prop
+    unfolding neg-ℚ
 
     iff-translate-diff-le-zero-ℚ : le-ℚ zero-ℚ (y -ℚ x) ↔ le-ℚ x y
     iff-translate-diff-le-zero-ℚ =
@@ -342,75 +368,82 @@ module _
   (x : ℚ)
   where
 
-  exists-lesser-ℚ : exists ℚ (λ q → le-ℚ-Prop q x)
-  exists-lesser-ℚ =
-    intro-exists
-      ( rational-fraction-ℤ frac)
-      ( preserves-le-left-rational-fraction-ℤ x frac
-        ( le-fraction-le-numerator-fraction-ℤ
-          ( frac)
-          ( fraction-ℚ x)
-          ( refl)
-          ( le-pred-ℤ (numerator-ℚ x))))
-    where
-    frac : fraction-ℤ
-    frac = (pred-ℤ (numerator-ℚ x) , positive-denominator-ℚ x)
+  abstract
+    exists-lesser-ℚ : exists ℚ (λ q → le-ℚ-Prop q x)
+    exists-lesser-ℚ =
+      intro-exists
+        ( rational-fraction-ℤ frac)
+        ( preserves-le-left-rational-fraction-ℤ x frac
+          ( le-fraction-le-numerator-fraction-ℤ
+            ( frac)
+            ( fraction-ℚ x)
+            ( refl)
+            ( le-pred-ℤ (numerator-ℚ x))))
+      where
+      frac : fraction-ℤ
+      frac = (pred-ℤ (numerator-ℚ x) , positive-denominator-ℚ x)
 
-  exists-greater-ℚ : exists ℚ (λ r → le-ℚ-Prop x r)
-  exists-greater-ℚ =
-    intro-exists
-      ( rational-fraction-ℤ frac)
-      ( preserves-le-right-rational-fraction-ℤ x frac
-        ( le-fraction-le-numerator-fraction-ℤ
-          ( fraction-ℚ x)
-          ( frac)
-          ( refl)
-          ( le-succ-ℤ (numerator-ℚ x))))
-    where
-    frac : fraction-ℤ
-    frac = (succ-ℤ (numerator-ℚ x) , positive-denominator-ℚ x)
+    exists-greater-ℚ : exists ℚ (λ r → le-ℚ-Prop x r)
+    exists-greater-ℚ =
+      intro-exists
+        ( rational-fraction-ℤ frac)
+        ( preserves-le-right-rational-fraction-ℤ x frac
+          ( le-fraction-le-numerator-fraction-ℤ
+            ( fraction-ℚ x)
+            ( frac)
+            ( refl)
+            ( le-succ-ℤ (numerator-ℚ x))))
+      where
+      frac : fraction-ℤ
+      frac = (succ-ℤ (numerator-ℚ x) , positive-denominator-ℚ x)
 ```
 
 ### For any two rational numbers `x` and `y`, either `x < y` or `y ≤ x`
 
 ```agda
-decide-le-leq-ℚ : (x y : ℚ) → le-ℚ x y + leq-ℚ y x
-decide-le-leq-ℚ x y =
-  map-coproduct
-    ( id)
-    ( λ H →
-      is-nonnegative-eq-ℤ
-        ( skew-commutative-cross-mul-diff-fraction-ℤ
-          ( fraction-ℚ x)
-          ( fraction-ℚ y))
-        ( is-nonnegative-neg-is-nonpositive-ℤ H))
-    ( decide-is-positive-is-nonpositive-ℤ)
+opaque
+  unfolding le-ℚ-Prop
+  unfolding leq-ℚ-Prop
 
-not-leq-le-ℚ : (x y : ℚ) → le-ℚ x y → ¬ leq-ℚ y x
-not-leq-le-ℚ x y H K =
-  is-not-positive-is-nonpositive-ℤ
-    ( tr
-      ( is-nonpositive-ℤ)
-      ( skew-commutative-cross-mul-diff-fraction-ℤ
-        ( fraction-ℚ y)
-        ( fraction-ℚ x))
-      ( is-nonpositive-neg-is-nonnegative-ℤ K))
-    ( H)
+  decide-le-leq-ℚ : (x y : ℚ) → le-ℚ x y + leq-ℚ y x
+  decide-le-leq-ℚ x y =
+    map-coproduct
+      ( id)
+      ( λ H →
+        is-nonnegative-eq-ℤ
+          ( skew-commutative-cross-mul-diff-fraction-ℤ
+            ( fraction-ℚ x)
+            ( fraction-ℚ y))
+          ( is-nonnegative-neg-is-nonpositive-ℤ H))
+      ( decide-is-positive-is-nonpositive-ℤ)
+
+  not-leq-le-ℚ : (x y : ℚ) → le-ℚ x y → ¬ leq-ℚ y x
+  not-leq-le-ℚ x y H K =
+    is-not-positive-is-nonpositive-ℤ
+      ( tr
+        ( is-nonpositive-ℤ)
+        ( skew-commutative-cross-mul-diff-fraction-ℤ
+          ( fraction-ℚ y)
+          ( fraction-ℚ x))
+        ( is-nonpositive-neg-is-nonnegative-ℤ K))
+      ( H)
 ```
 
 ### Trichotomy on the rationals
 
 ```agda
-trichotomy-le-ℚ :
-  {l : Level} {A : UU l} (x y : ℚ) →
-  ( le-ℚ x y → A) →
-  ( Id x y → A) →
-  ( le-ℚ y x → A) →
-  A
-trichotomy-le-ℚ x y left eq right with decide-le-leq-ℚ x y | decide-le-leq-ℚ y x
-... | inl I | _ = left I
-... | inr I | inl I' = right I'
-... | inr I | inr I' = eq (antisymmetric-leq-ℚ x y I' I)
+abstract
+  trichotomy-le-ℚ :
+    {l : Level} {A : UU l} (x y : ℚ) →
+    ( le-ℚ x y → A) →
+    ( Id x y → A) →
+    ( le-ℚ y x → A) →
+    A
+  trichotomy-le-ℚ x y left eq right
+    with decide-le-leq-ℚ x y | decide-le-leq-ℚ y x
+  ... | inl I | _ = left I
+  ... | inr I | inl I' = right I'
+  ... | inr I | inr I' = eq (antisymmetric-leq-ℚ x y I' I)
 ```
 
 ### The mediant of two distinct rationals is strictly between them
@@ -420,17 +453,21 @@ module _
   (x y : ℚ) (H : le-ℚ x y)
   where
 
-  le-left-mediant-ℚ : le-ℚ x (mediant-ℚ x y)
-  le-left-mediant-ℚ =
-    preserves-le-right-rational-fraction-ℤ x
-      ( mediant-fraction-ℤ (fraction-ℚ x) (fraction-ℚ y))
-      ( le-left-mediant-fraction-ℤ (fraction-ℚ x) (fraction-ℚ y) H)
+  opaque
+    unfolding le-ℚ-Prop
+    unfolding mediant-ℚ
 
-  le-right-mediant-ℚ : le-ℚ (mediant-ℚ x y) y
-  le-right-mediant-ℚ =
-    preserves-le-left-rational-fraction-ℤ y
-      ( mediant-fraction-ℤ (fraction-ℚ x) (fraction-ℚ y))
-      ( le-right-mediant-fraction-ℤ (fraction-ℚ x) (fraction-ℚ y) H)
+    le-left-mediant-ℚ : le-ℚ x (mediant-ℚ x y)
+    le-left-mediant-ℚ =
+      preserves-le-right-rational-fraction-ℤ x
+        ( mediant-fraction-ℤ (fraction-ℚ x) (fraction-ℚ y))
+        ( le-left-mediant-fraction-ℤ (fraction-ℚ x) (fraction-ℚ y) H)
+
+    le-right-mediant-ℚ : le-ℚ (mediant-ℚ x y) y
+    le-right-mediant-ℚ =
+      preserves-le-left-rational-fraction-ℤ y
+        ( mediant-fraction-ℤ (fraction-ℚ x) (fraction-ℚ y))
+        ( le-right-mediant-fraction-ℤ (fraction-ℚ x) (fraction-ℚ y) H)
 ```
 
 ### Strict inequality on the rational numbers is dense
@@ -440,63 +477,71 @@ module _
   (x y : ℚ) (H : le-ℚ x y)
   where
 
-  dense-le-ℚ : exists ℚ (λ r → le-ℚ-Prop x r ∧ le-ℚ-Prop r y)
-  dense-le-ℚ =
-    intro-exists
-      ( mediant-ℚ x y)
-      ( le-left-mediant-ℚ x y H , le-right-mediant-ℚ x y H)
+  abstract
+    dense-le-ℚ : exists ℚ (λ r → le-ℚ-Prop x r ∧ le-ℚ-Prop r y)
+    dense-le-ℚ =
+      intro-exists
+        ( mediant-ℚ x y)
+        ( le-left-mediant-ℚ x y H , le-right-mediant-ℚ x y H)
 ```
 
 ### Strict inequality on the rational numbers is located
 
 ```agda
-located-le-ℚ :
-  (x y z : ℚ) → le-ℚ y z → type-disjunction-Prop (le-ℚ-Prop y x) (le-ℚ-Prop x z)
-located-le-ℚ x y z H =
-  unit-trunc-Prop
-    ( map-coproduct
-      ( id)
-      ( λ p → concatenate-leq-le-ℚ x y z p H)
-      ( decide-le-leq-ℚ y x))
+abstract
+  located-le-ℚ :
+    (x y z : ℚ) → le-ℚ y z →
+    type-disjunction-Prop (le-ℚ-Prop y x) (le-ℚ-Prop x z)
+  located-le-ℚ x y z H =
+    unit-trunc-Prop
+      ( map-coproduct
+        ( id)
+        ( λ p → concatenate-leq-le-ℚ x y z p H)
+        ( decide-le-leq-ℚ y x))
 ```
 
 ### Negation reverses the ordering of strict inequality on the rational numbers
 
 ```agda
-neg-le-ℚ : (x y : ℚ) → le-ℚ x y → le-ℚ (neg-ℚ y) (neg-ℚ x)
-neg-le-ℚ x y = neg-le-fraction-ℤ (fraction-ℚ x) (fraction-ℚ y)
+opaque
+  unfolding le-ℚ-Prop
+  unfolding neg-ℚ
+
+  neg-le-ℚ : (x y : ℚ) → le-ℚ x y → le-ℚ (neg-ℚ y) (neg-ℚ x)
+  neg-le-ℚ x y = neg-le-fraction-ℤ (fraction-ℚ x) (fraction-ℚ y)
 ```
 
 ### Transposing additions on strict inequalities of rational numbers
 
 ```agda
-le-transpose-right-diff-ℚ : (x y z : ℚ) → le-ℚ x (y -ℚ z) → le-ℚ (x +ℚ z) y
-le-transpose-right-diff-ℚ x y z x<y-z =
-  tr
-    ( le-ℚ (x +ℚ z))
-    ( is-section-right-div-Group group-add-ℚ z y)
-    ( preserves-le-left-add-ℚ z x (y -ℚ z) x<y-z)
+abstract
+  le-transpose-right-diff-ℚ : (x y z : ℚ) → le-ℚ x (y -ℚ z) → le-ℚ (x +ℚ z) y
+  le-transpose-right-diff-ℚ x y z x<y-z =
+    tr
+      ( le-ℚ (x +ℚ z))
+      ( is-section-right-div-Group group-add-ℚ z y)
+      ( preserves-le-left-add-ℚ z x (y -ℚ z) x<y-z)
 
-le-transpose-right-add-ℚ : (x y z : ℚ) → le-ℚ x (y +ℚ z) → le-ℚ (x -ℚ z) y
-le-transpose-right-add-ℚ x y z x<y+z =
-  tr
-    ( le-ℚ (x -ℚ z))
-    ( is-retraction-right-div-Group group-add-ℚ z y)
-    ( preserves-le-left-add-ℚ (neg-ℚ z) x (y +ℚ z) x<y+z)
+  le-transpose-right-add-ℚ : (x y z : ℚ) → le-ℚ x (y +ℚ z) → le-ℚ (x -ℚ z) y
+  le-transpose-right-add-ℚ x y z x<y+z =
+    tr
+      ( le-ℚ (x -ℚ z))
+      ( is-retraction-right-div-Group group-add-ℚ z y)
+      ( preserves-le-left-add-ℚ (neg-ℚ z) x (y +ℚ z) x<y+z)
 
-le-transpose-left-diff-ℚ : (x y z : ℚ) → le-ℚ (x -ℚ y) z → le-ℚ x (z +ℚ y)
-le-transpose-left-diff-ℚ x y z x-y<z =
-  tr
-    ( λ w → le-ℚ w (z +ℚ y))
-    ( is-section-right-div-Group group-add-ℚ y x)
-    ( preserves-le-left-add-ℚ y (x -ℚ y) z x-y<z)
+  le-transpose-left-diff-ℚ : (x y z : ℚ) → le-ℚ (x -ℚ y) z → le-ℚ x (z +ℚ y)
+  le-transpose-left-diff-ℚ x y z x-y<z =
+    tr
+      ( λ w → le-ℚ w (z +ℚ y))
+      ( is-section-right-div-Group group-add-ℚ y x)
+      ( preserves-le-left-add-ℚ y (x -ℚ y) z x-y<z)
 
-le-transpose-left-add-ℚ : (x y z : ℚ) → le-ℚ (x +ℚ y) z → le-ℚ x (z -ℚ y)
-le-transpose-left-add-ℚ x y z x+y<z =
-  tr
-    ( λ w → le-ℚ w (z -ℚ y))
-    ( is-retraction-right-div-Group group-add-ℚ y x)
-    ( preserves-le-left-add-ℚ (neg-ℚ y) (x +ℚ y) z x+y<z)
+  le-transpose-left-add-ℚ : (x y z : ℚ) → le-ℚ (x +ℚ y) z → le-ℚ x (z -ℚ y)
+  le-transpose-left-add-ℚ x y z x+y<z =
+    tr
+      ( λ w → le-ℚ w (z -ℚ y))
+      ( is-retraction-right-div-Group group-add-ℚ y x)
+      ( preserves-le-left-add-ℚ (neg-ℚ y) (x +ℚ y) z x+y<z)
 
 le-iff-transpose-left-add-ℚ : (x y z : ℚ) → le-ℚ (x +ℚ y) z ↔ le-ℚ x (z -ℚ y)
 pr1 (le-iff-transpose-left-add-ℚ x y z) = le-transpose-left-add-ℚ x y z

--- a/src/elementary-number-theory/strict-inequality-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/strict-inequality-rational-numbers.lagda.md
@@ -184,6 +184,7 @@ module _
 
   opaque
     unfolding le-ℚ-Prop
+    unfolding rational-fraction-ℤ
 
     preserves-le-rational-fraction-ℤ :
       le-fraction-ℤ p q → le-ℚ (rational-fraction-ℤ p) (rational-fraction-ℤ q)
@@ -202,6 +203,8 @@ module _
 
   opaque
     unfolding le-ℚ-Prop
+    unfolding rational-fraction-ℤ
+
     preserves-le-right-rational-fraction-ℤ :
       le-fraction-ℤ (fraction-ℚ x) p → le-ℚ x (rational-fraction-ℤ p)
     preserves-le-right-rational-fraction-ℤ H =
@@ -232,6 +235,7 @@ module _
 
   opaque
     unfolding le-ℚ-Prop
+    unfolding rational-fraction-ℤ
 
     preserves-le-left-rational-fraction-ℤ :
       le-fraction-ℤ p (fraction-ℚ x) → le-ℚ (rational-fraction-ℤ p) x

--- a/src/elementary-number-theory/unit-fractions-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/unit-fractions-rational-numbers.lagda.md
@@ -64,6 +64,7 @@ reciprocal-rational-succ-ℕ n =
 
 ```agda
 opaque
+  unfolding inv-ℚ⁺
   unfolding leq-ℚ-Prop
 
   leq-reciprocal-rational-ℕ⁺ :
@@ -81,6 +82,7 @@ opaque
 
 ```agda
 opaque
+  unfolding inv-ℚ⁺
   unfolding le-ℚ-Prop
 
   le-reciprocal-rational-ℕ⁺ :

--- a/src/elementary-number-theory/unit-fractions-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/unit-fractions-rational-numbers.lagda.md
@@ -63,7 +63,9 @@ reciprocal-rational-succ-ℕ n =
 ### If `m ≤ n`, the reciprocal of `n` is less than or equal to the reciprocal of `n`
 
 ```agda
-abstract
+opaque
+  unfolding leq-ℚ-Prop
+
   leq-reciprocal-rational-ℕ⁺ :
     (m n : ℕ⁺) → leq-ℕ⁺ m n →
     leq-ℚ (reciprocal-rational-ℕ⁺ n) (reciprocal-rational-ℕ⁺ m)
@@ -78,7 +80,9 @@ abstract
 ### If `m < n`, the reciprocal of `n` is less than the reciprocal of `n`
 
 ```agda
-abstract
+opaque
+  unfolding le-ℚ-Prop
+
   le-reciprocal-rational-ℕ⁺ :
     (m n : ℕ⁺) → le-ℕ⁺ m n →
     le-ℚ⁺

--- a/src/real-numbers/absolute-value-real-numbers.lagda.md
+++ b/src/real-numbers/absolute-value-real-numbers.lagda.md
@@ -73,6 +73,7 @@ opaque
 ```agda
 opaque
   unfolding abs-ℝ
+  unfolding neg-ℚ
 
   is-nonnegative-abs-ℝ : {l : Level} → (x : ℝ l) → is-nonnegative-ℝ (abs-ℝ x)
   is-nonnegative-abs-ℝ x q q<0 =

--- a/src/real-numbers/addition-lower-dedekind-real-numbers.lagda.md
+++ b/src/real-numbers/addition-lower-dedekind-real-numbers.lagda.md
@@ -212,7 +212,9 @@ module _
   {l : Level} (x : lower-ℝ l)
   where
 
-  abstract
+  opaque
+    unfolding neg-ℚ
+
     right-unit-law-add-lower-ℝ : add-lower-ℝ x (lower-real-ℚ zero-ℚ) ＝ x
     right-unit-law-add-lower-ℝ =
       eq-sim-cut-lower-ℝ


### PR DESCRIPTION
This PR makes most rational arithmetic operations `opaque`, which improves compilation performance (avoiding expansion) and improves goal readability (since expanded rational operations tend to be extremely convoluted), so most goals will be phrased e.g. in terms of `add-Q` etc.

(This is not least based on struggles I've had with basing real arithmetic on rational numbers.)