### PR TITLE
Opacify real numbers

### DIFF
--- a/src/metric-spaces/limits-of-cauchy-approximations-metric-spaces.lagda.md
+++ b/src/metric-spaces/limits-of-cauchy-approximations-metric-spaces.lagda.md
@@ -68,6 +68,29 @@ module _
 
 ## Properties
 
+### Saturation of the limit
+
+```agda
+module _
+  {l1 l2 : Level} (A : Metric-Space l1 l2)
+  (f : cauchy-approximation-Metric-Space A)
+  (x : type-Metric-Space A)
+  where
+
+  abstract
+    saturated-is-limit-cauchy-approximation-Metric-Space :
+      is-limit-cauchy-approximation-Metric-Space A f x →
+      (ε : ℚ⁺) →
+      neighborhood-Metric-Space A ε
+        ( map-cauchy-approximation-Metric-Space A f ε)
+        ( x)
+    saturated-is-limit-cauchy-approximation-Metric-Space =
+      saturated-is-limit-cauchy-approximation-Pseudometric-Space
+        ( pseudometric-Metric-Space A)
+        ( f)
+        ( x)
+```
+
 ### Limits in a metric space are unique
 
 ```agda

--- a/src/metric-spaces/limits-of-cauchy-approximations-pseudometric-spaces.lagda.md
+++ b/src/metric-spaces/limits-of-cauchy-approximations-pseudometric-spaces.lagda.md
@@ -68,6 +68,26 @@ module _
 
 ## Properties
 
+### Saturation of the limit
+
+```agda
+module _
+  {l1 l2 : Level} (A : Pseudometric-Space l1 l2)
+  (f : cauchy-approximation-Pseudometric-Space A)
+  (x : type-Pseudometric-Space A)
+  where
+
+  abstract
+    saturated-is-limit-cauchy-approximation-Pseudometric-Space :
+      is-limit-cauchy-approximation-Pseudometric-Space A f x →
+      (ε : ℚ⁺) →
+      neighborhood-Pseudometric-Space A ε
+        ( map-cauchy-approximation-Pseudometric-Space A f ε)
+        ( x)
+    saturated-is-limit-cauchy-approximation-Pseudometric-Space is-lim ε =
+      saturated-neighborhood-Pseudometric-Space A ε _ _ (is-lim ε)
+```
+
 ### Limits of a Cauchy approximations in a pseudometric space are similar
 
 ```agda

--- a/src/metric-spaces/located-metric-spaces.lagda.md
+++ b/src/metric-spaces/located-metric-spaces.lagda.md
@@ -169,12 +169,14 @@ module _
         ( leq-zero-not-in-cut-upper-real-dist-Metric-Space M x y B zero-ℚ
           ( refl-leq-ℚ zero-ℚ)))
 
-  abstract
+  opaque
+    unfolding leq-ℝ-Prop' real-ℚ
+
     leq-real-dist-Metric-Space :
       (ε : ℚ⁺) →
-      leq-ℝ real-dist-located-Metric-Space (real-ℚ (rational-ℚ⁺ ε)) ↔
+      leq-ℝ real-dist-located-Metric-Space (real-ℚ⁺ ε) ↔
       neighborhood-Metric-Space M ε x y
     leq-real-dist-Metric-Space ε =
       leq-upper-real-dist-Metric-Space M x y B ε ∘iff
-      leq-iff-ℝ' real-dist-located-Metric-Space (real-ℚ (rational-ℚ⁺ ε))
+      leq-iff-ℝ' real-dist-located-Metric-Space (real-ℚ⁺ ε)
 ```

--- a/src/metric-spaces/located-metric-spaces.lagda.md
+++ b/src/metric-spaces/located-metric-spaces.lagda.md
@@ -170,7 +170,7 @@ module _
           ( refl-leq-ℚ zero-ℚ)))
 
   opaque
-    unfolding leq-ℝ-Prop' real-ℚ
+    unfolding leq-ℝ' real-ℚ
 
     leq-real-dist-Metric-Space :
       (ε : ℚ⁺) →

--- a/src/real-numbers.lagda.md
+++ b/src/real-numbers.lagda.md
@@ -11,6 +11,8 @@ open import real-numbers.addition-real-numbers public
 open import real-numbers.addition-upper-dedekind-real-numbers public
 open import real-numbers.apartness-real-numbers public
 open import real-numbers.arithmetically-located-dedekind-cuts public
+open import real-numbers.binary-maximum-real-numbers public
+open import real-numbers.binary-minimum-real-numbers public
 open import real-numbers.cauchy-completeness-dedekind-real-numbers public
 open import real-numbers.dedekind-real-numbers public
 open import real-numbers.difference-real-numbers public
@@ -23,11 +25,9 @@ open import real-numbers.isometry-addition-real-numbers public
 open import real-numbers.isometry-negation-real-numbers public
 open import real-numbers.lower-dedekind-real-numbers public
 open import real-numbers.maximum-lower-dedekind-real-numbers public
-open import real-numbers.maximum-real-numbers public
 open import real-numbers.maximum-upper-dedekind-real-numbers public
 open import real-numbers.metric-space-of-real-numbers public
 open import real-numbers.minimum-lower-dedekind-real-numbers public
-open import real-numbers.minimum-real-numbers public
 open import real-numbers.minimum-upper-dedekind-real-numbers public
 open import real-numbers.negation-lower-upper-dedekind-real-numbers public
 open import real-numbers.negation-real-numbers public

--- a/src/real-numbers/absolute-value-real-numbers.lagda.md
+++ b/src/real-numbers/absolute-value-real-numbers.lagda.md
@@ -72,7 +72,7 @@ opaque
 
 ```agda
 opaque
-  unfolding abs-ℝ leq-ℝ-Prop max-ℝ neg-ℚ neg-ℝ real-ℚ
+  unfolding abs-ℝ leq-ℝ max-ℝ neg-ℚ neg-ℝ real-ℚ
 
   is-nonnegative-abs-ℝ : {l : Level} → (x : ℝ l) → is-nonnegative-ℝ (abs-ℝ x)
   is-nonnegative-abs-ℝ x q q<0 =

--- a/src/real-numbers/absolute-value-real-numbers.lagda.md
+++ b/src/real-numbers/absolute-value-real-numbers.lagda.md
@@ -25,9 +25,9 @@ open import foundation.universe-levels
 open import metric-spaces.short-functions-metric-spaces
 
 open import real-numbers.addition-real-numbers
+open import real-numbers.binary-maximum-real-numbers
 open import real-numbers.dedekind-real-numbers
 open import real-numbers.inequality-real-numbers
-open import real-numbers.maximum-real-numbers
 open import real-numbers.metric-space-of-real-numbers
 open import real-numbers.negation-real-numbers
 open import real-numbers.nonnegative-real-numbers
@@ -42,7 +42,7 @@ open import real-numbers.similarity-real-numbers
 The
 {{#concept "absolute value" Disambiguation="of a real number" Agda=abs-ℝ WD="absolute value" WDID=Q120812}}
 of a [real number](real-numbers.dedekind-real-numbers.md) is the
-[maximum](real-numbers.maximum-real-numbers.md) of it and its
+[binary maximum](real-numbers.binary-maximum-real-numbers.md) of it and its
 [negation](real-numbers.negation-real-numbers.md). The absolute value is a
 [short function](metric-spaces.short-functions-metric-spaces.md) of the
 [metric space of real numbers](real-numbers.metric-space-of-real-numbers.md).
@@ -72,9 +72,7 @@ opaque
 
 ```agda
 opaque
-  unfolding abs-ℝ
-  unfolding neg-ℚ
-  unfolding max-ℝ
+  unfolding abs-ℝ leq-ℝ-Prop max-ℝ neg-ℚ neg-ℝ real-ℚ
 
   is-nonnegative-abs-ℝ : {l : Level} → (x : ℝ l) → is-nonnegative-ℝ (abs-ℝ x)
   is-nonnegative-abs-ℝ x q q<0 =
@@ -189,23 +187,23 @@ module _
         ( abs-ℝ y)
         ( leq-abs-leq-leq-neg-ℝ
           ( x)
-          ( abs-ℝ y +ℝ real-ℚ (rational-ℚ⁺ d))
+          ( abs-ℝ y +ℝ real-ℚ⁺ d)
           ( transitive-leq-ℝ
             ( x)
-            ( y +ℝ real-ℚ (rational-ℚ⁺ d))
-            ( abs-ℝ y +ℝ real-ℚ (rational-ℚ⁺ d))
+            ( y +ℝ real-ℚ⁺ d)
+            ( abs-ℝ y +ℝ real-ℚ⁺ d)
             ( preserves-leq-right-add-ℝ
-              ( real-ℚ (rational-ℚ⁺ d))
+              ( real-ℚ⁺ d)
               ( y)
               ( abs-ℝ y)
               ( leq-abs-ℝ y))
             ( left-leq-real-bound-neighborhood-ℝ d x y I))
           ( transitive-leq-ℝ
             ( neg-ℝ x)
-            ( neg-ℝ y +ℝ real-ℚ (rational-ℚ⁺ d))
-            ( abs-ℝ y +ℝ real-ℚ (rational-ℚ⁺ d))
+            ( neg-ℝ y +ℝ real-ℚ⁺ d)
+            ( abs-ℝ y +ℝ real-ℚ⁺ d)
             ( preserves-leq-right-add-ℝ
-              ( real-ℚ (rational-ℚ⁺ d))
+              ( real-ℚ⁺ d)
               ( neg-ℝ y)
               ( abs-ℝ y)
               ( neg-leq-abs-ℝ y))
@@ -216,23 +214,23 @@ module _
               ( right-leq-real-bound-neighborhood-ℝ d x y I))))
         ( leq-abs-leq-leq-neg-ℝ
           ( y)
-          ( abs-ℝ x +ℝ real-ℚ (rational-ℚ⁺ d))
+          ( abs-ℝ x +ℝ real-ℚ⁺ d)
           ( transitive-leq-ℝ
             ( y)
-            ( x +ℝ real-ℚ (rational-ℚ⁺ d))
-            ( abs-ℝ x +ℝ real-ℚ (rational-ℚ⁺ d))
+            ( x +ℝ real-ℚ⁺ d)
+            ( abs-ℝ x +ℝ real-ℚ⁺ d)
             ( preserves-leq-right-add-ℝ
-              ( real-ℚ (rational-ℚ⁺ d))
+              ( real-ℚ⁺ d)
               ( x)
               ( abs-ℝ x)
               ( leq-abs-ℝ x))
             ( right-leq-real-bound-neighborhood-ℝ d x y I))
           ( transitive-leq-ℝ
             ( neg-ℝ y)
-            ( neg-ℝ x +ℝ real-ℚ (rational-ℚ⁺ d))
-            ( abs-ℝ x +ℝ real-ℚ (rational-ℚ⁺ d))
+            ( neg-ℝ x +ℝ real-ℚ⁺ d)
+            ( abs-ℝ x +ℝ real-ℚ⁺ d)
             ( preserves-leq-right-add-ℝ
-              ( real-ℚ (rational-ℚ⁺ d))
+              ( real-ℚ⁺ d)
               ( neg-ℝ x)
               ( abs-ℝ x)
               ( neg-leq-abs-ℝ x))

--- a/src/real-numbers/addition-real-numbers.lagda.md
+++ b/src/real-numbers/addition-real-numbers.lagda.md
@@ -15,6 +15,7 @@ open import elementary-number-theory.positive-rational-numbers
 open import elementary-number-theory.rational-numbers
 open import elementary-number-theory.strict-inequality-rational-numbers
 
+open import foundation.action-on-identifications-binary-functions
 open import foundation.action-on-identifications-functions
 open import foundation.binary-transport
 open import foundation.cartesian-product-types
@@ -140,6 +141,12 @@ module _
 
 infixl 35 _+ℝ_
 _+ℝ_ = add-ℝ
+
+ap-add-ℝ :
+  {l1 : Level} {x x' : ℝ l1} → (x ＝ x') →
+  {l2 : Level} {y y' : ℝ l2} → (y ＝ y') →
+  (x +ℝ y) ＝ (x' +ℝ y')
+ap-add-ℝ x=x' y=y' = ap-binary add-ℝ x=x' y=y'
 ```
 
 ## Properties
@@ -189,7 +196,7 @@ module _
 
 ```agda
 opaque
-  unfolding add-ℝ
+  unfolding add-ℝ real-ℚ
 
   left-unit-law-add-ℝ : {l : Level} → (x : ℝ l) → zero-ℝ +ℝ x ＝ x
   left-unit-law-add-ℝ x =
@@ -210,7 +217,7 @@ opaque
 
 ```agda
 opaque
-  unfolding add-ℝ
+  unfolding add-ℝ neg-ℝ
 
   right-inverse-law-add-ℝ :
     {l : Level} → (x : ℝ l) → sim-ℝ (x +ℝ neg-ℝ x) zero-ℝ
@@ -241,6 +248,7 @@ opaque
                 ( -q<x) ,
                 x<p)))
 
+abstract
   left-inverse-law-add-ℝ : {l : Level} (x : ℝ l) → sim-ℝ (neg-ℝ x +ℝ x) zero-ℝ
   left-inverse-law-add-ℝ x =
     tr
@@ -258,8 +266,7 @@ module _
   where
 
   opaque
-    unfolding sim-ℝ
-    unfolding add-ℝ
+    unfolding add-ℝ sim-ℝ
 
     preserves-sim-right-add-ℝ : sim-ℝ x y → sim-ℝ (x +ℝ z) (y +ℝ z)
     pr1 (preserves-sim-right-add-ℝ (lx⊆ly , _)) q =
