### PR TITLE
Category of algebras of a theory

### DIFF
--- a/src/foundation/subtype-identity-principle.lagda.md
+++ b/src/foundation/subtype-identity-principle.lagda.md
@@ -107,4 +107,10 @@ module _
       ( map-extensionality-type-subtype f)
       ( is-equiv-map-equiv ∘ f)
       ( z)
+
+  inv-map-extensionality-type-subtype :
+    (f : (x : A) → (a ＝ x) ≃ Eq-A x) →
+    (z : Σ A (type-Prop ∘ P)) → Eq-A (pr1 z) → (a , p) ＝ z
+  inv-map-extensionality-type-subtype f z =
+    map-inv-equiv (extensionality-type-subtype f z)
 ```

--- a/src/lists/functoriality-tuples.lagda.md
+++ b/src/lists/functoriality-tuples.lagda.md
@@ -62,3 +62,20 @@ module _
   binary-map-tuple f empty-tuple empty-tuple = empty-tuple
   binary-map-tuple f (x ∷ v) (y ∷ w) = f x y ∷ binary-map-tuple f v w
 ```
+
+## Properties
+
+### The `tuple` functor preserves identity maps
+
+```agda
+preserves-id-map-tuple :
+  {l : Level} (A : UU l) (n : ℕ) (x : tuple A n) → x ＝ map-tuple id x
+preserves-id-map-tuple A zero-ℕ empty-tuple = refl
+preserves-id-map-tuple A (succ-ℕ n) (x ∷ xs) =
+  eq-Eq-tuple
+  ( succ-ℕ n)
+  ( x ∷ xs)
+  ( map-tuple id (x ∷ xs))
+  ( refl ,
+    Eq-eq-tuple n xs (map-tuple (λ a → a) xs) (preserves-id-map-tuple A n xs))
+```

--- a/src/lists/functoriality-tuples.lagda.md
+++ b/src/lists/functoriality-tuples.lagda.md
@@ -79,3 +79,18 @@ preserves-id-map-tuple A (succ-ℕ n) (x ∷ xs) =
   ( refl ,
     Eq-eq-tuple n xs (map-tuple (λ a → a) xs) (preserves-id-map-tuple A n xs))
 ```
+
+### The `tuple` functor preserves compositions
+
+```agda
+preserves-comp-map-tuple :
+  {l1 l2 l3 : Level} (A : UU l1) (B : UU l2) (C : UU l3) (n : ℕ) (x : tuple A n) (f : A → B) (g : B → C) → map-tuple g (map-tuple f x) ＝ map-tuple (g ∘ f) x
+preserves-comp-map-tuple A B C zero-ℕ empty-tuple f g = refl
+preserves-comp-map-tuple A B C (succ-ℕ n) (x ∷ xs) f g =
+  eq-Eq-tuple
+  ( succ-ℕ n)
+  ( map-tuple g (map-tuple f (x ∷ xs)))
+  ( map-tuple (g ∘ f) (x ∷ xs))
+  ( refl , Eq-eq-tuple n (map-tuple g (map-tuple f xs)) (map-tuple (g ∘ f) xs)
+    ( preserves-comp-map-tuple A B C n xs f g))
+```

--- a/src/lists/functoriality-tuples.lagda.md
+++ b/src/lists/functoriality-tuples.lagda.md
@@ -84,7 +84,10 @@ preserves-id-map-tuple A (succ-ℕ n) (x ∷ xs) =
 
 ```agda
 preserves-comp-map-tuple :
-  {l1 l2 l3 : Level} (A : UU l1) (B : UU l2) (C : UU l3) (n : ℕ) (x : tuple A n) (f : A → B) (g : B → C) → map-tuple g (map-tuple f x) ＝ map-tuple (g ∘ f) x
+  {l1 l2 l3 : Level}
+  (A : UU l1) (B : UU l2) (C : UU l3)
+  (n : ℕ) (x : tuple A n) (f : A → B) (g : B → C) →
+  map-tuple g (map-tuple f x) ＝ map-tuple (g ∘ f) x
 preserves-comp-map-tuple A B C zero-ℕ empty-tuple f g = refl
 preserves-comp-map-tuple A B C (succ-ℕ n) (x ∷ xs) f g =
   eq-Eq-tuple

--- a/src/universal-algebra.lagda.md
+++ b/src/universal-algebra.lagda.md
@@ -13,6 +13,7 @@ open import universal-algebra.congruences public
 open import universal-algebra.homomorphisms-of-algebras public
 open import universal-algebra.kernels public
 open import universal-algebra.models-of-signatures public
+open import universal-algebra.precategory-of-algebras-of-theories public
 open import universal-algebra.quotient-algebras public
 open import universal-algebra.signatures public
 open import universal-algebra.terms-over-signatures public

--- a/src/universal-algebra.lagda.md
+++ b/src/universal-algebra.lagda.md
@@ -9,6 +9,7 @@ open import universal-algebra.abstract-equations-over-signatures public
 open import universal-algebra.algebraic-theories public
 open import universal-algebra.algebraic-theory-of-groups public
 open import universal-algebra.algebras-of-theories public
+open import universal-algebra.category-of-algebras-of-theories public
 open import universal-algebra.congruences public
 open import universal-algebra.homomorphisms-of-algebras public
 open import universal-algebra.kernels public

--- a/src/universal-algebra.lagda.md
+++ b/src/universal-algebra.lagda.md
@@ -12,6 +12,7 @@ open import universal-algebra.algebras-of-theories public
 open import universal-algebra.category-of-algebras-of-theories public
 open import universal-algebra.congruences public
 open import universal-algebra.homomorphisms-of-algebras public
+open import universal-algebra.isomorphisms-of-algebras public
 open import universal-algebra.kernels public
 open import universal-algebra.models-of-signatures public
 open import universal-algebra.precategory-of-algebras-of-theories public

--- a/src/universal-algebra/algebras-of-theories.lagda.md
+++ b/src/universal-algebra/algebras-of-theories.lagda.md
@@ -107,6 +107,11 @@ module _
       ( λ e →
         ( is-prop-Π
           ( λ assign → is-set-type-Model-Signature Sg M _ _)))
+
+  is-algebra-Prop :
+    {l3 : Level} (X : Model-Signature Sg l3) → Prop (l2 ⊔ l3)
+  pr1 (is-algebra-Prop X) = is-algebra X
+  pr2 (is-algebra-Prop X) = is-prop-is-algebra X
 ```
 
 ### Characterizing identifications of algebras

--- a/src/universal-algebra/algebras-of-theories.lagda.md
+++ b/src/universal-algebra/algebras-of-theories.lagda.md
@@ -1,6 +1,8 @@
 # Algebras
 
 ```agda
