### PR TITLE
Suprema and infima of families of real numbers

### DIFF
--- a/src/real-numbers.lagda.md
+++ b/src/real-numbers.lagda.md
@@ -18,6 +18,7 @@ open import real-numbers.distance-real-numbers public
 open import real-numbers.inequality-lower-dedekind-real-numbers public
 open import real-numbers.inequality-real-numbers public
 open import real-numbers.inequality-upper-dedekind-real-numbers public
+open import real-numbers.infima-families-real-numbers public
 open import real-numbers.isometry-addition-real-numbers public
 open import real-numbers.isometry-negation-real-numbers public
 open import real-numbers.lower-dedekind-real-numbers public
@@ -40,6 +41,7 @@ open import real-numbers.real-numbers-from-lower-dedekind-real-numbers public
 open import real-numbers.real-numbers-from-upper-dedekind-real-numbers public
 open import real-numbers.similarity-real-numbers public
 open import real-numbers.strict-inequality-real-numbers public
+open import real-numbers.suprema-families-real-numbers public
 open import real-numbers.transposition-addition-subtraction-cuts-dedekind-real-numbers public
 open import real-numbers.upper-dedekind-real-numbers public
 ```

--- a/src/real-numbers/infima-families-real-numbers.lagda.md
+++ b/src/real-numbers/infima-families-real-numbers.lagda.md
@@ -1,0 +1,267 @@
+# Infima of families of real numbers
+
+```agda
+{-# OPTIONS --lossy-unification #-}
+
+module real-numbers.infima-families-real-numbers where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import elementary-number-theory.positive-rational-numbers
+
+open import foundation.binary-transport
+open import foundation.conjunction
+open import foundation.dependent-pair-types
+open import foundation.empty-types
+open import foundation.existential-quantification
+open import foundation.function-types
+open import foundation.identity-types
+open import foundation.logical-equivalences
+open import foundation.propositional-truncations
+open import foundation.propositions
+open import foundation.transport-along-identifications
+open import foundation.universe-levels
+
+open import logic.functoriality-existential-quantification
+
+open import order-theory.greatest-lower-bounds-large-posets
+open import order-theory.lower-bounds-large-posets
+open import order-theory.upper-bounds-large-posets
+
+open import real-numbers.addition-real-numbers
+open import real-numbers.dedekind-real-numbers
+open import real-numbers.difference-real-numbers
+open import real-numbers.inequality-real-numbers
+open import real-numbers.negation-real-numbers
+open import real-numbers.positive-real-numbers
+open import real-numbers.rational-real-numbers
+open import real-numbers.strict-inequality-real-numbers
+open import real-numbers.suprema-families-real-numbers
+```
+
+</details>
+
+## Idea
+
+A [real number](real-numbers.dedekind-real-numbers.md) `x` is the
+{{#concept "infimum" disambiguation="of a set of real numbers" Agda=is-infimum-family-ℝ WD="infimum" WDID=Q1199948}}
+of a family `y` of real numbers indexed by `I` if `x` is a
+[lower bound](order-theory.lower-bounds-large-posets.md) of `y` in the
+[large poset of real numbers](real-numbers.inequality-real-numbers.md) and `x`
+is approximated above by the `yᵢ`: for all `ε : ℚ⁺`, there
+[exists](foundation.existential-quantification.md) an `i : I` such that
+`yᵢ < x + ε`.
+
+Classically, infima and
+[greatest lower bounds](order-theory.greatest-lower-bounds-large-posets.md) are
+equivalent, but constructively being an infimum is a stronger condition, often
+required for constructive analysis.
+
+## Definition
+
+```agda
+module _
+  {l1 l2 : Level} {I : UU l1} (y : I → ℝ l2)
+  where
+
+  is-approximated-above-prop-family-ℝ :
+    {l3 : Level} → ℝ l3 → Prop (l1 ⊔ l2 ⊔ l3)
+  is-approximated-above-prop-family-ℝ x =
+    Π-Prop
+      ( ℚ⁺)
+      ( λ ε → ∃ I (λ i → le-ℝ-Prop (y i) (x +ℝ real-ℚ⁺ ε)))
+
+  is-approximated-above-family-ℝ : {l3 : Level} → ℝ l3 → UU (l1 ⊔ l2 ⊔ l3)
+  is-approximated-above-family-ℝ x =
+    type-Prop (is-approximated-above-prop-family-ℝ x)
+
+  is-infimum-prop-family-ℝ : {l3 : Level} → ℝ l3 → Prop (l1 ⊔ l2 ⊔ l3)
+  is-infimum-prop-family-ℝ x =
+    is-lower-bound-prop-family-of-elements-Large-Poset
+      ( ℝ-Large-Poset)
+      ( y)
+      ( x) ∧
+    is-approximated-above-prop-family-ℝ x
+
+  is-infimum-family-ℝ : {l3 : Level} → ℝ l3 → UU (l1 ⊔ l2 ⊔ l3)
+  is-infimum-family-ℝ x = type-Prop (is-infimum-prop-family-ℝ x)
+
+  is-lower-bound-is-infimum-family-ℝ :
+    {l3 : Level} → (x : ℝ l3) → is-infimum-family-ℝ x →
+    is-lower-bound-family-of-elements-Large-Poset ℝ-Large-Poset y x
+  is-lower-bound-is-infimum-family-ℝ _ = pr1
+
+  is-approximated-above-is-infimum-family-ℝ :
+    {l3 : Level} → (x : ℝ l3) → is-infimum-family-ℝ x →
+    is-approximated-above-family-ℝ x
+  is-approximated-above-is-infimum-family-ℝ _ = pr2
+```
+
+## Properties
+
+### A infimum is a greatest lower bound
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level} {I : UU l1} (y : I → ℝ l2) (x : ℝ l3)
+  (is-infimum-x-yᵢ : is-infimum-family-ℝ y x)
+  where
+
+  abstract
+    is-greatest-lower-bound-is-infimum-family-ℝ :
+      is-greatest-lower-bound-family-of-elements-Large-Poset
+        ( ℝ-Large-Poset)
+        ( y)
+        ( x)
+    pr1 (is-greatest-lower-bound-is-infimum-family-ℝ z) z≤yᵢ =
+      leq-not-le-ℝ x z
+        ( λ x<z →
+          let open do-syntax-trunc-Prop empty-Prop
+          in do
+            (ε⁺@(ε , _) , ε<z-x) ←
+              exists-ℚ⁺-in-lower-cut-ℝ⁺ (positive-diff-le-ℝ x z x<z)
+            (i , yᵢ<x+ε) ←
+              is-approximated-above-is-infimum-family-ℝ y x is-infimum-x-yᵢ ε⁺
+            not-leq-le-ℝ (y i) z
+              ( transitive-le-ℝ (y i) (x +ℝ real-ℚ ε) z
+                ( le-transpose-right-diff-ℝ' _ z _
+                  ( le-real-is-in-lower-cut-ℚ ε (z -ℝ x) ε<z-x))
+                ( yᵢ<x+ε))
+              ( z≤yᵢ i))
+    pr2 (is-greatest-lower-bound-is-infimum-family-ℝ z) z≤x i =
+      transitive-leq-ℝ z x (y i)
+        ( is-lower-bound-is-infimum-family-ℝ y x is-infimum-x-yᵢ i)
+        ( z≤x)
+```
+
+### A real number `r` is greater than the infimum of the `yᵢ` if and only if it is greater than some `yᵢ`
+
+```agda
+module _
+  {l1 l2 l3 : Level} {I : UU l1} (y : I → ℝ l2) (x : ℝ l3)
+  (is-infimum-x-yᵢ : is-infimum-family-ℝ y x)
+  where
+
+  le-infimum-le-element-family-ℝ :
+    {l4 : Level} → (z : ℝ l4) (i : I) → le-ℝ (y i) z → le-ℝ x z
+  le-infimum-le-element-family-ℝ z i =
+    concatenate-leq-le-ℝ x (y i) z
+      ( is-lower-bound-is-infimum-family-ℝ y x is-infimum-x-yᵢ i)
+
+  le-element-le-infimum-family-ℝ :
+    {l4 : Level} → (z : ℝ l4) → le-ℝ x z → exists I (λ i → le-ℝ-Prop (y i) z)
+  le-element-le-infimum-family-ℝ z x<z =
+    let open do-syntax-trunc-Prop (∃ I (λ i → le-ℝ-Prop (y i) z))
+    in do
+      (ε⁺@(ε , _) , ε<z-x) ←
+        exists-ℚ⁺-in-lower-cut-ℝ⁺ (positive-diff-le-ℝ x z x<z)
+      (i , yᵢ<x+ε) ←
+        is-approximated-above-is-infimum-family-ℝ y x is-infimum-x-yᵢ ε⁺
+      intro-exists
+        ( i)
+        ( transitive-le-ℝ (y i) (x +ℝ real-ℚ ε) z
+          ( le-transpose-right-diff-ℝ' _ z _
+            ( le-real-is-in-lower-cut-ℚ ε (z -ℝ x) ε<z-x))
+          ( yᵢ<x+ε))
+
+  le-infimum-iff-le-element-family-ℝ :
+    {l4 : Level} → (z : ℝ l4) →
+    (le-ℝ x z) ↔ (exists I (λ i → le-ℝ-Prop (y i) z))
+  pr1 (le-infimum-iff-le-element-family-ℝ z) =
+    le-element-le-infimum-family-ℝ z
+  pr2 (le-infimum-iff-le-element-family-ℝ z) =
+    elim-exists (le-ℝ-Prop x z) (le-infimum-le-element-family-ℝ z)
+```
+
+### The infimum of a family of real numbers is the negation of the supremum of the negation of the family
+
+```agda
+module _
+  {l1 l2 l3 : Level} {I : UU l1} (y : I → ℝ l2) (x : ℝ l3)
+  (is-supremum-x-neg-yᵢ : is-supremum-family-ℝ (neg-ℝ ∘ y) x)
+  where
+
+  abstract
+    is-lower-bound-neg-supremum-neg-family-ℝ :
+      is-lower-bound-family-of-elements-Large-Poset ℝ-Large-Poset y (neg-ℝ x)
+    is-lower-bound-neg-supremum-neg-family-ℝ i =
+      tr
+        ( leq-ℝ (neg-ℝ x))
+        ( neg-neg-ℝ (y i))
+        ( neg-leq-ℝ _ _
+          ( is-upper-bound-is-supremum-family-ℝ
+            ( neg-ℝ ∘ y)
+            ( x)
+            ( is-supremum-x-neg-yᵢ)
+            ( i)))
+
+    is-approximated-above-neg-supremum-neg-family-ℝ :
+      is-approximated-above-family-ℝ y (neg-ℝ x)
+    is-approximated-above-neg-supremum-neg-family-ℝ ε =
+      map-tot-exists
+        ( λ i x-ε<-yᵢ →
+          binary-tr le-ℝ
+            ( neg-neg-ℝ _)
+            ( distributive-neg-diff-ℝ _ _ ∙ commutative-add-ℝ _ _)
+            ( neg-le-ℝ (x -ℝ real-ℚ⁺ ε) (neg-ℝ (y i)) x-ε<-yᵢ))
+        ( is-approximated-below-is-supremum-family-ℝ
+          ( neg-ℝ ∘ y)
+          ( x)
+          ( is-supremum-x-neg-yᵢ)
+          ( ε))
+
+    is-infimum-neg-supremum-neg-family-ℝ : is-infimum-family-ℝ y (neg-ℝ x)
+    is-infimum-neg-supremum-neg-family-ℝ =
+      ( is-lower-bound-neg-supremum-neg-family-ℝ ,
+        is-approximated-above-neg-supremum-neg-family-ℝ)
+```
+
+### The supremum of a family of real numbers is the negation of the infimum of the negation of the family
+
+```agda
+module _
+  {l1 l2 l3 : Level} {I : UU l1} (y : I → ℝ l2) (x : ℝ l3)
+  (is-infimum-x-neg-yᵢ : is-infimum-family-ℝ (neg-ℝ ∘ y) x)
+  where
+
+  abstract
+    is-upper-bound-neg-infimum-neg-family-ℝ :
+      is-upper-bound-family-of-elements-Large-Poset ℝ-Large-Poset y (neg-ℝ x)
+    is-upper-bound-neg-infimum-neg-family-ℝ i =
+      tr
+        ( λ w → leq-ℝ w (neg-ℝ x))
+        ( neg-neg-ℝ (y i))
+        ( neg-leq-ℝ _ _
+          ( is-lower-bound-is-infimum-family-ℝ
+            ( neg-ℝ ∘ y)
+            ( x)
+            ( is-infimum-x-neg-yᵢ)
+            ( i)))
+
+    is-approximated-below-neg-infimum-neg-family-ℝ :
+      is-approximated-below-family-ℝ y (neg-ℝ x)
+    is-approximated-below-neg-infimum-neg-family-ℝ ε =
+      map-tot-exists
+        ( λ i -yᵢ<x+ε →
+          binary-tr le-ℝ
+            ( distributive-neg-add-ℝ _ _)
+            ( neg-neg-ℝ (y i))
+            ( neg-le-ℝ (neg-ℝ (y i)) (x +ℝ real-ℚ⁺ ε) -yᵢ<x+ε))
+        ( is-approximated-above-is-infimum-family-ℝ
+          ( neg-ℝ ∘ y)
+          ( x)
+          ( is-infimum-x-neg-yᵢ)
+          ( ε))
+
+    is-supremum-neg-infimum-neg-family-ℝ : is-supremum-family-ℝ y (neg-ℝ x)
+    is-supremum-neg-infimum-neg-family-ℝ =
+      ( is-upper-bound-neg-infimum-neg-family-ℝ ,
+        is-approximated-below-neg-infimum-neg-family-ℝ)
+```
+
+## See also
+
+- [Suprema of families of real numbers](real-numbers.suprema-families-real-numbers.md)
+- [Infima](https://ncatlab.org/nlab/show/join#constructive) at $n$Lab

--- a/src/real-numbers/rational-real-numbers.lagda.md
+++ b/src/real-numbers/rational-real-numbers.lagda.md
@@ -10,9 +10,9 @@ module real-numbers.rational-real-numbers where
 
 ```agda
 open import elementary-number-theory.inequality-rational-numbers
+open import elementary-number-theory.positive-rational-numbers
 open import elementary-number-theory.rational-numbers
 open import elementary-number-theory.strict-inequality-rational-numbers
-open import elementary-number-theory.positive-rational-numbers
 
 open import foundation.action-on-identifications-functions
 open import foundation.cartesian-product-types

--- a/src/real-numbers/rational-real-numbers.lagda.md
+++ b/src/real-numbers/rational-real-numbers.lagda.md
@@ -12,6 +12,7 @@ module real-numbers.rational-real-numbers where
 open import elementary-number-theory.inequality-rational-numbers
 open import elementary-number-theory.rational-numbers
 open import elementary-number-theory.strict-inequality-rational-numbers
+open import elementary-number-theory.positive-rational-numbers
 
 open import foundation.action-on-identifications-functions
 open import foundation.cartesian-product-types
@@ -76,6 +77,9 @@ is-dedekind-lower-upper-real-ℚ x =
 ```agda
 real-ℚ : ℚ → ℝ lzero
 real-ℚ x = (lower-real-ℚ x , upper-real-ℚ x , is-dedekind-lower-upper-real-ℚ x)
+
+real-ℚ⁺ : ℚ⁺ → ℝ lzero
+real-ℚ⁺ q = real-ℚ (rational-ℚ⁺ q)
 ```
 
 ### Zero as a real number

--- a/src/real-numbers/strict-inequality-real-numbers.lagda.md
+++ b/src/real-numbers/strict-inequality-real-numbers.lagda.md
@@ -578,6 +578,13 @@ module _
         ( cancel-right-diff-add-ℝ y z)
         ( preserves-le-right-add-ℝ z x (y -ℝ z) x<y-z)
 
+    le-transpose-right-diff-ℝ' : le-ℝ x (y -ℝ z) → le-ℝ (z +ℝ x) y
+    le-transpose-right-diff-ℝ' x<y-z =
+      tr
+        ( λ w → le-ℝ w y)
+        ( commutative-add-ℝ _ _)
+        ( le-transpose-right-diff-ℝ x<y-z)
+
 module _
   {l1 l2 l3 : Level} (x : ℝ l1) (y : ℝ l2) (z : ℝ l3)
   where

--- a/src/real-numbers/strict-inequality-real-numbers.lagda.md
+++ b/src/real-numbers/strict-inequality-real-numbers.lagda.md
@@ -559,6 +559,16 @@ module _
   where
 
   abstract
+    le-transpose-left-add-ℝ' : le-ℝ (x +ℝ y) z → le-ℝ y (z -ℝ x)
+    le-transpose-left-add-ℝ' x+y<z =
+      le-transpose-left-add-ℝ y x z
+        ( tr (λ w → le-ℝ w z) (commutative-add-ℝ _ _) x+y<z)
+
+module _
+  {l1 l2 l3 : Level} (x : ℝ l1) (y : ℝ l2) (z : ℝ l3)
+  where
+
+  abstract
     le-transpose-right-diff-ℝ : le-ℝ x (y -ℝ z) → le-ℝ (x +ℝ z) y
     le-transpose-right-diff-ℝ x<y-z =
       preserves-le-right-sim-ℝ
@@ -598,6 +608,15 @@ module _
   abstract
     le-transpose-right-add-ℝ : le-ℝ x (y +ℝ z) → le-ℝ (x -ℝ z) y
     le-transpose-right-add-ℝ = backward-implication (iff-add-right-le-ℝ x z y)
+
+module _
+  {l1 l2 l3 : Level} (x : ℝ l1) (y : ℝ l2) (z : ℝ l3)
+  where
+
+  abstract
+    le-transpose-right-add-ℝ' : le-ℝ x (y +ℝ z) → le-ℝ (x -ℝ y) z
+    le-transpose-right-add-ℝ' x<y+z =
+      le-transpose-right-add-ℝ x z y (tr (le-ℝ x) (commutative-add-ℝ _ _) x<y+z)
 ```
 
 ## References

--- a/src/real-numbers/suprema-families-real-numbers.lagda.md
+++ b/src/real-numbers/suprema-families-real-numbers.lagda.md
@@ -1,31 +1,34 @@
-# Suprema of real numbers
+# Suprema of families of real numbers
 
 ```agda
 {-# OPTIONS --lossy-unification #-}
 
-module real-numbers.suprema-real-numbers where
+module real-numbers.suprema-families-real-numbers where
 ```
 
 <details><summary>Imports</summary>
 
 ```agda
 open import elementary-number-theory.positive-rational-numbers
-open import real-numbers.difference-real-numbers
-open import real-numbers.rational-real-numbers
-open import real-numbers.positive-real-numbers
-open import real-numbers.strict-inequality-real-numbers
-open import foundation.empty-types
-open import foundation.dependent-pair-types
-open import foundation.logical-equivalences
-open import foundation.propositions
+
 open import foundation.conjunction
-open import foundation.propositional-truncations
-open import foundation.universe-levels
+open import foundation.dependent-pair-types
+open import foundation.empty-types
 open import foundation.existential-quantification
-open import real-numbers.dedekind-real-numbers
-open import real-numbers.inequality-real-numbers
-open import order-theory.upper-bounds-large-posets
+open import foundation.logical-equivalences
+open import foundation.propositional-truncations
+open import foundation.propositions
+open import foundation.universe-levels
+
 open import order-theory.least-upper-bounds-large-posets
+open import order-theory.upper-bounds-large-posets
+
+open import real-numbers.dedekind-real-numbers
+open import real-numbers.difference-real-numbers
+open import real-numbers.inequality-real-numbers
+open import real-numbers.positive-real-numbers
+open import real-numbers.rational-real-numbers
+open import real-numbers.strict-inequality-real-numbers
 ```
 
 </details>
@@ -36,14 +39,15 @@ A [real number](real-numbers.dedekind-real-numbers.md) `x` is the
 {{#concept "supremum" disambiguation="of a set of real numbers" Agda=is-supremum-family-ℝ WD="supremum" WDID=Q215071}}
 of a family `y` of real numbers indexed by `I` if `x` is an
 [upper bound](order-theory.upper-bounds-large-posets.md) of `y` in the
-[large poset of real numbers](real-numbers.inequality-real-numbers.md) and
-`x` is approximated below by the `yᵢ`: for all `ε : ℚ⁺`, there
+[large poset of real numbers](real-numbers.inequality-real-numbers.md) and `x`
+is approximated below by the `yᵢ`: for all `ε : ℚ⁺`, there
 [exists](foundation.existential-quantification.md) an `i : I` such that
 `x - yᵢ < ε`.
 
 Classically, suprema and
 [least upper bounds](order-theory.least-upper-bounds-large-posets.md) are
-equivalent, but constructively being a supremum is a stronger condition.
+equivalent, but constructively being a supremum is a stronger condition, often
+required for constructive analysis.
 
 ## Definition
 
@@ -130,37 +134,39 @@ module _
   (is-supremum-x-yᵢ : is-supremum-family-ℝ y x)
   where
 
-  le-supremum-le-element-family-ℝ :
-    {l4 : Level} → (z : ℝ l4) (i : I) → le-ℝ z (y i) → le-ℝ z x
-  le-supremum-le-element-family-ℝ z i z<yᵢ =
-    concatenate-le-leq-ℝ z (y i) x z<yᵢ (pr1 is-supremum-x-yᵢ i)
+  abstract
+    le-supremum-le-element-family-ℝ :
+      {l4 : Level} → (z : ℝ l4) (i : I) → le-ℝ z (y i) → le-ℝ z x
+    le-supremum-le-element-family-ℝ z i z<yᵢ =
+      concatenate-le-leq-ℝ z (y i) x z<yᵢ (pr1 is-supremum-x-yᵢ i)
 
-  le-element-le-supremum-family-ℝ :
-    {l4 : Level} → (z : ℝ l4) → le-ℝ z x → exists I (λ i → le-ℝ-Prop z (y i))
-  le-element-le-supremum-family-ℝ z z<x =
-    let open do-syntax-trunc-Prop (∃ I (λ i → le-ℝ-Prop z (y i)))
-    in do
-      (ε⁺@(ε , _) , ε<x-z) ←
-        exists-ℚ⁺-in-lower-cut-ℝ⁺ (positive-diff-le-ℝ z x z<x)
-      (i , x-ε<yᵢ) ←
-        is-approximated-below-is-supremum-family-ℝ y x is-supremum-x-yᵢ ε⁺
-      intro-exists
-        ( i)
-        ( transitive-le-ℝ z (x -ℝ real-ℚ ε) (y i)
-          ( x-ε<yᵢ)
-          ( le-transpose-left-add-ℝ' _ _ _
-            ( le-transpose-right-diff-ℝ _ _ _
-              ( le-real-is-in-lower-cut-ℚ ε (x -ℝ z) ε<x-z))))
+    le-element-le-supremum-family-ℝ :
+      {l4 : Level} → (z : ℝ l4) → le-ℝ z x → exists I (λ i → le-ℝ-Prop z (y i))
+    le-element-le-supremum-family-ℝ z z<x =
+      let open do-syntax-trunc-Prop (∃ I (λ i → le-ℝ-Prop z (y i)))
+      in do
+        (ε⁺@(ε , _) , ε<x-z) ←
+          exists-ℚ⁺-in-lower-cut-ℝ⁺ (positive-diff-le-ℝ z x z<x)
+        (i , x-ε<yᵢ) ←
+          is-approximated-below-is-supremum-family-ℝ y x is-supremum-x-yᵢ ε⁺
+        intro-exists
+          ( i)
+          ( transitive-le-ℝ z (x -ℝ real-ℚ ε) (y i)
+            ( x-ε<yᵢ)
+            ( le-transpose-left-add-ℝ' _ _ _
+              ( le-transpose-right-diff-ℝ _ _ _
+                ( le-real-is-in-lower-cut-ℚ ε (x -ℝ z) ε<x-z))))
 
-  le-supremum-iff-le-element-family-ℝ :
-    {l4 : Level} → (z : ℝ l4) →
-    (le-ℝ z x) ↔ (exists I (λ i → le-ℝ-Prop z (y i)))
-  pr1 (le-supremum-iff-le-element-family-ℝ z) =
-    le-element-le-supremum-family-ℝ z
-  pr2 (le-supremum-iff-le-element-family-ℝ z) =
-    elim-exists (le-ℝ-Prop z x) (le-supremum-le-element-family-ℝ z)
+    le-supremum-iff-le-element-family-ℝ :
+      {l4 : Level} → (z : ℝ l4) →
+      (le-ℝ z x) ↔ (exists I (λ i → le-ℝ-Prop z (y i)))
+    pr1 (le-supremum-iff-le-element-family-ℝ z) =
+      le-element-le-supremum-family-ℝ z
+    pr2 (le-supremum-iff-le-element-family-ℝ z) =
+      elim-exists (le-ℝ-Prop z x) (le-supremum-le-element-family-ℝ z)
 ```
 
 ## See also
 
-* [Suprema](https://ncatlab.org/nlab/show/join#constructive) at $n$Lab
+- [Infima of families of real numbers](real-numbers.infima-families-real-numbers.md)
+- [Suprema](https://ncatlab.org/nlab/show/join#constructive) at $n$Lab

--- a/src/real-numbers/suprema-real-numbers.lagda.md
+++ b/src/real-numbers/suprema-real-numbers.lagda.md
@@ -1,0 +1,166 @@
+# Suprema of real numbers
+
+```agda
+{-# OPTIONS --lossy-unification #-}
+
+module real-numbers.suprema-real-numbers where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import elementary-number-theory.positive-rational-numbers
+open import real-numbers.difference-real-numbers
+open import real-numbers.rational-real-numbers
+open import real-numbers.positive-real-numbers
+open import real-numbers.strict-inequality-real-numbers
+open import foundation.empty-types
+open import foundation.dependent-pair-types
+open import foundation.logical-equivalences
+open import foundation.propositions
+open import foundation.conjunction
+open import foundation.propositional-truncations
+open import foundation.universe-levels
+open import foundation.existential-quantification
+open import real-numbers.dedekind-real-numbers
+open import real-numbers.inequality-real-numbers
+open import order-theory.upper-bounds-large-posets
+open import order-theory.least-upper-bounds-large-posets
+```
+
+</details>
+
+## Idea
+
+A [real number](real-numbers.dedekind-real-numbers.md) `x` is the
+{{#concept "supremum" disambiguation="of a set of real numbers" Agda=is-supremum-family-ℝ WD="supremum" WDID=Q215071}}
+of a family `y` of real numbers indexed by `I` if `x` is an
+[upper bound](order-theory.upper-bounds-large-posets.md) of `y` in the
+[large poset of real numbers](real-numbers.inequality-real-numbers.md) and
+`x` is approximated below by the `yᵢ`: for all `ε : ℚ⁺`, there
+[exists](foundation.existential-quantification.md) an `i : I` such that
+`x - yᵢ < ε`.
+
+Classically, suprema and
+[least upper bounds](order-theory.least-upper-bounds-large-posets.md) are
+equivalent, but constructively being a supremum is a stronger condition.
+
+## Definition
+
+```agda
+module _
+  {l1 l2 : Level} {I : UU l1} (y : I → ℝ l2)
+  where
+
+  is-approximated-below-prop-family-ℝ :
+    {l3 : Level} → ℝ l3 → Prop (l1 ⊔ l2 ⊔ l3)
+  is-approximated-below-prop-family-ℝ x =
+    Π-Prop
+      ( ℚ⁺)
+      ( λ ε → ∃ I (λ i → le-ℝ-Prop (x -ℝ real-ℚ⁺ ε) (y i)))
+
+  is-approximated-below-family-ℝ : {l3 : Level} → ℝ l3 → UU (l1 ⊔ l2 ⊔ l3)
+  is-approximated-below-family-ℝ x =
+    type-Prop (is-approximated-below-prop-family-ℝ x)
+
+  is-supremum-prop-family-ℝ : {l3 : Level} → ℝ l3 → Prop (l1 ⊔ l2 ⊔ l3)
+  is-supremum-prop-family-ℝ x =
+    is-upper-bound-prop-family-of-elements-Large-Poset
+      ( ℝ-Large-Poset)
+      ( y)
+      ( x) ∧
+    is-approximated-below-prop-family-ℝ x
+
+  is-supremum-family-ℝ : {l3 : Level} → ℝ l3 → UU (l1 ⊔ l2 ⊔ l3)
+  is-supremum-family-ℝ x = type-Prop (is-supremum-prop-family-ℝ x)
+
+  is-upper-bound-is-supremum-family-ℝ :
+    {l3 : Level} → (x : ℝ l3) → is-supremum-family-ℝ x →
+    is-upper-bound-family-of-elements-Large-Poset ℝ-Large-Poset y x
+  is-upper-bound-is-supremum-family-ℝ _ = pr1
+
+  is-approximated-below-is-supremum-family-ℝ :
+    {l3 : Level} → (x : ℝ l3) → is-supremum-family-ℝ x →
+    is-approximated-below-family-ℝ x
+  is-approximated-below-is-supremum-family-ℝ _ = pr2
+```
+
+## Properties
+
+### A supremum is a least upper bound
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level} {I : UU l1} (y : I → ℝ l2) (x : ℝ l3)
+  (is-supremum-x-yᵢ : is-supremum-family-ℝ y x)
+  where
+
+  abstract
+    is-least-upper-bound-is-supremum-family-ℝ :
+      is-least-upper-bound-family-of-elements-Large-Poset
+        ( ℝ-Large-Poset)
+        ( y)
+        ( x)
+    pr1 (is-least-upper-bound-is-supremum-family-ℝ z) yᵢ≤z =
+      leq-not-le-ℝ z x
+        ( λ z<x →
+          let open do-syntax-trunc-Prop empty-Prop
+          in do
+            (ε⁺@(ε , _) , ε<x-z) ←
+              exists-ℚ⁺-in-lower-cut-ℝ⁺ (positive-diff-le-ℝ z x z<x)
+            (i , x-ε<yᵢ) ←
+              is-approximated-below-is-supremum-family-ℝ y x is-supremum-x-yᵢ ε⁺
+            not-leq-le-ℝ z (y i)
+              ( transitive-le-ℝ z (x -ℝ real-ℚ⁺ ε⁺) (y i)
+                ( x-ε<yᵢ)
+                ( le-transpose-left-add-ℝ' _ _ _
+                  ( le-transpose-right-diff-ℝ _ _ _
+                    ( le-real-is-in-lower-cut-ℚ ε (x -ℝ z) ε<x-z))))
+              ( yᵢ≤z i))
+    pr2 (is-least-upper-bound-is-supremum-family-ℝ z) x≤z i =
+      transitive-leq-ℝ (y i) x z x≤z
+        ( is-upper-bound-is-supremum-family-ℝ y x is-supremum-x-yᵢ i)
+```
+
+### A real number `r` is less than the supremum of the `yᵢ` if and only if it is less than some `yᵢ`
+
+```agda
+module _
+  {l1 l2 l3 : Level} {I : UU l1} (y : I → ℝ l2) (x : ℝ l3)
+  (is-supremum-x-yᵢ : is-supremum-family-ℝ y x)
+  where
+
+  le-supremum-le-element-family-ℝ :
+    {l4 : Level} → (z : ℝ l4) (i : I) → le-ℝ z (y i) → le-ℝ z x
+  le-supremum-le-element-family-ℝ z i z<yᵢ =
+    concatenate-le-leq-ℝ z (y i) x z<yᵢ (pr1 is-supremum-x-yᵢ i)
+
+  le-element-le-supremum-family-ℝ :
+    {l4 : Level} → (z : ℝ l4) → le-ℝ z x → exists I (λ i → le-ℝ-Prop z (y i))
+  le-element-le-supremum-family-ℝ z z<x =
+    let open do-syntax-trunc-Prop (∃ I (λ i → le-ℝ-Prop z (y i)))
+    in do
+      (ε⁺@(ε , _) , ε<x-z) ←
+        exists-ℚ⁺-in-lower-cut-ℝ⁺ (positive-diff-le-ℝ z x z<x)
+      (i , x-ε<yᵢ) ←
+        is-approximated-below-is-supremum-family-ℝ y x is-supremum-x-yᵢ ε⁺
+      intro-exists
+        ( i)
+        ( transitive-le-ℝ z (x -ℝ real-ℚ ε) (y i)
+          ( x-ε<yᵢ)
+          ( le-transpose-left-add-ℝ' _ _ _
+            ( le-transpose-right-diff-ℝ _ _ _
+              ( le-real-is-in-lower-cut-ℚ ε (x -ℝ z) ε<x-z))))
+
+  le-supremum-iff-le-element-family-ℝ :
+    {l4 : Level} → (z : ℝ l4) →
+    (le-ℝ z x) ↔ (exists I (λ i → le-ℝ-Prop z (y i)))
+  pr1 (le-supremum-iff-le-element-family-ℝ z) =
+    le-element-le-supremum-family-ℝ z
+  pr2 (le-supremum-iff-le-element-family-ℝ z) =
+    elim-exists (le-ℝ-Prop z x) (le-supremum-le-element-family-ℝ z)
+```
+
+## See also
+
+* [Suprema](https://ncatlab.org/nlab/show/join#constructive) at $n$Lab


### PR DESCRIPTION
As alluded to by nLab, constructive analysis often requires a definition of suprema and infima that is stronger than the least-upper-bound property.  This introduces that stronger definition.