@@ -373,7 +380,7 @@ module _
 
 ```agda
 opaque
-  unfolding add-ℝ
+  unfolding add-ℝ real-ℚ
 
   add-real-ℚ : (p q : ℚ) → real-ℚ p +ℝ real-ℚ q ＝ real-ℚ (p +ℚ q)
   add-real-ℚ p q =

--- a/src/real-numbers/apartness-real-numbers.lagda.md
+++ b/src/real-numbers/apartness-real-numbers.lagda.md
@@ -40,7 +40,7 @@ module _
   where
 
   apart-ℝ-Prop : Prop (l1 ⊔ l2)
-  apart-ℝ-Prop = le-ℝ-Prop x y ∨ le-ℝ-Prop y x
+  apart-ℝ-Prop = le-prop-ℝ x y ∨ le-prop-ℝ y x
 
   apart-ℝ : UU (l1 ⊔ l2)
   apart-ℝ = type-Prop apart-ℝ-Prop

--- a/src/real-numbers/binary-maximum-real-numbers.lagda.md
+++ b/src/real-numbers/binary-maximum-real-numbers.lagda.md
@@ -125,7 +125,7 @@ module _
   where
 
   opaque
-    unfolding leq-ℝ-Prop max-ℝ
+    unfolding leq-ℝ max-ℝ
 
     is-least-binary-upper-bound-max-ℝ :
       is-least-binary-upper-bound-Large-Poset
@@ -182,7 +182,7 @@ module _
   where
 
   opaque
-    unfolding leq-ℝ-Prop sim-ℝ
+    unfolding leq-ℝ sim-ℝ
 
     commutative-max-ℝ : max-ℝ x y ＝ max-ℝ y x
     commutative-max-ℝ =
@@ -392,13 +392,13 @@ module _
     approximate-below-max-ℝ :
       (ε : ℚ⁺) →
       type-disjunction-Prop
-        ( le-ℝ-Prop (max-ℝ x y -ℝ real-ℚ⁺ ε) x)
-        ( le-ℝ-Prop (max-ℝ x y -ℝ real-ℚ⁺ ε) y)
+        ( le-prop-ℝ (max-ℝ x y -ℝ real-ℚ⁺ ε) x)
+        ( le-prop-ℝ (max-ℝ x y -ℝ real-ℚ⁺ ε) y)
     approximate-below-max-ℝ ε⁺@(ε , _) =
       let
         motive =
-          ( le-ℝ-Prop (max-ℝ x y -ℝ real-ℚ ε) x) ∨
-          ( le-ℝ-Prop (max-ℝ x y -ℝ real-ℚ ε) y)
+          ( le-prop-ℝ (max-ℝ x y -ℝ real-ℚ ε) x) ∨
+          ( le-prop-ℝ (max-ℝ x y -ℝ real-ℚ ε) y)
         open do-syntax-trunc-Prop motive
       in do
         (q , max-ε<q , q<max) ←

--- a/src/real-numbers/binary-maximum-real-numbers.lagda.md
+++ b/src/real-numbers/binary-maximum-real-numbers.lagda.md
@@ -1,9 +1,9 @@
-# The maximum of real numbers
+# The binary maximum of real numbers
 
 ```agda
 {-# OPTIONS --lossy-unification #-}
 
-module real-numbers.maximum-real-numbers where
+module real-numbers.binary-maximum-real-numbers where
 ```
 
 <details><summary>Imports</summary>
@@ -24,6 +24,7 @@ open import foundation.universe-levels
 open import metric-spaces.metric-space-of-short-functions-metric-spaces
 open import metric-spaces.short-functions-metric-spaces
 
+open import order-theory.join-semilattices
 open import order-theory.large-join-semilattices
 open import order-theory.least-upper-bounds-large-posets
 
@@ -124,7 +125,7 @@ module _
   where
 
   opaque
-    unfolding max-ℝ
+    unfolding leq-ℝ-Prop max-ℝ
 
     is-least-binary-upper-bound-max-ℝ :
       is-least-binary-upper-bound-Large-Poset
@@ -181,7 +182,7 @@ module _
   where
 
   opaque
-    unfolding sim-ℝ
+    unfolding leq-ℝ-Prop sim-ℝ
 
     commutative-max-ℝ : max-ℝ x y ＝ max-ℝ y x
     commutative-max-ℝ =
@@ -206,6 +207,15 @@ has-joins-ℝ-Large-Poset : has-joins-Large-Poset ℝ-Large-Poset
 join-has-joins-Large-Poset has-joins-ℝ-Large-Poset = max-ℝ
 is-least-binary-upper-bound-join-has-joins-Large-Poset
   has-joins-ℝ-Large-Poset = is-least-binary-upper-bound-max-ℝ
+```
+
+### The real numbers at a specific universe level are a join semilattice
+
+```agda
+ℝ-Order-Theoretic-Join-Semilattice :
+  (l : Level) → Order-Theoretic-Join-Semilattice (lsuc l) l
+ℝ-Order-Theoretic-Join-Semilattice l =
+  ( ℝ-Poset l , λ x y → (max-ℝ x y , is-least-binary-upper-bound-max-ℝ x y))
 ```
 
 ### The binary maximum preserves similarity
@@ -257,51 +267,52 @@ module _
   (x : ℝ l1) (y : ℝ l2) (z : ℝ l3)
   where
 
-  preserves-lower-neighborhood-leq-left-max-ℝ :
-    leq-ℝ y (z +ℝ real-ℚ (rational-ℚ⁺ d)) →
-    leq-ℝ
-      ( max-ℝ x y)
-      ( (max-ℝ x z) +ℝ real-ℚ (rational-ℚ⁺ d))
-  preserves-lower-neighborhood-leq-left-max-ℝ z≤y+d =
-    leq-is-least-binary-upper-bound-Large-Poset
-      ( ℝ-Large-Poset)
-      ( x)
-      ( y)
-      ( is-least-binary-upper-bound-max-ℝ x y)
-      ( (max-ℝ x z) +ℝ real-ℚ (rational-ℚ⁺ d))
-      ( ( transitive-leq-ℝ
-          ( x)
-          ( max-ℝ x z)
-          ( max-ℝ x z +ℝ real-ℚ (rational-ℚ⁺ d))
-          ( leq-le-ℝ
+  abstract
+    preserves-lower-neighborhood-leq-left-max-ℝ :
+      leq-ℝ y (z +ℝ real-ℚ⁺ d) →
+      leq-ℝ
+        ( max-ℝ x y)
+        ( (max-ℝ x z) +ℝ real-ℚ⁺ d)
+    preserves-lower-neighborhood-leq-left-max-ℝ z≤y+d =
+      leq-is-least-binary-upper-bound-Large-Poset
+        ( ℝ-Large-Poset)
+        ( x)
+        ( y)
+        ( is-least-binary-upper-bound-max-ℝ x y)
+        ( (max-ℝ x z) +ℝ real-ℚ⁺ d)
+        ( ( transitive-leq-ℝ
+            ( x)
             ( max-ℝ x z)
-            ( max-ℝ x z +ℝ real-ℚ (rational-ℚ⁺ d))
-            ( le-left-add-real-ℝ⁺
+            ( max-ℝ x z +ℝ real-ℚ⁺ d)
+            ( leq-le-ℝ
               ( max-ℝ x z)
-              ( positive-real-ℚ⁺ d)))
-          ( leq-left-max-ℝ x z)) ,
-        ( transitive-leq-ℝ
-          ( y)
-          ( z +ℝ real-ℚ (rational-ℚ⁺ d))
-          ( max-ℝ x z +ℝ real-ℚ (rational-ℚ⁺ d))
-          ( preserves-leq-right-add-ℝ
-            ( real-ℚ (rational-ℚ⁺ d))
-            ( z)
-            ( max-ℝ x z)
-            ( leq-right-max-ℝ x z))
-          ( z≤y+d)))
+              ( max-ℝ x z +ℝ real-ℚ⁺ d)
+              ( le-left-add-real-ℝ⁺
+                ( max-ℝ x z)
+                ( positive-real-ℚ⁺ d)))
+            ( leq-left-max-ℝ x z)) ,
+          ( transitive-leq-ℝ
+            ( y)
+            ( z +ℝ real-ℚ⁺ d)
+            ( max-ℝ x z +ℝ real-ℚ⁺ d)
+            ( preserves-leq-right-add-ℝ
+              ( real-ℚ⁺ d)
+              ( z)
+              ( max-ℝ x z)
+              ( leq-right-max-ℝ x z))
+            ( z≤y+d)))
 
-  preserves-lower-neighborhood-leq-right-max-ℝ :
-    leq-ℝ y (z +ℝ real-ℚ (rational-ℚ⁺ d)) →
-    leq-ℝ
-      ( max-ℝ y x)
-      ( (max-ℝ z x) +ℝ real-ℚ (rational-ℚ⁺ d))
-  preserves-lower-neighborhood-leq-right-max-ℝ z≤y+d =
-    binary-tr
-      ( λ u v → leq-ℝ u (v +ℝ real-ℚ (rational-ℚ⁺ d)))
-      ( commutative-max-ℝ x y)
-      ( commutative-max-ℝ x z)
-      ( preserves-lower-neighborhood-leq-left-max-ℝ z≤y+d)
+    preserves-lower-neighborhood-leq-right-max-ℝ :
+      leq-ℝ y (z +ℝ real-ℚ⁺ d) →
+      leq-ℝ
+        ( max-ℝ y x)
+        ( (max-ℝ z x) +ℝ real-ℚ⁺ d)
+    preserves-lower-neighborhood-leq-right-max-ℝ z≤y+d =
+      binary-tr
+        ( λ u v → leq-ℝ u (v +ℝ real-ℚ⁺ d))
+        ( commutative-max-ℝ x y)
+        ( commutative-max-ℝ x z)
+        ( preserves-lower-neighborhood-leq-left-max-ℝ z≤y+d)
 ```
 
 ### The maximum with a real number is a short function `ℝ → ℝ`
@@ -311,20 +322,21 @@ module _
   {l1 l2 : Level} (x : ℝ l1)
   where
 
-  is-short-function-left-max-ℝ :
-    is-short-function-Metric-Space
-      ( metric-space-ℝ l2)
-      ( metric-space-ℝ (l1 ⊔ l2))
-      ( max-ℝ x)
-  is-short-function-left-max-ℝ d y z Nyz =
-    neighborhood-real-bound-each-leq-ℝ
-      ( d)
-      ( max-ℝ x y)
-      ( max-ℝ x z)
-      ( preserves-lower-neighborhood-leq-left-max-ℝ d x y z
-        ( left-leq-real-bound-neighborhood-ℝ d y z Nyz))
-      ( preserves-lower-neighborhood-leq-left-max-ℝ d x z y
-        ( right-leq-real-bound-neighborhood-ℝ d y z Nyz))
+  abstract
+    is-short-function-left-max-ℝ :
+      is-short-function-Metric-Space
+        ( metric-space-ℝ l2)
+        ( metric-space-ℝ (l1 ⊔ l2))
+        ( max-ℝ x)
+    is-short-function-left-max-ℝ d y z Nyz =
+      neighborhood-real-bound-each-leq-ℝ
+        ( d)
+        ( max-ℝ x y)
+        ( max-ℝ x z)
+        ( preserves-lower-neighborhood-leq-left-max-ℝ d x y z
+          ( left-leq-real-bound-neighborhood-ℝ d y z Nyz))
+        ( preserves-lower-neighborhood-leq-left-max-ℝ d x z y
+          ( right-leq-real-bound-neighborhood-ℝ d y z Nyz))
 
   short-left-max-ℝ :
     short-function-Metric-Space
@@ -341,22 +353,23 @@ module _
   {l1 l2 : Level}
   where
 
-  is-short-function-short-left-max-ℝ :
-    is-short-function-Metric-Space
-      ( metric-space-ℝ l1)
-      ( metric-space-of-short-functions-Metric-Space
-        ( metric-space-ℝ l2)
-        ( metric-space-ℝ (l1 ⊔ l2)))
-      ( short-left-max-ℝ)
-  is-short-function-short-left-max-ℝ d x y Nxy z =
-    neighborhood-real-bound-each-leq-ℝ
-      ( d)
-      ( max-ℝ x z)
-      ( max-ℝ y z)
-      ( preserves-lower-neighborhood-leq-right-max-ℝ d z x y
-        ( left-leq-real-bound-neighborhood-ℝ d x y Nxy))
-      ( preserves-lower-neighborhood-leq-right-max-ℝ d z y x
-        ( right-leq-real-bound-neighborhood-ℝ d x y Nxy))
+  abstract
+    is-short-function-short-left-max-ℝ :
+      is-short-function-Metric-Space
+        ( metric-space-ℝ l1)
+        ( metric-space-of-short-functions-Metric-Space
+          ( metric-space-ℝ l2)
+          ( metric-space-ℝ (l1 ⊔ l2)))
+        ( short-left-max-ℝ)
+    is-short-function-short-left-max-ℝ d x y Nxy z =
+      neighborhood-real-bound-each-leq-ℝ
+        ( d)
+        ( max-ℝ x z)
+        ( max-ℝ y z)
+        ( preserves-lower-neighborhood-leq-right-max-ℝ d z x y
+          ( left-leq-real-bound-neighborhood-ℝ d x y Nxy))
+        ( preserves-lower-neighborhood-leq-right-max-ℝ d z y x
+          ( right-leq-real-bound-neighborhood-ℝ d x y Nxy))
 
   short-max-ℝ :
     short-function-Metric-Space
@@ -375,55 +388,56 @@ module _
   {l1 l2 : Level} (x : ℝ l1) (y : ℝ l2)
   where
 
-  approximate-below-max-ℝ :
-    (ε : ℚ⁺) →
-    type-disjunction-Prop
-      ( le-ℝ-Prop (max-ℝ x y -ℝ real-ℚ⁺ ε) x)
-      ( le-ℝ-Prop (max-ℝ x y -ℝ real-ℚ⁺ ε) y)
-  approximate-below-max-ℝ ε⁺@(ε , _) =
-    let
-      motive =
-        ( le-ℝ-Prop (max-ℝ x y -ℝ real-ℚ ε) x) ∨
-        ( le-ℝ-Prop (max-ℝ x y -ℝ real-ℚ ε) y)
-      open do-syntax-trunc-Prop motive
-    in do
-      (q , max-ε<q , q<max) ←
-        dense-rational-le-ℝ
-          ( max-ℝ x y -ℝ real-ℚ ε)
-          ( max-ℝ x y)
-          ( le-diff-real-ℝ⁺ (max-ℝ x y) (positive-real-ℚ⁺ ε⁺))
-      (r , q-<ℝ-r , r<max) ← dense-rational-le-ℝ (real-ℚ q) (max-ℝ x y) q<max
-      let q<r = reflects-le-real-ℚ q r q-<ℝ-r
-      elim-disjunction motive
-        ( λ q<x →
-          inl-disjunction
-            ( transitive-le-ℝ
-              ( max-ℝ x y -ℝ real-ℚ ε)
-              ( real-ℚ q)
-              ( x)
-              ( le-real-is-in-lower-cut-ℚ q x q<x)
-              ( max-ε<q)))
-        ( λ x<r →
-          elim-disjunction motive
-            ( λ q<y →
-              inr-disjunction
-                ( transitive-le-ℝ
-                  ( max-ℝ x y -ℝ real-ℚ ε)
-                  ( real-ℚ q)
-                  ( y)
-                  ( le-real-is-in-lower-cut-ℚ q y q<y)
-                  ( max-ε<q)))
-            ( λ y<r →
-              ex-falso
-                ( irreflexive-le-ℝ
-                  ( max-ℝ x y)
-                  ( concatenate-leq-le-ℝ (max-ℝ x y) (real-ℚ r) (max-ℝ x y)
-                    ( leq-max-leq-leq-ℝ x y (real-ℚ r)
-                      ( leq-le-ℝ x (real-ℚ r)
-                        ( le-real-is-in-upper-cut-ℚ r x x<r))
-                      ( leq-le-ℝ y (real-ℚ r)
-                        ( le-real-is-in-upper-cut-ℚ r y y<r)))
-                    ( r<max))))
-            ( is-located-lower-upper-cut-ℝ y q r q<r))
-        ( is-located-lower-upper-cut-ℝ x q r q<r)
+  abstract
+    approximate-below-max-ℝ :
+      (ε : ℚ⁺) →
+      type-disjunction-Prop
+        ( le-ℝ-Prop (max-ℝ x y -ℝ real-ℚ⁺ ε) x)
+        ( le-ℝ-Prop (max-ℝ x y -ℝ real-ℚ⁺ ε) y)
+    approximate-below-max-ℝ ε⁺@(ε , _) =
+      let
+        motive =
+          ( le-ℝ-Prop (max-ℝ x y -ℝ real-ℚ ε) x) ∨
+          ( le-ℝ-Prop (max-ℝ x y -ℝ real-ℚ ε) y)
+        open do-syntax-trunc-Prop motive
+      in do
+        (q , max-ε<q , q<max) ←
+          dense-rational-le-ℝ
+            ( max-ℝ x y -ℝ real-ℚ ε)
+            ( max-ℝ x y)
+            ( le-diff-real-ℝ⁺ (max-ℝ x y) (positive-real-ℚ⁺ ε⁺))
+        (r , q-<ℝ-r , r<max) ← dense-rational-le-ℝ (real-ℚ q) (max-ℝ x y) q<max
+        let q<r = reflects-le-real-ℚ q r q-<ℝ-r
+        elim-disjunction motive
+          ( λ q<x →
+            inl-disjunction
+              ( transitive-le-ℝ
+                ( max-ℝ x y -ℝ real-ℚ ε)
+                ( real-ℚ q)
+                ( x)
+                ( le-real-is-in-lower-cut-ℚ q x q<x)
+                ( max-ε<q)))
+          ( λ x<r →
+            elim-disjunction motive
+              ( λ q<y →
+                inr-disjunction
+                  ( transitive-le-ℝ
+                    ( max-ℝ x y -ℝ real-ℚ ε)
+                    ( real-ℚ q)
+                    ( y)
+                    ( le-real-is-in-lower-cut-ℚ q y q<y)
+                    ( max-ε<q)))
+              ( λ y<r →
+                ex-falso
+                  ( irreflexive-le-ℝ
+                    ( max-ℝ x y)
+                    ( concatenate-leq-le-ℝ (max-ℝ x y) (real-ℚ r) (max-ℝ x y)
+                      ( leq-max-leq-leq-ℝ x y (real-ℚ r)
+                        ( leq-le-ℝ x (real-ℚ r)
+                          ( le-real-is-in-upper-cut-ℚ r x x<r))
+                        ( leq-le-ℝ y (real-ℚ r)
+                          ( le-real-is-in-upper-cut-ℚ r y y<r)))
+                      ( r<max))))
+              ( is-located-lower-upper-cut-ℝ y q r q<r))
+          ( is-located-lower-upper-cut-ℝ x q r q<r)
 ```

--- a/src/real-numbers/binary-minimum-real-numbers.lagda.md
+++ b/src/real-numbers/binary-minimum-real-numbers.lagda.md
@@ -1,9 +1,9 @@
-# The minimum of real numbers
+# The binary minimum of real numbers
 
 ```agda
 {-# OPTIONS --lossy-unification #-}
 
-module real-numbers.minimum-real-numbers where
+module real-numbers.binary-minimum-real-numbers where
 ```
 
 <details><summary>Imports</summary>
@@ -21,6 +21,7 @@ open import foundation.universe-levels
 
 open import order-theory.greatest-lower-bounds-large-posets
 open import order-theory.large-meet-semilattices
+open import order-theory.meet-semilattices
 
 open import real-numbers.addition-real-numbers
 open import real-numbers.dedekind-real-numbers
@@ -108,7 +109,7 @@ module _
   where
 
   opaque
-    unfolding min-ℝ
+    unfolding leq-ℝ-Prop min-ℝ
 
     is-greatest-binary-lower-bound-min-ℝ :
       is-greatest-binary-lower-bound-Large-Poset
@@ -129,6 +130,34 @@ module _
       forward-implication (is-greatest-binary-lower-bound-min-ℝ z) (x≤z , y≤z)
 ```
 
+### The binary minimum is a binary lower bound
+
+```agda
+module _
+  {l1 l2 : Level}
+  (x : ℝ l1) (y : ℝ l2)
+  where
+
+  abstract
+    leq-left-min-ℝ : leq-ℝ (min-ℝ x y) x
+    leq-left-min-ℝ =
+      pr1
+        ( is-binary-lower-bound-is-greatest-binary-lower-bound-Large-Poset
+          ( ℝ-Large-Poset)
+          ( x)
+          ( y)
+          ( is-greatest-binary-lower-bound-min-ℝ x y))
+
+    leq-right-min-ℝ : leq-ℝ (min-ℝ x y) y
+    leq-right-min-ℝ =
+      pr2
+        ( is-binary-lower-bound-is-greatest-binary-lower-bound-Large-Poset
+          ( ℝ-Large-Poset)
+          ( x)
+          ( y)
+          ( is-greatest-binary-lower-bound-min-ℝ x y))
+```
+
 ### The large poset of real numbers has meets
 
 ```agda
@@ -136,6 +165,15 @@ has-meets-ℝ-Large-Poset : has-meets-Large-Poset ℝ-Large-Poset
 meet-has-meets-Large-Poset has-meets-ℝ-Large-Poset = min-ℝ
 is-greatest-binary-lower-bound-meet-has-meets-Large-Poset
   has-meets-ℝ-Large-Poset = is-greatest-binary-lower-bound-min-ℝ
+```
+
+### The real numbers at a specific universe level are a meet semilattice
+
+```agda
+ℝ-Order-Theoretic-Meet-Semilattice :
+  (l : Level) → Order-Theoretic-Meet-Semilattice (lsuc l) l
+ℝ-Order-Theoretic-Meet-Semilattice l =
+  ( ℝ-Poset l , λ x y → (min-ℝ x y , is-greatest-binary-lower-bound-min-ℝ x y))
 ```
 
 ### For any `ε : ℚ⁺`, `(x < min-ℝ x y + ε) ∨ (y < min-ℝ x y + ε)`

--- a/src/real-numbers/binary-minimum-real-numbers.lagda.md
+++ b/src/real-numbers/binary-minimum-real-numbers.lagda.md
@@ -25,10 +25,10 @@ open import order-theory.large-meet-semilattices
 open import order-theory.meet-semilattices
 
 open import real-numbers.addition-real-numbers
+open import real-numbers.binary-maximum-real-numbers
 open import real-numbers.dedekind-real-numbers
 open import real-numbers.difference-real-numbers
 open import real-numbers.inequality-real-numbers
-open import real-numbers.maximum-real-numbers
 open import real-numbers.negation-real-numbers
 open import real-numbers.rational-real-numbers
 open import real-numbers.strict-inequality-real-numbers
@@ -68,7 +68,7 @@ module _
   where
 
   opaque
-    unfolding leq-ℝ-Prop min-ℝ
+    unfolding leq-ℝ min-ℝ
 
     is-greatest-binary-lower-bound-min-ℝ :
       is-greatest-binary-lower-bound-Large-Poset
@@ -164,8 +164,8 @@ module _
     approximate-above-min-ℝ :
       (ε : ℚ⁺) →
       type-disjunction-Prop
-        ( le-ℝ-Prop x (min-ℝ x y +ℝ real-ℚ⁺ ε))
-        ( le-ℝ-Prop y (min-ℝ x y +ℝ real-ℚ⁺ ε))
+        ( le-prop-ℝ x (min-ℝ x y +ℝ real-ℚ⁺ ε))
+        ( le-prop-ℝ y (min-ℝ x y +ℝ real-ℚ⁺ ε))
     approximate-above-min-ℝ ε =
       let
         case :
@@ -179,8 +179,8 @@ module _
             ( neg-le-ℝ _ (neg-ℝ w) max-ε<-w)
       in
         elim-disjunction
-          ( (le-ℝ-Prop x (min-ℝ x y +ℝ real-ℚ⁺ ε)) ∨
-            (le-ℝ-Prop y (min-ℝ x y +ℝ real-ℚ⁺ ε)))
+          ( (le-prop-ℝ x (min-ℝ x y +ℝ real-ℚ⁺ ε)) ∨
+            (le-prop-ℝ y (min-ℝ x y +ℝ real-ℚ⁺ ε)))
           ( λ max-ε<-x → inl-disjunction (case x max-ε<-x))
           ( λ max-ε<-y → inr-disjunction (case y max-ε<-y))
           ( approximate-below-max-ℝ (neg-ℝ x) (neg-ℝ y) ε)

--- a/src/real-numbers/cauchy-completeness-dedekind-real-numbers.lagda.md
+++ b/src/real-numbers/cauchy-completeness-dedekind-real-numbers.lagda.md
@@ -301,7 +301,9 @@ module _
     is-inhabited-upper-cut-lim-cauchy-approximation-ℝ ,
     is-rounded-upper-cut-lim-cauchy-approximation-ℝ
 
-  abstract
+  opaque
+    unfolding neighborhood-prop-ℝ
+
     is-disjoint-cut-lim-cauchy-approximation-ℝ :
       (q : ℚ) →
       ¬ ( is-in-subtype lower-cut-lim-cauchy-approximation-ℝ q ×
@@ -406,13 +408,14 @@ module _
                       ( 2ε⁺<ε'⁺)
                       ( 2ε⁺<ε'⁺)))))))
 
-  lim-cauchy-approximation-ℝ : ℝ l
-  lim-cauchy-approximation-ℝ =
-    real-lower-upper-ℝ
-      ( lower-real-lim-cauchy-approximation-ℝ)
-      ( upper-real-lim-cauchy-approximation-ℝ)
-      ( is-disjoint-cut-lim-cauchy-approximation-ℝ)
-      ( is-located-lower-upper-cut-lim-cauchy-approximation-ℝ)
+  opaque
+    lim-cauchy-approximation-ℝ : ℝ l
+    lim-cauchy-approximation-ℝ =
+      real-lower-upper-ℝ
+        ( lower-real-lim-cauchy-approximation-ℝ)
+        ( upper-real-lim-cauchy-approximation-ℝ)
+        ( is-disjoint-cut-lim-cauchy-approximation-ℝ)
+        ( is-located-lower-upper-cut-lim-cauchy-approximation-ℝ)
 ```
 
 ### The limit satisfies the definition of a limit of a Cauchy approximation
@@ -422,93 +425,110 @@ module _
   {l : Level} (x : cauchy-approximation-ℝ l)
   where
 
-  is-limit-lim-cauchy-approximation-ℝ :
-    is-limit-cauchy-approximation-Metric-Space
-      ( metric-space-ℝ l)
-      ( x)
-      ( lim-cauchy-approximation-ℝ x)
-  is-limit-lim-cauchy-approximation-ℝ ε⁺@(ε , _) θ⁺@(θ , _) =
-    let
-      open
-        do-syntax-trunc-Prop
-          ( neighborhood-prop-ℝ
-            ( l)
-            ( ε⁺ +ℚ⁺ θ⁺)
-            ( map-cauchy-approximation-ℝ x ε⁺)
-            ( lim-cauchy-approximation-ℝ x))
-      lim = lim-cauchy-approximation-ℝ x
-      xε = map-cauchy-approximation-ℝ x ε⁺
-      θ'⁺@(θ' , _) = left-summand-split-ℚ⁺ θ⁺
-      θ''⁺@(θ'' , _) = right-summand-split-ℚ⁺ θ⁺
-      ε+θ'+θ''=ε+θ =
-        associative-add-ℚ _ _ _ ∙
-        ap (ε +ℚ_) (ap rational-ℚ⁺ (eq-add-split-ℚ⁺ θ⁺))
-      ε+θ = real-ℚ (ε +ℚ θ)
-      ε+θ' = real-ℚ (ε +ℚ θ')
-    in do
-      ( r , xε+ε+θ'<r , r<xε+ε+θ) ←
-        tr
-          ( le-ℝ (xε +ℝ ε+θ'))
-          ( associative-add-ℝ _ _ _ ∙
-            ap ( xε +ℝ_) (add-real-ℚ _ _ ∙ ap real-ℚ ε+θ'+θ''=ε+θ))
-          ( le-left-add-real-ℝ⁺
-            ( xε +ℝ ε+θ')
-            ( positive-real-ℚ⁺ θ''⁺))
-      ( q , xε-ε-θ<q , q<xε-ε-θ') ←
-        tr
-          ( λ y → le-ℝ y (xε -ℝ ε+θ'))
-          ( associative-add-ℝ _ _ _ ∙
-            ap
-              ( xε +ℝ_)
-              ( inv (distributive-neg-add-ℝ _ _) ∙
-                ap neg-ℝ (add-real-ℚ _ _ ∙ ap real-ℚ ε+θ'+θ''=ε+θ)))
-          ( le-diff-real-ℝ⁺ (xε -ℝ ε+θ') (positive-real-ℚ⁺ θ''⁺))
-      neighborhood-dist-ℝ
-        ( ε⁺ +ℚ⁺ θ⁺)
-        ( xε)
-        ( lim)
-        ( leq-dist-leq-diff-ℝ
-          ( _)
-          ( _)
-          ( ε+θ)
-          ( swap-right-diff-leq-ℝ
-            ( xε)
+  opaque
+    unfolding le-ℝ-Prop
+    unfolding lim-cauchy-approximation-ℝ
+
+    is-limit-lim-cauchy-approximation-ℝ :
+      is-limit-cauchy-approximation-Metric-Space
+        ( metric-space-ℝ l)
+        ( x)
+        ( lim-cauchy-approximation-ℝ x)
+    is-limit-lim-cauchy-approximation-ℝ ε⁺@(ε , _) θ⁺@(θ , _) =
+      let
+        open
+          do-syntax-trunc-Prop
+            ( neighborhood-prop-ℝ
+              ( l)
+              ( ε⁺ +ℚ⁺ θ⁺)
+              ( map-cauchy-approximation-ℝ x ε⁺)
+              ( lim-cauchy-approximation-ℝ x))
+        lim = lim-cauchy-approximation-ℝ x
+        xε = map-cauchy-approximation-ℝ x ε⁺
+        θ'⁺@(θ' , _) = left-summand-split-ℚ⁺ θ⁺
+        θ''⁺@(θ'' , _) = right-summand-split-ℚ⁺ θ⁺
+        ε+θ'+θ''=ε+θ =
+          associative-add-ℚ _ _ _ ∙
+          ap (ε +ℚ_) (ap rational-ℚ⁺ (eq-add-split-ℚ⁺ θ⁺))
+        ε+θ = real-ℚ (ε +ℚ θ)
+        ε+θ' = real-ℚ (ε +ℚ θ')
+      in do
+        ( r , xε+ε+θ'<r , r<xε+ε+θ) ←
+          tr
+            ( le-ℝ (xε +ℝ ε+θ'))
+            ( associative-add-ℝ _ _ _ ∙
+              ap ( xε +ℝ_) (add-real-ℚ _ _ ∙ ap real-ℚ ε+θ'+θ''=ε+θ))
+            ( le-left-add-real-ℝ⁺
+              ( xε +ℝ ε+θ')
+              ( positive-real-ℚ⁺ θ''⁺))
+        ( q , xε-ε-θ<q , q<xε-ε-θ') ←
+          tr
+            ( λ y → le-ℝ y (xε -ℝ ε+θ'))
+            ( associative-add-ℝ _ _ _ ∙
+              ap
+                ( xε +ℝ_)
+                ( inv (distributive-neg-add-ℝ _ _) ∙
+                  ap neg-ℝ (add-real-ℚ _ _ ∙ ap real-ℚ ε+θ'+θ''=ε+θ)))
+            ( le-diff-real-ℝ⁺ (xε -ℝ ε+θ') (positive-real-ℚ⁺ θ''⁺))
+        neighborhood-dist-ℝ
+          ( ε⁺ +ℚ⁺ θ⁺)
+          ( xε)
+          ( lim)
+          ( leq-dist-leq-diff-ℝ
+            ( _)
+            ( _)
             ( ε+θ)
-            ( lim)
-            ( leq-le-ℝ
-              ( xε -ℝ ε+θ)
-              ( lim)
-              ( intro-exists
-                ( q)
-                ( xε-ε-θ<q ,
-                  intro-exists
-                    ( ε⁺ , θ'⁺)
-                    ( transpose-is-in-lower-cut-diff-ℝ
-                      ( xε)
-                      ( ε +ℚ θ')
-                      ( q)
-                      ( q<xε-ε-θ'))))))
-          ( swap-right-diff-leq-ℝ
-            ( lim)
-            ( real-ℚ (ε +ℚ θ))
-            ( xε)
-            ( leq-transpose-right-add-ℝ
-              ( lim)
+            ( swap-right-diff-leq-ℝ
               ( xε)
               ( ε+θ)
+              ( lim)
               ( leq-le-ℝ
+                ( xε -ℝ ε+θ)
                 ( lim)
-                ( xε +ℝ ε+θ)
                 ( intro-exists
-                  ( r)
+                  ( q)
+                  ( xε-ε-θ<q ,
+                    intro-exists
+                      ( ε⁺ , θ'⁺)
+                      ( transpose-is-in-lower-cut-diff-ℝ
+                        ( xε)
+                        ( ε +ℚ θ')
+                        ( q)
+                        ( q<xε-ε-θ'))))))
+            ( swap-right-diff-leq-ℝ
+              ( lim)
+              ( real-ℚ (ε +ℚ θ))
+              ( xε)
+              ( leq-transpose-right-add-ℝ
+                ( lim)
+                ( xε)
+                ( ε+θ)
+                ( leq-le-ℝ
+                  ( lim)
+                  ( xε +ℝ ε+θ)
                   ( intro-exists
-                    ( ε⁺ , θ'⁺)
-                    ( transpose-is-in-upper-cut-add-ℝ
-                      ( xε)
-                      ( ε +ℚ θ')
-                      ( r)
-                      ( xε+ε+θ'<r)) ,
-                    r<xε+ε+θ))))))
+                    ( r)
+                    ( intro-exists
+                      ( ε⁺ , θ'⁺)
+                      ( transpose-is-in-upper-cut-add-ℝ
+                        ( xε)
+                        ( ε +ℚ θ')
+                        ( r)
+                        ( xε+ε+θ'<r)) ,
+                      r<xε+ε+θ))))))
+
+  abstract
+    saturated-is-limit-lim-cauchy-approximation-ℝ :
+      (ε : ℚ⁺) →
+      neighborhood-ℝ l ε
+        ( map-cauchy-approximation-ℝ x ε)
+        ( lim-cauchy-approximation-ℝ x)
+    saturated-is-limit-lim-cauchy-approximation-ℝ =
+      saturated-is-limit-cauchy-approximation-Metric-Space
+        ( metric-space-ℝ l)
+        ( x)
+        ( _)
+        ( is-limit-lim-cauchy-approximation-ℝ)
 
   is-convergent-cauchy-approximation-ℝ :
     is-convergent-cauchy-approximation-Metric-Space

--- a/src/real-numbers/cauchy-completeness-dedekind-real-numbers.lagda.md
+++ b/src/real-numbers/cauchy-completeness-dedekind-real-numbers.lagda.md
@@ -302,7 +302,7 @@ module _
     is-rounded-upper-cut-lim-cauchy-approximation-ℝ
 
   opaque
-    unfolding neighborhood-prop-ℝ
+    unfolding neighborhood-ℝ
 
     is-disjoint-cut-lim-cauchy-approximation-ℝ :
       (q : ℚ) →
@@ -426,8 +426,7 @@ module _
   where
 
   opaque
-    unfolding le-ℝ-Prop
-    unfolding lim-cauchy-approximation-ℝ
+    unfolding le-ℝ lim-cauchy-approximation-ℝ
 
     is-limit-lim-cauchy-approximation-ℝ :
       is-limit-cauchy-approximation-Metric-Space

--- a/src/real-numbers/difference-real-numbers.lagda.md
+++ b/src/real-numbers/difference-real-numbers.lagda.md
@@ -12,6 +12,7 @@ module real-numbers.difference-real-numbers where
 open import elementary-number-theory.difference-rational-numbers
 open import elementary-number-theory.rational-numbers
 
+open import foundation.action-on-identifications-binary-functions
 open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types
 open import foundation.identity-types
@@ -40,6 +41,12 @@ diff-ℝ x y = add-ℝ x (neg-ℝ y)
 
 infixl 36 _-ℝ_
 _-ℝ_ = diff-ℝ
+
+ap-diff-ℝ :
+  {l1 : Level} {x x' : ℝ l1} → (x ＝ x') →
+  {l2 : Level} {y y' : ℝ l2} → (y ＝ y') →
+  (x -ℝ y) ＝ (x' -ℝ y')
+ap-diff-ℝ x=x' y=y' = ap-binary diff-ℝ x=x' y=y'
 ```
 
 ## Properties

--- a/src/real-numbers/distance-real-numbers.lagda.md
+++ b/src/real-numbers/distance-real-numbers.lagda.md
@@ -79,11 +79,13 @@ Two real numbers `x` and `y` are in an `ε`-neighborhood of each other if and
 only if their distance is at most `ε`.
 
 ```agda
-abstract
+opaque
+  unfolding leq-ℝ-Prop neighborhood-prop-ℝ
+
   diff-bound-neighborhood-ℝ :
     {l : Level} → (d : ℚ⁺) (x y : ℝ l) →
     neighborhood-ℝ l d x y →
-    x -ℝ y ≤-ℝ real-ℚ (rational-ℚ⁺ d)
+    x -ℝ y ≤-ℝ real-ℚ⁺ d
   diff-bound-neighborhood-ℝ d⁺@(d , _) x y (H , K) =
     leq-transpose-right-add-ℝ
       ( x)
@@ -101,17 +103,18 @@ abstract
               ( q -ℚ d)
               ( inv-tr (is-in-lower-cut-ℝ x) (is-section-diff-ℚ d q) q<x))))
 
+abstract
   reversed-diff-bound-neighborhood-ℝ :
     {l : Level} → (d : ℚ⁺) (x y : ℝ l) →
     neighborhood-ℝ l d x y →
-    y -ℝ x ≤-ℝ real-ℚ (rational-ℚ⁺ d)
+    y -ℝ x ≤-ℝ real-ℚ⁺ d
   reversed-diff-bound-neighborhood-ℝ d x y H =
     diff-bound-neighborhood-ℝ d y x (is-symmetric-neighborhood-ℝ d x y H)
 
   leq-dist-neighborhood-ℝ :
     {l : Level} → (d : ℚ⁺) (x y : ℝ l) →
     neighborhood-ℝ l d x y →
-    dist-ℝ x y ≤-ℝ real-ℚ (rational-ℚ⁺ d)
+    dist-ℝ x y ≤-ℝ real-ℚ⁺ d
   leq-dist-neighborhood-ℝ d⁺@(d , _) x y H =
     leq-abs-leq-leq-neg-ℝ
       ( x -ℝ y)
@@ -124,7 +127,7 @@ abstract
 
   lower-neighborhood-diff-ℝ :
     {l : Level} → (d : ℚ⁺) (x y : ℝ l) →
-    x -ℝ y ≤-ℝ real-ℚ (rational-ℚ⁺ d) →
+    x -ℝ y ≤-ℝ real-ℚ⁺ d →
     lower-neighborhood-ℝ d y x
   lower-neighborhood-diff-ℝ d⁺@(d , _) x y x-y≤d q q+d<x =
     is-in-lower-cut-le-real-ℚ
@@ -140,9 +143,12 @@ abstract
           ( transpose-add-is-in-lower-cut-ℝ x q d q+d<x))
         ( swap-right-diff-leq-ℝ x y (real-ℚ d) x-y≤d))
 
+opaque
+  unfolding neighborhood-prop-ℝ
+
   neighborhood-dist-ℝ :
     {l : Level} → (d : ℚ⁺) (x y : ℝ l) →
-    dist-ℝ x y ≤-ℝ real-ℚ (rational-ℚ⁺ d) →
+    dist-ℝ x y ≤-ℝ real-ℚ⁺ d →
     neighborhood-ℝ l d x y
   neighborhood-dist-ℝ d⁺@(d , _) x y |x-y|≤d =
     ( lower-neighborhood-diff-ℝ
@@ -169,10 +175,11 @@ abstract
         ( |x-y|≤d)
         ( leq-abs-ℝ _)))
 
+abstract
   neighborhood-iff-leq-dist-ℝ :
     {l : Level} → (d : ℚ⁺) (x y : ℝ l) →
     neighborhood-ℝ l d x y ↔
-    dist-ℝ x y ≤-ℝ real-ℚ (rational-ℚ⁺ d)
+    dist-ℝ x y ≤-ℝ real-ℚ⁺ d
   neighborhood-iff-leq-dist-ℝ d x y =
     ( leq-dist-neighborhood-ℝ d x y ,
       neighborhood-dist-ℝ d x y)

--- a/src/real-numbers/distance-real-numbers.lagda.md
+++ b/src/real-numbers/distance-real-numbers.lagda.md
@@ -80,7 +80,7 @@ only if their distance is at most `ε`.
 
 ```agda
 opaque
-  unfolding leq-ℝ-Prop neighborhood-prop-ℝ
+  unfolding leq-ℝ neighborhood-ℝ
 
   diff-bound-neighborhood-ℝ :
     {l : Level} → (d : ℚ⁺) (x y : ℝ l) →
@@ -144,7 +144,7 @@ abstract
         ( swap-right-diff-leq-ℝ x y (real-ℚ d) x-y≤d))
 
 opaque
-  unfolding neighborhood-prop-ℝ
+  unfolding neighborhood-ℝ
 
   neighborhood-dist-ℝ :
     {l : Level} → (d : ℚ⁺) (x y : ℝ l) →

--- a/src/real-numbers/inequality-lower-dedekind-real-numbers.lagda.md
+++ b/src/real-numbers/inequality-lower-dedekind-real-numbers.lagda.md
@@ -56,6 +56,9 @@ module _
 
   leq-lower-ℝ : UU (l1 ⊔ l2)
   leq-lower-ℝ = type-Prop leq-lower-ℝ-Prop
+
+  is-prop-leq-lower-ℝ : is-prop leq-lower-ℝ
+  is-prop-leq-lower-ℝ = is-prop-type-Prop leq-lower-ℝ-Prop
 ```
 
 ## Properties

--- a/src/real-numbers/inequality-real-numbers.lagda.md
+++ b/src/real-numbers/inequality-real-numbers.lagda.md
@@ -69,11 +69,14 @@ module _
   where
 
   opaque
-    leq-ℝ-Prop : Prop (l1 ⊔ l2)
-    leq-ℝ-Prop = leq-lower-ℝ-Prop (lower-real-ℝ x) (lower-real-ℝ y)
+    leq-ℝ : UU (l1 ⊔ l2)
+    leq-ℝ = leq-lower-ℝ (lower-real-ℝ x) (lower-real-ℝ y)
 
-  leq-ℝ : UU (l1 ⊔ l2)
-  leq-ℝ = type-Prop leq-ℝ-Prop
+    is-prop-leq-ℝ : is-prop leq-ℝ
+    is-prop-leq-ℝ = is-prop-leq-lower-ℝ (lower-real-ℝ x) (lower-real-ℝ y)
+
+  leq-prop-ℝ : Prop (l1 ⊔ l2)
+  leq-prop-ℝ = (leq-ℝ , is-prop-leq-ℝ)
 
 infix 30 _≤-ℝ_
 _≤-ℝ_ = leq-ℝ
@@ -89,14 +92,17 @@ module _
   where
 
   opaque
-    leq-ℝ-Prop' : Prop (l1 ⊔ l2)
-    leq-ℝ-Prop' = leq-upper-ℝ-Prop (upper-real-ℝ x) (upper-real-ℝ y)
+    leq-ℝ' : UU (l1 ⊔ l2)
+    leq-ℝ' = leq-upper-ℝ (upper-real-ℝ x) (upper-real-ℝ y)
 
-  leq-ℝ' : UU (l1 ⊔ l2)
-  leq-ℝ' = type-Prop leq-ℝ-Prop'
+    is-prop-leq-ℝ' : is-prop leq-ℝ'
+    is-prop-leq-ℝ' = is-prop-leq-upper-ℝ (upper-real-ℝ x) (upper-real-ℝ y)
+
+  leq-prop-ℝ' : Prop (l1 ⊔ l2)
+  leq-prop-ℝ' = (leq-ℝ' , is-prop-leq-ℝ')
 
   opaque
-    unfolding leq-ℝ-Prop leq-ℝ-Prop'
+    unfolding leq-ℝ leq-ℝ'
 
     leq'-leq-ℝ : leq-ℝ x y → leq-ℝ'
     leq'-leq-ℝ lx⊆ly q y<q =
@@ -144,7 +150,7 @@ module _
 
 ```agda
 opaque
-  unfolding leq-ℝ-Prop
+  unfolding leq-ℝ
 
   refl-leq-ℝ : {l : Level} → (x : ℝ l) → leq-ℝ x x
   refl-leq-ℝ x = refl-leq-Large-Preorder lower-ℝ-Large-Preorder (lower-real-ℝ x)
@@ -153,7 +159,7 @@ opaque
   leq-eq-ℝ x y x=y = tr (leq-ℝ x) x=y (refl-leq-ℝ x)
 
 opaque
-  unfolding leq-ℝ-Prop sim-ℝ
+  unfolding leq-ℝ sim-ℝ
 
   leq-sim-ℝ : {l1 l2 : Level} → (x : ℝ l1) (y : ℝ l2) → sim-ℝ x y → leq-ℝ x y
   leq-sim-ℝ _ _ = pr1
@@ -163,7 +169,7 @@ opaque
 
 ```agda
 opaque
-  unfolding leq-ℝ-Prop sim-ℝ
+  unfolding leq-ℝ sim-ℝ
 
   sim-antisymmetric-leq-ℝ :
     {l1 l2 : Level} (x : ℝ l1) (y : ℝ l2) → leq-ℝ x y → leq-ℝ y x → sim-ℝ x y
@@ -186,7 +192,7 @@ module _
   where
 
   opaque
-    unfolding leq-ℝ-Prop
+    unfolding leq-ℝ
 
     transitive-leq-ℝ : leq-ℝ y z → leq-ℝ x y → leq-ℝ x z
     transitive-leq-ℝ =
@@ -198,7 +204,7 @@ module _
 ```agda
 ℝ-Large-Preorder : Large-Preorder lsuc _⊔_
 type-Large-Preorder ℝ-Large-Preorder = ℝ
-leq-prop-Large-Preorder ℝ-Large-Preorder = leq-ℝ-Prop
+leq-prop-Large-Preorder ℝ-Large-Preorder = leq-prop-ℝ
 refl-leq-Large-Preorder ℝ-Large-Preorder = refl-leq-ℝ
 transitive-leq-Large-Preorder ℝ-Large-Preorder = transitive-leq-ℝ
 ```
@@ -215,7 +221,7 @@ antisymmetric-leq-Large-Poset ℝ-Large-Poset = antisymmetric-leq-ℝ
 
 ```agda
 opaque
-  unfolding leq-ℝ-Prop sim-ℝ
+  unfolding leq-ℝ sim-ℝ
 
   sim-sim-leq-ℝ :
     {l1 l2 : Level} {x : ℝ l1} {y : ℝ l2} →
@@ -247,7 +253,7 @@ opaque
 
 ```agda
 opaque
-  unfolding leq-ℝ-Prop real-ℚ
+  unfolding leq-ℝ real-ℚ
 
   preserves-leq-real-ℚ : (x y : ℚ) → leq-ℚ x y → leq-ℝ (real-ℚ x) (real-ℚ y)
   preserves-leq-real-ℚ = preserves-leq-lower-real-ℚ
@@ -267,7 +273,7 @@ module _
   where
 
   opaque
-    unfolding leq-ℝ-Prop leq-ℝ-Prop' neg-ℝ
+    unfolding leq-ℝ leq-ℝ' neg-ℝ
 
     neg-leq-ℝ : leq-ℝ x y → leq-ℝ (neg-ℝ y) (neg-ℝ x)
     neg-leq-ℝ x≤y = leq-leq'-ℝ (neg-ℝ y) (neg-ℝ x) (x≤y ∘ neg-ℚ)
@@ -281,7 +287,7 @@ module _
   where
 
   opaque
-    unfolding leq-ℝ-Prop sim-ℝ
+    unfolding leq-ℝ sim-ℝ
 
     preserves-leq-left-sim-ℝ : leq-ℝ x z → leq-ℝ y z
     preserves-leq-left-sim-ℝ x≤z q q<y = x≤z q (pr2 x~y q q<y)
@@ -313,7 +319,7 @@ module _
   where
 
   opaque
-    unfolding add-ℝ leq-ℝ-Prop
+    unfolding add-ℝ leq-ℝ
 
     preserves-leq-right-add-ℝ : leq-ℝ x y → leq-ℝ (x +ℝ z) (y +ℝ z)
     preserves-leq-right-add-ℝ x≤y _ =

--- a/src/real-numbers/inequality-real-numbers.lagda.md
+++ b/src/real-numbers/inequality-real-numbers.lagda.md
@@ -1,6 +1,8 @@
 # Inequality on the real numbers
 
 ```agda
+{-# OPTIONS --lossy-unification #-}
+
 module real-numbers.inequality-real-numbers where
 ```
 
@@ -66,8 +68,9 @@ module _
   {l1 l2 : Level} (x : ℝ l1) (y : ℝ l2)
   where
 
-  leq-ℝ-Prop : Prop (l1 ⊔ l2)
-  leq-ℝ-Prop = leq-lower-ℝ-Prop (lower-real-ℝ x) (lower-real-ℝ y)
+  opaque
+    leq-ℝ-Prop : Prop (l1 ⊔ l2)
+    leq-ℝ-Prop = leq-lower-ℝ-Prop (lower-real-ℝ x) (lower-real-ℝ y)
 
   leq-ℝ : UU (l1 ⊔ l2)
   leq-ℝ = type-Prop leq-ℝ-Prop
@@ -85,13 +88,16 @@ module _
   {l1 l2 : Level} (x : ℝ l1) (y : ℝ l2)
   where
 
-  leq-ℝ-Prop' : Prop (l1 ⊔ l2)
-  leq-ℝ-Prop' = leq-upper-ℝ-Prop (upper-real-ℝ x) (upper-real-ℝ y)
+  opaque
+    leq-ℝ-Prop' : Prop (l1 ⊔ l2)
+    leq-ℝ-Prop' = leq-upper-ℝ-Prop (upper-real-ℝ x) (upper-real-ℝ y)
 
   leq-ℝ' : UU (l1 ⊔ l2)
   leq-ℝ' = type-Prop leq-ℝ-Prop'
 
-  abstract
+  opaque
+    unfolding leq-ℝ-Prop leq-ℝ-Prop'
+
     leq'-leq-ℝ : leq-ℝ x y → leq-ℝ'
     leq'-leq-ℝ lx⊆ly q y<q =
       elim-exists
@@ -137,7 +143,9 @@ module _
 ### Inequality on the real numbers is reflexive
 
 ```agda
-abstract
+opaque
+  unfolding leq-ℝ-Prop
+
   refl-leq-ℝ : {l : Level} → (x : ℝ l) → leq-ℝ x x
   refl-leq-ℝ x = refl-leq-Large-Preorder lower-ℝ-Large-Preorder (lower-real-ℝ x)
 
@@ -145,7 +153,7 @@ abstract
   leq-eq-ℝ x y x=y = tr (leq-ℝ x) x=y (refl-leq-ℝ x)
 
 opaque
-  unfolding sim-ℝ
+  unfolding leq-ℝ-Prop sim-ℝ
 
   leq-sim-ℝ : {l1 l2 : Level} → (x : ℝ l1) (y : ℝ l2) → sim-ℝ x y → leq-ℝ x y
   leq-sim-ℝ _ _ = pr1
@@ -155,7 +163,7 @@ opaque
 
 ```agda
 opaque
-  unfolding sim-ℝ
+  unfolding leq-ℝ-Prop sim-ℝ
 
   sim-antisymmetric-leq-ℝ :
     {l1 l2 : Level} (x : ℝ l1) (y : ℝ l2) → leq-ℝ x y → leq-ℝ y x → sim-ℝ x y
@@ -177,9 +185,12 @@ module _
   (z : ℝ l3)
   where
 
-  transitive-leq-ℝ : leq-ℝ y z → leq-ℝ x y → leq-ℝ x z
-  transitive-leq-ℝ =
-    transitive-leq-subtype (lower-cut-ℝ x) (lower-cut-ℝ y) (lower-cut-ℝ z)
+  opaque
+    unfolding leq-ℝ-Prop
+
+    transitive-leq-ℝ : leq-ℝ y z → leq-ℝ x y → leq-ℝ x z
+    transitive-leq-ℝ =
+      transitive-leq-subtype (lower-cut-ℝ x) (lower-cut-ℝ y) (lower-cut-ℝ z)
 ```
 
 ### The large preorder of real numbers
@@ -204,7 +215,7 @@ antisymmetric-leq-Large-Poset ℝ-Large-Poset = antisymmetric-leq-ℝ
 
 ```agda
 opaque
-  unfolding sim-ℝ
+  unfolding leq-ℝ-Prop sim-ℝ
 
   sim-sim-leq-ℝ :
     {l1 l2 : Level} {x : ℝ l1} {y : ℝ l2} →
@@ -235,14 +246,17 @@ opaque
 ### The canonical map from rational numbers to the reals preserves and reflects inequality
 
 ```agda
-preserves-leq-real-ℚ : (x y : ℚ) → leq-ℚ x y → leq-ℝ (real-ℚ x) (real-ℚ y)
-preserves-leq-real-ℚ = preserves-leq-lower-real-ℚ
+opaque
+  unfolding leq-ℝ-Prop real-ℚ
 
-reflects-leq-real-ℚ : (x y : ℚ) → leq-ℝ (real-ℚ x) (real-ℚ y) → leq-ℚ x y
-reflects-leq-real-ℚ = reflects-leq-lower-real-ℚ
+  preserves-leq-real-ℚ : (x y : ℚ) → leq-ℚ x y → leq-ℝ (real-ℚ x) (real-ℚ y)
+  preserves-leq-real-ℚ = preserves-leq-lower-real-ℚ
 
-iff-leq-real-ℚ : (x y : ℚ) → leq-ℚ x y ↔ leq-ℝ (real-ℚ x) (real-ℚ y)
-iff-leq-real-ℚ = iff-leq-lower-real-ℚ
+  reflects-leq-real-ℚ : (x y : ℚ) → leq-ℝ (real-ℚ x) (real-ℚ y) → leq-ℚ x y
+  reflects-leq-real-ℚ = reflects-leq-lower-real-ℚ
+
+  iff-leq-real-ℚ : (x y : ℚ) → leq-ℚ x y ↔ leq-ℝ (real-ℚ x) (real-ℚ y)
+  iff-leq-real-ℚ = iff-leq-lower-real-ℚ
 ```
 
 ### Negation reverses inequality on the real numbers
@@ -252,8 +266,11 @@ module _
   {l1 l2 : Level} (x : ℝ l1) (y : ℝ l2)
   where
 
-  neg-leq-ℝ : leq-ℝ x y → leq-ℝ (neg-ℝ y) (neg-ℝ x)
-  neg-leq-ℝ x≤y = leq-leq'-ℝ (neg-ℝ y) (neg-ℝ x) (x≤y ∘ neg-ℚ)
+  opaque
+    unfolding leq-ℝ-Prop leq-ℝ-Prop' neg-ℝ
+
+    neg-leq-ℝ : leq-ℝ x y → leq-ℝ (neg-ℝ y) (neg-ℝ x)
+    neg-leq-ℝ x≤y = leq-leq'-ℝ (neg-ℝ y) (neg-ℝ x) (x≤y ∘ neg-ℚ)
 ```
 
 ### Inequality on the real numbers is invariant under similarity
@@ -264,7 +281,7 @@ module _
   where
 
   opaque
-    unfolding sim-ℝ
+    unfolding leq-ℝ-Prop sim-ℝ
 
     preserves-leq-left-sim-ℝ : leq-ℝ x z → leq-ℝ y z
     preserves-leq-left-sim-ℝ x≤z q q<y = x≤z q (pr2 x~y q q<y)
@@ -296,7 +313,7 @@ module _
   where
 
   opaque
-    unfolding add-ℝ
+    unfolding add-ℝ leq-ℝ-Prop
 
     preserves-leq-right-add-ℝ : leq-ℝ x y → leq-ℝ (x +ℝ z) (y +ℝ z)
     preserves-leq-right-add-ℝ x≤y _ =
@@ -305,6 +322,12 @@ module _
     preserves-leq-left-add-ℝ : leq-ℝ x y → leq-ℝ (z +ℝ x) (z +ℝ y)
     preserves-leq-left-add-ℝ x≤y _ =
       map-tot-exists (λ (_ , qx) → map-product id (map-product (x≤y qx) id))
+
+abstract
+  preserves-leq-diff-ℝ :
+    {l1 l2 l3 : Level} (z : ℝ l1) (x : ℝ l2) (y : ℝ l3) →
+    leq-ℝ x y → leq-ℝ (x -ℝ z) (y -ℝ z)
+  preserves-leq-diff-ℝ z = preserves-leq-right-add-ℝ (neg-ℝ z)
 
 module _
   {l1 l2 l3 : Level} (z : ℝ l1) (x : ℝ l2) (y : ℝ l3)
@@ -427,32 +450,33 @@ module _
   (x : ℝ l1) (y : ℝ l2) (z : ℝ l3)
   where
 
-  preserves-lower-neighborhood-leq-left-add-ℝ :
-    leq-ℝ y (z +ℝ real-ℚ (rational-ℚ⁺ d)) →
-    leq-ℝ
-      ( add-ℝ x y)
-      ( (add-ℝ x z) +ℝ real-ℚ (rational-ℚ⁺ d))
-  preserves-lower-neighborhood-leq-left-add-ℝ z≤y+d =
-    inv-tr
-      ( leq-ℝ (x +ℝ y))
-      ( associative-add-ℝ x z (real-ℚ (rational-ℚ⁺ d)))
-      ( preserves-leq-left-add-ℝ
-        ( x)
-        ( y)
-        ( z +ℝ real-ℚ (rational-ℚ⁺ d))
-        ( z≤y+d))
+  abstract
+    preserves-lower-neighborhood-leq-left-add-ℝ :
+      leq-ℝ y (z +ℝ real-ℚ⁺ d) →
+      leq-ℝ
+        ( add-ℝ x y)
+        ( (add-ℝ x z) +ℝ real-ℚ⁺ d)
+    preserves-lower-neighborhood-leq-left-add-ℝ z≤y+d =
+      inv-tr
+        ( leq-ℝ (x +ℝ y))
+        ( associative-add-ℝ x z (real-ℚ⁺ d))
+        ( preserves-leq-left-add-ℝ
+          ( x)
+          ( y)
+          ( z +ℝ real-ℚ⁺ d)
+          ( z≤y+d))
 
-  preserves-lower-neighborhood-leq-right-add-ℝ :
-    leq-ℝ y (z +ℝ real-ℚ (rational-ℚ⁺ d)) →
-    leq-ℝ
-      ( add-ℝ y x)
-      ( (add-ℝ z x) +ℝ real-ℚ (rational-ℚ⁺ d))
-  preserves-lower-neighborhood-leq-right-add-ℝ z≤y+d =
-    binary-tr
-      ( λ u v → leq-ℝ u (v +ℝ real-ℚ (rational-ℚ⁺ d)))
-      ( commutative-add-ℝ x y)
-      ( commutative-add-ℝ x z)
-      ( preserves-lower-neighborhood-leq-left-add-ℝ z≤y+d)
+    preserves-lower-neighborhood-leq-right-add-ℝ :
+      leq-ℝ y (z +ℝ real-ℚ⁺ d) →
+      leq-ℝ
+        ( add-ℝ y x)
+        ( (add-ℝ z x) +ℝ real-ℚ⁺ d)
+    preserves-lower-neighborhood-leq-right-add-ℝ z≤y+d =
+      binary-tr
+        ( λ u v → leq-ℝ u (v +ℝ real-ℚ⁺ d))
+        ( commutative-add-ℝ x y)
+        ( commutative-add-ℝ x z)
+        ( preserves-lower-neighborhood-leq-left-add-ℝ z≤y+d)
 ```
 
 ### Addition of real numbers reflects lower neighborhoods
@@ -463,33 +487,34 @@ module _
   (x : ℝ l1) (y : ℝ l2) (z : ℝ l3)
   where
 
-  reflects-lower-neighborhood-leq-left-add-ℝ :
-    leq-ℝ
-      ( add-ℝ x y)
-      ( (add-ℝ x z) +ℝ real-ℚ (rational-ℚ⁺ d)) →
-    leq-ℝ y (z +ℝ real-ℚ (rational-ℚ⁺ d))
-  reflects-lower-neighborhood-leq-left-add-ℝ x+y≤x+z+d =
-    reflects-leq-left-add-ℝ
-      ( x)
-      ( y)
-      ( z +ℝ real-ℚ (rational-ℚ⁺ d))
-      ( tr
-        ( leq-ℝ (x +ℝ y))
-        ( associative-add-ℝ x z (real-ℚ (rational-ℚ⁺ d)))
-        ( x+y≤x+z+d))
+  abstract
+    reflects-lower-neighborhood-leq-left-add-ℝ :
+      leq-ℝ
+        ( add-ℝ x y)
+        ( (add-ℝ x z) +ℝ real-ℚ⁺ d) →
+      leq-ℝ y (z +ℝ real-ℚ⁺ d)
+    reflects-lower-neighborhood-leq-left-add-ℝ x+y≤x+z+d =
+      reflects-leq-left-add-ℝ
+        ( x)
+        ( y)
+        ( z +ℝ real-ℚ⁺ d)
+        ( tr
+          ( leq-ℝ (x +ℝ y))
+          ( associative-add-ℝ x z (real-ℚ⁺ d))
+          ( x+y≤x+z+d))
 
-  reflects-lower-neighborhood-leq-right-add-ℝ :
-    leq-ℝ
-      ( add-ℝ y x)
-      ( (add-ℝ z x) +ℝ real-ℚ (rational-ℚ⁺ d)) →
-    leq-ℝ y (z +ℝ real-ℚ (rational-ℚ⁺ d))
-  reflects-lower-neighborhood-leq-right-add-ℝ y+x≤z+y+d =
-    reflects-lower-neighborhood-leq-left-add-ℝ
-      ( binary-tr
-        ( λ u v → leq-ℝ u (v +ℝ real-ℚ (rational-ℚ⁺ d)))
-        ( commutative-add-ℝ y x)
-        ( commutative-add-ℝ z x)
-        ( y+x≤z+y+d))
+    reflects-lower-neighborhood-leq-right-add-ℝ :
+      leq-ℝ
+        ( add-ℝ y x)
+        ( (add-ℝ z x) +ℝ real-ℚ⁺ d) →
+      leq-ℝ y (z +ℝ real-ℚ⁺ d)
+    reflects-lower-neighborhood-leq-right-add-ℝ y+x≤z+y+d =
+      reflects-lower-neighborhood-leq-left-add-ℝ
+        ( binary-tr
+          ( λ u v → leq-ℝ u (v +ℝ real-ℚ⁺ d))
+          ( commutative-add-ℝ y x)
+          ( commutative-add-ℝ z x)
+          ( y+x≤z+y+d))
 ```
 
 ### Negation of real numbers reverses lower neighborhoods
@@ -501,20 +526,20 @@ module _
   where
 
   reverses-lower-neighborhood-neg-ℝ :
-    leq-ℝ x (y +ℝ real-ℚ (rational-ℚ⁺ d)) →
-    leq-ℝ (neg-ℝ y) (neg-ℝ x +ℝ real-ℚ (rational-ℚ⁺ d))
+    leq-ℝ x (y +ℝ real-ℚ⁺ d) →
+    leq-ℝ (neg-ℝ y) (neg-ℝ x +ℝ real-ℚ⁺ d)
   reverses-lower-neighborhood-neg-ℝ x≤y+d =
     tr
       ( leq-ℝ (neg-ℝ y))
       ( ( distributive-neg-add-ℝ x ((neg-ℝ ∘ real-ℚ ∘ rational-ℚ⁺) d)) ∙
-        ( ap (add-ℝ (neg-ℝ x)) (neg-neg-ℝ (real-ℚ (rational-ℚ⁺ d)))))
+        ( ap (add-ℝ (neg-ℝ x)) (neg-neg-ℝ (real-ℚ⁺ d))))
       ( neg-leq-ℝ
-        ( x -ℝ real-ℚ (rational-ℚ⁺ d))
+        ( x -ℝ real-ℚ⁺ d)
         ( y)
         ( leq-transpose-right-add-ℝ
           ( x)
           ( y)
-          ( real-ℚ (rational-ℚ⁺ d))
+          ( real-ℚ⁺ d)
           ( x≤y+d)))
 ```
 

--- a/src/real-numbers/inequality-upper-dedekind-real-numbers.lagda.md
+++ b/src/real-numbers/inequality-upper-dedekind-real-numbers.lagda.md
@@ -55,6 +55,9 @@ module _
 
   leq-upper-ℝ : UU (l1 ⊔ l2)
   leq-upper-ℝ = type-Prop leq-upper-ℝ-Prop
+
+  is-prop-leq-upper-ℝ : is-prop leq-upper-ℝ
+  is-prop-leq-upper-ℝ = is-prop-type-Prop leq-upper-ℝ-Prop
 ```
 
 ## Properties

--- a/src/real-numbers/infima-families-real-numbers.lagda.md
+++ b/src/real-numbers/infima-families-real-numbers.lagda.md
@@ -76,7 +76,7 @@ module _
   is-approximated-above-prop-family-ℝ x =
     Π-Prop
       ( ℚ⁺)
-      ( λ ε → ∃ I (λ i → le-ℝ-Prop (y i) (x +ℝ real-ℚ⁺ ε)))
+      ( λ ε → ∃ I (λ i → le-prop-ℝ (y i) (x +ℝ real-ℚ⁺ ε)))
 
   is-approximated-above-family-ℝ : {l3 : Level} → ℝ l3 → UU (l1 ⊔ l2 ⊔ l3)
   is-approximated-above-family-ℝ x =
@@ -215,9 +215,9 @@ module _
       ( is-lower-bound-is-infimum-family-ℝ y x is-infimum-x-yᵢ i)
 
   le-element-le-infimum-family-ℝ :
-    {l4 : Level} → (z : ℝ l4) → le-ℝ x z → exists I (λ i → le-ℝ-Prop (y i) z)
+    {l4 : Level} → (z : ℝ l4) → le-ℝ x z → exists I (λ i → le-prop-ℝ (y i) z)
   le-element-le-infimum-family-ℝ z x<z =
-    let open do-syntax-trunc-Prop (∃ I (λ i → le-ℝ-Prop (y i) z))
+    let open do-syntax-trunc-Prop (∃ I (λ i → le-prop-ℝ (y i) z))
     in do
       (ε⁺@(ε , _) , ε<z-x) ←
         exists-ℚ⁺-in-lower-cut-ℝ⁺ (positive-diff-le-ℝ x z x<z)
@@ -232,11 +232,11 @@ module _
 
   le-infimum-iff-le-element-family-ℝ :
     {l4 : Level} → (z : ℝ l4) →
-    (le-ℝ x z) ↔ (exists I (λ i → le-ℝ-Prop (y i) z))
+    (le-ℝ x z) ↔ (exists I (λ i → le-prop-ℝ (y i) z))
   pr1 (le-infimum-iff-le-element-family-ℝ z) =
     le-element-le-infimum-family-ℝ z
   pr2 (le-infimum-iff-le-element-family-ℝ z) =
-    elim-exists (le-ℝ-Prop x z) (le-infimum-le-element-family-ℝ z)
+    elim-exists (le-prop-ℝ x z) (le-infimum-le-element-family-ℝ z)
 ```
 
 ### The infimum of a family of real numbers is the negation of the supremum of the negation of the family

--- a/src/real-numbers/isometry-negation-real-numbers.lagda.md
+++ b/src/real-numbers/isometry-negation-real-numbers.lagda.md
@@ -43,24 +43,25 @@ module _
   {l1 : Level}
   where
 
-  neg-neighborhood-ℝ : (d : ℚ⁺) (x y : ℝ l1) →
-    neighborhood-ℝ l1 d x y →
-    neighborhood-ℝ l1 d (neg-ℝ x) (neg-ℝ y)
-  neg-neighborhood-ℝ d x y H =
-    neighborhood-real-bound-each-leq-ℝ
-      ( d)
-      ( neg-ℝ x)
-      ( neg-ℝ y)
-      ( reverses-lower-neighborhood-neg-ℝ
+  abstract
+    neg-neighborhood-ℝ : (d : ℚ⁺) (x y : ℝ l1) →
+      neighborhood-ℝ l1 d x y →
+      neighborhood-ℝ l1 d (neg-ℝ x) (neg-ℝ y)
+    neg-neighborhood-ℝ d x y H =
+      neighborhood-real-bound-each-leq-ℝ
         ( d)
-        ( y)
-        ( x)
-        ( right-leq-real-bound-neighborhood-ℝ d x y H))
-      ( reverses-lower-neighborhood-neg-ℝ
-        ( d)
-        ( x)
-        ( y)
-        ( left-leq-real-bound-neighborhood-ℝ d x y H))
+        ( neg-ℝ x)
+        ( neg-ℝ y)
+        ( reverses-lower-neighborhood-neg-ℝ
+          ( d)
+          ( y)
+          ( x)
+          ( right-leq-real-bound-neighborhood-ℝ d x y H))
+        ( reverses-lower-neighborhood-neg-ℝ
+          ( d)
+          ( x)
+          ( y)
+          ( left-leq-real-bound-neighborhood-ℝ d x y H))
 ```
 
 ### Negation on the real numbers is an isometry
@@ -70,21 +71,22 @@ module _
   {l1 : Level}
   where
 
-  is-isometry-neg-ℝ :
-    is-isometry-Metric-Space
-      ( metric-space-ℝ l1)
-      ( metric-space-ℝ l1)
-      ( neg-ℝ)
-  is-isometry-neg-ℝ d x y =
-    ( neg-neighborhood-ℝ d x y) ,
-    ( ( binary-tr
-        ( neighborhood-ℝ l1 d)
-        ( neg-neg-ℝ x)
-        ( neg-neg-ℝ y)) ∘
-      ( neg-neighborhood-ℝ
-        ( d)
-        ( neg-ℝ x)
-        ( neg-ℝ y)))
+  abstract
+    is-isometry-neg-ℝ :
+      is-isometry-Metric-Space
+        ( metric-space-ℝ l1)
+        ( metric-space-ℝ l1)
+        ( neg-ℝ)
+    is-isometry-neg-ℝ d x y =
+      ( neg-neighborhood-ℝ d x y) ,
+      ( ( binary-tr
+          ( neighborhood-ℝ l1 d)
+          ( neg-neg-ℝ x)
+          ( neg-neg-ℝ y)) ∘
+        ( neg-neighborhood-ℝ
+          ( d)
+          ( neg-ℝ x)
+          ( neg-ℝ y)))
 
   isometry-neg-ℝ :
     isometry-Metric-Space

--- a/src/real-numbers/metric-space-of-real-numbers.lagda.md
+++ b/src/real-numbers/metric-space-of-real-numbers.lagda.md
@@ -16,6 +16,7 @@ open import elementary-number-theory.rational-numbers
 
 open import foundation.action-on-identifications-functions
 open import foundation.binary-relations
+open import foundation.cartesian-product-types
 open import foundation.dependent-pair-types
 open import foundation.diagonal-maps-cartesian-products-of-types
 open import foundation.existential-quantification
@@ -86,15 +87,24 @@ module _
   lower-neighborhood-ℝ =
     type-Prop lower-neighborhood-prop-ℝ
 
-opaque
-  neighborhood-prop-ℝ : (l : Level) → Rational-Neighborhood-Relation l (ℝ l)
-  neighborhood-prop-ℝ l d x y =
-    product-Prop
-      ( lower-neighborhood-prop-ℝ d x y)
-      ( lower-neighborhood-prop-ℝ d y x)
+  is-prop-lower-neighborhood-ℝ : is-prop lower-neighborhood-ℝ
+  is-prop-lower-neighborhood-ℝ = is-prop-type-Prop lower-neighborhood-prop-ℝ
 
-neighborhood-ℝ : (l : Level) → ℚ⁺ → Relation l (ℝ l)
-neighborhood-ℝ l d x y = type-Prop (neighborhood-prop-ℝ l d x y)
+opaque
+  neighborhood-ℝ : (l : Level) → ℚ⁺ → Relation l (ℝ l)
+  neighborhood-ℝ l d x y =
+    lower-neighborhood-ℝ d x y × lower-neighborhood-ℝ d y x
+
+  is-prop-neighborhood-ℝ :
+    (l : Level) → (ε : ℚ⁺) (x y : ℝ l) → is-prop (neighborhood-ℝ l ε x y)
+  is-prop-neighborhood-ℝ l ε x y =
+    is-prop-product
+      ( is-prop-lower-neighborhood-ℝ ε x y)
+      ( is-prop-lower-neighborhood-ℝ ε y x)
+
+neighborhood-prop-ℝ : (l : Level) → Rational-Neighborhood-Relation l (ℝ l)
+neighborhood-prop-ℝ l d x y =
+  ( neighborhood-ℝ l d x y , is-prop-neighborhood-ℝ l d x y)
 ```
 
 ## Properties
@@ -111,7 +121,7 @@ module _
   where
 
   opaque
-    unfolding neighborhood-prop-ℝ
+    unfolding neighborhood-ℝ
 
     is-reflexive-neighborhood-ℝ :
       is-reflexive-Rational-Neighborhood-Relation (neighborhood-prop-ℝ l)
@@ -194,7 +204,7 @@ module _
   where
 
   opaque
-    unfolding neighborhood-prop-ℝ
+    unfolding neighborhood-ℝ
 
     is-tight-pseudometric-space-ℝ :
       is-tight-Pseudometric-Space (pseudometric-space-ℝ l)
@@ -290,7 +300,7 @@ module _
           ( leq-transpose-right-add-ℝ y x (real-ℚ d) y≤x+d))
 
   opaque
-    unfolding leq-ℝ-Prop
+    unfolding leq-ℝ
 
     real-bound-leq-lower-neighborhood-ℝ :
       (d : ℚ⁺) (x y : ℝ l) →
@@ -310,7 +320,7 @@ module _
   where
 
   opaque
-    unfolding neighborhood-prop-ℝ
+    unfolding neighborhood-ℝ
 
     neighborhood-real-bound-each-leq-ℝ :
       leq-ℝ x (y +ℝ real-ℚ⁺ d) →
@@ -376,7 +386,7 @@ module _
 
 ```agda
 opaque
-  unfolding neighborhood-prop-ℝ real-ℚ
+  unfolding neighborhood-ℝ real-ℚ
 
   is-isometry-metric-space-real-ℚ :
     is-isometry-Metric-Space

--- a/src/real-numbers/metric-space-of-real-numbers.lagda.md
+++ b/src/real-numbers/metric-space-of-real-numbers.lagda.md
@@ -86,11 +86,12 @@ module _
   lower-neighborhood-ℝ =
     type-Prop lower-neighborhood-prop-ℝ
 
-neighborhood-prop-ℝ : (l : Level) → Rational-Neighborhood-Relation l (ℝ l)
-neighborhood-prop-ℝ l d x y =
-  product-Prop
-    ( lower-neighborhood-prop-ℝ d x y)
-    ( lower-neighborhood-prop-ℝ d y x)
+opaque
+  neighborhood-prop-ℝ : (l : Level) → Rational-Neighborhood-Relation l (ℝ l)
+  neighborhood-prop-ℝ l d x y =
+    product-Prop
+      ( lower-neighborhood-prop-ℝ d x y)
+      ( lower-neighborhood-prop-ℝ d y x)
 
 neighborhood-ℝ : (l : Level) → ℚ⁺ → Relation l (ℝ l)
 neighborhood-ℝ l d x y = type-Prop (neighborhood-prop-ℝ l d x y)
@@ -109,66 +110,71 @@ module _
   {l : Level}
   where
 
-  is-reflexive-neighborhood-ℝ :
-    is-reflexive-Rational-Neighborhood-Relation (neighborhood-prop-ℝ l)
-  is-reflexive-neighborhood-ℝ d x =
-    diagonal-product
-      ( (r : ℚ) →
-        is-in-lower-cut-ℝ x (r +ℚ (rational-ℚ⁺ d)) → is-in-lower-cut-ℝ x r)
-      ( λ r →
-        le-lower-cut-ℝ x r (r +ℚ rational-ℚ⁺ d) (le-right-add-rational-ℚ⁺ r d))
+  opaque
+    unfolding neighborhood-prop-ℝ
 
-  is-symmetric-neighborhood-ℝ :
-    is-symmetric-Rational-Neighborhood-Relation (neighborhood-prop-ℝ l)
-  is-symmetric-neighborhood-ℝ d x y (H , K) = (K , H)
+    is-reflexive-neighborhood-ℝ :
+      is-reflexive-Rational-Neighborhood-Relation (neighborhood-prop-ℝ l)
+    is-reflexive-neighborhood-ℝ d x =
+      diagonal-product
+        ( (r : ℚ) →
+          is-in-lower-cut-ℝ x (r +ℚ (rational-ℚ⁺ d)) → is-in-lower-cut-ℝ x r)
+        ( λ r →
+          le-lower-cut-ℝ x r
+            ( r +ℚ rational-ℚ⁺ d)
+            ( le-right-add-rational-ℚ⁺ r d))
 
-  is-triangular-neighborhood-ℝ :
-    is-triangular-Rational-Neighborhood-Relation (neighborhood-prop-ℝ l)
-  pr1 (is-triangular-neighborhood-ℝ x y z dxy dyz Hyz Hxy) r =
-    pr1 Hxy r ∘
-    pr1 Hyz (r +ℚ rational-ℚ⁺ dxy) ∘
-    inv-tr
-      ( is-in-lower-cut-ℝ z)
-      ( associative-add-ℚ r (rational-ℚ⁺ dxy) (rational-ℚ⁺ dyz))
-  pr2 (is-triangular-neighborhood-ℝ x y z dxy dyz Hyz Hxy) r =
-    pr2 Hyz r ∘
-    pr2 Hxy (r +ℚ rational-ℚ⁺ dyz) ∘
-    inv-tr
-      ( is-in-lower-cut-ℝ x)
-      ( associative-add-ℚ r (rational-ℚ⁺ dyz) (rational-ℚ⁺ dxy) ∙
-        ap (add-ℚ r) (commutative-add-ℚ (rational-ℚ⁺ dyz) (rational-ℚ⁺ dxy)))
+    is-symmetric-neighborhood-ℝ :
+      is-symmetric-Rational-Neighborhood-Relation (neighborhood-prop-ℝ l)
+    is-symmetric-neighborhood-ℝ d x y (H , K) = (K , H)
 
-  is-saturated-neighborhood-ℝ :
-    is-saturated-Rational-Neighborhood-Relation (neighborhood-prop-ℝ l)
-  is-saturated-neighborhood-ℝ ε x y H =
-    ( is-closed-lower-neighborhood-ℝ x y ε (pr1 ∘ H) ,
-      is-closed-lower-neighborhood-ℝ y x ε (pr2 ∘ H))
-    where
+    is-triangular-neighborhood-ℝ :
+      is-triangular-Rational-Neighborhood-Relation (neighborhood-prop-ℝ l)
+    pr1 (is-triangular-neighborhood-ℝ x y z dxy dyz Hyz Hxy) r =
+      pr1 Hxy r ∘
+      pr1 Hyz (r +ℚ rational-ℚ⁺ dxy) ∘
+      inv-tr
+        ( is-in-lower-cut-ℝ z)
+        ( associative-add-ℚ r (rational-ℚ⁺ dxy) (rational-ℚ⁺ dyz))
+    pr2 (is-triangular-neighborhood-ℝ x y z dxy dyz Hyz Hxy) r =
+      pr2 Hyz r ∘
+      pr2 Hxy (r +ℚ rational-ℚ⁺ dyz) ∘
+      inv-tr
+        ( is-in-lower-cut-ℝ x)
+        ( associative-add-ℚ r (rational-ℚ⁺ dyz) (rational-ℚ⁺ dxy) ∙
+          ap (add-ℚ r) (commutative-add-ℚ (rational-ℚ⁺ dyz) (rational-ℚ⁺ dxy)))
 
-    is-closed-lower-neighborhood-ℝ :
-      (x y : ℝ l) (ε : ℚ⁺) →
-      ((δ : ℚ⁺) → lower-neighborhood-ℝ (ε +ℚ⁺ δ) x y) →
-      lower-neighborhood-ℝ ε x y
-    is-closed-lower-neighborhood-ℝ x y ε H r I =
-      elim-exists
-        ( lower-cut-ℝ x r)
-        ( λ r' (K , I') →
-          H ( positive-diff-le-ℚ (r +ℚ rational-ℚ⁺ ε) r' K)
-            ( r)
-            ( tr
-              ( is-in-lower-cut-ℝ y)
-              ( ( inv
-                  ( right-law-positive-diff-le-ℚ
-                    ( r +ℚ rational-ℚ⁺ ε)
-                    ( r')
-                    ( K))) ∙
-                ( associative-add-ℚ
-                  ( r)
-                  ( rational-ℚ⁺ ε)
-                      ( r' -ℚ (r +ℚ rational-ℚ⁺ ε))))
-              ( I')))
-        ( forward-implication
-          ( is-rounded-lower-cut-ℝ y (r +ℚ rational-ℚ⁺ ε)) I)
+    is-saturated-neighborhood-ℝ :
+      is-saturated-Rational-Neighborhood-Relation (neighborhood-prop-ℝ l)
+    is-saturated-neighborhood-ℝ ε x y H =
+      ( is-closed-lower-neighborhood-ℝ x y ε (pr1 ∘ H) ,
+        is-closed-lower-neighborhood-ℝ y x ε (pr2 ∘ H))
+      where
+
+      is-closed-lower-neighborhood-ℝ :
+        (x y : ℝ l) (ε : ℚ⁺) →
+        ((δ : ℚ⁺) → lower-neighborhood-ℝ (ε +ℚ⁺ δ) x y) →
+        lower-neighborhood-ℝ ε x y
+      is-closed-lower-neighborhood-ℝ x y ε H r I =
+        elim-exists
+          ( lower-cut-ℝ x r)
+          ( λ r' (K , I') →
+            H ( positive-diff-le-ℚ (r +ℚ rational-ℚ⁺ ε) r' K)
+              ( r)
+              ( tr
+                ( is-in-lower-cut-ℝ y)
+                ( ( inv
+                    ( right-law-positive-diff-le-ℚ
+                      ( r +ℚ rational-ℚ⁺ ε)
+                      ( r')
+                      ( K))) ∙
+                  ( associative-add-ℚ
+                    ( r)
+                    ( rational-ℚ⁺ ε)
+                        ( r' -ℚ (r +ℚ rational-ℚ⁺ ε))))
+                ( I')))
+          ( forward-implication
+            ( is-rounded-lower-cut-ℝ y (r +ℚ rational-ℚ⁺ ε)) I)
 
 module _
   (l : Level)
@@ -187,39 +193,42 @@ module _
   {l : Level}
   where
 
-  is-tight-pseudometric-space-ℝ :
-    is-tight-Pseudometric-Space (pseudometric-space-ℝ l)
-  is-tight-pseudometric-space-ℝ x y H =
-    eq-eq-lower-cut-ℝ
-      ( x)
-      ( y)
-      ( antisymmetric-leq-subtype
-        ( lower-cut-ℝ x)
-        ( lower-cut-ℝ y)
-        ( λ r Lxr →
-          elim-exists
-            ( lower-cut-ℝ y r)
-            ( λ s (r<s , Lxs) →
-              pr2
-                ( H (positive-diff-le-ℚ r s r<s))
-                ( r)
-                ( inv-tr
-                  ( λ u → is-in-lower-cut-ℝ x u)
-                  ( right-law-positive-diff-le-ℚ r s r<s)
-                  ( Lxs)))
-            ( forward-implication (is-rounded-lower-cut-ℝ x r) Lxr))
-        ( λ r Lyr →
-          elim-exists
-            ( lower-cut-ℝ x r)
-            ( λ s (r<s , Lys) →
-              pr1
-                ( H (positive-diff-le-ℚ r s r<s))
-                ( r)
-                ( inv-tr
-                  ( λ u → is-in-lower-cut-ℝ y u)
-                  ( right-law-positive-diff-le-ℚ r s r<s)
-                  ( Lys)))
-            ( forward-implication (is-rounded-lower-cut-ℝ y r) Lyr)))
+  opaque
+    unfolding neighborhood-prop-ℝ
+
+    is-tight-pseudometric-space-ℝ :
+      is-tight-Pseudometric-Space (pseudometric-space-ℝ l)
+    is-tight-pseudometric-space-ℝ x y H =
+      eq-eq-lower-cut-ℝ
+        ( x)
+        ( y)
+        ( antisymmetric-leq-subtype
+          ( lower-cut-ℝ x)
+          ( lower-cut-ℝ y)
+          ( λ r Lxr →
+            elim-exists
+              ( lower-cut-ℝ y r)
+              ( λ s (r<s , Lxs) →
+                pr2
+                  ( H (positive-diff-le-ℚ r s r<s))
+                  ( r)
+                  ( inv-tr
+                    ( λ u → is-in-lower-cut-ℝ x u)
+                    ( right-law-positive-diff-le-ℚ r s r<s)
+                    ( Lxs)))
+              ( forward-implication (is-rounded-lower-cut-ℝ x r) Lxr))
+          ( λ r Lyr →
+            elim-exists
+              ( lower-cut-ℝ x r)
+              ( λ s (r<s , Lys) →
+                pr1
+                  ( H (positive-diff-le-ℚ r s r<s))
+                  ( r)
+                  ( inv-tr
+                    ( λ u → is-in-lower-cut-ℝ y u)
+                    ( right-law-positive-diff-le-ℚ r s r<s)
+                    ( Lys)))
+              ( forward-implication (is-rounded-lower-cut-ℝ y r) Lyr)))
 
   is-extensional-pseudometric-space-ℝ :
     is-extensional-Pseudometric-Space (pseudometric-space-ℝ l)
@@ -257,62 +266,69 @@ module _
   {l : Level}
   where
 
-  lower-neighborhood-real-bound-leq-ℝ :
-    (d : ℚ⁺) (x y : ℝ l) →
-    leq-ℝ y (x +ℝ real-ℚ (rational-ℚ⁺ d)) →
-    lower-neighborhood-ℝ d x y
-  lower-neighborhood-real-bound-leq-ℝ (d , _) x y y≤x+d q q+d<y =
-    is-in-lower-cut-le-real-ℚ
-      ( q)
-      ( x)
-      ( concatenate-le-leq-ℝ
-        ( real-ℚ q)
-        ( y -ℝ real-ℚ d)
+  abstract
+    lower-neighborhood-real-bound-leq-ℝ :
+      (d : ℚ⁺) (x y : ℝ l) →
+      leq-ℝ y (x +ℝ real-ℚ⁺ d) →
+      lower-neighborhood-ℝ d x y
+    lower-neighborhood-real-bound-leq-ℝ (d , _) x y y≤x+d q q+d<y =
+      is-in-lower-cut-le-real-ℚ
+        ( q)
         ( x)
-        ( le-transpose-left-add-ℝ
+        ( concatenate-le-leq-ℝ
           ( real-ℚ q)
-          ( real-ℚ d)
-          ( y)
-          ( inv-tr
-            ( λ z → le-ℝ z y)
-            ( add-real-ℚ q d)
-            ( le-real-is-in-lower-cut-ℚ (q +ℚ d) y q+d<y)))
-        ( leq-transpose-right-add-ℝ y x (real-ℚ d) y≤x+d))
+          ( y -ℝ real-ℚ d)
+          ( x)
+          ( le-transpose-left-add-ℝ
+            ( real-ℚ q)
+            ( real-ℚ d)
+            ( y)
+            ( inv-tr
+              ( λ z → le-ℝ z y)
+              ( add-real-ℚ q d)
+              ( le-real-is-in-lower-cut-ℚ (q +ℚ d) y q+d<y)))
+          ( leq-transpose-right-add-ℝ y x (real-ℚ d) y≤x+d))
 
-  real-bound-leq-lower-neighborhood-ℝ :
-    (d : ℚ⁺) (x y : ℝ l) →
-    lower-neighborhood-ℝ d x y →
-    leq-ℝ y (x +ℝ real-ℚ (rational-ℚ⁺ d))
-  real-bound-leq-lower-neighborhood-ℝ (d , _) x y H r =
-    ( transpose-diff-is-in-lower-cut-ℝ x r d) ∘
-    ( H (r -ℚ d)) ∘
-    ( inv-tr
-      ( is-in-lower-cut-ℝ y)
-      ( ( associative-add-ℚ r (neg-ℚ d) d) ∙
-        ( ap (add-ℚ r) (left-inverse-law-add-ℚ d)) ∙
-        ( right-unit-law-add-ℚ r)))
+  opaque
+    unfolding leq-ℝ-Prop
+
+    real-bound-leq-lower-neighborhood-ℝ :
+      (d : ℚ⁺) (x y : ℝ l) →
+      lower-neighborhood-ℝ d x y →
+      leq-ℝ y (x +ℝ real-ℚ⁺ d)
+    real-bound-leq-lower-neighborhood-ℝ (d , _) x y H r =
+      ( transpose-diff-is-in-lower-cut-ℝ x r d) ∘
+      ( H (r -ℚ d)) ∘
+      ( inv-tr
+        ( is-in-lower-cut-ℝ y)
+        ( ( associative-add-ℚ r (neg-ℚ d) d) ∙
+          ( ap (add-ℚ r) (left-inverse-law-add-ℚ d)) ∙
+          ( right-unit-law-add-ℚ r)))
 
 module _
   {l : Level} (d : ℚ⁺) (x y : ℝ l)
   where
 
-  neighborhood-real-bound-each-leq-ℝ :
-    leq-ℝ x (y +ℝ real-ℚ (rational-ℚ⁺ d)) →
-    leq-ℝ y (x +ℝ real-ℚ (rational-ℚ⁺ d)) →
-    neighborhood-ℝ l d x y
-  neighborhood-real-bound-each-leq-ℝ x≤y+d y≤x+d =
-    ( lower-neighborhood-real-bound-leq-ℝ d x y y≤x+d) ,
-    ( lower-neighborhood-real-bound-leq-ℝ d y x x≤y+d)
+  opaque
+    unfolding neighborhood-prop-ℝ
 
-  left-leq-real-bound-neighborhood-ℝ :
-    neighborhood-ℝ l d x y → leq-ℝ x (y +ℝ real-ℚ (rational-ℚ⁺ d))
-  left-leq-real-bound-neighborhood-ℝ (_ , K) =
-    real-bound-leq-lower-neighborhood-ℝ d y x K
+    neighborhood-real-bound-each-leq-ℝ :
+      leq-ℝ x (y +ℝ real-ℚ⁺ d) →
+      leq-ℝ y (x +ℝ real-ℚ⁺ d) →
+      neighborhood-ℝ l d x y
+    neighborhood-real-bound-each-leq-ℝ x≤y+d y≤x+d =
+      ( lower-neighborhood-real-bound-leq-ℝ d x y y≤x+d) ,
+      ( lower-neighborhood-real-bound-leq-ℝ d y x x≤y+d)
 
-  right-leq-real-bound-neighborhood-ℝ :
-    neighborhood-ℝ l d x y → leq-ℝ y (x +ℝ real-ℚ (rational-ℚ⁺ d))
-  right-leq-real-bound-neighborhood-ℝ (H , _) =
-    real-bound-leq-lower-neighborhood-ℝ d x y H
+    left-leq-real-bound-neighborhood-ℝ :
+      neighborhood-ℝ l d x y → leq-ℝ x (y +ℝ real-ℚ⁺ d)
+    left-leq-real-bound-neighborhood-ℝ (_ , K) =
+      real-bound-leq-lower-neighborhood-ℝ d y x K
+
+    right-leq-real-bound-neighborhood-ℝ :
+      neighborhood-ℝ l d x y → leq-ℝ y (x +ℝ real-ℚ⁺ d)
+    right-leq-real-bound-neighborhood-ℝ (H , _) =
+      real-bound-leq-lower-neighborhood-ℝ d x y H
 ```
 
 ### Similarity of real numbers preserves neighborhoods
@@ -333,11 +349,11 @@ module _
       ( preserves-leq-sim-ℝ
         ( x)
         ( x')
-        ( y +ℝ real-ℚ (rational-ℚ⁺ d))
-        ( y' +ℝ real-ℚ (rational-ℚ⁺ d))
+        ( y +ℝ real-ℚ⁺ d)
+        ( y' +ℝ real-ℚ⁺ d)
         ( x~x')
         ( preserves-sim-right-add-ℝ
-          ( real-ℚ (rational-ℚ⁺ d))
+          ( real-ℚ⁺ d)
           ( y)
           ( y')
           ( y~y'))
@@ -345,11 +361,11 @@ module _
       ( preserves-leq-sim-ℝ
         ( y)
         ( y')
-        ( x +ℝ real-ℚ (rational-ℚ⁺ d))
-        ( x' +ℝ real-ℚ (rational-ℚ⁺ d))
+        ( x +ℝ real-ℚ⁺ d)
+        ( x' +ℝ real-ℚ⁺ d)
         ( y~y')
         ( preserves-sim-right-add-ℝ
-          ( real-ℚ (rational-ℚ⁺ d))
+          ( real-ℚ⁺ d)
           ( x)
           ( x')
           ( x~x'))
@@ -359,19 +375,22 @@ module _
 ### The canonical embedding from rational to real numbers is an isometry between metric spaces
 
 ```agda
-is-isometry-metric-space-real-ℚ :
-  is-isometry-Metric-Space
-    ( metric-space-ℚ)
-    ( metric-space-ℝ lzero)
-    ( real-ℚ)
-is-isometry-metric-space-real-ℚ d x y =
-  pair
-    ( map-product
-      ( le-le-add-positive-leq-add-positive-ℚ x y d)
-      ( le-le-add-positive-leq-add-positive-ℚ y x d))
-    ( map-product
-      ( leq-add-positive-le-le-add-positive-ℚ x y d)
-      ( leq-add-positive-le-le-add-positive-ℚ y x d))
+opaque
+  unfolding neighborhood-prop-ℝ real-ℚ
+
+  is-isometry-metric-space-real-ℚ :
+    is-isometry-Metric-Space
+      ( metric-space-ℚ)
+      ( metric-space-ℝ lzero)
+      ( real-ℚ)
+  is-isometry-metric-space-real-ℚ d x y =
+    pair
+      ( map-product
+        ( le-le-add-positive-leq-add-positive-ℚ x y d)
+        ( le-le-add-positive-leq-add-positive-ℚ y x d))
+      ( map-product
+        ( leq-add-positive-le-le-add-positive-ℚ x y d)
+        ( leq-add-positive-le-le-add-positive-ℚ y x d))
 
 isometry-metric-space-real-ℚ :
   isometry-Metric-Space
@@ -388,29 +407,30 @@ module _
   {l0 : Level} (l : Level)
   where
 
-  is-isometry-metric-space-raise-ℝ :
-    is-isometry-Metric-Space
-      ( metric-space-ℝ l0)
-      ( metric-space-ℝ (l0 ⊔ l))
-      ( raise-ℝ l)
-  pr1 (is-isometry-metric-space-raise-ℝ d x y) =
-    preserves-neighborhood-sim-ℝ
-      ( d)
-      ( x)
-      ( y)
-      ( raise-ℝ l x)
-      ( raise-ℝ l y)
-      ( sim-raise-ℝ l x)
-      ( sim-raise-ℝ l y)
-  pr2 (is-isometry-metric-space-raise-ℝ d x y) =
-    preserves-neighborhood-sim-ℝ
-      ( d)
-      ( raise-ℝ l x)
-      ( raise-ℝ l y)
-      ( x)
-      ( y)
-      ( symmetric-sim-ℝ (sim-raise-ℝ l x))
-      ( symmetric-sim-ℝ (sim-raise-ℝ l y))
+  abstract
+    is-isometry-metric-space-raise-ℝ :
+      is-isometry-Metric-Space
+        ( metric-space-ℝ l0)
+        ( metric-space-ℝ (l0 ⊔ l))
+        ( raise-ℝ l)
+    pr1 (is-isometry-metric-space-raise-ℝ d x y) =
+      preserves-neighborhood-sim-ℝ
+        ( d)
+        ( x)
+        ( y)
+        ( raise-ℝ l x)
+        ( raise-ℝ l y)
+        ( sim-raise-ℝ l x)
+        ( sim-raise-ℝ l y)
+    pr2 (is-isometry-metric-space-raise-ℝ d x y) =
+      preserves-neighborhood-sim-ℝ
+        ( d)
+        ( raise-ℝ l x)
+        ( raise-ℝ l y)
+        ( x)
+        ( y)
+        ( symmetric-sim-ℝ (sim-raise-ℝ l x))
+        ( symmetric-sim-ℝ (sim-raise-ℝ l y))
 
   isometry-metric-space-raise-ℝ :
     isometry-Metric-Space
@@ -439,16 +459,17 @@ module _
       ( isometry-metric-space-raise-ℝ l)
       ( isometry-metric-space-real-ℚ)
 
-  is-isometry-metric-space-raise-real-ℚ :
-    is-isometry-Metric-Space
-      ( metric-space-ℚ)
-      ( metric-space-ℝ l)
-      ( raise-real-ℚ l)
-  is-isometry-metric-space-raise-real-ℚ =
-    is-isometry-map-isometry-Metric-Space
-      ( metric-space-ℚ)
-      ( metric-space-ℝ l)
-      ( isometry-metric-space-raise-real-ℚ)
+  abstract
+    is-isometry-metric-space-raise-real-ℚ :
+      is-isometry-Metric-Space
+        ( metric-space-ℚ)
+        ( metric-space-ℝ l)
+        ( raise-real-ℚ l)
+    is-isometry-metric-space-raise-real-ℚ =
+      is-isometry-map-isometry-Metric-Space
+        ( metric-space-ℚ)
+        ( metric-space-ℝ l)
+        ( isometry-metric-space-raise-real-ℚ)
 ```
 
 ## References

--- a/src/real-numbers/negation-real-numbers.lagda.md
+++ b/src/real-numbers/negation-real-numbers.lagda.md
@@ -84,13 +84,14 @@ module _
       ( inl-disjunction)
       ( is-located-lower-upper-cut-ℝ x (neg-ℚ r) (neg-ℚ q) (neg-le-ℚ q r q<r))
 
-  neg-ℝ : ℝ l
-  neg-ℝ =
-    real-lower-upper-ℝ
-      ( lower-real-neg-ℝ)
-      ( upper-real-neg-ℝ)
-      ( is-disjoint-cut-neg-ℝ)
-      ( is-located-lower-upper-cut-neg-ℝ)
+  opaque
+    neg-ℝ : ℝ l
+    neg-ℝ =
+      real-lower-upper-ℝ
+        ( lower-real-neg-ℝ)
+        ( upper-real-neg-ℝ)
+        ( is-disjoint-cut-neg-ℝ)
+        ( is-located-lower-upper-cut-neg-ℝ)
 ```
 
 ## Properties
@@ -98,37 +99,45 @@ module _
 ### The negation function on real numbers is an involution
 
 ```agda
-neg-neg-ℝ : {l : Level} → (x : ℝ l) → neg-ℝ (neg-ℝ x) ＝ x
-neg-neg-ℝ x =
-  eq-eq-lower-cut-ℝ
-    ( neg-ℝ (neg-ℝ x))
-    ( x)
-    ( eq-has-same-elements-subtype
-      ( lower-cut-ℝ (neg-ℝ (neg-ℝ x)))
-      ( lower-cut-ℝ x)
-      ( λ q →
-        tr (is-in-lower-cut-ℝ x) (neg-neg-ℚ q) ,
-        tr (is-in-lower-cut-ℝ x) (inv (neg-neg-ℚ q))))
+opaque
+  unfolding neg-ℝ
+
+  neg-neg-ℝ : {l : Level} → (x : ℝ l) → neg-ℝ (neg-ℝ x) ＝ x
+  neg-neg-ℝ x =
+    eq-eq-lower-cut-ℝ
+      ( neg-ℝ (neg-ℝ x))
+      ( x)
+      ( eq-has-same-elements-subtype
+        ( lower-cut-ℝ (neg-ℝ (neg-ℝ x)))
+        ( lower-cut-ℝ x)
+        ( λ q →
+          tr (is-in-lower-cut-ℝ x) (neg-neg-ℚ q) ,
+          tr (is-in-lower-cut-ℝ x) (inv (neg-neg-ℚ q))))
 ```
 
 ### Negation preserves rationality
 
 ```agda
-neg-Rational-ℝ : {l : Level} → Rational-ℝ l → Rational-ℝ l
-neg-Rational-ℝ (x , q , q≮x , x≮q) =
-  neg-ℝ x ,
-  neg-ℚ q ,
-  x≮q ∘ tr (is-in-upper-cut-ℝ x) (neg-neg-ℚ q) ,
-  q≮x ∘ tr (is-in-lower-cut-ℝ x) (neg-neg-ℚ q)
+opaque
+  unfolding neg-ℝ
 
-neg-real-ℚ : (q : ℚ) → neg-ℝ (real-ℚ q) ＝ real-ℚ (neg-ℚ q)
-neg-real-ℚ q = eq-sim-ℝ (sim-rational-ℝ (neg-Rational-ℝ (rational-real-ℚ q)))
+  neg-Rational-ℝ : {l : Level} → Rational-ℝ l → Rational-ℝ l
+  neg-Rational-ℝ (x , q , q≮x , x≮q) =
+    neg-ℝ x ,
+    neg-ℚ q ,
+    x≮q ∘ tr (is-in-upper-cut-ℝ x) (neg-neg-ℚ q) ,
+    q≮x ∘ tr (is-in-lower-cut-ℝ x) (neg-neg-ℚ q)
+
+  neg-real-ℚ : (q : ℚ) → neg-ℝ (real-ℚ q) ＝ real-ℚ (neg-ℚ q)
+  neg-real-ℚ q = eq-sim-ℝ (sim-rational-ℝ (neg-Rational-ℝ (rational-real-ℚ q)))
 ```
 
 ### Negation preserves similarity
 
 ```agda
-abstract
+opaque
+  unfolding neg-ℝ
+
   preserves-sim-neg-ℝ :
     {l1 l2 : Level} {x : ℝ l1} {x' : ℝ l2} →
     sim-ℝ x x' → sim-ℝ (neg-ℝ x) (neg-ℝ x')

--- a/src/real-numbers/nonnegative-real-numbers.lagda.md
+++ b/src/real-numbers/nonnegative-real-numbers.lagda.md
@@ -33,7 +33,7 @@ is-nonnegative-ℝ : {l : Level} → ℝ l → UU l
 is-nonnegative-ℝ = leq-ℝ zero-ℝ
 
 is-nonnegative-prop-ℝ : {l : Level} → ℝ l → Prop l
-is-nonnegative-prop-ℝ = leq-ℝ-Prop zero-ℝ
+is-nonnegative-prop-ℝ = leq-prop-ℝ zero-ℝ
 
 nonnegative-ℝ : (l : Level) → UU (lsuc l)
 nonnegative-ℝ l = type-subtype (is-nonnegative-prop-ℝ {l})

--- a/src/real-numbers/positive-real-numbers.lagda.md
+++ b/src/real-numbers/positive-real-numbers.lagda.md
@@ -54,7 +54,7 @@ is [strictly less than](real-numbers.strict-inequality-real-numbers.md) it.
 
 ```agda
 is-positive-prop-ℝ : {l : Level} → ℝ l → Prop l
-is-positive-prop-ℝ = le-ℝ-Prop zero-ℝ
+is-positive-prop-ℝ = le-prop-ℝ zero-ℝ
 
 is-positive-ℝ : {l : Level} → ℝ l → UU l
 is-positive-ℝ x = type-Prop (is-positive-prop-ℝ x)
@@ -99,7 +99,7 @@ module _
   where
 
   opaque
-    unfolding le-ℝ-Prop real-ℚ
+    unfolding le-ℝ real-ℚ
 
     exists-ℚ⁺-in-lower-cut-is-positive-ℝ :
       is-positive-ℝ x → exists ℚ⁺ (λ p → lower-cut-ℝ x (rational-ℚ⁺ p))
@@ -134,7 +134,7 @@ exists-ℚ⁺-in-lower-cut-ℝ⁺ = ind-Σ exists-ℚ⁺-in-lower-cut-is-positiv
 ```agda
 opaque
   unfolding add-ℝ
-  unfolding le-ℝ-Prop
+  unfolding le-ℝ
 
   le-left-add-real-ℝ⁺ :
     {l1 l2 : Level} → (x : ℝ l1) (d : ℝ⁺ l2) → le-ℝ x (x +ℝ real-ℝ⁺ d)
@@ -197,11 +197,11 @@ is-positive-real-positive-ℚ q pos-q =
   preserves-le-real-ℚ zero-ℚ q (le-zero-is-positive-ℚ q pos-q)
 
 opaque
-  unfolding le-ℝ-Prop real-ℚ
+  unfolding le-ℝ real-ℚ
 
-  is-positive-rational-positive-real-ℚ :
+  is-positive-rational-is-positive-real-ℚ :
     (q : ℚ) → is-positive-ℝ (real-ℚ q) → is-positive-ℚ q
-  is-positive-rational-positive-real-ℚ q =
+  is-positive-rational-is-positive-real-ℚ q =
     elim-exists
       ( is-positive-prop-ℚ q)
       ( λ r (0<r , r<q) →

--- a/src/real-numbers/positive-real-numbers.lagda.md
+++ b/src/real-numbers/positive-real-numbers.lagda.md
@@ -98,21 +98,24 @@ module _
   {l : Level} (x : ℝ l)
   where
 
-  exists-ℚ⁺-in-lower-cut-is-positive-ℝ :
-    is-positive-ℝ x → exists ℚ⁺ (λ p → lower-cut-ℝ x (rational-ℚ⁺ p))
-  exists-ℚ⁺-in-lower-cut-is-positive-ℝ =
-    elim-exists
-      ( ∃ ℚ⁺ (λ p → lower-cut-ℝ x (rational-ℚ⁺ p)))
-      ( λ p (0<p , p<x) → intro-exists (p , is-positive-le-zero-ℚ p 0<p) p<x)
+  opaque
+    unfolding le-ℝ-Prop real-ℚ
 
-  is-positive-exists-ℚ⁺-in-lower-cut-ℝ :
-    exists ℚ⁺ (λ p → lower-cut-ℝ x (rational-ℚ⁺ p)) →
-    is-positive-ℝ x
-  is-positive-exists-ℚ⁺-in-lower-cut-ℝ =
-    elim-exists
-      ( is-positive-prop-ℝ x)
-      ( λ (p , pos-p) p<x →
-        intro-exists p (le-zero-is-positive-ℚ p pos-p , p<x))
+    exists-ℚ⁺-in-lower-cut-is-positive-ℝ :
+      is-positive-ℝ x → exists ℚ⁺ (λ p → lower-cut-ℝ x (rational-ℚ⁺ p))
+    exists-ℚ⁺-in-lower-cut-is-positive-ℝ =
+      elim-exists
+        ( ∃ ℚ⁺ (λ p → lower-cut-ℝ x (rational-ℚ⁺ p)))
+        ( λ p (0<p , p<x) → intro-exists (p , is-positive-le-zero-ℚ p 0<p) p<x)
+
+    is-positive-exists-ℚ⁺-in-lower-cut-ℝ :
+      exists ℚ⁺ (λ p → lower-cut-ℝ x (rational-ℚ⁺ p)) →
+      is-positive-ℝ x
+    is-positive-exists-ℚ⁺-in-lower-cut-ℝ =
+      elim-exists
+        ( is-positive-prop-ℝ x)
+        ( λ (p , pos-p) p<x →
+          intro-exists p (le-zero-is-positive-ℚ p pos-p , p<x))
 
   is-positive-iff-exists-ℚ⁺-in-lower-cut-ℝ :
     is-positive-ℝ x ↔ exists ℚ⁺ (λ p → lower-cut-ℝ x (rational-ℚ⁺ p))
@@ -131,6 +134,7 @@ exists-ℚ⁺-in-lower-cut-ℝ⁺ = ind-Σ exists-ℚ⁺-in-lower-cut-is-positiv
 ```agda
 opaque
   unfolding add-ℝ
+  unfolding le-ℝ-Prop
 
   le-left-add-real-ℝ⁺ :
     {l1 l2 : Level} → (x : ℝ l1) (d : ℝ⁺ l2) → le-ℝ x (x +ℝ real-ℝ⁺ d)
@@ -192,13 +196,16 @@ is-positive-real-positive-ℚ :
 is-positive-real-positive-ℚ q pos-q =
   preserves-le-real-ℚ zero-ℚ q (le-zero-is-positive-ℚ q pos-q)
 
-is-positive-rational-positive-real-ℚ :
-  (q : ℚ) → is-positive-ℝ (real-ℚ q) → is-positive-ℚ q
-is-positive-rational-positive-real-ℚ q =
-  elim-exists
-    ( is-positive-prop-ℚ q)
-    ( λ r (0<r , r<q) →
-      is-positive-le-zero-ℚ q (transitive-le-ℚ zero-ℚ r q r<q 0<r))
+opaque
+  unfolding le-ℝ-Prop real-ℚ
+
+  is-positive-rational-positive-real-ℚ :
+    (q : ℚ) → is-positive-ℝ (real-ℚ q) → is-positive-ℚ q
+  is-positive-rational-positive-real-ℚ q =
+    elim-exists
+      ( is-positive-prop-ℚ q)
+      ( λ r (0<r , r<q) →
+        is-positive-le-zero-ℚ q (transitive-le-ℚ zero-ℚ r q r<q 0<r))
 
 positive-real-ℚ⁺ : ℚ⁺ → ℝ⁺ lzero
 positive-real-ℚ⁺ (q , pos-q) = (real-ℚ q , is-positive-real-positive-ℚ q pos-q)

--- a/src/real-numbers/rational-real-numbers.lagda.md
+++ b/src/real-numbers/rational-real-numbers.lagda.md
@@ -75,8 +75,10 @@ is-dedekind-lower-upper-real-ℚ x =
 ### The canonical map from `ℚ` to `ℝ lzero`
 
 ```agda
-real-ℚ : ℚ → ℝ lzero
-real-ℚ x = (lower-real-ℚ x , upper-real-ℚ x , is-dedekind-lower-upper-real-ℚ x)
+opaque
+  real-ℚ : ℚ → ℝ lzero
+  real-ℚ x =
+    (lower-real-ℚ x , upper-real-ℚ x , is-dedekind-lower-upper-real-ℚ x)
 
 real-ℚ⁺ : ℚ⁺ → ℝ lzero
 real-ℚ⁺ q = real-ℚ (rational-ℚ⁺ q)
@@ -190,15 +192,18 @@ module _
 ### The real embedding of a rational number is rational
 
 ```agda
-is-rational-real-ℚ : (p : ℚ) → is-rational-ℝ (real-ℚ p) p
-is-rational-real-ℚ p = (irreflexive-le-ℚ p , irreflexive-le-ℚ p)
+opaque
+  unfolding real-ℚ
+
+  is-rational-real-ℚ : (p : ℚ) → is-rational-ℝ (real-ℚ p) p
+  is-rational-real-ℚ p = (irreflexive-le-ℚ p , irreflexive-le-ℚ p)
 ```
 
 ### Rational real numbers are embedded rationals
 
 ```agda
 opaque
-  unfolding sim-ℝ
+  unfolding real-ℚ sim-ℝ
 
   sim-rational-ℝ :
     {l : Level} →

--- a/src/real-numbers/strict-inequality-real-numbers.lagda.md
+++ b/src/real-numbers/strict-inequality-real-numbers.lagda.md
@@ -64,8 +64,9 @@ presence of a [rational number](elementary-number-theory.rational-numbers.md)
 between them. This is the definition used in {{#cite UF13}}, section 11.2.1.
 
 ```agda
-le-ℝ-Prop : Large-Relation-Prop _⊔_ ℝ
-le-ℝ-Prop x y = ∃ ℚ (λ q → upper-cut-ℝ x q ∧ lower-cut-ℝ y q)
+opaque
+  le-ℝ-Prop : Large-Relation-Prop _⊔_ ℝ
+  le-ℝ-Prop x y = ∃ ℚ (λ q → upper-cut-ℝ x q ∧ lower-cut-ℝ y q)
 
 le-ℝ : Large-Relation _⊔_ ℝ
 le-ℝ x y = type-Prop (le-ℝ-Prop x y)
@@ -83,7 +84,10 @@ module _
   {l1 l2 : Level} (x : ℝ l1) (y : ℝ l2)
   where
 
-  abstract
+  opaque
+    unfolding le-ℝ-Prop
+    unfolding leq-ℝ-Prop
+
     leq-le-ℝ : le-ℝ x y → leq-ℝ x y
     leq-le-ℝ x<y p p<x =
       elim-exists
@@ -101,11 +105,14 @@ module _
   (x : ℝ l)
   where
 
-  irreflexive-le-ℝ : ¬ (le-ℝ x x)
-  irreflexive-le-ℝ =
-    elim-exists
-      ( empty-Prop)
-      ( λ q (x<q , q<x) → is-disjoint-cut-ℝ x q (q<x , x<q))
+  opaque
+    unfolding le-ℝ-Prop
+
+    irreflexive-le-ℝ : ¬ (le-ℝ x x)
+    irreflexive-le-ℝ =
+      elim-exists
+        ( empty-Prop)
+        ( λ q (x<q , q<x) → is-disjoint-cut-ℝ x q (q<x , x<q))
 ```
 
 ### Strict inequality on the reals is asymmetric
@@ -117,7 +124,9 @@ module _
   (y : ℝ l2)
   where
 
-  abstract
+  opaque
+    unfolding le-ℝ-Prop
+
     asymmetric-le-ℝ : le-ℝ x y → ¬ (le-ℝ y x)
     asymmetric-le-ℝ x<y y<x =
       let
@@ -147,7 +156,9 @@ module _
   (z : ℝ l3)
   where
 
-  abstract
+  opaque
+    unfolding le-ℝ-Prop
+
     transitive-le-ℝ : le-ℝ y z → le-ℝ x y → le-ℝ x z
     transitive-le-ℝ y<z x<y =
       let
@@ -168,7 +179,9 @@ module _
   (x y : ℚ)
   where
 
-  abstract
+  opaque
+    unfolding le-ℝ-Prop real-ℚ
+
     preserves-le-real-ℚ : le-ℚ x y → le-ℝ (real-ℚ x) (real-ℚ y)
     preserves-le-real-ℚ x<y =
       intro-exists
@@ -196,7 +209,9 @@ module _
   (z : ℝ l3)
   where
 
-  abstract
+  opaque
+    unfolding le-ℝ-Prop leq-ℝ-Prop leq-ℝ-Prop'
+
     concatenate-le-leq-ℝ : le-ℝ x y → leq-ℝ y z → le-ℝ x z
     concatenate-le-leq-ℝ x<y y≤z =
       map-tot-exists (λ p → map-product id (y≤z p)) x<y
@@ -214,14 +229,18 @@ module _
   {l : Level} (q : ℚ) (x : ℝ l)
   where
 
-  le-real-iff-lower-cut-ℚ : is-in-lower-cut-ℝ x q ↔ le-ℝ (real-ℚ q) x
-  le-real-iff-lower-cut-ℚ = is-rounded-lower-cut-ℝ x q
+  opaque
+    unfolding le-ℝ-Prop real-ℚ
 
-  le-real-is-in-lower-cut-ℚ : is-in-lower-cut-ℝ x q → le-ℝ (real-ℚ q) x
-  le-real-is-in-lower-cut-ℚ = forward-implication le-real-iff-lower-cut-ℚ
+    le-real-iff-lower-cut-ℚ : is-in-lower-cut-ℝ x q ↔ le-ℝ (real-ℚ q) x
+    le-real-iff-lower-cut-ℚ = is-rounded-lower-cut-ℝ x q
 
-  is-in-lower-cut-le-real-ℚ : le-ℝ (real-ℚ q) x → is-in-lower-cut-ℝ x q
-  is-in-lower-cut-le-real-ℚ = backward-implication le-real-iff-lower-cut-ℚ
+  abstract
+    le-real-is-in-lower-cut-ℚ : is-in-lower-cut-ℝ x q → le-ℝ (real-ℚ q) x
+    le-real-is-in-lower-cut-ℚ = forward-implication le-real-iff-lower-cut-ℚ
+
+    is-in-lower-cut-le-real-ℚ : le-ℝ (real-ℚ q) x → is-in-lower-cut-ℝ x q
+    is-in-lower-cut-le-real-ℚ = backward-implication le-real-iff-lower-cut-ℚ
 ```
 
 ### A rational is in the upper cut of `x` iff its real projection is greater than `x`
@@ -231,17 +250,20 @@ module _
   {l : Level} (q : ℚ) (x : ℝ l)
   where
 
-  abstract
+  opaque
+    unfolding le-ℝ-Prop real-ℚ
+
     le-iff-upper-cut-real-ℚ : is-in-upper-cut-ℝ x q ↔ le-ℝ x (real-ℚ q)
     le-iff-upper-cut-real-ℚ =
       iff-tot-exists (λ _ → iff-equiv commutative-product) ∘iff
       is-rounded-upper-cut-ℝ x q
 
-  le-real-is-in-upper-cut-ℚ : is-in-upper-cut-ℝ x q → le-ℝ x (real-ℚ q)
-  le-real-is-in-upper-cut-ℚ = forward-implication le-iff-upper-cut-real-ℚ
+  abstract
+    le-real-is-in-upper-cut-ℚ : is-in-upper-cut-ℝ x q → le-ℝ x (real-ℚ q)
+    le-real-is-in-upper-cut-ℚ = forward-implication le-iff-upper-cut-real-ℚ
 
-  is-in-upper-cut-le-real-ℚ : le-ℝ x (real-ℚ q) → is-in-upper-cut-ℝ x q
-  is-in-upper-cut-le-real-ℚ = backward-implication le-iff-upper-cut-real-ℚ
+    is-in-upper-cut-le-real-ℚ : le-ℝ x (real-ℚ q) → is-in-upper-cut-ℝ x q
+    is-in-upper-cut-le-real-ℚ = backward-implication le-iff-upper-cut-real-ℚ
 ```
 
 ### The reals have no lower or upper bound
@@ -279,7 +301,9 @@ module _
   (y : ℝ l2)
   where
 
-  abstract
+  opaque
+    unfolding le-ℝ-Prop neg-ℝ
+
     neg-le-ℝ : le-ℝ x y → le-ℝ (neg-ℝ y) (neg-ℝ x)
     neg-le-ℝ x<y =
       let
@@ -299,7 +323,10 @@ module _
   {l1 l2 : Level} (x : ℝ l1) (y : ℝ l2)
   where
 
-  abstract
+  opaque
+    unfolding le-ℝ-Prop
+    unfolding leq-ℝ-Prop
+
     not-leq-le-ℝ : le-ℝ x y → ¬ (leq-ℝ y x)
     not-leq-le-ℝ x<y y≤x =
       elim-exists
@@ -315,7 +342,10 @@ module _
   {l1 l2 : Level} (x : ℝ l1) (y : ℝ l2)
   where
 
-  abstract
+  opaque
+    unfolding le-ℝ-Prop
+    unfolding leq-ℝ-Prop
+
     leq-not-le-ℝ : ¬ (le-ℝ x y) → leq-ℝ y x
     leq-not-le-ℝ x≮y p p<y =
       let
@@ -362,7 +392,9 @@ module _
   (y : ℝ l2)
   where
 
-  abstract
+  opaque
+    unfolding le-ℝ-Prop real-ℚ
+
     dense-rational-le-ℝ :
       le-ℝ x y →
       exists ℚ (λ z → le-ℝ-Prop x (real-ℚ z) ∧ le-ℝ-Prop (real-ℚ z) y)
@@ -403,7 +435,9 @@ module _
 ### Strict inequality on the real numbers is cotransitive
 
 ```agda
-abstract
+opaque
+  unfolding le-ℝ-Prop
+
   cotransitive-le-ℝ : is-cotransitive-Large-Relation-Prop ℝ le-ℝ-Prop
   cotransitive-le-ℝ x y z x<y =
     let
@@ -430,6 +464,7 @@ module _
 
   opaque
     unfolding sim-ℝ
+    unfolding le-ℝ-Prop
 
     preserves-le-left-sim-ℝ : le-ℝ x z → le-ℝ y z
     preserves-le-left-sim-ℝ =
@@ -468,6 +503,7 @@ module _
 
   opaque
     unfolding add-ℝ
+    unfolding le-ℝ-Prop
 
     preserves-le-right-add-ℝ : le-ℝ x y → le-ℝ (x +ℝ z) (y +ℝ z)
     preserves-le-right-add-ℝ x<y =
@@ -519,6 +555,18 @@ module _
         ( commutative-add-ℝ x z)
         ( commutative-add-ℝ y z)
         ( preserves-le-right-add-ℝ x<y)
+
+abstract
+  preserves-le-diff-ℝ :
+    {l1 l2 l3 : Level} (z : ℝ l1) (x : ℝ l2) (y : ℝ l3) →
+    le-ℝ x y → le-ℝ (x -ℝ z) (y -ℝ z)
+  preserves-le-diff-ℝ z = preserves-le-right-add-ℝ (neg-ℝ z)
+
+  reverses-le-diff-ℝ :
+    {l1 l2 l3 : Level} (z : ℝ l1) (x : ℝ l2) (y : ℝ l3) →
+    le-ℝ x y → le-ℝ (z -ℝ y) (z -ℝ x)
+  reverses-le-diff-ℝ z x y x<y =
+    preserves-le-left-add-ℝ z _ _ (neg-le-ℝ _ _ x<y)
 
 module _
   {l1 l2 l3 : Level} (z : ℝ l1) (x : ℝ l2) (y : ℝ l3)
@@ -645,6 +693,32 @@ module _
     le-transpose-right-add-ℝ' : le-ℝ x (y +ℝ z) → le-ℝ (x -ℝ y) z
     le-transpose-right-add-ℝ' x<y+z =
       le-transpose-right-add-ℝ x z y (tr (le-ℝ x) (commutative-add-ℝ _ _) x<y+z)
+```
+
+### If `x < y`, then there is some `ε : ℚ⁺` with `x + ε < y`
+
+```agda
+module _
+  {l1 l2 : Level} {x : ℝ l1} {y : ℝ l2} (x<y : le-ℝ x y)
+  where
+
+  abstract
+    exists-positive-rational-separation-le-ℝ :
+      exists ℚ⁺ (λ q → le-ℝ-Prop (x +ℝ real-ℚ⁺ q) y)
+    exists-positive-rational-separation-le-ℝ =
+      let open do-syntax-trunc-Prop (∃ ℚ⁺ (λ q → le-ℝ-Prop (x +ℝ real-ℚ⁺ q) y))
+      in do
+        (q , 0<q , q<y-x) ←
+          dense-rational-le-ℝ zero-ℝ (y -ℝ x)
+            ( preserves-le-left-sim-ℝ
+              ( y -ℝ x)
+              ( x -ℝ x)
+              ( zero-ℝ)
+              ( right-inverse-law-add-ℝ x)
+              ( preserves-le-right-add-ℝ (neg-ℝ x) x y x<y))
+        intro-exists
+          ( q , is-positive-le-zero-ℚ q (reflects-le-real-ℚ _ _ 0<q))
+          ( le-transpose-right-diff-ℝ' _ _ _ q<y-x)
 ```
 
 ## References

--- a/src/real-numbers/strict-inequality-real-numbers.lagda.md
+++ b/src/real-numbers/strict-inequality-real-numbers.lagda.md
@@ -65,14 +65,14 @@ between them. This is the definition used in {{#cite UF13}}, section 11.2.1.
 
 ```agda
 opaque
-  le-ℝ-Prop : Large-Relation-Prop _⊔_ ℝ
-  le-ℝ-Prop x y = ∃ ℚ (λ q → upper-cut-ℝ x q ∧ lower-cut-ℝ y q)
+  le-ℝ : Large-Relation _⊔_ ℝ
+  le-ℝ x y = exists ℚ (λ q → upper-cut-ℝ x q ∧ lower-cut-ℝ y q)
 
-le-ℝ : Large-Relation _⊔_ ℝ
-le-ℝ x y = type-Prop (le-ℝ-Prop x y)
+  is-prop-le-ℝ : {l1 l2 : Level} → (x : ℝ l1) (y : ℝ l2) → is-prop (le-ℝ x y)
+  is-prop-le-ℝ x y = is-prop-exists ℚ (λ q → upper-cut-ℝ x q ∧ lower-cut-ℝ y q)
 
-is-prop-le-ℝ : {l1 l2 : Level} → (x : ℝ l1) (y : ℝ l2) → is-prop (le-ℝ x y)
-is-prop-le-ℝ x y = is-prop-type-Prop (le-ℝ-Prop x y)
+le-prop-ℝ : Large-Relation-Prop _⊔_ ℝ
+le-prop-ℝ x y = (le-ℝ x y , is-prop-le-ℝ x y)
 ```
 
 ## Properties
@@ -85,8 +85,7 @@ module _
   where
 
   opaque
-    unfolding le-ℝ-Prop
-    unfolding leq-ℝ-Prop
+    unfolding le-ℝ leq-ℝ
 
     leq-le-ℝ : le-ℝ x y → leq-ℝ x y
     leq-le-ℝ x<y p p<x =
@@ -106,7 +105,7 @@ module _
   where
 
   opaque
-    unfolding le-ℝ-Prop
+    unfolding le-ℝ
 
     irreflexive-le-ℝ : ¬ (le-ℝ x x)
     irreflexive-le-ℝ =
@@ -125,7 +124,7 @@ module _
   where
 
   opaque
-    unfolding le-ℝ-Prop
+    unfolding le-ℝ
 
     asymmetric-le-ℝ : le-ℝ x y → ¬ (le-ℝ y x)
     asymmetric-le-ℝ x<y y<x =
@@ -157,12 +156,12 @@ module _
   where
 
   opaque
-    unfolding le-ℝ-Prop
+    unfolding le-ℝ
 
     transitive-le-ℝ : le-ℝ y z → le-ℝ x y → le-ℝ x z
     transitive-le-ℝ y<z x<y =
       let
-        open do-syntax-trunc-Prop (le-ℝ-Prop x z)
+        open do-syntax-trunc-Prop (le-prop-ℝ x z)
       in do
         ( p , x<p , p<y) ← x<y
         ( q , y<q , q<z) ← y<z
@@ -180,7 +179,7 @@ module _
   where
 
   opaque
-    unfolding le-ℝ-Prop real-ℚ
+    unfolding le-ℝ real-ℚ
 
     preserves-le-real-ℚ : le-ℚ x y → le-ℝ (real-ℚ x) (real-ℚ y)
     preserves-le-real-ℚ x<y =
@@ -210,7 +209,7 @@ module _
   where
 
   opaque
-    unfolding le-ℝ-Prop leq-ℝ-Prop leq-ℝ-Prop'
+    unfolding le-ℝ leq-ℝ leq-ℝ'
 
     concatenate-le-leq-ℝ : le-ℝ x y → leq-ℝ y z → le-ℝ x z
     concatenate-le-leq-ℝ x<y y≤z =
@@ -230,7 +229,7 @@ module _
   where
 
   opaque
-    unfolding le-ℝ-Prop real-ℚ
+    unfolding le-ℝ real-ℚ
 
     le-real-iff-lower-cut-ℚ : is-in-lower-cut-ℝ x q ↔ le-ℝ (real-ℚ q) x
     le-real-iff-lower-cut-ℚ = is-rounded-lower-cut-ℝ x q
@@ -251,7 +250,7 @@ module _
   where
 
   opaque
-    unfolding le-ℝ-Prop real-ℚ
+    unfolding le-ℝ real-ℚ
 
     le-iff-upper-cut-real-ℚ : is-in-upper-cut-ℝ x q ↔ le-ℝ x (real-ℚ q)
     le-iff-upper-cut-real-ℚ =
@@ -275,18 +274,18 @@ module _
   where
 
   abstract
-    exists-lesser-ℝ : exists (ℝ lzero) (λ y → le-ℝ-Prop y x)
+    exists-lesser-ℝ : exists (ℝ lzero) (λ y → le-prop-ℝ y x)
     exists-lesser-ℝ =
       let
-        open do-syntax-trunc-Prop (∃ (ℝ lzero) (λ y → le-ℝ-Prop y x))
+        open do-syntax-trunc-Prop (∃ (ℝ lzero) (λ y → le-prop-ℝ y x))
       in do
         ( q , q<x) ← is-inhabited-lower-cut-ℝ x
         intro-exists (real-ℚ q) (le-real-is-in-lower-cut-ℚ q x q<x)
 
-    exists-greater-ℝ : exists (ℝ lzero) (λ y → le-ℝ-Prop x y)
+    exists-greater-ℝ : exists (ℝ lzero) (λ y → le-prop-ℝ x y)
     exists-greater-ℝ =
       let
-        open do-syntax-trunc-Prop (∃ (ℝ lzero) (le-ℝ-Prop x))
+        open do-syntax-trunc-Prop (∃ (ℝ lzero) (le-prop-ℝ x))
       in do
         ( q , x<q) ← is-inhabited-upper-cut-ℝ x
         intro-exists (real-ℚ q) (le-real-is-in-upper-cut-ℚ q x x<q)
@@ -302,12 +301,12 @@ module _
   where
 
   opaque
-    unfolding le-ℝ-Prop neg-ℝ
+    unfolding le-ℝ neg-ℝ
 
     neg-le-ℝ : le-ℝ x y → le-ℝ (neg-ℝ y) (neg-ℝ x)
     neg-le-ℝ x<y =
       let
-        open do-syntax-trunc-Prop (le-ℝ-Prop (neg-ℝ y) (neg-ℝ x))
+        open do-syntax-trunc-Prop (le-prop-ℝ (neg-ℝ y) (neg-ℝ x))
       in do
         (p , x<p , p<y) ← x<y
         intro-exists
@@ -324,8 +323,8 @@ module _
   where
 
   opaque
-    unfolding le-ℝ-Prop
-    unfolding leq-ℝ-Prop
+    unfolding le-ℝ
+    unfolding leq-ℝ
 
     not-leq-le-ℝ : le-ℝ x y → ¬ (leq-ℝ y x)
     not-leq-le-ℝ x<y y≤x =
@@ -343,8 +342,8 @@ module _
   where
 
   opaque
-    unfolding le-ℝ-Prop
-    unfolding leq-ℝ-Prop
+    unfolding le-ℝ
+    unfolding leq-ℝ
 
     leq-not-le-ℝ : ¬ (le-ℝ x y) → leq-ℝ y x
     leq-not-le-ℝ x≮y p p<y =
@@ -393,16 +392,16 @@ module _
   where
 
   opaque
-    unfolding le-ℝ-Prop real-ℚ
+    unfolding le-ℝ real-ℚ
 
     dense-rational-le-ℝ :
       le-ℝ x y →
-      exists ℚ (λ z → le-ℝ-Prop x (real-ℚ z) ∧ le-ℝ-Prop (real-ℚ z) y)
+      exists ℚ (λ z → le-prop-ℝ x (real-ℚ z) ∧ le-prop-ℝ (real-ℚ z) y)
     dense-rational-le-ℝ x<y =
       let
         open
           do-syntax-trunc-Prop
-            ( ∃ ℚ (λ z → le-ℝ-Prop x (real-ℚ z) ∧ le-ℝ-Prop (real-ℚ z) y))
+            ( ∃ ℚ (λ z → le-prop-ℝ x (real-ℚ z) ∧ le-prop-ℝ (real-ℚ z) y))
       in do
         ( q , x<q , q<y) ← x<y
         ( p , p<q , x<p) ← forward-implication (is-rounded-upper-cut-ℝ x q) x<q
@@ -423,7 +422,7 @@ module _
 
   abstract
     dense-le-ℝ :
-      le-ℝ x y → exists (ℝ lzero) (λ z → le-ℝ-Prop x z ∧ le-ℝ-Prop z y)
+      le-ℝ x y → exists (ℝ lzero) (λ z → le-prop-ℝ x z ∧ le-prop-ℝ z y)
     dense-le-ℝ x<y =
       map-exists
         ( _)
@@ -436,20 +435,20 @@ module _
 
 ```agda
 opaque
-  unfolding le-ℝ-Prop
+  unfolding le-ℝ
 
-  cotransitive-le-ℝ : is-cotransitive-Large-Relation-Prop ℝ le-ℝ-Prop
+  cotransitive-le-ℝ : is-cotransitive-Large-Relation-Prop ℝ le-prop-ℝ
   cotransitive-le-ℝ x y z x<y =
     let
-      open do-syntax-trunc-Prop (le-ℝ-Prop x z ∨ le-ℝ-Prop z y)
+      open do-syntax-trunc-Prop (le-prop-ℝ x z ∨ le-prop-ℝ z y)
     in do
       ( q , x<q , q<y) ← x<y
       ( p , p<q , x<p) ← forward-implication (is-rounded-upper-cut-ℝ x q) x<q
       map-disjunction
         ( lower-cut-ℝ z p)
-        ( le-ℝ-Prop x z)
+        ( le-prop-ℝ x z)
         ( upper-cut-ℝ z q)
-        ( le-ℝ-Prop z y)
+        ( le-prop-ℝ z y)
         ( λ p<z → intro-exists p (x<p , p<z))
         ( λ z<q → intro-exists q (z<q , q<y))
         ( is-located-lower-upper-cut-ℝ z p q p<q)
@@ -464,7 +463,7 @@ module _
 
   opaque
     unfolding sim-ℝ
-    unfolding le-ℝ-Prop
+    unfolding le-ℝ
 
     preserves-le-left-sim-ℝ : le-ℝ x z → le-ℝ y z
     preserves-le-left-sim-ℝ =
@@ -503,7 +502,7 @@ module _
 
   opaque
     unfolding add-ℝ
-    unfolding le-ℝ-Prop
+    unfolding le-ℝ
 
     preserves-le-right-add-ℝ : le-ℝ x y → le-ℝ (x +ℝ z) (y +ℝ z)
     preserves-le-right-add-ℝ x<y =
@@ -704,9 +703,9 @@ module _
 
   abstract
     exists-positive-rational-separation-le-ℝ :
-      exists ℚ⁺ (λ q → le-ℝ-Prop (x +ℝ real-ℚ⁺ q) y)
+      exists ℚ⁺ (λ q → le-prop-ℝ (x +ℝ real-ℚ⁺ q) y)
     exists-positive-rational-separation-le-ℝ =
-      let open do-syntax-trunc-Prop (∃ ℚ⁺ (λ q → le-ℝ-Prop (x +ℝ real-ℚ⁺ q) y))
+      let open do-syntax-trunc-Prop (∃ ℚ⁺ (λ q → le-prop-ℝ (x +ℝ real-ℚ⁺ q) y))
       in do
         (q , 0<q , q<y-x) ←
           dense-rational-le-ℝ zero-ℝ (y -ℝ x)

--- a/src/real-numbers/suprema-families-real-numbers.lagda.md
+++ b/src/real-numbers/suprema-families-real-numbers.lagda.md
@@ -66,7 +66,7 @@ module _
   is-approximated-below-prop-family-ℝ x =
     Π-Prop
       ( ℚ⁺)
-      ( λ ε → ∃ I (λ i → le-ℝ-Prop (x -ℝ real-ℚ⁺ ε) (y i)))
+      ( λ ε → ∃ I (λ i → le-prop-ℝ (x -ℝ real-ℚ⁺ ε) (y i)))
 
   is-approximated-below-family-ℝ : {l3 : Level} → ℝ l3 → UU (l1 ⊔ l2 ⊔ l3)
   is-approximated-below-family-ℝ x =
@@ -204,9 +204,9 @@ module _
       concatenate-le-leq-ℝ z (y i) x z<yᵢ (pr1 is-supremum-x-yᵢ i)
 
     le-element-le-supremum-family-ℝ :
-      {l4 : Level} → (z : ℝ l4) → le-ℝ z x → exists I (λ i → le-ℝ-Prop z (y i))
+      {l4 : Level} → (z : ℝ l4) → le-ℝ z x → exists I (λ i → le-prop-ℝ z (y i))
     le-element-le-supremum-family-ℝ z z<x =
-      let open do-syntax-trunc-Prop (∃ I (λ i → le-ℝ-Prop z (y i)))
+      let open do-syntax-trunc-Prop (∃ I (λ i → le-prop-ℝ z (y i)))
       in do
         (ε⁺@(ε , _) , ε<x-z) ←
           exists-ℚ⁺-in-lower-cut-ℝ⁺ (positive-diff-le-ℝ z x z<x)
@@ -222,11 +222,11 @@ module _
 
     le-supremum-iff-le-element-family-ℝ :
       {l4 : Level} → (z : ℝ l4) →
-      (le-ℝ z x) ↔ (exists I (λ i → le-ℝ-Prop z (y i)))
+      (le-ℝ z x) ↔ (exists I (λ i → le-prop-ℝ z (y i)))
     pr1 (le-supremum-iff-le-element-family-ℝ z) =
       le-element-le-supremum-family-ℝ z
     pr2 (le-supremum-iff-le-element-family-ℝ z) =
-      elim-exists (le-ℝ-Prop z x) (le-supremum-le-element-family-ℝ z)
+      elim-exists (le-prop-ℝ z x) (le-supremum-le-element-family-ℝ z)
 ```
 
 ## See also


### PR DESCRIPTION
Marks more things in `real-numbers` opaque, and does a few other cleanups here and there.

In general, it's strongly preferable to see things like `neg-R` in goals rather than...the mess you get if it's not opaque...and the same for most things about the real numbers.