+{-# OPTIONS --lossy-unification #-}
+
 module universal-algebra.algebras-of-theories where
 ```
 
@@ -141,6 +143,17 @@ module _
     ( refl-Eq-Model-Signature Sg A)
     ( Eq-eq-Algebra (A , p))
     ( is-equiv-Eq-eq-Model-Signature Sg A)
+
+  equiv-Eq-eq-Algebra :
+    {l3 : Level} (A B : Algebra Sg Th l3) →
+    (A ＝ B) ≃ Eq-Algebra A B
+  pr1 (equiv-Eq-eq-Algebra A B) = Eq-eq-Algebra A B
+  pr2 (equiv-Eq-eq-Algebra A B) = is-equiv-Eq-eq-Algebra A B
+
+  eq-Eq-Algebra :
+    {l3 : Level} (A B : Algebra Sg Th l3) →
+    Eq-Algebra A B → A ＝ B
+  eq-Eq-Algebra A B = map-inv-equiv (equiv-Eq-eq-Algebra A B)
 
   is-torsorial-Eq-Algebra :
     {l3 : Level} (A : Algebra Sg Th l3) → is-torsorial (Eq-Algebra A)

--- a/src/universal-algebra/algebras-of-theories.lagda.md
+++ b/src/universal-algebra/algebras-of-theories.lagda.md
@@ -11,7 +11,10 @@ open import foundation.dependent-pair-types
 open import foundation.identity-types
 open import foundation.propositions
 open import foundation.sets
+open import foundation.subtype-identity-principle
 open import foundation.universe-levels
+
+open import foundation-core.equivalences
 
 open import universal-algebra.abstract-equations-over-signatures
 open import universal-algebra.algebraic-theories
@@ -102,4 +105,29 @@ module _
       ( λ e →
         ( is-prop-Π
           ( λ assign → is-set-type-Model-Signature Sg M _ _)))
+```
+
+### Characterizing identifications of algebras
+
+```agda
+module _
+  { l1 : Level} ( Sg : signature l1)
+  { l2 : Level} ( Th : Theory Sg l2)
+  where
+
+  Eq-eq-Algebra :
+    {l3 : Level} (A B : Algebra Sg Th l3) → A ＝ B →
+    Eq-Model-Signature Sg (model-Algebra Sg Th A) (model-Algebra Sg Th B)
+  Eq-eq-Algebra A .A refl = refl-Eq-Model-Signature Sg (model-Algebra Sg Th A)
+
+  is-equiv-Eq-eq-Algebra :
+    {l3 : Level} (A B : Algebra Sg Th l3) →
+    is-equiv (Eq-eq-Algebra A B)
+  is-equiv-Eq-eq-Algebra (A , p) =
+    subtype-identity-principle
+    ( is-prop-is-algebra Sg Th)
+    ( p)
+    ( refl-Eq-Model-Signature Sg A)
+    ( Eq-eq-Algebra (A , p))
+    ( is-equiv-Eq-eq-Model-Signature Sg A)
 ```

--- a/src/universal-algebra/algebras-of-theories.lagda.md
+++ b/src/universal-algebra/algebras-of-theories.lagda.md
@@ -8,10 +8,12 @@ module universal-algebra.algebras-of-theories where
 
 ```agda
 open import foundation.dependent-pair-types
+open import foundation.fundamental-theorem-of-identity-types
 open import foundation.identity-types
 open import foundation.propositions
 open import foundation.sets
 open import foundation.subtype-identity-principle
+open import foundation.torsorial-type-families
 open import foundation.universe-levels
 
 open import foundation-core.equivalences
@@ -115,9 +117,13 @@ module _
   { l2 : Level} ( Th : Theory Sg l2)
   where
 
+  Eq-Algebra : {l3 : Level} (A B : Algebra Sg Th l3) → UU (l1 ⊔ l3)
+  Eq-Algebra A B =
+    Eq-Model-Signature Sg (model-Algebra Sg Th A) (model-Algebra Sg Th B)
+
   Eq-eq-Algebra :
     {l3 : Level} (A B : Algebra Sg Th l3) → A ＝ B →
-    Eq-Model-Signature Sg (model-Algebra Sg Th A) (model-Algebra Sg Th B)
+    Eq-Algebra A B
   Eq-eq-Algebra A .A refl = refl-Eq-Model-Signature Sg (model-Algebra Sg Th A)
 
   is-equiv-Eq-eq-Algebra :
@@ -130,4 +136,11 @@ module _
     ( refl-Eq-Model-Signature Sg A)
     ( Eq-eq-Algebra (A , p))
     ( is-equiv-Eq-eq-Model-Signature Sg A)
+
+  is-torsorial-Eq-Algebra :
+    {l3 : Level} (A : Algebra Sg Th l3) → is-torsorial (Eq-Algebra A)
+  is-torsorial-Eq-Algebra A =
+    fundamental-theorem-id'
+    ( Eq-eq-Algebra A)
+    ( λ B → is-equiv-Eq-eq-Algebra A B)
 ```

--- a/src/universal-algebra/category-of-algebras-of-theories.lagda.md
+++ b/src/universal-algebra/category-of-algebras-of-theories.lagda.md
@@ -1,6 +1,8 @@
 # The category of algebras of theories
 
 ```agda
+{-# OPTIONS --lossy-unification #-}
+
 module universal-algebra.category-of-algebras-of-theories where
 ```
 
@@ -23,6 +25,7 @@ open import foundation-core.identity-types
 
 open import universal-algebra.algebraic-theories
 open import universal-algebra.algebras-of-theories
+open import universal-algebra.isomorphisms-of-algebras
 open import universal-algebra.homomorphisms-of-algebras
 open import universal-algebra.models-of-signatures
 open import universal-algebra.precategory-of-algebras-of-theories
@@ -46,7 +49,7 @@ module _
 
   is-large-category-Algebra-Large-Precategory :
     is-large-category-Large-Precategory (Algebra-Large-Precategory S T)
-  is-large-category-Algebra-Large-Precategory (X , p) = {!   !}
+  is-large-category-Algebra-Large-Precategory = is-equiv-iso-eq-Algebra S T
 
   Algebra-Large-Category :
     Large-Category (λ l → l1 ⊔ l2 ⊔ lsuc l) (λ l3 → _⊔_ (l1 ⊔ l3))

--- a/src/universal-algebra/category-of-algebras-of-theories.lagda.md
+++ b/src/universal-algebra/category-of-algebras-of-theories.lagda.md
@@ -25,8 +25,8 @@ open import foundation-core.identity-types
 
 open import universal-algebra.algebraic-theories
 open import universal-algebra.algebras-of-theories
-open import universal-algebra.isomorphisms-of-algebras
 open import universal-algebra.homomorphisms-of-algebras
+open import universal-algebra.isomorphisms-of-algebras
 open import universal-algebra.models-of-signatures
 open import universal-algebra.precategory-of-algebras-of-theories
 open import universal-algebra.signatures

--- a/src/universal-algebra/category-of-algebras-of-theories.lagda.md
+++ b/src/universal-algebra/category-of-algebras-of-theories.lagda.md
@@ -7,9 +7,9 @@ module universal-algebra.category-of-algebras-of-theories where
 <details><summary>Imports</summary>
 
 ```agda
+open import category-theory.isomorphisms-in-large-precategories
 open import category-theory.large-categories
 open import category-theory.large-precategories
-open import category-theory.isomorphisms-in-large-precategories
 
 open import foundation.dependent-pair-types
 open import foundation.sets
@@ -24,8 +24,8 @@ open import universal-algebra.algebraic-theories
 open import universal-algebra.algebras-of-theories
 open import universal-algebra.homomorphisms-of-algebras
 open import universal-algebra.models-of-signatures
-open import universal-algebra.signatures
 open import universal-algebra.precategory-of-algebras-of-theories
+open import universal-algebra.signatures
 ```
 
 </details>

--- a/src/universal-algebra/category-of-algebras-of-theories.lagda.md
+++ b/src/universal-algebra/category-of-algebras-of-theories.lagda.md
@@ -1,0 +1,62 @@
+# The category of algebras of theories
+
+```agda
+module universal-algebra.category-of-algebras-of-theories where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import category-theory.large-categories
+open import category-theory.large-precategories
+open import category-theory.isomorphisms-in-large-precategories
+
+open import foundation.dependent-pair-types
+open import foundation.sets
+open import foundation.subtype-identity-principle
+open import foundation.universe-levels
+
+open import foundation-core.equality-dependent-pair-types
+open import foundation-core.equivalences
+open import foundation-core.identity-types
+
+open import universal-algebra.algebraic-theories
+open import universal-algebra.algebras-of-theories
+open import universal-algebra.homomorphisms-of-algebras
+open import universal-algebra.models-of-signatures
+open import universal-algebra.signatures
+open import universal-algebra.precategory-of-algebras-of-theories
+```
+
+</details>
+
+## Idea
+
+The
+[precategory of algebras of a theory](universal-algebra.precategory-of-algebras-of-theories.md)
+is a [category](category-theory.large-categories.md).
+
+## Definition
+
+```agda
+module _
+  {l1 l2 : Level} (S : signature l1) (T : Theory S l2)
+  where
+
+  is-large-category-Algebra-Large-Precategory :
+    is-large-category-Large-Precategory (Algebra-Large-Precategory S T)
+  is-large-category-Algebra-Large-Precategory (X , p) =
+    subtype-identity-principle
+    ( is-prop-is-algebra S T)
+    ( p)
+    {! eq-pair-Σ  !}
+    {!   !}
+    {!   !}
+
+  Algebra-Large-Category :
+    Large-Category (λ l → l1 ⊔ l2 ⊔ lsuc l) (λ l3 → _⊔_ (l1 ⊔ l3))
+  large-precategory-Large-Category Algebra-Large-Category =
+    Algebra-Large-Precategory S T
+  is-large-category-Large-Category Algebra-Large-Category =
+    is-large-category-Algebra-Large-Precategory
+```

--- a/src/universal-algebra/homomorphisms-of-algebras.lagda.md
+++ b/src/universal-algebra/homomorphisms-of-algebras.lagda.md
@@ -15,26 +15,18 @@ open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
 open import foundation.equivalences
 open import foundation.function-extensionality
-open import foundation.functoriality-dependent-pair-types
-open import foundation.fundamental-theorem-of-identity-types
 open import foundation.identity-types
 open import foundation.raising-universe-levels
 open import foundation.sets
-open import foundation.structure-identity-principle
 open import foundation.subtype-identity-principle
-open import foundation.transport-along-equivalences
 open import foundation.unit-type
 open import foundation.universe-levels
 
 open import foundation-core.cartesian-product-types
-open import foundation-core.dependent-identifications
-open import foundation-core.equality-dependent-pair-types
 open import foundation-core.function-types
 open import foundation-core.homotopies
 open import foundation-core.propositions
 open import foundation-core.subtypes
-open import foundation-core.torsorial-type-families
-open import foundation-core.transport-along-identifications
 
 open import lists.functoriality-tuples
 open import lists.tuples

--- a/src/universal-algebra/homomorphisms-of-algebras.lagda.md
+++ b/src/universal-algebra/homomorphisms-of-algebras.lagda.md
@@ -13,28 +13,28 @@ open import elementary-number-theory.natural-numbers
 
 open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
-open import foundation.fundamental-theorem-of-identity-types
 open import foundation.equivalences
 open import foundation.function-extensionality
-open import foundation.identity-types
 open import foundation.functoriality-dependent-pair-types
+open import foundation.fundamental-theorem-of-identity-types
+open import foundation.identity-types
 open import foundation.raising-universe-levels
+open import foundation.sets
+open import foundation.structure-identity-principle
+open import foundation.subtype-identity-principle
 open import foundation.transport-along-equivalences
 open import foundation.unit-type
-open import foundation.structure-identity-principle
-open import foundation.sets
-open import foundation.subtype-identity-principle
 open import foundation.universe-levels
 
-open import foundation-core.equality-dependent-pair-types
 open import foundation-core.cartesian-product-types
-open import foundation-core.function-types
 open import foundation-core.dependent-identifications
-open import foundation-core.transport-along-identifications
+open import foundation-core.equality-dependent-pair-types
+open import foundation-core.function-types
 open import foundation-core.homotopies
-open import foundation-core.torsorial-type-families
 open import foundation-core.propositions
 open import foundation-core.subtypes
+open import foundation-core.torsorial-type-families
+open import foundation-core.transport-along-identifications
 
 open import lists.functoriality-tuples
 open import lists.tuples

--- a/src/universal-algebra/homomorphisms-of-algebras.lagda.md
+++ b/src/universal-algebra/homomorphisms-of-algebras.lagda.md
@@ -7,15 +7,19 @@ module universal-algebra.homomorphisms-of-algebras where
 <details><summary>Imports</summary>
 
 ```agda
+open import elementary-number-theory.natural-numbers
+
 open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
+open import foundation.equivalences
 open import foundation.function-extensionality
 open import foundation.identity-types
+open import foundation.raising-universe-levels
+open import foundation.unit-type
 open import foundation.sets
 open import foundation.subtype-identity-principle
 open import foundation.universe-levels
 
-open import foundation-core.equivalences
 open import foundation-core.function-types
 open import foundation-core.homotopies
 open import foundation-core.propositions
@@ -250,4 +254,64 @@ module _
     eq-htpy-hom-Algebra Sg Th Alg1 Alg2
     ( comp-hom-Algebra Sg Th Alg1 Alg1 Alg2 f (id-hom-Algebra Sg Th Alg1)) f
     ( refl-htpy)
+```
+
+### The inverse of an equivalence of algebras
+
+```agda
+module _
+  { l1 : Level} ( Sg : signature l1)
+  { l2 : Level} ( Th : Theory Sg l2)
+  { l3 l4 : Level}
+  ( Alg1 : Algebra Sg Th l3)
+  ( Alg2 : Algebra Sg Th l4)
+  ( f : hom-Algebra Sg Th Alg1 Alg2)
+  ( eq : is-equiv (map-hom-Algebra Sg Th Alg1 Alg2 f))
+  where
+
+  inv-equiv-hom-Algebra : hom-Algebra Sg Th Alg2 Alg1
+  pr1 inv-equiv-hom-Algebra =
+    map-inv-is-equiv eq
+  pr2 inv-equiv-hom-Algebra op v =
+    map-inv-is-equiv
+    ( is-emb-is-equiv eq
+      ( pr1 inv-equiv-hom-Algebra (pr2 (pr1 Alg2) op v))
+      ( pr2 (pr1 Alg1) op (map-tuple (pr1 inv-equiv-hom-Algebra) v)))
+    ( is-section-map-inv-is-equiv eq (pr2 (pr1 Alg2) op v) ∙
+      ( ap (pr2 (pr1 Alg2) op) (eq-Eq-tuple (pr2 Sg op) v (map-tuple (pr1 f)
+        ( map-tuple (pr1 inv-equiv-hom-Algebra) v)) (eq2 (pr2 Sg op) v)) ∙
+        ( inv (pr2 f op (map-tuple (pr1 inv-equiv-hom-Algebra) v)))))
+          where
+          eq2 : (n : ℕ) (w : tuple (pr1 (pr1 (pr1 Alg2))) n) →
+            Eq-tuple n w (map-tuple (pr1 f) (map-tuple (map-inv-is-equiv eq) w))
+          eq2 zero-ℕ empty-tuple = map-raise star
+          pr1 (eq2 (succ-ℕ n) (x ∷ w)) =
+            inv (is-section-map-section-is-equiv eq x)
+          pr2 (eq2 (succ-ℕ n) (x ∷ w)) = eq2 n w
+```
+
+### The property that a homomorphism of algebras is an equivalence
+
+```agda
+module _
+  { l1 : Level} ( Sg : signature l1)
+  { l2 : Level} ( Th : Theory Sg l2)
+  { l3 l4 : Level}
+  ( Alg1 : Algebra Sg Th l3)
+  ( Alg2 : Algebra Sg Th l4)
+  where
+
+  is-equiv-hom-Algebra : (f : hom-Algebra Sg Th Alg1 Alg2) → UU (l3 ⊔ l4)
+  is-equiv-hom-Algebra f = is-equiv (map-hom-Algebra Sg Th Alg1 Alg2 f)
+
+  is-prop-is-equiv-hom-Algebra :
+    (f : hom-Algebra Sg Th Alg1 Alg2) → is-prop (is-equiv-hom-Algebra f)
+  is-prop-is-equiv-hom-Algebra f = is-property-is-equiv (pr1 f)
+
+  is-equiv-hom-Algebra-Prop : (f : hom-Algebra Sg Th Alg1 Alg2) → Prop (l3 ⊔ l4)
+  pr1 (is-equiv-hom-Algebra-Prop f) = is-equiv-hom-Algebra f
+  pr2 (is-equiv-hom-Algebra-Prop f) = is-prop-is-equiv-hom-Algebra f
+
+  equiv-hom-Algebra : UU (l1 ⊔ l3 ⊔ l4)
+  equiv-hom-Algebra = Σ (hom-Algebra Sg Th Alg1 Alg2) is-equiv-hom-Algebra
 ```

--- a/src/universal-algebra/homomorphisms-of-algebras.lagda.md
+++ b/src/universal-algebra/homomorphisms-of-algebras.lagda.md
@@ -8,8 +8,17 @@ module universal-algebra.homomorphisms-of-algebras where
 
 ```agda
 open import foundation.dependent-pair-types
+open import foundation.function-extensionality
 open import foundation.identity-types
+open import foundation.subtype-identity-principle
 open import foundation.universe-levels
+open import foundation.sets
+
+open import foundation-core.identity-types
+open import foundation-core.equivalences
+open import foundation-core.homotopies
+open import foundation-core.subtypes
+open import foundation-core.propositions
 
 open import lists.functoriality-tuples
 open import lists.tuples
@@ -47,6 +56,19 @@ module _
         ( f (is-model-set-Algebra Sg Th Alg1 op v) ＝
           ( is-model-set-Algebra Sg Th Alg2 op (map-tuple f v)))
 
+  is-prop-preserves-operations-Algebra :
+    (f : type-Algebra Sg Th Alg1 → type-Algebra Sg Th Alg2) →
+    is-prop (preserves-operations-Algebra f)
+  is-prop-preserves-operations-Algebra f =
+    is-prop-Π (λ x →
+      is-prop-Π (λ y → pr2 (pr1 (pr1 Alg2)) (f (pr2 (pr1 Alg1) x y))
+        (pr2 (pr1 Alg2) x (map-tuple f y))))
+
+  preserves-operations-Algebra-Prop :
+    (f : type-Algebra Sg Th Alg1 → type-Algebra Sg Th Alg2) → Prop (l1 ⊔ l3 ⊔ l4)
+  preserves-operations-Algebra-Prop f =
+    ( preserves-operations-Algebra f) , (is-prop-preserves-operations-Algebra f)
+
   hom-Algebra : UU (l1 ⊔ l3 ⊔ l4)
   hom-Algebra =
     Σ ( type-Algebra Sg Th Alg1 → type-Algebra Sg Th Alg2)
@@ -62,4 +84,28 @@ module _
     ( f : hom-Algebra) →
     preserves-operations-Algebra (map-hom-Algebra f)
   preserves-operations-hom-Algebra = pr2
+
+  hom-Algebra-Subtype :
+    subtype (l1 ⊔ l3 ⊔ l4) (type-Algebra Sg Th Alg1 → type-Algebra Sg Th Alg2)
+  hom-Algebra-Subtype = preserves-operations-Algebra-Prop
+```
+
+## Properties
+
+### The type of algebra homomorphisms for any theory is a set
+
+```agda
+module _
+  { l1 : Level} ( Sg : signature l1)
+  { l2 : Level} ( Th : Theory Sg l2)
+  { l3 l4 : Level}
+  ( Alg1 : Algebra Sg Th l3)
+  ( Alg2 : Algebra Sg Th l4)
+  where
+
+  is-set-hom-Algebra : is-set (hom-Algebra Sg Th Alg1 Alg2)
+  is-set-hom-Algebra =
+    is-set-type-subtype
+    ( hom-Algebra-Subtype Sg Th Alg1 Alg2)
+    ( is-set-hom-Set (set-Algebra Sg Th Alg1) (set-Algebra Sg Th Alg2))
 ```

--- a/src/universal-algebra/homomorphisms-of-algebras.lagda.md
+++ b/src/universal-algebra/homomorphisms-of-algebras.lagda.md
@@ -66,7 +66,8 @@ module _
         (pr2 (pr1 Alg2) x (map-tuple f y))))
 
   preserves-operations-Algebra-Prop :
-    (f : type-Algebra Sg Th Alg1 → type-Algebra Sg Th Alg2) → Prop (l1 ⊔ l3 ⊔ l4)
+    (f : type-Algebra Sg Th Alg1 → type-Algebra Sg Th Alg2) →
+    Prop (l1 ⊔ l3 ⊔ l4)
   preserves-operations-Algebra-Prop f =
     ( preserves-operations-Algebra f) , (is-prop-preserves-operations-Algebra f)
 

--- a/src/universal-algebra/homomorphisms-of-algebras.lagda.md
+++ b/src/universal-algebra/homomorphisms-of-algebras.lagda.md
@@ -14,8 +14,10 @@ open import foundation.subtype-identity-principle
 open import foundation.universe-levels
 open import foundation.sets
 
+open import foundation.action-on-identifications-functions
 open import foundation-core.identity-types
 open import foundation-core.equivalences
+open import foundation-core.function-types
 open import foundation-core.homotopies
 open import foundation-core.subtypes
 open import foundation-core.propositions
@@ -111,4 +113,20 @@ module _
 
   set-hom-Algebra : Set (l1 ⊔ l3 ⊔ l4)
   set-hom-Algebra = (hom-Algebra Sg Th Alg1 Alg2) , is-set-hom-Algebra
+```
+
+### The identity map is an algebra homomorphism
+
+```agda
+module _
+  { l1 : Level} ( Sg : signature l1)
+  { l2 : Level} ( Th : Theory Sg l2)
+  { l3 : Level} ( Alg : Algebra Sg Th l3)
+  where
+
+  is-hom-id-Algebra : preserves-operations-Algebra Sg Th Alg Alg id
+  is-hom-id-Algebra op v = ap (pr2 (pr1 Alg) op) (preserves-id-map-tuple (pr1 (pr1 (pr1 Alg))) (pr2 Sg op) v)
+
+  id-hom-Algebra : hom-Algebra Sg Th Alg Alg
+  id-hom-Algebra = id , is-hom-id-Algebra
 ```

--- a/src/universal-algebra/homomorphisms-of-algebras.lagda.md
+++ b/src/universal-algebra/homomorphisms-of-algebras.lagda.md
@@ -92,6 +92,40 @@ module _
   hom-Algebra-Subtype = preserves-operations-Algebra-Prop
 ```
 
+### Composition of algebra homomorphisms
+
+```agda
+module _
+  { l1 : Level} ( Sg : signature l1)
+  { l2 : Level} ( Th : Theory Sg l2)
+  { l3 l4 l5 : Level}
+  { Alg1 : Algebra Sg Th l3}
+  { Alg2 : Algebra Sg Th l4}
+  { Alg3 : Algebra Sg Th l5}
+  where
+
+  comp-hom-Algebra :
+    (f : hom-Algebra Sg Th Alg2 Alg3) (g : hom-Algebra Sg Th Alg1 Alg2) →
+    hom-Algebra Sg Th Alg1 Alg3
+  pr1 (comp-hom-Algebra (f , p) (g , q)) = f ∘ g
+  pr2 (comp-hom-Algebra (f , p) (g , q)) op v =
+    equational-reasoning
+    pr1 (comp-hom-Algebra (f , p) (g , q)) (pr2 (pr1 Alg1) op v)
+    ＝ f (pr2 (pr1 Alg2) op (map-tuple g v))
+      by ap f (q op v)
+    ＝ pr2 (pr1 Alg3) op (map-tuple f (map-tuple g v))
+      by p op (map-tuple g v)
+    ＝ pr2 (pr1 Alg3) op
+      (map-tuple (pr1 (comp-hom-Algebra (f , p) (g , q))) v)
+      by ap (pr2 (pr1 Alg3) op)
+      ( preserves-comp-map-tuple
+        ( pr1 (pr1 (pr1 Alg1)))
+        ( pr1 (pr1 (pr1 Alg2)))
+        ( pr1 (pr1 (pr1 Alg3)))
+        ( pr2 Sg op)
+        v g f)
+```
+
 ## Properties
 
 ### The type of algebra homomorphisms for any theory is a set
@@ -125,7 +159,10 @@ module _
   where
 
   is-hom-id-Algebra : preserves-operations-Algebra Sg Th Alg Alg id
-  is-hom-id-Algebra op v = ap (pr2 (pr1 Alg) op) (preserves-id-map-tuple (pr1 (pr1 (pr1 Alg))) (pr2 Sg op) v)
+  is-hom-id-Algebra op v =
+    ap
+    ( pr2 (pr1 Alg) op)
+    ( preserves-id-map-tuple (pr1 (pr1 (pr1 Alg))) (pr2 Sg op) v)
 
   id-hom-Algebra : hom-Algebra Sg Th Alg Alg
   id-hom-Algebra = id , is-hom-id-Algebra

--- a/src/universal-algebra/homomorphisms-of-algebras.lagda.md
+++ b/src/universal-algebra/homomorphisms-of-algebras.lagda.md
@@ -108,4 +108,7 @@ module _
     is-set-type-subtype
     ( hom-Algebra-Subtype Sg Th Alg1 Alg2)
     ( is-set-hom-Set (set-Algebra Sg Th Alg1) (set-Algebra Sg Th Alg2))
+
+  set-hom-Algebra : Set (l1 ⊔ l3 ⊔ l4)
+  set-hom-Algebra = (hom-Algebra Sg Th Alg1 Alg2) , is-set-hom-Algebra
 ```

--- a/src/universal-algebra/homomorphisms-of-algebras.lagda.md
+++ b/src/universal-algebra/homomorphisms-of-algebras.lagda.md
@@ -1,6 +1,8 @@
 # Homomorphisms of algebras
 
 ```agda
+{-# OPTIONS --lossy-unification #-}
+
 module universal-algebra.homomorphisms-of-algebras where
 ```
 
@@ -11,17 +13,23 @@ open import elementary-number-theory.natural-numbers
 
 open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
+open import foundation.fundamental-theorem-of-identity-types
 open import foundation.equivalences
 open import foundation.function-extensionality
 open import foundation.identity-types
 open import foundation.raising-universe-levels
+open import foundation.transport-along-equivalences
 open import foundation.unit-type
 open import foundation.sets
 open import foundation.subtype-identity-principle
 open import foundation.universe-levels
 
+open import foundation-core.equality-dependent-pair-types
 open import foundation-core.function-types
+open import foundation-core.dependent-identifications
+open import foundation-core.transport-along-identifications
 open import foundation-core.homotopies
+open import foundation-core.torsorial-type-families
 open import foundation-core.propositions
 open import foundation-core.subtypes
 
@@ -30,6 +38,7 @@ open import lists.tuples
 
 open import universal-algebra.algebraic-theories
 open import universal-algebra.algebras-of-theories
+open import universal-algebra.models-of-signatures
 open import universal-algebra.signatures
 ```
 
@@ -177,6 +186,10 @@ module _
   eq-htpy-hom-Algebra :
     (f g : hom-Algebra Sg Th Alg1 Alg2) → htpy-hom-Algebra f g → f ＝ g
   eq-htpy-hom-Algebra f g = map-inv-equiv (equiv-htpy-eq-hom-Algebra f g)
+
+  refl-htpy-hom-Algebra :
+    (f : hom-Algebra Sg Th Alg1 Alg2) → htpy-hom-Algebra f f
+  refl-htpy-hom-Algebra f = refl-htpy
 ```
 
 ### The identity map is an algebra homomorphism
@@ -314,4 +327,42 @@ module _
 
   equiv-hom-Algebra : UU (l1 ⊔ l3 ⊔ l4)
   equiv-hom-Algebra = Σ (hom-Algebra Sg Th Alg1 Alg2) is-equiv-hom-Algebra
+```
+
+### Another characterization of the identity types of algebras
+
+```agda
+module _
+  { l1 : Level} ( Sg : signature l1)
+  { l2 : Level} ( Th : Theory Sg l2)
+  { l3 : Level} ( A : Algebra Sg Th l3)
+  where
+
+  id-equiv-hom-Algebra : equiv-hom-Algebra Sg Th A A
+  pr1 id-equiv-hom-Algebra = id-hom-Algebra Sg Th A
+  pr2 id-equiv-hom-Algebra = is-equiv-id
+
+  equiv-eq-hom-Algebra :
+    (B : Algebra Sg Th l3) → A ＝ B → equiv-hom-Algebra Sg Th A B
+  equiv-eq-hom-Algebra .A refl = id-equiv-hom-Algebra
+
+  is-torsorial-equiv-eq-hom-Algebra :
+    is-torsorial (λ z → equiv-hom-Algebra Sg Th A z)
+  pr1 (pr1 is-torsorial-equiv-eq-hom-Algebra) = A
+  pr2 (pr1 is-torsorial-equiv-eq-hom-Algebra) = id-equiv-hom-Algebra
+  pr2 is-torsorial-equiv-eq-hom-Algebra ((B , p) , ((f , q) , eq)) =
+    eq-pair-Σ
+    ( eq-type-subtype (is-algebra-Prop Sg Th)
+      ( eq-Eq-Model-Signature Sg (model-Algebra Sg Th A) B
+        (( f , eq) , (λ g → eq-htpy (λ x → {!   !})))))
+    ( eq-type-subtype (is-equiv-hom-Algebra-Prop Sg Th A (B , p))
+      ( eq-htpy-hom-Algebra Sg Th A (B , p) {!   !} (f , q)
+        ( λ x → {!   !})))
+
+  is-equiv-equiv-eq-hom-Algebra :
+    (B : Algebra Sg Th l3) → is-equiv (equiv-eq-hom-Algebra B)
+  is-equiv-equiv-eq-hom-Algebra =
+    fundamental-theorem-id
+      is-torsorial-equiv-eq-hom-Algebra
+      equiv-eq-hom-Algebra
 ```

--- a/src/universal-algebra/homomorphisms-of-algebras.lagda.md
+++ b/src/universal-algebra/homomorphisms-of-algebras.lagda.md
@@ -7,20 +7,19 @@ module universal-algebra.homomorphisms-of-algebras where
 <details><summary>Imports</summary>
 
 ```agda
+open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
 open import foundation.function-extensionality
 open import foundation.identity-types
+open import foundation.sets
 open import foundation.subtype-identity-principle
 open import foundation.universe-levels
-open import foundation.sets
 
-open import foundation.action-on-identifications-functions
-open import foundation-core.identity-types
 open import foundation-core.equivalences
 open import foundation-core.function-types
 open import foundation-core.homotopies
-open import foundation-core.subtypes
 open import foundation-core.propositions
+open import foundation-core.subtypes
 
 open import lists.functoriality-tuples
 open import lists.tuples
@@ -201,10 +200,10 @@ module _
   { l1 : Level} ( Sg : signature l1)
   { l2 : Level} ( Th : Theory Sg l2)
   { l3 l4 l5 l6 : Level}
-  { Alg1 : Algebra Sg Th l3}
-  { Alg2 : Algebra Sg Th l4}
-  { Alg3 : Algebra Sg Th l5}
-  { Alg4 : Algebra Sg Th l6}
+  ( Alg1 : Algebra Sg Th l3)
+  ( Alg2 : Algebra Sg Th l4)
+  ( Alg3 : Algebra Sg Th l5)
+  ( Alg4 : Algebra Sg Th l6)
   where
 
   associative-comp-hom-Algebra :
@@ -231,8 +230,8 @@ module _
   { l1 : Level} ( Sg : signature l1)
   { l2 : Level} ( Th : Theory Sg l2)
   { l3 l4 : Level}
-  { Alg1 : Algebra Sg Th l3}
-  { Alg2 : Algebra Sg Th l4}
+  ( Alg1 : Algebra Sg Th l3)
+  ( Alg2 : Algebra Sg Th l4)
   where
 
   left-unit-law-comp-hom-Algebra :

--- a/src/universal-algebra/homomorphisms-of-algebras.lagda.md
+++ b/src/universal-algebra/homomorphisms-of-algebras.lagda.md
@@ -99,31 +99,31 @@ module _
   { l1 : Level} ( Sg : signature l1)
   { l2 : Level} ( Th : Theory Sg l2)
   { l3 l4 l5 : Level}
-  { Alg1 : Algebra Sg Th l3}
-  { Alg2 : Algebra Sg Th l4}
-  { Alg3 : Algebra Sg Th l5}
+  ( Alg1 : Algebra Sg Th l3)
+  ( Alg2 : Algebra Sg Th l4)
+  ( Alg3 : Algebra Sg Th l5)
   where
 
   comp-hom-Algebra :
-    (f : hom-Algebra Sg Th Alg2 Alg3) (g : hom-Algebra Sg Th Alg1 Alg2) →
+    (g : hom-Algebra Sg Th Alg2 Alg3) (f : hom-Algebra Sg Th Alg1 Alg2) →
     hom-Algebra Sg Th Alg1 Alg3
-  pr1 (comp-hom-Algebra (f , p) (g , q)) = f ∘ g
-  pr2 (comp-hom-Algebra (f , p) (g , q)) op v =
+  pr1 (comp-hom-Algebra (g , _) (f , _)) = g ∘ f
+  pr2 (comp-hom-Algebra (g , q) (f , p)) op v =
     equational-reasoning
-    pr1 (comp-hom-Algebra (f , p) (g , q)) (pr2 (pr1 Alg1) op v)
-    ＝ f (pr2 (pr1 Alg2) op (map-tuple g v))
-      by ap f (q op v)
-    ＝ pr2 (pr1 Alg3) op (map-tuple f (map-tuple g v))
-      by p op (map-tuple g v)
+    pr1 (comp-hom-Algebra (g , q) (f , p)) (pr2 (pr1 Alg1) op v)
+    ＝ g (pr2 (pr1 Alg2) op (map-tuple f v))
+      by ap g (p op v)
+    ＝ pr2 (pr1 Alg3) op (map-tuple g (map-tuple f v))
+      by q op (map-tuple f v)
     ＝ pr2 (pr1 Alg3) op
-      (map-tuple (pr1 (comp-hom-Algebra (f , p) (g , q))) v)
+      (map-tuple (pr1 (comp-hom-Algebra (g , q) (f , p))) v)
       by ap (pr2 (pr1 Alg3) op)
       ( preserves-comp-map-tuple
         ( pr1 (pr1 (pr1 Alg1)))
         ( pr1 (pr1 (pr1 Alg2)))
         ( pr1 (pr1 (pr1 Alg3)))
         ( pr2 Sg op)
-        v g f)
+        v f g)
 ```
 
 ## Properties
@@ -147,6 +147,32 @@ module _
 
   set-hom-Algebra : Set (l1 ⊔ l3 ⊔ l4)
   set-hom-Algebra = (hom-Algebra Sg Th Alg1 Alg2) , is-set-hom-Algebra
+
+  htpy-hom-Algebra : (f g : hom-Algebra Sg Th Alg1 Alg2) → UU (l3 ⊔ l4)
+  htpy-hom-Algebra (f , _) (g , _) = f ~ g
+
+  htpy-eq-hom-Algebra :
+    (f g : hom-Algebra Sg Th Alg1 Alg2) → f ＝ g → htpy-hom-Algebra f g
+  htpy-eq-hom-Algebra f .f refl x = refl
+
+  is-equiv-htpy-eq-hom-Algebra :
+    (f g : hom-Algebra Sg Th Alg1 Alg2) → is-equiv (htpy-eq-hom-Algebra f g)
+  is-equiv-htpy-eq-hom-Algebra (f , p) =
+    subtype-identity-principle
+    ( is-prop-preserves-operations-Algebra Sg Th Alg1 Alg2)
+    ( p)
+    ( refl-htpy)
+    ( htpy-eq-hom-Algebra (f , p))
+    ( funext f)
+
+  equiv-htpy-eq-hom-Algebra :
+    (f g : hom-Algebra Sg Th Alg1 Alg2) → (f ＝ g) ≃ (htpy-hom-Algebra f g)
+  equiv-htpy-eq-hom-Algebra f g =
+    (htpy-eq-hom-Algebra f g) , is-equiv-htpy-eq-hom-Algebra f g
+
+  eq-htpy-hom-Algebra :
+    (f g : hom-Algebra Sg Th Alg1 Alg2) → htpy-hom-Algebra f g → f ＝ g
+  eq-htpy-hom-Algebra f g = map-inv-equiv (equiv-htpy-eq-hom-Algebra f g)
 ```
 
 ### The identity map is an algebra homomorphism
@@ -166,4 +192,62 @@ module _
 
   id-hom-Algebra : hom-Algebra Sg Th Alg Alg
   id-hom-Algebra = id , is-hom-id-Algebra
+```
+
+### Composition of algebra homomorphisms is associative
+
+```agda
+module _
+  { l1 : Level} ( Sg : signature l1)
+  { l2 : Level} ( Th : Theory Sg l2)
+  { l3 l4 l5 l6 : Level}
+  { Alg1 : Algebra Sg Th l3}
+  { Alg2 : Algebra Sg Th l4}
+  { Alg3 : Algebra Sg Th l5}
+  { Alg4 : Algebra Sg Th l6}
+  where
+
+  associative-comp-hom-Algebra :
+    (h : hom-Algebra Sg Th Alg3 Alg4)
+    (g : hom-Algebra Sg Th Alg2 Alg3)
+    (f : hom-Algebra Sg Th Alg1 Alg2) →
+    comp-hom-Algebra Sg Th Alg1 Alg2 Alg4
+      ( comp-hom-Algebra Sg Th Alg2 Alg3 Alg4 h g) f ＝
+    comp-hom-Algebra Sg Th Alg1 Alg3 Alg4 h
+      ( comp-hom-Algebra Sg Th Alg1 Alg2 Alg3 g f)
+  associative-comp-hom-Algebra h g f =
+    eq-htpy-hom-Algebra Sg Th Alg1 Alg4
+    ( comp-hom-Algebra Sg Th Alg1 Alg2 Alg4
+      ( comp-hom-Algebra Sg Th Alg2 Alg3 Alg4 h g) f)
+    ( comp-hom-Algebra Sg Th Alg1 Alg3 Alg4 h
+      ( comp-hom-Algebra Sg Th Alg1 Alg2 Alg3 g f))
+    ( refl-htpy)
+```
+
+### Left and right unit laws for homomorphism composition
+
+```agda
+module _
+  { l1 : Level} ( Sg : signature l1)
+  { l2 : Level} ( Th : Theory Sg l2)
+  { l3 l4 : Level}
+  { Alg1 : Algebra Sg Th l3}
+  { Alg2 : Algebra Sg Th l4}
+  where
+
+  left-unit-law-comp-hom-Algebra :
+    (f : hom-Algebra Sg Th Alg1 Alg2) →
+    comp-hom-Algebra Sg Th Alg1 Alg2 Alg2 (id-hom-Algebra Sg Th Alg2) f ＝ f
+  left-unit-law-comp-hom-Algebra f =
+    eq-htpy-hom-Algebra Sg Th Alg1 Alg2
+    ( comp-hom-Algebra Sg Th Alg1 Alg2 Alg2 (id-hom-Algebra Sg Th Alg2) f) f
+    ( refl-htpy)
+
+  right-unit-law-comp-hom-Algebra :
+    (f : hom-Algebra Sg Th Alg1 Alg2) →
+    comp-hom-Algebra Sg Th Alg1 Alg1 Alg2 f (id-hom-Algebra Sg Th Alg1) ＝ f
+  right-unit-law-comp-hom-Algebra f =
+    eq-htpy-hom-Algebra Sg Th Alg1 Alg2
+    ( comp-hom-Algebra Sg Th Alg1 Alg1 Alg2 f (id-hom-Algebra Sg Th Alg1)) f
+    ( refl-htpy)
 ```

--- a/src/universal-algebra/homomorphisms-of-algebras.lagda.md
+++ b/src/universal-algebra/homomorphisms-of-algebras.lagda.md
@@ -17,14 +17,17 @@ open import foundation.fundamental-theorem-of-identity-types
 open import foundation.equivalences
 open import foundation.function-extensionality
 open import foundation.identity-types
+open import foundation.functoriality-dependent-pair-types
 open import foundation.raising-universe-levels
 open import foundation.transport-along-equivalences
 open import foundation.unit-type
+open import foundation.structure-identity-principle
 open import foundation.sets
 open import foundation.subtype-identity-principle
 open import foundation.universe-levels
 
 open import foundation-core.equality-dependent-pair-types
+open import foundation-core.cartesian-product-types
 open import foundation-core.function-types
 open import foundation-core.dependent-identifications
 open import foundation-core.transport-along-identifications
@@ -329,7 +332,10 @@ module _
   equiv-hom-Algebra = Σ (hom-Algebra Sg Th Alg1 Alg2) is-equiv-hom-Algebra
 ```
 
-### Another characterization of the identity types of algebras
+### A useful factorization for characterizing isomorphisms of algebras
+
+Although we do not prove it here for cyclic module dependency reasons, this
+gives another characterization of the identity types of algebras.
 
 ```agda
 module _
@@ -338,31 +344,13 @@ module _
   { l3 : Level} ( A : Algebra Sg Th l3)
   where
 
-  id-equiv-hom-Algebra : equiv-hom-Algebra Sg Th A A
-  pr1 id-equiv-hom-Algebra = id-hom-Algebra Sg Th A
-  pr2 id-equiv-hom-Algebra = is-equiv-id
-
-  equiv-eq-hom-Algebra :
-    (B : Algebra Sg Th l3) → A ＝ B → equiv-hom-Algebra Sg Th A B
-  equiv-eq-hom-Algebra .A refl = id-equiv-hom-Algebra
-
-  is-torsorial-equiv-eq-hom-Algebra :
-    is-torsorial (λ z → equiv-hom-Algebra Sg Th A z)
-  pr1 (pr1 is-torsorial-equiv-eq-hom-Algebra) = A
-  pr2 (pr1 is-torsorial-equiv-eq-hom-Algebra) = id-equiv-hom-Algebra
-  pr2 is-torsorial-equiv-eq-hom-Algebra ((B , p) , ((f , q) , eq)) =
-    eq-pair-Σ
-    ( eq-type-subtype (is-algebra-Prop Sg Th)
-      ( eq-Eq-Model-Signature Sg (model-Algebra Sg Th A) B
-        (( f , eq) , (λ g → eq-htpy (λ x → {!   !})))))
-    ( eq-type-subtype (is-equiv-hom-Algebra-Prop Sg Th A (B , p))
-      ( eq-htpy-hom-Algebra Sg Th A (B , p) {!   !} (f , q)
-        ( λ x → {!   !})))
-
-  is-equiv-equiv-eq-hom-Algebra :
-    (B : Algebra Sg Th l3) → is-equiv (equiv-eq-hom-Algebra B)
-  is-equiv-equiv-eq-hom-Algebra =
-    fundamental-theorem-id
-      is-torsorial-equiv-eq-hom-Algebra
-      equiv-eq-hom-Algebra
+  equiv-equiv-hom-Algebra' :
+    (B : Algebra Sg Th l3) → equiv-hom-Algebra Sg Th A B ≃
+    Σ (hom-Set (pr1 (pr1 A)) (pr1 (pr1 B)))
+      (λ f → is-equiv f × preserves-operations-Algebra Sg Th A B f)
+  pr1 (equiv-equiv-hom-Algebra' B) ((f , p) , eq) = f , eq , p
+  pr1 (pr1 (pr2 (equiv-equiv-hom-Algebra' B))) (f , eq , p) = (f , p) , eq
+  pr2 (pr1 (pr2 (equiv-equiv-hom-Algebra' B))) _ = refl
+  pr1 (pr2 (pr2 (equiv-equiv-hom-Algebra' B))) (f , eq , p) = (f , p) , eq
+  pr2 (pr2 (pr2 (equiv-equiv-hom-Algebra' B))) _ = refl
 ```

--- a/src/universal-algebra/isomorphisms-algebras-of-theories.lagda.md
+++ b/src/universal-algebra/isomorphisms-algebras-of-theories.lagda.md
@@ -107,52 +107,14 @@ module _
       htpy : map-inv-is-equiv eq ∘ pr1 f ~ pr1 (pr2 eq) ∘ pr1 f
       htpy x = htpy-map-inv-equiv-retraction (pr1 f , eq) (pr2 eq) (pr1 f x)
 
-  Eq-Algebra-equiv-Algebra :
-    Eq-Algebra S T A B → Σ (hom-Algebra S T A B) (is-equiv-hom-Algebra S T A B)
-  pr1 (pr1 (Eq-Algebra-equiv-Algebra ((f , eq) , p))) = f
-  pr2 (pr1 (Eq-Algebra-equiv-Algebra ((f , eq) , p))) op v =
-    {!   !} ∙
-    pr2 (pr1 eq)
-    ( pr2 (pr1 B) op
-    ( map-tuple (pr1 (pr1 (Eq-Algebra-equiv-Algebra ((f , eq) , p)))) v))
-  pr2 (Eq-Algebra-equiv-Algebra ((f , eq) , p)) = eq
-
-  equiv-Algebra-Eq-Algebra :
-    Σ (hom-Algebra S T A B) (is-equiv-hom-Algebra S T A B) → Eq-Algebra S T A B
-  pr1 (equiv-Algebra-Eq-Algebra ((f , _) , eq)) = f , eq
-  pr2 (equiv-Algebra-Eq-Algebra ((f , p) , eq)) g = eq-htpy htpy
-    where
-    htpy :
-      map-tr-equiv
-      ( λ v → (x : pr1 S) → tuple v (pr2 S x) → v)
-      ( pr1 (equiv-Algebra-Eq-Algebra ((f , p) , eq))) (pr2 (pr1 A)) g ~
-      pr2 (pr1 B) g
-    htpy x = {!   !} ∙ {!   !}
-
-  equiv-Eq-Algebra-equiv-Algebra :
-    Eq-Algebra S T A B ≃ Σ (hom-Algebra S T A B) (is-equiv-hom-Algebra S T A B)
-  pr1 equiv-Eq-Algebra-equiv-Algebra = Eq-Algebra-equiv-Algebra
-  pr1 (pr1 (pr2 equiv-Eq-Algebra-equiv-Algebra)) = equiv-Algebra-Eq-Algebra
-  pr2 (pr1 (pr2 equiv-Eq-Algebra-equiv-Algebra)) (f , p) =
-    eq-type-subtype
-    ( is-equiv-hom-Algebra-Prop S T A B)
-    ( eq-htpy-hom-Algebra S T A B (pr1
-      (( pr1 equiv-Eq-Algebra-equiv-Algebra ∘
-        pr1 (pr1 (pr2 equiv-Eq-Algebra-equiv-Algebra)))
-        ( f , p))) f (λ x → refl))
-  pr1 (pr2 (pr2 equiv-Eq-Algebra-equiv-Algebra)) = equiv-Algebra-Eq-Algebra
-  pr2 (pr2 (pr2 equiv-Eq-Algebra-equiv-Algebra)) (f , p) =
-    eq-type-subtype
-    ( tr-is-model-signature-equiv-Set-Prop S (pr1 A) (pr1 (pr1 B)) (pr2 (pr1 B)))
-    (eq-type-subtype is-equiv-Prop (eq-htpy (λ x → refl)))
-
   equiv-iso-Eq-Algebra : Eq-Algebra S T A B ≃ iso-Algebra
   equiv-iso-Eq-Algebra =
     equiv-type-subtype
     ( is-prop-is-equiv-hom-Algebra S T A B)
     ( is-prop-is-iso-Algebra)
     ( is-equiv-is-iso-Algebra)
-    ( is-iso-is-equiv-Algebra) ∘e {!   !}
+    ( is-iso-is-equiv-Algebra) ∘e
+    {!   !}
 
 module _
   { l1 : Level} ( S : signature l1)

--- a/src/universal-algebra/isomorphisms-algebras-of-theories.lagda.md
+++ b/src/universal-algebra/isomorphisms-algebras-of-theories.lagda.md
@@ -45,8 +45,18 @@ module _
   { l2 : Level} ( T : Theory S l2)
   where
 
+  iso-Eq-Model-Signature :
+    {l3 : Level} (A B : Algebra S T l3)
+    (b : Eq-Model-Signature S (model-Algebra S T A) (model-Algebra S T B)) →
+    iso-Large-Precategory (Algebra-Large-Precategory S T) A B
+  pr1 (iso-Eq-Model-Signature A B b) = {!   !}
+  pr1 (pr2 (iso-Eq-Model-Signature A B b)) = {!   !}
+  pr1 (pr2 (pr2 (iso-Eq-Model-Signature A B b))) = {!   !}
+  pr2 (pr2 (pr2 (iso-Eq-Model-Signature A B b))) = {!   !}
+
   id-iso-comp-htpy-Algebra :
     {l3 : Level} (A B : Algebra S T l3) →
-    iso-eq-Large-Precategory (Algebra-Large-Precategory S T) A B ~ {!   !} ∘ {!   !}
+    iso-eq-Large-Precategory (Algebra-Large-Precategory S T) A B ~
+    {!   !} ∘ Eq-eq-Algebra S T A B
   id-iso-comp-htpy-Algebra A B = {!   !}
 ```

--- a/src/universal-algebra/isomorphisms-algebras-of-theories.lagda.md
+++ b/src/universal-algebra/isomorphisms-algebras-of-theories.lagda.md
@@ -1,6 +1,8 @@
 # Isomorphisms of algebras of theories
 
 ```agda
+{-# OPTIONS --lossy-unification #-}
+
 module universal-algebra.isomorphisms-algebras-of-theories where
 ```
 
@@ -12,16 +14,31 @@ open import category-theory.isomorphisms-in-categories
 open import category-theory.large-categories
 open import category-theory.large-precategories
 
+open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
+open import foundation.functoriality-dependent-pair-types
+open import foundation.function-extensionality
+open import foundation.equivalences
 open import foundation.sets
+open import foundation.subtypes
 open import foundation.subtype-identity-principle
 open import foundation.universe-levels
+open import foundation.transport-along-equivalences
+open import foundation.torsorial-type-families
+open import foundation.fundamental-theorem-of-identity-types
 
+open import foundation-core.transport-along-identifications
+open import foundation-core.contractible-types
 open import foundation-core.equality-dependent-pair-types
-open import foundation-core.equivalences
 open import foundation-core.function-types
+open import foundation-core.propositions
+open import foundation-core.sections
+open import foundation-core.retractions
 open import foundation-core.homotopies
 open import foundation-core.identity-types
+
+open import lists.functoriality-tuples
+open import lists.tuples
 
 open import universal-algebra.algebraic-theories
 open import universal-algebra.algebras-of-theories
@@ -43,20 +60,110 @@ We characterize
 module _
   { l1 : Level} ( S : signature l1)
   { l2 : Level} ( T : Theory S l2)
+  { l3 : Level} ( A B : Algebra S T l3)
   where
 
-  iso-Eq-Model-Signature :
-    {l3 : Level} (A B : Algebra S T l3)
-    (b : Eq-Model-Signature S (model-Algebra S T A) (model-Algebra S T B)) →
-    iso-Large-Precategory (Algebra-Large-Precategory S T) A B
-  pr1 (iso-Eq-Model-Signature A B b) = {!   !}
-  pr1 (pr2 (iso-Eq-Model-Signature A B b)) = {!   !}
-  pr1 (pr2 (pr2 (iso-Eq-Model-Signature A B b))) = {!   !}
-  pr2 (pr2 (pr2 (iso-Eq-Model-Signature A B b))) = {!   !}
+  is-iso-Algebra : (f : hom-Algebra S T A B) → UU (l1 ⊔ l3)
+  is-iso-Algebra f =
+    is-iso-Large-Precategory (Algebra-Large-Precategory S T) {X = A} {Y = B} f
 
-  id-iso-comp-htpy-Algebra :
-    {l3 : Level} (A B : Algebra S T l3) →
-    iso-eq-Large-Precategory (Algebra-Large-Precategory S T) A B ~
-    {!   !} ∘ Eq-eq-Algebra S T A B
-  id-iso-comp-htpy-Algebra A B = {!   !}
+  iso-Algebra : UU (l1 ⊔ l3)
+  iso-Algebra = iso-Large-Precategory (Algebra-Large-Precategory S T) A B
+
+  is-prop-is-iso-Algebra :
+    (f : hom-Algebra S T A B) → is-prop (is-iso-Algebra f)
+  is-prop-is-iso-Algebra =
+    is-prop-is-iso-Large-Precategory (Algebra-Large-Precategory S T)
+
+  is-iso-is-equiv-Algebra :
+    (f : hom-Algebra S T A B) →
+    is-iso-Algebra f →
+    is-equiv-hom-Algebra S T A B f
+  pr1 (pr1 (is-iso-is-equiv-Algebra f (g , p))) = map-hom-Algebra S T B A g
+  pr2 (pr1 (is-iso-is-equiv-Algebra f (g , (p , q)))) =
+    htpy-eq-hom-Algebra S T B B
+    ( comp-hom-Algebra S T B A B f g)
+    ( id-hom-Algebra S T B) p
+  pr1 (pr2 (is-iso-is-equiv-Algebra f (g , p))) = map-hom-Algebra S T B A g
+  pr2 (pr2 (is-iso-is-equiv-Algebra f (g , (p , q)))) =
+    htpy-eq-hom-Algebra S T A A
+    ( comp-hom-Algebra S T A B A g f)
+    ( id-hom-Algebra S T A) q
+
+  is-equiv-is-iso-Algebra :
+    (f : hom-Algebra S T A B) → is-equiv-hom-Algebra S T A B f → is-iso-Algebra f
+  pr1 (is-equiv-is-iso-Algebra f eq) = inv-equiv-hom-Algebra S T A B f eq
+  pr1 (pr2 (is-equiv-is-iso-Algebra f eq)) =
+    eq-htpy-hom-Algebra S T B B
+    ( comp-hom-Algebra S T B A B f
+      ( inv-equiv-hom-Algebra S T A B f eq))
+    ( id-hom-Algebra S T B) (pr2 (pr1 eq))
+  pr2 (pr2 (is-equiv-is-iso-Algebra f eq)) =
+    eq-htpy-hom-Algebra S T A A
+    ( comp-hom-Algebra S T A B A
+      ( inv-equiv-hom-Algebra S T A B f eq) f)
+    ( id-hom-Algebra S T A) (htpy ∙h pr2 (pr2 eq))
+      where
+      htpy : map-inv-is-equiv eq ∘ pr1 f ~ pr1 (pr2 eq) ∘ pr1 f
+      htpy x = htpy-map-inv-equiv-retraction (pr1 f , eq) (pr2 eq) (pr1 f x)
+
+  Eq-Algebra-equiv-Algebra :
+    Eq-Algebra S T A B → Σ (hom-Algebra S T A B) (is-equiv-hom-Algebra S T A B)
+  pr1 (pr1 (Eq-Algebra-equiv-Algebra ((f , eq) , p))) = f
+  pr2 (pr1 (Eq-Algebra-equiv-Algebra ((f , eq) , p))) op v =
+    {!   !} ∙
+    pr2 (pr1 eq)
+    ( pr2 (pr1 B) op
+    ( map-tuple (pr1 (pr1 (Eq-Algebra-equiv-Algebra ((f , eq) , p)))) v))
+  pr2 (Eq-Algebra-equiv-Algebra ((f , eq) , p)) = eq
+
+  equiv-Algebra-Eq-Algebra :
+    Σ (hom-Algebra S T A B) (is-equiv-hom-Algebra S T A B) → Eq-Algebra S T A B
+  pr1 (equiv-Algebra-Eq-Algebra ((f , _) , eq)) = f , eq
+  pr2 (equiv-Algebra-Eq-Algebra ((f , p) , eq)) g = eq-htpy htpy
+    where
+    htpy :
+      map-tr-equiv
+      ( λ v → (x : pr1 S) → tuple v (pr2 S x) → v)
+      ( pr1 (equiv-Algebra-Eq-Algebra ((f , p) , eq))) (pr2 (pr1 A)) g ~
+      pr2 (pr1 B) g
+    htpy x = {!   !} ∙ {!   !}
+
+  equiv-Eq-Algebra-equiv-Algebra :
+    Eq-Algebra S T A B ≃ Σ (hom-Algebra S T A B) (is-equiv-hom-Algebra S T A B)
+  pr1 equiv-Eq-Algebra-equiv-Algebra = Eq-Algebra-equiv-Algebra
+  pr1 (pr1 (pr2 equiv-Eq-Algebra-equiv-Algebra)) = equiv-Algebra-Eq-Algebra
+  pr2 (pr1 (pr2 equiv-Eq-Algebra-equiv-Algebra)) (f , p) =
+    eq-type-subtype
+    ( is-equiv-hom-Algebra-Prop S T A B)
+    ( eq-htpy-hom-Algebra S T A B (pr1
+      (( pr1 equiv-Eq-Algebra-equiv-Algebra ∘
+        pr1 (pr1 (pr2 equiv-Eq-Algebra-equiv-Algebra)))
+        ( f , p))) f (λ x → refl))
+  pr1 (pr2 (pr2 equiv-Eq-Algebra-equiv-Algebra)) = equiv-Algebra-Eq-Algebra
+  pr2 (pr2 (pr2 equiv-Eq-Algebra-equiv-Algebra)) (f , p) =
+    eq-type-subtype
+    ( tr-is-model-signature-equiv-Set-Prop S (pr1 A) (pr1 (pr1 B)) (pr2 (pr1 B)))
+    (eq-type-subtype is-equiv-Prop (eq-htpy (λ x → refl)))
+
+  equiv-iso-Eq-Algebra : Eq-Algebra S T A B ≃ iso-Algebra
+  equiv-iso-Eq-Algebra =
+    equiv-type-subtype
+    ( is-prop-is-equiv-hom-Algebra S T A B)
+    ( is-prop-is-iso-Algebra)
+    ( is-equiv-is-iso-Algebra)
+    ( is-iso-is-equiv-Algebra) ∘e {!   !}
+
+module _
+  { l1 : Level} ( S : signature l1)
+  { l2 : Level} ( T : Theory S l2)
+  { l3 : Level} ( A : Algebra S T l3)
+  where
+
+  is-torsorial-iso-Algebra : is-torsorial (iso-Algebra S T A)
+  is-torsorial-iso-Algebra =
+    is-contr-equiv'
+    ( Σ (Algebra S T l3) (Eq-Algebra S T A))
+    ( equiv-tot (equiv-iso-Eq-Algebra S T A))
+    ( is-torsorial-Eq-Algebra S T A)
 ```

--- a/src/universal-algebra/isomorphisms-algebras-of-theories.lagda.md
+++ b/src/universal-algebra/isomorphisms-algebras-of-theories.lagda.md
@@ -1,13 +1,14 @@
-# The category of algebras of theories
+# Isomorphisms of algebras of theories
 
 ```agda
-module universal-algebra.category-of-algebras-of-theories where
+module universal-algebra.isomorphisms-algebras-of-theories where
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
 open import category-theory.isomorphisms-in-large-precategories
+open import category-theory.isomorphisms-in-categories
 open import category-theory.large-categories
 open import category-theory.large-precategories
 
@@ -19,6 +20,7 @@ open import foundation.universe-levels
 open import foundation-core.equality-dependent-pair-types
 open import foundation-core.equivalences
 open import foundation-core.function-types
+open import foundation-core.homotopies
 open import foundation-core.identity-types
 
 open import universal-algebra.algebraic-theories
@@ -33,25 +35,18 @@ open import universal-algebra.signatures
 
 ## Idea
 
-The
-[precategory of algebras of a theory](universal-algebra.precategory-of-algebras-of-theories.md)
-is a [category](category-theory.large-categories.md).
-
-## Definition
+We characterize
+[isomorphisms](category-theory.isomorphisms-in-large-precategories.md) of
+[algebras of theories](universal-algebra.precategory-of-algebras-of-theories.md).
 
 ```agda
 module _
-  {l1 l2 : Level} (S : signature l1) (T : Theory S l2)
+  { l1 : Level} ( S : signature l1)
+  { l2 : Level} ( T : Theory S l2)
   where
 
-  is-large-category-Algebra-Large-Precategory :
-    is-large-category-Large-Precategory (Algebra-Large-Precategory S T)
-  is-large-category-Algebra-Large-Precategory (X , p) = {!   !}
-
-  Algebra-Large-Category :
-    Large-Category (λ l → l1 ⊔ l2 ⊔ lsuc l) (λ l3 → _⊔_ (l1 ⊔ l3))
-  large-precategory-Large-Category Algebra-Large-Category =
-    Algebra-Large-Precategory S T
-  is-large-category-Large-Category Algebra-Large-Category =
-    is-large-category-Algebra-Large-Precategory
+  id-iso-comp-htpy-Algebra :
+    {l3 : Level} (A B : Algebra S T l3) →
+    iso-eq-Large-Precategory (Algebra-Large-Precategory S T) A B ~ {!   !} ∘ {!   !}
+  id-iso-comp-htpy-Algebra A B = {!   !}
 ```

--- a/src/universal-algebra/isomorphisms-of-algebras.lagda.md
+++ b/src/universal-algebra/isomorphisms-of-algebras.lagda.md
@@ -3,7 +3,7 @@
 ```agda
 {-# OPTIONS --lossy-unification #-}
 
-module universal-algebra.isomorphisms-algebras-of-theories where
+module universal-algebra.isomorphisms-of-algebras where
 ```
 
 <details><summary>Imports</summary>
@@ -114,7 +114,14 @@ module _
     ( is-prop-is-iso-Algebra)
     ( is-equiv-is-iso-Algebra)
     ( is-iso-is-equiv-Algebra) ∘e
-    {!   !}
+    ( inv-equiv (equiv-equiv-hom-Algebra' S T A B)) ∘e
+    ( equiv-Eq-Model-Signature' S (pr1 A) (pr1 B))
+
+  iso-Eq-Algebra : Eq-Algebra S T A B → iso-Algebra
+  iso-Eq-Algebra = map-equiv equiv-iso-Eq-Algebra
+
+  is-equiv-iso-Eq-Algebra : is-equiv iso-Eq-Algebra
+  is-equiv-iso-Eq-Algebra = is-equiv-map-equiv equiv-iso-Eq-Algebra
 
 module _
   { l1 : Level} ( S : signature l1)
@@ -128,4 +135,12 @@ module _
     ( Σ (Algebra S T l3) (Eq-Algebra S T A))
     ( equiv-tot (equiv-iso-Eq-Algebra S T A))
     ( is-torsorial-Eq-Algebra S T A)
+
+  is-equiv-iso-eq-Algebra :
+    (B : Algebra S T l3) →
+    is-equiv (iso-eq-Large-Precategory (Algebra-Large-Precategory S T) A B)
+  is-equiv-iso-eq-Algebra =
+    fundamental-theorem-id
+    ( is-torsorial-iso-Algebra)
+    ( iso-eq-Large-Precategory (Algebra-Large-Precategory S T) A)
 ```

--- a/src/universal-algebra/isomorphisms-of-algebras.lagda.md
+++ b/src/universal-algebra/isomorphisms-of-algebras.lagda.md
@@ -9,33 +9,23 @@ module universal-algebra.isomorphisms-of-algebras where
 <details><summary>Imports</summary>
 
 ```agda
-open import category-theory.isomorphisms-in-categories
 open import category-theory.isomorphisms-in-large-precategories
-open import category-theory.large-categories
 open import category-theory.large-precategories
 
-open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
 open import foundation.equivalences
-open import foundation.function-extensionality
 open import foundation.functoriality-dependent-pair-types
 open import foundation.fundamental-theorem-of-identity-types
 open import foundation.sets
-open import foundation.subtype-identity-principle
 open import foundation.subtypes
 open import foundation.torsorial-type-families
-open import foundation.transport-along-equivalences
 open import foundation.universe-levels
 
 open import foundation-core.contractible-types
-open import foundation-core.equality-dependent-pair-types
 open import foundation-core.function-types
 open import foundation-core.homotopies
 open import foundation-core.identity-types
 open import foundation-core.propositions
-open import foundation-core.retractions
-open import foundation-core.sections
-open import foundation-core.transport-along-identifications
 
 open import lists.functoriality-tuples
 open import lists.tuples

--- a/src/universal-algebra/isomorphisms-of-algebras.lagda.md
+++ b/src/universal-algebra/isomorphisms-of-algebras.lagda.md
@@ -9,33 +9,33 @@ module universal-algebra.isomorphisms-of-algebras where
 <details><summary>Imports</summary>
 
 ```agda
-open import category-theory.isomorphisms-in-large-precategories
 open import category-theory.isomorphisms-in-categories
+open import category-theory.isomorphisms-in-large-precategories
 open import category-theory.large-categories
 open import category-theory.large-precategories
 
 open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
-open import foundation.functoriality-dependent-pair-types
-open import foundation.function-extensionality
 open import foundation.equivalences
-open import foundation.sets
-open import foundation.subtypes
-open import foundation.subtype-identity-principle
-open import foundation.universe-levels
-open import foundation.transport-along-equivalences
-open import foundation.torsorial-type-families
+open import foundation.function-extensionality
+open import foundation.functoriality-dependent-pair-types
 open import foundation.fundamental-theorem-of-identity-types
+open import foundation.sets
+open import foundation.subtype-identity-principle
+open import foundation.subtypes
+open import foundation.torsorial-type-families
+open import foundation.transport-along-equivalences
+open import foundation.universe-levels
 
-open import foundation-core.transport-along-identifications
 open import foundation-core.contractible-types
 open import foundation-core.equality-dependent-pair-types
 open import foundation-core.function-types
-open import foundation-core.propositions
-open import foundation-core.sections
-open import foundation-core.retractions
 open import foundation-core.homotopies
 open import foundation-core.identity-types
+open import foundation-core.propositions
+open import foundation-core.retractions
+open import foundation-core.sections
+open import foundation-core.transport-along-identifications
 
 open import lists.functoriality-tuples
 open import lists.tuples
@@ -91,7 +91,9 @@ module _
     ( id-hom-Algebra S T A) q
 
   is-equiv-is-iso-Algebra :
-    (f : hom-Algebra S T A B) → is-equiv-hom-Algebra S T A B f → is-iso-Algebra f
+    (f : hom-Algebra S T A B) →
+    is-equiv-hom-Algebra S T A B f →
+    is-iso-Algebra f
   pr1 (is-equiv-is-iso-Algebra f eq) = inv-equiv-hom-Algebra S T A B f eq
   pr1 (pr2 (is-equiv-is-iso-Algebra f eq)) =
     eq-htpy-hom-Algebra S T B B

--- a/src/universal-algebra/models-of-signatures.lagda.md
+++ b/src/universal-algebra/models-of-signatures.lagda.md
@@ -19,11 +19,11 @@ open import foundation.universe-levels
 open import foundation-core.dependent-identifications
 open import foundation-core.equality-dependent-pair-types
 open import foundation-core.equivalences
-open import foundation-core.identity-types
 open import foundation-core.function-types
 open import foundation-core.homotopies
-open import foundation-core.transport-along-identifications
+open import foundation-core.identity-types
 open import foundation-core.torsorial-type-families
+open import foundation-core.transport-along-identifications
 
 open import lists.tuples
 
@@ -86,9 +86,12 @@ module _
 
   tr-is-model-signature-equiv-Set :
     {l2 : Level} (X : Model-Signature S l2) (Y : Set l2) →
-    is-model-signature S Y → equiv-Set (set-Model-Signature S X) Y → UU (l1 ⊔ l2)
+    is-model-signature S Y →
+    equiv-Set (set-Model-Signature S X) Y →
+    UU (l1 ⊔ l2)
   tr-is-model-signature-equiv-Set (X , X-assign) Y Y-assign f =
-    map-tr-equiv (λ v → (x : pr1 S) → tuple v (pr2 S x) → v) f X-assign ~ Y-assign
+    map-tr-equiv (λ v → (x : pr1 S) → tuple v (pr2 S x) → v) f X-assign ~
+    Y-assign
 
   Eq-Model-Signature : {l2 : Level} (X Y : Model-Signature S l2) → UU (l1 ⊔ l2)
   Eq-Model-Signature (X , X-assign) (Y , Y-assign) =

--- a/src/universal-algebra/models-of-signatures.lagda.md
+++ b/src/universal-algebra/models-of-signatures.lagda.md
@@ -7,9 +7,23 @@ module universal-algebra.models-of-signatures where
 <details><summary>Imports</summary>
 
 ```agda
+open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
+open import foundation.function-extensionality
+open import foundation.fundamental-theorem-of-identity-types
 open import foundation.sets
+open import foundation.structure-identity-principle
+open import foundation.transport-along-equivalences
 open import foundation.universe-levels
+
+open import foundation-core.dependent-identifications
+open import foundation-core.equality-dependent-pair-types
+open import foundation-core.equivalences
+open import foundation-core.identity-types
+open import foundation-core.function-types
+open import foundation-core.homotopies
+open import foundation-core.transport-along-identifications
+open import foundation-core.torsorial-type-families
 
 open import lists.tuples
 
@@ -61,4 +75,80 @@ module _
     ( M : Model-Signature l2) →
     is-set (type-Model-Signature M)
   is-set-type-Model-Signature M = pr2 (set-Model-Signature M)
+```
+
+### Characterizing the identity type of models of signatures
+
+```agda
+module _
+  {l1 : Level} (S : signature l1)
+  where
+
+  tr-is-model-signature-equiv-Set :
+    {l2 : Level} (X : Model-Signature S l2) (Y : Set l2) →
+    is-model-signature S Y → equiv-Set (set-Model-Signature S X) Y → UU (l1 ⊔ l2)
+  tr-is-model-signature-equiv-Set (X , X-assign) Y Y-assign f =
+    map-tr-equiv (λ v → (x : pr1 S) → tuple v (pr2 S x) → v) f X-assign ~ Y-assign
+
+  Eq-Model-Signature : {l2 : Level} (X Y : Model-Signature S l2) → UU (l1 ⊔ l2)
+  Eq-Model-Signature (X , X-assign) (Y , Y-assign) =
+    Σ
+    ( equiv-Set X Y)
+    ( tr-is-model-signature-equiv-Set (X , X-assign) Y Y-assign)
+
+  refl-Eq-Model-Signature :
+    {l2 : Level} (X : Model-Signature S l2) → Eq-Model-Signature X X
+  pr1 (refl-Eq-Model-Signature X) = id-equiv
+  pr2 (refl-Eq-Model-Signature (X , X-assign)) f =
+    ap
+    ( λ z → z X-assign f)
+    ( compute-map-tr-equiv-id-equiv (λ v → (x : pr1 S) → tuple v (pr2 S x) → v))
+
+  Eq-eq-Model-Signature :
+    {l2 : Level} (X Y : Model-Signature S l2) → X ＝ Y → Eq-Model-Signature X Y
+  Eq-eq-Model-Signature X .X refl = refl-Eq-Model-Signature X
+
+  tr-eq-refl-is-model-signature-equiv-Set :
+    {l2 : Level} (X : Set l2) (f g : is-model-signature S X) →
+    f ＝ g → tr-is-model-signature-equiv-Set (X , f) X g id-equiv
+  tr-eq-refl-is-model-signature-equiv-Set X f .f refl g =
+    ap
+    ( λ z → z f g)
+    ( compute-map-tr-equiv-id-equiv (λ v → (x : pr1 S) → tuple v (pr2 S x) → v))
+
+  is-torsorial-tr-is-model-signature-equiv-Set :
+    {l2 : Level} (X : Set l2) (f : is-model-signature S X) →
+    is-torsorial (λ z → tr-is-model-signature-equiv-Set (X , f) X z id-equiv)
+  pr1 (pr1 (is-torsorial-tr-is-model-signature-equiv-Set X f)) = f
+  pr2 (pr1 (is-torsorial-tr-is-model-signature-equiv-Set X f)) =
+    htpy-eq
+    ( ap (λ z → z f)
+      ( compute-map-tr-equiv-id-equiv
+        ( λ v → (x : pr1 S) → tuple v (pr2 S x) → v)))
+  pr2 (is-torsorial-tr-is-model-signature-equiv-Set X f) (g , htpy) =
+    eq-pair-Σ
+    ( eq-htpy (inv-htpy (λ h → ap (λ j x → j f h x)
+      ( compute-map-tr-equiv-id-equiv
+        ( λ v → (x : pr1 S) → tuple v (pr2 S x) → v))) ∙h htpy))
+    ( eq-htpy λ x → {!   !})
+
+  is-equiv-tr-eq-refl-is-model-signature-equiv-Set :
+    {l2 : Level} (X : Set l2) (f g : is-model-signature S X) →
+    is-equiv (tr-eq-refl-is-model-signature-equiv-Set X f g)
+  is-equiv-tr-eq-refl-is-model-signature-equiv-Set X f =
+    fundamental-theorem-id
+    ( is-torsorial-tr-is-model-signature-equiv-Set X f)
+    ( tr-eq-refl-is-model-signature-equiv-Set X f)
+
+  is-equiv-Eq-eq-Model-Signature :
+    {l2 : Level} (X Y : Model-Signature S l2) →
+    is-equiv (Eq-eq-Model-Signature X Y)
+  is-equiv-Eq-eq-Model-Signature (X , X-assign) =
+    structure-identity-principle
+    ( λ {Y} → tr-is-model-signature-equiv-Set (X , X-assign) Y)
+    ( id-equiv)
+    ( pr2 (refl-Eq-Model-Signature (X , X-assign)))
+    ( Eq-eq-Model-Signature (X , X-assign))
+    ( is-equiv-equiv-eq-Set X)
+    ( λ f → is-equiv-tr-eq-refl-is-model-signature-equiv-Set X X-assign f)
 ```

--- a/src/universal-algebra/models-of-signatures.lagda.md
+++ b/src/universal-algebra/models-of-signatures.lagda.md
@@ -13,6 +13,7 @@ open import foundation.function-extensionality
 open import foundation.fundamental-theorem-of-identity-types
 open import foundation.sets
 open import foundation.structure-identity-principle
+open import foundation.subtype-identity-principle
 open import foundation.transport-along-equivalences
 open import foundation.universe-levels
 
@@ -22,6 +23,7 @@ open import foundation-core.equivalences
 open import foundation-core.function-types
 open import foundation-core.homotopies
 open import foundation-core.identity-types
+open import foundation-core.propositions
 open import foundation-core.torsorial-type-families
 open import foundation-core.transport-along-identifications
 
@@ -119,21 +121,38 @@ module _
     ( λ z → z f g)
     ( compute-map-tr-equiv-id-equiv (λ v → (x : pr1 S) → tuple v (pr2 S x) → v))
 
+  is-prop-tr-eq-refl-is-model-signature-equiv-Set :
+    {l2 : Level} (X : Set l2) (f g : is-model-signature S X) →
+    is-prop (tr-is-model-signature-equiv-Set (X , f) X g id-equiv)
+  is-prop-tr-eq-refl-is-model-signature-equiv-Set X f g =
+    is-prop-Π (λ h → is-set-hom-Set (tuple-Set X (pr2 S h)) X
+      ( map-tr-equiv (λ v → (x : pr1 S) →
+        tuple v (pr2 S x) → v) id-equiv f h) (g h))
+
+  tr-eq-refl-is-model-signature-equiv-Set-Prop :
+    {l2 : Level} (X : Set l2) (f g : is-model-signature S X) →
+    Prop (l1 ⊔ l2)
+  pr1 (tr-eq-refl-is-model-signature-equiv-Set-Prop X f g) =
+    tr-is-model-signature-equiv-Set (X , f) X g id-equiv
+  pr2 (tr-eq-refl-is-model-signature-equiv-Set-Prop X f g) =
+    is-prop-tr-eq-refl-is-model-signature-equiv-Set X f g
+
   is-torsorial-tr-is-model-signature-equiv-Set :
     {l2 : Level} (X : Set l2) (f : is-model-signature S X) →
     is-torsorial (λ z → tr-is-model-signature-equiv-Set (X , f) X z id-equiv)
   pr1 (pr1 (is-torsorial-tr-is-model-signature-equiv-Set X f)) = f
   pr2 (pr1 (is-torsorial-tr-is-model-signature-equiv-Set X f)) =
-    htpy-eq
-    ( ap (λ z → z f)
+    tr-eq-refl-is-model-signature-equiv-Set X f f refl
+  pr2 (is-torsorial-tr-is-model-signature-equiv-Set X f) (g , p) =
+    inv-map-extensionality-type-subtype
+    ( tr-eq-refl-is-model-signature-equiv-Set-Prop X f)
+    ( tr-eq-refl-is-model-signature-equiv-Set X f f refl)
+    ( refl-htpy)
+    ( λ h → equiv-funext)
+    ( g , p)
+    ( inv-htpy (λ h → ap (λ j x → j f h x)
       ( compute-map-tr-equiv-id-equiv
-        ( λ v → (x : pr1 S) → tuple v (pr2 S x) → v)))
-  pr2 (is-torsorial-tr-is-model-signature-equiv-Set X f) (g , htpy) =
-    eq-pair-Σ
-    ( eq-htpy (inv-htpy (λ h → ap (λ j x → j f h x)
-      ( compute-map-tr-equiv-id-equiv
-        ( λ v → (x : pr1 S) → tuple v (pr2 S x) → v))) ∙h htpy))
-    ( eq-htpy λ x → {!   !})
+        ( λ v → (x₁ : pr1 S) → tuple v (pr2 S x₁) → v))) ∙h p)
 
   is-equiv-tr-eq-refl-is-model-signature-equiv-Set :
     {l2 : Level} (X : Set l2) (f g : is-model-signature S X) →

--- a/src/universal-algebra/models-of-signatures.lagda.md
+++ b/src/universal-algebra/models-of-signatures.lagda.md
@@ -12,11 +12,8 @@ module universal-algebra.models-of-signatures where
 open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
 open import foundation.function-extensionality
-open import foundation.fundamental-theorem-of-identity-types
 open import foundation.sets
 open import foundation.structure-identity-principle
-open import foundation.subtype-identity-principle
-open import foundation.transport-along-equivalences
 open import foundation.universe-levels
 
 open import foundation-core.cartesian-product-types
@@ -28,7 +25,6 @@ open import foundation-core.homotopies
 open import foundation-core.identity-types
 open import foundation-core.propositions
 open import foundation-core.torsorial-type-families
-open import foundation-core.transport-along-identifications
 
 open import lists.functoriality-tuples
 open import lists.tuples

--- a/src/universal-algebra/models-of-signatures.lagda.md
+++ b/src/universal-algebra/models-of-signatures.lagda.md
@@ -1,6 +1,8 @@
 # Models of signatures
 
 ```agda
+{-# OPTIONS --lossy-unification #-}
+
 module universal-algebra.models-of-signatures where
 ```
 
@@ -21,6 +23,7 @@ open import foundation-core.dependent-identifications
 open import foundation-core.equality-dependent-pair-types
 open import foundation-core.equivalences
 open import foundation-core.function-types
+open import foundation-core.cartesian-product-types
 open import foundation-core.homotopies
 open import foundation-core.identity-types
 open import foundation-core.propositions
@@ -87,22 +90,22 @@ module _
   {l1 : Level} (S : signature l1)
   where
 
-  preserves-operations-equiv-Model-Signature :
+  preserves-operations-Model-Signature :
     {l2 : Level} (X Y : Model-Signature S l2)
-    (f : equiv-Set (set-Model-Signature S X) (set-Model-Signature S Y)) →
+    (f : hom-Set (set-Model-Signature S X) (set-Model-Signature S Y)) →
     UU (l1 ⊔ l2)
-  preserves-operations-equiv-Model-Signature
-    ((X , _) , assign-X) (Y , assign-Y) (f , _) =
+  preserves-operations-Model-Signature
+    ((X , _) , assign-X) (Y , assign-Y) f =
       ( op : operation-signature S)
       ( v : tuple X (arity-operation-signature S op)) →
         f (assign-X op v) ＝ assign-Y op (map-tuple f v)
 
-  is-prop-preserves-operations-equiv-Model-Signature :
+  is-prop-preserves-operations-Model-Signature :
     {l2 : Level} (X Y : Model-Signature S l2)
-    (f : equiv-Set (set-Model-Signature S X) (set-Model-Signature S Y)) →
-    is-prop (preserves-operations-equiv-Model-Signature X Y f)
-  is-prop-preserves-operations-equiv-Model-Signature
-    ((X , set-X) , assign-X) ((Y , set-Y) , assign-Y) (f , _) =
+    (f : hom-Set (set-Model-Signature S X) (set-Model-Signature S Y)) →
+    is-prop (preserves-operations-Model-Signature X Y f)
+  is-prop-preserves-operations-Model-Signature
+    ((X , set-X) , assign-X) ((Y , set-Y) , assign-Y) f =
     is-prop-Π (λ op →
       is-prop-Π (λ v → set-Y (f (assign-X op v)) (assign-Y op (map-tuple f v))))
 
@@ -110,12 +113,23 @@ module _
   Eq-Model-Signature (X , X-assign) (Y , Y-assign) =
     Σ
     ( equiv-Set X Y)
-    ( preserves-operations-equiv-Model-Signature (X , X-assign) (Y , Y-assign))
+    ( λ (f , _) →
+      preserves-operations-Model-Signature (X , X-assign) (Y , Y-assign) f)
 
-  preserves-operations-id-equiv-Model-Signature :
+  equiv-Eq-Model-Signature' :
+    {l2 : Level} (X Y : Model-Signature S l2) → Eq-Model-Signature X Y ≃
+    Σ (hom-Set (pr1 X) (pr1 Y))
+      (λ f → is-equiv f × preserves-operations-Model-Signature X Y f)
+  pr1 (equiv-Eq-Model-Signature' X Y) ((f , eq) , p) = f , eq , p
+  pr1 (pr1 (pr2 (equiv-Eq-Model-Signature' X Y))) (f , eq , p) = (f , eq) , p
+  pr2 (pr1 (pr2 (equiv-Eq-Model-Signature' X Y))) _ = refl
+  pr1 (pr2 (pr2 (equiv-Eq-Model-Signature' X Y))) (f , eq , p) = (f , eq) , p
+  pr2 (pr2 (pr2 (equiv-Eq-Model-Signature' X Y))) _ = refl
+
+  preserves-operations-id-Model-Signature :
     {l2 : Level} (X : Model-Signature S l2) →
-    preserves-operations-equiv-Model-Signature X X id-equiv
-  preserves-operations-id-equiv-Model-Signature ((X , _) , assign-X) op v =
+    preserves-operations-Model-Signature X X id
+  preserves-operations-id-Model-Signature ((X , _) , assign-X) op v =
     ap
     ( assign-X op)
     ( preserves-id-map-tuple X (arity-operation-signature S op) v)
@@ -124,12 +138,12 @@ module _
     {l2 : Level} (X : Model-Signature S l2) → Eq-Model-Signature X X
   pr1 (refl-Eq-Model-Signature X) = id-equiv
   pr2 (refl-Eq-Model-Signature X) =
-    preserves-operations-id-equiv-Model-Signature X
+    preserves-operations-id-Model-Signature X
 
   htpy-preserves-operations-Model-Signature :
     {l2 : Level} (X : Set l2) (f g : is-model-signature S X) → UU (l1 ⊔ l2)
   htpy-preserves-operations-Model-Signature X f g =
-    preserves-operations-equiv-Model-Signature (X , f) (X , g) id-equiv
+    preserves-operations-Model-Signature (X , f) (X , g) id
 
   htpy-eq-preserves-operations-Model-Signature :
     {l2 : Level} (X : Set l2) (f g : is-model-signature S X) →
@@ -181,13 +195,13 @@ module _
     is-equiv (Eq-eq-Model-Signature X Y)
   is-equiv-Eq-eq-Model-Signature (X , X-assign) =
     structure-identity-principle
-    ( λ {x} z →
-        preserves-operations-equiv-Model-Signature (X , X-assign) (x , z))
+    ( λ {Y} f (eq , _) →
+        preserves-operations-Model-Signature (X , X-assign) (Y , f) eq)
     ( id-equiv)
-    ( preserves-operations-id-equiv-Model-Signature (X , X-assign))
+    ( preserves-operations-id-Model-Signature (X , X-assign))
     ( Eq-eq-Model-Signature (X , X-assign))
     ( is-equiv-equiv-eq-Set X)
-    ( λ f → is-equiv-htpy-eq-preserves-operations-Model-Signature X X-assign f)
+    ( is-equiv-htpy-eq-preserves-operations-Model-Signature X X-assign)
 
   equiv-Eq-eq-Model-Signature :
     {l2 : Level} (X Y : Model-Signature S l2) →

--- a/src/universal-algebra/models-of-signatures.lagda.md
+++ b/src/universal-algebra/models-of-signatures.lagda.md
@@ -192,4 +192,14 @@ module _
     ( Eq-eq-Model-Signature (X , X-assign))
     ( is-equiv-equiv-eq-Set X)
     ( λ f → is-equiv-tr-eq-refl-is-model-signature-equiv-Set X X-assign f)
+
+  equiv-Eq-eq-Model-Signature :
+    {l2 : Level} (X Y : Model-Signature S l2) →
+    (X ＝ Y) ≃ Eq-Model-Signature X Y
+  pr1 (equiv-Eq-eq-Model-Signature X Y) = Eq-eq-Model-Signature X Y
+  pr2 (equiv-Eq-eq-Model-Signature X Y) = is-equiv-Eq-eq-Model-Signature X Y
+
+  eq-Eq-Model-Signature :
+    {l2 : Level} (X Y : Model-Signature S l2) → Eq-Model-Signature X Y → X ＝ Y
+  eq-Eq-Model-Signature X Y = map-inv-equiv (equiv-Eq-eq-Model-Signature X Y)
 ```

--- a/src/universal-algebra/models-of-signatures.lagda.md
+++ b/src/universal-algebra/models-of-signatures.lagda.md
@@ -19,19 +19,19 @@ open import foundation.subtype-identity-principle
 open import foundation.transport-along-equivalences
 open import foundation.universe-levels
 
+open import foundation-core.cartesian-product-types
 open import foundation-core.dependent-identifications
 open import foundation-core.equality-dependent-pair-types
 open import foundation-core.equivalences
 open import foundation-core.function-types
-open import foundation-core.cartesian-product-types
 open import foundation-core.homotopies
 open import foundation-core.identity-types
 open import foundation-core.propositions
 open import foundation-core.torsorial-type-families
 open import foundation-core.transport-along-identifications
 
-open import lists.tuples
 open import lists.functoriality-tuples
+open import lists.tuples
 
 open import universal-algebra.signatures
 ```
@@ -177,14 +177,15 @@ module _
       ( p op v))))
   pr1 (pr2 (is-equiv-htpy-eq-preserves-operations-Model-Signature X f g)) =
     eq-htpy-preserves-operations-Model-Signature X f g
-  pr2 (pr2 (is-equiv-htpy-eq-preserves-operations-Model-Signature X f .f)) refl =
-    is-set-has-uip
-    ( is-set-Π (λ op → is-set-function-type (pr2 X)))
-    ( f)
-    ( f)
-    (( eq-htpy-preserves-operations-Model-Signature X f f
-      ∘ htpy-eq-preserves-operations-Model-Signature X f f) refl)
-    ( refl)
+  pr2 (pr2 (is-equiv-htpy-eq-preserves-operations-Model-Signature X f .f))
+    refl =
+      is-set-has-uip
+      ( is-set-Π (λ op → is-set-function-type (pr2 X)))
+      ( f)
+      ( f)
+      (( eq-htpy-preserves-operations-Model-Signature X f f
+        ∘ htpy-eq-preserves-operations-Model-Signature X f f) refl)
+      ( refl)
 
   Eq-eq-Model-Signature :
     {l2 : Level} (X Y : Model-Signature S l2) → X ＝ Y → Eq-Model-Signature X Y

--- a/src/universal-algebra/models-of-signatures.lagda.md
+++ b/src/universal-algebra/models-of-signatures.lagda.md
@@ -95,6 +95,25 @@ module _
     map-tr-equiv (λ v → (x : pr1 S) → tuple v (pr2 S x) → v) f X-assign ~
     Y-assign
 
+  is-prop-tr-is-model-signature-equiv-Set :
+    {l2 : Level} (X : Model-Signature S l2) (Y : Set l2)
+    (p : is-model-signature S Y) (eq : equiv-Set (set-Model-Signature S X) Y) →
+    is-prop (tr-is-model-signature-equiv-Set X Y p eq)
+  is-prop-tr-is-model-signature-equiv-Set X Y p eq =
+    is-prop-Π
+    ( λ f → is-set-function-type (pr2 Y)
+      ( map-tr-equiv (λ v → (x : pr1 S) → tuple v (pr2 S x) → v) eq (pr2 X) f)
+      ( p f))
+
+  tr-is-model-signature-equiv-Set-Prop :
+    {l2 : Level} (X : Model-Signature S l2) (Y : Set l2)
+    (p : is-model-signature S Y) (eq : equiv-Set (set-Model-Signature S X) Y) →
+    Prop (l1 ⊔ l2)
+  pr1 (tr-is-model-signature-equiv-Set-Prop X Y p eq) =
+    tr-is-model-signature-equiv-Set X Y p eq
+  pr2 (tr-is-model-signature-equiv-Set-Prop X Y p eq) =
+    is-prop-tr-is-model-signature-equiv-Set X Y p eq
+
   Eq-Model-Signature : {l2 : Level} (X Y : Model-Signature S l2) → UU (l1 ⊔ l2)
   Eq-Model-Signature (X , X-assign) (Y , Y-assign) =
     Σ

--- a/src/universal-algebra/precategory-of-algebras-of-theories.lagda.md
+++ b/src/universal-algebra/precategory-of-algebras-of-theories.lagda.md
@@ -15,11 +15,11 @@ open import foundation.universe-levels
 
 open import foundation-core.identity-types
 
-open import universal-algebra.signatures
-open import universal-algebra.models-of-signatures
 open import universal-algebra.algebraic-theories
 open import universal-algebra.algebras-of-theories
 open import universal-algebra.homomorphisms-of-algebras
+open import universal-algebra.models-of-signatures
+open import universal-algebra.signatures
 ```
 
 </details>
@@ -46,7 +46,8 @@ module _
     ( set-hom-Algebra S T)
     ( λ {l3} {l4} {l5} {X} {Y} {Z} → comp-hom-Algebra S T X Y Z)
     ( λ {l} {X} → id-hom-Algebra S T X)
-    ( associative-comp-hom-Algebra S T)
-    ( left-unit-law-comp-hom-Algebra S T)
-    ( right-unit-law-comp-hom-Algebra S T)
+    ( λ {l3} {l4} {l5} {l6} {X} {Y} {Z} {W} →
+      associative-comp-hom-Algebra S T X Y Z W)
+    ( λ {l3} {l4} {X} {Y} → left-unit-law-comp-hom-Algebra S T X Y)
+    ( λ {l3} {l4} {X} {Y} → right-unit-law-comp-hom-Algebra S T X Y)
 ```

--- a/src/universal-algebra/precategory-of-algebras-of-theories.lagda.md
+++ b/src/universal-algebra/precategory-of-algebras-of-theories.lagda.md
@@ -40,13 +40,13 @@ module _
   where
 
   Algebra-Large-Precategory :
-    Large-Precategory (λ l → l1 ⊔ l2 ⊔ lsuc l) {!   !}
+    Large-Precategory (λ l → l1 ⊔ l2 ⊔ lsuc l) (λ l3 l4 → l1 ⊔ l3 ⊔ l4)
   Algebra-Large-Precategory = make-Large-Precategory
     ( Algebra S T)
     ( set-hom-Algebra S T)
-    ( comp-hom-Algebra S T)
+    ( λ {l3} {l4} {l5} {X} {Y} {Z} → comp-hom-Algebra S T X Y Z)
     ( λ {l} {X} → id-hom-Algebra S T X)
-    {!   !}
-    {!   !}
-    {!   !}
+    ( associative-comp-hom-Algebra S T)
+    ( left-unit-law-comp-hom-Algebra S T)
+    ( right-unit-law-comp-hom-Algebra S T)
 ```

--- a/src/universal-algebra/precategory-of-algebras-of-theories.lagda.md
+++ b/src/universal-algebra/precategory-of-algebras-of-theories.lagda.md
@@ -1,0 +1,50 @@
+# The precategory of algebras of an equational theory
+
+```agda
+module universal-algebra.precategory-of-algebras-of-theories where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import category-theory.large-precategories
+
+open import foundation.dependent-pair-types
+open import foundation.sets
+open import foundation.universe-levels
+
+open import universal-algebra.signatures
+open import universal-algebra.models-of-signatures
+open import universal-algebra.algebraic-theories
+open import universal-algebra.algebras-of-theories
+open import universal-algebra.homomorphisms-of-algebras
+```
+
+</details>
+
+## Idea
+
+For any [signature](universal-algebra.signatures.md) `S` and
+`S`-[theory](universal-algebra.algebraic-theories.md) `T`, there is a
+[large precategory](category-theory.large-precategories.md) of
+`T`-[algebras](universal-algebra.algebras-of-theories.md) and `T`-algebra
+[homomorphisms](universal-algebra.homomorphisms-of-algebras.md).
+
+## Definition
+
+```agda
+module _
+  {l1 l2 : Level} (S : signature l1) (T : Theory S l2)
+  where
+
+  Algebra-Large-Precategory :
+    Large-Precategory (λ l → l1 ⊔ l2 ⊔ lsuc l) {!   !}
+  Algebra-Large-Precategory = make-Large-Precategory
+    (Algebra S T)
+    (set-hom-Algebra S T)
+    {!   !}
+    {!   !}
+    {!   !}
+    {!   !}
+    {!   !}
+```

--- a/src/universal-algebra/precategory-of-algebras-of-theories.lagda.md
+++ b/src/universal-algebra/precategory-of-algebras-of-theories.lagda.md
@@ -44,7 +44,7 @@ module _
   Algebra-Large-Precategory = make-Large-Precategory
     ( Algebra S T)
     ( set-hom-Algebra S T)
-    {!   !}
+    ( comp-hom-Algebra S T)
     ( λ {l} {X} → id-hom-Algebra S T X)
     {!   !}
     {!   !}

--- a/src/universal-algebra/precategory-of-algebras-of-theories.lagda.md
+++ b/src/universal-algebra/precategory-of-algebras-of-theories.lagda.md
@@ -13,6 +13,8 @@ open import foundation.dependent-pair-types
 open import foundation.sets
 open import foundation.universe-levels
 
+open import foundation-core.identity-types
+
 open import universal-algebra.signatures
 open import universal-algebra.models-of-signatures
 open import universal-algebra.algebraic-theories
@@ -40,10 +42,10 @@ module _
   Algebra-Large-Precategory :
     Large-Precategory (λ l → l1 ⊔ l2 ⊔ lsuc l) {!   !}
   Algebra-Large-Precategory = make-Large-Precategory
-    (Algebra S T)
-    (set-hom-Algebra S T)
+    ( Algebra S T)
+    ( set-hom-Algebra S T)
     {!   !}
-    {!   !}
+    ( λ {l} {X} → id-hom-Algebra S T X)
     {!   !}
     {!   !}
     {!   !}


### PR DESCRIPTION
For a signature `S` and `S`-theory `T`, there is a large precategory of `T`-algebras and `T`-algebra homomorphisms. Even better, this (large) precategory is a (large) category. 

To define this category, this PR also characterizes the identity types of `T`-algebras, as both homomorphisms which are also equivalences and as equivalences which preserve operations, making good use of various identity-type technology in the `foundation` namespace.