### PR TITLE
Refactor the natural numbers and integers up to present code standards

### DIFF
--- a/src/commutative-algebra/polynomials-commutative-semirings.lagda.md
+++ b/src/commutative-algebra/polynomials-commutative-semirings.lagda.md
@@ -704,7 +704,7 @@ module _
                     rec-coproduct
                       ( λ j<Nq →
                         ex-falso
-                          ( anti-reflexive-le-ℕ
+                          ( irreflexive-le-ℕ
                             ( n)
                             ( tr
                               ( λ m → le-ℕ m n)
@@ -948,10 +948,10 @@ module _
                             ( rearrange)
                             ( eq-type-subtype
                               ( λ (i , j , n) →
-                                ( ( le-ℕ-Prop i Np) ∧
-                                  ( le-ℕ-Prop j Nq) ∧
+                                ( ( le-prop-ℕ i Np) ∧
+                                  ( le-prop-ℕ j Nq) ∧
                                   ( Id-Prop ℕ-Set (j +ℕ i) n) ∧
-                                  ( le-ℕ-Prop n (Nq +ℕ Np))))
+                                  ( le-prop-ℕ n (Nq +ℕ Np))))
                               refl)))
                 ( _)
           ＝

--- a/src/elementary-number-theory.lagda.md
+++ b/src/elementary-number-theory.lagda.md
@@ -44,7 +44,6 @@ open import elementary-number-theory.closed-intervals-rational-numbers public
 open import elementary-number-theory.cofibonacci public
 open import elementary-number-theory.collatz-bijection public
 open import elementary-number-theory.collatz-conjecture public
-open import elementary-number-theory.commutative-semiring-of-natural-numbers public
 open import elementary-number-theory.conatural-numbers public
 open import elementary-number-theory.congruence-integers public
 open import elementary-number-theory.congruence-natural-numbers public
@@ -181,6 +180,7 @@ open import elementary-number-theory.retracts-of-natural-numbers public
 open import elementary-number-theory.ring-extension-rational-numbers-of-rational-numbers public
 open import elementary-number-theory.ring-of-integers public
 open import elementary-number-theory.ring-of-rational-numbers public
+open import elementary-number-theory.semiring-of-natural-numbers public
 open import elementary-number-theory.sieve-of-eratosthenes public
 open import elementary-number-theory.square-free-natural-numbers public
 open import elementary-number-theory.squares-integers public

--- a/src/elementary-number-theory/absolute-value-integers.lagda.md
+++ b/src/elementary-number-theory/absolute-value-integers.lagda.md
@@ -214,36 +214,39 @@ multiplicative-abs-ℤ x y =
 ### `|(-x)y| ＝ |xy|`
 
 ```agda
-left-negative-law-mul-abs-ℤ :
-  (x y : ℤ) → abs-ℤ (x *ℤ y) ＝ abs-ℤ ((neg-ℤ x) *ℤ y)
-left-negative-law-mul-abs-ℤ x y =
-  equational-reasoning
-    abs-ℤ (x *ℤ y)
-    ＝ abs-ℤ (neg-ℤ (x *ℤ y))
-      by (inv (negative-law-abs-ℤ (x *ℤ y)))
-    ＝ abs-ℤ ((neg-ℤ x) *ℤ y)
-      by (ap abs-ℤ (inv (left-negative-law-mul-ℤ x y)))
+abstract
+  left-negative-law-mul-abs-ℤ :
+    (x y : ℤ) → abs-ℤ (x *ℤ y) ＝ abs-ℤ ((neg-ℤ x) *ℤ y)
+  left-negative-law-mul-abs-ℤ x y =
+    equational-reasoning
+      abs-ℤ (x *ℤ y)
+      ＝ abs-ℤ (neg-ℤ (x *ℤ y))
+        by (inv (negative-law-abs-ℤ (x *ℤ y)))
+      ＝ abs-ℤ ((neg-ℤ x) *ℤ y)
+        by (ap abs-ℤ (inv (left-negative-law-mul-ℤ x y)))
 ```
 
 ### `|x(-y)| ＝ |xy|`
 
 ```agda
-right-negative-law-mul-abs-ℤ :
-  (x y : ℤ) → abs-ℤ (x *ℤ y) ＝ abs-ℤ (x *ℤ (neg-ℤ y))
-right-negative-law-mul-abs-ℤ x y =
-  equational-reasoning
-    abs-ℤ (x *ℤ y)
-    ＝ abs-ℤ (neg-ℤ (x *ℤ y))
-      by (inv (negative-law-abs-ℤ (x *ℤ y)))
-    ＝ abs-ℤ (x *ℤ (neg-ℤ y))
-      by (ap abs-ℤ (inv (right-negative-law-mul-ℤ x y)))
+abstract
+  right-negative-law-mul-abs-ℤ :
+    (x y : ℤ) → abs-ℤ (x *ℤ y) ＝ abs-ℤ (x *ℤ (neg-ℤ y))
+  right-negative-law-mul-abs-ℤ x y =
+    equational-reasoning
+      abs-ℤ (x *ℤ y)
+      ＝ abs-ℤ (neg-ℤ (x *ℤ y))
+        by (inv (negative-law-abs-ℤ (x *ℤ y)))
+      ＝ abs-ℤ (x *ℤ (neg-ℤ y))
+        by (ap abs-ℤ (inv (right-negative-law-mul-ℤ x y)))
 ```
 
 ### `|(-x)(-y)| ＝ |xy|`
 
 ```agda
-double-negative-law-mul-abs-ℤ :
-  (x y : ℤ) → abs-ℤ (x *ℤ y) ＝ abs-ℤ ((neg-ℤ x) *ℤ (neg-ℤ y))
-double-negative-law-mul-abs-ℤ x y =
-  (right-negative-law-mul-abs-ℤ x y) ∙ (left-negative-law-mul-abs-ℤ x (neg-ℤ y))
+abstract
+  double-negative-law-mul-abs-ℤ :
+    (x y : ℤ) → abs-ℤ (x *ℤ y) ＝ abs-ℤ ((neg-ℤ x) *ℤ (neg-ℤ y))
+  double-negative-law-mul-abs-ℤ x y =
+    ap abs-ℤ (inv (double-negative-law-mul-ℤ x y))
 ```

--- a/src/elementary-number-theory/addition-integers.lagda.md
+++ b/src/elementary-number-theory/addition-integers.lagda.md
@@ -367,10 +367,11 @@ abstract
 
 abstract
   is-equiv-left-add-ℤ : (x : ℤ) → is-equiv (x +ℤ_)
-  pr1 (pr1 (is-equiv-left-add-ℤ x)) = add-ℤ (neg-ℤ x)
-  pr2 (pr1 (is-equiv-left-add-ℤ x)) = is-section-left-add-neg-ℤ x
-  pr1 (pr2 (is-equiv-left-add-ℤ x)) = add-ℤ (neg-ℤ x)
-  pr2 (pr2 (is-equiv-left-add-ℤ x)) = is-retraction-left-add-neg-ℤ x
+  is-equiv-left-add-ℤ x =
+    is-equiv-is-invertible
+      ( add-ℤ (neg-ℤ x))
+      ( is-section-left-add-neg-ℤ x)
+      ( is-retraction-left-add-neg-ℤ x)
 
 equiv-left-add-ℤ : ℤ → (ℤ ≃ ℤ)
 pr1 (equiv-left-add-ℤ x) = add-ℤ x
@@ -403,10 +404,11 @@ abstract
 
 abstract
   is-equiv-right-add-ℤ : (y : ℤ) → is-equiv (_+ℤ y)
-  pr1 (pr1 (is-equiv-right-add-ℤ y)) = _+ℤ (neg-ℤ y)
-  pr2 (pr1 (is-equiv-right-add-ℤ y)) = is-section-right-add-neg-ℤ y
-  pr1 (pr2 (is-equiv-right-add-ℤ y)) = _+ℤ (neg-ℤ y)
-  pr2 (pr2 (is-equiv-right-add-ℤ y)) = is-retraction-right-add-neg-ℤ y
+  is-equiv-right-add-ℤ y =
+    is-equiv-is-invertible
+      ( _+ℤ (neg-ℤ y))
+      ( is-section-right-add-neg-ℤ y)
+      ( is-retraction-right-add-neg-ℤ y)
 
 equiv-right-add-ℤ : ℤ → (ℤ ≃ ℤ)
 pr1 (equiv-right-add-ℤ y) = _+ℤ y

--- a/src/elementary-number-theory/archimedean-property-integers.lagda.md
+++ b/src/elementary-number-theory/archimedean-property-integers.lagda.md
@@ -59,7 +59,7 @@ abstract
           ( le-ℤ)
           ( ap pr1 (is-section-nat-nonnegative-ℤ (y , nonneg-y)))
           ( inv (mul-int-ℕ n nx) ∙ ap (int-ℕ n *ℤ_) nx=x)
-          ( le-natural-le-ℤ
+          ( preserves-le-int-ℕ
             ( nat-nonnegative-ℤ (y , nonneg-y))
             ( n *ℕ nx)
             ( ny<n*nx))
@@ -71,7 +71,7 @@ abstract
       pos-ℤ-to-ℕ (inr (inr n)) H = succ-ℕ n , (λ ()) , refl
 
   archimedean-property-ℤ :
-    (x y : ℤ) → is-positive-ℤ x → exists ℕ (λ n → le-ℤ-Prop y (int-ℕ n *ℤ x))
+    (x y : ℤ) → is-positive-ℤ x → exists ℕ (λ n → le-prop-ℤ y (int-ℕ n *ℤ x))
   archimedean-property-ℤ x y pos-x =
     unit-trunc-Prop (bound-archimedean-property-ℤ x y pos-x)
 ```

--- a/src/elementary-number-theory/archimedean-property-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/archimedean-property-natural-numbers.lagda.md
@@ -45,7 +45,7 @@ abstract
         ( strict-upper-bound-remainder-euclidean-division-ℕ x y nonzero-x))
 
   archimedean-property-ℕ :
-    (x y : ℕ) → is-nonzero-ℕ x → exists ℕ (λ n → le-ℕ-Prop y (n *ℕ x))
+    (x y : ℕ) → is-nonzero-ℕ x → exists ℕ (λ n → le-prop-ℕ y (n *ℕ x))
   archimedean-property-ℕ x y nonzero-x =
     unit-trunc-Prop (bound-archimedean-property-ℕ x y nonzero-x)
 ```

--- a/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/bezouts-lemma-natural-numbers.lagda.md
@@ -92,7 +92,7 @@ is-distance-between-multiples-sym-ℕ :
   (x y z : ℕ) → is-distance-between-multiples-ℕ x y z →
   is-distance-between-multiples-ℕ y x z
 is-distance-between-multiples-sym-ℕ x y z (pair k (pair l eqn)) =
-  pair l (pair k (symmetric-dist-ℕ (l *ℕ y) (k *ℕ x) ∙ eqn))
+  pair l (pair k (commutative-dist-ℕ (l *ℕ y) (k *ℕ x) ∙ eqn))
 ```
 
 ## Lemmas
@@ -600,7 +600,7 @@ is-distance-between-multiples-div-mod-ℕ (succ-ℕ x) y z (u , p) =
         dist-ℕ ((abs-ℤ a) *ℕ (succ-ℕ x)) ((nat-Fin (succ-ℕ x) u) *ℕ y)
         ＝ dist-ℕ ((nat-Fin (succ-ℕ x) u) *ℕ y) ((abs-ℤ a) *ℕ (succ-ℕ x))
           by
-          symmetric-dist-ℕ
+          commutative-dist-ℕ
             ( (abs-ℤ a) *ℕ (succ-ℕ x))
             ( (nat-Fin (succ-ℕ x) u) *ℕ y)
         ＝ dist-ℤ
@@ -1304,7 +1304,7 @@ remainder-min-dist-succ-x-is-distance x y =
         ( s *ℕ (succ-ℕ x))
         ( tysx)
         ( inv (dist-sx-ty-eq-d) ∙
-          symmetric-dist-ℕ (s *ℕ (succ-ℕ x)) (t *ℕ y))
+          commutative-dist-ℕ (s *ℕ (succ-ℕ x)) (t *ℕ y))
 
     quotient-min-dist-succ-x-nonzero : is-nonzero-ℕ q
     quotient-min-dist-succ-x-nonzero iszero =
@@ -1708,7 +1708,7 @@ remainder-min-dist-succ-x-is-distance x y =
           ((abs-ℤ (((int-ℕ q) *ℤ (int-ℕ s)) +ℤ (neg-ℤ one-ℤ))) *ℕ
             (succ-ℕ x))
             ((q *ℕ t) *ℕ y)
-          by symmetric-dist-ℕ
+          by commutative-dist-ℕ
             ((q *ℕ t) *ℕ y)
             (mul-ℕ (abs-ℤ (add-ℤ (mul-ℤ (int-ℕ q)
               (int-ℕ s)) (neg-ℤ one-ℤ)))
@@ -1914,7 +1914,7 @@ gcd-ℕ-div-dist-between-mult x y z dist =
     rewrite-dist =
       rewrite-right-dist-add-ℕ (t *ℕ y) z (s *ℕ x) tysx
         ( inv (is-distance-between-multiples-eqn-ℕ dist) ∙
-          symmetric-dist-ℕ (s *ℕ x) (t *ℕ y))
+          commutative-dist-ℕ (s *ℕ x) (t *ℕ y))
 
     div-gcd-x : div-ℕ (gcd-ℕ x y) (s *ℕ x)
     div-gcd-x = div-mul-ℕ s (gcd-ℕ x y) x (pr1 (is-common-divisor-gcd-ℕ x y))

--- a/src/elementary-number-theory/binomial-coefficients.lagda.md
+++ b/src/elementary-number-theory/binomial-coefficients.lagda.md
@@ -10,11 +10,11 @@ module elementary-number-theory.binomial-coefficients where
 open import commutative-algebra.commutative-semirings
 
 open import elementary-number-theory.addition-natural-numbers
-open import elementary-number-theory.commutative-semiring-of-natural-numbers
 open import elementary-number-theory.factorials
 open import elementary-number-theory.inequality-natural-numbers
 open import elementary-number-theory.multiplication-natural-numbers
 open import elementary-number-theory.natural-numbers
+open import elementary-number-theory.semiring-of-natural-numbers
 open import elementary-number-theory.strict-inequality-natural-numbers
 
 open import foundation.action-on-identifications-binary-functions

--- a/src/elementary-number-theory/binomial-theorem-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/binomial-theorem-natural-numbers.lagda.md
@@ -10,11 +10,11 @@ module elementary-number-theory.binomial-theorem-natural-numbers where
 open import commutative-algebra.binomial-theorem-commutative-semirings
 
 open import elementary-number-theory.addition-natural-numbers
-open import elementary-number-theory.commutative-semiring-of-natural-numbers
 open import elementary-number-theory.distance-natural-numbers
 open import elementary-number-theory.exponentiation-natural-numbers
 open import elementary-number-theory.multiplication-natural-numbers
 open import elementary-number-theory.natural-numbers
+open import elementary-number-theory.semiring-of-natural-numbers
 
 open import foundation.homotopies
 open import foundation.identity-types

--- a/src/elementary-number-theory/congruence-integers.lagda.md
+++ b/src/elementary-number-theory/congruence-integers.lagda.md
@@ -28,6 +28,14 @@ open import foundation.universe-levels
 
 </details>
 
+## Idea
+
+Two [integers](elementary-number-theory.integers.md) are
+{{#concept "congruent" WDID=Q3773677 WD="congruence of integers" Agda=cong-ℤ}}
+mod an integer `k` if their
+[difference](elementary-number-theory.difference-integers.md) is
+[divisible](elementary-number-theory.divisibility-integers.md) by `k`.
+
 ## Definitions
 
 ```agda
@@ -40,6 +48,8 @@ is-cong-zero-ℤ k x = cong-ℤ k x zero-ℤ
 
 ## Properties
 
+### `k | x` if and only if `x` is congruent to zero mod `k`
+
 ```agda
 is-cong-zero-div-ℤ : (k x : ℤ) → div-ℤ k x → is-cong-zero-ℤ k x
 pr1 (is-cong-zero-div-ℤ k x (pair d p)) = d
@@ -48,33 +58,55 @@ pr2 (is-cong-zero-div-ℤ k x (pair d p)) = p ∙ inv (right-unit-law-add-ℤ x)
 div-is-cong-zero-ℤ : (k x : ℤ) → is-cong-zero-ℤ k x → div-ℤ k x
 pr1 (div-is-cong-zero-ℤ k x (pair d p)) = d
 pr2 (div-is-cong-zero-ℤ k x (pair d p)) = p ∙ right-unit-law-add-ℤ x
+```
 
+### If `k` is a unit, all integers are congruent mod `k`
+
+```agda
 is-indiscrete-cong-ℤ : (k : ℤ) → is-unit-ℤ k → (x y : ℤ) → cong-ℤ k x y
 is-indiscrete-cong-ℤ k H x y = div-is-unit-ℤ k (x -ℤ y) H
+```
 
+### If `k` is zero and `x` and `y` are congruent mod `k`, `x = y`
+
+```agda
 is-discrete-cong-ℤ : (k : ℤ) → is-zero-ℤ k → (x y : ℤ) → cong-ℤ k x y → x ＝ y
 is-discrete-cong-ℤ .zero-ℤ refl x y K =
   eq-diff-ℤ (is-zero-div-zero-ℤ (x -ℤ y) K)
+```
 
-is-unit-cong-succ-ℤ : (k x : ℤ) → cong-ℤ k x (succ-ℤ x) → is-unit-ℤ k
-pr1 (is-unit-cong-succ-ℤ k x (pair y p)) = neg-ℤ y
-pr2 (is-unit-cong-succ-ℤ k x (pair y p)) =
-  ( left-negative-law-mul-ℤ y k) ∙
-  ( is-injective-neg-ℤ
-    ( ( neg-neg-ℤ (y *ℤ k)) ∙
-      ( ( p) ∙
-        ( ( ap (x +ℤ_) (neg-succ-ℤ x)) ∙
-          ( ( right-predecessor-law-add-ℤ x (neg-ℤ x)) ∙
-            ( ap pred-ℤ (right-inverse-law-add-ℤ x)))))))
+### If `x` and `succ-ℤ x` are congruent mod `k`, `k` is a unit
 
-is-unit-cong-pred-ℤ : (k x : ℤ) → cong-ℤ k x (pred-ℤ x) → is-unit-ℤ k
-pr1 (is-unit-cong-pred-ℤ k x (pair y p)) = y
-pr2 (is-unit-cong-pred-ℤ k x (pair y p)) =
-  ( p) ∙
-  ( ( ap (x +ℤ_) (neg-pred-ℤ x)) ∙
-    ( ( right-successor-law-add-ℤ x (neg-ℤ x)) ∙
-      ( ap succ-ℤ (right-inverse-law-add-ℤ x))))
+```agda
+abstract
+  is-unit-cong-succ-ℤ : (k x : ℤ) → cong-ℤ k x (succ-ℤ x) → is-unit-ℤ k
+  pr1 (is-unit-cong-succ-ℤ k x (pair y p)) = neg-ℤ y
+  pr2 (is-unit-cong-succ-ℤ k x (pair y p)) =
+    ( left-negative-law-mul-ℤ y k) ∙
+    ( is-injective-neg-ℤ
+      ( ( neg-neg-ℤ (y *ℤ k)) ∙
+        ( ( p) ∙
+          ( ( ap (x +ℤ_) (neg-succ-ℤ x)) ∙
+            ( ( right-predecessor-law-add-ℤ x (neg-ℤ x)) ∙
+              ( ap pred-ℤ (right-inverse-law-add-ℤ x)))))))
+```
 
+### If `x` and `pred-ℤ x` are congruent mod `k`, `k` is a unit
+
+```agda
+abstract
+  is-unit-cong-pred-ℤ : (k x : ℤ) → cong-ℤ k x (pred-ℤ x) → is-unit-ℤ k
+  pr1 (is-unit-cong-pred-ℤ k x (pair y p)) = y
+  pr2 (is-unit-cong-pred-ℤ k x (pair y p)) =
+    ( p) ∙
+    ( ( ap (x +ℤ_) (neg-pred-ℤ x)) ∙
+      ( ( right-successor-law-add-ℤ x (neg-ℤ x)) ∙
+        ( ap succ-ℤ (right-inverse-law-add-ℤ x))))
+```
+
+### Congruence mod `k` is an equivalence relation
+
+```agda
 refl-cong-ℤ : (k : ℤ) → is-reflexive (cong-ℤ k)
 pr1 (refl-cong-ℤ k x) = zero-ℤ
 pr2 (refl-cong-ℤ k x) = left-zero-law-mul-ℤ k ∙ inv (is-zero-diff-ℤ' x)
@@ -92,7 +124,11 @@ pr2 (transitive-cong-ℤ k x y z (pair e q) (pair d p)) =
   ( right-distributive-mul-add-ℤ d e k) ∙
   ( ( ap-add-ℤ p q) ∙
     ( triangle-diff-ℤ x y z))
+```
 
+### Concatenating congruence and equality
+
+```agda
 concatenate-eq-cong-ℤ :
   (k x x' y : ℤ) → x ＝ x' → cong-ℤ k x' y → cong-ℤ k x y
 concatenate-eq-cong-ℤ k x .x y refl = id
@@ -114,7 +150,11 @@ concatenate-cong-cong-cong-ℤ :
   (k x y z w : ℤ) → cong-ℤ k x y → cong-ℤ k y z → cong-ℤ k z w → cong-ℤ k x w
 concatenate-cong-cong-cong-ℤ k x y z w H K L =
   transitive-cong-ℤ k x y w (transitive-cong-ℤ k y z w L K) H
+```
 
+### If `-x` and `-y` are congruent mod `k`, so are `x` and `y`
+
+```agda
 cong-cong-neg-ℤ : (k x y : ℤ) → cong-ℤ k (neg-ℤ x) (neg-ℤ y) → cong-ℤ k x y
 pr1 (cong-cong-neg-ℤ k x y (pair d p)) = neg-ℤ d
 pr2 (cong-cong-neg-ℤ k x y (pair d p)) =
@@ -130,6 +170,8 @@ pr2 (cong-neg-cong-ℤ k x y (pair d p)) =
   ( ( ap neg-ℤ p) ∙
     ( distributive-neg-add-ℤ x (neg-ℤ y)))
 ```
+
+### The canonical embedding of natural numbers preserves and reflects congruence
 
 ```agda
 cong-int-cong-ℕ :

--- a/src/elementary-number-theory/congruence-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/congruence-natural-numbers.lagda.md
@@ -80,7 +80,7 @@ cong-identification-ℕ k {x} refl = refl-cong-ℕ k x
 
 symmetric-cong-ℕ : (k : ℕ) → is-symmetric (cong-ℕ k)
 pr1 (symmetric-cong-ℕ k x y (pair d p)) = d
-pr2 (symmetric-cong-ℕ k x y (pair d p)) = p ∙ (symmetric-dist-ℕ x y)
+pr2 (symmetric-cong-ℕ k x y (pair d p)) = p ∙ (commutative-dist-ℕ x y)
 
 cong-zero-ℕ' : (k : ℕ) → cong-ℕ k zero-ℕ k
 cong-zero-ℕ' k =

--- a/src/elementary-number-theory/distance-integers.lagda.md
+++ b/src/elementary-number-theory/distance-integers.lagda.md
@@ -26,7 +26,10 @@ open import foundation.identity-types
 
 ## Idea
 
-The distance function between integers measures how far two integers are apart.
+The
+{{#concept "distance function" Disambiguation="between integers" Agda=dist-ℤ}}
+between [integers](elementary-number-theory.integers.md) measures how far two
+integers are apart.
 
 ## Definition
 
@@ -37,43 +40,60 @@ dist-ℤ x y = abs-ℤ (x -ℤ y)
 ap-dist-ℤ :
   {x x' y y' : ℤ} → x ＝ x' → y ＝ y' → dist-ℤ x y ＝ dist-ℤ x' y'
 ap-dist-ℤ p q = ap-binary dist-ℤ p q
+```
 
-left-zero-law-dist-ℤ : (x : ℤ) → dist-ℤ zero-ℤ x ＝ abs-ℤ x
-left-zero-law-dist-ℤ x = ap abs-ℤ (left-zero-law-diff-ℤ x) ∙ abs-neg-ℤ x
+## Properties
 
-right-zero-law-dist-ℤ : (x : ℤ) → dist-ℤ x zero-ℤ ＝ abs-ℤ x
-right-zero-law-dist-ℤ x = ap abs-ℤ (right-zero-law-diff-ℤ x)
+### Zero laws
 
-dist-int-ℕ :
-  (x y : ℕ) → dist-ℤ (int-ℕ x) (int-ℕ y) ＝ dist-ℕ x y
-dist-int-ℕ zero-ℕ zero-ℕ = refl
-dist-int-ℕ zero-ℕ (succ-ℕ y) = left-zero-law-dist-ℤ (int-ℕ (succ-ℕ y))
-dist-int-ℕ (succ-ℕ x) zero-ℕ = right-zero-law-dist-ℤ (int-ℕ (succ-ℕ x))
-dist-int-ℕ (succ-ℕ x) (succ-ℕ y) =
-  ( ( ap-dist-ℤ (inv (succ-int-ℕ x)) (inv (succ-int-ℕ y))) ∙
-    ( ap abs-ℤ (diff-succ-ℤ (int-ℕ x) (int-ℕ y)))) ∙
-  ( dist-int-ℕ x y)
+```agda
+abstract
+  left-zero-law-dist-ℤ : (x : ℤ) → dist-ℤ zero-ℤ x ＝ abs-ℤ x
+  left-zero-law-dist-ℤ x = ap abs-ℤ (left-zero-law-diff-ℤ x) ∙ abs-neg-ℤ x
 
-dist-abs-ℤ :
-  (x y : ℤ) → (H : is-nonnegative-ℤ x) → (K : is-nonnegative-ℤ y) →
-  dist-ℕ (abs-ℤ x) (abs-ℤ y) ＝ dist-ℤ x y
-dist-abs-ℤ (inr (inl _)) y H K =
-  equational-reasoning
-    dist-ℕ 0 (abs-ℤ y)
-    ＝ abs-ℤ y
-      by left-unit-law-dist-ℕ (abs-ℤ y)
-    ＝ dist-ℤ (zero-ℤ) y
-      by inv (left-zero-law-dist-ℤ y)
-dist-abs-ℤ (inr (inr x)) (inr (inl _)) H K =
-  equational-reasoning
-    dist-ℕ (abs-ℤ (inr (inr x))) 0
-    ＝ succ-ℕ x
-      by right-unit-law-dist-ℕ (abs-ℤ (inr (inr x)))
-    ＝ dist-ℤ (inr (inr x)) zero-ℤ
-      by inv (right-zero-law-dist-ℤ (inr (inr x)))
-dist-abs-ℤ (inr (inr x)) (inr (inr y)) H K =
-  equational-reasoning
-    dist-ℕ (succ-ℕ x) (succ-ℕ y)
-    ＝ dist-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ (succ-ℕ y))
-      by inv (dist-int-ℕ (succ-ℕ x) (succ-ℕ y))
+  right-zero-law-dist-ℤ : (x : ℤ) → dist-ℤ x zero-ℤ ＝ abs-ℤ x
+  right-zero-law-dist-ℤ x = ap abs-ℤ (right-zero-law-diff-ℤ x)
+```
+
+### The canonical embedding of natural numbers into the integers preserves distance
+
+```agda
+abstract
+  dist-int-ℕ :
+    (x y : ℕ) → dist-ℤ (int-ℕ x) (int-ℕ y) ＝ dist-ℕ x y
+  dist-int-ℕ zero-ℕ zero-ℕ = refl
+  dist-int-ℕ zero-ℕ (succ-ℕ y) = left-zero-law-dist-ℤ (int-ℕ (succ-ℕ y))
+  dist-int-ℕ (succ-ℕ x) zero-ℕ = right-zero-law-dist-ℤ (int-ℕ (succ-ℕ x))
+  dist-int-ℕ (succ-ℕ x) (succ-ℕ y) =
+    ( ( ap-dist-ℤ (inv (succ-int-ℕ x)) (inv (succ-int-ℕ y))) ∙
+      ( ap abs-ℤ (diff-succ-ℤ (int-ℕ x) (int-ℕ y)))) ∙
+    ( dist-int-ℕ x y)
+```
+
+### If two integers are nonnegative, the distance between their absolute values is the distance between them
+
+```agda
+abstract
+  dist-abs-ℤ :
+    (x y : ℤ) → (H : is-nonnegative-ℤ x) → (K : is-nonnegative-ℤ y) →
+    dist-ℕ (abs-ℤ x) (abs-ℤ y) ＝ dist-ℤ x y
+  dist-abs-ℤ (inr (inl _)) y H K =
+    equational-reasoning
+      dist-ℕ 0 (abs-ℤ y)
+      ＝ abs-ℤ y
+        by left-unit-law-dist-ℕ (abs-ℤ y)
+      ＝ dist-ℤ (zero-ℤ) y
+        by inv (left-zero-law-dist-ℤ y)
+  dist-abs-ℤ (inr (inr x)) (inr (inl _)) H K =
+    equational-reasoning
+      dist-ℕ (abs-ℤ (inr (inr x))) 0
+      ＝ succ-ℕ x
+        by right-unit-law-dist-ℕ (abs-ℤ (inr (inr x)))
+      ＝ dist-ℤ (inr (inr x)) zero-ℤ
+        by inv (right-zero-law-dist-ℤ (inr (inr x)))
+  dist-abs-ℤ (inr (inr x)) (inr (inr y)) H K =
+    equational-reasoning
+      dist-ℕ (succ-ℕ x) (succ-ℕ y)
+      ＝ dist-ℤ (int-ℕ (succ-ℕ x)) (int-ℕ (succ-ℕ y))
+        by inv (dist-int-ℕ (succ-ℕ x) (succ-ℕ y))
 ```

--- a/src/elementary-number-theory/distance-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/distance-natural-numbers.lagda.md
@@ -59,180 +59,192 @@ ap-dist-ℕ p q = ap-binary dist-ℕ p q
 ### Two natural numbers are equal if and only if their distance is zero
 
 ```agda
-eq-dist-ℕ : (m n : ℕ) → is-zero-ℕ (dist-ℕ m n) → m ＝ n
-eq-dist-ℕ zero-ℕ zero-ℕ p = refl
-eq-dist-ℕ (succ-ℕ m) (succ-ℕ n) p = ap succ-ℕ (eq-dist-ℕ m n p)
+abstract
+  eq-dist-ℕ : (m n : ℕ) → is-zero-ℕ (dist-ℕ m n) → m ＝ n
+  eq-dist-ℕ zero-ℕ zero-ℕ p = refl
+  eq-dist-ℕ (succ-ℕ m) (succ-ℕ n) p = ap succ-ℕ (eq-dist-ℕ m n p)
 
-dist-eq-ℕ' : (n : ℕ) → is-zero-ℕ (dist-ℕ n n)
-dist-eq-ℕ' zero-ℕ = refl
-dist-eq-ℕ' (succ-ℕ n) = dist-eq-ℕ' n
+  dist-eq-ℕ' : (n : ℕ) → is-zero-ℕ (dist-ℕ n n)
+  dist-eq-ℕ' zero-ℕ = refl
+  dist-eq-ℕ' (succ-ℕ n) = dist-eq-ℕ' n
 
-dist-eq-ℕ : (m n : ℕ) → m ＝ n → is-zero-ℕ (dist-ℕ m n)
-dist-eq-ℕ m .m refl = dist-eq-ℕ' m
+  dist-eq-ℕ : (m n : ℕ) → m ＝ n → is-zero-ℕ (dist-ℕ m n)
+  dist-eq-ℕ m .m refl = dist-eq-ℕ' m
 
-dist-neq-ℕ : (m n : ℕ) → m ≠ n → is-nonzero-ℕ (dist-ℕ m n)
-dist-neq-ℕ m n = map-neg (eq-dist-ℕ m n)
+  dist-neq-ℕ : (m n : ℕ) → m ≠ n → is-nonzero-ℕ (dist-ℕ m n)
+  dist-neq-ℕ m n = map-neg (eq-dist-ℕ m n)
 
-dist-neq-ℕ' : (m n : ℕ) → m ≠ n → is-successor-ℕ (dist-ℕ m n)
-dist-neq-ℕ' m n np = is-successor-is-nonzero-ℕ (dist-neq-ℕ m n np)
-
-is-one-dist-succ-ℕ : (x : ℕ) → is-one-ℕ (dist-ℕ x (succ-ℕ x))
-is-one-dist-succ-ℕ zero-ℕ = refl
-is-one-dist-succ-ℕ (succ-ℕ x) = is-one-dist-succ-ℕ x
-
-is-one-dist-succ-ℕ' : (x : ℕ) → is-one-ℕ (dist-ℕ (succ-ℕ x) x)
-is-one-dist-succ-ℕ' zero-ℕ = refl
-is-one-dist-succ-ℕ' (succ-ℕ x) = is-one-dist-succ-ℕ' x
+  dist-neq-ℕ' : (m n : ℕ) → m ≠ n → is-successor-ℕ (dist-ℕ m n)
+  dist-neq-ℕ' m n np = is-successor-is-nonzero-ℕ (dist-neq-ℕ m n np)
 ```
 
-### The distance function is symmetric
+### The distance between a natural number and its successor is one
 
 ```agda
-symmetric-dist-ℕ :
-  (m n : ℕ) → dist-ℕ m n ＝ dist-ℕ n m
-symmetric-dist-ℕ zero-ℕ zero-ℕ = refl
-symmetric-dist-ℕ zero-ℕ (succ-ℕ n) = refl
-symmetric-dist-ℕ (succ-ℕ m) zero-ℕ = refl
-symmetric-dist-ℕ (succ-ℕ m) (succ-ℕ n) = symmetric-dist-ℕ m n
+abstract
+  is-one-dist-succ-ℕ : (x : ℕ) → is-one-ℕ (dist-ℕ x (succ-ℕ x))
+  is-one-dist-succ-ℕ zero-ℕ = refl
+  is-one-dist-succ-ℕ (succ-ℕ x) = is-one-dist-succ-ℕ x
+
+  is-one-dist-succ-ℕ' : (x : ℕ) → is-one-ℕ (dist-ℕ (succ-ℕ x) x)
+  is-one-dist-succ-ℕ' zero-ℕ = refl
+  is-one-dist-succ-ℕ' (succ-ℕ x) = is-one-dist-succ-ℕ' x
+```
+
+### The distance function is commutative
+
+```agda
+abstract
+  commutative-dist-ℕ :
+    (m n : ℕ) → dist-ℕ m n ＝ dist-ℕ n m
+  commutative-dist-ℕ zero-ℕ zero-ℕ = refl
+  commutative-dist-ℕ zero-ℕ (succ-ℕ n) = refl
+  commutative-dist-ℕ (succ-ℕ m) zero-ℕ = refl
+  commutative-dist-ℕ (succ-ℕ m) (succ-ℕ n) = commutative-dist-ℕ m n
 ```
 
 ### The distance from zero
 
 ```agda
-left-unit-law-dist-ℕ :
-  (n : ℕ) → dist-ℕ zero-ℕ n ＝ n
-left-unit-law-dist-ℕ zero-ℕ = refl
-left-unit-law-dist-ℕ (succ-ℕ n) = refl
+abstract
+  left-unit-law-dist-ℕ :
+    (n : ℕ) → dist-ℕ zero-ℕ n ＝ n
+  left-unit-law-dist-ℕ zero-ℕ = refl
+  left-unit-law-dist-ℕ (succ-ℕ n) = refl
 
-right-unit-law-dist-ℕ :
-  (n : ℕ) → dist-ℕ n zero-ℕ ＝ n
-right-unit-law-dist-ℕ zero-ℕ = refl
-right-unit-law-dist-ℕ (succ-ℕ n) = refl
+  right-unit-law-dist-ℕ :
+    (n : ℕ) → dist-ℕ n zero-ℕ ＝ n
+  right-unit-law-dist-ℕ zero-ℕ = refl
+  right-unit-law-dist-ℕ (succ-ℕ n) = refl
 ```
 
 ## The triangle inequality
 
 ```agda
-triangle-inequality-dist-ℕ :
-  (m n k : ℕ) → (dist-ℕ m n) ≤-ℕ ((dist-ℕ m k) +ℕ (dist-ℕ k n))
-triangle-inequality-dist-ℕ zero-ℕ zero-ℕ zero-ℕ = star
-triangle-inequality-dist-ℕ zero-ℕ zero-ℕ (succ-ℕ k) = star
-triangle-inequality-dist-ℕ zero-ℕ (succ-ℕ n) zero-ℕ =
-  tr
-    ( leq-ℕ (succ-ℕ n))
-    ( inv (left-unit-law-add-ℕ (succ-ℕ n)))
-    ( refl-leq-ℕ (succ-ℕ n))
-triangle-inequality-dist-ℕ zero-ℕ (succ-ℕ n) (succ-ℕ k) =
-  concatenate-eq-leq-eq-ℕ
-    ( inv (ap succ-ℕ (left-unit-law-dist-ℕ n)))
-    ( triangle-inequality-dist-ℕ zero-ℕ n k)
-    ( ( ap (succ-ℕ ∘ (_+ℕ (dist-ℕ k n))) (left-unit-law-dist-ℕ k)) ∙
-      ( inv (left-successor-law-add-ℕ k (dist-ℕ k n))))
-triangle-inequality-dist-ℕ (succ-ℕ m) zero-ℕ zero-ℕ = refl-leq-ℕ (succ-ℕ m)
-triangle-inequality-dist-ℕ (succ-ℕ m) zero-ℕ (succ-ℕ k) =
-  concatenate-eq-leq-eq-ℕ
-    ( inv (ap succ-ℕ (right-unit-law-dist-ℕ m)))
-    ( triangle-inequality-dist-ℕ m zero-ℕ k)
-    ( ap (succ-ℕ ∘ ((dist-ℕ m k) +ℕ_)) (right-unit-law-dist-ℕ k))
-triangle-inequality-dist-ℕ (succ-ℕ m) (succ-ℕ n) zero-ℕ =
-  concatenate-leq-eq-ℕ
-    ( dist-ℕ m n)
-    ( transitive-leq-ℕ
+abstract
+  triangle-inequality-dist-ℕ :
+    (m n k : ℕ) → (dist-ℕ m n) ≤-ℕ ((dist-ℕ m k) +ℕ (dist-ℕ k n))
+  triangle-inequality-dist-ℕ zero-ℕ zero-ℕ zero-ℕ = star
+  triangle-inequality-dist-ℕ zero-ℕ zero-ℕ (succ-ℕ k) = star
+  triangle-inequality-dist-ℕ zero-ℕ (succ-ℕ n) zero-ℕ =
+    tr
+      ( leq-ℕ (succ-ℕ n))
+      ( inv (left-unit-law-add-ℕ (succ-ℕ n)))
+      ( refl-leq-ℕ (succ-ℕ n))
+  triangle-inequality-dist-ℕ zero-ℕ (succ-ℕ n) (succ-ℕ k) =
+    concatenate-eq-leq-eq-ℕ
+      ( inv (ap succ-ℕ (left-unit-law-dist-ℕ n)))
+      ( triangle-inequality-dist-ℕ zero-ℕ n k)
+      ( ( ap (succ-ℕ ∘ (_+ℕ (dist-ℕ k n))) (left-unit-law-dist-ℕ k)) ∙
+        ( inv (left-successor-law-add-ℕ k (dist-ℕ k n))))
+  triangle-inequality-dist-ℕ (succ-ℕ m) zero-ℕ zero-ℕ = refl-leq-ℕ (succ-ℕ m)
+  triangle-inequality-dist-ℕ (succ-ℕ m) zero-ℕ (succ-ℕ k) =
+    concatenate-eq-leq-eq-ℕ
+      ( inv (ap succ-ℕ (right-unit-law-dist-ℕ m)))
+      ( triangle-inequality-dist-ℕ m zero-ℕ k)
+      ( ap (succ-ℕ ∘ ((dist-ℕ m k) +ℕ_)) (right-unit-law-dist-ℕ k))
+  triangle-inequality-dist-ℕ (succ-ℕ m) (succ-ℕ n) zero-ℕ =
+    concatenate-leq-eq-ℕ
       ( dist-ℕ m n)
-      ( succ-ℕ ((dist-ℕ m zero-ℕ) +ℕ (dist-ℕ zero-ℕ n)))
-      ( succ-ℕ (succ-ℕ ((dist-ℕ m zero-ℕ) +ℕ (dist-ℕ zero-ℕ n))))
-      ( succ-leq-ℕ (succ-ℕ ((dist-ℕ m zero-ℕ) +ℕ (dist-ℕ zero-ℕ n))))
       ( transitive-leq-ℕ
         ( dist-ℕ m n)
-        ( (dist-ℕ m zero-ℕ) +ℕ (dist-ℕ zero-ℕ n))
         ( succ-ℕ ((dist-ℕ m zero-ℕ) +ℕ (dist-ℕ zero-ℕ n)))
-        ( succ-leq-ℕ ((dist-ℕ m zero-ℕ) +ℕ (dist-ℕ zero-ℕ n)))
-        ( triangle-inequality-dist-ℕ m n zero-ℕ)))
-    ( ( ap
-        ( succ-ℕ ∘ succ-ℕ)
-        ( ap-add-ℕ (right-unit-law-dist-ℕ m) (left-unit-law-dist-ℕ n))) ∙
-      ( inv (left-successor-law-add-ℕ m (succ-ℕ n))))
-triangle-inequality-dist-ℕ (succ-ℕ m) (succ-ℕ n) (succ-ℕ k) =
-  triangle-inequality-dist-ℕ m n k
+        ( succ-ℕ (succ-ℕ ((dist-ℕ m zero-ℕ) +ℕ (dist-ℕ zero-ℕ n))))
+        ( succ-leq-ℕ (succ-ℕ ((dist-ℕ m zero-ℕ) +ℕ (dist-ℕ zero-ℕ n))))
+        ( transitive-leq-ℕ
+          ( dist-ℕ m n)
+          ( (dist-ℕ m zero-ℕ) +ℕ (dist-ℕ zero-ℕ n))
+          ( succ-ℕ ((dist-ℕ m zero-ℕ) +ℕ (dist-ℕ zero-ℕ n)))
+          ( succ-leq-ℕ ((dist-ℕ m zero-ℕ) +ℕ (dist-ℕ zero-ℕ n)))
+          ( triangle-inequality-dist-ℕ m n zero-ℕ)))
+      ( ( ap
+          ( succ-ℕ ∘ succ-ℕ)
+          ( ap-add-ℕ (right-unit-law-dist-ℕ m) (left-unit-law-dist-ℕ n))) ∙
+        ( inv (left-successor-law-add-ℕ m (succ-ℕ n))))
+  triangle-inequality-dist-ℕ (succ-ℕ m) (succ-ℕ n) (succ-ℕ k) =
+    triangle-inequality-dist-ℕ m n k
 ```
 
 ### `dist-ℕ x y` is a solution in `z` to `x + z ＝ y`
 
 ```agda
-is-additive-right-inverse-dist-ℕ :
-  (x y : ℕ) → x ≤-ℕ y → x +ℕ (dist-ℕ x y) ＝ y
-is-additive-right-inverse-dist-ℕ zero-ℕ zero-ℕ H = refl
-is-additive-right-inverse-dist-ℕ zero-ℕ (succ-ℕ y) star =
-  left-unit-law-add-ℕ (succ-ℕ y)
-is-additive-right-inverse-dist-ℕ (succ-ℕ x) (succ-ℕ y) H =
-  ( left-successor-law-add-ℕ x (dist-ℕ x y)) ∙
-  ( ap succ-ℕ (is-additive-right-inverse-dist-ℕ x y H))
+abstract
+  is-additive-right-inverse-dist-ℕ :
+    (x y : ℕ) → x ≤-ℕ y → x +ℕ (dist-ℕ x y) ＝ y
+  is-additive-right-inverse-dist-ℕ zero-ℕ zero-ℕ H = refl
+  is-additive-right-inverse-dist-ℕ zero-ℕ (succ-ℕ y) star =
+    left-unit-law-add-ℕ (succ-ℕ y)
+  is-additive-right-inverse-dist-ℕ (succ-ℕ x) (succ-ℕ y) H =
+    ( left-successor-law-add-ℕ x (dist-ℕ x y)) ∙
+    ( ap succ-ℕ (is-additive-right-inverse-dist-ℕ x y H))
 
-rewrite-left-add-dist-ℕ :
-  (x y z : ℕ) → x +ℕ y ＝ z → x ＝ dist-ℕ y z
-rewrite-left-add-dist-ℕ zero-ℕ zero-ℕ .zero-ℕ refl = refl
-rewrite-left-add-dist-ℕ zero-ℕ (succ-ℕ y) .(succ-ℕ (zero-ℕ +ℕ y)) refl =
-  ( inv (dist-eq-ℕ' y)) ∙
-  ( inv (ap (dist-ℕ (succ-ℕ y)) (left-unit-law-add-ℕ (succ-ℕ y))))
-rewrite-left-add-dist-ℕ (succ-ℕ x) zero-ℕ .(succ-ℕ x) refl = refl
-rewrite-left-add-dist-ℕ (succ-ℕ x) (succ-ℕ y) ._ refl =
-  rewrite-left-add-dist-ℕ (succ-ℕ x) y ((succ-ℕ x) +ℕ y) refl
+  rewrite-left-add-dist-ℕ :
+    (x y z : ℕ) → x +ℕ y ＝ z → x ＝ dist-ℕ y z
+  rewrite-left-add-dist-ℕ zero-ℕ zero-ℕ .zero-ℕ refl = refl
+  rewrite-left-add-dist-ℕ zero-ℕ (succ-ℕ y) .(succ-ℕ (zero-ℕ +ℕ y)) refl =
+    ( inv (dist-eq-ℕ' y)) ∙
+    ( inv (ap (dist-ℕ (succ-ℕ y)) (left-unit-law-add-ℕ (succ-ℕ y))))
+  rewrite-left-add-dist-ℕ (succ-ℕ x) zero-ℕ .(succ-ℕ x) refl = refl
+  rewrite-left-add-dist-ℕ (succ-ℕ x) (succ-ℕ y) ._ refl =
+    rewrite-left-add-dist-ℕ (succ-ℕ x) y ((succ-ℕ x) +ℕ y) refl
 
-rewrite-left-dist-add-ℕ :
-  (x y z : ℕ) → y ≤-ℕ z → x ＝ dist-ℕ y z → x +ℕ y ＝ z
-rewrite-left-dist-add-ℕ .(dist-ℕ y z) y z H refl =
-  ( commutative-add-ℕ (dist-ℕ y z) y) ∙
-  ( is-additive-right-inverse-dist-ℕ y z H)
+  rewrite-left-dist-add-ℕ :
+    (x y z : ℕ) → y ≤-ℕ z → x ＝ dist-ℕ y z → x +ℕ y ＝ z
+  rewrite-left-dist-add-ℕ .(dist-ℕ y z) y z H refl =
+    ( commutative-add-ℕ (dist-ℕ y z) y) ∙
+    ( is-additive-right-inverse-dist-ℕ y z H)
 
-rewrite-right-add-dist-ℕ :
-  (x y z : ℕ) → x +ℕ y ＝ z → y ＝ dist-ℕ x z
-rewrite-right-add-dist-ℕ x y z p =
-  rewrite-left-add-dist-ℕ y x z (commutative-add-ℕ y x ∙ p)
+  rewrite-right-add-dist-ℕ :
+    (x y z : ℕ) → x +ℕ y ＝ z → y ＝ dist-ℕ x z
+  rewrite-right-add-dist-ℕ x y z p =
+    rewrite-left-add-dist-ℕ y x z (commutative-add-ℕ y x ∙ p)
 
-rewrite-right-dist-add-ℕ :
-  (x y z : ℕ) → x ≤-ℕ z → y ＝ dist-ℕ x z → x +ℕ y ＝ z
-rewrite-right-dist-add-ℕ x .(dist-ℕ x z) z H refl =
-  is-additive-right-inverse-dist-ℕ x z H
+  rewrite-right-dist-add-ℕ :
+    (x y z : ℕ) → x ≤-ℕ z → y ＝ dist-ℕ x z → x +ℕ y ＝ z
+  rewrite-right-dist-add-ℕ x .(dist-ℕ x z) z H refl =
+    is-additive-right-inverse-dist-ℕ x z H
 
-is-difference-dist-ℕ :
-  (x y : ℕ) → x ≤-ℕ y → x +ℕ (dist-ℕ x y) ＝ y
-is-difference-dist-ℕ zero-ℕ zero-ℕ H = refl
-is-difference-dist-ℕ zero-ℕ (succ-ℕ y) H = left-unit-law-add-ℕ (succ-ℕ y)
-is-difference-dist-ℕ (succ-ℕ x) (succ-ℕ y) H =
-  ( left-successor-law-add-ℕ x (dist-ℕ x y)) ∙
-  ( ap succ-ℕ (is-difference-dist-ℕ x y H))
+  is-difference-dist-ℕ :
+    (x y : ℕ) → x ≤-ℕ y → x +ℕ (dist-ℕ x y) ＝ y
+  is-difference-dist-ℕ zero-ℕ zero-ℕ H = refl
+  is-difference-dist-ℕ zero-ℕ (succ-ℕ y) H = left-unit-law-add-ℕ (succ-ℕ y)
+  is-difference-dist-ℕ (succ-ℕ x) (succ-ℕ y) H =
+    ( left-successor-law-add-ℕ x (dist-ℕ x y)) ∙
+    ( ap succ-ℕ (is-difference-dist-ℕ x y H))
 
-is-difference-dist-ℕ' :
-  (x y : ℕ) → x ≤-ℕ y → (dist-ℕ x y) +ℕ x ＝ y
-is-difference-dist-ℕ' x y H =
-  ( commutative-add-ℕ (dist-ℕ x y) x) ∙
-  ( is-difference-dist-ℕ x y H)
+  is-difference-dist-ℕ' :
+    (x y : ℕ) → x ≤-ℕ y → (dist-ℕ x y) +ℕ x ＝ y
+  is-difference-dist-ℕ' x y H =
+    ( commutative-add-ℕ (dist-ℕ x y) x) ∙
+    ( is-difference-dist-ℕ x y H)
 ```
 
 ### The distance from `n` to `n + m` is `m`
 
 ```agda
-dist-add-ℕ : (x y : ℕ) → dist-ℕ x (x +ℕ y) ＝ y
-dist-add-ℕ x y = inv (rewrite-right-add-dist-ℕ x y (x +ℕ y) refl)
+abstract
+  dist-add-ℕ : (x y : ℕ) → dist-ℕ x (x +ℕ y) ＝ y
+  dist-add-ℕ x y = inv (rewrite-right-add-dist-ℕ x y (x +ℕ y) refl)
 
-dist-add-ℕ' : (x y : ℕ) → dist-ℕ (x +ℕ y) x ＝ y
-dist-add-ℕ' x y = symmetric-dist-ℕ (x +ℕ y) x ∙ dist-add-ℕ x y
+  dist-add-ℕ' : (x y : ℕ) → dist-ℕ (x +ℕ y) x ＝ y
+  dist-add-ℕ' x y = commutative-dist-ℕ (x +ℕ y) x ∙ dist-add-ℕ x y
 ```
 
 ### If three elements are ordered linearly, then their distances add up
 
 ```agda
-triangle-equality-dist-ℕ :
-  (x y z : ℕ) → (x ≤-ℕ y) → (y ≤-ℕ z) →
-  (dist-ℕ x y) +ℕ (dist-ℕ y z) ＝ dist-ℕ x z
-triangle-equality-dist-ℕ zero-ℕ zero-ℕ zero-ℕ H1 H2 = refl
-triangle-equality-dist-ℕ zero-ℕ zero-ℕ (succ-ℕ z) star star =
-  ap succ-ℕ (left-unit-law-add-ℕ z)
-triangle-equality-dist-ℕ zero-ℕ (succ-ℕ y) (succ-ℕ z) star H2 =
-  left-successor-law-add-ℕ y (dist-ℕ y z) ∙
-  ap succ-ℕ (is-additive-right-inverse-dist-ℕ y z H2)
-triangle-equality-dist-ℕ (succ-ℕ x) (succ-ℕ y) (succ-ℕ z) H1 H2 =
-  triangle-equality-dist-ℕ x y z H1 H2
+abstract
+  triangle-equality-dist-ℕ :
+    (x y z : ℕ) → (x ≤-ℕ y) → (y ≤-ℕ z) →
+    (dist-ℕ x y) +ℕ (dist-ℕ y z) ＝ dist-ℕ x z
+  triangle-equality-dist-ℕ zero-ℕ zero-ℕ zero-ℕ H1 H2 = refl
+  triangle-equality-dist-ℕ zero-ℕ zero-ℕ (succ-ℕ z) star star =
+    ap succ-ℕ (left-unit-law-add-ℕ z)
+  triangle-equality-dist-ℕ zero-ℕ (succ-ℕ y) (succ-ℕ z) star H2 =
+    left-successor-law-add-ℕ y (dist-ℕ y z) ∙
+    ap succ-ℕ (is-additive-right-inverse-dist-ℕ y z H2)
+  triangle-equality-dist-ℕ (succ-ℕ x) (succ-ℕ y) (succ-ℕ z) H1 H2 =
+    triangle-equality-dist-ℕ x y z H1 H2
 
 cases-dist-ℕ :
   (x y z : ℕ) → UU lzero
@@ -241,155 +253,162 @@ cases-dist-ℕ x y z =
   ( ( (dist-ℕ y z) +ℕ (dist-ℕ x z) ＝ dist-ℕ x y) +
     ( (dist-ℕ x z) +ℕ (dist-ℕ x y) ＝ dist-ℕ y z))
 
-is-total-dist-ℕ :
-  (x y z : ℕ) → cases-dist-ℕ x y z
-is-total-dist-ℕ x y z with order-three-elements-ℕ x y z
-is-total-dist-ℕ x y z | inl (inl (pair H1 H2)) =
-  inl (triangle-equality-dist-ℕ x y z H1 H2)
-is-total-dist-ℕ x y z | inl (inr (pair H1 H2)) =
-  inr
-    ( inl
-      ( ( commutative-add-ℕ (dist-ℕ y z) (dist-ℕ x z)) ∙
-        ( ( ap ((dist-ℕ x z) +ℕ_) (symmetric-dist-ℕ y z)) ∙
-          ( triangle-equality-dist-ℕ x z y H1 H2))))
-is-total-dist-ℕ x y z | inr (inl (inl (pair H1 H2))) =
-  inr
-    ( inl
-      ( ( ap ((dist-ℕ y z) +ℕ_) (symmetric-dist-ℕ x z)) ∙
-        ( ( triangle-equality-dist-ℕ y z x H1 H2) ∙
-          ( symmetric-dist-ℕ y x))))
-is-total-dist-ℕ x y z | inr (inl (inr (pair H1 H2))) =
-  inr
-    ( inr
-      ( ( ap ((dist-ℕ x z) +ℕ_) (symmetric-dist-ℕ x y)) ∙
-        ( ( commutative-add-ℕ (dist-ℕ x z) (dist-ℕ y x)) ∙
-          ( triangle-equality-dist-ℕ y x z H1 H2))))
-is-total-dist-ℕ x y z | inr (inr (inl (pair H1 H2))) =
-  inr
-    ( inr
-      ( ( ap (_+ℕ (dist-ℕ x y)) (symmetric-dist-ℕ x z)) ∙
-        ( ( triangle-equality-dist-ℕ z x y H1 H2) ∙
-          ( symmetric-dist-ℕ z y))))
-is-total-dist-ℕ x y z | inr (inr (inr (pair H1 H2))) =
-  inl
-    ( ( ap-add-ℕ (symmetric-dist-ℕ x y) (symmetric-dist-ℕ y z)) ∙
-      ( ( commutative-add-ℕ (dist-ℕ y x) (dist-ℕ z y)) ∙
-        ( ( triangle-equality-dist-ℕ z y x H1 H2) ∙
-          ( symmetric-dist-ℕ z x))))
+abstract
+  is-total-dist-ℕ :
+    (x y z : ℕ) → cases-dist-ℕ x y z
+  is-total-dist-ℕ x y z with order-three-elements-ℕ x y z
+  is-total-dist-ℕ x y z | inl (inl (pair H1 H2)) =
+    inl (triangle-equality-dist-ℕ x y z H1 H2)
+  is-total-dist-ℕ x y z | inl (inr (pair H1 H2)) =
+    inr
+      ( inl
+        ( ( commutative-add-ℕ (dist-ℕ y z) (dist-ℕ x z)) ∙
+          ( ( ap ((dist-ℕ x z) +ℕ_) (commutative-dist-ℕ y z)) ∙
+            ( triangle-equality-dist-ℕ x z y H1 H2))))
+  is-total-dist-ℕ x y z | inr (inl (inl (pair H1 H2))) =
+    inr
+      ( inl
+        ( ( ap ((dist-ℕ y z) +ℕ_) (commutative-dist-ℕ x z)) ∙
+          ( ( triangle-equality-dist-ℕ y z x H1 H2) ∙
+            ( commutative-dist-ℕ y x))))
+  is-total-dist-ℕ x y z | inr (inl (inr (pair H1 H2))) =
+    inr
+      ( inr
+        ( ( ap ((dist-ℕ x z) +ℕ_) (commutative-dist-ℕ x y)) ∙
+          ( ( commutative-add-ℕ (dist-ℕ x z) (dist-ℕ y x)) ∙
+            ( triangle-equality-dist-ℕ y x z H1 H2))))
+  is-total-dist-ℕ x y z | inr (inr (inl (pair H1 H2))) =
+    inr
+      ( inr
+        ( ( ap (_+ℕ (dist-ℕ x y)) (commutative-dist-ℕ x z)) ∙
+          ( ( triangle-equality-dist-ℕ z x y H1 H2) ∙
+            ( commutative-dist-ℕ z y))))
+  is-total-dist-ℕ x y z | inr (inr (inr (pair H1 H2))) =
+    inl
+      ( ( ap-add-ℕ (commutative-dist-ℕ x y) (commutative-dist-ℕ y z)) ∙
+        ( ( commutative-add-ℕ (dist-ℕ y x) (dist-ℕ z y)) ∙
+          ( ( triangle-equality-dist-ℕ z y x H1 H2) ∙
+            ( commutative-dist-ℕ z x))))
 ```
 
-### If `x ≤ y` then the distance between `x` and `y` is less than `y`
+### If `x ≤ y` then the distance between `x` and `y` is less than or equal to `y`
 
 ```agda
-leq-dist-ℕ :
-  (x y : ℕ) → x ≤-ℕ y → dist-ℕ x y ≤-ℕ y
-leq-dist-ℕ zero-ℕ zero-ℕ H = refl-leq-ℕ zero-ℕ
-leq-dist-ℕ zero-ℕ (succ-ℕ y) H = refl-leq-ℕ y
-leq-dist-ℕ (succ-ℕ x) (succ-ℕ y) H =
-  transitive-leq-ℕ (dist-ℕ x y) y (succ-ℕ y) (succ-leq-ℕ y) (leq-dist-ℕ x y H)
+abstract
+  leq-dist-ℕ :
+    (x y : ℕ) → x ≤-ℕ y → dist-ℕ x y ≤-ℕ y
+  leq-dist-ℕ zero-ℕ zero-ℕ H = refl-leq-ℕ zero-ℕ
+  leq-dist-ℕ zero-ℕ (succ-ℕ y) H = refl-leq-ℕ y
+  leq-dist-ℕ (succ-ℕ x) (succ-ℕ y) H =
+    transitive-leq-ℕ (dist-ℕ x y) y (succ-ℕ y) (succ-leq-ℕ y) (leq-dist-ℕ x y H)
 ```
 
 ### If `x < b` and `y < b`, then `dist-ℕ x y < b`
 
 ```agda
-strict-upper-bound-dist-ℕ :
-  (b x y : ℕ) → x <-ℕ b → y <-ℕ b → dist-ℕ x y <-ℕ b
-strict-upper-bound-dist-ℕ (succ-ℕ b) zero-ℕ y H K = K
-strict-upper-bound-dist-ℕ (succ-ℕ b) (succ-ℕ x) zero-ℕ H K = H
-strict-upper-bound-dist-ℕ (succ-ℕ b) (succ-ℕ x) (succ-ℕ y) H K =
-  preserves-le-succ-ℕ (dist-ℕ x y) b (strict-upper-bound-dist-ℕ b x y H K)
+abstract
+  strict-upper-bound-dist-ℕ :
+    (b x y : ℕ) → x <-ℕ b → y <-ℕ b → dist-ℕ x y <-ℕ b
+  strict-upper-bound-dist-ℕ (succ-ℕ b) zero-ℕ y H K = K
+  strict-upper-bound-dist-ℕ (succ-ℕ b) (succ-ℕ x) zero-ℕ H K = H
+  strict-upper-bound-dist-ℕ (succ-ℕ b) (succ-ℕ x) (succ-ℕ y) H K =
+    preserves-le-succ-ℕ (dist-ℕ x y) b (strict-upper-bound-dist-ℕ b x y H K)
 ```
 
 ### If `x < y` then `dist-ℕ x (succ-ℕ y) = succ-ℕ (dist-ℕ x y)`
 
 ```agda
-right-successor-law-dist-ℕ :
-  (x y : ℕ) → x ≤-ℕ y → dist-ℕ x (succ-ℕ y) ＝ succ-ℕ (dist-ℕ x y)
-right-successor-law-dist-ℕ zero-ℕ zero-ℕ star = refl
-right-successor-law-dist-ℕ zero-ℕ (succ-ℕ y) star = refl
-right-successor-law-dist-ℕ (succ-ℕ x) (succ-ℕ y) H =
-  right-successor-law-dist-ℕ x y H
+abstract
+  right-successor-law-dist-ℕ :
+    (x y : ℕ) → x ≤-ℕ y → dist-ℕ x (succ-ℕ y) ＝ succ-ℕ (dist-ℕ x y)
+  right-successor-law-dist-ℕ zero-ℕ zero-ℕ star = refl
+  right-successor-law-dist-ℕ zero-ℕ (succ-ℕ y) star = refl
+  right-successor-law-dist-ℕ (succ-ℕ x) (succ-ℕ y) H =
+    right-successor-law-dist-ℕ x y H
 
-left-successor-law-dist-ℕ :
-  (x y : ℕ) → y ≤-ℕ x → dist-ℕ (succ-ℕ x) y ＝ succ-ℕ (dist-ℕ x y)
-left-successor-law-dist-ℕ zero-ℕ zero-ℕ star = refl
-left-successor-law-dist-ℕ (succ-ℕ x) zero-ℕ star = refl
-left-successor-law-dist-ℕ (succ-ℕ x) (succ-ℕ y) H =
-  left-successor-law-dist-ℕ x y H
+  left-successor-law-dist-ℕ :
+    (x y : ℕ) → y ≤-ℕ x → dist-ℕ (succ-ℕ x) y ＝ succ-ℕ (dist-ℕ x y)
+  left-successor-law-dist-ℕ zero-ℕ zero-ℕ star = refl
+  left-successor-law-dist-ℕ (succ-ℕ x) zero-ℕ star = refl
+  left-successor-law-dist-ℕ (succ-ℕ x) (succ-ℕ y) H =
+    left-successor-law-dist-ℕ x y H
 ```
 
 ### `dist-ℕ` is translation invariant
 
 ```agda
-translation-invariant-dist-ℕ :
-  (k m n : ℕ) → dist-ℕ (k +ℕ m) (k +ℕ n) ＝ dist-ℕ m n
-translation-invariant-dist-ℕ zero-ℕ m n =
-  ap-dist-ℕ (left-unit-law-add-ℕ m) (left-unit-law-add-ℕ n)
-translation-invariant-dist-ℕ (succ-ℕ k) m n =
-  ( ap-dist-ℕ (left-successor-law-add-ℕ k m) (left-successor-law-add-ℕ k n)) ∙
-  ( translation-invariant-dist-ℕ k m n)
+abstract
+  translation-invariant-dist-ℕ :
+    (k m n : ℕ) → dist-ℕ (k +ℕ m) (k +ℕ n) ＝ dist-ℕ m n
+  translation-invariant-dist-ℕ zero-ℕ m n =
+    ap-dist-ℕ (left-unit-law-add-ℕ m) (left-unit-law-add-ℕ n)
+  translation-invariant-dist-ℕ (succ-ℕ k) m n =
+    ( ap-dist-ℕ (left-successor-law-add-ℕ k m) (left-successor-law-add-ℕ k n)) ∙
+    ( translation-invariant-dist-ℕ k m n)
 
-translation-invariant-dist-ℕ' :
-  (k m n : ℕ) → dist-ℕ (m +ℕ k) (n +ℕ k) ＝ dist-ℕ m n
-translation-invariant-dist-ℕ' k m n =
-  ( ap-dist-ℕ (commutative-add-ℕ m k) (commutative-add-ℕ n k)) ∙
-  ( translation-invariant-dist-ℕ k m n)
+  translation-invariant-dist-ℕ' :
+    (k m n : ℕ) → dist-ℕ (m +ℕ k) (n +ℕ k) ＝ dist-ℕ m n
+  translation-invariant-dist-ℕ' k m n =
+    ( ap-dist-ℕ (commutative-add-ℕ m k) (commutative-add-ℕ n k)) ∙
+    ( translation-invariant-dist-ℕ k m n)
 ```
 
 ### `dist-ℕ` is linear with respect to scalar multiplication
 
 ```agda
-left-distributive-mul-dist-ℕ :
-  (m n k : ℕ) → k *ℕ (dist-ℕ m n) ＝ dist-ℕ (k *ℕ m) (k *ℕ n)
-left-distributive-mul-dist-ℕ zero-ℕ zero-ℕ zero-ℕ = refl
-left-distributive-mul-dist-ℕ zero-ℕ zero-ℕ (succ-ℕ k) =
-  left-distributive-mul-dist-ℕ zero-ℕ zero-ℕ k
-left-distributive-mul-dist-ℕ zero-ℕ (succ-ℕ n) zero-ℕ = refl
-left-distributive-mul-dist-ℕ zero-ℕ (succ-ℕ n) (succ-ℕ k) =
-  ap
-    ( dist-ℕ' ((succ-ℕ k) *ℕ (succ-ℕ n)))
-    ( inv (right-zero-law-mul-ℕ (succ-ℕ k)))
-left-distributive-mul-dist-ℕ (succ-ℕ m) zero-ℕ zero-ℕ = refl
-left-distributive-mul-dist-ℕ (succ-ℕ m) zero-ℕ (succ-ℕ k) =
-  ap
-    ( dist-ℕ ((succ-ℕ k) *ℕ (succ-ℕ m)))
-    ( inv (right-zero-law-mul-ℕ (succ-ℕ k)))
-left-distributive-mul-dist-ℕ (succ-ℕ m) (succ-ℕ n) zero-ℕ = refl
-left-distributive-mul-dist-ℕ (succ-ℕ m) (succ-ℕ n) (succ-ℕ k) =
-  inv
-    ( ( ap-dist-ℕ
-        ( right-successor-law-mul-ℕ (succ-ℕ k) m)
-        ( right-successor-law-mul-ℕ (succ-ℕ k) n)) ∙
-      ( ( translation-invariant-dist-ℕ
-          ( succ-ℕ k)
-          ( (succ-ℕ k) *ℕ m)
-          ( (succ-ℕ k) *ℕ n)) ∙
-        ( inv (left-distributive-mul-dist-ℕ m n (succ-ℕ k)))))
+abstract
+  left-distributive-mul-dist-ℕ :
+    (m n k : ℕ) → k *ℕ (dist-ℕ m n) ＝ dist-ℕ (k *ℕ m) (k *ℕ n)
+  left-distributive-mul-dist-ℕ zero-ℕ zero-ℕ zero-ℕ = refl
+  left-distributive-mul-dist-ℕ zero-ℕ zero-ℕ (succ-ℕ k) =
+    left-distributive-mul-dist-ℕ zero-ℕ zero-ℕ k
+  left-distributive-mul-dist-ℕ zero-ℕ (succ-ℕ n) zero-ℕ = refl
+  left-distributive-mul-dist-ℕ zero-ℕ (succ-ℕ n) (succ-ℕ k) =
+    ap
+      ( dist-ℕ' ((succ-ℕ k) *ℕ (succ-ℕ n)))
+      ( inv (right-zero-law-mul-ℕ (succ-ℕ k)))
+  left-distributive-mul-dist-ℕ (succ-ℕ m) zero-ℕ zero-ℕ = refl
+  left-distributive-mul-dist-ℕ (succ-ℕ m) zero-ℕ (succ-ℕ k) =
+    ap
+      ( dist-ℕ ((succ-ℕ k) *ℕ (succ-ℕ m)))
+      ( inv (right-zero-law-mul-ℕ (succ-ℕ k)))
+  left-distributive-mul-dist-ℕ (succ-ℕ m) (succ-ℕ n) zero-ℕ = refl
+  left-distributive-mul-dist-ℕ (succ-ℕ m) (succ-ℕ n) (succ-ℕ k) =
+    inv
+      ( ( ap-dist-ℕ
+          ( right-successor-law-mul-ℕ (succ-ℕ k) m)
+          ( right-successor-law-mul-ℕ (succ-ℕ k) n)) ∙
+        ( ( translation-invariant-dist-ℕ
+            ( succ-ℕ k)
+            ( (succ-ℕ k) *ℕ m)
+            ( (succ-ℕ k) *ℕ n)) ∙
+          ( inv (left-distributive-mul-dist-ℕ m n (succ-ℕ k)))))
 
-left-distributive-mul-dist-ℕ' :
-  (m n k : ℕ) → dist-ℕ (k *ℕ m) (k *ℕ n) ＝ k *ℕ (dist-ℕ m n)
-left-distributive-mul-dist-ℕ' m n k =
-  inv (left-distributive-mul-dist-ℕ m n k)
+  left-distributive-mul-dist-ℕ' :
+    (m n k : ℕ) → dist-ℕ (k *ℕ m) (k *ℕ n) ＝ k *ℕ (dist-ℕ m n)
+  left-distributive-mul-dist-ℕ' m n k =
+    inv (left-distributive-mul-dist-ℕ m n k)
 
-right-distributive-mul-dist-ℕ :
-  (x y k : ℕ) → (dist-ℕ x y) *ℕ k ＝ dist-ℕ (x *ℕ k) (y *ℕ k)
-right-distributive-mul-dist-ℕ x y k =
-  ( commutative-mul-ℕ (dist-ℕ x y) k) ∙
-  ( ( left-distributive-mul-dist-ℕ x y k) ∙
-    ( ap-dist-ℕ (commutative-mul-ℕ k x) (commutative-mul-ℕ k y)))
+  right-distributive-mul-dist-ℕ :
+    (x y k : ℕ) → (dist-ℕ x y) *ℕ k ＝ dist-ℕ (x *ℕ k) (y *ℕ k)
+  right-distributive-mul-dist-ℕ x y k =
+    ( commutative-mul-ℕ (dist-ℕ x y) k) ∙
+    ( ( left-distributive-mul-dist-ℕ x y k) ∙
+      ( ap-dist-ℕ (commutative-mul-ℕ k x) (commutative-mul-ℕ k y)))
 ```
 
 ### The distance is the difference between the maximum and the minimum
 
 ```agda
-eq-max-dist-min-ℕ : (x y : ℕ) → dist-ℕ x y +ℕ min-ℕ x y ＝ max-ℕ x y
-eq-max-dist-min-ℕ zero-ℕ y = refl
-eq-max-dist-min-ℕ (succ-ℕ x) zero-ℕ = refl
-eq-max-dist-min-ℕ (succ-ℕ x) (succ-ℕ y) = ap succ-ℕ (eq-max-dist-min-ℕ x y)
+abstract
+  eq-max-dist-min-ℕ : (x y : ℕ) → dist-ℕ x y +ℕ min-ℕ x y ＝ max-ℕ x y
+  eq-max-dist-min-ℕ zero-ℕ y = refl
+  eq-max-dist-min-ℕ (succ-ℕ x) zero-ℕ = refl
+  eq-max-dist-min-ℕ (succ-ℕ x) (succ-ℕ y) = ap succ-ℕ (eq-max-dist-min-ℕ x y)
 
-dist-max-min-ℕ : (x y : ℕ) → dist-ℕ x y ＝ dist-ℕ (max-ℕ x y) (min-ℕ x y)
-dist-max-min-ℕ zero-ℕ zero-ℕ = refl
-dist-max-min-ℕ zero-ℕ (succ-ℕ y) = refl
-dist-max-min-ℕ (succ-ℕ x) zero-ℕ = refl
-dist-max-min-ℕ (succ-ℕ x) (succ-ℕ y) = dist-max-min-ℕ x y
+  dist-max-min-ℕ : (x y : ℕ) → dist-ℕ x y ＝ dist-ℕ (max-ℕ x y) (min-ℕ x y)
+  dist-max-min-ℕ zero-ℕ zero-ℕ = refl
+  dist-max-min-ℕ zero-ℕ (succ-ℕ y) = refl
+  dist-max-min-ℕ (succ-ℕ x) zero-ℕ = refl
+  dist-max-min-ℕ (succ-ℕ x) (succ-ℕ y) = dist-max-min-ℕ x y
 ```

--- a/src/elementary-number-theory/divisibility-integers.lagda.md
+++ b/src/elementary-number-theory/divisibility-integers.lagda.md
@@ -157,17 +157,16 @@ abstract
 Note that the divisibility relation on the integers is not antisymmetric.
 
 ```agda
-abstract
-  refl-div-ℤ : is-reflexive div-ℤ
-  pr1 (refl-div-ℤ x) = one-ℤ
-  pr2 (refl-div-ℤ x) = left-unit-law-mul-ℤ x
+refl-div-ℤ : is-reflexive div-ℤ
+pr1 (refl-div-ℤ x) = one-ℤ
+pr2 (refl-div-ℤ x) = left-unit-law-mul-ℤ x
 
-  transitive-div-ℤ : is-transitive div-ℤ
-  pr1 (transitive-div-ℤ x y z (pair e q) (pair d p)) = e *ℤ d
-  pr2 (transitive-div-ℤ x y z (pair e q) (pair d p)) =
-    ( associative-mul-ℤ e d x) ∙
-      ( ( ap (e *ℤ_) p) ∙
-        ( q))
+transitive-div-ℤ : is-transitive div-ℤ
+pr1 (transitive-div-ℤ x y z (pair e q) (pair d p)) = e *ℤ d
+pr2 (transitive-div-ℤ x y z (pair e q) (pair d p)) =
+  ( associative-mul-ℤ e d x) ∙
+    ( ( ap (e *ℤ_) p) ∙
+      ( q))
 ```
 
 ### Every integer is divisible by `1`
@@ -222,63 +221,58 @@ abstract
 ### If `x` divides both `y` and `z`, then it divides `y + z`
 
 ```agda
-abstract
-  div-add-ℤ : (x y z : ℤ) → div-ℤ x y → div-ℤ x z → div-ℤ x (y +ℤ z)
-  pr1 (div-add-ℤ x y z (pair d p) (pair e q)) = d +ℤ e
-  pr2 (div-add-ℤ x y z (pair d p) (pair e q)) =
-    ( right-distributive-mul-add-ℤ d e x) ∙
-    ( ap-add-ℤ p q)
+div-add-ℤ : (x y z : ℤ) → div-ℤ x y → div-ℤ x z → div-ℤ x (y +ℤ z)
+pr1 (div-add-ℤ x y z (pair d p) (pair e q)) = d +ℤ e
+pr2 (div-add-ℤ x y z (pair d p) (pair e q)) =
+  ( right-distributive-mul-add-ℤ d e x) ∙
+  ( ap-add-ℤ p q)
 ```
 
 ### If `x` divides `y` then `x` divides any multiple of `y`
 
 ```agda
-abstract
-  div-mul-ℤ :
-    (k x y : ℤ) → div-ℤ x y → div-ℤ x (k *ℤ y)
-  div-mul-ℤ k x y = transitive-div-ℤ x y (k *ℤ y) (k , refl)
+div-mul-ℤ :
+  (k x y : ℤ) → div-ℤ x y → div-ℤ x (k *ℤ y)
+div-mul-ℤ k x y = transitive-div-ℤ x y (k *ℤ y) (k , refl)
 ```
 
 ### If `x` divides `y` then it divides `-y`
 
 ```agda
-abstract
-  div-neg-ℤ : (x y : ℤ) → div-ℤ x y → div-ℤ x (neg-ℤ y)
-  pr1 (div-neg-ℤ x y (pair d p)) = neg-ℤ d
-  pr2 (div-neg-ℤ x y (pair d p)) = left-negative-law-mul-ℤ d x ∙ ap neg-ℤ p
+div-neg-ℤ : (x y : ℤ) → div-ℤ x y → div-ℤ x (neg-ℤ y)
+pr1 (div-neg-ℤ x y (pair d p)) = neg-ℤ d
+pr2 (div-neg-ℤ x y (pair d p)) = left-negative-law-mul-ℤ d x ∙ ap neg-ℤ p
 ```
 
 ### If `x` divides `y` then `-x` divides `y`
 
 ```agda
-abstract
-  neg-div-ℤ : (x y : ℤ) → div-ℤ x y → div-ℤ (neg-ℤ x) y
-  pr1 (neg-div-ℤ x y (pair d p)) = neg-ℤ d
-  pr2 (neg-div-ℤ x y (pair d p)) =
-    equational-reasoning
-      (neg-ℤ d) *ℤ (neg-ℤ x)
-      ＝ neg-ℤ (d *ℤ (neg-ℤ x))
-        by left-negative-law-mul-ℤ d (neg-ℤ x)
-      ＝ neg-ℤ (neg-ℤ (d *ℤ x))
-        by ap neg-ℤ (right-negative-law-mul-ℤ d x)
-      ＝ (d *ℤ x)
-        by neg-neg-ℤ (d *ℤ x)
-      ＝ y
-        by p
+neg-div-ℤ : (x y : ℤ) → div-ℤ x y → div-ℤ (neg-ℤ x) y
+pr1 (neg-div-ℤ x y (pair d p)) = neg-ℤ d
+pr2 (neg-div-ℤ x y (pair d p)) =
+  equational-reasoning
+    (neg-ℤ d) *ℤ (neg-ℤ x)
+    ＝ neg-ℤ (d *ℤ (neg-ℤ x))
+      by left-negative-law-mul-ℤ d (neg-ℤ x)
+    ＝ neg-ℤ (neg-ℤ (d *ℤ x))
+      by ap neg-ℤ (right-negative-law-mul-ℤ d x)
+    ＝ (d *ℤ x)
+      by neg-neg-ℤ (d *ℤ x)
+    ＝ y
+      by p
 ```
 
 ### Multiplication preserves divisibility
 
 ```agda
-abstract
-  preserves-div-mul-ℤ :
-    (k x y : ℤ) → div-ℤ x y → div-ℤ (k *ℤ x) (k *ℤ y)
-  pr1 (preserves-div-mul-ℤ k x y (pair q p)) = q
-  pr2 (preserves-div-mul-ℤ k x y (pair q p)) =
-    ( inv (associative-mul-ℤ q k x)) ∙
-      ( ( ap (_*ℤ x) (commutative-mul-ℤ q k)) ∙
-        ( ( associative-mul-ℤ k q x) ∙
-          ( ap (k *ℤ_) p)))
+preserves-div-mul-ℤ :
+  (k x y : ℤ) → div-ℤ x y → div-ℤ (k *ℤ x) (k *ℤ y)
+pr1 (preserves-div-mul-ℤ k x y (pair q p)) = q
+pr2 (preserves-div-mul-ℤ k x y (pair q p)) =
+  ( inv (associative-mul-ℤ q k x)) ∙
+  ( ap (_*ℤ x) (commutative-mul-ℤ q k)) ∙
+  ( associative-mul-ℤ k q x) ∙
+  ( ap (k *ℤ_) p)
 ```
 
 ### Multiplication by a nonzero number reflects divisibility
@@ -291,63 +285,61 @@ abstract
   pr2 (reflects-div-mul-ℤ k x y H (pair q p)) =
     is-injective-left-mul-ℤ k H
       ( ( inv (associative-mul-ℤ k q x)) ∙
-        ( ( ap (_*ℤ x) (commutative-mul-ℤ k q)) ∙
-          ( ( associative-mul-ℤ q k x) ∙
-            ( p))))
+        ( ap (_*ℤ x) (commutative-mul-ℤ k q)) ∙
+        ( associative-mul-ℤ q k x) ∙
+        ( p))
 ```
 
 ### If a nonzero number `d` divides `y`, then `dx` divides `y` if and only if `x` divides the quotient `y/d`
 
 ```agda
-abstract
-  div-quotient-div-div-ℤ :
-    (x y d : ℤ) (H : div-ℤ d y) → is-nonzero-ℤ d →
-    div-ℤ (d *ℤ x) y → div-ℤ x (quotient-div-ℤ d y H)
-  div-quotient-div-div-ℤ x y d H f K =
-    reflects-div-mul-ℤ d x
-      ( quotient-div-ℤ d y H)
-      ( f)
-      ( tr (div-ℤ (d *ℤ x)) (inv (eq-quotient-div-ℤ' d y H)) K)
+div-quotient-div-div-ℤ :
+  (x y d : ℤ) (H : div-ℤ d y) → is-nonzero-ℤ d →
+  div-ℤ (d *ℤ x) y → div-ℤ x (quotient-div-ℤ d y H)
+div-quotient-div-div-ℤ x y d H f K =
+  reflects-div-mul-ℤ d x
+    ( quotient-div-ℤ d y H)
+    ( f)
+    ( tr (div-ℤ (d *ℤ x)) (inv (eq-quotient-div-ℤ' d y H)) K)
 
-  div-div-quotient-div-ℤ :
-    (x y d : ℤ) (H : div-ℤ d y) →
-    div-ℤ x (quotient-div-ℤ d y H) → div-ℤ (d *ℤ x) y
-  div-div-quotient-div-ℤ x y d H K =
-    tr
-      ( div-ℤ (d *ℤ x))
-      ( eq-quotient-div-ℤ' d y H)
-      ( preserves-div-mul-ℤ d x (quotient-div-ℤ d y H) K)
+div-div-quotient-div-ℤ :
+  (x y d : ℤ) (H : div-ℤ d y) →
+  div-ℤ x (quotient-div-ℤ d y H) → div-ℤ (d *ℤ x) y
+div-div-quotient-div-ℤ x y d H K =
+  tr
+    ( div-ℤ (d *ℤ x))
+    ( eq-quotient-div-ℤ' d y H)
+    ( preserves-div-mul-ℤ d x (quotient-div-ℤ d y H) K)
 ```
 
-### Comparison of divisibility on `ℕ` and on `ℤ`
+### The canonical embedding of natural numbers preserves and reflects divisibility
 
 ```agda
-abstract
-  div-int-div-ℕ :
-    {x y : ℕ} → div-ℕ x y → div-ℤ (int-ℕ x) (int-ℕ y)
-  pr1 (div-int-div-ℕ {x} {y} (pair d p)) = int-ℕ d
-  pr2 (div-int-div-ℕ {x} {y} (pair d p)) = mul-int-ℕ d x ∙ ap int-ℕ p
+div-int-div-ℕ :
+  {x y : ℕ} → div-ℕ x y → div-ℤ (int-ℕ x) (int-ℕ y)
+pr1 (div-int-div-ℕ {x} {y} (pair d p)) = int-ℕ d
+pr2 (div-int-div-ℕ {x} {y} (pair d p)) = mul-int-ℕ d x ∙ ap int-ℕ p
 
-  div-div-int-ℕ :
-    {x y : ℕ} → div-ℤ (int-ℕ x) (int-ℕ y) → div-ℕ x y
-  div-div-int-ℕ {zero-ℕ} {y} (pair d p) =
-    div-eq-ℕ zero-ℕ y
-      ( inv (is-injective-int-ℕ (is-zero-div-zero-ℤ (int-ℕ y) (pair d p))))
-  pr1 (div-div-int-ℕ {succ-ℕ x} {y} (pair d p)) = abs-ℤ d
-  pr2 (div-div-int-ℕ {succ-ℕ x} {y} (pair d p)) =
-    is-injective-int-ℕ
-      ( ( inv (mul-int-ℕ (abs-ℤ d) (succ-ℕ x))) ∙
-        ( ( ap
-            ( _*ℤ (inr (inr x)))
-            { int-abs-ℤ d}
-            { d}
-            ( int-abs-is-nonnegative-ℤ d
-              ( is-nonnegative-left-factor-mul-ℤ
-                { d}
-                { inr (inr x)}
-                ( is-nonnegative-eq-ℤ (inv p) (is-nonnegative-int-ℕ y))
-                ( star)))) ∙
-          ( p)))
+div-div-int-ℕ :
+  {x y : ℕ} → div-ℤ (int-ℕ x) (int-ℕ y) → div-ℕ x y
+div-div-int-ℕ {zero-ℕ} {y} (pair d p) =
+  div-eq-ℕ zero-ℕ y
+    ( inv (is-injective-int-ℕ (is-zero-div-zero-ℤ (int-ℕ y) (pair d p))))
+pr1 (div-div-int-ℕ {succ-ℕ x} {y} (pair d p)) = abs-ℤ d
+pr2 (div-div-int-ℕ {succ-ℕ x} {y} (pair d p)) =
+  is-injective-int-ℕ
+    ( ( inv (mul-int-ℕ (abs-ℤ d) (succ-ℕ x))) ∙
+      ( ( ap
+          ( _*ℤ (inr (inr x)))
+          { int-abs-ℤ d}
+          { d}
+          ( int-abs-is-nonnegative-ℤ d
+            ( is-nonnegative-left-factor-mul-ℤ
+              { d}
+              { inr (inr x)}
+              ( is-nonnegative-eq-ℤ (inv p) (is-nonnegative-int-ℕ y))
+              ( star)))) ∙
+        ( p)))
 ```
 
 ### An integer is a unit if and only if it is `1` or `-1`

--- a/src/elementary-number-theory/divisibility-integers.lagda.md
+++ b/src/elementary-number-theory/divisibility-integers.lagda.md
@@ -67,32 +67,6 @@ div-ℤ d x = Σ ℤ (λ k → k *ℤ d ＝ x)
 
 quotient-div-ℤ : (x y : ℤ) → div-ℤ x y → ℤ
 quotient-div-ℤ x y H = pr1 H
-
-eq-quotient-div-ℤ :
-  (x y : ℤ) (H : div-ℤ x y) → (quotient-div-ℤ x y H) *ℤ x ＝ y
-eq-quotient-div-ℤ x y H = pr2 H
-
-eq-quotient-div-ℤ' :
-  (x y : ℤ) (H : div-ℤ x y) → x *ℤ (quotient-div-ℤ x y H) ＝ y
-eq-quotient-div-ℤ' x y H =
-  commutative-mul-ℤ x (quotient-div-ℤ x y H) ∙ eq-quotient-div-ℤ x y H
-
-div-quotient-div-ℤ :
-  (d x : ℤ) (H : div-ℤ d x) → div-ℤ (quotient-div-ℤ d x H) x
-pr1 (div-quotient-div-ℤ d x (u , p)) = d
-pr2 (div-quotient-div-ℤ d x (u , p)) = commutative-mul-ℤ d u ∙ p
-
-concatenate-eq-div-ℤ :
-  {x y z : ℤ} → x ＝ y → div-ℤ y z → div-ℤ x z
-concatenate-eq-div-ℤ refl p = p
-
-concatenate-div-eq-ℤ :
-  {x y z : ℤ} → div-ℤ x y → y ＝ z → div-ℤ x z
-concatenate-div-eq-ℤ p refl = p
-
-concatenate-eq-div-eq-ℤ :
-  {x y z w : ℤ} → x ＝ y → div-ℤ y z → z ＝ w → div-ℤ x w
-concatenate-eq-div-eq-ℤ refl p refl = p
 ```
 
 ### Unit integers
@@ -132,11 +106,50 @@ sim-unit-ℤ x y = ¬ (is-zero-ℤ x × is-zero-ℤ y) → presim-unit-ℤ x y
 
 ## Properties
 
+### If `d` divides `x`, the quotient times `d` equals `x`
+
+```agda
+eq-quotient-div-ℤ :
+  (x y : ℤ) (H : div-ℤ x y) → (quotient-div-ℤ x y H) *ℤ x ＝ y
+eq-quotient-div-ℤ x y H = pr2 H
+
+eq-quotient-div-ℤ' :
+  (x y : ℤ) (H : div-ℤ x y) → x *ℤ (quotient-div-ℤ x y H) ＝ y
+eq-quotient-div-ℤ' x y H =
+  commutative-mul-ℤ x (quotient-div-ℤ x y H) ∙ eq-quotient-div-ℤ x y H
+```
+
+### If `d` divides `x`, the quotient also divides `x`
+
+```agda
+div-quotient-div-ℤ :
+  (d x : ℤ) (H : div-ℤ d x) → div-ℤ (quotient-div-ℤ d x H) x
+pr1 (div-quotient-div-ℤ d x (u , p)) = d
+pr2 (div-quotient-div-ℤ d x (u , p)) = commutative-mul-ℤ d u ∙ p
+```
+
+### Concatenating equalities and divisibility
+
+```agda
+concatenate-eq-div-ℤ :
+  {x y z : ℤ} → x ＝ y → div-ℤ y z → div-ℤ x z
+concatenate-eq-div-ℤ refl p = p
+
+concatenate-div-eq-ℤ :
+  {x y z : ℤ} → div-ℤ x y → y ＝ z → div-ℤ x z
+concatenate-div-eq-ℤ p refl = p
+
+concatenate-eq-div-eq-ℤ :
+  {x y z w : ℤ} → x ＝ y → div-ℤ y z → z ＝ w → div-ℤ x w
+concatenate-eq-div-eq-ℤ refl p refl = p
+```
+
 ### Divisibility by a nonzero integer is a property
 
 ```agda
-is-prop-div-ℤ : (d x : ℤ) → is-nonzero-ℤ d → is-prop (div-ℤ d x)
-is-prop-div-ℤ d x f = is-prop-map-is-emb (is-emb-right-mul-ℤ d f) x
+abstract
+  is-prop-div-ℤ : (d x : ℤ) → is-nonzero-ℤ d → is-prop (div-ℤ d x)
+  is-prop-div-ℤ d x f = is-prop-map-is-emb (is-emb-right-mul-ℤ d f) x
 ```
 
 ### The divisibility relation is a preorder
@@ -144,16 +157,17 @@ is-prop-div-ℤ d x f = is-prop-map-is-emb (is-emb-right-mul-ℤ d f) x
 Note that the divisibility relation on the integers is not antisymmetric.
 
 ```agda
-refl-div-ℤ : is-reflexive div-ℤ
-pr1 (refl-div-ℤ x) = one-ℤ
-pr2 (refl-div-ℤ x) = left-unit-law-mul-ℤ x
+abstract
+  refl-div-ℤ : is-reflexive div-ℤ
+  pr1 (refl-div-ℤ x) = one-ℤ
+  pr2 (refl-div-ℤ x) = left-unit-law-mul-ℤ x
 
-transitive-div-ℤ : is-transitive div-ℤ
-pr1 (transitive-div-ℤ x y z (pair e q) (pair d p)) = e *ℤ d
-pr2 (transitive-div-ℤ x y z (pair e q) (pair d p)) =
-  ( associative-mul-ℤ e d x) ∙
-    ( ( ap (e *ℤ_) p) ∙
-      ( q))
+  transitive-div-ℤ : is-transitive div-ℤ
+  pr1 (transitive-div-ℤ x y z (pair e q) (pair d p)) = e *ℤ d
+  pr2 (transitive-div-ℤ x y z (pair e q) (pair d p)) =
+    ( associative-mul-ℤ e d x) ∙
+      ( ( ap (e *ℤ_) p) ∙
+        ( q))
 ```
 
 ### Every integer is divisible by `1`
@@ -175,154 +189,165 @@ pr2 (div-zero-ℤ x) = left-zero-law-mul-ℤ x
 ### Every integer that is divisible by `0` is `0`
 
 ```agda
-is-zero-div-zero-ℤ :
-  (x : ℤ) → div-ℤ zero-ℤ x → is-zero-ℤ x
-is-zero-div-zero-ℤ x (pair d p) = inv p ∙ right-zero-law-mul-ℤ d
+abstract
+  is-zero-div-zero-ℤ :
+    (x : ℤ) → div-ℤ zero-ℤ x → is-zero-ℤ x
+  is-zero-div-zero-ℤ x (pair d p) = inv p ∙ right-zero-law-mul-ℤ d
 ```
 
 ### The quotient of `x` by one is `x`
 
 ```agda
-eq-quotient-div-is-one-ℤ :
-  (k x : ℤ) → is-one-ℤ k → (H : div-ℤ k x) → quotient-div-ℤ k x H ＝ x
-eq-quotient-div-is-one-ℤ .one-ℤ x refl H =
-  ap
-    ( quotient-div-ℤ one-ℤ x)
-    ( inv
-      ( eq-is-prop'
-        ( is-prop-div-ℤ one-ℤ x (λ ()))
-        ( div-one-ℤ x)
-        ( H)))
+abstract
+  eq-quotient-div-is-one-ℤ :
+    (k x : ℤ) → is-one-ℤ k → (H : div-ℤ k x) → quotient-div-ℤ k x H ＝ x
+  eq-quotient-div-is-one-ℤ .one-ℤ x refl H =
+    ap
+      ( quotient-div-ℤ one-ℤ x)
+      ( inv
+        ( eq-is-prop'
+          ( is-prop-div-ℤ one-ℤ x (λ ()))
+          ( div-one-ℤ x)
+          ( H)))
 ```
 
 ### If `k` divides `x` and `k` is `0` then `x` is `0`
 
 ```agda
-is-zero-is-zero-div-ℤ : (x k : ℤ) → div-ℤ k x → is-zero-ℤ k → is-zero-ℤ x
-is-zero-is-zero-div-ℤ x .zero-ℤ k-div-x refl = is-zero-div-zero-ℤ x k-div-x
+abstract
+  is-zero-is-zero-div-ℤ : (x k : ℤ) → div-ℤ k x → is-zero-ℤ k → is-zero-ℤ x
+  is-zero-is-zero-div-ℤ x .zero-ℤ k-div-x refl = is-zero-div-zero-ℤ x k-div-x
 ```
 
 ### If `x` divides both `y` and `z`, then it divides `y + z`
 
 ```agda
-div-add-ℤ : (x y z : ℤ) → div-ℤ x y → div-ℤ x z → div-ℤ x (y +ℤ z)
-pr1 (div-add-ℤ x y z (pair d p) (pair e q)) = d +ℤ e
-pr2 (div-add-ℤ x y z (pair d p) (pair e q)) =
-  ( right-distributive-mul-add-ℤ d e x) ∙
-  ( ap-add-ℤ p q)
+abstract
+  div-add-ℤ : (x y z : ℤ) → div-ℤ x y → div-ℤ x z → div-ℤ x (y +ℤ z)
+  pr1 (div-add-ℤ x y z (pair d p) (pair e q)) = d +ℤ e
+  pr2 (div-add-ℤ x y z (pair d p) (pair e q)) =
+    ( right-distributive-mul-add-ℤ d e x) ∙
+    ( ap-add-ℤ p q)
 ```
 
 ### If `x` divides `y` then `x` divides any multiple of `y`
 
 ```agda
-div-mul-ℤ :
-  (k x y : ℤ) → div-ℤ x y → div-ℤ x (k *ℤ y)
-div-mul-ℤ k x y = transitive-div-ℤ x y (k *ℤ y) (k , refl)
+abstract
+  div-mul-ℤ :
+    (k x y : ℤ) → div-ℤ x y → div-ℤ x (k *ℤ y)
+  div-mul-ℤ k x y = transitive-div-ℤ x y (k *ℤ y) (k , refl)
 ```
 
 ### If `x` divides `y` then it divides `-y`
 
 ```agda
-div-neg-ℤ : (x y : ℤ) → div-ℤ x y → div-ℤ x (neg-ℤ y)
-pr1 (div-neg-ℤ x y (pair d p)) = neg-ℤ d
-pr2 (div-neg-ℤ x y (pair d p)) = left-negative-law-mul-ℤ d x ∙ ap neg-ℤ p
+abstract
+  div-neg-ℤ : (x y : ℤ) → div-ℤ x y → div-ℤ x (neg-ℤ y)
+  pr1 (div-neg-ℤ x y (pair d p)) = neg-ℤ d
+  pr2 (div-neg-ℤ x y (pair d p)) = left-negative-law-mul-ℤ d x ∙ ap neg-ℤ p
 ```
 
 ### If `x` divides `y` then `-x` divides `y`
 
 ```agda
-neg-div-ℤ : (x y : ℤ) → div-ℤ x y → div-ℤ (neg-ℤ x) y
-pr1 (neg-div-ℤ x y (pair d p)) = neg-ℤ d
-pr2 (neg-div-ℤ x y (pair d p)) =
-  equational-reasoning
-    (neg-ℤ d) *ℤ (neg-ℤ x)
-    ＝ neg-ℤ (d *ℤ (neg-ℤ x))
-      by left-negative-law-mul-ℤ d (neg-ℤ x)
-    ＝ neg-ℤ (neg-ℤ (d *ℤ x))
-      by ap neg-ℤ (right-negative-law-mul-ℤ d x)
-    ＝ (d *ℤ x)
-      by neg-neg-ℤ (d *ℤ x)
-    ＝ y
-      by p
+abstract
+  neg-div-ℤ : (x y : ℤ) → div-ℤ x y → div-ℤ (neg-ℤ x) y
+  pr1 (neg-div-ℤ x y (pair d p)) = neg-ℤ d
+  pr2 (neg-div-ℤ x y (pair d p)) =
+    equational-reasoning
+      (neg-ℤ d) *ℤ (neg-ℤ x)
+      ＝ neg-ℤ (d *ℤ (neg-ℤ x))
+        by left-negative-law-mul-ℤ d (neg-ℤ x)
+      ＝ neg-ℤ (neg-ℤ (d *ℤ x))
+        by ap neg-ℤ (right-negative-law-mul-ℤ d x)
+      ＝ (d *ℤ x)
+        by neg-neg-ℤ (d *ℤ x)
+      ＝ y
+        by p
 ```
 
 ### Multiplication preserves divisibility
 
 ```agda
-preserves-div-mul-ℤ :
-  (k x y : ℤ) → div-ℤ x y → div-ℤ (k *ℤ x) (k *ℤ y)
-pr1 (preserves-div-mul-ℤ k x y (pair q p)) = q
-pr2 (preserves-div-mul-ℤ k x y (pair q p)) =
-  ( inv (associative-mul-ℤ q k x)) ∙
-    ( ( ap (_*ℤ x) (commutative-mul-ℤ q k)) ∙
-      ( ( associative-mul-ℤ k q x) ∙
-        ( ap (k *ℤ_) p)))
+abstract
+  preserves-div-mul-ℤ :
+    (k x y : ℤ) → div-ℤ x y → div-ℤ (k *ℤ x) (k *ℤ y)
+  pr1 (preserves-div-mul-ℤ k x y (pair q p)) = q
+  pr2 (preserves-div-mul-ℤ k x y (pair q p)) =
+    ( inv (associative-mul-ℤ q k x)) ∙
+      ( ( ap (_*ℤ x) (commutative-mul-ℤ q k)) ∙
+        ( ( associative-mul-ℤ k q x) ∙
+          ( ap (k *ℤ_) p)))
 ```
 
 ### Multiplication by a nonzero number reflects divisibility
 
 ```agda
-reflects-div-mul-ℤ :
-  (k x y : ℤ) → is-nonzero-ℤ k → div-ℤ (k *ℤ x) (k *ℤ y) → div-ℤ x y
-pr1 (reflects-div-mul-ℤ k x y H (pair q p)) = q
-pr2 (reflects-div-mul-ℤ k x y H (pair q p)) =
-  is-injective-left-mul-ℤ k H
-    ( ( inv (associative-mul-ℤ k q x)) ∙
-      ( ( ap (_*ℤ x) (commutative-mul-ℤ k q)) ∙
-        ( ( associative-mul-ℤ q k x) ∙
-          ( p))))
+abstract
+  reflects-div-mul-ℤ :
+    (k x y : ℤ) → is-nonzero-ℤ k → div-ℤ (k *ℤ x) (k *ℤ y) → div-ℤ x y
+  pr1 (reflects-div-mul-ℤ k x y H (pair q p)) = q
+  pr2 (reflects-div-mul-ℤ k x y H (pair q p)) =
+    is-injective-left-mul-ℤ k H
+      ( ( inv (associative-mul-ℤ k q x)) ∙
+        ( ( ap (_*ℤ x) (commutative-mul-ℤ k q)) ∙
+          ( ( associative-mul-ℤ q k x) ∙
+            ( p))))
 ```
 
 ### If a nonzero number `d` divides `y`, then `dx` divides `y` if and only if `x` divides the quotient `y/d`
 
 ```agda
-div-quotient-div-div-ℤ :
-  (x y d : ℤ) (H : div-ℤ d y) → is-nonzero-ℤ d →
-  div-ℤ (d *ℤ x) y → div-ℤ x (quotient-div-ℤ d y H)
-div-quotient-div-div-ℤ x y d H f K =
-  reflects-div-mul-ℤ d x
-    ( quotient-div-ℤ d y H)
-    ( f)
-    ( tr (div-ℤ (d *ℤ x)) (inv (eq-quotient-div-ℤ' d y H)) K)
+abstract
+  div-quotient-div-div-ℤ :
+    (x y d : ℤ) (H : div-ℤ d y) → is-nonzero-ℤ d →
+    div-ℤ (d *ℤ x) y → div-ℤ x (quotient-div-ℤ d y H)
+  div-quotient-div-div-ℤ x y d H f K =
+    reflects-div-mul-ℤ d x
+      ( quotient-div-ℤ d y H)
+      ( f)
+      ( tr (div-ℤ (d *ℤ x)) (inv (eq-quotient-div-ℤ' d y H)) K)
 
-div-div-quotient-div-ℤ :
-  (x y d : ℤ) (H : div-ℤ d y) →
-  div-ℤ x (quotient-div-ℤ d y H) → div-ℤ (d *ℤ x) y
-div-div-quotient-div-ℤ x y d H K =
-  tr
-    ( div-ℤ (d *ℤ x))
-    ( eq-quotient-div-ℤ' d y H)
-    ( preserves-div-mul-ℤ d x (quotient-div-ℤ d y H) K)
+  div-div-quotient-div-ℤ :
+    (x y d : ℤ) (H : div-ℤ d y) →
+    div-ℤ x (quotient-div-ℤ d y H) → div-ℤ (d *ℤ x) y
+  div-div-quotient-div-ℤ x y d H K =
+    tr
+      ( div-ℤ (d *ℤ x))
+      ( eq-quotient-div-ℤ' d y H)
+      ( preserves-div-mul-ℤ d x (quotient-div-ℤ d y H) K)
 ```
 
 ### Comparison of divisibility on `ℕ` and on `ℤ`
 
 ```agda
-div-int-div-ℕ :
-  {x y : ℕ} → div-ℕ x y → div-ℤ (int-ℕ x) (int-ℕ y)
-pr1 (div-int-div-ℕ {x} {y} (pair d p)) = int-ℕ d
-pr2 (div-int-div-ℕ {x} {y} (pair d p)) = mul-int-ℕ d x ∙ ap int-ℕ p
+abstract
+  div-int-div-ℕ :
+    {x y : ℕ} → div-ℕ x y → div-ℤ (int-ℕ x) (int-ℕ y)
+  pr1 (div-int-div-ℕ {x} {y} (pair d p)) = int-ℕ d
+  pr2 (div-int-div-ℕ {x} {y} (pair d p)) = mul-int-ℕ d x ∙ ap int-ℕ p
 
-div-div-int-ℕ :
-  {x y : ℕ} → div-ℤ (int-ℕ x) (int-ℕ y) → div-ℕ x y
-div-div-int-ℕ {zero-ℕ} {y} (pair d p) =
-  div-eq-ℕ zero-ℕ y
-    ( inv (is-injective-int-ℕ (is-zero-div-zero-ℤ (int-ℕ y) (pair d p))))
-pr1 (div-div-int-ℕ {succ-ℕ x} {y} (pair d p)) = abs-ℤ d
-pr2 (div-div-int-ℕ {succ-ℕ x} {y} (pair d p)) =
-  is-injective-int-ℕ
-    ( ( inv (mul-int-ℕ (abs-ℤ d) (succ-ℕ x))) ∙
-      ( ( ap
-          ( _*ℤ (inr (inr x)))
-          { int-abs-ℤ d}
-          { d}
-          ( int-abs-is-nonnegative-ℤ d
-            ( is-nonnegative-left-factor-mul-ℤ
-              { d}
-              { inr (inr x)}
-              ( is-nonnegative-eq-ℤ (inv p) (is-nonnegative-int-ℕ y))
-              ( star)))) ∙
-        ( p)))
+  div-div-int-ℕ :
+    {x y : ℕ} → div-ℤ (int-ℕ x) (int-ℕ y) → div-ℕ x y
+  div-div-int-ℕ {zero-ℕ} {y} (pair d p) =
+    div-eq-ℕ zero-ℕ y
+      ( inv (is-injective-int-ℕ (is-zero-div-zero-ℤ (int-ℕ y) (pair d p))))
+  pr1 (div-div-int-ℕ {succ-ℕ x} {y} (pair d p)) = abs-ℤ d
+  pr2 (div-div-int-ℕ {succ-ℕ x} {y} (pair d p)) =
+    is-injective-int-ℕ
+      ( ( inv (mul-int-ℕ (abs-ℤ d) (succ-ℕ x))) ∙
+        ( ( ap
+            ( _*ℤ (inr (inr x)))
+            { int-abs-ℤ d}
+            { d}
+            ( int-abs-is-nonnegative-ℤ d
+              ( is-nonnegative-left-factor-mul-ℤ
+                { d}
+                { inr (inr x)}
+                ( is-nonnegative-eq-ℤ (inv p) (is-nonnegative-int-ℕ y))
+                ( star)))) ∙
+          ( p)))
 ```
 
 ### An integer is a unit if and only if it is `1` or `-1`
@@ -359,51 +384,53 @@ is-unit-is-one-or-neg-one-ℤ :
 is-unit-is-one-or-neg-one-ℤ x (inl p) = is-unit-is-one-ℤ x p
 is-unit-is-one-or-neg-one-ℤ x (inr p) = is-unit-is-neg-one-ℤ x p
 
-is-one-or-neg-one-is-unit-ℤ :
-  (x : ℤ) → is-unit-ℤ x → is-one-or-neg-one-ℤ x
-is-one-or-neg-one-is-unit-ℤ (inl zero-ℕ) (pair d p) = inr refl
-is-one-or-neg-one-is-unit-ℤ (inl (succ-ℕ x)) (pair (inl zero-ℕ) p) =
-  ex-falso (Eq-eq-ℤ (inv p ∙ compute-mul-ℤ neg-one-ℤ (inl (succ-ℕ x))))
-is-one-or-neg-one-is-unit-ℤ (inl (succ-ℕ x)) (pair (inl (succ-ℕ d)) p) =
-  ex-falso (Eq-eq-ℤ (inv p ∙ compute-mul-ℤ (inl (succ-ℕ d)) (inl (succ-ℕ x))))
-is-one-or-neg-one-is-unit-ℤ (inl (succ-ℕ x)) (pair (inr (inl star)) p) =
-  ex-falso (Eq-eq-ℤ (inv p ∙ compute-mul-ℤ zero-ℤ (inl (succ-ℕ x))))
-is-one-or-neg-one-is-unit-ℤ (inl (succ-ℕ x)) (pair (inr (inr zero-ℕ)) p) =
-  ex-falso (Eq-eq-ℤ (inv p ∙ compute-mul-ℤ one-ℤ (inl (succ-ℕ x))))
-is-one-or-neg-one-is-unit-ℤ (inl (succ-ℕ x)) (pair (inr (inr (succ-ℕ d))) p) =
-  ex-falso
-    ( Eq-eq-ℤ (inv p ∙ compute-mul-ℤ (inr (inr (succ-ℕ d))) (inl (succ-ℕ x))))
-is-one-or-neg-one-is-unit-ℤ (inr (inl star)) (pair d p) =
-  ex-falso (Eq-eq-ℤ (inv (right-zero-law-mul-ℤ d) ∙ p))
-is-one-or-neg-one-is-unit-ℤ (inr (inr zero-ℕ)) (pair d p) = inl refl
-is-one-or-neg-one-is-unit-ℤ (inr (inr (succ-ℕ x))) (pair (inl zero-ℕ) p) =
-  ex-falso (Eq-eq-ℤ (inv p ∙ compute-mul-ℤ neg-one-ℤ (inr (inr (succ-ℕ x)))))
-is-one-or-neg-one-is-unit-ℤ (inr (inr (succ-ℕ x))) (pair (inl (succ-ℕ d)) p) =
-  ex-falso
-    ( Eq-eq-ℤ (inv p ∙ compute-mul-ℤ (inl (succ-ℕ d)) (inr (inr (succ-ℕ x)))))
-is-one-or-neg-one-is-unit-ℤ (inr (inr (succ-ℕ x))) (pair (inr (inl star)) p) =
-  ex-falso (Eq-eq-ℤ (inv p ∙ compute-mul-ℤ zero-ℤ (inr (inr (succ-ℕ x)))))
-is-one-or-neg-one-is-unit-ℤ (inr (inr (succ-ℕ x))) (pair (inr (inr zero-ℕ)) p) =
-  ex-falso (Eq-eq-ℤ (inv p ∙ compute-mul-ℤ one-ℤ (inr (inr (succ-ℕ x)))))
-is-one-or-neg-one-is-unit-ℤ
-  (inr (inr (succ-ℕ x))) (pair (inr (inr (succ-ℕ d))) p) =
-  ex-falso
-    ( Eq-eq-ℤ
-      ( inv p ∙ compute-mul-ℤ (inr (inr (succ-ℕ d))) (inr (inr (succ-ℕ x)))))
+abstract
+  is-one-or-neg-one-is-unit-ℤ :
+    (x : ℤ) → is-unit-ℤ x → is-one-or-neg-one-ℤ x
+  is-one-or-neg-one-is-unit-ℤ (inl zero-ℕ) (pair d p) = inr refl
+  is-one-or-neg-one-is-unit-ℤ (inl (succ-ℕ x)) (pair (inl zero-ℕ) p) =
+    ex-falso (Eq-eq-ℤ (inv p ∙ compute-mul-ℤ neg-one-ℤ (inl (succ-ℕ x))))
+  is-one-or-neg-one-is-unit-ℤ (inl (succ-ℕ x)) (pair (inl (succ-ℕ d)) p) =
+    ex-falso (Eq-eq-ℤ (inv p ∙ compute-mul-ℤ (inl (succ-ℕ d)) (inl (succ-ℕ x))))
+  is-one-or-neg-one-is-unit-ℤ (inl (succ-ℕ x)) (pair (inr (inl star)) p) =
+    ex-falso (Eq-eq-ℤ (inv p ∙ compute-mul-ℤ zero-ℤ (inl (succ-ℕ x))))
+  is-one-or-neg-one-is-unit-ℤ (inl (succ-ℕ x)) (pair (inr (inr zero-ℕ)) p) =
+    ex-falso (Eq-eq-ℤ (inv p ∙ compute-mul-ℤ one-ℤ (inl (succ-ℕ x))))
+  is-one-or-neg-one-is-unit-ℤ (inl (succ-ℕ x)) (pair (inr (inr (succ-ℕ d))) p) =
+    ex-falso
+      ( Eq-eq-ℤ (inv p ∙ compute-mul-ℤ (inr (inr (succ-ℕ d))) (inl (succ-ℕ x))))
+  is-one-or-neg-one-is-unit-ℤ (inr (inl star)) (pair d p) =
+    ex-falso (Eq-eq-ℤ (inv (right-zero-law-mul-ℤ d) ∙ p))
+  is-one-or-neg-one-is-unit-ℤ (inr (inr zero-ℕ)) (pair d p) = inl refl
+  is-one-or-neg-one-is-unit-ℤ (inr (inr (succ-ℕ x))) (pair (inl zero-ℕ) p) =
+    ex-falso (Eq-eq-ℤ (inv p ∙ compute-mul-ℤ neg-one-ℤ (inr (inr (succ-ℕ x)))))
+  is-one-or-neg-one-is-unit-ℤ (inr (inr (succ-ℕ x))) (pair (inl (succ-ℕ d)) p) =
+    ex-falso
+      ( Eq-eq-ℤ (inv p ∙ compute-mul-ℤ (inl (succ-ℕ d)) (inr (inr (succ-ℕ x)))))
+  is-one-or-neg-one-is-unit-ℤ (inr (inr (succ-ℕ x))) (pair (inr (inl star)) p) =
+    ex-falso (Eq-eq-ℤ (inv p ∙ compute-mul-ℤ zero-ℤ (inr (inr (succ-ℕ x)))))
+  is-one-or-neg-one-is-unit-ℤ
+    (inr (inr (succ-ℕ x))) (pair (inr (inr zero-ℕ)) p) =
+    ex-falso (Eq-eq-ℤ (inv p ∙ compute-mul-ℤ one-ℤ (inr (inr (succ-ℕ x)))))
+  is-one-or-neg-one-is-unit-ℤ
+    (inr (inr (succ-ℕ x))) (pair (inr (inr (succ-ℕ d))) p) =
+    ex-falso
+      ( Eq-eq-ℤ
+        ( inv p ∙ compute-mul-ℤ (inr (inr (succ-ℕ d))) (inr (inr (succ-ℕ x)))))
 ```
 
 ### Units are idempotent
 
 ```agda
-idempotent-is-unit-ℤ : {x : ℤ} → is-unit-ℤ x → x *ℤ x ＝ one-ℤ
-idempotent-is-unit-ℤ {x} H =
-  f (is-one-or-neg-one-is-unit-ℤ x H)
-  where
-  f : is-one-or-neg-one-ℤ x → x *ℤ x ＝ one-ℤ
-  f (inl refl) = refl
-  f (inr refl) = refl
-
 abstract
+  idempotent-is-unit-ℤ : {x : ℤ} → is-unit-ℤ x → x *ℤ x ＝ one-ℤ
+  idempotent-is-unit-ℤ {x} H =
+    f (is-one-or-neg-one-is-unit-ℤ x H)
+    where
+    f : is-one-or-neg-one-ℤ x → x *ℤ x ＝ one-ℤ
+    f (inl refl) = refl
+    f (inr refl) = refl
+
   is-one-is-unit-int-ℕ : (x : ℕ) → is-unit-ℤ (int-ℕ x) → is-one-ℕ x
   is-one-is-unit-int-ℕ x H with is-one-or-neg-one-is-unit-ℤ (int-ℕ x) H
   ... | inl p = is-injective-int-ℕ p
@@ -413,263 +440,274 @@ abstract
 ### The product `xy` is a unit if and only if both `x` and `y` are units
 
 ```agda
-is-unit-mul-ℤ :
-  (x y : ℤ) → is-unit-ℤ x → is-unit-ℤ y → is-unit-ℤ (x *ℤ y)
-pr1 (is-unit-mul-ℤ x y (pair d p) (pair e q)) = e *ℤ d
-pr2 (is-unit-mul-ℤ x y (pair d p) (pair e q)) =
-  ( associative-mul-ℤ e d (x *ℤ y)) ∙
-    ( ( ap
-        ( e *ℤ_)
-        ( ( inv (associative-mul-ℤ d x y)) ∙
-          ( ap (_*ℤ y) p))) ∙
-      ( q))
+abstract
+  is-unit-mul-ℤ :
+    (x y : ℤ) → is-unit-ℤ x → is-unit-ℤ y → is-unit-ℤ (x *ℤ y)
+  pr1 (is-unit-mul-ℤ x y (pair d p) (pair e q)) = e *ℤ d
+  pr2 (is-unit-mul-ℤ x y (pair d p) (pair e q)) =
+    ( associative-mul-ℤ e d (x *ℤ y)) ∙
+      ( ( ap
+          ( e *ℤ_)
+          ( ( inv (associative-mul-ℤ d x y)) ∙
+            ( ap (_*ℤ y) p))) ∙
+        ( q))
 
 mul-unit-ℤ : unit-ℤ → unit-ℤ → unit-ℤ
 pr1 (mul-unit-ℤ (pair x H) (pair y K)) = x *ℤ y
 pr2 (mul-unit-ℤ (pair x H) (pair y K)) = is-unit-mul-ℤ x y H K
 
-is-unit-left-factor-mul-ℤ :
-  (x y : ℤ) → is-unit-ℤ (x *ℤ y) → is-unit-ℤ x
-pr1 (is-unit-left-factor-mul-ℤ x y (pair d p)) = d *ℤ y
-pr2 (is-unit-left-factor-mul-ℤ x y (pair d p)) =
-  associative-mul-ℤ d y x ∙ (ap (d *ℤ_) (commutative-mul-ℤ y x) ∙ p)
+abstract
+  is-unit-left-factor-mul-ℤ :
+    (x y : ℤ) → is-unit-ℤ (x *ℤ y) → is-unit-ℤ x
+  pr1 (is-unit-left-factor-mul-ℤ x y (pair d p)) = d *ℤ y
+  pr2 (is-unit-left-factor-mul-ℤ x y (pair d p)) =
+    associative-mul-ℤ d y x ∙ (ap (d *ℤ_) (commutative-mul-ℤ y x) ∙ p)
 
-is-unit-right-factor-ℤ :
-  (x y : ℤ) → is-unit-ℤ (x *ℤ y) → is-unit-ℤ y
-is-unit-right-factor-ℤ x y (pair d p) =
-  is-unit-left-factor-mul-ℤ y x
-    ( pair d (ap (d *ℤ_) (commutative-mul-ℤ y x) ∙ p))
+  is-unit-right-factor-ℤ :
+    (x y : ℤ) → is-unit-ℤ (x *ℤ y) → is-unit-ℤ y
+  is-unit-right-factor-ℤ x y (pair d p) =
+    is-unit-left-factor-mul-ℤ y x
+      ( pair d (ap (d *ℤ_) (commutative-mul-ℤ y x) ∙ p))
 ```
 
 ### The relations `presim-unit-ℤ` and `sim-unit-ℤ` are logically equivalent
 
 ```agda
-sim-unit-presim-unit-ℤ :
-  {x y : ℤ} → presim-unit-ℤ x y → sim-unit-ℤ x y
-sim-unit-presim-unit-ℤ {x} {y} H f = H
+abstract
+  sim-unit-presim-unit-ℤ :
+    {x y : ℤ} → presim-unit-ℤ x y → sim-unit-ℤ x y
+  sim-unit-presim-unit-ℤ {x} {y} H f = H
 
-presim-unit-sim-unit-ℤ :
-  {x y : ℤ} → sim-unit-ℤ x y → presim-unit-ℤ x y
-presim-unit-sim-unit-ℤ {inl x} {inl y} H = H (λ t → Eq-eq-ℤ (pr1 t))
-presim-unit-sim-unit-ℤ {inl x} {inr y} H = H (λ t → Eq-eq-ℤ (pr1 t))
-presim-unit-sim-unit-ℤ {inr x} {inl y} H = H (λ t → Eq-eq-ℤ (pr2 t))
-pr1 (presim-unit-sim-unit-ℤ {inr (inl star)} {inr (inl star)} H) = one-unit-ℤ
-pr2 (presim-unit-sim-unit-ℤ {inr (inl star)} {inr (inl star)} H) = refl
-presim-unit-sim-unit-ℤ {inr (inl star)} {inr (inr y)} H =
-  H (λ t → Eq-eq-ℤ (pr2 t))
-presim-unit-sim-unit-ℤ {inr (inr x)} {inr (inl star)} H =
-  H (λ t → Eq-eq-ℤ (pr1 t))
-presim-unit-sim-unit-ℤ {inr (inr x)} {inr (inr y)} H =
-  H (λ t → Eq-eq-ℤ (pr1 t))
+  presim-unit-sim-unit-ℤ :
+    {x y : ℤ} → sim-unit-ℤ x y → presim-unit-ℤ x y
+  presim-unit-sim-unit-ℤ {inl x} {inl y} H = H (λ t → Eq-eq-ℤ (pr1 t))
+  presim-unit-sim-unit-ℤ {inl x} {inr y} H = H (λ t → Eq-eq-ℤ (pr1 t))
+  presim-unit-sim-unit-ℤ {inr x} {inl y} H = H (λ t → Eq-eq-ℤ (pr2 t))
+  pr1 (presim-unit-sim-unit-ℤ {inr (inl star)} {inr (inl star)} H) = one-unit-ℤ
+  pr2 (presim-unit-sim-unit-ℤ {inr (inl star)} {inr (inl star)} H) = refl
+  presim-unit-sim-unit-ℤ {inr (inl star)} {inr (inr y)} H =
+    H (λ t → Eq-eq-ℤ (pr2 t))
+  presim-unit-sim-unit-ℤ {inr (inr x)} {inr (inl star)} H =
+    H (λ t → Eq-eq-ℤ (pr1 t))
+  presim-unit-sim-unit-ℤ {inr (inr x)} {inr (inr y)} H =
+    H (λ t → Eq-eq-ℤ (pr1 t))
 ```
 
 ### The relations `presim-unit-ℤ` and `sim-unit-ℤ` relate `zero-ℤ` only to itself
 
 ```agda
-is-nonzero-presim-unit-ℤ :
-  {x y : ℤ} → presim-unit-ℤ x y → is-nonzero-ℤ x → is-nonzero-ℤ y
-is-nonzero-presim-unit-ℤ {x} {y} (pair (pair v (pair u α)) β) f p =
-  Eq-eq-ℤ (ap (_*ℤ u) (inv q) ∙ (commutative-mul-ℤ v u ∙ α))
-  where
-  q : is-zero-ℤ v
-  q = is-injective-right-mul-ℤ x f {v} {zero-ℤ} (β ∙ p)
+abstract
+  is-nonzero-presim-unit-ℤ :
+    {x y : ℤ} → presim-unit-ℤ x y → is-nonzero-ℤ x → is-nonzero-ℤ y
+  is-nonzero-presim-unit-ℤ {x} {y} (pair (pair v (pair u α)) β) f p =
+    Eq-eq-ℤ (ap (_*ℤ u) (inv q) ∙ (commutative-mul-ℤ v u ∙ α))
+    where
+    q : is-zero-ℤ v
+    q = is-injective-right-mul-ℤ x f {v} {zero-ℤ} (β ∙ p)
 
-is-nonzero-sim-unit-ℤ :
-  {x y : ℤ} → sim-unit-ℤ x y → is-nonzero-ℤ x → is-nonzero-ℤ y
-is-nonzero-sim-unit-ℤ H f =
-  is-nonzero-presim-unit-ℤ (H (f ∘ pr1)) f
+  is-nonzero-sim-unit-ℤ :
+    {x y : ℤ} → sim-unit-ℤ x y → is-nonzero-ℤ x → is-nonzero-ℤ y
+  is-nonzero-sim-unit-ℤ H f =
+    is-nonzero-presim-unit-ℤ (H (f ∘ pr1)) f
 
-is-zero-sim-unit-ℤ :
-  {x y : ℤ} → sim-unit-ℤ x y → is-zero-ℤ x → is-zero-ℤ y
-is-zero-sim-unit-ℤ {x} {y} H p =
-  double-negation-elim-is-decidable
-    ( has-decidable-equality-ℤ y zero-ℤ)
-    ( λ g → g (inv (β g) ∙ (ap ((u g) *ℤ_) p ∙ right-zero-law-mul-ℤ (u g))))
-  where
-  K : is-nonzero-ℤ y → presim-unit-ℤ x y
-  K g = H (λ (u , v) → g v)
-  u : is-nonzero-ℤ y → ℤ
-  u g = pr1 (pr1 (K g))
-  v : is-nonzero-ℤ y → ℤ
-  v g = pr1 (pr2 (pr1 (K g)))
-  β : (g : is-nonzero-ℤ y) → (u g) *ℤ x ＝ y
-  β g = pr2 (K g)
+  is-zero-sim-unit-ℤ :
+    {x y : ℤ} → sim-unit-ℤ x y → is-zero-ℤ x → is-zero-ℤ y
+  is-zero-sim-unit-ℤ {x} {y} H p =
+    double-negation-elim-is-decidable
+      ( has-decidable-equality-ℤ y zero-ℤ)
+      ( λ g → g (inv (β g) ∙ (ap ((u g) *ℤ_) p ∙ right-zero-law-mul-ℤ (u g))))
+    where
+    K : is-nonzero-ℤ y → presim-unit-ℤ x y
+    K g = H (λ (u , v) → g v)
+    u : is-nonzero-ℤ y → ℤ
+    u g = pr1 (pr1 (K g))
+    v : is-nonzero-ℤ y → ℤ
+    v g = pr1 (pr2 (pr1 (K g)))
+    β : (g : is-nonzero-ℤ y) → (u g) *ℤ x ＝ y
+    β g = pr2 (K g)
 ```
 
 ### The relations `presim-unit-ℤ` and `sim-unit-ℤ` are equivalence relations
 
 ```agda
-refl-presim-unit-ℤ : is-reflexive presim-unit-ℤ
-pr1 (refl-presim-unit-ℤ x) = one-unit-ℤ
-pr2 (refl-presim-unit-ℤ x) = left-unit-law-mul-ℤ x
+abstract
+  refl-presim-unit-ℤ : is-reflexive presim-unit-ℤ
+  pr1 (refl-presim-unit-ℤ x) = one-unit-ℤ
+  pr2 (refl-presim-unit-ℤ x) = left-unit-law-mul-ℤ x
 
-refl-sim-unit-ℤ : is-reflexive sim-unit-ℤ
-refl-sim-unit-ℤ x f = refl-presim-unit-ℤ x
+  refl-sim-unit-ℤ : is-reflexive sim-unit-ℤ
+  refl-sim-unit-ℤ x f = refl-presim-unit-ℤ x
 
-presim-unit-eq-ℤ : {x y : ℤ} → x ＝ y → presim-unit-ℤ x y
-presim-unit-eq-ℤ {x} refl = refl-presim-unit-ℤ x
+  presim-unit-eq-ℤ : {x y : ℤ} → x ＝ y → presim-unit-ℤ x y
+  presim-unit-eq-ℤ {x} refl = refl-presim-unit-ℤ x
 
-sim-unit-eq-ℤ : {x y : ℤ} → x ＝ y → sim-unit-ℤ x y
-sim-unit-eq-ℤ {x} refl = refl-sim-unit-ℤ x
+  sim-unit-eq-ℤ : {x y : ℤ} → x ＝ y → sim-unit-ℤ x y
+  sim-unit-eq-ℤ {x} refl = refl-sim-unit-ℤ x
 
-symmetric-presim-unit-ℤ : is-symmetric presim-unit-ℤ
-symmetric-presim-unit-ℤ x y (pair (pair u H) p) =
-  f (is-one-or-neg-one-is-unit-ℤ u H)
-  where
-  f : is-one-or-neg-one-ℤ u → presim-unit-ℤ y x
-  pr1 (f (inl refl)) = one-unit-ℤ
-  pr2 (f (inl refl)) = inv p
-  pr1 (f (inr refl)) = neg-one-unit-ℤ
-  pr2 (f (inr refl)) = inv (inv (neg-neg-ℤ x) ∙ ap (neg-one-ℤ *ℤ_) p)
+  symmetric-presim-unit-ℤ : is-symmetric presim-unit-ℤ
+  symmetric-presim-unit-ℤ x y (pair (pair u H) p) =
+    f (is-one-or-neg-one-is-unit-ℤ u H)
+    where
+    f : is-one-or-neg-one-ℤ u → presim-unit-ℤ y x
+    pr1 (f (inl refl)) = one-unit-ℤ
+    pr2 (f (inl refl)) = inv p
+    pr1 (f (inr refl)) = neg-one-unit-ℤ
+    pr2 (f (inr refl)) = inv (inv (neg-neg-ℤ x) ∙ ap (neg-one-ℤ *ℤ_) p)
 
-symmetric-sim-unit-ℤ : is-symmetric sim-unit-ℤ
-symmetric-sim-unit-ℤ x y H f =
-  symmetric-presim-unit-ℤ x y (H (λ p → f (pair (pr2 p) (pr1 p))))
+  symmetric-sim-unit-ℤ : is-symmetric sim-unit-ℤ
+  symmetric-sim-unit-ℤ x y H f =
+    symmetric-presim-unit-ℤ x y (H (λ p → f (pair (pr2 p) (pr1 p))))
 
-is-nonzero-sim-unit-ℤ' :
-  {x y : ℤ} → sim-unit-ℤ x y → is-nonzero-ℤ y → is-nonzero-ℤ x
-is-nonzero-sim-unit-ℤ' {x} {y} H =
-  is-nonzero-sim-unit-ℤ (symmetric-sim-unit-ℤ x y H)
+  is-nonzero-sim-unit-ℤ' :
+    {x y : ℤ} → sim-unit-ℤ x y → is-nonzero-ℤ y → is-nonzero-ℤ x
+  is-nonzero-sim-unit-ℤ' {x} {y} H =
+    is-nonzero-sim-unit-ℤ (symmetric-sim-unit-ℤ x y H)
 
-is-zero-sim-unit-ℤ' :
-  {x y : ℤ} → sim-unit-ℤ x y → is-zero-ℤ y → is-zero-ℤ x
-is-zero-sim-unit-ℤ' {x} {y} H = is-zero-sim-unit-ℤ (symmetric-sim-unit-ℤ x y H)
+  is-zero-sim-unit-ℤ' :
+    {x y : ℤ} → sim-unit-ℤ x y → is-zero-ℤ y → is-zero-ℤ x
+  is-zero-sim-unit-ℤ' {x} {y} H =
+    is-zero-sim-unit-ℤ (symmetric-sim-unit-ℤ x y H)
 
-transitive-presim-unit-ℤ : is-transitive presim-unit-ℤ
-transitive-presim-unit-ℤ x y z (pair (pair v K) q) (pair (pair u H) p) =
-  f (is-one-or-neg-one-is-unit-ℤ u H) (is-one-or-neg-one-is-unit-ℤ v K)
-  where
-  f : is-one-or-neg-one-ℤ u → is-one-or-neg-one-ℤ v → presim-unit-ℤ x z
-  pr1 (f (inl refl) (inl refl)) = one-unit-ℤ
-  pr2 (f (inl refl) (inl refl)) = p ∙ q
-  pr1 (f (inl refl) (inr refl)) = neg-one-unit-ℤ
-  pr2 (f (inl refl) (inr refl)) = ap neg-ℤ p ∙ q
-  pr1 (f (inr refl) (inl refl)) = neg-one-unit-ℤ
-  pr2 (f (inr refl) (inl refl)) = p ∙ q
-  pr1 (f (inr refl) (inr refl)) = one-unit-ℤ
-  pr2 (f (inr refl) (inr refl)) = inv (neg-neg-ℤ x) ∙ (ap neg-ℤ p ∙ q)
+  transitive-presim-unit-ℤ : is-transitive presim-unit-ℤ
+  transitive-presim-unit-ℤ x y z (pair (pair v K) q) (pair (pair u H) p) =
+    f (is-one-or-neg-one-is-unit-ℤ u H) (is-one-or-neg-one-is-unit-ℤ v K)
+    where
+    f : is-one-or-neg-one-ℤ u → is-one-or-neg-one-ℤ v → presim-unit-ℤ x z
+    pr1 (f (inl refl) (inl refl)) = one-unit-ℤ
+    pr2 (f (inl refl) (inl refl)) = p ∙ q
+    pr1 (f (inl refl) (inr refl)) = neg-one-unit-ℤ
+    pr2 (f (inl refl) (inr refl)) = ap neg-ℤ p ∙ q
+    pr1 (f (inr refl) (inl refl)) = neg-one-unit-ℤ
+    pr2 (f (inr refl) (inl refl)) = p ∙ q
+    pr1 (f (inr refl) (inr refl)) = one-unit-ℤ
+    pr2 (f (inr refl) (inr refl)) = inv (neg-neg-ℤ x) ∙ (ap neg-ℤ p ∙ q)
 
-transitive-sim-unit-ℤ : is-transitive sim-unit-ℤ
-transitive-sim-unit-ℤ x y z K H f =
-  transitive-presim-unit-ℤ x y z
-    ( K (λ (p , q) → f (is-zero-sim-unit-ℤ' H p , q)))
-    ( H (λ (p , q) → f (p , is-zero-sim-unit-ℤ K q)))
+  transitive-sim-unit-ℤ : is-transitive sim-unit-ℤ
+  transitive-sim-unit-ℤ x y z K H f =
+    transitive-presim-unit-ℤ x y z
+      ( K (λ (p , q) → f (is-zero-sim-unit-ℤ' H p , q)))
+      ( H (λ (p , q) → f (p , is-zero-sim-unit-ℤ K q)))
 ```
 
 ### `sim-unit-ℤ x y` holds if and only if `x|y` and `y|x`
 
 ```agda
-antisymmetric-div-ℤ :
-  (x y : ℤ) → div-ℤ x y → div-ℤ y x → sim-unit-ℤ x y
-antisymmetric-div-ℤ x y (pair d p) (pair e q) H =
-  f (is-decidable-is-zero-ℤ x)
-  where
-  f : is-decidable (is-zero-ℤ x) → presim-unit-ℤ x y
-  f (inl refl) = presim-unit-eq-ℤ (inv (right-zero-law-mul-ℤ d) ∙ p)
-  pr1 (pr1 (f (inr g))) = d
-  pr1 (pr2 (pr1 (f (inr g)))) = e
-  pr2 (pr2 (pr1 (f (inr g)))) =
-    is-injective-left-mul-ℤ x g
-      ( ( commutative-mul-ℤ x (e *ℤ d)) ∙
-        ( ( associative-mul-ℤ e d x) ∙
-          ( ( ap (e *ℤ_) p) ∙
-            ( q ∙ inv (right-unit-law-mul-ℤ x)))))
-  pr2 (f (inr g)) = p
+abstract
+  antisymmetric-div-ℤ :
+    (x y : ℤ) → div-ℤ x y → div-ℤ y x → sim-unit-ℤ x y
+  antisymmetric-div-ℤ x y (pair d p) (pair e q) H =
+    f (is-decidable-is-zero-ℤ x)
+    where
+    f : is-decidable (is-zero-ℤ x) → presim-unit-ℤ x y
+    f (inl refl) = presim-unit-eq-ℤ (inv (right-zero-law-mul-ℤ d) ∙ p)
+    pr1 (pr1 (f (inr g))) = d
+    pr1 (pr2 (pr1 (f (inr g)))) = e
+    pr2 (pr2 (pr1 (f (inr g)))) =
+      is-injective-left-mul-ℤ x g
+        ( ( commutative-mul-ℤ x (e *ℤ d)) ∙
+          ( ( associative-mul-ℤ e d x) ∙
+            ( ( ap (e *ℤ_) p) ∙
+              ( q ∙ inv (right-unit-law-mul-ℤ x)))))
+    pr2 (f (inr g)) = p
 ```
 
 ### `sim-unit-ℤ |x| x` holds
 
 ```agda
-sim-unit-abs-ℤ : (x : ℤ) → sim-unit-ℤ (int-abs-ℤ x) x
-pr1 (sim-unit-abs-ℤ (inl x) f) = neg-one-unit-ℤ
-pr2 (sim-unit-abs-ℤ (inl x) f) = refl
-sim-unit-abs-ℤ (inr (inl star)) = refl-sim-unit-ℤ zero-ℤ
-sim-unit-abs-ℤ (inr (inr x)) = refl-sim-unit-ℤ (inr (inr x))
+abstract
+  sim-unit-abs-ℤ : (x : ℤ) → sim-unit-ℤ (int-abs-ℤ x) x
+  pr1 (sim-unit-abs-ℤ (inl x) f) = neg-one-unit-ℤ
+  pr2 (sim-unit-abs-ℤ (inl x) f) = refl
+  sim-unit-abs-ℤ (inr (inl star)) = refl-sim-unit-ℤ zero-ℤ
+  sim-unit-abs-ℤ (inr (inr x)) = refl-sim-unit-ℤ (inr (inr x))
 
-div-presim-unit-ℤ :
-  {x y x' y' : ℤ} → presim-unit-ℤ x x' → presim-unit-ℤ y y' →
-  div-ℤ x y → div-ℤ x' y'
-pr1 (div-presim-unit-ℤ {x} {y} {x'} {y'} (pair u q) (pair v r) (pair d p)) =
-  ((int-unit-ℤ v) *ℤ d) *ℤ (int-unit-ℤ u)
-pr2 (div-presim-unit-ℤ {x} {y} {x'} {y'} (pair u q) (pair v r) (pair d p)) =
-  ( ap ((((int-unit-ℤ v) *ℤ d) *ℤ (int-unit-ℤ u)) *ℤ_) (inv q)) ∙
-  ( ( associative-mul-ℤ
-      ( (int-unit-ℤ v) *ℤ d)
-      ( int-unit-ℤ u)
-      ( (int-unit-ℤ u) *ℤ x)) ∙
-    ( ( ap
-        ( ((int-unit-ℤ v) *ℤ d) *ℤ_)
-        ( ( inv (associative-mul-ℤ (int-unit-ℤ u) (int-unit-ℤ u) x)) ∙
-          ( ap (_*ℤ x) (idempotent-is-unit-ℤ (is-unit-int-unit-ℤ u))))) ∙
-      ( ( associative-mul-ℤ (int-unit-ℤ v) d x) ∙
-        ( ( ap ((int-unit-ℤ v) *ℤ_) p) ∙
-          ( r)))))
+  div-presim-unit-ℤ :
+    {x y x' y' : ℤ} → presim-unit-ℤ x x' → presim-unit-ℤ y y' →
+    div-ℤ x y → div-ℤ x' y'
+  pr1 (div-presim-unit-ℤ {x} {y} {x'} {y'} (pair u q) (pair v r) (pair d p)) =
+    ((int-unit-ℤ v) *ℤ d) *ℤ (int-unit-ℤ u)
+  pr2 (div-presim-unit-ℤ {x} {y} {x'} {y'} (pair u q) (pair v r) (pair d p)) =
+    ( ap ((((int-unit-ℤ v) *ℤ d) *ℤ (int-unit-ℤ u)) *ℤ_) (inv q)) ∙
+    ( ( associative-mul-ℤ
+        ( (int-unit-ℤ v) *ℤ d)
+        ( int-unit-ℤ u)
+        ( (int-unit-ℤ u) *ℤ x)) ∙
+      ( ( ap
+          ( ((int-unit-ℤ v) *ℤ d) *ℤ_)
+          ( ( inv (associative-mul-ℤ (int-unit-ℤ u) (int-unit-ℤ u) x)) ∙
+            ( ap (_*ℤ x) (idempotent-is-unit-ℤ (is-unit-int-unit-ℤ u))))) ∙
+        ( ( associative-mul-ℤ (int-unit-ℤ v) d x) ∙
+          ( ( ap ((int-unit-ℤ v) *ℤ_) p) ∙
+            ( r)))))
 
-div-sim-unit-ℤ :
-  {x y x' y' : ℤ} → sim-unit-ℤ x x' → sim-unit-ℤ y y' →
-  div-ℤ x y → div-ℤ x' y'
-div-sim-unit-ℤ {x} {y} {x'} {y'} H K =
-  div-presim-unit-ℤ (presim-unit-sim-unit-ℤ H) (presim-unit-sim-unit-ℤ K)
+  div-sim-unit-ℤ :
+    {x y x' y' : ℤ} → sim-unit-ℤ x x' → sim-unit-ℤ y y' →
+    div-ℤ x y → div-ℤ x' y'
+  div-sim-unit-ℤ {x} {y} {x'} {y'} H K =
+    div-presim-unit-ℤ (presim-unit-sim-unit-ℤ H) (presim-unit-sim-unit-ℤ K)
 
-div-int-abs-div-ℤ :
-  {x y : ℤ} → div-ℤ x y → div-ℤ (int-abs-ℤ x) y
-div-int-abs-div-ℤ {x} {y} =
-  div-sim-unit-ℤ
-    ( symmetric-sim-unit-ℤ (int-abs-ℤ x) x (sim-unit-abs-ℤ x))
-    ( refl-sim-unit-ℤ y)
+  div-int-abs-div-ℤ :
+    {x y : ℤ} → div-ℤ x y → div-ℤ (int-abs-ℤ x) y
+  div-int-abs-div-ℤ {x} {y} =
+    div-sim-unit-ℤ
+      ( symmetric-sim-unit-ℤ (int-abs-ℤ x) x (sim-unit-abs-ℤ x))
+      ( refl-sim-unit-ℤ y)
 
-div-div-int-abs-ℤ :
-  {x y : ℤ} → div-ℤ (int-abs-ℤ x) y → div-ℤ x y
-div-div-int-abs-ℤ {x} {y} =
-  div-sim-unit-ℤ (sim-unit-abs-ℤ x) (refl-sim-unit-ℤ y)
+  div-div-int-abs-ℤ :
+    {x y : ℤ} → div-ℤ (int-abs-ℤ x) y → div-ℤ x y
+  div-div-int-abs-ℤ {x} {y} =
+    div-sim-unit-ℤ (sim-unit-abs-ℤ x) (refl-sim-unit-ℤ y)
 ```
 
 ### If we have that `sim-unit-ℤ x y`, then they must differ only by sign
 
 ```agda
-is-plus-or-minus-sim-unit-ℤ :
-  {x y : ℤ} → sim-unit-ℤ x y → is-plus-or-minus-ℤ x y
-is-plus-or-minus-sim-unit-ℤ {x} {y} H with ( is-decidable-is-zero-ℤ x)
-is-plus-or-minus-sim-unit-ℤ {x} {y} H | inl z =
-  inl (z ∙ inv (is-zero-sim-unit-ℤ H z))
-is-plus-or-minus-sim-unit-ℤ {x} {y} H | inr nz
-  with
-  ( is-one-or-neg-one-is-unit-ℤ
-    ( int-unit-ℤ (pr1 (H (λ u → nz (pr1 u)))))
-    ( is-unit-int-unit-ℤ (pr1 (H (λ u → nz (pr1 u))))))
-is-plus-or-minus-sim-unit-ℤ {x} {y} H | inr nz | inl pos =
-  inl
-    ( equational-reasoning
-      x
-      ＝ one-ℤ *ℤ x
-        by (inv (left-unit-law-mul-ℤ x))
-      ＝ (int-unit-ℤ (pr1 (H (λ u → nz (pr1 u))))) *ℤ x
-        by inv (ap (_*ℤ x) pos)
-      ＝ y
-        by pr2 (H (λ u → nz (pr1 u))))
-is-plus-or-minus-sim-unit-ℤ {x} {y} H | inr nz | inr p =
-  inr
-    ( equational-reasoning
-      neg-ℤ x
-      ＝ (int-unit-ℤ (pr1 (H (λ u → nz (pr1 u))))) *ℤ x
-        by ap (_*ℤ x) (inv p)
-      ＝ y
-        by pr2 (H (λ u → nz (pr1 u))))
+abstract
+  is-plus-or-minus-sim-unit-ℤ :
+    {x y : ℤ} → sim-unit-ℤ x y → is-plus-or-minus-ℤ x y
+  is-plus-or-minus-sim-unit-ℤ {x} {y} H with ( is-decidable-is-zero-ℤ x)
+  is-plus-or-minus-sim-unit-ℤ {x} {y} H | inl z =
+    inl (z ∙ inv (is-zero-sim-unit-ℤ H z))
+  is-plus-or-minus-sim-unit-ℤ {x} {y} H | inr nz
+    with
+    ( is-one-or-neg-one-is-unit-ℤ
+      ( int-unit-ℤ (pr1 (H (λ u → nz (pr1 u)))))
+      ( is-unit-int-unit-ℤ (pr1 (H (λ u → nz (pr1 u))))))
+  is-plus-or-minus-sim-unit-ℤ {x} {y} H | inr nz | inl pos =
+    inl
+      ( equational-reasoning
+        x
+        ＝ one-ℤ *ℤ x
+          by (inv (left-unit-law-mul-ℤ x))
+        ＝ (int-unit-ℤ (pr1 (H (λ u → nz (pr1 u))))) *ℤ x
+          by inv (ap (_*ℤ x) pos)
+        ＝ y
+          by pr2 (H (λ u → nz (pr1 u))))
+  is-plus-or-minus-sim-unit-ℤ {x} {y} H | inr nz | inr p =
+    inr
+      ( equational-reasoning
+        neg-ℤ x
+        ＝ (int-unit-ℤ (pr1 (H (λ u → nz (pr1 u))))) *ℤ x
+          by ap (_*ℤ x) (inv p)
+        ＝ y
+          by pr2 (H (λ u → nz (pr1 u))))
 ```
 
 ### If `sim-unit-ℤ x y` holds and both `x` and `y` have the same sign, then `x ＝ y`
 
 ```agda
-eq-sim-unit-is-nonnegative-ℤ :
-  {a b : ℤ} → is-nonnegative-ℤ a → is-nonnegative-ℤ b → sim-unit-ℤ a b → a ＝ b
-eq-sim-unit-is-nonnegative-ℤ {a} {b} H H' K =
-  rec-coproduct
-    ( id)
-    ( λ K' →
-      eq-is-zero-ℤ
-        ( is-zero-is-nonnegative-neg-is-nonnegative-ℤ H
-          ( is-nonnegative-eq-ℤ (inv K') H'))
-        ( is-zero-is-nonnegative-neg-is-nonnegative-ℤ H'
-          ( is-nonnegative-eq-ℤ (inv (neg-neg-ℤ a) ∙ ap neg-ℤ K') H)))
-    ( is-plus-or-minus-sim-unit-ℤ K)
+abstract
+  eq-sim-unit-is-nonnegative-ℤ :
+    {a b : ℤ} → is-nonnegative-ℤ a → is-nonnegative-ℤ b → sim-unit-ℤ a b →
+    a ＝ b
+  eq-sim-unit-is-nonnegative-ℤ {a} {b} H H' K =
+    rec-coproduct
+      ( id)
+      ( λ K' →
+        eq-is-zero-ℤ
+          ( is-zero-is-nonnegative-neg-is-nonnegative-ℤ H
+            ( is-nonnegative-eq-ℤ (inv K') H'))
+          ( is-zero-is-nonnegative-neg-is-nonnegative-ℤ H'
+            ( is-nonnegative-eq-ℤ (inv (neg-neg-ℤ a) ∙ ap neg-ℤ K') H)))
+      ( is-plus-or-minus-sim-unit-ℤ K)
 ```

--- a/src/elementary-number-theory/divisibility-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/divisibility-natural-numbers.lagda.md
@@ -281,57 +281,55 @@ abstract
 ### If `x` divides `y` then `x` divides any multiple of `y`
 
 ```agda
-abstract
-  div-mul-ℕ :
-    (k x y : ℕ) → div-ℕ x y → div-ℕ x (k *ℕ y)
-  div-mul-ℕ k x y H =
-    transitive-div-ℕ x y (k *ℕ y) (pair k refl) H
+div-mul-ℕ :
+  (k x y : ℕ) → div-ℕ x y → div-ℕ x (k *ℕ y)
+div-mul-ℕ k x y H =
+  transitive-div-ℕ x y (k *ℕ y) (pair k refl) H
 
-  div-mul-ℕ' :
-    (k x y : ℕ) → div-ℕ x y → div-ℕ x (y *ℕ k)
-  div-mul-ℕ' k x y H =
-    tr (div-ℕ x) (commutative-mul-ℕ k y) (div-mul-ℕ k x y H)
+div-mul-ℕ' :
+  (k x y : ℕ) → div-ℕ x y → div-ℕ x (y *ℕ k)
+div-mul-ℕ' k x y H =
+  tr (div-ℕ x) (commutative-mul-ℕ k y) (div-mul-ℕ k x y H)
 ```
 
 ### A 3-for-2 property of division with respect to addition
 
 ```agda
-abstract
-  div-add-ℕ :
-    (d x y : ℕ) → div-ℕ d x → div-ℕ d y → div-ℕ d (x +ℕ y)
-  pr1 (div-add-ℕ d x y (pair n p) (pair m q)) = n +ℕ m
-  pr2 (div-add-ℕ d x y (pair n p) (pair m q)) =
-    ( right-distributive-mul-add-ℕ n m d) ∙
-    ( ap-add-ℕ p q)
+div-add-ℕ :
+  (d x y : ℕ) → div-ℕ d x → div-ℕ d y → div-ℕ d (x +ℕ y)
+pr1 (div-add-ℕ d x y (pair n p) (pair m q)) = n +ℕ m
+pr2 (div-add-ℕ d x y (pair n p) (pair m q)) =
+  ( right-distributive-mul-add-ℕ n m d) ∙
+  ( ap-add-ℕ p q)
 
-  div-left-summand-ℕ :
-    (d x y : ℕ) → div-ℕ d y → div-ℕ d (x +ℕ y) → div-ℕ d x
-  div-left-summand-ℕ zero-ℕ x y (pair m q) (pair n p) =
-    pair zero-ℕ
-      ( ( inv (right-zero-law-mul-ℕ n)) ∙
-        ( p ∙ (ap (x +ℕ_) ((inv q) ∙ (right-zero-law-mul-ℕ m)))))
-  pr1 (div-left-summand-ℕ (succ-ℕ d) x y (pair m q) (pair n p)) = dist-ℕ m n
-  pr2 (div-left-summand-ℕ (succ-ℕ d) x y (pair m q) (pair n p)) =
-    is-injective-right-add-ℕ (m *ℕ (succ-ℕ d))
-      ( ( inv
-          ( ( right-distributive-mul-add-ℕ m (dist-ℕ m n) (succ-ℕ d)) ∙
-            ( commutative-add-ℕ
-              ( m *ℕ (succ-ℕ d))
-              ( (dist-ℕ m n) *ℕ (succ-ℕ d))))) ∙
-        ( ( ap
-            ( _*ℕ (succ-ℕ d))
-            ( is-additive-right-inverse-dist-ℕ m n
-              ( reflects-order-mul-ℕ d m n
-                ( concatenate-eq-leq-eq-ℕ q
-                  ( leq-add-ℕ' y x)
-                  ( inv p))))) ∙
-          ( p ∙ (ap (x +ℕ_) (inv q)))))
+div-left-summand-ℕ :
+  (d x y : ℕ) → div-ℕ d y → div-ℕ d (x +ℕ y) → div-ℕ d x
+div-left-summand-ℕ zero-ℕ x y (pair m q) (pair n p) =
+  pair zero-ℕ
+    ( ( inv (right-zero-law-mul-ℕ n)) ∙
+      ( p ∙ (ap (x +ℕ_) ((inv q) ∙ (right-zero-law-mul-ℕ m)))))
+pr1 (div-left-summand-ℕ (succ-ℕ d) x y (pair m q) (pair n p)) = dist-ℕ m n
+pr2 (div-left-summand-ℕ (succ-ℕ d) x y (pair m q) (pair n p)) =
+  is-injective-right-add-ℕ (m *ℕ (succ-ℕ d))
+    ( ( inv
+        ( ( right-distributive-mul-add-ℕ m (dist-ℕ m n) (succ-ℕ d)) ∙
+          ( commutative-add-ℕ
+            ( m *ℕ (succ-ℕ d))
+            ( (dist-ℕ m n) *ℕ (succ-ℕ d))))) ∙
+      ( ( ap
+          ( _*ℕ (succ-ℕ d))
+          ( is-additive-right-inverse-dist-ℕ m n
+            ( reflects-order-mul-ℕ d m n
+              ( concatenate-eq-leq-eq-ℕ q
+                ( leq-add-ℕ' y x)
+                ( inv p))))) ∙
+        ( p ∙ (ap (x +ℕ_) (inv q)))))
 
-  div-right-summand-ℕ :
-    (d x y : ℕ) → div-ℕ d x → div-ℕ d (x +ℕ y) → div-ℕ d y
-  div-right-summand-ℕ d x y H1 H2 =
-    div-left-summand-ℕ d y x H1
-      ( concatenate-div-eq-ℕ H2 (commutative-add-ℕ x y))
+div-right-summand-ℕ :
+  (d x y : ℕ) → div-ℕ d x → div-ℕ d (x +ℕ y) → div-ℕ d y
+div-right-summand-ℕ d x y H1 H2 =
+  div-left-summand-ℕ d y x H1
+    ( concatenate-div-eq-ℕ H2 (commutative-add-ℕ x y))
 ```
 
 ### If `d` divides both `x` and `x + 1`, then `d ＝ 1`

--- a/src/elementary-number-theory/divisibility-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/divisibility-natural-numbers.lagda.md
@@ -319,7 +319,7 @@ pr2 (div-left-summand-ℕ (succ-ℕ d) x y (pair m q) (pair n p)) =
       ( ( ap
           ( _*ℕ (succ-ℕ d))
           ( is-additive-right-inverse-dist-ℕ m n
-            ( reflects-order-mul-ℕ d m n
+            ( reflects-leq-mul-ℕ d m n
               ( concatenate-eq-leq-eq-ℕ q
                 ( leq-add-ℕ' y x)
                 ( inv p))))) ∙

--- a/src/elementary-number-theory/divisibility-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/divisibility-natural-numbers.lagda.md
@@ -54,20 +54,6 @@ div-ℕ m n = Σ ℕ (λ k → k *ℕ m ＝ n)
 
 quotient-div-ℕ : (x y : ℕ) → div-ℕ x y → ℕ
 quotient-div-ℕ x y H = pr1 H
-
-eq-quotient-div-ℕ :
-  (x y : ℕ) (H : div-ℕ x y) → (quotient-div-ℕ x y H) *ℕ x ＝ y
-eq-quotient-div-ℕ x y H = pr2 H
-
-eq-quotient-div-ℕ' :
-  (x y : ℕ) (H : div-ℕ x y) → x *ℕ (quotient-div-ℕ x y H) ＝ y
-eq-quotient-div-ℕ' x y H =
-  commutative-mul-ℕ x (quotient-div-ℕ x y H) ∙ eq-quotient-div-ℕ x y H
-
-div-quotient-div-ℕ :
-  (d x : ℕ) (H : div-ℕ d x) → div-ℕ (quotient-div-ℕ d x H) x
-pr1 (div-quotient-div-ℕ d x (u , p)) = d
-pr2 (div-quotient-div-ℕ d x (u , p)) = commutative-mul-ℕ d u ∙ p
 ```
 
 ### Concatenating equality and divisibility
@@ -88,33 +74,57 @@ concatenate-eq-div-eq-ℕ refl p refl = p
 
 ## Properties
 
+### If `x` divides `y`, then the quotient times `x` is `y`
+
+```agda
+eq-quotient-div-ℕ :
+  (x y : ℕ) (H : div-ℕ x y) → (quotient-div-ℕ x y H) *ℕ x ＝ y
+eq-quotient-div-ℕ x y H = pr2 H
+
+eq-quotient-div-ℕ' :
+  (x y : ℕ) (H : div-ℕ x y) → x *ℕ (quotient-div-ℕ x y H) ＝ y
+eq-quotient-div-ℕ' x y H =
+  commutative-mul-ℕ x (quotient-div-ℕ x y H) ∙ eq-quotient-div-ℕ x y H
+```
+
+### If `x` divides `y`, the quotient also divides `y`
+
+```agda
+div-quotient-div-ℕ :
+  (d x : ℕ) (H : div-ℕ d x) → div-ℕ (quotient-div-ℕ d x H) x
+pr1 (div-quotient-div-ℕ d x (u , p)) = d
+pr2 (div-quotient-div-ℕ d x (u , p)) = commutative-mul-ℕ d u ∙ p
+```
+
 ### The quotients of a natural number `n` by two natural numbers `p` and `q` are equal if `p` and `q` are equal
 
 ```agda
-eq-quotient-div-eq-div-ℕ :
-  (x y z : ℕ) → is-nonzero-ℕ x → x ＝ y →
-  (H : div-ℕ x z) → (I : div-ℕ y z) →
-  quotient-div-ℕ x z H ＝ quotient-div-ℕ y z I
-eq-quotient-div-eq-div-ℕ x y z n e H I =
-  is-injective-left-mul-ℕ
-    ( x)
-    ( n)
-  ( tr
-    ( λ p →
-      x *ℕ (quotient-div-ℕ x z H) ＝
-      p *ℕ (quotient-div-ℕ y z I))
-    ( inv e)
-    ( commutative-mul-ℕ x (quotient-div-ℕ x z H) ∙
-      ( eq-quotient-div-ℕ x z H ∙
-        ( inv (eq-quotient-div-ℕ y z I) ∙
-          commutative-mul-ℕ (quotient-div-ℕ y z I) y))))
+abstract
+  eq-quotient-div-eq-div-ℕ :
+    (x y z : ℕ) → is-nonzero-ℕ x → x ＝ y →
+    (H : div-ℕ x z) → (I : div-ℕ y z) →
+    quotient-div-ℕ x z H ＝ quotient-div-ℕ y z I
+  eq-quotient-div-eq-div-ℕ x y z n e H I =
+    is-injective-left-mul-ℕ
+      ( x)
+      ( n)
+    ( tr
+      ( λ p →
+        x *ℕ (quotient-div-ℕ x z H) ＝
+        p *ℕ (quotient-div-ℕ y z I))
+      ( inv e)
+      ( commutative-mul-ℕ x (quotient-div-ℕ x z H) ∙
+        ( eq-quotient-div-ℕ x z H ∙
+          ( inv (eq-quotient-div-ℕ y z I) ∙
+            commutative-mul-ℕ (quotient-div-ℕ y z I) y))))
 ```
 
 ### Divisibility by a nonzero natural number is a property
 
 ```agda
-is-prop-div-ℕ : (k x : ℕ) → is-nonzero-ℕ k → is-prop (div-ℕ k x)
-is-prop-div-ℕ k x f = is-prop-map-is-emb (is-emb-right-mul-ℕ k f) x
+abstract
+  is-prop-div-ℕ : (k x : ℕ) → is-nonzero-ℕ k → is-prop (div-ℕ k x)
+  is-prop-div-ℕ k x f = is-prop-map-is-emb (is-emb-right-mul-ℕ k f) x
 ```
 
 ### The divisibility relation is a partial order on the natural numbers
@@ -127,63 +137,68 @@ pr2 (refl-div-ℕ x) = left-unit-law-mul-ℕ x
 div-eq-ℕ : (x y : ℕ) → x ＝ y → div-ℕ x y
 div-eq-ℕ x .x refl = refl-div-ℕ x
 
-antisymmetric-div-ℕ : is-antisymmetric div-ℕ
-antisymmetric-div-ℕ zero-ℕ zero-ℕ H K = refl
-antisymmetric-div-ℕ zero-ℕ (succ-ℕ y) (pair k p) K =
-  inv (right-zero-law-mul-ℕ k) ∙ p
-antisymmetric-div-ℕ (succ-ℕ x) zero-ℕ H (pair l q) =
-  inv q ∙ right-zero-law-mul-ℕ l
-antisymmetric-div-ℕ (succ-ℕ x) (succ-ℕ y) (pair k p) (pair l q) =
-  ( inv (left-unit-law-mul-ℕ (succ-ℕ x))) ∙
-  ( ( ap
-      ( _*ℕ (succ-ℕ x))
-      ( inv
-        ( is-one-right-is-one-mul-ℕ l k
-          ( is-one-is-left-unit-mul-ℕ (l *ℕ k) x
-            ( ( associative-mul-ℕ l k (succ-ℕ x)) ∙
-              ( ap (l *ℕ_) p ∙ q)))))) ∙
-    ( p))
+abstract
+  antisymmetric-div-ℕ : is-antisymmetric div-ℕ
+  antisymmetric-div-ℕ zero-ℕ zero-ℕ H K = refl
+  antisymmetric-div-ℕ zero-ℕ (succ-ℕ y) (pair k p) K =
+    inv (right-zero-law-mul-ℕ k) ∙ p
+  antisymmetric-div-ℕ (succ-ℕ x) zero-ℕ H (pair l q) =
+    inv q ∙ right-zero-law-mul-ℕ l
+  antisymmetric-div-ℕ (succ-ℕ x) (succ-ℕ y) (pair k p) (pair l q) =
+    ( inv (left-unit-law-mul-ℕ (succ-ℕ x))) ∙
+    ( ( ap
+        ( _*ℕ (succ-ℕ x))
+        ( inv
+          ( is-one-right-is-one-mul-ℕ l k
+            ( is-one-is-left-unit-mul-ℕ (l *ℕ k) x
+              ( ( associative-mul-ℕ l k (succ-ℕ x)) ∙
+                ( ap (l *ℕ_) p ∙ q)))))) ∙
+      ( p))
 
-transitive-div-ℕ : is-transitive div-ℕ
-pr1 (transitive-div-ℕ x y z (pair l q) (pair k p)) = l *ℕ k
-pr2 (transitive-div-ℕ x y z (pair l q) (pair k p)) =
-  associative-mul-ℕ l k x ∙ (ap (l *ℕ_) p ∙ q)
+  transitive-div-ℕ : is-transitive div-ℕ
+  pr1 (transitive-div-ℕ x y z (pair l q) (pair k p)) = l *ℕ k
+  pr2 (transitive-div-ℕ x y z (pair l q) (pair k p)) =
+    associative-mul-ℕ l k x ∙ (ap (l *ℕ_) p ∙ q)
 ```
 
 ### If `x` is nonzero and `d | x`, then `d ≤ x`
 
 ```agda
-leq-div-succ-ℕ : (d x : ℕ) → div-ℕ d (succ-ℕ x) → leq-ℕ d (succ-ℕ x)
-leq-div-succ-ℕ d x (pair (succ-ℕ k) p) =
-  concatenate-leq-eq-ℕ d (leq-mul-ℕ' k d) p
+abstract
+  leq-div-succ-ℕ : (d x : ℕ) → div-ℕ d (succ-ℕ x) → leq-ℕ d (succ-ℕ x)
+  leq-div-succ-ℕ d x (pair (succ-ℕ k) p) =
+    concatenate-leq-eq-ℕ d (leq-mul-ℕ' k d) p
 
-leq-div-ℕ : (d x : ℕ) → is-nonzero-ℕ x → div-ℕ d x → leq-ℕ d x
-leq-div-ℕ d x f H with is-successor-is-nonzero-ℕ f
-... | (pair y refl) = leq-div-succ-ℕ d y H
+  leq-div-ℕ : (d x : ℕ) → is-nonzero-ℕ x → div-ℕ d x → leq-ℕ d x
+  leq-div-ℕ d x f H with is-successor-is-nonzero-ℕ f
+  ... | (pair y refl) = leq-div-succ-ℕ d y H
 
-leq-quotient-div-ℕ :
-  (d x : ℕ) → is-nonzero-ℕ x → (H : div-ℕ d x) → leq-ℕ (quotient-div-ℕ d x H) x
-leq-quotient-div-ℕ d x f H =
-  leq-div-ℕ (quotient-div-ℕ d x H) x f (div-quotient-div-ℕ d x H)
+  leq-quotient-div-ℕ :
+    (d x : ℕ) → is-nonzero-ℕ x → (H : div-ℕ d x) →
+    leq-ℕ (quotient-div-ℕ d x H) x
+  leq-quotient-div-ℕ d x f H =
+    leq-div-ℕ (quotient-div-ℕ d x H) x f (div-quotient-div-ℕ d x H)
 
-leq-quotient-div-ℕ' :
-  (d x : ℕ) → is-nonzero-ℕ d → (H : div-ℕ d x) → leq-ℕ (quotient-div-ℕ d x H) x
-leq-quotient-div-ℕ' d zero-ℕ f (zero-ℕ , p) = star
-leq-quotient-div-ℕ' d zero-ℕ f (succ-ℕ n , p) =
-  f (is-zero-right-is-zero-add-ℕ _ d p)
-leq-quotient-div-ℕ' d (succ-ℕ x) f H =
-  leq-quotient-div-ℕ d (succ-ℕ x) (is-nonzero-succ-ℕ x) H
+  leq-quotient-div-ℕ' :
+    (d x : ℕ) → is-nonzero-ℕ d → (H : div-ℕ d x) →
+    leq-ℕ (quotient-div-ℕ d x H) x
+  leq-quotient-div-ℕ' d zero-ℕ f (zero-ℕ , p) = star
+  leq-quotient-div-ℕ' d zero-ℕ f (succ-ℕ n , p) =
+    f (is-zero-right-is-zero-add-ℕ _ d p)
+  leq-quotient-div-ℕ' d (succ-ℕ x) f H =
+    leq-quotient-div-ℕ d (succ-ℕ x) (is-nonzero-succ-ℕ x) H
 ```
 
 ### If `x` is nonzero, if `d | x` and `d ≠ x`, then `d < x`
 
 ```agda
-le-div-succ-ℕ :
-  (d x : ℕ) → div-ℕ d (succ-ℕ x) → d ≠ succ-ℕ x → le-ℕ d (succ-ℕ x)
-le-div-succ-ℕ d x H f = le-leq-neq-ℕ (leq-div-succ-ℕ d x H) f
+abstract
+  le-div-succ-ℕ :
+    (d x : ℕ) → div-ℕ d (succ-ℕ x) → d ≠ succ-ℕ x → le-ℕ d (succ-ℕ x)
+  le-div-succ-ℕ d x H f = le-leq-neq-ℕ (leq-div-succ-ℕ d x H) f
 
-le-div-ℕ : (d x : ℕ) → is-nonzero-ℕ x → div-ℕ d x → d ≠ x → le-ℕ d x
-le-div-ℕ d x H K f = le-leq-neq-ℕ (leq-div-ℕ d x H K) f
+  le-div-ℕ : (d x : ℕ) → is-nonzero-ℕ x → div-ℕ d x → d ≠ x → le-ℕ d x
+  le-div-ℕ d x H K f = le-leq-neq-ℕ (leq-div-ℕ d x H K) f
 ```
 
 ### `1` divides any number
@@ -232,294 +247,313 @@ is-zero-is-zero-div-ℕ .zero-ℕ y d refl = is-zero-div-zero-ℕ y d
 ### Any divisor of a nonzero number is nonzero
 
 ```agda
-is-nonzero-div-ℕ :
-  (d x : ℕ) → div-ℕ d x → is-nonzero-ℕ x → is-nonzero-ℕ d
-is-nonzero-div-ℕ .zero-ℕ x H K refl = K (is-zero-div-zero-ℕ x H)
+abstract
+  is-nonzero-div-ℕ :
+    (d x : ℕ) → div-ℕ d x → is-nonzero-ℕ x → is-nonzero-ℕ d
+  is-nonzero-div-ℕ .zero-ℕ x H K refl = K (is-zero-div-zero-ℕ x H)
 ```
 
 ### Any divisor of a number at least `1` is at least `1`
 
 ```agda
-leq-one-div-ℕ :
-  (d x : ℕ) → div-ℕ d x → leq-ℕ 1 x → leq-ℕ 1 d
-leq-one-div-ℕ d x H L =
-  leq-one-is-nonzero-ℕ d (is-nonzero-div-ℕ d x H (is-nonzero-leq-one-ℕ x L))
+abstract
+  leq-one-div-ℕ :
+    (d x : ℕ) → div-ℕ d x → leq-ℕ 1 x → leq-ℕ 1 d
+  leq-one-div-ℕ d x H L =
+    leq-one-is-nonzero-ℕ d (is-nonzero-div-ℕ d x H (is-nonzero-leq-one-ℕ x L))
 ```
 
 ### If `x < d` and `d | x`, then `x` must be `0`
 
 ```agda
-is-zero-div-ℕ :
-  (d x : ℕ) → le-ℕ x d → div-ℕ d x → is-zero-ℕ x
-is-zero-div-ℕ d zero-ℕ H D = refl
-is-zero-div-ℕ d (succ-ℕ x) H (pair (succ-ℕ k) p) =
-  ex-falso
-    ( contradiction-le-ℕ
-      ( succ-ℕ x) d H
-      ( concatenate-leq-eq-ℕ d
-        ( leq-add-ℕ' d (k *ℕ d)) p))
+abstract
+  is-zero-div-ℕ :
+    (d x : ℕ) → le-ℕ x d → div-ℕ d x → is-zero-ℕ x
+  is-zero-div-ℕ d zero-ℕ H D = refl
+  is-zero-div-ℕ d (succ-ℕ x) H (pair (succ-ℕ k) p) =
+    ex-falso
+      ( contradiction-le-ℕ
+        ( succ-ℕ x) d H
+        ( concatenate-leq-eq-ℕ d
+          ( leq-add-ℕ' d (k *ℕ d)) p))
 ```
 
 ### If `x` divides `y` then `x` divides any multiple of `y`
 
 ```agda
-div-mul-ℕ :
-  (k x y : ℕ) → div-ℕ x y → div-ℕ x (k *ℕ y)
-div-mul-ℕ k x y H =
-  transitive-div-ℕ x y (k *ℕ y) (pair k refl) H
+abstract
+  div-mul-ℕ :
+    (k x y : ℕ) → div-ℕ x y → div-ℕ x (k *ℕ y)
+  div-mul-ℕ k x y H =
+    transitive-div-ℕ x y (k *ℕ y) (pair k refl) H
 
-div-mul-ℕ' :
-  (k x y : ℕ) → div-ℕ x y → div-ℕ x (y *ℕ k)
-div-mul-ℕ' k x y H =
-  tr (div-ℕ x) (commutative-mul-ℕ k y) (div-mul-ℕ k x y H)
+  div-mul-ℕ' :
+    (k x y : ℕ) → div-ℕ x y → div-ℕ x (y *ℕ k)
+  div-mul-ℕ' k x y H =
+    tr (div-ℕ x) (commutative-mul-ℕ k y) (div-mul-ℕ k x y H)
 ```
 
 ### A 3-for-2 property of division with respect to addition
 
 ```agda
-div-add-ℕ :
-  (d x y : ℕ) → div-ℕ d x → div-ℕ d y → div-ℕ d (x +ℕ y)
-pr1 (div-add-ℕ d x y (pair n p) (pair m q)) = n +ℕ m
-pr2 (div-add-ℕ d x y (pair n p) (pair m q)) =
-  ( right-distributive-mul-add-ℕ n m d) ∙
-  ( ap-add-ℕ p q)
+abstract
+  div-add-ℕ :
+    (d x y : ℕ) → div-ℕ d x → div-ℕ d y → div-ℕ d (x +ℕ y)
+  pr1 (div-add-ℕ d x y (pair n p) (pair m q)) = n +ℕ m
+  pr2 (div-add-ℕ d x y (pair n p) (pair m q)) =
+    ( right-distributive-mul-add-ℕ n m d) ∙
+    ( ap-add-ℕ p q)
 
-div-left-summand-ℕ :
-  (d x y : ℕ) → div-ℕ d y → div-ℕ d (x +ℕ y) → div-ℕ d x
-div-left-summand-ℕ zero-ℕ x y (pair m q) (pair n p) =
-  pair zero-ℕ
-    ( ( inv (right-zero-law-mul-ℕ n)) ∙
-      ( p ∙ (ap (x +ℕ_) ((inv q) ∙ (right-zero-law-mul-ℕ m)))))
-pr1 (div-left-summand-ℕ (succ-ℕ d) x y (pair m q) (pair n p)) = dist-ℕ m n
-pr2 (div-left-summand-ℕ (succ-ℕ d) x y (pair m q) (pair n p)) =
-  is-injective-right-add-ℕ (m *ℕ (succ-ℕ d))
-    ( ( inv
-        ( ( right-distributive-mul-add-ℕ m (dist-ℕ m n) (succ-ℕ d)) ∙
-          ( commutative-add-ℕ
-            ( m *ℕ (succ-ℕ d))
-            ( (dist-ℕ m n) *ℕ (succ-ℕ d))))) ∙
-      ( ( ap
-          ( _*ℕ (succ-ℕ d))
-          ( is-additive-right-inverse-dist-ℕ m n
-            ( reflects-order-mul-ℕ d m n
-              ( concatenate-eq-leq-eq-ℕ q
-                ( leq-add-ℕ' y x)
-                ( inv p))))) ∙
-        ( p ∙ (ap (x +ℕ_) (inv q)))))
+  div-left-summand-ℕ :
+    (d x y : ℕ) → div-ℕ d y → div-ℕ d (x +ℕ y) → div-ℕ d x
+  div-left-summand-ℕ zero-ℕ x y (pair m q) (pair n p) =
+    pair zero-ℕ
+      ( ( inv (right-zero-law-mul-ℕ n)) ∙
+        ( p ∙ (ap (x +ℕ_) ((inv q) ∙ (right-zero-law-mul-ℕ m)))))
+  pr1 (div-left-summand-ℕ (succ-ℕ d) x y (pair m q) (pair n p)) = dist-ℕ m n
+  pr2 (div-left-summand-ℕ (succ-ℕ d) x y (pair m q) (pair n p)) =
+    is-injective-right-add-ℕ (m *ℕ (succ-ℕ d))
+      ( ( inv
+          ( ( right-distributive-mul-add-ℕ m (dist-ℕ m n) (succ-ℕ d)) ∙
+            ( commutative-add-ℕ
+              ( m *ℕ (succ-ℕ d))
+              ( (dist-ℕ m n) *ℕ (succ-ℕ d))))) ∙
+        ( ( ap
+            ( _*ℕ (succ-ℕ d))
+            ( is-additive-right-inverse-dist-ℕ m n
+              ( reflects-order-mul-ℕ d m n
+                ( concatenate-eq-leq-eq-ℕ q
+                  ( leq-add-ℕ' y x)
+                  ( inv p))))) ∙
+          ( p ∙ (ap (x +ℕ_) (inv q)))))
 
-div-right-summand-ℕ :
-  (d x y : ℕ) → div-ℕ d x → div-ℕ d (x +ℕ y) → div-ℕ d y
-div-right-summand-ℕ d x y H1 H2 =
-  div-left-summand-ℕ d y x H1 (concatenate-div-eq-ℕ H2 (commutative-add-ℕ x y))
+  div-right-summand-ℕ :
+    (d x y : ℕ) → div-ℕ d x → div-ℕ d (x +ℕ y) → div-ℕ d y
+  div-right-summand-ℕ d x y H1 H2 =
+    div-left-summand-ℕ d y x H1
+      ( concatenate-div-eq-ℕ H2 (commutative-add-ℕ x y))
 ```
 
 ### If `d` divides both `x` and `x + 1`, then `d ＝ 1`
 
 ```agda
-is-one-div-ℕ : (x y : ℕ) → div-ℕ x y → div-ℕ x (succ-ℕ y) → is-one-ℕ x
-is-one-div-ℕ x y H K = is-one-div-one-ℕ x (div-right-summand-ℕ x y 1 H K)
+abstract
+  is-one-div-ℕ : (x y : ℕ) → div-ℕ x y → div-ℕ x (succ-ℕ y) → is-one-ℕ x
+  is-one-div-ℕ x y H K = is-one-div-one-ℕ x (div-right-summand-ℕ x y 1 H K)
 ```
 
 ### Multiplication preserves divisibility
 
 ```agda
-preserves-div-mul-ℕ :
-  (k x y : ℕ) → div-ℕ x y → div-ℕ (k *ℕ x) (k *ℕ y)
-pr1 (preserves-div-mul-ℕ k x y (pair q p)) = q
-pr2 (preserves-div-mul-ℕ k x y (pair q p)) =
-  ( inv (associative-mul-ℕ q k x)) ∙
-    ( ( ap (_*ℕ x) (commutative-mul-ℕ q k)) ∙
-      ( ( associative-mul-ℕ k q x) ∙
-        ( ap (k *ℕ_) p)))
+abstract
+  preserves-div-mul-ℕ :
+    (k x y : ℕ) → div-ℕ x y → div-ℕ (k *ℕ x) (k *ℕ y)
+  pr1 (preserves-div-mul-ℕ k x y (pair q p)) = q
+  pr2 (preserves-div-mul-ℕ k x y (pair q p)) =
+    ( inv (associative-mul-ℕ q k x)) ∙
+      ( ( ap (_*ℕ x) (commutative-mul-ℕ q k)) ∙
+        ( ( associative-mul-ℕ k q x) ∙
+          ( ap (k *ℕ_) p)))
 ```
 
 ### Multiplication by a nonzero number reflects divisibility
 
 ```agda
-reflects-div-mul-ℕ :
-  (k x y : ℕ) → is-nonzero-ℕ k → div-ℕ (k *ℕ x) (k *ℕ y) → div-ℕ x y
-pr1 (reflects-div-mul-ℕ k x y H (pair q p)) = q
-pr2 (reflects-div-mul-ℕ k x y H (pair q p)) =
-  is-injective-left-mul-ℕ k H
-    ( ( inv (associative-mul-ℕ k q x)) ∙
-      ( ( ap (_*ℕ x) (commutative-mul-ℕ k q)) ∙
-        ( ( associative-mul-ℕ q k x) ∙
-          ( p))))
+abstract
+  reflects-div-mul-ℕ :
+    (k x y : ℕ) → is-nonzero-ℕ k → div-ℕ (k *ℕ x) (k *ℕ y) → div-ℕ x y
+  pr1 (reflects-div-mul-ℕ k x y H (pair q p)) = q
+  pr2 (reflects-div-mul-ℕ k x y H (pair q p)) =
+    is-injective-left-mul-ℕ k H
+      ( ( inv (associative-mul-ℕ k q x)) ∙
+        ( ( ap (_*ℕ x) (commutative-mul-ℕ k q)) ∙
+          ( ( associative-mul-ℕ q k x) ∙
+            ( p))))
 ```
 
 ### If a nonzero number `d` divides `y`, then `dx` divides `y` if and only if `x` divides the quotient `y/d`
 
 ```agda
-div-quotient-div-div-ℕ :
-  (x y d : ℕ) (H : div-ℕ d y) → is-nonzero-ℕ d →
-  div-ℕ (d *ℕ x) y → div-ℕ x (quotient-div-ℕ d y H)
-div-quotient-div-div-ℕ x y d H f K =
-  reflects-div-mul-ℕ d x
-    ( quotient-div-ℕ d y H)
-    ( f)
-    ( tr (div-ℕ (d *ℕ x)) (inv (eq-quotient-div-ℕ' d y H)) K)
+abstract
+  div-quotient-div-div-ℕ :
+    (x y d : ℕ) (H : div-ℕ d y) → is-nonzero-ℕ d →
+    div-ℕ (d *ℕ x) y → div-ℕ x (quotient-div-ℕ d y H)
+  div-quotient-div-div-ℕ x y d H f K =
+    reflects-div-mul-ℕ d x
+      ( quotient-div-ℕ d y H)
+      ( f)
+      ( tr (div-ℕ (d *ℕ x)) (inv (eq-quotient-div-ℕ' d y H)) K)
 
-div-div-quotient-div-ℕ :
-  (x y d : ℕ) (H : div-ℕ d y) →
-  div-ℕ x (quotient-div-ℕ d y H) → div-ℕ (d *ℕ x) y
-div-div-quotient-div-ℕ x y d H K =
-  tr
-    ( div-ℕ (d *ℕ x))
-    ( eq-quotient-div-ℕ' d y H)
-    ( preserves-div-mul-ℕ d x (quotient-div-ℕ d y H) K)
+  div-div-quotient-div-ℕ :
+    (x y d : ℕ) (H : div-ℕ d y) →
+    div-ℕ x (quotient-div-ℕ d y H) → div-ℕ (d *ℕ x) y
+  div-div-quotient-div-ℕ x y d H K =
+    tr
+      ( div-ℕ (d *ℕ x))
+      ( eq-quotient-div-ℕ' d y H)
+      ( preserves-div-mul-ℕ d x (quotient-div-ℕ d y H) K)
 ```
 
 ### If `d` divides a nonzero number `x`, then the quotient `x/d` is also nonzero
 
 ```agda
-is-nonzero-quotient-div-ℕ :
-  {d x : ℕ} (H : div-ℕ d x) →
-  is-nonzero-ℕ x → is-nonzero-ℕ (quotient-div-ℕ d x H)
-is-nonzero-quotient-div-ℕ {d} {.(k *ℕ d)} (pair k refl) =
-  is-nonzero-left-factor-mul-ℕ k d
+abstract
+  is-nonzero-quotient-div-ℕ :
+    {d x : ℕ} (H : div-ℕ d x) →
+    is-nonzero-ℕ x → is-nonzero-ℕ (quotient-div-ℕ d x H)
+  is-nonzero-quotient-div-ℕ {d} {.(k *ℕ d)} (pair k refl) =
+    is-nonzero-left-factor-mul-ℕ k d
 ```
 
 ### If `d` divides a number `1 ≤ x`, then `1 ≤ x/d`
 
 ```agda
-leq-one-quotient-div-ℕ :
-  (d x : ℕ) (H : div-ℕ d x) → leq-ℕ 1 x → leq-ℕ 1 (quotient-div-ℕ d x H)
-leq-one-quotient-div-ℕ d x H K =
-  leq-one-div-ℕ
-    ( quotient-div-ℕ d x H)
-    ( x)
-    ( div-quotient-div-ℕ d x H)
-    ( K)
+abstract
+  leq-one-quotient-div-ℕ :
+    (d x : ℕ) (H : div-ℕ d x) → leq-ℕ 1 x → leq-ℕ 1 (quotient-div-ℕ d x H)
+  leq-one-quotient-div-ℕ d x H K =
+    leq-one-div-ℕ
+      ( quotient-div-ℕ d x H)
+      ( x)
+      ( div-quotient-div-ℕ d x H)
+      ( K)
 ```
 
 ### `a/a ＝ 1`
 
 ```agda
-is-idempotent-quotient-div-ℕ :
-  (a : ℕ) → is-nonzero-ℕ a → (H : div-ℕ a a) → is-one-ℕ (quotient-div-ℕ a a H)
-is-idempotent-quotient-div-ℕ zero-ℕ nz (u , p) = ex-falso (nz refl)
-is-idempotent-quotient-div-ℕ (succ-ℕ a) nz (u , p) =
-  is-one-is-left-unit-mul-ℕ u a p
+abstract
+  is-idempotent-quotient-div-ℕ :
+    (a : ℕ) → is-nonzero-ℕ a → (H : div-ℕ a a) → is-one-ℕ (quotient-div-ℕ a a H)
+  is-idempotent-quotient-div-ℕ zero-ℕ nz (u , p) = ex-falso (nz refl)
+  is-idempotent-quotient-div-ℕ (succ-ℕ a) nz (u , p) =
+    is-one-is-left-unit-mul-ℕ u a p
 ```
 
 ### If `b` divides `a` and `c` divides `b` and `c` is nonzero, then `a/b · b/c ＝ a/c`
 
 ```agda
-simplify-mul-quotient-div-ℕ :
-  {a b c : ℕ} → is-nonzero-ℕ c →
-  (H : div-ℕ b a) (K : div-ℕ c b) (L : div-ℕ c a) →
-  ( (quotient-div-ℕ b a H) *ℕ (quotient-div-ℕ c b K)) ＝
-  ( quotient-div-ℕ c a L)
-simplify-mul-quotient-div-ℕ {a} {b} {c} nz H K L =
-  is-injective-right-mul-ℕ c nz
-    ( equational-reasoning
-      (a/b *ℕ b/c) *ℕ c
-      ＝ a/b *ℕ (b/c *ℕ c)
-        by associative-mul-ℕ a/b b/c c
-      ＝ a/b *ℕ b
-        by ap (a/b *ℕ_) (eq-quotient-div-ℕ c b K)
-      ＝ a
-        by eq-quotient-div-ℕ b a H
-      ＝ a/c *ℕ c
-        by inv (eq-quotient-div-ℕ c a L))
-  where
-  a/b : ℕ
-  a/b = quotient-div-ℕ b a H
-  b/c : ℕ
-  b/c = quotient-div-ℕ c b K
-  a/c : ℕ
-  a/c = quotient-div-ℕ c a L
+abstract
+  simplify-mul-quotient-div-ℕ :
+    {a b c : ℕ} → is-nonzero-ℕ c →
+    (H : div-ℕ b a) (K : div-ℕ c b) (L : div-ℕ c a) →
+    ( (quotient-div-ℕ b a H) *ℕ (quotient-div-ℕ c b K)) ＝
+    ( quotient-div-ℕ c a L)
+  simplify-mul-quotient-div-ℕ {a} {b} {c} nz H K L =
+    is-injective-right-mul-ℕ c nz
+      ( equational-reasoning
+        (a/b *ℕ b/c) *ℕ c
+        ＝ a/b *ℕ (b/c *ℕ c)
+          by associative-mul-ℕ a/b b/c c
+        ＝ a/b *ℕ b
+          by ap (a/b *ℕ_) (eq-quotient-div-ℕ c b K)
+        ＝ a
+          by eq-quotient-div-ℕ b a H
+        ＝ a/c *ℕ c
+          by inv (eq-quotient-div-ℕ c a L))
+    where
+    a/b : ℕ
+    a/b = quotient-div-ℕ b a H
+    b/c : ℕ
+    b/c = quotient-div-ℕ c b K
+    a/c : ℕ
+    a/c = quotient-div-ℕ c a L
 ```
 
 ### If `d | a` and `d` is nonzero, then `x | a/d` if and only if `xd | a`
 
 ```agda
-simplify-div-quotient-div-ℕ :
-  {a d x : ℕ} → is-nonzero-ℕ d → (H : div-ℕ d a) →
-  (div-ℕ x (quotient-div-ℕ d a H)) ↔ (div-ℕ (x *ℕ d) a)
-pr1 (pr1 (simplify-div-quotient-div-ℕ nz H) (u , p)) = u
-pr2 (pr1 (simplify-div-quotient-div-ℕ {a} {d} {x} nz H) (u , p)) =
-  equational-reasoning
-    u *ℕ (x *ℕ d)
-    ＝ (u *ℕ x) *ℕ d
-      by inv (associative-mul-ℕ u x d)
-    ＝ (quotient-div-ℕ d a H) *ℕ d
-      by ap (_*ℕ d) p
-    ＝ a
-      by eq-quotient-div-ℕ d a H
-pr1 (pr2 (simplify-div-quotient-div-ℕ nz H) (u , p)) = u
-pr2 (pr2 (simplify-div-quotient-div-ℕ {a} {d} {x} nz H) (u , p)) =
-  is-injective-right-mul-ℕ d nz
-    ( equational-reasoning
-        (u *ℕ x) *ℕ d
-        ＝ u *ℕ (x *ℕ d)
-          by associative-mul-ℕ u x d
-        ＝ a
-          by p
-        ＝ (quotient-div-ℕ d a H) *ℕ d
-          by inv (eq-quotient-div-ℕ d a H))
+abstract
+  simplify-div-quotient-div-ℕ :
+    {a d x : ℕ} → is-nonzero-ℕ d → (H : div-ℕ d a) →
+    (div-ℕ x (quotient-div-ℕ d a H)) ↔ (div-ℕ (x *ℕ d) a)
+  pr1 (pr1 (simplify-div-quotient-div-ℕ nz H) (u , p)) = u
+  pr2 (pr1 (simplify-div-quotient-div-ℕ {a} {d} {x} nz H) (u , p)) =
+    equational-reasoning
+      u *ℕ (x *ℕ d)
+      ＝ (u *ℕ x) *ℕ d
+        by inv (associative-mul-ℕ u x d)
+      ＝ (quotient-div-ℕ d a H) *ℕ d
+        by ap (_*ℕ d) p
+      ＝ a
+        by eq-quotient-div-ℕ d a H
+  pr1 (pr2 (simplify-div-quotient-div-ℕ nz H) (u , p)) = u
+  pr2 (pr2 (simplify-div-quotient-div-ℕ {a} {d} {x} nz H) (u , p)) =
+    is-injective-right-mul-ℕ d nz
+      ( equational-reasoning
+          (u *ℕ x) *ℕ d
+          ＝ u *ℕ (x *ℕ d)
+            by associative-mul-ℕ u x d
+          ＝ a
+            by p
+          ＝ (quotient-div-ℕ d a H) *ℕ d
+            by inv (eq-quotient-div-ℕ d a H))
 ```
 
 ### Suppose `H : b | a` and `K : c | b`, where `c` is nonzero. If `d` divides `b/c` then `d` divides `a/c`
 
 ```agda
-div-quotient-div-div-quotient-div-ℕ :
-  {a b c d : ℕ} → is-nonzero-ℕ c → (H : div-ℕ b a)
-  (K : div-ℕ c b) (L : div-ℕ c a) →
-  div-ℕ d (quotient-div-ℕ c b K) →
-  div-ℕ d (quotient-div-ℕ c a L)
-div-quotient-div-div-quotient-div-ℕ {a} {b} {c} {d} nz H K L M =
-  tr
-    ( div-ℕ d)
-    ( simplify-mul-quotient-div-ℕ nz H K L)
-    ( div-mul-ℕ
-      ( quotient-div-ℕ b a H)
-      ( d)
-      ( quotient-div-ℕ c b K)
-      ( M))
+abstract
+  div-quotient-div-div-quotient-div-ℕ :
+    {a b c d : ℕ} → is-nonzero-ℕ c → (H : div-ℕ b a)
+    (K : div-ℕ c b) (L : div-ℕ c a) →
+    div-ℕ d (quotient-div-ℕ c b K) →
+    div-ℕ d (quotient-div-ℕ c a L)
+  div-quotient-div-div-quotient-div-ℕ {a} {b} {c} {d} nz H K L M =
+    tr
+      ( div-ℕ d)
+      ( simplify-mul-quotient-div-ℕ nz H K L)
+      ( div-mul-ℕ
+        ( quotient-div-ℕ b a H)
+        ( d)
+        ( quotient-div-ℕ c b K)
+        ( M))
 ```
 
 ### If `x` is nonzero and `d | x`, then `x/d ＝ 1` if and only if `d ＝ x`
 
 ```agda
-is-one-quotient-div-ℕ :
-  (d x : ℕ) → is-nonzero-ℕ x → (H : div-ℕ d x) → (d ＝ x) →
-  is-one-ℕ (quotient-div-ℕ d x H)
-is-one-quotient-div-ℕ d .d f H refl = is-idempotent-quotient-div-ℕ d f H
+abstract
+  is-one-quotient-div-ℕ :
+    (d x : ℕ) → is-nonzero-ℕ x → (H : div-ℕ d x) → (d ＝ x) →
+    is-one-ℕ (quotient-div-ℕ d x H)
+  is-one-quotient-div-ℕ d .d f H refl = is-idempotent-quotient-div-ℕ d f H
 
-eq-is-one-quotient-div-ℕ :
-  (d x : ℕ) → (H : div-ℕ d x) → is-one-ℕ (quotient-div-ℕ d x H) → d ＝ x
-eq-is-one-quotient-div-ℕ d x (.1 , q) refl = inv (left-unit-law-mul-ℕ d) ∙ q
+  eq-is-one-quotient-div-ℕ :
+    (d x : ℕ) → (H : div-ℕ d x) → is-one-ℕ (quotient-div-ℕ d x H) → d ＝ x
+  eq-is-one-quotient-div-ℕ d x (.1 , q) refl = inv (left-unit-law-mul-ℕ d) ∙ q
 ```
 
 ### If `x` is nonzero and `d | x`, then `x/d ＝ x` if and only if `d ＝ 1`
 
 ```agda
-compute-quotient-div-is-one-ℕ :
-  (d x : ℕ) → (H : div-ℕ d x) → is-one-ℕ d → quotient-div-ℕ d x H ＝ x
-compute-quotient-div-is-one-ℕ .1 x (u , q) refl =
-  inv (right-unit-law-mul-ℕ u) ∙ q
+abstract
+  compute-quotient-div-is-one-ℕ :
+    (d x : ℕ) → (H : div-ℕ d x) → is-one-ℕ d → quotient-div-ℕ d x H ＝ x
+  compute-quotient-div-is-one-ℕ .1 x (u , q) refl =
+    inv (right-unit-law-mul-ℕ u) ∙ q
 
-is-one-divisor-ℕ :
-  (d x : ℕ) → is-nonzero-ℕ x → (H : div-ℕ d x) →
-  quotient-div-ℕ d x H ＝ x → is-one-ℕ d
-is-one-divisor-ℕ d x f (.x , q) refl =
-  is-injective-left-mul-ℕ x f (q ∙ inv (right-unit-law-mul-ℕ x))
+  is-one-divisor-ℕ :
+    (d x : ℕ) → is-nonzero-ℕ x → (H : div-ℕ d x) →
+    quotient-div-ℕ d x H ＝ x → is-one-ℕ d
+  is-one-divisor-ℕ d x f (.x , q) refl =
+    is-injective-left-mul-ℕ x f (q ∙ inv (right-unit-law-mul-ℕ x))
 ```
 
 ### If `x` is nonzero and `d | x` is a nontrivial divisor, then `x/d < x`
 
 ```agda
-le-quotient-div-ℕ :
-  (d x : ℕ) → is-nonzero-ℕ x → (H : div-ℕ d x) → ¬ (is-one-ℕ d) →
-  le-ℕ (quotient-div-ℕ d x H) x
-le-quotient-div-ℕ d x f H g =
-  map-left-unit-law-coproduct-is-empty
-    ( quotient-div-ℕ d x H ＝ x)
-    ( le-ℕ (quotient-div-ℕ d x H) x)
-    ( map-neg (is-one-divisor-ℕ d x f H) g)
-    ( eq-or-le-leq-ℕ
-      ( quotient-div-ℕ d x H)
-      ( x)
-      ( leq-quotient-div-ℕ d x f H))
+abstract
+  le-quotient-div-ℕ :
+    (d x : ℕ) → is-nonzero-ℕ x → (H : div-ℕ d x) → ¬ (is-one-ℕ d) →
+    le-ℕ (quotient-div-ℕ d x H) x
+  le-quotient-div-ℕ d x f H g =
+    map-left-unit-law-coproduct-is-empty
+      ( quotient-div-ℕ d x H ＝ x)
+      ( le-ℕ (quotient-div-ℕ d x H) x)
+      ( map-neg (is-one-divisor-ℕ d x f H) g)
+      ( eq-or-le-leq-ℕ
+        ( quotient-div-ℕ d x H)
+        ( x)
+        ( leq-quotient-div-ℕ d x f H))
 ```

--- a/src/elementary-number-theory/equality-integers.lagda.md
+++ b/src/elementary-number-theory/equality-integers.lagda.md
@@ -33,8 +33,9 @@ open import foundation.universe-levels
 
 ## Idea
 
-An equality predicate is defined by pattern matching on the integers. Then we
-show that this predicate characterizes the identit type of the integers
+We define equality on the [integers](elementary-number-theory.integers.md) by
+pattern matching, and show that this characterizes the
+[identity type](foundation.identity-types.md) on the integers.
 
 ## Definition
 

--- a/src/elementary-number-theory/equality-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/equality-natural-numbers.lagda.md
@@ -33,6 +33,13 @@ open import foundation-core.torsorial-type-families
 
 </details>
 
+## Idea
+
+We define equality on the
+[natural numbers](elementary-number-theory.natural-numbers.md) by pattern
+matching, and show that this characterizes the
+[identity type](foundation.identity-types.md) on the natural numbers.
+
 ## Definitions
 
 ### Observational equality on the natural numbers
@@ -86,8 +93,9 @@ pr2 ℕ-Set = is-set-ℕ
 ### The property of being zero
 
 ```agda
-is-prop-is-zero-ℕ : (n : ℕ) → is-prop (is-zero-ℕ n)
-is-prop-is-zero-ℕ n = is-set-ℕ n zero-ℕ
+abstract
+  is-prop-is-zero-ℕ : (n : ℕ) → is-prop (is-zero-ℕ n)
+  is-prop-is-zero-ℕ n = is-set-ℕ n zero-ℕ
 
 is-zero-ℕ-Prop : ℕ → Prop lzero
 pr1 (is-zero-ℕ-Prop n) = is-zero-ℕ n
@@ -97,8 +105,9 @@ pr2 (is-zero-ℕ-Prop n) = is-prop-is-zero-ℕ n
 ### The property of being one
 
 ```agda
-is-prop-is-one-ℕ : (n : ℕ) → is-prop (is-one-ℕ n)
-is-prop-is-one-ℕ n = is-set-ℕ n 1
+abstract
+  is-prop-is-one-ℕ : (n : ℕ) → is-prop (is-one-ℕ n)
+  is-prop-is-one-ℕ n = is-set-ℕ n 1
 
 is-one-ℕ-Prop : ℕ → Prop lzero
 pr1 (is-one-ℕ-Prop n) = is-one-ℕ n

--- a/src/elementary-number-theory/euclidean-division-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/euclidean-division-natural-numbers.lagda.md
@@ -131,7 +131,7 @@ eq-euclidean-division-ℕ (succ-ℕ k) x =
   ( ap
     ( _+ℕ (remainder-euclidean-division-ℕ (succ-ℕ k) x))
     ( ( pr2 (cong-euclidean-division-ℕ (succ-ℕ k) x)) ∙
-      ( symmetric-dist-ℕ x
+      ( commutative-dist-ℕ x
         ( remainder-euclidean-division-ℕ (succ-ℕ k) x)))) ∙
   ( is-difference-dist-ℕ' (remainder-euclidean-division-ℕ (succ-ℕ k) x) x
     ( leq-nat-mod-succ-ℕ k x))

--- a/src/elementary-number-theory/exponentiation-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/exponentiation-natural-numbers.lagda.md
@@ -10,10 +10,10 @@ module elementary-number-theory.exponentiation-natural-numbers where
 open import commutative-algebra.powers-of-elements-commutative-semirings
 
 open import elementary-number-theory.addition-natural-numbers
-open import elementary-number-theory.commutative-semiring-of-natural-numbers
 open import elementary-number-theory.multiplication-natural-numbers
 open import elementary-number-theory.natural-numbers
 open import elementary-number-theory.products-of-natural-numbers
+open import elementary-number-theory.semiring-of-natural-numbers
 
 open import foundation.action-on-identifications-functions
 open import foundation.identity-types
@@ -45,44 +45,61 @@ power-ℕ = power-Commutative-Semiring ℕ-Commutative-Semiring
 
 ## Properties
 
-### Tarski's high school arithmetic laws for exponentiation
+### 1^n = 1 for all n
 
 ```agda
-annihilation-law-exp-ℕ : (n : ℕ) → 1 ^ℕ n ＝ 1
-annihilation-law-exp-ℕ zero-ℕ = refl
-annihilation-law-exp-ℕ (succ-ℕ n) =
-  right-unit-law-mul-ℕ (1 ^ℕ n) ∙ annihilation-law-exp-ℕ n
-
-left-distributive-exp-add-ℕ :
-  (x y z : ℕ) → x ^ℕ (y +ℕ z) ＝ (x ^ℕ y) *ℕ (x ^ℕ z)
-left-distributive-exp-add-ℕ x y zero-ℕ = inv (right-unit-law-mul-ℕ (x ^ℕ y))
-left-distributive-exp-add-ℕ x y (succ-ℕ z) =
-  ( ap (_*ℕ x) (left-distributive-exp-add-ℕ x y z)) ∙
-  ( associative-mul-ℕ (x ^ℕ y) (x ^ℕ z) x)
-
-right-distributive-exp-mul-ℕ :
-  (x y z : ℕ) → (x *ℕ y) ^ℕ z ＝ (x ^ℕ z) *ℕ (y ^ℕ z)
-right-distributive-exp-mul-ℕ x y zero-ℕ = refl
-right-distributive-exp-mul-ℕ x y (succ-ℕ z) =
-  ( ap (_*ℕ (x *ℕ y)) (right-distributive-exp-mul-ℕ x y z)) ∙
-  ( interchange-law-mul-mul-ℕ (x ^ℕ z) (y ^ℕ z) x y)
-
-exp-mul-ℕ : (x y z : ℕ) → x ^ℕ (y *ℕ z) ＝ (x ^ℕ y) ^ℕ z
-exp-mul-ℕ x zero-ℕ z = inv (annihilation-law-exp-ℕ z)
-exp-mul-ℕ x (succ-ℕ y) z =
-  ( left-distributive-exp-add-ℕ x (y *ℕ z) z) ∙
-  ( ( ap (_*ℕ (x ^ℕ z)) (exp-mul-ℕ x y z)) ∙
-    ( inv (right-distributive-exp-mul-ℕ (x ^ℕ y) x z)))
+abstract
+  annihilation-law-exp-ℕ : (n : ℕ) → 1 ^ℕ n ＝ 1
+  annihilation-law-exp-ℕ zero-ℕ = refl
+  annihilation-law-exp-ℕ (succ-ℕ n) =
+    right-unit-law-mul-ℕ (1 ^ℕ n) ∙ annihilation-law-exp-ℕ n
 ```
 
-### The exponent $m^n$ is always nonzero
+### `xʸ⁺ᶻ = xʸ xᶻ`
 
 ```agda
-is-nonzero-exp-ℕ :
-  (m n : ℕ) → is-nonzero-ℕ m → is-nonzero-ℕ (m ^ℕ n)
-is-nonzero-exp-ℕ m zero-ℕ p = is-nonzero-one-ℕ
-is-nonzero-exp-ℕ m (succ-ℕ n) p =
-  is-nonzero-mul-ℕ (m ^ℕ n) m (is-nonzero-exp-ℕ m n p) p
+abstract
+  left-distributive-exp-add-ℕ :
+    (x y z : ℕ) → x ^ℕ (y +ℕ z) ＝ (x ^ℕ y) *ℕ (x ^ℕ z)
+  left-distributive-exp-add-ℕ x y zero-ℕ = inv (right-unit-law-mul-ℕ (x ^ℕ y))
+  left-distributive-exp-add-ℕ x y (succ-ℕ z) =
+    ( ap (_*ℕ x) (left-distributive-exp-add-ℕ x y z)) ∙
+    ( associative-mul-ℕ (x ^ℕ y) (x ^ℕ z) x)
+```
+
+### `(xy)ᶻ = xᶻ yᶻ`
+
+```agda
+abstract
+  right-distributive-exp-mul-ℕ :
+    (x y z : ℕ) → (x *ℕ y) ^ℕ z ＝ (x ^ℕ z) *ℕ (y ^ℕ z)
+  right-distributive-exp-mul-ℕ x y zero-ℕ = refl
+  right-distributive-exp-mul-ℕ x y (succ-ℕ z) =
+    ( ap (_*ℕ (x *ℕ y)) (right-distributive-exp-mul-ℕ x y z)) ∙
+    ( interchange-law-mul-mul-ℕ (x ^ℕ z) (y ^ℕ z) x y)
+```
+
+### `xʸᶻ = (xʸ)ᶻ`
+
+```agda
+abstract
+  exp-mul-ℕ : (x y z : ℕ) → x ^ℕ (y *ℕ z) ＝ (x ^ℕ y) ^ℕ z
+  exp-mul-ℕ x zero-ℕ z = inv (annihilation-law-exp-ℕ z)
+  exp-mul-ℕ x (succ-ℕ y) z =
+    ( left-distributive-exp-add-ℕ x (y *ℕ z) z) ∙
+    ( ( ap (_*ℕ (x ^ℕ z)) (exp-mul-ℕ x y z)) ∙
+      ( inv (right-distributive-exp-mul-ℕ (x ^ℕ y) x z)))
+```
+
+### If `m` is nonzero, `mⁿ` is nonzero
+
+```agda
+abstract
+  is-nonzero-exp-ℕ :
+    (m n : ℕ) → is-nonzero-ℕ m → is-nonzero-ℕ (m ^ℕ n)
+  is-nonzero-exp-ℕ m zero-ℕ p = is-nonzero-one-ℕ
+  is-nonzero-exp-ℕ m (succ-ℕ n) p =
+    is-nonzero-mul-ℕ (m ^ℕ n) m (is-nonzero-exp-ℕ m n p) p
 ```
 
 ### The exponent $m^n$ is equal to the $n$-fold product of $m$

--- a/src/elementary-number-theory/factorials.lagda.md
+++ b/src/elementary-number-theory/factorials.lagda.md
@@ -37,40 +37,51 @@ factorial-ℕ (succ-ℕ m) = (factorial-ℕ m) *ℕ (succ-ℕ m)
 
 ## Properties
 
+### If `x ≤ n` and `x` is nonzero, `x | n!`
+
 ```agda
-div-factorial-ℕ :
-  (n x : ℕ) → leq-ℕ x n → is-nonzero-ℕ x → div-ℕ x (factorial-ℕ n)
-div-factorial-ℕ zero-ℕ zero-ℕ l H = ex-falso (H refl)
-div-factorial-ℕ (succ-ℕ n) x l H with
-  decide-leq-succ-ℕ x n l
-... | inl l' =
-  transitive-div-ℕ x
-    ( factorial-ℕ n)
-    ( factorial-ℕ (succ-ℕ n))
-    ( pair (succ-ℕ n) (commutative-mul-ℕ (succ-ℕ n) (factorial-ℕ n)))
-    ( div-factorial-ℕ n x l' H)
-... | inr refl = pair (factorial-ℕ n) refl
+abstract
+  div-factorial-ℕ :
+    (n x : ℕ) → leq-ℕ x n → is-nonzero-ℕ x → div-ℕ x (factorial-ℕ n)
+  div-factorial-ℕ zero-ℕ zero-ℕ l H = ex-falso (H refl)
+  div-factorial-ℕ (succ-ℕ n) x l H with
+    decide-leq-succ-ℕ x n l
+  ... | inl l' =
+    transitive-div-ℕ x
+      ( factorial-ℕ n)
+      ( factorial-ℕ (succ-ℕ n))
+      ( pair (succ-ℕ n) (commutative-mul-ℕ (succ-ℕ n) (factorial-ℕ n)))
+      ( div-factorial-ℕ n x l' H)
+  ... | inr refl = pair (factorial-ℕ n) refl
 ```
 
-```agda
-is-nonzero-factorial-ℕ :
-  (x : ℕ) → is-nonzero-ℕ (factorial-ℕ x)
-is-nonzero-factorial-ℕ zero-ℕ = Eq-eq-ℕ
-is-nonzero-factorial-ℕ (succ-ℕ x) =
-  is-nonzero-mul-ℕ
-    ( factorial-ℕ x)
-    ( succ-ℕ x)
-    ( is-nonzero-factorial-ℕ x)
-    ( is-nonzero-succ-ℕ x)
+### All factorials are nonzero
 
-leq-factorial-ℕ :
-  (n : ℕ) → leq-ℕ n (factorial-ℕ n)
-leq-factorial-ℕ zero-ℕ = leq-zero-ℕ 1
-leq-factorial-ℕ (succ-ℕ n) =
-  leq-mul-is-nonzero-ℕ'
-    ( factorial-ℕ n)
-    ( succ-ℕ n)
-    ( is-nonzero-factorial-ℕ n)
+```agda
+abstract
+  is-nonzero-factorial-ℕ :
+    (x : ℕ) → is-nonzero-ℕ (factorial-ℕ x)
+  is-nonzero-factorial-ℕ zero-ℕ = Eq-eq-ℕ
+  is-nonzero-factorial-ℕ (succ-ℕ x) =
+    is-nonzero-mul-ℕ
+      ( factorial-ℕ x)
+      ( succ-ℕ x)
+      ( is-nonzero-factorial-ℕ x)
+      ( is-nonzero-succ-ℕ x)
+```
+
+### `n ≤ n!`
+
+```agda
+abstract
+  leq-factorial-ℕ :
+    (n : ℕ) → leq-ℕ n (factorial-ℕ n)
+  leq-factorial-ℕ zero-ℕ = leq-zero-ℕ 1
+  leq-factorial-ℕ (succ-ℕ n) =
+    leq-mul-is-nonzero-ℕ'
+      ( factorial-ℕ n)
+      ( succ-ℕ n)
+      ( is-nonzero-factorial-ℕ n)
 ```
 
 ## External links

--- a/src/elementary-number-theory/greatest-common-divisor-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/greatest-common-divisor-natural-numbers.lagda.md
@@ -78,88 +78,95 @@ is-multiple-of-gcd-ℕ a b n =
 ### Reflexivity for common divisors
 
 ```agda
-refl-is-common-divisor-ℕ :
-  (x : ℕ) → is-common-divisor-ℕ x x x
-pr1 (refl-is-common-divisor-ℕ x) = refl-div-ℕ x
-pr2 (refl-is-common-divisor-ℕ x) = refl-div-ℕ x
+abstract
+  refl-is-common-divisor-ℕ :
+    (x : ℕ) → is-common-divisor-ℕ x x x
+  pr1 (refl-is-common-divisor-ℕ x) = refl-div-ℕ x
+  pr2 (refl-is-common-divisor-ℕ x) = refl-div-ℕ x
 ```
 
 ### Being a common divisor is decidable
 
 ```agda
-is-decidable-is-common-divisor-ℕ :
-  (a b : ℕ) → is-decidable-family (is-common-divisor-ℕ a b)
-is-decidable-is-common-divisor-ℕ a b x =
-  is-decidable-product
-    ( is-decidable-div-ℕ x a)
-    ( is-decidable-div-ℕ x b)
+abstract
+  is-decidable-is-common-divisor-ℕ :
+    (a b : ℕ) → is-decidable-family (is-common-divisor-ℕ a b)
+  is-decidable-is-common-divisor-ℕ a b x =
+    is-decidable-product
+      ( is-decidable-div-ℕ x a)
+      ( is-decidable-div-ℕ x b)
 ```
 
 ### Any greatest common divisor is a common divisor
 
 ```agda
-is-common-divisor-is-gcd-ℕ :
-  (a b d : ℕ) → is-gcd-ℕ a b d → is-common-divisor-ℕ a b d
-is-common-divisor-is-gcd-ℕ a b d H = pr2 (H d) (refl-div-ℕ d)
+abstract
+  is-common-divisor-is-gcd-ℕ :
+    (a b d : ℕ) → is-gcd-ℕ a b d → is-common-divisor-ℕ a b d
+  is-common-divisor-is-gcd-ℕ a b d H = pr2 (H d) (refl-div-ℕ d)
 ```
 
 ### Uniqueness of greatest common divisors
 
 ```agda
-uniqueness-is-gcd-ℕ :
-  (a b d d' : ℕ) → is-gcd-ℕ a b d → is-gcd-ℕ a b d' → d ＝ d'
-uniqueness-is-gcd-ℕ a b d d' H H' =
-  antisymmetric-div-ℕ d d'
-    ( pr1 (H' d) (is-common-divisor-is-gcd-ℕ a b d H))
-    ( pr1 (H d') (is-common-divisor-is-gcd-ℕ a b d' H'))
+abstract
+  uniqueness-is-gcd-ℕ :
+    (a b d d' : ℕ) → is-gcd-ℕ a b d → is-gcd-ℕ a b d' → d ＝ d'
+  uniqueness-is-gcd-ℕ a b d d' H H' =
+    antisymmetric-div-ℕ d d'
+      ( pr1 (H' d) (is-common-divisor-is-gcd-ℕ a b d H))
+      ( pr1 (H d') (is-common-divisor-is-gcd-ℕ a b d' H'))
 ```
 
 ### If `d` is a common divisor of `a` and `b`, and `a + b ≠ 0`, then `d ≤ a + b`
 
 ```agda
-leq-sum-is-common-divisor-ℕ' :
-  (a b d : ℕ) →
-  is-successor-ℕ (a +ℕ b) → is-common-divisor-ℕ a b d → leq-ℕ d (a +ℕ b)
-leq-sum-is-common-divisor-ℕ' a zero-ℕ d (pair k p) H =
-  concatenate-leq-eq-ℕ d
-    ( leq-div-succ-ℕ d k (concatenate-div-eq-ℕ (pr1 H) p))
-    ( inv p)
-leq-sum-is-common-divisor-ℕ' a (succ-ℕ b) d (pair k p) H =
-  leq-div-succ-ℕ d (a +ℕ b) (div-add-ℕ d a (succ-ℕ b) (pr1 H) (pr2 H))
+abstract
+  leq-sum-is-common-divisor-ℕ' :
+    (a b d : ℕ) →
+    is-successor-ℕ (a +ℕ b) → is-common-divisor-ℕ a b d → leq-ℕ d (a +ℕ b)
+  leq-sum-is-common-divisor-ℕ' a zero-ℕ d (pair k p) H =
+    concatenate-leq-eq-ℕ d
+      ( leq-div-succ-ℕ d k (concatenate-div-eq-ℕ (pr1 H) p))
+      ( inv p)
+  leq-sum-is-common-divisor-ℕ' a (succ-ℕ b) d (pair k p) H =
+    leq-div-succ-ℕ d (a +ℕ b) (div-add-ℕ d a (succ-ℕ b) (pr1 H) (pr2 H))
 
-leq-sum-is-common-divisor-ℕ :
-  (a b d : ℕ) →
-  is-nonzero-ℕ (a +ℕ b) → is-common-divisor-ℕ a b d → leq-ℕ d (a +ℕ b)
-leq-sum-is-common-divisor-ℕ a b d H =
-  leq-sum-is-common-divisor-ℕ' a b d (is-successor-is-nonzero-ℕ H)
+  leq-sum-is-common-divisor-ℕ :
+    (a b d : ℕ) →
+    is-nonzero-ℕ (a +ℕ b) → is-common-divisor-ℕ a b d → leq-ℕ d (a +ℕ b)
+  leq-sum-is-common-divisor-ℕ a b d H =
+    leq-sum-is-common-divisor-ℕ' a b d (is-successor-is-nonzero-ℕ H)
 ```
 
 ### Being a multiple of the greatest common divisor is decidable
 
 ```agda
-is-decidable-is-multiple-of-gcd-ℕ :
-  (a b : ℕ) → is-decidable-family (is-multiple-of-gcd-ℕ a b)
-is-decidable-is-multiple-of-gcd-ℕ a b n =
-  is-decidable-function-type'
-    ( is-decidable-neg (is-decidable-is-zero-ℕ (a +ℕ b)))
-    ( λ np →
-      is-decidable-product
-        ( is-decidable-neg (is-decidable-is-zero-ℕ n))
-        ( is-decidable-bounded-Π-ℕ
-          ( is-common-divisor-ℕ a b)
-          ( λ x → div-ℕ x n)
-          ( is-decidable-is-common-divisor-ℕ a b)
-          ( λ x → is-decidable-div-ℕ x n)
-          ( a +ℕ b)
-          ( λ x → leq-sum-is-common-divisor-ℕ a b x np)))
+abstract
+  is-decidable-is-multiple-of-gcd-ℕ :
+    (a b : ℕ) → is-decidable-family (is-multiple-of-gcd-ℕ a b)
+  is-decidable-is-multiple-of-gcd-ℕ a b n =
+    is-decidable-function-type'
+      ( is-decidable-neg (is-decidable-is-zero-ℕ (a +ℕ b)))
+      ( λ np →
+        is-decidable-product
+          ( is-decidable-neg (is-decidable-is-zero-ℕ n))
+          ( is-decidable-bounded-Π-ℕ
+            ( is-common-divisor-ℕ a b)
+            ( λ x → div-ℕ x n)
+            ( is-decidable-is-common-divisor-ℕ a b)
+            ( λ x → is-decidable-div-ℕ x n)
+            ( a +ℕ b)
+            ( λ x → leq-sum-is-common-divisor-ℕ a b x np)))
 ```
 
 ### The sum of `a` and `b` is a multiple of the greatest common divisor of `a` and `b`
 
 ```agda
-sum-is-multiple-of-gcd-ℕ : (a b : ℕ) → is-multiple-of-gcd-ℕ a b (a +ℕ b)
-pr1 (sum-is-multiple-of-gcd-ℕ a b np) = np
-pr2 (sum-is-multiple-of-gcd-ℕ a b np) x H = div-add-ℕ x a b (pr1 H) (pr2 H)
+abstract
+  sum-is-multiple-of-gcd-ℕ : (a b : ℕ) → is-multiple-of-gcd-ℕ a b (a +ℕ b)
+  pr1 (sum-is-multiple-of-gcd-ℕ a b np) = np
+  pr2 (sum-is-multiple-of-gcd-ℕ a b np) x H = div-add-ℕ x a b (pr1 H) (pr2 H)
 ```
 
 ### The greatest common divisor exists
@@ -187,40 +194,42 @@ is-lower-bound-gcd-ℕ a b = pr2 (pr2 (GCD-ℕ a b))
 ### `a + b = 0` if and only if `gcd a b = 0`
 
 ```agda
-is-zero-gcd-ℕ :
-  (a b : ℕ) → is-zero-ℕ (a +ℕ b) → is-zero-ℕ (gcd-ℕ a b)
-is-zero-gcd-ℕ a b p =
-  is-zero-leq-zero-ℕ
-    ( gcd-ℕ a b)
-    ( concatenate-leq-eq-ℕ
+abstract
+  is-zero-gcd-ℕ :
+    (a b : ℕ) → is-zero-ℕ (a +ℕ b) → is-zero-ℕ (gcd-ℕ a b)
+  is-zero-gcd-ℕ a b p =
+    is-zero-leq-zero-ℕ
       ( gcd-ℕ a b)
-      ( is-lower-bound-gcd-ℕ a b
-        ( a +ℕ b)
-        ( sum-is-multiple-of-gcd-ℕ a b))
-      ( p))
+      ( concatenate-leq-eq-ℕ
+        ( gcd-ℕ a b)
+        ( is-lower-bound-gcd-ℕ a b
+          ( a +ℕ b)
+          ( sum-is-multiple-of-gcd-ℕ a b))
+        ( p))
 
-is-zero-gcd-zero-zero-ℕ : is-zero-ℕ (gcd-ℕ zero-ℕ zero-ℕ)
-is-zero-gcd-zero-zero-ℕ = is-zero-gcd-ℕ zero-ℕ zero-ℕ refl
+  is-zero-gcd-zero-zero-ℕ : is-zero-ℕ (gcd-ℕ zero-ℕ zero-ℕ)
+  is-zero-gcd-zero-zero-ℕ = is-zero-gcd-ℕ zero-ℕ zero-ℕ refl
 
-is-zero-add-is-zero-gcd-ℕ :
-  (a b : ℕ) → is-zero-ℕ (gcd-ℕ a b) → is-zero-ℕ (a +ℕ b)
-is-zero-add-is-zero-gcd-ℕ a b H =
-  double-negation-elim-is-decidable
-    ( is-decidable-is-zero-ℕ (a +ℕ b))
-    ( λ f → pr1 (is-multiple-of-gcd-gcd-ℕ a b f) H)
+  is-zero-add-is-zero-gcd-ℕ :
+    (a b : ℕ) → is-zero-ℕ (gcd-ℕ a b) → is-zero-ℕ (a +ℕ b)
+  is-zero-add-is-zero-gcd-ℕ a b H =
+    double-negation-elim-is-decidable
+      ( is-decidable-is-zero-ℕ (a +ℕ b))
+      ( λ f → pr1 (is-multiple-of-gcd-gcd-ℕ a b f) H)
 ```
 
 ### If at least one of `a` and `b` is nonzero, then their gcd is nonzero
 
 ```agda
-is-nonzero-gcd-ℕ :
-  (a b : ℕ) → is-nonzero-ℕ (a +ℕ b) → is-nonzero-ℕ (gcd-ℕ a b)
-is-nonzero-gcd-ℕ a b ne = pr1 (is-multiple-of-gcd-gcd-ℕ a b ne)
+abstract
+  is-nonzero-gcd-ℕ :
+    (a b : ℕ) → is-nonzero-ℕ (a +ℕ b) → is-nonzero-ℕ (gcd-ℕ a b)
+  is-nonzero-gcd-ℕ a b ne = pr1 (is-multiple-of-gcd-gcd-ℕ a b ne)
 
-is-successor-gcd-ℕ :
-  (a b : ℕ) → is-nonzero-ℕ (a +ℕ b) → is-successor-ℕ (gcd-ℕ a b)
-is-successor-gcd-ℕ a b ne =
-  is-successor-is-nonzero-ℕ (is-nonzero-gcd-ℕ a b ne)
+  is-successor-gcd-ℕ :
+    (a b : ℕ) → is-nonzero-ℕ (a +ℕ b) → is-successor-ℕ (gcd-ℕ a b)
+  is-successor-gcd-ℕ a b ne =
+    is-successor-is-nonzero-ℕ (is-nonzero-gcd-ℕ a b ne)
 ```
 
 ### Any common divisor is also a divisor of the greatest common divisor
@@ -237,15 +246,16 @@ div-gcd-is-common-divisor-ℕ a b x H with
 ### If every common divisor divides a number `r < gcd a b`, then `r = 0`
 
 ```agda
-is-zero-is-common-divisor-le-gcd-ℕ :
-  (a b r : ℕ) → le-ℕ r (gcd-ℕ a b) →
-  ((x : ℕ) → is-common-divisor-ℕ a b x → div-ℕ x r) → is-zero-ℕ r
-is-zero-is-common-divisor-le-gcd-ℕ a b r l d with is-decidable-is-zero-ℕ r
-... | inl H = H
-... | inr x =
-  ex-falso
-    ( contradiction-le-ℕ r (gcd-ℕ a b) l
-      ( is-lower-bound-gcd-ℕ a b r (λ np → pair x d)))
+abstract
+  is-zero-is-common-divisor-le-gcd-ℕ :
+    (a b r : ℕ) → le-ℕ r (gcd-ℕ a b) →
+    ((x : ℕ) → is-common-divisor-ℕ a b x → div-ℕ x r) → is-zero-ℕ r
+  is-zero-is-common-divisor-le-gcd-ℕ a b r l d with is-decidable-is-zero-ℕ r
+  ... | inl H = H
+  ... | inr x =
+    ex-falso
+      ( contradiction-le-ℕ r (gcd-ℕ a b) l
+        ( is-lower-bound-gcd-ℕ a b r (λ np → pair x d)))
 ```
 
 ### Any divisor of `gcd a b` is a common divisor of `a` and `b`
@@ -344,17 +354,18 @@ pr2 (is-gcd-gcd-ℕ a b x) = is-common-divisor-div-gcd-ℕ a b x
 ### The gcd is commutative
 
 ```agda
-is-commutative-gcd-ℕ : (a b : ℕ) → gcd-ℕ a b ＝ gcd-ℕ b a
-is-commutative-gcd-ℕ a b =
-  antisymmetric-div-ℕ
-    ( gcd-ℕ a b)
-    ( gcd-ℕ b a)
-    ( pr1 (is-gcd-gcd-ℕ b a (gcd-ℕ a b)) (σ (is-common-divisor-gcd-ℕ a b)))
-    ( pr1 (is-gcd-gcd-ℕ a b (gcd-ℕ b a)) (σ (is-common-divisor-gcd-ℕ b a)))
-  where
-  σ : {A B : UU lzero} → A × B → B × A
-  pr1 (σ (pair x y)) = y
-  pr2 (σ (pair x y)) = x
+abstract
+  is-commutative-gcd-ℕ : (a b : ℕ) → gcd-ℕ a b ＝ gcd-ℕ b a
+  is-commutative-gcd-ℕ a b =
+    antisymmetric-div-ℕ
+      ( gcd-ℕ a b)
+      ( gcd-ℕ b a)
+      ( pr1 (is-gcd-gcd-ℕ b a (gcd-ℕ a b)) (σ (is-common-divisor-gcd-ℕ a b)))
+      ( pr1 (is-gcd-gcd-ℕ a b (gcd-ℕ b a)) (σ (is-common-divisor-gcd-ℕ b a)))
+    where
+    σ : {A B : UU lzero} → A × B → B × A
+    pr1 (σ (pair x y)) = y
+    pr2 (σ (pair x y)) = x
 ```
 
 ### If `d` is a common divisor of `a` and `b`, then `kd` is a common divisor of `ka` and `kb`
@@ -381,43 +392,47 @@ reflects-is-common-divisor-mul-ℕ k a b d H =
 ### `gcd-ℕ 1 b ＝ 1`
 
 ```agda
-is-one-is-gcd-one-ℕ : {b x : ℕ} → is-gcd-ℕ 1 b x → is-one-ℕ x
-is-one-is-gcd-one-ℕ {b} {x} H =
-  is-one-div-one-ℕ x (pr1 (is-common-divisor-is-gcd-ℕ 1 b x H))
+abstract
+  is-one-is-gcd-one-ℕ : {b x : ℕ} → is-gcd-ℕ 1 b x → is-one-ℕ x
+  is-one-is-gcd-one-ℕ {b} {x} H =
+    is-one-div-one-ℕ x (pr1 (is-common-divisor-is-gcd-ℕ 1 b x H))
 
-is-one-gcd-one-ℕ : (b : ℕ) → is-one-ℕ (gcd-ℕ 1 b)
-is-one-gcd-one-ℕ b = is-one-is-gcd-one-ℕ (is-gcd-gcd-ℕ 1 b)
+  is-one-gcd-one-ℕ : (b : ℕ) → is-one-ℕ (gcd-ℕ 1 b)
+  is-one-gcd-one-ℕ b = is-one-is-gcd-one-ℕ (is-gcd-gcd-ℕ 1 b)
 ```
 
 ### `gcd-ℕ a 1 ＝ 1`
 
 ```agda
-is-one-is-gcd-one-ℕ' : {a x : ℕ} → is-gcd-ℕ a 1 x → is-one-ℕ x
-is-one-is-gcd-one-ℕ' {a} {x} H =
-  is-one-div-one-ℕ x (pr2 (is-common-divisor-is-gcd-ℕ a 1 x H))
+abstract
+  is-one-is-gcd-one-ℕ' : {a x : ℕ} → is-gcd-ℕ a 1 x → is-one-ℕ x
+  is-one-is-gcd-one-ℕ' {a} {x} H =
+    is-one-div-one-ℕ x (pr2 (is-common-divisor-is-gcd-ℕ a 1 x H))
 
-is-one-gcd-one-ℕ' : (a : ℕ) → is-one-ℕ (gcd-ℕ a 1)
-is-one-gcd-one-ℕ' a = is-one-is-gcd-one-ℕ' (is-gcd-gcd-ℕ a 1)
+  is-one-gcd-one-ℕ' : (a : ℕ) → is-one-ℕ (gcd-ℕ a 1)
+  is-one-gcd-one-ℕ' a = is-one-is-gcd-one-ℕ' (is-gcd-gcd-ℕ a 1)
 ```
 
 ### `gcd-ℕ 0 b ＝ b`
 
 ```agda
-is-id-is-gcd-zero-ℕ : {b x : ℕ} → gcd-ℕ 0 b ＝ x → x ＝ b
-is-id-is-gcd-zero-ℕ {b} {x} H = antisymmetric-div-ℕ x b
-  (pr2 (is-common-divisor-is-gcd-ℕ 0 b x
-    (tr (λ t → is-gcd-ℕ 0 b t) H (is-gcd-gcd-ℕ 0 b))))
-  (tr (λ t → div-ℕ b t) H
-    (div-gcd-is-common-divisor-ℕ 0 b b
-      (pair' (div-zero-ℕ b) (refl-div-ℕ b))))
+abstract
+  is-id-is-gcd-zero-ℕ : {b x : ℕ} → gcd-ℕ 0 b ＝ x → x ＝ b
+  is-id-is-gcd-zero-ℕ {b} {x} H = antisymmetric-div-ℕ x b
+    (pr2 (is-common-divisor-is-gcd-ℕ 0 b x
+      (tr (λ t → is-gcd-ℕ 0 b t) H (is-gcd-gcd-ℕ 0 b))))
+    (tr (λ t → div-ℕ b t) H
+      (div-gcd-is-common-divisor-ℕ 0 b b
+        (pair' (div-zero-ℕ b) (refl-div-ℕ b))))
 ```
 
 ### `gcd-ℕ a 0 ＝ a`
 
 ```agda
-is-id-is-gcd-zero-ℕ' : {a x : ℕ} → gcd-ℕ a 0 ＝ x → x ＝ a
-is-id-is-gcd-zero-ℕ' {a} {x} H = is-id-is-gcd-zero-ℕ {a} {x}
-  ((is-commutative-gcd-ℕ 0 a) ∙ H)
+abstract
+  is-id-is-gcd-zero-ℕ' : {a x : ℕ} → gcd-ℕ a 0 ＝ x → x ＝ a
+  is-id-is-gcd-zero-ℕ' {a} {x} H = is-id-is-gcd-zero-ℕ {a} {x}
+    ((is-commutative-gcd-ℕ 0 a) ∙ H)
 ```
 
 ### Consider a common divisor `d` of `a` and `b` and let `e` be a divisor of `d`. Then any divisor of `d/e` is a common divisor of `a/e` and `b/e`
@@ -456,32 +471,33 @@ pr2 (pr2 (simplify-is-common-divisor-quotient-div-ℕ nz H) K) =
 ### The greatest common divisor of `a/d` and `b/d` is `gcd(a,b)/d`
 
 ```agda
-is-gcd-quotient-div-gcd-ℕ :
-  {a b d : ℕ} → is-nonzero-ℕ d → (H : is-common-divisor-ℕ a b d) →
-  is-gcd-ℕ
-    ( quotient-div-ℕ d a (pr1 H))
-    ( quotient-div-ℕ d b (pr2 H))
-    ( quotient-div-ℕ d
-      ( gcd-ℕ a b)
-      ( div-gcd-is-common-divisor-ℕ a b d H))
-is-gcd-quotient-div-gcd-ℕ {a} {b} {d} nz H x =
-  logical-equivalence-reasoning
-    is-common-divisor-ℕ
+abstract
+  is-gcd-quotient-div-gcd-ℕ :
+    {a b d : ℕ} → is-nonzero-ℕ d → (H : is-common-divisor-ℕ a b d) →
+    is-gcd-ℕ
       ( quotient-div-ℕ d a (pr1 H))
       ( quotient-div-ℕ d b (pr2 H))
-      ( x)
-    ↔ is-common-divisor-ℕ a b (x *ℕ d)
-      by simplify-is-common-divisor-quotient-div-ℕ nz H
-    ↔ div-ℕ (x *ℕ d) (gcd-ℕ a b)
-      by is-gcd-gcd-ℕ a b (x *ℕ d)
-    ↔ div-ℕ x
-        ( quotient-div-ℕ d
-          ( gcd-ℕ a b)
-          ( div-gcd-is-common-divisor-ℕ a b d H))
-      by
-      inv-iff
-        ( simplify-div-quotient-div-ℕ nz
-          ( div-gcd-is-common-divisor-ℕ a b d H))
+      ( quotient-div-ℕ d
+        ( gcd-ℕ a b)
+        ( div-gcd-is-common-divisor-ℕ a b d H))
+  is-gcd-quotient-div-gcd-ℕ {a} {b} {d} nz H x =
+    logical-equivalence-reasoning
+      is-common-divisor-ℕ
+        ( quotient-div-ℕ d a (pr1 H))
+        ( quotient-div-ℕ d b (pr2 H))
+        ( x)
+      ↔ is-common-divisor-ℕ a b (x *ℕ d)
+        by simplify-is-common-divisor-quotient-div-ℕ nz H
+      ↔ div-ℕ (x *ℕ d) (gcd-ℕ a b)
+        by is-gcd-gcd-ℕ a b (x *ℕ d)
+      ↔ div-ℕ x
+          ( quotient-div-ℕ d
+            ( gcd-ℕ a b)
+            ( div-gcd-is-common-divisor-ℕ a b d H))
+        by
+        inv-iff
+          ( simplify-div-quotient-div-ℕ nz
+            ( div-gcd-is-common-divisor-ℕ a b d H))
 ```
 
 ## References

--- a/src/elementary-number-theory/group-of-integers.lagda.md
+++ b/src/elementary-number-theory/group-of-integers.lagda.md
@@ -22,8 +22,9 @@ open import group-theory.semigroups
 
 ## Idea
 
-The type of integers, equipped with a zero-element, addition, and negatives,
-forms a group.
+The type of [integers](elementary-number-theory.integers.md), equipped with
+zero, [addition](elementary-number-theory.addition-integers.md), and negation,
+forms a [group](group-theory.groups.md).
 
 ## Definition
 

--- a/src/elementary-number-theory/inequality-integers.lagda.md
+++ b/src/elementary-number-theory/inequality-integers.lagda.md
@@ -83,20 +83,21 @@ leq-zero-one-ℤ = star
 ### Inequality on the integers is reflexive, antisymmetric and transitive
 
 ```agda
-refl-leq-ℤ : (k : ℤ) → leq-ℤ k k
-refl-leq-ℤ k = tr is-nonnegative-ℤ (inv (right-inverse-law-add-ℤ k)) star
+abstract
+  refl-leq-ℤ : (k : ℤ) → leq-ℤ k k
+  refl-leq-ℤ k = tr is-nonnegative-ℤ (inv (right-inverse-law-add-ℤ k)) star
 
-antisymmetric-leq-ℤ : {x y : ℤ} → leq-ℤ x y → leq-ℤ y x → x ＝ y
-antisymmetric-leq-ℤ {x} {y} H K =
-  eq-diff-ℤ
-    ( is-zero-is-nonnegative-neg-is-nonnegative-ℤ K
-      ( is-nonnegative-eq-ℤ (inv (distributive-neg-diff-ℤ x y)) H))
+  antisymmetric-leq-ℤ : {x y : ℤ} → leq-ℤ x y → leq-ℤ y x → x ＝ y
+  antisymmetric-leq-ℤ {x} {y} H K =
+    eq-diff-ℤ
+      ( is-zero-is-nonnegative-neg-is-nonnegative-ℤ K
+        ( is-nonnegative-eq-ℤ (inv (distributive-neg-diff-ℤ x y)) H))
 
-transitive-leq-ℤ : (k l m : ℤ) → leq-ℤ l m → leq-ℤ k l → leq-ℤ k m
-transitive-leq-ℤ k l m H K =
-  is-nonnegative-eq-ℤ
-    ( triangle-diff-ℤ m l k)
-    ( is-nonnegative-add-ℤ H K)
+  transitive-leq-ℤ : (k l m : ℤ) → leq-ℤ l m → leq-ℤ k l → leq-ℤ k m
+  transitive-leq-ℤ k l m H K =
+    is-nonnegative-eq-ℤ
+      ( triangle-diff-ℤ m l k)
+      ( is-nonnegative-add-ℤ H K)
 ```
 
 ### Inequality on the integers is decidable
@@ -141,16 +142,17 @@ linear-leq-ℤ x y =
 ### An integer is lesser than its successor
 
 ```agda
-succ-leq-ℤ : (k : ℤ) → leq-ℤ k (succ-ℤ k)
-succ-leq-ℤ k =
-  is-nonnegative-eq-ℤ
-    ( inv
-      ( ( left-successor-law-add-ℤ k (neg-ℤ k)) ∙
-        ( ap succ-ℤ (right-inverse-law-add-ℤ k))))
-    ( star)
+abstract
+  succ-leq-ℤ : (k : ℤ) → leq-ℤ k (succ-ℤ k)
+  succ-leq-ℤ k =
+    is-nonnegative-eq-ℤ
+      ( inv
+        ( ( left-successor-law-add-ℤ k (neg-ℤ k)) ∙
+          ( ap succ-ℤ (right-inverse-law-add-ℤ k))))
+      ( star)
 
-leq-ℤ-succ-leq-ℤ : (k l : ℤ) → leq-ℤ k l → leq-ℤ k (succ-ℤ l)
-leq-ℤ-succ-leq-ℤ k l = transitive-leq-ℤ k l (succ-ℤ l) (succ-leq-ℤ l)
+  leq-ℤ-succ-leq-ℤ : (k l : ℤ) → leq-ℤ k l → leq-ℤ k (succ-ℤ l)
+  leq-ℤ-succ-leq-ℤ k l = transitive-leq-ℤ k l (succ-ℤ l) (succ-leq-ℤ l)
 ```
 
 ### Chaining rules for equality and inequality
@@ -172,25 +174,26 @@ concatenate-eq-leq-ℤ y refl H = H
 ### Addition on the integers preserves inequality
 
 ```agda
-preserves-leq-left-add-ℤ :
-  (z x y : ℤ) → leq-ℤ x y → leq-ℤ (x +ℤ z) (y +ℤ z)
-preserves-leq-left-add-ℤ z x y =
-  is-nonnegative-eq-ℤ (inv (right-translation-diff-ℤ y x z))
+abstract
+  preserves-leq-left-add-ℤ :
+    (z x y : ℤ) → leq-ℤ x y → leq-ℤ (x +ℤ z) (y +ℤ z)
+  preserves-leq-left-add-ℤ z x y =
+    is-nonnegative-eq-ℤ (inv (right-translation-diff-ℤ y x z))
 
-preserves-leq-right-add-ℤ :
-  (z x y : ℤ) → leq-ℤ x y → leq-ℤ (z +ℤ x) (z +ℤ y)
-preserves-leq-right-add-ℤ z x y =
-  is-nonnegative-eq-ℤ (inv (left-translation-diff-ℤ y x z))
+  preserves-leq-right-add-ℤ :
+    (z x y : ℤ) → leq-ℤ x y → leq-ℤ (z +ℤ x) (z +ℤ y)
+  preserves-leq-right-add-ℤ z x y =
+    is-nonnegative-eq-ℤ (inv (left-translation-diff-ℤ y x z))
 
-preserves-leq-add-ℤ :
-  {a b c d : ℤ} → leq-ℤ a b → leq-ℤ c d → leq-ℤ (a +ℤ c) (b +ℤ d)
-preserves-leq-add-ℤ {a} {b} {c} {d} H K =
-  transitive-leq-ℤ
-    ( a +ℤ c)
-    ( b +ℤ c)
-    ( b +ℤ d)
-    ( preserves-leq-right-add-ℤ b c d K)
-    ( preserves-leq-left-add-ℤ c a b H)
+  preserves-leq-add-ℤ :
+    {a b c d : ℤ} → leq-ℤ a b → leq-ℤ c d → leq-ℤ (a +ℤ c) (b +ℤ d)
+  preserves-leq-add-ℤ {a} {b} {c} {d} H K =
+    transitive-leq-ℤ
+      ( a +ℤ c)
+      ( b +ℤ c)
+      ( b +ℤ d)
+      ( preserves-leq-right-add-ℤ b c d K)
+      ( preserves-leq-left-add-ℤ c a b H)
 
 right-add-hom-leq-ℤ : (z : ℤ) → hom-Poset ℤ-Poset ℤ-Poset
 pr1 (right-add-hom-leq-ℤ z) x = x +ℤ z
@@ -204,31 +207,33 @@ pr2 (left-add-hom-leq-ℤ z) = preserves-leq-right-add-ℤ z
 ### Addition on the integers reflects inequality
 
 ```agda
-reflects-leq-left-add-ℤ :
-  (z x y : ℤ) → leq-ℤ (x +ℤ z) (y +ℤ z) → leq-ℤ x y
-reflects-leq-left-add-ℤ z x y =
-  is-nonnegative-eq-ℤ (right-translation-diff-ℤ y x z)
+abstract
+  reflects-leq-left-add-ℤ :
+    (z x y : ℤ) → leq-ℤ (x +ℤ z) (y +ℤ z) → leq-ℤ x y
+  reflects-leq-left-add-ℤ z x y =
+    is-nonnegative-eq-ℤ (right-translation-diff-ℤ y x z)
 
-reflects-leq-right-add-ℤ :
-  (z x y : ℤ) → leq-ℤ (z +ℤ x) (z +ℤ y) → leq-ℤ x y
-reflects-leq-right-add-ℤ z x y =
-  is-nonnegative-eq-ℤ (left-translation-diff-ℤ y x z)
+  reflects-leq-right-add-ℤ :
+    (z x y : ℤ) → leq-ℤ (z +ℤ x) (z +ℤ y) → leq-ℤ x y
+  reflects-leq-right-add-ℤ z x y =
+    is-nonnegative-eq-ℤ (left-translation-diff-ℤ y x z)
 ```
 
 ### The inclusion of ℕ into ℤ preserves inequality
 
 ```agda
-leq-int-ℕ : (x y : ℕ) → leq-ℕ x y → leq-ℤ (int-ℕ x) (int-ℕ y)
-leq-int-ℕ zero-ℕ y H =
-  tr
-    ( is-nonnegative-ℤ)
-    ( inv (right-unit-law-add-ℤ (int-ℕ y)))
-    ( is-nonnegative-int-ℕ y)
-leq-int-ℕ (succ-ℕ x) (succ-ℕ y) H = tr (is-nonnegative-ℤ)
-  ( inv (diff-succ-ℤ (int-ℕ y) (int-ℕ x)) ∙
-    ( ap (_-ℤ (succ-ℤ (int-ℕ x))) (succ-int-ℕ y) ∙
-      ap ((int-ℕ (succ-ℕ y)) -ℤ_) (succ-int-ℕ x)))
-  ( leq-int-ℕ x y H)
+abstract
+  leq-int-ℕ : (x y : ℕ) → leq-ℕ x y → leq-ℤ (int-ℕ x) (int-ℕ y)
+  leq-int-ℕ zero-ℕ y H =
+    tr
+      ( is-nonnegative-ℤ)
+      ( inv (right-unit-law-add-ℤ (int-ℕ y)))
+      ( is-nonnegative-int-ℕ y)
+  leq-int-ℕ (succ-ℕ x) (succ-ℕ y) H = tr (is-nonnegative-ℤ)
+    ( inv (diff-succ-ℤ (int-ℕ y) (int-ℕ x)) ∙
+      ( ap (_-ℤ (succ-ℤ (int-ℕ x))) (succ-int-ℕ y) ∙
+        ap ((int-ℕ (succ-ℕ y)) -ℤ_) (succ-int-ℕ x)))
+    ( leq-int-ℕ x y H)
 ```
 
 ### An integer `x` is nonnegative if and only if `0 ≤ x`
@@ -307,64 +312,66 @@ module _
 ### Negation of integers reverses inequality
 
 ```agda
-neg-leq-ℤ : (x y : ℤ) → leq-ℤ x y → leq-ℤ (neg-ℤ y) (neg-ℤ x)
-neg-leq-ℤ x y =
-  tr
-    ( is-nonnegative-ℤ)
-    ( ap (_+ℤ neg-ℤ x) (inv (neg-neg-ℤ y)) ∙
-      commutative-add-ℤ (neg-ℤ (neg-ℤ y)) (neg-ℤ x))
+abstract
+  neg-leq-ℤ : (x y : ℤ) → leq-ℤ x y → leq-ℤ (neg-ℤ y) (neg-ℤ x)
+  neg-leq-ℤ x y =
+    tr
+      ( is-nonnegative-ℤ)
+      ( ap (_+ℤ neg-ℤ x) (inv (neg-neg-ℤ y)) ∙
+        commutative-add-ℤ (neg-ℤ (neg-ℤ y)) (neg-ℤ x))
 ```
 
 ### Transposing additions over inequalities of integers
 
 ```agda
-leq-transpose-right-diff-ℤ : (x y z : ℤ) → x ≤-ℤ (y -ℤ z) → x +ℤ z ≤-ℤ y
-leq-transpose-right-diff-ℤ x y z x≤y-z =
-  leq-transpose-is-section-hom-Poset
-    ( ℤ-Poset)
-    ( ℤ-Poset)
-    ( right-add-hom-leq-ℤ z)
-    ( _-ℤ z)
-    ( is-section-right-add-neg-ℤ z)
-    ( x)
-    ( y)
-    ( x≤y-z)
+abstract
+  leq-transpose-right-diff-ℤ : (x y z : ℤ) → x ≤-ℤ (y -ℤ z) → x +ℤ z ≤-ℤ y
+  leq-transpose-right-diff-ℤ x y z x≤y-z =
+    leq-transpose-is-section-hom-Poset
+      ( ℤ-Poset)
+      ( ℤ-Poset)
+      ( right-add-hom-leq-ℤ z)
+      ( _-ℤ z)
+      ( is-section-right-add-neg-ℤ z)
+      ( x)
+      ( y)
+      ( x≤y-z)
 
-leq-transpose-right-add-ℤ : (x y z : ℤ) → x ≤-ℤ y +ℤ z → x -ℤ z ≤-ℤ y
-leq-transpose-right-add-ℤ x y z x≤y+z =
-  leq-transpose-is-section-hom-Poset
-    ( ℤ-Poset)
-    ( ℤ-Poset)
-    ( right-add-hom-leq-ℤ (neg-ℤ z))
-    ( _+ℤ z)
-    ( is-retraction-right-add-neg-ℤ z)
-    ( x)
-    ( y)
-    ( x≤y+z)
+  leq-transpose-right-add-ℤ : (x y z : ℤ) → x ≤-ℤ y +ℤ z → x -ℤ z ≤-ℤ y
+  leq-transpose-right-add-ℤ x y z x≤y+z =
+    leq-transpose-is-section-hom-Poset
+      ( ℤ-Poset)
+      ( ℤ-Poset)
+      ( right-add-hom-leq-ℤ (neg-ℤ z))
+      ( _+ℤ z)
+      ( is-retraction-right-add-neg-ℤ z)
+      ( x)
+      ( y)
+      ( x≤y+z)
 
-leq-transpose-left-add-ℤ : (x y z : ℤ) → x +ℤ y ≤-ℤ z → x ≤-ℤ z -ℤ y
-leq-transpose-left-add-ℤ x y z x+y≤z =
-  leq-transpose-is-retraction-hom-Poset
-    ( ℤ-Poset)
-    ( ℤ-Poset)
-    ( _+ℤ y)
-    ( right-add-hom-leq-ℤ (neg-ℤ y))
-    ( is-retraction-right-add-neg-ℤ y)
-    ( x)
-    ( z)
-    ( x+y≤z)
+  leq-transpose-left-add-ℤ : (x y z : ℤ) → x +ℤ y ≤-ℤ z → x ≤-ℤ z -ℤ y
+  leq-transpose-left-add-ℤ x y z x+y≤z =
+    leq-transpose-is-retraction-hom-Poset
+      ( ℤ-Poset)
+      ( ℤ-Poset)
+      ( _+ℤ y)
+      ( right-add-hom-leq-ℤ (neg-ℤ y))
+      ( is-retraction-right-add-neg-ℤ y)
+      ( x)
+      ( z)
+      ( x+y≤z)
 
-leq-transpose-left-diff-ℤ : (x y z : ℤ) → x -ℤ y ≤-ℤ z → x ≤-ℤ z +ℤ y
-leq-transpose-left-diff-ℤ x y z x-y≤z =
-  leq-transpose-is-retraction-hom-Poset
-    ( ℤ-Poset)
-    ( ℤ-Poset)
-    ( _-ℤ y)
-    ( right-add-hom-leq-ℤ y)
-    ( is-section-right-add-neg-ℤ y)
-    ( x)
-    ( z)
-    ( x-y≤z)
+  leq-transpose-left-diff-ℤ : (x y z : ℤ) → x -ℤ y ≤-ℤ z → x ≤-ℤ z +ℤ y
+  leq-transpose-left-diff-ℤ x y z x-y≤z =
+    leq-transpose-is-retraction-hom-Poset
+      ( ℤ-Poset)
+      ( ℤ-Poset)
+      ( _-ℤ y)
+      ( right-add-hom-leq-ℤ y)
+      ( is-section-right-add-neg-ℤ y)
+      ( x)
+      ( z)
+      ( x-y≤z)
 
 leq-iff-transpose-left-add-ℤ : (x y z : ℤ) → (x +ℤ y ≤-ℤ z) ↔ (x ≤-ℤ z -ℤ y)
 pr1 (leq-iff-transpose-left-add-ℤ x y z) = leq-transpose-left-add-ℤ x y z

--- a/src/elementary-number-theory/inequality-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/inequality-natural-numbers.lagda.md
@@ -423,28 +423,28 @@ abstract
 
 ```agda
 abstract
-  reflects-order-mul-ℕ :
+  reflects-leq-mul-ℕ :
     (k m n : ℕ) → (m *ℕ (succ-ℕ k)) ≤-ℕ (n *ℕ (succ-ℕ k)) → m ≤-ℕ n
-  reflects-order-mul-ℕ k zero-ℕ n p = star
-  reflects-order-mul-ℕ k (succ-ℕ m) (succ-ℕ n) p =
-    reflects-order-mul-ℕ k m n
+  reflects-leq-mul-ℕ k zero-ℕ n p = star
+  reflects-leq-mul-ℕ k (succ-ℕ m) (succ-ℕ n) p =
+    reflects-leq-mul-ℕ k m n
       ( reflects-leq-left-add-ℕ
         ( succ-ℕ k)
         ( m *ℕ (succ-ℕ k))
         ( n *ℕ (succ-ℕ k))
         ( p))
 
-  reflects-order-mul-ℕ' :
+  reflects-leq-mul-ℕ' :
     (k m n : ℕ) → ((succ-ℕ k) *ℕ m) ≤-ℕ ((succ-ℕ k) *ℕ n) → m ≤-ℕ n
-  reflects-order-mul-ℕ' k m n H =
-    reflects-order-mul-ℕ k m n
+  reflects-leq-mul-ℕ' k m n H =
+    reflects-leq-mul-ℕ k m n
       ( concatenate-eq-leq-eq-ℕ
         ( commutative-mul-ℕ m (succ-ℕ k))
         ( H)
         ( commutative-mul-ℕ (succ-ℕ k) n))
 ```
 
-### Any number `x` is less than or equal to a nonzero multiple of itself
+### Any number `x` is less than or equal to any nonzero multiple of itself
 
 ```agda
 abstract

--- a/src/elementary-number-theory/inequality-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/inequality-natural-numbers.lagda.md
@@ -67,12 +67,13 @@ data leq-ℕ' : ℕ → ℕ → UU lzero where
 ### Inequality on the natural numbers is a proposition
 
 ```agda
-is-prop-leq-ℕ :
-  (m n : ℕ) → is-prop (leq-ℕ m n)
-is-prop-leq-ℕ zero-ℕ zero-ℕ = is-prop-unit
-is-prop-leq-ℕ zero-ℕ (succ-ℕ n) = is-prop-unit
-is-prop-leq-ℕ (succ-ℕ m) zero-ℕ = is-prop-empty
-is-prop-leq-ℕ (succ-ℕ m) (succ-ℕ n) = is-prop-leq-ℕ m n
+abstract
+  is-prop-leq-ℕ :
+    (m n : ℕ) → is-prop (leq-ℕ m n)
+  is-prop-leq-ℕ zero-ℕ zero-ℕ = is-prop-unit
+  is-prop-leq-ℕ zero-ℕ (succ-ℕ n) = is-prop-unit
+  is-prop-leq-ℕ (succ-ℕ m) zero-ℕ = is-prop-empty
+  is-prop-leq-ℕ (succ-ℕ m) (succ-ℕ n) = is-prop-leq-ℕ m n
 
 leq-ℕ-Prop : ℕ → ℕ → Prop lzero
 pr1 (leq-ℕ-Prop m n) = leq-ℕ m n
@@ -120,10 +121,11 @@ leq-eq-ℕ m .m refl = refl-leq-ℕ m
 ### Inequality on the natural numbers is transitive
 
 ```agda
-transitive-leq-ℕ : is-transitive leq-ℕ
-transitive-leq-ℕ zero-ℕ m l p q = star
-transitive-leq-ℕ (succ-ℕ n) (succ-ℕ m) (succ-ℕ l) p q =
-  transitive-leq-ℕ n m l p q
+abstract
+  transitive-leq-ℕ : is-transitive leq-ℕ
+  transitive-leq-ℕ zero-ℕ m l p q = star
+  transitive-leq-ℕ (succ-ℕ n) (succ-ℕ m) (succ-ℕ l) p q =
+    transitive-leq-ℕ n m l p q
 ```
 
 ### Inequality on the natural numbers is antisymmetric
@@ -208,7 +210,7 @@ leq-zero-ℕ :
 leq-zero-ℕ n = star
 ```
 
-### Any natural number less than zero is zero
+### Any natural number less than or equal to zero is zero
 
 ```agda
 is-zero-leq-zero-ℕ :
@@ -220,25 +222,27 @@ is-zero-leq-zero-ℕ' :
 is-zero-leq-zero-ℕ' zero-ℕ star = refl
 ```
 
-### Any number is nonzero natural number if it is at least `1`
+### A natural number is nonzero if and only if it is at least `1`
 
 ```agda
-leq-one-is-nonzero-ℕ :
-  (x : ℕ) → is-nonzero-ℕ x → leq-ℕ 1 x
-leq-one-is-nonzero-ℕ zero-ℕ H = ex-falso (H refl)
-leq-one-is-nonzero-ℕ (succ-ℕ x) H = star
+abstract
+  leq-one-is-nonzero-ℕ :
+    (x : ℕ) → is-nonzero-ℕ x → leq-ℕ 1 x
+  leq-one-is-nonzero-ℕ zero-ℕ H = ex-falso (H refl)
+  leq-one-is-nonzero-ℕ (succ-ℕ x) H = star
 
-is-nonzero-leq-one-ℕ :
-  (x : ℕ) → leq-ℕ 1 x → is-nonzero-ℕ x
-is-nonzero-leq-one-ℕ .zero-ℕ () refl
+  is-nonzero-leq-one-ℕ :
+    (x : ℕ) → leq-ℕ 1 x → is-nonzero-ℕ x
+  is-nonzero-leq-one-ℕ .zero-ℕ () refl
 ```
 
 ### Any natural number is less than or equal to its own successor
 
 ```agda
-succ-leq-ℕ : (n : ℕ) → n ≤-ℕ (succ-ℕ n)
-succ-leq-ℕ zero-ℕ = star
-succ-leq-ℕ (succ-ℕ n) = succ-leq-ℕ n
+abstract
+  succ-leq-ℕ : (n : ℕ) → n ≤-ℕ (succ-ℕ n)
+  succ-leq-ℕ zero-ℕ = star
+  succ-leq-ℕ (succ-ℕ n) = succ-leq-ℕ n
 ```
 
 ### Any natural number less than or equal to `n+1` is either less than or equal to `n` or it is `n+1`
@@ -257,18 +261,20 @@ decide-leq-succ-ℕ (succ-ℕ m) (succ-ℕ n) l =
 ### If `m` is less than `n`, then it is less than `n+1`
 
 ```agda
-preserves-leq-succ-ℕ :
-  (m n : ℕ) → m ≤-ℕ n → m ≤-ℕ (succ-ℕ n)
-preserves-leq-succ-ℕ m n p = transitive-leq-ℕ m n (succ-ℕ n) (succ-leq-ℕ n) p
+abstract
+  preserves-leq-succ-ℕ :
+    (m n : ℕ) → m ≤-ℕ n → m ≤-ℕ (succ-ℕ n)
+  preserves-leq-succ-ℕ m n p = transitive-leq-ℕ m n (succ-ℕ n) (succ-leq-ℕ n) p
 ```
 
 ### The successor of `n` is not less than or equal to `n`
 
 ```agda
-neg-succ-leq-ℕ :
-  (n : ℕ) → ¬ (leq-ℕ (succ-ℕ n) n)
-neg-succ-leq-ℕ zero-ℕ = id
-neg-succ-leq-ℕ (succ-ℕ n) = neg-succ-leq-ℕ n
+abstract
+  neg-succ-leq-ℕ :
+    (n : ℕ) → ¬ (leq-ℕ (succ-ℕ n) n)
+  neg-succ-leq-ℕ zero-ℕ = id
+  neg-succ-leq-ℕ (succ-ℕ n) = neg-succ-leq-ℕ n
 ```
 
 ### If `m ≤ n + 1` then either `m ≤ n` or `m = n + 1`
@@ -292,73 +298,77 @@ cases-leq-succ-reflexive-leq-ℕ {succ-ℕ n} =
 ### `m ≤ n` if and only if `n + 1 ≰ m`
 
 ```agda
-contradiction-leq-ℕ : (m n : ℕ) → m ≤-ℕ n → ¬ ((succ-ℕ n) ≤-ℕ m)
-contradiction-leq-ℕ (succ-ℕ m) (succ-ℕ n) H K = contradiction-leq-ℕ m n H K
+abstract
+  contradiction-leq-ℕ : (m n : ℕ) → m ≤-ℕ n → ¬ ((succ-ℕ n) ≤-ℕ m)
+  contradiction-leq-ℕ (succ-ℕ m) (succ-ℕ n) H K = contradiction-leq-ℕ m n H K
 
-contradiction-leq-ℕ' : (m n : ℕ) → (succ-ℕ n) ≤-ℕ m → ¬ (m ≤-ℕ n)
-contradiction-leq-ℕ' m n K H = contradiction-leq-ℕ m n H K
+  contradiction-leq-ℕ' : (m n : ℕ) → (succ-ℕ n) ≤-ℕ m → ¬ (m ≤-ℕ n)
+  contradiction-leq-ℕ' m n K H = contradiction-leq-ℕ m n H K
 ```
 
 ### Addition preserves inequality of natural numbers
 
 ```agda
-preserves-leq-left-add-ℕ :
-  (k m n : ℕ) → m ≤-ℕ n → (m +ℕ k) ≤-ℕ (n +ℕ k)
-preserves-leq-left-add-ℕ zero-ℕ m n = id
-preserves-leq-left-add-ℕ (succ-ℕ k) m n H = preserves-leq-left-add-ℕ k m n H
+abstract
+  preserves-leq-left-add-ℕ :
+    (k m n : ℕ) → m ≤-ℕ n → (m +ℕ k) ≤-ℕ (n +ℕ k)
+  preserves-leq-left-add-ℕ zero-ℕ m n = id
+  preserves-leq-left-add-ℕ (succ-ℕ k) m n H = preserves-leq-left-add-ℕ k m n H
 
-preserves-leq-right-add-ℕ : (k m n : ℕ) → m ≤-ℕ n → (k +ℕ m) ≤-ℕ (k +ℕ n)
-preserves-leq-right-add-ℕ k m n H =
-  concatenate-eq-leq-eq-ℕ
-    ( commutative-add-ℕ k m)
-    ( preserves-leq-left-add-ℕ k m n H)
-    ( commutative-add-ℕ n k)
+  preserves-leq-right-add-ℕ : (k m n : ℕ) → m ≤-ℕ n → (k +ℕ m) ≤-ℕ (k +ℕ n)
+  preserves-leq-right-add-ℕ k m n H =
+    concatenate-eq-leq-eq-ℕ
+      ( commutative-add-ℕ k m)
+      ( preserves-leq-left-add-ℕ k m n H)
+      ( commutative-add-ℕ n k)
 
-preserves-leq-add-ℕ :
-  {m m' n n' : ℕ} → m ≤-ℕ m' → n ≤-ℕ n' → (m +ℕ n) ≤-ℕ (m' +ℕ n')
-preserves-leq-add-ℕ {m} {m'} {n} {n'} H K =
-  transitive-leq-ℕ
-    ( m +ℕ n)
-    ( m' +ℕ n)
-    ( m' +ℕ n')
-    ( preserves-leq-right-add-ℕ m' n n' K)
-    ( preserves-leq-left-add-ℕ n m m' H)
+  preserves-leq-add-ℕ :
+    {m m' n n' : ℕ} → m ≤-ℕ m' → n ≤-ℕ n' → (m +ℕ n) ≤-ℕ (m' +ℕ n')
+  preserves-leq-add-ℕ {m} {m'} {n} {n'} H K =
+    transitive-leq-ℕ
+      ( m +ℕ n)
+      ( m' +ℕ n)
+      ( m' +ℕ n')
+      ( preserves-leq-right-add-ℕ m' n n' K)
+      ( preserves-leq-left-add-ℕ n m m' H)
 ```
 
 ### Addition reflects inequality of natural numbers
 
 ```agda
-reflects-leq-left-add-ℕ :
-  (k m n : ℕ) → (m +ℕ k) ≤-ℕ (n +ℕ k) → m ≤-ℕ n
-reflects-leq-left-add-ℕ zero-ℕ m n = id
-reflects-leq-left-add-ℕ (succ-ℕ k) m n = reflects-leq-left-add-ℕ k m n
+abstract
+  reflects-leq-left-add-ℕ :
+    (k m n : ℕ) → (m +ℕ k) ≤-ℕ (n +ℕ k) → m ≤-ℕ n
+  reflects-leq-left-add-ℕ zero-ℕ m n = id
+  reflects-leq-left-add-ℕ (succ-ℕ k) m n = reflects-leq-left-add-ℕ k m n
 
-reflects-leq-right-add-ℕ :
-  (k m n : ℕ) → (k +ℕ m) ≤-ℕ (k +ℕ n) → m ≤-ℕ n
-reflects-leq-right-add-ℕ k m n H =
-  reflects-leq-left-add-ℕ k m n
-    ( concatenate-eq-leq-eq-ℕ
-      ( commutative-add-ℕ m k)
-      ( H)
-      ( commutative-add-ℕ k n))
+  reflects-leq-right-add-ℕ :
+    (k m n : ℕ) → (k +ℕ m) ≤-ℕ (k +ℕ n) → m ≤-ℕ n
+  reflects-leq-right-add-ℕ k m n H =
+    reflects-leq-left-add-ℕ k m n
+      ( concatenate-eq-leq-eq-ℕ
+        ( commutative-add-ℕ m k)
+        ( H)
+        ( commutative-add-ℕ k n))
 ```
 
 ### `m ≤ m + n` for any two natural numbers `m` and `n`
 
 ```agda
-leq-add-ℕ : (m n : ℕ) → m ≤-ℕ (m +ℕ n)
-leq-add-ℕ m zero-ℕ = refl-leq-ℕ m
-leq-add-ℕ m (succ-ℕ n) =
-  transitive-leq-ℕ
-    ( m)
-    ( m +ℕ n)
-    ( succ-ℕ (m +ℕ n))
-    ( succ-leq-ℕ (m +ℕ n))
-    ( leq-add-ℕ m n)
+abstract
+  leq-add-ℕ : (m n : ℕ) → m ≤-ℕ (m +ℕ n)
+  leq-add-ℕ m zero-ℕ = refl-leq-ℕ m
+  leq-add-ℕ m (succ-ℕ n) =
+    transitive-leq-ℕ
+      ( m)
+      ( m +ℕ n)
+      ( succ-ℕ (m +ℕ n))
+      ( succ-leq-ℕ (m +ℕ n))
+      ( leq-add-ℕ m n)
 
-leq-add-ℕ' : (m n : ℕ) → m ≤-ℕ (n +ℕ m)
-leq-add-ℕ' m n =
-  concatenate-leq-eq-ℕ m (leq-add-ℕ m n) (commutative-add-ℕ m n)
+  leq-add-ℕ' : (m n : ℕ) → m ≤-ℕ (n +ℕ m)
+  leq-add-ℕ' m n =
+    concatenate-leq-eq-ℕ m (leq-add-ℕ m n) (commutative-add-ℕ m n)
 ```
 
 ### We have `n ≤ m` if and only if there is a number `l` such that `l+n=m`
@@ -380,85 +390,88 @@ leq-subtraction-ℕ (succ-ℕ n) (succ-ℕ m) l p =
 ### Multiplication preserves inequality of natural numbers
 
 ```agda
-preserves-leq-left-mul-ℕ :
-  (k m n : ℕ) → m ≤-ℕ n → (m *ℕ k) ≤-ℕ (n *ℕ k)
-preserves-leq-left-mul-ℕ k zero-ℕ n p = star
-preserves-leq-left-mul-ℕ k (succ-ℕ m) (succ-ℕ n) p =
-  preserves-leq-left-add-ℕ k
-    ( m *ℕ k)
-    ( n *ℕ k)
-    ( preserves-leq-left-mul-ℕ k m n p)
+abstract
+  preserves-leq-left-mul-ℕ :
+    (k m n : ℕ) → m ≤-ℕ n → (m *ℕ k) ≤-ℕ (n *ℕ k)
+  preserves-leq-left-mul-ℕ k zero-ℕ n p = star
+  preserves-leq-left-mul-ℕ k (succ-ℕ m) (succ-ℕ n) p =
+    preserves-leq-left-add-ℕ k
+      ( m *ℕ k)
+      ( n *ℕ k)
+      ( preserves-leq-left-mul-ℕ k m n p)
 
-preserves-leq-right-mul-ℕ :
-  (k m n : ℕ) → m ≤-ℕ n → (k *ℕ m) ≤-ℕ (k *ℕ n)
-preserves-leq-right-mul-ℕ k m n H =
-  concatenate-eq-leq-eq-ℕ
-    ( commutative-mul-ℕ k m)
-    ( preserves-leq-left-mul-ℕ k m n H)
-    ( commutative-mul-ℕ n k)
+  preserves-leq-right-mul-ℕ :
+    (k m n : ℕ) → m ≤-ℕ n → (k *ℕ m) ≤-ℕ (k *ℕ n)
+  preserves-leq-right-mul-ℕ k m n H =
+    concatenate-eq-leq-eq-ℕ
+      ( commutative-mul-ℕ k m)
+      ( preserves-leq-left-mul-ℕ k m n H)
+      ( commutative-mul-ℕ n k)
 
-preserves-leq-mul-ℕ :
-  (m m' n n' : ℕ) → m ≤-ℕ m' → n ≤-ℕ n' → (m *ℕ n) ≤-ℕ (m' *ℕ n')
-preserves-leq-mul-ℕ m m' n n' H K =
-  transitive-leq-ℕ
-    ( m *ℕ n)
-    ( m' *ℕ n)
-    ( m' *ℕ n')
-    ( preserves-leq-right-mul-ℕ m' n n' K)
-    ( preserves-leq-left-mul-ℕ n m m' H)
+  preserves-leq-mul-ℕ :
+    (m m' n n' : ℕ) → m ≤-ℕ m' → n ≤-ℕ n' → (m *ℕ n) ≤-ℕ (m' *ℕ n')
+  preserves-leq-mul-ℕ m m' n n' H K =
+    transitive-leq-ℕ
+      ( m *ℕ n)
+      ( m' *ℕ n)
+      ( m' *ℕ n')
+      ( preserves-leq-right-mul-ℕ m' n n' K)
+      ( preserves-leq-left-mul-ℕ n m m' H)
 ```
 
 ### Multiplication by a nonzero natural number reflects inequality of natural numbers
 
 ```agda
-reflects-order-mul-ℕ :
-  (k m n : ℕ) → (m *ℕ (succ-ℕ k)) ≤-ℕ (n *ℕ (succ-ℕ k)) → m ≤-ℕ n
-reflects-order-mul-ℕ k zero-ℕ n p = star
-reflects-order-mul-ℕ k (succ-ℕ m) (succ-ℕ n) p =
-  reflects-order-mul-ℕ k m n
-    ( reflects-leq-left-add-ℕ
-      ( succ-ℕ k)
-      ( m *ℕ (succ-ℕ k))
-      ( n *ℕ (succ-ℕ k))
-      ( p))
+abstract
+  reflects-order-mul-ℕ :
+    (k m n : ℕ) → (m *ℕ (succ-ℕ k)) ≤-ℕ (n *ℕ (succ-ℕ k)) → m ≤-ℕ n
+  reflects-order-mul-ℕ k zero-ℕ n p = star
+  reflects-order-mul-ℕ k (succ-ℕ m) (succ-ℕ n) p =
+    reflects-order-mul-ℕ k m n
+      ( reflects-leq-left-add-ℕ
+        ( succ-ℕ k)
+        ( m *ℕ (succ-ℕ k))
+        ( n *ℕ (succ-ℕ k))
+        ( p))
 
-reflects-order-mul-ℕ' :
-  (k m n : ℕ) → ((succ-ℕ k) *ℕ m) ≤-ℕ ((succ-ℕ k) *ℕ n) → m ≤-ℕ n
-reflects-order-mul-ℕ' k m n H =
-  reflects-order-mul-ℕ k m n
-    ( concatenate-eq-leq-eq-ℕ
-      ( commutative-mul-ℕ m (succ-ℕ k))
-      ( H)
-      ( commutative-mul-ℕ (succ-ℕ k) n))
+  reflects-order-mul-ℕ' :
+    (k m n : ℕ) → ((succ-ℕ k) *ℕ m) ≤-ℕ ((succ-ℕ k) *ℕ n) → m ≤-ℕ n
+  reflects-order-mul-ℕ' k m n H =
+    reflects-order-mul-ℕ k m n
+      ( concatenate-eq-leq-eq-ℕ
+        ( commutative-mul-ℕ m (succ-ℕ k))
+        ( H)
+        ( commutative-mul-ℕ (succ-ℕ k) n))
 ```
 
 ### Any number `x` is less than or equal to a nonzero multiple of itself
 
 ```agda
-leq-mul-ℕ :
-  (k x : ℕ) → x ≤-ℕ (x *ℕ (succ-ℕ k))
-leq-mul-ℕ k x =
-  concatenate-eq-leq-ℕ
-    ( x *ℕ (succ-ℕ k))
-    ( inv (right-unit-law-mul-ℕ x))
-    ( preserves-leq-right-mul-ℕ x 1 (succ-ℕ k) (leq-zero-ℕ k))
+abstract
+  leq-mul-ℕ :
+    (k x : ℕ) → x ≤-ℕ (x *ℕ (succ-ℕ k))
+  leq-mul-ℕ k x =
+    concatenate-eq-leq-ℕ
+      ( x *ℕ (succ-ℕ k))
+      ( inv (right-unit-law-mul-ℕ x))
+      ( preserves-leq-right-mul-ℕ x 1 (succ-ℕ k) (leq-zero-ℕ k))
 
-leq-mul-ℕ' :
-  (k x : ℕ) → x ≤-ℕ ((succ-ℕ k) *ℕ x)
-leq-mul-ℕ' k x =
-  concatenate-leq-eq-ℕ x
-    ( leq-mul-ℕ k x)
-    ( commutative-mul-ℕ x (succ-ℕ k))
+  leq-mul-ℕ' :
+    (k x : ℕ) → x ≤-ℕ ((succ-ℕ k) *ℕ x)
+  leq-mul-ℕ' k x =
+    concatenate-leq-eq-ℕ x
+      ( leq-mul-ℕ k x)
+      ( commutative-mul-ℕ x (succ-ℕ k))
 
-leq-mul-is-nonzero-ℕ :
-  (k x : ℕ) → is-nonzero-ℕ k → x ≤-ℕ (x *ℕ k)
-leq-mul-is-nonzero-ℕ k x H with is-successor-is-nonzero-ℕ H
-... | (l , refl) = leq-mul-ℕ l x
+  leq-mul-is-nonzero-ℕ :
+    (k x : ℕ) → is-nonzero-ℕ k → x ≤-ℕ (x *ℕ k)
+  leq-mul-is-nonzero-ℕ k x H with is-successor-is-nonzero-ℕ H
+  ... | (l , refl) = leq-mul-ℕ l x
 
-leq-mul-is-nonzero-ℕ' :
-  (k x : ℕ) → is-nonzero-ℕ k → x ≤-ℕ (k *ℕ x)
-leq-mul-is-nonzero-ℕ' k x H with is-successor-is-nonzero-ℕ H
-... | (l , refl) = leq-mul-ℕ' l x
+  leq-mul-is-nonzero-ℕ' :
+    (k x : ℕ) → is-nonzero-ℕ k → x ≤-ℕ (k *ℕ x)
+  leq-mul-is-nonzero-ℕ' k x H with is-successor-is-nonzero-ℕ H
+  ... | (l , refl) = leq-mul-ℕ' l x
 ```
 
 ## See also

--- a/src/elementary-number-theory/inequality-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/inequality-standard-finite-types.lagda.md
@@ -31,6 +31,13 @@ open import univalent-combinatorics.standard-finite-types
 
 </details>
 
+## Idea
+
+Inequality on the
+[standard finite types](univalent-combinatorics.standard-finite-types.md) is
+defined inductively with the rules that all elements of `Fin (succ-ℕ n)` are
+`≤ neg-one-Fin n`, and otherwise `inl-Fin a ≤ inl-Fin b` if `a ≤ b`.
+
 ## Definitions
 
 ```agda
@@ -50,63 +57,40 @@ abstract
 leq-Fin-Prop : (k : ℕ) → Fin k → Fin k → Prop lzero
 pr1 (leq-Fin-Prop k x y) = leq-Fin k x y
 pr2 (leq-Fin-Prop k x y) = is-prop-leq-Fin k x y
+```
 
+## Properties
+
+### For all `k : Fin (succ-ℕ n)`, `k ≤ neg-one-Fin n`
+
+```agda
 leq-neg-one-Fin :
   (k : ℕ) (x : Fin (succ-ℕ k)) → leq-Fin (succ-ℕ k) x (neg-one-Fin k)
 leq-neg-one-Fin k x = star
-
-refl-leq-Fin : (k : ℕ) → is-reflexive (leq-Fin k)
-refl-leq-Fin (succ-ℕ k) (inl x) = refl-leq-Fin k x
-refl-leq-Fin (succ-ℕ k) (inr star) = star
-
-antisymmetric-leq-Fin :
-  (k : ℕ) (x y : Fin k) → leq-Fin k x y → leq-Fin k y x → x ＝ y
-antisymmetric-leq-Fin (succ-ℕ k) (inl x) (inl y) H K =
-  ap inl (antisymmetric-leq-Fin k x y H K)
-antisymmetric-leq-Fin (succ-ℕ k) (inr star) (inr star) H K = refl
-
-transitive-leq-Fin :
-  (k : ℕ) → is-transitive (leq-Fin k)
-transitive-leq-Fin (succ-ℕ k) (inl x) (inl y) (inl z) H K =
-  transitive-leq-Fin k x y z H K
-transitive-leq-Fin (succ-ℕ k) (inl x) (inl y) (inr star) H K = star
-transitive-leq-Fin (succ-ℕ k) (inl x) (inr star) (inr star) H K = star
-transitive-leq-Fin (succ-ℕ k) (inr star) (inr star) (inr star) H K = star
-
-concatenate-eq-leq-eq-Fin :
-  (k : ℕ) {x1 x2 x3 x4 : Fin k} →
-  x1 ＝ x2 → leq-Fin k x2 x3 → x3 ＝ x4 → leq-Fin k x1 x4
-concatenate-eq-leq-eq-Fin k refl H refl = H
-
-leq-succ-Fin :
-  (k : ℕ) (x : Fin k) →
-  leq-Fin (succ-ℕ k) (inl-Fin k x) (succ-Fin (succ-ℕ k) (inl-Fin k x))
-leq-succ-Fin (succ-ℕ k) (inl x) = leq-succ-Fin k x
-leq-succ-Fin (succ-ℕ k) (inr star) = star
-
-preserves-leq-nat-Fin :
-  (k : ℕ) {x y : Fin k} → leq-Fin k x y → leq-ℕ (nat-Fin k x) (nat-Fin k y)
-preserves-leq-nat-Fin (succ-ℕ k) {inl x} {inl y} H =
-  preserves-leq-nat-Fin k H
-preserves-leq-nat-Fin (succ-ℕ k) {inl x} {inr star} H =
-  leq-le-ℕ (nat-Fin k x) k (strict-upper-bound-nat-Fin k x)
-preserves-leq-nat-Fin (succ-ℕ k) {inr star} {inr star} H =
-  refl-leq-ℕ k
-
-reflects-leq-nat-Fin :
-  (k : ℕ) {x y : Fin k} → leq-ℕ (nat-Fin k x) (nat-Fin k y) → leq-Fin k x y
-reflects-leq-nat-Fin (succ-ℕ k) {inl x} {inl y} H =
-  reflects-leq-nat-Fin k H
-reflects-leq-nat-Fin (succ-ℕ k) {inr star} {inl y} H =
-  ex-falso
-    ( contradiction-le-ℕ (nat-Fin k y) k (strict-upper-bound-nat-Fin k y) H)
-reflects-leq-nat-Fin (succ-ℕ k) {inl x} {inr star} H = star
-reflects-leq-nat-Fin (succ-ℕ k) {inr star} {inr star} H = star
 ```
 
-### The partial order on the standard finite types
+### Inequality on the standard finite types is a partial order
 
 ```agda
+abstract
+  refl-leq-Fin : (k : ℕ) → is-reflexive (leq-Fin k)
+  refl-leq-Fin (succ-ℕ k) (inl x) = refl-leq-Fin k x
+  refl-leq-Fin (succ-ℕ k) (inr star) = star
+
+  antisymmetric-leq-Fin :
+    (k : ℕ) (x y : Fin k) → leq-Fin k x y → leq-Fin k y x → x ＝ y
+  antisymmetric-leq-Fin (succ-ℕ k) (inl x) (inl y) H K =
+    ap inl (antisymmetric-leq-Fin k x y H K)
+  antisymmetric-leq-Fin (succ-ℕ k) (inr star) (inr star) H K = refl
+
+  transitive-leq-Fin :
+    (k : ℕ) → is-transitive (leq-Fin k)
+  transitive-leq-Fin (succ-ℕ k) (inl x) (inl y) (inl z) H K =
+    transitive-leq-Fin k x y z H K
+  transitive-leq-Fin (succ-ℕ k) (inl x) (inl y) (inr star) H K = star
+  transitive-leq-Fin (succ-ℕ k) (inl x) (inr star) (inr star) H K = star
+  transitive-leq-Fin (succ-ℕ k) (inr star) (inr star) (inr star) H K = star
+
 Fin-Preorder : ℕ → Preorder lzero lzero
 pr1 (Fin-Preorder k) = Fin k
 pr1 (pr2 (Fin-Preorder k)) = leq-Fin-Prop k
@@ -118,7 +102,48 @@ pr1 (Fin-Poset k) = Fin-Preorder k
 pr2 (Fin-Poset k) = antisymmetric-leq-Fin k
 ```
 
-## Properties
+### Concatenation laws with equality
+
+```agda
+concatenate-eq-leq-eq-Fin :
+  (k : ℕ) {x1 x2 x3 x4 : Fin k} →
+  x1 ＝ x2 → leq-Fin k x2 x3 → x3 ＝ x4 → leq-Fin k x1 x4
+concatenate-eq-leq-eq-Fin k refl H refl = H
+```
+
+### `inl-Fin k ≤ succ-Fin (inl-Fin k)`
+
+```agda
+leq-succ-Fin :
+  (k : ℕ) (x : Fin k) →
+  leq-Fin (succ-ℕ k) (inl-Fin k x) (succ-Fin (succ-ℕ k) (inl-Fin k x))
+leq-succ-Fin (succ-ℕ k) (inl x) = leq-succ-Fin k x
+leq-succ-Fin (succ-ℕ k) (inr star) = star
+```
+
+### The canonical embedding of the standard finite types in the natural numbers preserves and reflects inequality
+
+```agda
+abstract
+  preserves-leq-nat-Fin :
+    (k : ℕ) {x y : Fin k} → leq-Fin k x y → leq-ℕ (nat-Fin k x) (nat-Fin k y)
+  preserves-leq-nat-Fin (succ-ℕ k) {inl x} {inl y} H =
+    preserves-leq-nat-Fin k H
+  preserves-leq-nat-Fin (succ-ℕ k) {inl x} {inr star} H =
+    leq-le-ℕ (nat-Fin k x) k (strict-upper-bound-nat-Fin k x)
+  preserves-leq-nat-Fin (succ-ℕ k) {inr star} {inr star} H =
+    refl-leq-ℕ k
+
+  reflects-leq-nat-Fin :
+    (k : ℕ) {x y : Fin k} → leq-ℕ (nat-Fin k x) (nat-Fin k y) → leq-Fin k x y
+  reflects-leq-nat-Fin (succ-ℕ k) {inl x} {inl y} H =
+    reflects-leq-nat-Fin k H
+  reflects-leq-nat-Fin (succ-ℕ k) {inr star} {inl y} H =
+    ex-falso
+      ( contradiction-le-ℕ (nat-Fin k y) k (strict-upper-bound-nat-Fin k y) H)
+  reflects-leq-nat-Fin (succ-ℕ k) {inl x} {inr star} H = star
+  reflects-leq-nat-Fin (succ-ℕ k) {inr star} {inr star} H = star
+```
 
 ### Ordering on the standard finite types is decidable
 

--- a/src/elementary-number-theory/integers.lagda.md
+++ b/src/elementary-number-theory/integers.lagda.md
@@ -21,6 +21,7 @@ open import foundation.function-types
 open import foundation.homotopies
 open import foundation.identity-types
 open import foundation.injective-maps
+open import foundation.involutions
 open import foundation.negated-equality
 open import foundation.negation
 open import foundation.propositions
@@ -185,10 +186,8 @@ abstract
 
 abstract
   is-equiv-succ-ℤ : is-equiv succ-ℤ
-  pr1 (pr1 is-equiv-succ-ℤ) = pred-ℤ
-  pr2 (pr1 is-equiv-succ-ℤ) = is-section-pred-ℤ
-  pr1 (pr2 is-equiv-succ-ℤ) = pred-ℤ
-  pr2 (pr2 is-equiv-succ-ℤ) = is-retraction-pred-ℤ
+  is-equiv-succ-ℤ =
+    is-equiv-is-invertible pred-ℤ is-section-pred-ℤ is-retraction-pred-ℤ
 
 equiv-succ-ℤ : ℤ ≃ ℤ
 pr1 equiv-succ-ℤ = succ-ℤ
@@ -196,10 +195,8 @@ pr2 equiv-succ-ℤ = is-equiv-succ-ℤ
 
 abstract
   is-equiv-pred-ℤ : is-equiv pred-ℤ
-  pr1 (pr1 is-equiv-pred-ℤ) = succ-ℤ
-  pr2 (pr1 is-equiv-pred-ℤ) = is-retraction-pred-ℤ
-  pr1 (pr2 is-equiv-pred-ℤ) = succ-ℤ
-  pr2 (pr2 is-equiv-pred-ℤ) = is-section-pred-ℤ
+  is-equiv-pred-ℤ =
+    is-equiv-is-invertible succ-ℤ is-retraction-pred-ℤ is-section-pred-ℤ
 
 equiv-pred-ℤ : ℤ ≃ ℤ
 pr1 equiv-pred-ℤ = pred-ℤ
@@ -211,8 +208,7 @@ pr2 equiv-pred-ℤ = is-equiv-pred-ℤ
 ```agda
 abstract
   is-injective-succ-ℤ : is-injective succ-ℤ
-  is-injective-succ-ℤ {x} {y} p =
-    inv (is-retraction-pred-ℤ x) ∙ ap pred-ℤ p ∙ is-retraction-pred-ℤ y
+  is-injective-succ-ℤ = is-injective-is-equiv is-equiv-succ-ℤ
 
   has-no-fixed-points-succ-ℤ : (x : ℤ) → succ-ℤ x ≠ x
   has-no-fixed-points-succ-ℤ (inl zero-ℕ) ()
@@ -220,7 +216,7 @@ abstract
   has-no-fixed-points-succ-ℤ (inr (inl star)) ()
 ```
 
-### The negative function is an involution
+### The negation function is an involution
 
 ```agda
 abstract
@@ -228,18 +224,23 @@ abstract
   neg-neg-ℤ (inl n) = refl
   neg-neg-ℤ (inr (inl star)) = refl
   neg-neg-ℤ (inr (inr n)) = refl
+```
 
+### The negation function is an equivalence
+
+```agda
 abstract
   is-equiv-neg-ℤ : is-equiv neg-ℤ
-  pr1 (pr1 is-equiv-neg-ℤ) = neg-ℤ
-  pr2 (pr1 is-equiv-neg-ℤ) = neg-neg-ℤ
-  pr1 (pr2 is-equiv-neg-ℤ) = neg-ℤ
-  pr2 (pr2 is-equiv-neg-ℤ) = neg-neg-ℤ
+  is-equiv-neg-ℤ = is-equiv-is-involution neg-neg-ℤ
 
 equiv-neg-ℤ : ℤ ≃ ℤ
 pr1 equiv-neg-ℤ = neg-ℤ
 pr2 equiv-neg-ℤ = is-equiv-neg-ℤ
+```
 
+### The negation function is an embedding
+
+```agda
 abstract
   is-emb-neg-ℤ : is-emb neg-ℤ
   is-emb-neg-ℤ = is-emb-is-equiv is-equiv-neg-ℤ
@@ -247,20 +248,34 @@ abstract
 emb-neg-ℤ : ℤ ↪ ℤ
 pr1 emb-neg-ℤ = neg-ℤ
 pr2 emb-neg-ℤ = is-emb-neg-ℤ
+```
 
+### The negation of the predecessor of `x` is the successor of the negation of `x`
+
+```agda
 abstract
   neg-pred-ℤ : (k : ℤ) → neg-ℤ (pred-ℤ k) ＝ succ-ℤ (neg-ℤ k)
   neg-pred-ℤ (inl x) = refl
   neg-pred-ℤ (inr (inl star)) = refl
   neg-pred-ℤ (inr (inr zero-ℕ)) = refl
   neg-pred-ℤ (inr (inr (succ-ℕ x))) = refl
+```
 
+### The negation of the successor of `x` is the predecessor of the negation of `x`
+
+```agda
+abstract
   neg-succ-ℤ : (x : ℤ) → neg-ℤ (succ-ℤ x) ＝ pred-ℤ (neg-ℤ x)
   neg-succ-ℤ (inl zero-ℕ) = refl
   neg-succ-ℤ (inl (succ-ℕ x)) = refl
   neg-succ-ℤ (inr (inl star)) = refl
   neg-succ-ℤ (inr (inr x)) = refl
+```
 
+### The predecessor of the negation of `x` is the negation of the successor of `x`
+
+```agda
+abstract
   pred-neg-ℤ :
     (k : ℤ) → pred-ℤ (neg-ℤ k) ＝ neg-ℤ (succ-ℤ k)
   pred-neg-ℤ (inl zero-ℕ) = refl
@@ -269,12 +284,12 @@ abstract
   pred-neg-ℤ (inr (inr x)) = refl
 ```
 
-### The negative function is injective
+### The negation function is injective
 
 ```agda
 abstract
   is-injective-neg-ℤ : is-injective neg-ℤ
-  is-injective-neg-ℤ {x} {y} p = inv (neg-neg-ℤ x) ∙ ap neg-ℤ p ∙ neg-neg-ℤ y
+  is-injective-neg-ℤ = is-injective-is-equiv is-equiv-neg-ℤ
 ```
 
 ### The integer successor of a natural number is the successor of the natural number

--- a/src/elementary-number-theory/lower-bounds-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/lower-bounds-natural-numbers.lagda.md
@@ -26,16 +26,18 @@ open import foundation.universe-levels
 
 ## Idea
 
-A lower bound for a type family `P` over the natural numbers is a natural number
-`n` such that `P x → n ≤ x` for all `x : ℕ`.
+A
+{{#concept "lower bound" Disambiguation="for a type family over ℕ" Agda=is-lower-bound-ℕ}}
+for a type family `P` over the
+[natural numbers](elementary-number-theory.natural-numbers.md) is a natural
+number `n` such that `P x → n ≤ x` for all `x : ℕ`.
 
 ## Definition
 
 ```agda
 is-lower-bound-ℕ :
   {l : Level} (P : ℕ → UU l) (n : ℕ) → UU l
-is-lower-bound-ℕ P n =
-  (m : ℕ) → P m → leq-ℕ n m
+is-lower-bound-ℕ P n = (m : ℕ) → P m → leq-ℕ n m
 ```
 
 ## Properties

--- a/src/elementary-number-theory/maximum-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/maximum-natural-numbers.lagda.md
@@ -57,51 +57,52 @@ max-Fin-ℕ (succ-ℕ n) f = max-ℕ (f (inr star)) (max-Fin-ℕ n (λ k → f (
 
 ## Properties
 
-### Maximum is a least upper bound
+### The maximum is a least upper bound
 
 ```agda
-leq-max-ℕ :
-  (k m n : ℕ) → m ≤-ℕ k → n ≤-ℕ k → (max-ℕ m n) ≤-ℕ k
-leq-max-ℕ zero-ℕ zero-ℕ zero-ℕ H K = star
-leq-max-ℕ (succ-ℕ k) zero-ℕ zero-ℕ H K = star
-leq-max-ℕ (succ-ℕ k) zero-ℕ (succ-ℕ n) H K = K
-leq-max-ℕ (succ-ℕ k) (succ-ℕ m) zero-ℕ H K = H
-leq-max-ℕ (succ-ℕ k) (succ-ℕ m) (succ-ℕ n) H K = leq-max-ℕ k m n H K
+abstract
+  leq-max-ℕ :
+    (k m n : ℕ) → m ≤-ℕ k → n ≤-ℕ k → (max-ℕ m n) ≤-ℕ k
+  leq-max-ℕ zero-ℕ zero-ℕ zero-ℕ H K = star
+  leq-max-ℕ (succ-ℕ k) zero-ℕ zero-ℕ H K = star
+  leq-max-ℕ (succ-ℕ k) zero-ℕ (succ-ℕ n) H K = K
+  leq-max-ℕ (succ-ℕ k) (succ-ℕ m) zero-ℕ H K = H
+  leq-max-ℕ (succ-ℕ k) (succ-ℕ m) (succ-ℕ n) H K = leq-max-ℕ k m n H K
 
-leq-left-leq-max-ℕ :
-  (k m n : ℕ) → (max-ℕ m n) ≤-ℕ k → m ≤-ℕ k
-leq-left-leq-max-ℕ k zero-ℕ zero-ℕ H = star
-leq-left-leq-max-ℕ k zero-ℕ (succ-ℕ n) H = star
-leq-left-leq-max-ℕ k (succ-ℕ m) zero-ℕ H = H
-leq-left-leq-max-ℕ (succ-ℕ k) (succ-ℕ m) (succ-ℕ n) H =
-  leq-left-leq-max-ℕ k m n H
+  leq-left-leq-max-ℕ :
+    (k m n : ℕ) → (max-ℕ m n) ≤-ℕ k → m ≤-ℕ k
+  leq-left-leq-max-ℕ k zero-ℕ zero-ℕ H = star
+  leq-left-leq-max-ℕ k zero-ℕ (succ-ℕ n) H = star
+  leq-left-leq-max-ℕ k (succ-ℕ m) zero-ℕ H = H
+  leq-left-leq-max-ℕ (succ-ℕ k) (succ-ℕ m) (succ-ℕ n) H =
+    leq-left-leq-max-ℕ k m n H
 
-leq-right-leq-max-ℕ :
-  (k m n : ℕ) → (max-ℕ m n) ≤-ℕ k → n ≤-ℕ k
-leq-right-leq-max-ℕ k zero-ℕ zero-ℕ H = star
-leq-right-leq-max-ℕ k zero-ℕ (succ-ℕ n) H = H
-leq-right-leq-max-ℕ k (succ-ℕ m) zero-ℕ H = star
-leq-right-leq-max-ℕ (succ-ℕ k) (succ-ℕ m) (succ-ℕ n) H =
-  leq-right-leq-max-ℕ k m n H
+  leq-right-leq-max-ℕ :
+    (k m n : ℕ) → (max-ℕ m n) ≤-ℕ k → n ≤-ℕ k
+  leq-right-leq-max-ℕ k zero-ℕ zero-ℕ H = star
+  leq-right-leq-max-ℕ k zero-ℕ (succ-ℕ n) H = H
+  leq-right-leq-max-ℕ k (succ-ℕ m) zero-ℕ H = star
+  leq-right-leq-max-ℕ (succ-ℕ k) (succ-ℕ m) (succ-ℕ n) H =
+    leq-right-leq-max-ℕ k m n H
 
-left-leq-max-ℕ : (m n : ℕ) → leq-ℕ m (max-ℕ m n)
-left-leq-max-ℕ m n =
-  leq-left-leq-max-ℕ (max-ℕ m n) m n (refl-leq-ℕ (max-ℕ m n))
+  left-leq-max-ℕ : (m n : ℕ) → leq-ℕ m (max-ℕ m n)
+  left-leq-max-ℕ m n =
+    leq-left-leq-max-ℕ (max-ℕ m n) m n (refl-leq-ℕ (max-ℕ m n))
 
-right-leq-max-ℕ : (m n : ℕ) → leq-ℕ n (max-ℕ m n)
-right-leq-max-ℕ m n =
-  leq-right-leq-max-ℕ (max-ℕ m n) m n (refl-leq-ℕ (max-ℕ m n))
+  right-leq-max-ℕ : (m n : ℕ) → leq-ℕ n (max-ℕ m n)
+  right-leq-max-ℕ m n =
+    leq-right-leq-max-ℕ (max-ℕ m n) m n (refl-leq-ℕ (max-ℕ m n))
 
-is-least-upper-bound-max-ℕ :
-  (m n : ℕ) → is-least-binary-upper-bound-Poset ℕ-Poset m n (max-ℕ m n)
-is-least-upper-bound-max-ℕ m n =
-  prove-is-least-binary-upper-bound-Poset
-    ( ℕ-Poset)
-    { m}
-    { n}
-    { max-ℕ m n}
-    ( left-leq-max-ℕ m n , right-leq-max-ℕ m n)
-    ( λ x (H , K) → leq-max-ℕ x m n H K)
+  is-least-upper-bound-max-ℕ :
+    (m n : ℕ) → is-least-binary-upper-bound-Poset ℕ-Poset m n (max-ℕ m n)
+  is-least-upper-bound-max-ℕ m n =
+    prove-is-least-binary-upper-bound-Poset
+      ( ℕ-Poset)
+      { m}
+      { n}
+      { max-ℕ m n}
+      ( left-leq-max-ℕ m n , right-leq-max-ℕ m n)
+      ( λ x (H , K) → leq-max-ℕ x m n H K)
 ```
 
 ### The maximum computes to the greater of the two numbers
@@ -127,14 +128,15 @@ abstract
 ### Associativity of `max-ℕ`
 
 ```agda
-associative-max-ℕ :
-  (x y z : ℕ) → max-ℕ (max-ℕ x y) z ＝ max-ℕ x (max-ℕ y z)
-associative-max-ℕ zero-ℕ y z = refl
-associative-max-ℕ (succ-ℕ x) zero-ℕ zero-ℕ = refl
-associative-max-ℕ (succ-ℕ x) zero-ℕ (succ-ℕ z) = refl
-associative-max-ℕ (succ-ℕ x) (succ-ℕ y) zero-ℕ = refl
-associative-max-ℕ (succ-ℕ x) (succ-ℕ y) (succ-ℕ z) =
-  ap succ-ℕ (associative-max-ℕ x y z)
+abstract
+  associative-max-ℕ :
+    (x y z : ℕ) → max-ℕ (max-ℕ x y) z ＝ max-ℕ x (max-ℕ y z)
+  associative-max-ℕ zero-ℕ y z = refl
+  associative-max-ℕ (succ-ℕ x) zero-ℕ zero-ℕ = refl
+  associative-max-ℕ (succ-ℕ x) zero-ℕ (succ-ℕ z) = refl
+  associative-max-ℕ (succ-ℕ x) (succ-ℕ y) zero-ℕ = refl
+  associative-max-ℕ (succ-ℕ x) (succ-ℕ y) (succ-ℕ z) =
+    ap succ-ℕ (associative-max-ℕ x y z)
 ```
 
 ### Unit laws for `max-ℕ`
@@ -151,54 +153,58 @@ right-unit-law-max-ℕ (succ-ℕ x) = refl
 ### Commutativity of `max-ℕ`
 
 ```agda
-commutative-max-ℕ : (x y : ℕ) → max-ℕ x y ＝ max-ℕ y x
-commutative-max-ℕ zero-ℕ zero-ℕ = refl
-commutative-max-ℕ zero-ℕ (succ-ℕ y) = refl
-commutative-max-ℕ (succ-ℕ x) zero-ℕ = refl
-commutative-max-ℕ (succ-ℕ x) (succ-ℕ y) = ap succ-ℕ (commutative-max-ℕ x y)
+abstract
+  commutative-max-ℕ : (x y : ℕ) → max-ℕ x y ＝ max-ℕ y x
+  commutative-max-ℕ zero-ℕ zero-ℕ = refl
+  commutative-max-ℕ zero-ℕ (succ-ℕ y) = refl
+  commutative-max-ℕ (succ-ℕ x) zero-ℕ = refl
+  commutative-max-ℕ (succ-ℕ x) (succ-ℕ y) = ap succ-ℕ (commutative-max-ℕ x y)
 ```
 
 ### `max-ℕ` is idempotent
 
 ```agda
-idempotent-max-ℕ : (x : ℕ) → max-ℕ x x ＝ x
-idempotent-max-ℕ zero-ℕ = refl
-idempotent-max-ℕ (succ-ℕ x) = ap succ-ℕ (idempotent-max-ℕ x)
+abstract
+  idempotent-max-ℕ : (x : ℕ) → max-ℕ x x ＝ x
+  idempotent-max-ℕ zero-ℕ = refl
+  idempotent-max-ℕ (succ-ℕ x) = ap succ-ℕ (idempotent-max-ℕ x)
 ```
 
 ### Successor diagonal laws for `max-ℕ`
 
 ```agda
-left-successor-diagonal-law-max-ℕ : (x : ℕ) → max-ℕ (succ-ℕ x) x ＝ succ-ℕ x
-left-successor-diagonal-law-max-ℕ zero-ℕ = refl
-left-successor-diagonal-law-max-ℕ (succ-ℕ x) =
-  ap succ-ℕ (left-successor-diagonal-law-max-ℕ x)
+abstract
+  left-successor-diagonal-law-max-ℕ : (x : ℕ) → max-ℕ (succ-ℕ x) x ＝ succ-ℕ x
+  left-successor-diagonal-law-max-ℕ zero-ℕ = refl
+  left-successor-diagonal-law-max-ℕ (succ-ℕ x) =
+    ap succ-ℕ (left-successor-diagonal-law-max-ℕ x)
 
-right-successor-diagonal-law-max-ℕ : (x : ℕ) → max-ℕ x (succ-ℕ x) ＝ succ-ℕ x
-right-successor-diagonal-law-max-ℕ zero-ℕ = refl
-right-successor-diagonal-law-max-ℕ (succ-ℕ x) =
-  ap succ-ℕ (right-successor-diagonal-law-max-ℕ x)
+  right-successor-diagonal-law-max-ℕ : (x : ℕ) → max-ℕ x (succ-ℕ x) ＝ succ-ℕ x
+  right-successor-diagonal-law-max-ℕ zero-ℕ = refl
+  right-successor-diagonal-law-max-ℕ (succ-ℕ x) =
+    ap succ-ℕ (right-successor-diagonal-law-max-ℕ x)
 ```
 
 ### Addition distributes over `max-ℕ`
 
 ```agda
-left-distributive-add-max-ℕ :
-  (x y z : ℕ) → x +ℕ (max-ℕ y z) ＝ max-ℕ (x +ℕ y) (x +ℕ z)
-left-distributive-add-max-ℕ zero-ℕ y z =
-  ( left-unit-law-add-ℕ (max-ℕ y z)) ∙
-  ( ap-max-ℕ (inv (left-unit-law-add-ℕ y)) (inv (left-unit-law-add-ℕ z)))
-left-distributive-add-max-ℕ (succ-ℕ x) y z =
-  ( left-successor-law-add-ℕ x (max-ℕ y z)) ∙
-  ( ( ap succ-ℕ (left-distributive-add-max-ℕ x y z)) ∙
-    ( ap-max-ℕ
-      ( inv (left-successor-law-add-ℕ x y))
-      ( inv (left-successor-law-add-ℕ x z))))
+abstract
+  left-distributive-add-max-ℕ :
+    (x y z : ℕ) → x +ℕ (max-ℕ y z) ＝ max-ℕ (x +ℕ y) (x +ℕ z)
+  left-distributive-add-max-ℕ zero-ℕ y z =
+    ( left-unit-law-add-ℕ (max-ℕ y z)) ∙
+    ( ap-max-ℕ (inv (left-unit-law-add-ℕ y)) (inv (left-unit-law-add-ℕ z)))
+  left-distributive-add-max-ℕ (succ-ℕ x) y z =
+    ( left-successor-law-add-ℕ x (max-ℕ y z)) ∙
+    ( ( ap succ-ℕ (left-distributive-add-max-ℕ x y z)) ∙
+      ( ap-max-ℕ
+        ( inv (left-successor-law-add-ℕ x y))
+        ( inv (left-successor-law-add-ℕ x z))))
 
-right-distributive-add-max-ℕ :
-  (x y z : ℕ) → (max-ℕ x y) +ℕ z ＝ max-ℕ (x +ℕ z) (y +ℕ z)
-right-distributive-add-max-ℕ x y z =
-  ( commutative-add-ℕ (max-ℕ x y) z) ∙
-  ( ( left-distributive-add-max-ℕ z x y) ∙
-    ( ap-max-ℕ (commutative-add-ℕ z x) (commutative-add-ℕ z y)))
+  right-distributive-add-max-ℕ :
+    (x y z : ℕ) → (max-ℕ x y) +ℕ z ＝ max-ℕ (x +ℕ z) (y +ℕ z)
+  right-distributive-add-max-ℕ x y z =
+    ( commutative-add-ℕ (max-ℕ x y) z) ∙
+    ( ( left-distributive-add-max-ℕ z x y) ∙
+      ( ap-max-ℕ (commutative-add-ℕ z x) (commutative-add-ℕ z y)))
 ```

--- a/src/elementary-number-theory/minimum-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/minimum-natural-numbers.lagda.md
@@ -52,40 +52,41 @@ min-Fin-ℕ (succ-ℕ n) f = min-ℕ (f (inr star)) (min-Fin-ℕ n (λ k → f (
 ### The minimum of two natural numbers is a greatest lower bound
 
 ```agda
-leq-min-ℕ :
-  (k m n : ℕ) → k ≤-ℕ m → k ≤-ℕ n → k ≤-ℕ (min-ℕ m n)
-leq-min-ℕ zero-ℕ zero-ℕ zero-ℕ H K = star
-leq-min-ℕ zero-ℕ zero-ℕ (succ-ℕ n) H K = star
-leq-min-ℕ zero-ℕ (succ-ℕ m) zero-ℕ H K = star
-leq-min-ℕ zero-ℕ (succ-ℕ m) (succ-ℕ n) H K = star
-leq-min-ℕ (succ-ℕ k) (succ-ℕ m) (succ-ℕ n) H K = leq-min-ℕ k m n H K
+abstract
+  leq-min-ℕ :
+    (k m n : ℕ) → k ≤-ℕ m → k ≤-ℕ n → k ≤-ℕ (min-ℕ m n)
+  leq-min-ℕ zero-ℕ zero-ℕ zero-ℕ H K = star
+  leq-min-ℕ zero-ℕ zero-ℕ (succ-ℕ n) H K = star
+  leq-min-ℕ zero-ℕ (succ-ℕ m) zero-ℕ H K = star
+  leq-min-ℕ zero-ℕ (succ-ℕ m) (succ-ℕ n) H K = star
+  leq-min-ℕ (succ-ℕ k) (succ-ℕ m) (succ-ℕ n) H K = leq-min-ℕ k m n H K
 
-leq-left-leq-min-ℕ :
-  (k m n : ℕ) → k ≤-ℕ (min-ℕ m n) → k ≤-ℕ m
-leq-left-leq-min-ℕ zero-ℕ zero-ℕ zero-ℕ H = star
-leq-left-leq-min-ℕ zero-ℕ zero-ℕ (succ-ℕ n) H = star
-leq-left-leq-min-ℕ zero-ℕ (succ-ℕ m) zero-ℕ H = star
-leq-left-leq-min-ℕ zero-ℕ (succ-ℕ m) (succ-ℕ n) H = star
-leq-left-leq-min-ℕ (succ-ℕ k) (succ-ℕ m) (succ-ℕ n) H =
-  leq-left-leq-min-ℕ k m n H
+  leq-left-leq-min-ℕ :
+    (k m n : ℕ) → k ≤-ℕ (min-ℕ m n) → k ≤-ℕ m
+  leq-left-leq-min-ℕ zero-ℕ zero-ℕ zero-ℕ H = star
+  leq-left-leq-min-ℕ zero-ℕ zero-ℕ (succ-ℕ n) H = star
+  leq-left-leq-min-ℕ zero-ℕ (succ-ℕ m) zero-ℕ H = star
+  leq-left-leq-min-ℕ zero-ℕ (succ-ℕ m) (succ-ℕ n) H = star
+  leq-left-leq-min-ℕ (succ-ℕ k) (succ-ℕ m) (succ-ℕ n) H =
+    leq-left-leq-min-ℕ k m n H
 
-leq-right-leq-min-ℕ :
-  (k m n : ℕ) → k ≤-ℕ (min-ℕ m n) → k ≤-ℕ n
-leq-right-leq-min-ℕ zero-ℕ zero-ℕ zero-ℕ H = star
-leq-right-leq-min-ℕ zero-ℕ zero-ℕ (succ-ℕ n) H = star
-leq-right-leq-min-ℕ zero-ℕ (succ-ℕ m) zero-ℕ H = star
-leq-right-leq-min-ℕ zero-ℕ (succ-ℕ m) (succ-ℕ n) H = star
-leq-right-leq-min-ℕ (succ-ℕ k) (succ-ℕ m) (succ-ℕ n) H =
-  leq-right-leq-min-ℕ k m n H
+  leq-right-leq-min-ℕ :
+    (k m n : ℕ) → k ≤-ℕ (min-ℕ m n) → k ≤-ℕ n
+  leq-right-leq-min-ℕ zero-ℕ zero-ℕ zero-ℕ H = star
+  leq-right-leq-min-ℕ zero-ℕ zero-ℕ (succ-ℕ n) H = star
+  leq-right-leq-min-ℕ zero-ℕ (succ-ℕ m) zero-ℕ H = star
+  leq-right-leq-min-ℕ zero-ℕ (succ-ℕ m) (succ-ℕ n) H = star
+  leq-right-leq-min-ℕ (succ-ℕ k) (succ-ℕ m) (succ-ℕ n) H =
+    leq-right-leq-min-ℕ k m n H
 
-is-greatest-lower-bound-min-ℕ :
-  (l m : ℕ) → is-greatest-binary-lower-bound-Poset ℕ-Poset l m (min-ℕ l m)
-is-greatest-lower-bound-min-ℕ l m =
-  prove-is-greatest-binary-lower-bound-Poset
-    ( ℕ-Poset)
-    ( leq-left-leq-min-ℕ (min-ℕ l m) l m (refl-leq-ℕ (min-ℕ l m)) ,
-      leq-right-leq-min-ℕ (min-ℕ l m) l m (refl-leq-ℕ (min-ℕ l m)))
-    ( λ x (H , K) → leq-min-ℕ x l m H K)
+  is-greatest-lower-bound-min-ℕ :
+    (l m : ℕ) → is-greatest-binary-lower-bound-Poset ℕ-Poset l m (min-ℕ l m)
+  is-greatest-lower-bound-min-ℕ l m =
+    prove-is-greatest-binary-lower-bound-Poset
+      ( ℕ-Poset)
+      ( leq-left-leq-min-ℕ (min-ℕ l m) l m (refl-leq-ℕ (min-ℕ l m)) ,
+        leq-right-leq-min-ℕ (min-ℕ l m) l m (refl-leq-ℕ (min-ℕ l m)))
+      ( λ x (H , K) → leq-min-ℕ x l m H K)
 ```
 
 ### The minimum computes to the lesser of the two numbers
@@ -111,14 +112,15 @@ abstract
 ### Associativity of `min-ℕ`
 
 ```agda
-associative-min-ℕ :
-  (x y z : ℕ) → min-ℕ (min-ℕ x y) z ＝ min-ℕ x (min-ℕ y z)
-associative-min-ℕ zero-ℕ y z = refl
-associative-min-ℕ (succ-ℕ x) zero-ℕ zero-ℕ = refl
-associative-min-ℕ (succ-ℕ x) zero-ℕ (succ-ℕ z) = refl
-associative-min-ℕ (succ-ℕ x) (succ-ℕ y) zero-ℕ = refl
-associative-min-ℕ (succ-ℕ x) (succ-ℕ y) (succ-ℕ z) =
-  ap succ-ℕ (associative-min-ℕ x y z)
+abstract
+  associative-min-ℕ :
+    (x y z : ℕ) → min-ℕ (min-ℕ x y) z ＝ min-ℕ x (min-ℕ y z)
+  associative-min-ℕ zero-ℕ y z = refl
+  associative-min-ℕ (succ-ℕ x) zero-ℕ zero-ℕ = refl
+  associative-min-ℕ (succ-ℕ x) zero-ℕ (succ-ℕ z) = refl
+  associative-min-ℕ (succ-ℕ x) (succ-ℕ y) zero-ℕ = refl
+  associative-min-ℕ (succ-ℕ x) (succ-ℕ y) (succ-ℕ z) =
+    ap succ-ℕ (associative-min-ℕ x y z)
 ```
 
 ### Zero laws for `min-ℕ`
@@ -135,40 +137,43 @@ right-zero-law-min-ℕ (succ-ℕ x) = refl
 ### Commutativity of `min-ℕ`
 
 ```agda
-commutative-min-ℕ : (x y : ℕ) → min-ℕ x y ＝ min-ℕ y x
-commutative-min-ℕ zero-ℕ zero-ℕ = refl
-commutative-min-ℕ zero-ℕ (succ-ℕ y) = refl
-commutative-min-ℕ (succ-ℕ x) zero-ℕ = refl
-commutative-min-ℕ (succ-ℕ x) (succ-ℕ y) = ap succ-ℕ (commutative-min-ℕ x y)
+abstract
+  commutative-min-ℕ : (x y : ℕ) → min-ℕ x y ＝ min-ℕ y x
+  commutative-min-ℕ zero-ℕ zero-ℕ = refl
+  commutative-min-ℕ zero-ℕ (succ-ℕ y) = refl
+  commutative-min-ℕ (succ-ℕ x) zero-ℕ = refl
+  commutative-min-ℕ (succ-ℕ x) (succ-ℕ y) = ap succ-ℕ (commutative-min-ℕ x y)
 ```
 
 ### `min-ℕ` is idempotent
 
 ```agda
-idempotent-min-ℕ : (x : ℕ) → min-ℕ x x ＝ x
-idempotent-min-ℕ zero-ℕ = refl
-idempotent-min-ℕ (succ-ℕ x) = ap succ-ℕ (idempotent-min-ℕ x)
+abstract
+  idempotent-min-ℕ : (x : ℕ) → min-ℕ x x ＝ x
+  idempotent-min-ℕ zero-ℕ = refl
+  idempotent-min-ℕ (succ-ℕ x) = ap succ-ℕ (idempotent-min-ℕ x)
 ```
 
 ### Addition distributes over `min-ℕ`
 
 ```agda
-left-distributive-add-min-ℕ :
-  (x y z : ℕ) → x +ℕ (min-ℕ y z) ＝ min-ℕ (x +ℕ y) (x +ℕ z)
-left-distributive-add-min-ℕ zero-ℕ y z =
-  ( left-unit-law-add-ℕ (min-ℕ y z)) ∙
-  ( ap-min-ℕ (inv (left-unit-law-add-ℕ y)) (inv (left-unit-law-add-ℕ z)))
-left-distributive-add-min-ℕ (succ-ℕ x) y z =
-  ( left-successor-law-add-ℕ x (min-ℕ y z)) ∙
-  ( ( ap succ-ℕ (left-distributive-add-min-ℕ x y z)) ∙
-    ( ap-min-ℕ
-      ( inv (left-successor-law-add-ℕ x y))
-      ( inv (left-successor-law-add-ℕ x z))))
+abstract
+  left-distributive-add-min-ℕ :
+    (x y z : ℕ) → x +ℕ (min-ℕ y z) ＝ min-ℕ (x +ℕ y) (x +ℕ z)
+  left-distributive-add-min-ℕ zero-ℕ y z =
+    ( left-unit-law-add-ℕ (min-ℕ y z)) ∙
+    ( ap-min-ℕ (inv (left-unit-law-add-ℕ y)) (inv (left-unit-law-add-ℕ z)))
+  left-distributive-add-min-ℕ (succ-ℕ x) y z =
+    ( left-successor-law-add-ℕ x (min-ℕ y z)) ∙
+    ( ( ap succ-ℕ (left-distributive-add-min-ℕ x y z)) ∙
+      ( ap-min-ℕ
+        ( inv (left-successor-law-add-ℕ x y))
+        ( inv (left-successor-law-add-ℕ x z))))
 
-right-distributive-add-min-ℕ :
-  (x y z : ℕ) → (min-ℕ x y) +ℕ z ＝ min-ℕ (x +ℕ z) (y +ℕ z)
-right-distributive-add-min-ℕ x y z =
-  ( commutative-add-ℕ (min-ℕ x y) z) ∙
-  ( ( left-distributive-add-min-ℕ z x y) ∙
-    ( ap-min-ℕ (commutative-add-ℕ z x) (commutative-add-ℕ z y)))
+  right-distributive-add-min-ℕ :
+    (x y z : ℕ) → (min-ℕ x y) +ℕ z ＝ min-ℕ (x +ℕ z) (y +ℕ z)
+  right-distributive-add-min-ℕ x y z =
+    ( commutative-add-ℕ (min-ℕ x y) z) ∙
+    ( ( left-distributive-add-min-ℕ z x y) ∙
+      ( ap-min-ℕ (commutative-add-ℕ z x) (commutative-add-ℕ z y)))
 ```

--- a/src/elementary-number-theory/multiplication-integers.lagda.md
+++ b/src/elementary-number-theory/multiplication-integers.lagda.md
@@ -98,446 +98,465 @@ is-plus-or-minus-ℤ x y = (x ＝ y) + (neg-one-ℤ *ℤ x ＝ y)
 ### Multiplication by zero is zero
 
 ```agda
-left-zero-law-mul-ℤ : (k : ℤ) → zero-ℤ *ℤ k ＝ zero-ℤ
-left-zero-law-mul-ℤ k = refl
+abstract
+  left-zero-law-mul-ℤ : (k : ℤ) → zero-ℤ *ℤ k ＝ zero-ℤ
+  left-zero-law-mul-ℤ k = refl
 
-right-zero-law-mul-ℤ : (k : ℤ) → k *ℤ zero-ℤ ＝ zero-ℤ
-right-zero-law-mul-ℤ (inl zero-ℕ) = refl
-right-zero-law-mul-ℤ (inl (succ-ℕ n)) =
-  right-zero-law-mul-ℤ (inl n)
-right-zero-law-mul-ℤ (inr (inl star)) = refl
-right-zero-law-mul-ℤ (inr (inr zero-ℕ)) = refl
-right-zero-law-mul-ℤ (inr (inr (succ-ℕ n))) =
-  right-zero-law-mul-ℤ (inr (inr n))
+  right-zero-law-mul-ℤ : (k : ℤ) → k *ℤ zero-ℤ ＝ zero-ℤ
+  right-zero-law-mul-ℤ (inl zero-ℕ) = refl
+  right-zero-law-mul-ℤ (inl (succ-ℕ n)) =
+    right-zero-law-mul-ℤ (inl n)
+  right-zero-law-mul-ℤ (inr (inl star)) = refl
+  right-zero-law-mul-ℤ (inr (inr zero-ℕ)) = refl
+  right-zero-law-mul-ℤ (inr (inr (succ-ℕ n))) =
+    right-zero-law-mul-ℤ (inr (inr n))
 ```
 
 ### Unit laws
 
 ```agda
-left-unit-law-mul-ℤ : (k : ℤ) → one-ℤ *ℤ k ＝ k
-left-unit-law-mul-ℤ k = refl
+abstract
+  left-unit-law-mul-ℤ : (k : ℤ) → one-ℤ *ℤ k ＝ k
+  left-unit-law-mul-ℤ k = refl
 
-right-unit-law-mul-ℤ : (k : ℤ) → k *ℤ one-ℤ ＝ k
-right-unit-law-mul-ℤ (inl zero-ℕ) = refl
-right-unit-law-mul-ℤ (inl (succ-ℕ n)) =
-  ap ((neg-one-ℤ) +ℤ_) (right-unit-law-mul-ℤ (inl n))
-right-unit-law-mul-ℤ (inr (inl star)) = refl
-right-unit-law-mul-ℤ (inr (inr zero-ℕ)) = refl
-right-unit-law-mul-ℤ (inr (inr (succ-ℕ n))) =
-  ap (one-ℤ +ℤ_) (right-unit-law-mul-ℤ (inr (inr n)))
+  right-unit-law-mul-ℤ : (k : ℤ) → k *ℤ one-ℤ ＝ k
+  right-unit-law-mul-ℤ (inl zero-ℕ) = refl
+  right-unit-law-mul-ℤ (inl (succ-ℕ n)) =
+    ap ((neg-one-ℤ) +ℤ_) (right-unit-law-mul-ℤ (inl n))
+  right-unit-law-mul-ℤ (inr (inl star)) = refl
+  right-unit-law-mul-ℤ (inr (inr zero-ℕ)) = refl
+  right-unit-law-mul-ℤ (inr (inr (succ-ℕ n))) =
+    ap (one-ℤ +ℤ_) (right-unit-law-mul-ℤ (inr (inr n)))
 ```
 
 ### Multiplication of an integer by `-1` is equal to the negative
 
 ```agda
-left-neg-unit-law-mul-ℤ : (k : ℤ) → neg-one-ℤ *ℤ k ＝ neg-ℤ k
-left-neg-unit-law-mul-ℤ k = refl
+abstract
+  left-neg-unit-law-mul-ℤ : (k : ℤ) → neg-one-ℤ *ℤ k ＝ neg-ℤ k
+  left-neg-unit-law-mul-ℤ k = refl
 
-right-neg-unit-law-mul-ℤ : (k : ℤ) → k *ℤ neg-one-ℤ ＝ neg-ℤ k
-right-neg-unit-law-mul-ℤ (inl zero-ℕ) = refl
-right-neg-unit-law-mul-ℤ (inl (succ-ℕ n)) =
-  ap (one-ℤ +ℤ_) (right-neg-unit-law-mul-ℤ (inl n))
-right-neg-unit-law-mul-ℤ (inr (inl star)) = refl
-right-neg-unit-law-mul-ℤ (inr (inr zero-ℕ)) = refl
-right-neg-unit-law-mul-ℤ (inr (inr (succ-ℕ n))) =
-  ap (neg-one-ℤ +ℤ_) (right-neg-unit-law-mul-ℤ (inr (inr n)))
+  right-neg-unit-law-mul-ℤ : (k : ℤ) → k *ℤ neg-one-ℤ ＝ neg-ℤ k
+  right-neg-unit-law-mul-ℤ (inl zero-ℕ) = refl
+  right-neg-unit-law-mul-ℤ (inl (succ-ℕ n)) =
+    ap (one-ℤ +ℤ_) (right-neg-unit-law-mul-ℤ (inl n))
+  right-neg-unit-law-mul-ℤ (inr (inl star)) = refl
+  right-neg-unit-law-mul-ℤ (inr (inr zero-ℕ)) = refl
+  right-neg-unit-law-mul-ℤ (inr (inr (succ-ℕ n))) =
+    ap (neg-one-ℤ +ℤ_) (right-neg-unit-law-mul-ℤ (inr (inr n)))
 ```
 
 ### Multiplication by the successor or the predecessor of an integer
 
 ```agda
-left-successor-law-mul-ℤ :
-  (k l : ℤ) → (succ-ℤ k) *ℤ l ＝ l +ℤ (k *ℤ l)
-left-successor-law-mul-ℤ (inl zero-ℕ) l =
-  inv (right-inverse-law-add-ℤ l)
-left-successor-law-mul-ℤ (inl (succ-ℕ n)) l =
-  ( ( inv (left-unit-law-add-ℤ ((inl n) *ℤ l))) ∙
+abstract
+  left-successor-law-mul-ℤ :
+    (k l : ℤ) → (succ-ℤ k) *ℤ l ＝ l +ℤ (k *ℤ l)
+  left-successor-law-mul-ℤ (inl zero-ℕ) l =
+    inv (right-inverse-law-add-ℤ l)
+  left-successor-law-mul-ℤ (inl (succ-ℕ n)) l =
+    ( ( inv (left-unit-law-add-ℤ ((inl n) *ℤ l))) ∙
+      ( ap
+        ( _+ℤ ((inl n) *ℤ l))
+        ( inv (right-inverse-law-add-ℤ l)))) ∙
+    ( associative-add-ℤ l (neg-ℤ l) ((inl n) *ℤ l))
+  left-successor-law-mul-ℤ (inr (inl star)) l =
+    inv (right-unit-law-add-ℤ l)
+  left-successor-law-mul-ℤ (inr (inr n)) l = refl
+
+  left-successor-law-mul-ℤ' :
+    (k l : ℤ) → (succ-ℤ k) *ℤ l ＝ (k *ℤ l) +ℤ l
+  left-successor-law-mul-ℤ' k l =
+    left-successor-law-mul-ℤ k l ∙
+    commutative-add-ℤ l (k *ℤ l)
+
+  left-predecessor-law-mul-ℤ :
+    (k l : ℤ) → (pred-ℤ k) *ℤ l ＝ (neg-ℤ l) +ℤ (k *ℤ l)
+  left-predecessor-law-mul-ℤ (inl n) l = refl
+  left-predecessor-law-mul-ℤ (inr (inl star)) l =
+    ( left-neg-unit-law-mul-ℤ l) ∙
+    ( inv (right-unit-law-add-ℤ (neg-ℤ l)))
+  left-predecessor-law-mul-ℤ (inr (inr zero-ℕ)) l =
+    inv (left-inverse-law-add-ℤ l)
+  left-predecessor-law-mul-ℤ (inr (inr (succ-ℕ x))) l =
     ( ap
-      ( _+ℤ ((inl n) *ℤ l))
-      ( inv (right-inverse-law-add-ℤ l)))) ∙
-  ( associative-add-ℤ l (neg-ℤ l) ((inl n) *ℤ l))
-left-successor-law-mul-ℤ (inr (inl star)) l =
-  inv (right-unit-law-add-ℤ l)
-left-successor-law-mul-ℤ (inr (inr n)) l = refl
+      ( _+ℤ ((in-pos-ℤ x) *ℤ l))
+      ( inv (left-inverse-law-add-ℤ l))) ∙
+    ( associative-add-ℤ (neg-ℤ l) l ((in-pos-ℤ x) *ℤ l))
 
-left-successor-law-mul-ℤ' :
-  (k l : ℤ) → (succ-ℤ k) *ℤ l ＝ (k *ℤ l) +ℤ l
-left-successor-law-mul-ℤ' k l =
-  left-successor-law-mul-ℤ k l ∙
-  commutative-add-ℤ l (k *ℤ l)
+  left-predecessor-law-mul-ℤ' :
+    (k l : ℤ) → (pred-ℤ k) *ℤ l ＝ (k *ℤ l) +ℤ (neg-ℤ l)
+  left-predecessor-law-mul-ℤ' k l =
+    left-predecessor-law-mul-ℤ k l ∙
+    commutative-add-ℤ (neg-ℤ l) (k *ℤ l)
 
-left-predecessor-law-mul-ℤ :
-  (k l : ℤ) → (pred-ℤ k) *ℤ l ＝ (neg-ℤ l) +ℤ (k *ℤ l)
-left-predecessor-law-mul-ℤ (inl n) l = refl
-left-predecessor-law-mul-ℤ (inr (inl star)) l =
-  ( left-neg-unit-law-mul-ℤ l) ∙
-  ( inv (right-unit-law-add-ℤ (neg-ℤ l)))
-left-predecessor-law-mul-ℤ (inr (inr zero-ℕ)) l =
-  inv (left-inverse-law-add-ℤ l)
-left-predecessor-law-mul-ℤ (inr (inr (succ-ℕ x))) l =
-  ( ap
-    ( _+ℤ ((in-pos-ℤ x) *ℤ l))
-    ( inv (left-inverse-law-add-ℤ l))) ∙
-  ( associative-add-ℤ (neg-ℤ l) l ((in-pos-ℤ x) *ℤ l))
+  right-successor-law-mul-ℤ :
+    (k l : ℤ) → k *ℤ (succ-ℤ l) ＝ k +ℤ (k *ℤ l)
+  right-successor-law-mul-ℤ (inl zero-ℕ) l = inv (pred-neg-ℤ l)
+  right-successor-law-mul-ℤ (inl (succ-ℕ n)) l =
+    ( left-predecessor-law-mul-ℤ (inl n) (succ-ℤ l)) ∙
+    ( ( ap ((neg-ℤ (succ-ℤ l)) +ℤ_) (right-successor-law-mul-ℤ (inl n) l)) ∙
+      ( ( inv (associative-add-ℤ (neg-ℤ (succ-ℤ l)) (inl n) ((inl n) *ℤ l))) ∙
+        ( ( ap
+            ( _+ℤ ((inl n) *ℤ l))
+            { x = (neg-ℤ (succ-ℤ l)) +ℤ (inl n)}
+            { y = (inl (succ-ℕ n)) +ℤ (neg-ℤ l)}
+            ( ( right-successor-law-add-ℤ (neg-ℤ (succ-ℤ l)) (inl (succ-ℕ n))) ∙
+              ( ( ap succ-ℤ
+                  ( commutative-add-ℤ (neg-ℤ (succ-ℤ l)) (inl (succ-ℕ n)))) ∙
+                ( ( inv
+                    ( right-successor-law-add-ℤ
+                      ( inl (succ-ℕ n))
+                      ( neg-ℤ (succ-ℤ l)))) ∙
+                  ( ap
+                    ( (inl (succ-ℕ n)) +ℤ_)
+                    ( ( ap succ-ℤ (inv (pred-neg-ℤ l))) ∙
+                      ( is-section-pred-ℤ (neg-ℤ l)))))))) ∙
+          ( associative-add-ℤ (inl (succ-ℕ n)) (neg-ℤ l) ((inl n) *ℤ l)))))
+  right-successor-law-mul-ℤ (inr (inl star)) l = refl
+  right-successor-law-mul-ℤ (inr (inr zero-ℕ)) l = refl
+  right-successor-law-mul-ℤ (inr (inr (succ-ℕ n))) l =
+    ( left-successor-law-mul-ℤ (in-pos-ℤ n) (succ-ℤ l)) ∙
+    ( ( ap ((succ-ℤ l) +ℤ_) (right-successor-law-mul-ℤ (inr (inr n)) l)) ∙
+      ( ( inv (associative-add-ℤ (succ-ℤ l) (in-pos-ℤ n) ((in-pos-ℤ n) *ℤ l))) ∙
+        ( ( ap
+            ( _+ℤ ((in-pos-ℤ n) *ℤ l))
+            { x = (succ-ℤ l) +ℤ (in-pos-ℤ n)}
+            { y = (in-pos-ℤ (succ-ℕ n)) +ℤ l}
+            ( ( left-successor-law-add-ℤ l (in-pos-ℤ n)) ∙
+              ( ( ap succ-ℤ (commutative-add-ℤ l (in-pos-ℤ n))) ∙
+                ( inv (left-successor-law-add-ℤ (in-pos-ℤ n) l))))) ∙
+          ( associative-add-ℤ (inr (inr (succ-ℕ n))) l ((inr (inr n)) *ℤ l)))))
 
-left-predecessor-law-mul-ℤ' :
-  (k l : ℤ) → (pred-ℤ k) *ℤ l ＝ (k *ℤ l) +ℤ (neg-ℤ l)
-left-predecessor-law-mul-ℤ' k l =
-  left-predecessor-law-mul-ℤ k l ∙
-  commutative-add-ℤ (neg-ℤ l) (k *ℤ l)
+  right-successor-law-mul-ℤ' :
+    (k l : ℤ) → k *ℤ (succ-ℤ l) ＝ (k *ℤ l) +ℤ k
+  right-successor-law-mul-ℤ' k l =
+    right-successor-law-mul-ℤ k l ∙
+    commutative-add-ℤ k (k *ℤ l)
 
-right-successor-law-mul-ℤ :
-  (k l : ℤ) → k *ℤ (succ-ℤ l) ＝ k +ℤ (k *ℤ l)
-right-successor-law-mul-ℤ (inl zero-ℕ) l = inv (pred-neg-ℤ l)
-right-successor-law-mul-ℤ (inl (succ-ℕ n)) l =
-  ( left-predecessor-law-mul-ℤ (inl n) (succ-ℤ l)) ∙
-  ( ( ap ((neg-ℤ (succ-ℤ l)) +ℤ_) (right-successor-law-mul-ℤ (inl n) l)) ∙
-    ( ( inv (associative-add-ℤ (neg-ℤ (succ-ℤ l)) (inl n) ((inl n) *ℤ l))) ∙
-      ( ( ap
-          ( _+ℤ ((inl n) *ℤ l))
-          { x = (neg-ℤ (succ-ℤ l)) +ℤ (inl n)}
-          { y = (inl (succ-ℕ n)) +ℤ (neg-ℤ l)}
-          ( ( right-successor-law-add-ℤ (neg-ℤ (succ-ℤ l)) (inl (succ-ℕ n))) ∙
-            ( ( ap succ-ℤ
-                ( commutative-add-ℤ (neg-ℤ (succ-ℤ l)) (inl (succ-ℕ n)))) ∙
-              ( ( inv
-                  ( right-successor-law-add-ℤ
-                    ( inl (succ-ℕ n))
-                    ( neg-ℤ (succ-ℤ l)))) ∙
-                ( ap
-                  ( (inl (succ-ℕ n)) +ℤ_)
-                  ( ( ap succ-ℤ (inv (pred-neg-ℤ l))) ∙
-                    ( is-section-pred-ℤ (neg-ℤ l)))))))) ∙
-        ( associative-add-ℤ (inl (succ-ℕ n)) (neg-ℤ l) ((inl n) *ℤ l)))))
-right-successor-law-mul-ℤ (inr (inl star)) l = refl
-right-successor-law-mul-ℤ (inr (inr zero-ℕ)) l = refl
-right-successor-law-mul-ℤ (inr (inr (succ-ℕ n))) l =
-  ( left-successor-law-mul-ℤ (in-pos-ℤ n) (succ-ℤ l)) ∙
-  ( ( ap ((succ-ℤ l) +ℤ_) (right-successor-law-mul-ℤ (inr (inr n)) l)) ∙
-    ( ( inv (associative-add-ℤ (succ-ℤ l) (in-pos-ℤ n) ((in-pos-ℤ n) *ℤ l))) ∙
-      ( ( ap
-          ( _+ℤ ((in-pos-ℤ n) *ℤ l))
-          { x = (succ-ℤ l) +ℤ (in-pos-ℤ n)}
-          { y = (in-pos-ℤ (succ-ℕ n)) +ℤ l}
-          ( ( left-successor-law-add-ℤ l (in-pos-ℤ n)) ∙
-            ( ( ap succ-ℤ (commutative-add-ℤ l (in-pos-ℤ n))) ∙
-              ( inv (left-successor-law-add-ℤ (in-pos-ℤ n) l))))) ∙
-        ( associative-add-ℤ (inr (inr (succ-ℕ n))) l ((inr (inr n)) *ℤ l)))))
+  right-predecessor-law-mul-ℤ :
+    (k l : ℤ) → k *ℤ (pred-ℤ l) ＝ (neg-ℤ k) +ℤ (k *ℤ l)
+  right-predecessor-law-mul-ℤ (inl zero-ℕ) l =
+    ( left-neg-unit-law-mul-ℤ (pred-ℤ l)) ∙
+    ( neg-pred-ℤ l)
+  right-predecessor-law-mul-ℤ (inl (succ-ℕ n)) l =
+    ( left-predecessor-law-mul-ℤ (inl n) (pred-ℤ l)) ∙
+    ( ( ap ((neg-ℤ (pred-ℤ l)) +ℤ_) (right-predecessor-law-mul-ℤ (inl n) l)) ∙
+      ( ( inv
+          ( associative-add-ℤ (neg-ℤ (pred-ℤ l)) (in-pos-ℤ n) ((inl n) *ℤ l))) ∙
+        ( ( ap
+            ( _+ℤ ((inl n) *ℤ l))
+            { x = (neg-ℤ (pred-ℤ l)) +ℤ (inr (inr n))}
+            { y = (neg-ℤ (inl (succ-ℕ n))) +ℤ (neg-ℤ l)}
+            ( ( ap (_+ℤ (in-pos-ℤ n)) (neg-pred-ℤ l)) ∙
+              ( ( left-successor-law-add-ℤ (neg-ℤ l) (in-pos-ℤ n)) ∙
+                ( ( ap succ-ℤ (commutative-add-ℤ (neg-ℤ l) (in-pos-ℤ n))) ∙
+                  ( inv (left-successor-law-add-ℤ (in-pos-ℤ n) (neg-ℤ l))))))) ∙
+          ( associative-add-ℤ (in-pos-ℤ (succ-ℕ n)) (neg-ℤ l) ((inl n) *ℤ l)))))
+  right-predecessor-law-mul-ℤ (inr (inl star)) l = refl
+  right-predecessor-law-mul-ℤ (inr (inr zero-ℕ)) l = refl
+  right-predecessor-law-mul-ℤ (inr (inr (succ-ℕ n))) l =
+    ( left-successor-law-mul-ℤ (in-pos-ℤ n) (pred-ℤ l)) ∙
+    ( ( ap ((pred-ℤ l) +ℤ_) (right-predecessor-law-mul-ℤ (inr (inr n)) l)) ∙
+      ( ( inv (associative-add-ℤ (pred-ℤ l) (inl n) ((inr (inr n)) *ℤ l))) ∙
+        ( ( ap
+            ( _+ℤ ((in-pos-ℤ n) *ℤ l))
+            { x = (pred-ℤ l) +ℤ (inl n)}
+            { y = (neg-ℤ (in-pos-ℤ (succ-ℕ n))) +ℤ l}
+            ( ( left-predecessor-law-add-ℤ l (inl n)) ∙
+              ( ( ap pred-ℤ (commutative-add-ℤ l (inl n))) ∙
+                ( inv (left-predecessor-law-add-ℤ (inl n) l))))) ∙
+          ( associative-add-ℤ (inl (succ-ℕ n)) l ((inr (inr n)) *ℤ l)))))
 
-right-successor-law-mul-ℤ' :
-  (k l : ℤ) → k *ℤ (succ-ℤ l) ＝ (k *ℤ l) +ℤ k
-right-successor-law-mul-ℤ' k l =
-  right-successor-law-mul-ℤ k l ∙
-  commutative-add-ℤ k (k *ℤ l)
-
-right-predecessor-law-mul-ℤ :
-  (k l : ℤ) → k *ℤ (pred-ℤ l) ＝ (neg-ℤ k) +ℤ (k *ℤ l)
-right-predecessor-law-mul-ℤ (inl zero-ℕ) l =
-  ( left-neg-unit-law-mul-ℤ (pred-ℤ l)) ∙
-  ( neg-pred-ℤ l)
-right-predecessor-law-mul-ℤ (inl (succ-ℕ n)) l =
-  ( left-predecessor-law-mul-ℤ (inl n) (pred-ℤ l)) ∙
-  ( ( ap ((neg-ℤ (pred-ℤ l)) +ℤ_) (right-predecessor-law-mul-ℤ (inl n) l)) ∙
-    ( ( inv
-        ( associative-add-ℤ (neg-ℤ (pred-ℤ l)) (in-pos-ℤ n) ((inl n) *ℤ l))) ∙
-      ( ( ap
-          ( _+ℤ ((inl n) *ℤ l))
-          { x = (neg-ℤ (pred-ℤ l)) +ℤ (inr (inr n))}
-          { y = (neg-ℤ (inl (succ-ℕ n))) +ℤ (neg-ℤ l)}
-          ( ( ap (_+ℤ (in-pos-ℤ n)) (neg-pred-ℤ l)) ∙
-            ( ( left-successor-law-add-ℤ (neg-ℤ l) (in-pos-ℤ n)) ∙
-              ( ( ap succ-ℤ (commutative-add-ℤ (neg-ℤ l) (in-pos-ℤ n))) ∙
-                ( inv (left-successor-law-add-ℤ (in-pos-ℤ n) (neg-ℤ l))))))) ∙
-        ( associative-add-ℤ (in-pos-ℤ (succ-ℕ n)) (neg-ℤ l) ((inl n) *ℤ l)))))
-right-predecessor-law-mul-ℤ (inr (inl star)) l = refl
-right-predecessor-law-mul-ℤ (inr (inr zero-ℕ)) l = refl
-right-predecessor-law-mul-ℤ (inr (inr (succ-ℕ n))) l =
-  ( left-successor-law-mul-ℤ (in-pos-ℤ n) (pred-ℤ l)) ∙
-  ( ( ap ((pred-ℤ l) +ℤ_) (right-predecessor-law-mul-ℤ (inr (inr n)) l)) ∙
-    ( ( inv (associative-add-ℤ (pred-ℤ l) (inl n) ((inr (inr n)) *ℤ l))) ∙
-      ( ( ap
-          ( _+ℤ ((in-pos-ℤ n) *ℤ l))
-          { x = (pred-ℤ l) +ℤ (inl n)}
-          { y = (neg-ℤ (in-pos-ℤ (succ-ℕ n))) +ℤ l}
-          ( ( left-predecessor-law-add-ℤ l (inl n)) ∙
-            ( ( ap pred-ℤ (commutative-add-ℤ l (inl n))) ∙
-              ( inv (left-predecessor-law-add-ℤ (inl n) l))))) ∙
-        ( associative-add-ℤ (inl (succ-ℕ n)) l ((inr (inr n)) *ℤ l)))))
-
-right-predecessor-law-mul-ℤ' :
-  (k l : ℤ) → k *ℤ (pred-ℤ l) ＝ (k *ℤ l) +ℤ (neg-ℤ k)
-right-predecessor-law-mul-ℤ' k l =
-  right-predecessor-law-mul-ℤ k l ∙
-  commutative-add-ℤ (neg-ℤ k) (k *ℤ l)
+  right-predecessor-law-mul-ℤ' :
+    (k l : ℤ) → k *ℤ (pred-ℤ l) ＝ (k *ℤ l) +ℤ (neg-ℤ k)
+  right-predecessor-law-mul-ℤ' k l =
+    right-predecessor-law-mul-ℤ k l ∙
+    commutative-add-ℤ (neg-ℤ k) (k *ℤ l)
 ```
 
 ### Multiplication on the integers distributes on the right over addition
 
 ```agda
-right-distributive-mul-add-ℤ :
-  (k l m : ℤ) → (k +ℤ l) *ℤ m ＝ (k *ℤ m) +ℤ (l *ℤ m)
-right-distributive-mul-add-ℤ (inl zero-ℕ) l m =
-  ( left-predecessor-law-mul-ℤ l m) ∙
-  ( ap
-    ( _+ℤ (l *ℤ m))
-    ( inv
-      ( ( left-predecessor-law-mul-ℤ zero-ℤ m) ∙
-        ( right-unit-law-add-ℤ (neg-ℤ m)))))
-right-distributive-mul-add-ℤ (inl (succ-ℕ x)) l m =
-  ( left-predecessor-law-mul-ℤ ((inl x) +ℤ l) m) ∙
-  ( ( ap ((neg-ℤ m) +ℤ_) (right-distributive-mul-add-ℤ (inl x) l m)) ∙
-    ( inv (associative-add-ℤ (neg-ℤ m) ((inl x) *ℤ m) (l *ℤ m))))
-right-distributive-mul-add-ℤ (inr (inl star)) l m = refl
-right-distributive-mul-add-ℤ (inr (inr zero-ℕ)) l m =
-  left-successor-law-mul-ℤ l m
-right-distributive-mul-add-ℤ (inr (inr (succ-ℕ n))) l m =
-  ( left-successor-law-mul-ℤ ((in-pos-ℤ n) +ℤ l) m) ∙
-  ( ( ap (m +ℤ_) (right-distributive-mul-add-ℤ (inr (inr n)) l m)) ∙
-    ( inv (associative-add-ℤ m ((in-pos-ℤ n) *ℤ m) (l *ℤ m))))
+abstract
+  right-distributive-mul-add-ℤ :
+    (k l m : ℤ) → (k +ℤ l) *ℤ m ＝ (k *ℤ m) +ℤ (l *ℤ m)
+  right-distributive-mul-add-ℤ (inl zero-ℕ) l m =
+    ( left-predecessor-law-mul-ℤ l m) ∙
+    ( ap
+      ( _+ℤ (l *ℤ m))
+      ( inv
+        ( ( left-predecessor-law-mul-ℤ zero-ℤ m) ∙
+          ( right-unit-law-add-ℤ (neg-ℤ m)))))
+  right-distributive-mul-add-ℤ (inl (succ-ℕ x)) l m =
+    ( left-predecessor-law-mul-ℤ ((inl x) +ℤ l) m) ∙
+    ( ( ap ((neg-ℤ m) +ℤ_) (right-distributive-mul-add-ℤ (inl x) l m)) ∙
+      ( inv (associative-add-ℤ (neg-ℤ m) ((inl x) *ℤ m) (l *ℤ m))))
+  right-distributive-mul-add-ℤ (inr (inl star)) l m = refl
+  right-distributive-mul-add-ℤ (inr (inr zero-ℕ)) l m =
+    left-successor-law-mul-ℤ l m
+  right-distributive-mul-add-ℤ (inr (inr (succ-ℕ n))) l m =
+    ( left-successor-law-mul-ℤ ((in-pos-ℤ n) +ℤ l) m) ∙
+    ( ( ap (m +ℤ_) (right-distributive-mul-add-ℤ (inr (inr n)) l m)) ∙
+      ( inv (associative-add-ℤ m ((in-pos-ℤ n) *ℤ m) (l *ℤ m))))
 ```
 
 ### Left multiplication by the negative of an integer is the negative of the multiplication
 
 ```agda
-left-negative-law-mul-ℤ :
-  (k l : ℤ) → (neg-ℤ k) *ℤ l ＝ neg-ℤ (k *ℤ l)
-left-negative-law-mul-ℤ (inl zero-ℕ) l =
-  ( left-unit-law-mul-ℤ l) ∙
-  ( inv (neg-neg-ℤ l))
-left-negative-law-mul-ℤ (inl (succ-ℕ n)) l =
-  ( ap (_*ℤ l) (neg-pred-ℤ (inl n))) ∙
-  ( ( left-successor-law-mul-ℤ (neg-ℤ (inl n)) l) ∙
-    ( ( ap (l +ℤ_) (left-negative-law-mul-ℤ (inl n) l)) ∙
-      ( right-negative-law-add-ℤ l ((inl n) *ℤ l))))
-left-negative-law-mul-ℤ (inr (inl star)) l = refl
-left-negative-law-mul-ℤ (inr (inr zero-ℕ)) l = refl
-left-negative-law-mul-ℤ (inr (inr (succ-ℕ n))) l =
-  ( left-predecessor-law-mul-ℤ (inl n) l) ∙
-  ( ( ap ((neg-ℤ l) +ℤ_) (left-negative-law-mul-ℤ (inr (inr n)) l)) ∙
-    ( inv (distributive-neg-add-ℤ l ((in-pos-ℤ n) *ℤ l))))
+abstract
+  left-negative-law-mul-ℤ :
+    (k l : ℤ) → (neg-ℤ k) *ℤ l ＝ neg-ℤ (k *ℤ l)
+  left-negative-law-mul-ℤ (inl zero-ℕ) l =
+    ( left-unit-law-mul-ℤ l) ∙
+    ( inv (neg-neg-ℤ l))
+  left-negative-law-mul-ℤ (inl (succ-ℕ n)) l =
+    ( ap (_*ℤ l) (neg-pred-ℤ (inl n))) ∙
+    ( ( left-successor-law-mul-ℤ (neg-ℤ (inl n)) l) ∙
+      ( ( ap (l +ℤ_) (left-negative-law-mul-ℤ (inl n) l)) ∙
+        ( right-negative-law-add-ℤ l ((inl n) *ℤ l))))
+  left-negative-law-mul-ℤ (inr (inl star)) l = refl
+  left-negative-law-mul-ℤ (inr (inr zero-ℕ)) l = refl
+  left-negative-law-mul-ℤ (inr (inr (succ-ℕ n))) l =
+    ( left-predecessor-law-mul-ℤ (inl n) l) ∙
+    ( ( ap ((neg-ℤ l) +ℤ_) (left-negative-law-mul-ℤ (inr (inr n)) l)) ∙
+      ( inv (distributive-neg-add-ℤ l ((in-pos-ℤ n) *ℤ l))))
 ```
 
 ### Multiplication on the integers is associative
 
 ```agda
-associative-mul-ℤ :
-  (k l m : ℤ) → (k *ℤ l) *ℤ m ＝ k *ℤ (l *ℤ m)
-associative-mul-ℤ (inl zero-ℕ) l m =
-  left-negative-law-mul-ℤ l m
-associative-mul-ℤ (inl (succ-ℕ n)) l m =
-  ( right-distributive-mul-add-ℤ (neg-ℤ l) ((inl n) *ℤ l) m) ∙
-  ( ( ap (((neg-ℤ l) *ℤ m) +ℤ_) (associative-mul-ℤ (inl n) l m)) ∙
-    ( ap
-      ( _+ℤ ((inl n) *ℤ (l *ℤ m)))
-      ( left-negative-law-mul-ℤ l m)))
-associative-mul-ℤ (inr (inl star)) l m = refl
-associative-mul-ℤ (inr (inr zero-ℕ)) l m = refl
-associative-mul-ℤ (inr (inr (succ-ℕ n))) l m =
-  ( right-distributive-mul-add-ℤ l ((in-pos-ℤ n) *ℤ l) m) ∙
-  ( ap ((l *ℤ m) +ℤ_) (associative-mul-ℤ (inr (inr n)) l m))
+abstract
+  associative-mul-ℤ :
+    (k l m : ℤ) → (k *ℤ l) *ℤ m ＝ k *ℤ (l *ℤ m)
+  associative-mul-ℤ (inl zero-ℕ) l m =
+    left-negative-law-mul-ℤ l m
+  associative-mul-ℤ (inl (succ-ℕ n)) l m =
+    ( right-distributive-mul-add-ℤ (neg-ℤ l) ((inl n) *ℤ l) m) ∙
+    ( ( ap (((neg-ℤ l) *ℤ m) +ℤ_) (associative-mul-ℤ (inl n) l m)) ∙
+      ( ap
+        ( _+ℤ ((inl n) *ℤ (l *ℤ m)))
+        ( left-negative-law-mul-ℤ l m)))
+  associative-mul-ℤ (inr (inl star)) l m = refl
+  associative-mul-ℤ (inr (inr zero-ℕ)) l m = refl
+  associative-mul-ℤ (inr (inr (succ-ℕ n))) l m =
+    ( right-distributive-mul-add-ℤ l ((in-pos-ℤ n) *ℤ l) m) ∙
+    ( ap ((l *ℤ m) +ℤ_) (associative-mul-ℤ (inr (inr n)) l m))
 ```
 
 ### Multiplication on the integers is commutative
 
 ```agda
-commutative-mul-ℤ :
-  (k l : ℤ) → k *ℤ l ＝ l *ℤ k
-commutative-mul-ℤ (inl zero-ℕ) l = inv (right-neg-unit-law-mul-ℤ l)
-commutative-mul-ℤ (inl (succ-ℕ n)) l =
-  ( ap ((neg-ℤ l) +ℤ_) (commutative-mul-ℤ (inl n) l)) ∙
-  ( inv (right-predecessor-law-mul-ℤ l (inl n)))
-commutative-mul-ℤ (inr (inl star)) l = inv (right-zero-law-mul-ℤ l)
-commutative-mul-ℤ (inr (inr zero-ℕ)) l = inv (right-unit-law-mul-ℤ l)
-commutative-mul-ℤ (inr (inr (succ-ℕ n))) l =
-  ( ap (l +ℤ_) (commutative-mul-ℤ (inr (inr n)) l)) ∙
-  ( inv (right-successor-law-mul-ℤ l (in-pos-ℤ n)))
+abstract
+  commutative-mul-ℤ :
+    (k l : ℤ) → k *ℤ l ＝ l *ℤ k
+  commutative-mul-ℤ (inl zero-ℕ) l = inv (right-neg-unit-law-mul-ℤ l)
+  commutative-mul-ℤ (inl (succ-ℕ n)) l =
+    ( ap ((neg-ℤ l) +ℤ_) (commutative-mul-ℤ (inl n) l)) ∙
+    ( inv (right-predecessor-law-mul-ℤ l (inl n)))
+  commutative-mul-ℤ (inr (inl star)) l = inv (right-zero-law-mul-ℤ l)
+  commutative-mul-ℤ (inr (inr zero-ℕ)) l = inv (right-unit-law-mul-ℤ l)
+  commutative-mul-ℤ (inr (inr (succ-ℕ n))) l =
+    ( ap (l +ℤ_) (commutative-mul-ℤ (inr (inr n)) l)) ∙
+    ( inv (right-successor-law-mul-ℤ l (in-pos-ℤ n)))
 ```
 
 ### Multiplication on the integers distributes on the left over addition
 
 ```agda
-left-distributive-mul-add-ℤ :
-  (m k l : ℤ) → m *ℤ (k +ℤ l) ＝ (m *ℤ k) +ℤ (m *ℤ l)
-left-distributive-mul-add-ℤ m k l =
-  commutative-mul-ℤ m (k +ℤ l) ∙
-    ( ( right-distributive-mul-add-ℤ k l m) ∙
-      ( ap-add-ℤ (commutative-mul-ℤ k m) (commutative-mul-ℤ l m)))
+abstract
+  left-distributive-mul-add-ℤ :
+    (m k l : ℤ) → m *ℤ (k +ℤ l) ＝ (m *ℤ k) +ℤ (m *ℤ l)
+  left-distributive-mul-add-ℤ m k l =
+    ( commutative-mul-ℤ m (k +ℤ l)) ∙
+    ( right-distributive-mul-add-ℤ k l m) ∙
+    ( ap-add-ℤ (commutative-mul-ℤ k m) (commutative-mul-ℤ l m))
 ```
 
 ### Right multiplication by the negative of an integer is the negative of the multiplication
 
 ```agda
-right-negative-law-mul-ℤ :
-  (k l : ℤ) → k *ℤ (neg-ℤ l) ＝ neg-ℤ (k *ℤ l)
-right-negative-law-mul-ℤ k l =
-  ( ( commutative-mul-ℤ k (neg-ℤ l)) ∙
-    ( left-negative-law-mul-ℤ l k)) ∙
-  ( ap neg-ℤ (commutative-mul-ℤ l k))
+abstract
+  right-negative-law-mul-ℤ :
+    (k l : ℤ) → k *ℤ (neg-ℤ l) ＝ neg-ℤ (k *ℤ l)
+  right-negative-law-mul-ℤ k l =
+    ( commutative-mul-ℤ k (neg-ℤ l)) ∙
+    ( left-negative-law-mul-ℤ l k) ∙
+    ( ap neg-ℤ (commutative-mul-ℤ l k))
 ```
 
 ### The multiplication of the negatives of two integers is equal to their multiplication
 
 ```agda
-double-negative-law-mul-ℤ : (k l : ℤ) → (neg-ℤ k) *ℤ (neg-ℤ l) ＝ k *ℤ l
-double-negative-law-mul-ℤ k l =
-  equational-reasoning
-    (neg-ℤ k) *ℤ (neg-ℤ l)
-    ＝ neg-ℤ (k *ℤ (neg-ℤ l))
-      by left-negative-law-mul-ℤ k (neg-ℤ l)
-    ＝ neg-ℤ (neg-ℤ (k *ℤ l))
-      by ap neg-ℤ (right-negative-law-mul-ℤ k l)
-    ＝ k *ℤ l
-      by neg-neg-ℤ (k *ℤ l)
+abstract
+  double-negative-law-mul-ℤ : (k l : ℤ) → (neg-ℤ k) *ℤ (neg-ℤ l) ＝ k *ℤ l
+  double-negative-law-mul-ℤ k l =
+    equational-reasoning
+      (neg-ℤ k) *ℤ (neg-ℤ l)
+      ＝ neg-ℤ (k *ℤ (neg-ℤ l))
+        by left-negative-law-mul-ℤ k (neg-ℤ l)
+      ＝ neg-ℤ (neg-ℤ (k *ℤ l))
+        by ap neg-ℤ (right-negative-law-mul-ℤ k l)
+      ＝ k *ℤ l
+        by neg-neg-ℤ (k *ℤ l)
 ```
 
 ### Interchange law
 
 ```agda
-interchange-law-mul-mul-ℤ :
-  (x y u v : ℤ) → (x *ℤ y) *ℤ (u *ℤ v) ＝ (x *ℤ u) *ℤ (y *ℤ v)
-interchange-law-mul-mul-ℤ =
-  interchange-law-commutative-and-associative
-    mul-ℤ
-    commutative-mul-ℤ
-    associative-mul-ℤ
+abstract
+  interchange-law-mul-mul-ℤ :
+    (x y u v : ℤ) → (x *ℤ y) *ℤ (u *ℤ v) ＝ (x *ℤ u) *ℤ (y *ℤ v)
+  interchange-law-mul-mul-ℤ =
+    interchange-law-commutative-and-associative
+      mul-ℤ
+      commutative-mul-ℤ
+      associative-mul-ℤ
 ```
 
-### Computing multiplication of integers that come from natural numbers
+### The canonical embedding of natural numbers in the integers preserves multiplication
 
 ```agda
-mul-int-ℕ : (x y : ℕ) → (int-ℕ x) *ℤ (int-ℕ y) ＝ int-ℕ (x *ℕ y)
-mul-int-ℕ zero-ℕ y = refl
-mul-int-ℕ (succ-ℕ x) y =
-  ( ap (_*ℤ (int-ℕ y)) (inv (succ-int-ℕ x))) ∙
-  ( ( left-successor-law-mul-ℤ (int-ℕ x) (int-ℕ y)) ∙
-    ( ( ( ap ((int-ℕ y) +ℤ_) (mul-int-ℕ x y)) ∙
-        ( add-int-ℕ y (x *ℕ y))) ∙
-      ( ap int-ℕ (commutative-add-ℕ y (x *ℕ y)))))
+abstract
+  mul-int-ℕ : (x y : ℕ) → (int-ℕ x) *ℤ (int-ℕ y) ＝ int-ℕ (x *ℕ y)
+  mul-int-ℕ zero-ℕ y = refl
+  mul-int-ℕ (succ-ℕ x) y =
+    ( ap (_*ℤ (int-ℕ y)) (inv (succ-int-ℕ x))) ∙
+    ( ( left-successor-law-mul-ℤ (int-ℕ x) (int-ℕ y)) ∙
+      ( ( ( ap ((int-ℕ y) +ℤ_) (mul-int-ℕ x y)) ∙
+          ( add-int-ℕ y (x *ℕ y))) ∙
+        ( ap int-ℕ (commutative-add-ℕ y (x *ℕ y)))))
 
-compute-mul-ℤ : (x y : ℤ) → x *ℤ y ＝ explicit-mul-ℤ x y
-compute-mul-ℤ (inl zero-ℕ) (inl y) =
-  inv (ap int-ℕ (left-unit-law-mul-ℕ (succ-ℕ y)))
-compute-mul-ℤ (inl (succ-ℕ x)) (inl y) =
-  ( ( ap ((int-ℕ (succ-ℕ y)) +ℤ_) (compute-mul-ℤ (inl x) (inl y))) ∙
-    ( commutative-add-ℤ
-      ( int-ℕ (succ-ℕ y))
-      ( int-ℕ ((succ-ℕ x) *ℕ (succ-ℕ y))))) ∙
-  ( add-int-ℕ ((succ-ℕ x) *ℕ (succ-ℕ y)) (succ-ℕ y))
-compute-mul-ℤ (inl zero-ℕ) (inr (inl star)) = refl
-compute-mul-ℤ (inl zero-ℕ) (inr (inr x)) = ap inl (inv (left-unit-law-add-ℕ x))
-compute-mul-ℤ (inl (succ-ℕ x)) (inr (inl star)) = right-zero-law-mul-ℤ (inl x)
-compute-mul-ℤ (inl (succ-ℕ x)) (inr (inr y)) =
-  ( ( ( ap ((inl y) +ℤ_) (compute-mul-ℤ (inl x) (inr (inr y)))) ∙
-      ( inv
-        ( distributive-neg-add-ℤ
-          ( inr (inr y))
-          ( int-ℕ ((succ-ℕ x) *ℕ (succ-ℕ y)))))) ∙
-    ( ap
-      ( neg-ℤ)
+  compute-mul-ℤ : (x y : ℤ) → x *ℤ y ＝ explicit-mul-ℤ x y
+  compute-mul-ℤ (inl zero-ℕ) (inl y) =
+    inv (ap int-ℕ (left-unit-law-mul-ℕ (succ-ℕ y)))
+  compute-mul-ℤ (inl (succ-ℕ x)) (inl y) =
+    ( ( ap ((int-ℕ (succ-ℕ y)) +ℤ_) (compute-mul-ℤ (inl x) (inl y))) ∙
       ( commutative-add-ℤ
         ( int-ℕ (succ-ℕ y))
-        ( int-ℕ ((succ-ℕ x) *ℕ (succ-ℕ y)))))) ∙
-  ( ap neg-ℤ (add-int-ℕ ((succ-ℕ x) *ℕ (succ-ℕ y)) (succ-ℕ y)))
-compute-mul-ℤ (inr (inl star)) (inl y) = refl
-compute-mul-ℤ (inr (inr zero-ℕ)) (inl y) = ap inl (inv (left-unit-law-add-ℕ y))
-compute-mul-ℤ (inr (inr (succ-ℕ x))) (inl y) =
-  ( ap ((inl y) +ℤ_) (compute-mul-ℤ (inr (inr x)) (inl y))) ∙
-  ( ( ( inv
-        ( distributive-neg-add-ℤ
-          ( inr (inr y))
-          ( inr (inr ((x *ℕ (succ-ℕ y)) +ℕ y))))) ∙
+        ( int-ℕ ((succ-ℕ x) *ℕ (succ-ℕ y))))) ∙
+    ( add-int-ℕ ((succ-ℕ x) *ℕ (succ-ℕ y)) (succ-ℕ y))
+  compute-mul-ℤ (inl zero-ℕ) (inr (inl star)) = refl
+  compute-mul-ℤ (inl zero-ℕ) (inr (inr x)) =
+    ap inl (inv (left-unit-law-add-ℕ x))
+  compute-mul-ℤ (inl (succ-ℕ x)) (inr (inl star)) = right-zero-law-mul-ℤ (inl x)
+  compute-mul-ℤ (inl (succ-ℕ x)) (inr (inr y)) =
+    ( ( ( ap ((inl y) +ℤ_) (compute-mul-ℤ (inl x) (inr (inr y)))) ∙
+        ( inv
+          ( distributive-neg-add-ℤ
+            ( inr (inr y))
+            ( int-ℕ ((succ-ℕ x) *ℕ (succ-ℕ y)))))) ∙
       ( ap
         ( neg-ℤ)
-        ( ( add-int-ℕ (succ-ℕ y) ((succ-ℕ x) *ℕ (succ-ℕ y))) ∙
-          ( ap
-            ( inr ∘ inr)
-            ( left-successor-law-add-ℕ y ((x *ℕ (succ-ℕ y)) +ℕ y)))))) ∙
-    ( ap inl (commutative-add-ℕ y ((succ-ℕ x) *ℕ (succ-ℕ y)))))
-compute-mul-ℤ (inr (inl star)) (inr (inl star)) = refl
-compute-mul-ℤ (inr (inl star)) (inr (inr y)) = refl
-compute-mul-ℤ (inr (inr zero-ℕ)) (inr (inl star)) = refl
-compute-mul-ℤ (inr (inr (succ-ℕ x))) (inr (inl star)) =
-  right-zero-law-mul-ℤ (inr (inr (succ-ℕ x)))
-compute-mul-ℤ (inr (inr zero-ℕ)) (inr (inr y)) =
-  ap
-    ( inr ∘ inr)
-    ( inv
-      ( ( ap (_+ℕ y) (left-zero-law-mul-ℕ (succ-ℕ y))) ∙
-        ( left-unit-law-add-ℕ y)))
-compute-mul-ℤ (inr (inr (succ-ℕ x))) (inr (inr y)) =
-  ( ap ((inr (inr y)) +ℤ_) (compute-mul-ℤ (inr (inr x)) (inr (inr y)))) ∙
-  ( ( add-int-ℕ (succ-ℕ y) ((succ-ℕ x) *ℕ (succ-ℕ y))) ∙
-    ( ap int-ℕ (commutative-add-ℕ (succ-ℕ y) ((succ-ℕ x) *ℕ (succ-ℕ y)))))
+        ( commutative-add-ℤ
+          ( int-ℕ (succ-ℕ y))
+          ( int-ℕ ((succ-ℕ x) *ℕ (succ-ℕ y)))))) ∙
+    ( ap neg-ℤ (add-int-ℕ ((succ-ℕ x) *ℕ (succ-ℕ y)) (succ-ℕ y)))
+  compute-mul-ℤ (inr (inl star)) (inl y) = refl
+  compute-mul-ℤ (inr (inr zero-ℕ)) (inl y) =
+    ap inl (inv (left-unit-law-add-ℕ y))
+  compute-mul-ℤ (inr (inr (succ-ℕ x))) (inl y) =
+    ( ap ((inl y) +ℤ_) (compute-mul-ℤ (inr (inr x)) (inl y))) ∙
+    ( ( ( inv
+          ( distributive-neg-add-ℤ
+            ( inr (inr y))
+            ( inr (inr ((x *ℕ (succ-ℕ y)) +ℕ y))))) ∙
+        ( ap
+          ( neg-ℤ)
+          ( ( add-int-ℕ (succ-ℕ y) ((succ-ℕ x) *ℕ (succ-ℕ y))) ∙
+            ( ap
+              ( inr ∘ inr)
+              ( left-successor-law-add-ℕ y ((x *ℕ (succ-ℕ y)) +ℕ y)))))) ∙
+      ( ap inl (commutative-add-ℕ y ((succ-ℕ x) *ℕ (succ-ℕ y)))))
+  compute-mul-ℤ (inr (inl star)) (inr (inl star)) = refl
+  compute-mul-ℤ (inr (inl star)) (inr (inr y)) = refl
+  compute-mul-ℤ (inr (inr zero-ℕ)) (inr (inl star)) = refl
+  compute-mul-ℤ (inr (inr (succ-ℕ x))) (inr (inl star)) =
+    right-zero-law-mul-ℤ (inr (inr (succ-ℕ x)))
+  compute-mul-ℤ (inr (inr zero-ℕ)) (inr (inr y)) =
+    ap
+      ( inr ∘ inr)
+      ( inv
+        ( ( ap (_+ℕ y) (left-zero-law-mul-ℕ (succ-ℕ y))) ∙
+          ( left-unit-law-add-ℕ y)))
+  compute-mul-ℤ (inr (inr (succ-ℕ x))) (inr (inr y)) =
+    ( ap ((inr (inr y)) +ℤ_) (compute-mul-ℤ (inr (inr x)) (inr (inr y)))) ∙
+    ( ( add-int-ℕ (succ-ℕ y) ((succ-ℕ x) *ℕ (succ-ℕ y))) ∙
+      ( ap int-ℕ (commutative-add-ℕ (succ-ℕ y) ((succ-ℕ x) *ℕ (succ-ℕ y)))))
 ```
 
 ### Multiplication on integers distributes over the difference
 
 ```agda
-left-distributive-mul-diff-ℤ :
-  (z x y : ℤ) → z *ℤ (x -ℤ y) ＝ (z *ℤ x) -ℤ (z *ℤ y)
-left-distributive-mul-diff-ℤ z x y =
-  ( left-distributive-mul-add-ℤ z x (neg-ℤ y)) ∙
-  ( ap ((z *ℤ x) +ℤ_) (right-negative-law-mul-ℤ z y))
+abstract
+  left-distributive-mul-diff-ℤ :
+    (z x y : ℤ) → z *ℤ (x -ℤ y) ＝ (z *ℤ x) -ℤ (z *ℤ y)
+  left-distributive-mul-diff-ℤ z x y =
+    ( left-distributive-mul-add-ℤ z x (neg-ℤ y)) ∙
+    ( ap ((z *ℤ x) +ℤ_) (right-negative-law-mul-ℤ z y))
 
-right-distributive-mul-diff-ℤ :
-  (x y z : ℤ) → (x -ℤ y) *ℤ z ＝ (x *ℤ z) -ℤ (y *ℤ z)
-right-distributive-mul-diff-ℤ x y z =
-  ( right-distributive-mul-add-ℤ x (neg-ℤ y) z) ∙
-  ( ap ((x *ℤ z) +ℤ_) (left-negative-law-mul-ℤ y z))
+  right-distributive-mul-diff-ℤ :
+    (x y z : ℤ) → (x -ℤ y) *ℤ z ＝ (x *ℤ z) -ℤ (y *ℤ z)
+  right-distributive-mul-diff-ℤ x y z =
+    ( right-distributive-mul-add-ℤ x (neg-ℤ y) z) ∙
+    ( ap ((x *ℤ z) +ℤ_) (left-negative-law-mul-ℤ y z))
 ```
 
 ### If the product of two integers is zero, one of the factors is zero
 
 ```agda
-is-zero-is-zero-mul-ℤ :
-  (x y : ℤ) → is-zero-ℤ (x *ℤ y) → (is-zero-ℤ x) + (is-zero-ℤ y)
-is-zero-is-zero-mul-ℤ (inl x) (inl y) H =
-  ex-falso (Eq-eq-ℤ (inv (compute-mul-ℤ (inl x) (inl y)) ∙ H))
-is-zero-is-zero-mul-ℤ (inl x) (inr (inl star)) H = inr refl
-is-zero-is-zero-mul-ℤ (inl x) (inr (inr y)) H =
-  ex-falso (Eq-eq-ℤ (inv (compute-mul-ℤ (inl x) (inr (inr y))) ∙ H))
-is-zero-is-zero-mul-ℤ (inr (inl star)) y H = inl refl
-is-zero-is-zero-mul-ℤ (inr (inr x)) (inl y) H =
-  ex-falso (Eq-eq-ℤ (inv (compute-mul-ℤ (inr (inr x)) (inl y)) ∙ H))
-is-zero-is-zero-mul-ℤ (inr (inr x)) (inr (inl star)) H = inr refl
-is-zero-is-zero-mul-ℤ (inr (inr x)) (inr (inr y)) H =
-  ex-falso (Eq-eq-ℤ (inv (compute-mul-ℤ (inr (inr x)) (inr (inr y))) ∙ H))
+abstract
+  is-zero-is-zero-mul-ℤ :
+    (x y : ℤ) → is-zero-ℤ (x *ℤ y) → (is-zero-ℤ x) + (is-zero-ℤ y)
+  is-zero-is-zero-mul-ℤ (inl x) (inl y) H =
+    ex-falso (Eq-eq-ℤ (inv (compute-mul-ℤ (inl x) (inl y)) ∙ H))
+  is-zero-is-zero-mul-ℤ (inl x) (inr (inl star)) H = inr refl
+  is-zero-is-zero-mul-ℤ (inl x) (inr (inr y)) H =
+    ex-falso (Eq-eq-ℤ (inv (compute-mul-ℤ (inl x) (inr (inr y))) ∙ H))
+  is-zero-is-zero-mul-ℤ (inr (inl star)) y H = inl refl
+  is-zero-is-zero-mul-ℤ (inr (inr x)) (inl y) H =
+    ex-falso (Eq-eq-ℤ (inv (compute-mul-ℤ (inr (inr x)) (inl y)) ∙ H))
+  is-zero-is-zero-mul-ℤ (inr (inr x)) (inr (inl star)) H = inr refl
+  is-zero-is-zero-mul-ℤ (inr (inr x)) (inr (inr y)) H =
+    ex-falso (Eq-eq-ℤ (inv (compute-mul-ℤ (inr (inr x)) (inr (inr y))) ∙ H))
 ```
 
 ### Injectivity of multiplication by a nonzero integer
 
 ```agda
-is-injective-left-mul-ℤ :
-  (x : ℤ) → is-nonzero-ℤ x → is-injective (x *ℤ_)
-is-injective-left-mul-ℤ x f {y} {z} p =
-  eq-diff-ℤ
-    ( map-left-unit-law-coproduct-is-empty
-      ( is-zero-ℤ x)
-      ( is-zero-ℤ (y -ℤ z))
-      ( f)
-      ( is-zero-is-zero-mul-ℤ x
-        ( y -ℤ z)
-        ( left-distributive-mul-diff-ℤ x y z ∙ is-zero-diff-ℤ p)))
+abstract
+  is-injective-left-mul-ℤ :
+    (x : ℤ) → is-nonzero-ℤ x → is-injective (x *ℤ_)
+  is-injective-left-mul-ℤ x f {y} {z} p =
+    eq-diff-ℤ
+      ( map-left-unit-law-coproduct-is-empty
+        ( is-zero-ℤ x)
+        ( is-zero-ℤ (y -ℤ z))
+        ( f)
+        ( is-zero-is-zero-mul-ℤ x
+          ( y -ℤ z)
+          ( left-distributive-mul-diff-ℤ x y z ∙ is-zero-diff-ℤ p)))
 
-is-injective-right-mul-ℤ :
-  (x : ℤ) → is-nonzero-ℤ x → is-injective (_*ℤ x)
-is-injective-right-mul-ℤ x f {y} {z} p =
-  is-injective-left-mul-ℤ
-    ( x)
-    ( f)
-    ( commutative-mul-ℤ x y ∙ (p ∙ commutative-mul-ℤ z x))
+  is-injective-right-mul-ℤ :
+    (x : ℤ) → is-nonzero-ℤ x → is-injective (_*ℤ x)
+  is-injective-right-mul-ℤ x f {y} {z} p =
+    is-injective-left-mul-ℤ
+      ( x)
+      ( f)
+      ( commutative-mul-ℤ x y ∙ (p ∙ commutative-mul-ℤ z x))
 ```
 
 ### Multiplication by a nonzero integer is an embedding
 
 ```agda
-is-emb-left-mul-ℤ : (x : ℤ) → is-nonzero-ℤ x → is-emb (x *ℤ_)
-is-emb-left-mul-ℤ x f =
-  is-emb-is-injective is-set-ℤ (is-injective-left-mul-ℤ x f)
+abstract
+  is-emb-left-mul-ℤ : (x : ℤ) → is-nonzero-ℤ x → is-emb (x *ℤ_)
+  is-emb-left-mul-ℤ x f =
+    is-emb-is-injective is-set-ℤ (is-injective-left-mul-ℤ x f)
 
-is-emb-right-mul-ℤ : (x : ℤ) → is-nonzero-ℤ x → is-emb (_*ℤ x)
-is-emb-right-mul-ℤ x f =
-  is-emb-is-injective is-set-ℤ (is-injective-right-mul-ℤ x f)
+  is-emb-right-mul-ℤ : (x : ℤ) → is-nonzero-ℤ x → is-emb (_*ℤ x)
+  is-emb-right-mul-ℤ x f =
+    is-emb-is-injective is-set-ℤ (is-injective-right-mul-ℤ x f)
 ```
 
 ## See also

--- a/src/elementary-number-theory/multiplication-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/multiplication-natural-numbers.lagda.md
@@ -68,6 +68,8 @@ triple-ℕ x = 3 *ℕ x
 
 ## Properties
 
+### Zero laws of multiplication
+
 ```agda
 abstract
   left-zero-law-mul-ℕ :
@@ -79,7 +81,11 @@ abstract
   right-zero-law-mul-ℕ zero-ℕ = refl
   right-zero-law-mul-ℕ (succ-ℕ x) =
     ( right-unit-law-add-ℕ (x *ℕ zero-ℕ)) ∙ (right-zero-law-mul-ℕ x)
+```
 
+### Unit laws of multiplication
+
+```agda
 abstract
   right-unit-law-mul-ℕ :
     (x : ℕ) → x *ℕ 1 ＝ x
@@ -90,7 +96,11 @@ abstract
     (x : ℕ) → 1 *ℕ x ＝ x
   left-unit-law-mul-ℕ zero-ℕ = refl
   left-unit-law-mul-ℕ (succ-ℕ x) = ap succ-ℕ (left-unit-law-mul-ℕ x)
+```
 
+### Successor laws of multiplication
+
+```agda
 abstract
   left-successor-law-mul-ℕ :
     (x y : ℕ) → (succ-ℕ x) *ℕ y ＝ (x *ℕ y) +ℕ y
@@ -103,7 +113,11 @@ abstract
     ( ( ap (λ t → succ-ℕ (t +ℕ y)) (right-successor-law-mul-ℕ x y)) ∙
       ( ap succ-ℕ (associative-add-ℕ x (x *ℕ y) y))) ∙
     ( inv (left-successor-law-add-ℕ x ((x *ℕ y) +ℕ y)))
+```
 
+### Commutativity of multiplication
+
+```agda
 abstract
   commutative-mul-ℕ :
     (x y : ℕ) → x *ℕ y ＝ y *ℕ x
@@ -112,7 +126,11 @@ abstract
     ( commutative-add-ℕ (x *ℕ y) y) ∙
     ( ( ap (y +ℕ_) (commutative-mul-ℕ x y)) ∙
       ( inv (right-successor-law-mul-ℕ y x)))
+```
 
+### Distributivity of multiplication over addition
+
+```agda
 abstract
   left-distributive-mul-add-ℕ :
     (x y z : ℕ) → x *ℕ (y +ℕ z) ＝ (x *ℕ y) +ℕ (x *ℕ z)
@@ -128,7 +146,6 @@ abstract
                 ( associative-add-ℕ y (x *ℕ z) z)))) ∙
           ( inv (associative-add-ℕ (x *ℕ y) y ((x *ℕ z) +ℕ z))))))
 
-abstract
   right-distributive-mul-add-ℕ :
     (x y z : ℕ) → (x +ℕ y) *ℕ z ＝ (x *ℕ z) +ℕ (y *ℕ z)
   right-distributive-mul-add-ℕ x y z =
@@ -136,7 +153,11 @@ abstract
     ( ( left-distributive-mul-add-ℕ z x y) ∙
       ( ( ap (_+ℕ (z *ℕ y)) (commutative-mul-ℕ z x)) ∙
         ( ap ((x *ℕ z) +ℕ_) (commutative-mul-ℕ z y))))
+```
 
+### Associativity of multiplication
+
+```agda
 abstract
   associative-mul-ℕ :
     (x y z : ℕ) → (x *ℕ y) *ℕ z ＝ x *ℕ (y *ℕ z)
@@ -144,7 +165,11 @@ abstract
   associative-mul-ℕ (succ-ℕ x) y z =
     ( right-distributive-mul-add-ℕ (x *ℕ y) y z) ∙
     ( ap (_+ℕ (y *ℕ z)) (associative-mul-ℕ x y z))
+```
 
+### Multiplying a natural number by two is adding it to itself
+
+```agda
 left-two-law-mul-ℕ :
   (x : ℕ) → 2 *ℕ x ＝ x +ℕ x
 left-two-law-mul-ℕ x =
@@ -156,44 +181,62 @@ right-two-law-mul-ℕ :
 right-two-law-mul-ℕ x =
   ( right-successor-law-mul-ℕ x 1) ∙
   ( ap (x +ℕ_) (right-unit-law-mul-ℕ x))
+```
 
+### Interchange laws of multiplication
+
+```agda
 interchange-law-mul-mul-ℕ : interchange-law mul-ℕ mul-ℕ
 interchange-law-mul-mul-ℕ =
   interchange-law-commutative-and-associative
     mul-ℕ
     commutative-mul-ℕ
     associative-mul-ℕ
+```
 
-is-injective-right-mul-succ-ℕ :
-  (k : ℕ) → is-injective (_*ℕ (succ-ℕ k))
-is-injective-right-mul-succ-ℕ k {zero-ℕ} {zero-ℕ} p = refl
-is-injective-right-mul-succ-ℕ k {succ-ℕ m} {succ-ℕ n} p =
-  ap succ-ℕ
-    ( is-injective-right-mul-succ-ℕ k {m} {n}
-      ( is-injective-right-add-ℕ
-        ( succ-ℕ k)
-        ( ( inv (left-successor-law-mul-ℕ m (succ-ℕ k))) ∙
-          ( ( p) ∙
-            ( left-successor-law-mul-ℕ n (succ-ℕ k))))))
+### Right multiplication by a nonzero natural number is injective
 
-is-injective-right-mul-ℕ : (k : ℕ) → is-nonzero-ℕ k → is-injective (_*ℕ k)
-is-injective-right-mul-ℕ k H p with
-  is-successor-is-nonzero-ℕ H
-... | pair l refl = is-injective-right-mul-succ-ℕ l p
+```agda
+abstract
+  is-injective-right-mul-succ-ℕ :
+    (k : ℕ) → is-injective (_*ℕ (succ-ℕ k))
+  is-injective-right-mul-succ-ℕ k {zero-ℕ} {zero-ℕ} p = refl
+  is-injective-right-mul-succ-ℕ k {succ-ℕ m} {succ-ℕ n} p =
+    ap succ-ℕ
+      ( is-injective-right-mul-succ-ℕ k {m} {n}
+        ( is-injective-right-add-ℕ
+          ( succ-ℕ k)
+          ( ( inv (left-successor-law-mul-ℕ m (succ-ℕ k))) ∙
+            ( ( p) ∙
+              ( left-successor-law-mul-ℕ n (succ-ℕ k))))))
 
-is-injective-left-mul-succ-ℕ :
-  (k : ℕ) → is-injective ((succ-ℕ k) *ℕ_)
-is-injective-left-mul-succ-ℕ k {m} {n} p =
-  is-injective-right-mul-succ-ℕ k
-    ( ( commutative-mul-ℕ m (succ-ℕ k)) ∙
-      ( p ∙ commutative-mul-ℕ (succ-ℕ k) n))
+  is-injective-right-mul-ℕ : (k : ℕ) → is-nonzero-ℕ k → is-injective (_*ℕ k)
+  is-injective-right-mul-ℕ k H p with
+    is-successor-is-nonzero-ℕ H
+  ... | pair l refl = is-injective-right-mul-succ-ℕ l p
+```
 
-is-injective-left-mul-ℕ :
-  (k : ℕ) → is-nonzero-ℕ k → is-injective (k *ℕ_)
-is-injective-left-mul-ℕ k H p with
-  is-successor-is-nonzero-ℕ H
-... | pair l refl = is-injective-left-mul-succ-ℕ l p
+### Left multiplication by a nonzero natural number is injective
 
+```agda
+abstract
+  is-injective-left-mul-succ-ℕ :
+    (k : ℕ) → is-injective ((succ-ℕ k) *ℕ_)
+  is-injective-left-mul-succ-ℕ k {m} {n} p =
+    is-injective-right-mul-succ-ℕ k
+      ( ( commutative-mul-ℕ m (succ-ℕ k)) ∙
+        ( p ∙ commutative-mul-ℕ (succ-ℕ k) n))
+
+  is-injective-left-mul-ℕ :
+    (k : ℕ) → is-nonzero-ℕ k → is-injective (k *ℕ_)
+  is-injective-left-mul-ℕ k H p with
+    is-successor-is-nonzero-ℕ H
+  ... | pair l refl = is-injective-left-mul-succ-ℕ l p
+```
+
+### Multiplication by a nonzero natural number is an embedding
+
+```agda
 is-emb-left-mul-ℕ : (x : ℕ) → is-nonzero-ℕ x → is-emb (x *ℕ_)
 is-emb-left-mul-ℕ x H =
   is-emb-is-injective is-set-ℕ (is-injective-left-mul-ℕ x H)
@@ -201,88 +244,105 @@ is-emb-left-mul-ℕ x H =
 is-emb-right-mul-ℕ : (x : ℕ) → is-nonzero-ℕ x → is-emb (_*ℕ x)
 is-emb-right-mul-ℕ x H =
   is-emb-is-injective is-set-ℕ (is-injective-right-mul-ℕ x H)
-
-is-nonzero-mul-ℕ :
-  (x y : ℕ) → is-nonzero-ℕ x → is-nonzero-ℕ y → is-nonzero-ℕ (x *ℕ y)
-is-nonzero-mul-ℕ x y H K p =
-  K (is-injective-left-mul-ℕ x H (p ∙ (inv (right-zero-law-mul-ℕ x))))
-
-is-nonzero-left-factor-mul-ℕ :
-  (x y : ℕ) → is-nonzero-ℕ (x *ℕ y) → is-nonzero-ℕ x
-is-nonzero-left-factor-mul-ℕ .zero-ℕ y H refl = H (left-zero-law-mul-ℕ y)
-
-is-nonzero-right-factor-mul-ℕ :
-  (x y : ℕ) → is-nonzero-ℕ (x *ℕ y) → is-nonzero-ℕ y
-is-nonzero-right-factor-mul-ℕ x .zero-ℕ H refl = H (right-zero-law-mul-ℕ x)
 ```
 
-We conclude that $y = 1$ if $(x+1)y = x+1$.
+### The product of two natural numbers is nonzero if and only if both are nonzero
 
 ```agda
-is-one-is-right-unit-mul-ℕ :
-  (x y : ℕ) → (succ-ℕ x) *ℕ y ＝ succ-ℕ x → is-one-ℕ y
-is-one-is-right-unit-mul-ℕ x y p =
-  is-injective-left-mul-succ-ℕ x (p ∙ inv (right-unit-law-mul-ℕ (succ-ℕ x)))
+abstract
+  is-nonzero-mul-ℕ :
+    (x y : ℕ) → is-nonzero-ℕ x → is-nonzero-ℕ y → is-nonzero-ℕ (x *ℕ y)
+  is-nonzero-mul-ℕ x y H K p =
+    K (is-injective-left-mul-ℕ x H (p ∙ (inv (right-zero-law-mul-ℕ x))))
 
-is-one-is-left-unit-mul-ℕ :
-  (x y : ℕ) → x *ℕ (succ-ℕ y) ＝ succ-ℕ y → is-one-ℕ x
-is-one-is-left-unit-mul-ℕ x y p =
-  is-injective-right-mul-succ-ℕ y (p ∙ inv (left-unit-law-mul-ℕ (succ-ℕ y)))
+  is-nonzero-left-factor-mul-ℕ :
+    (x y : ℕ) → is-nonzero-ℕ (x *ℕ y) → is-nonzero-ℕ x
+  is-nonzero-left-factor-mul-ℕ .zero-ℕ y H refl = H (left-zero-law-mul-ℕ y)
 
-is-one-right-is-one-mul-ℕ :
-  (x y : ℕ) → is-one-ℕ (x *ℕ y) → is-one-ℕ y
-is-one-right-is-one-mul-ℕ zero-ℕ zero-ℕ p = p
-is-one-right-is-one-mul-ℕ zero-ℕ (succ-ℕ y) ()
-is-one-right-is-one-mul-ℕ (succ-ℕ x) zero-ℕ p =
-  is-one-right-is-one-mul-ℕ x zero-ℕ p
-is-one-right-is-one-mul-ℕ (succ-ℕ x) (succ-ℕ y) p =
-  ap
-    ( succ-ℕ)
-    ( is-zero-right-is-zero-add-ℕ (x *ℕ (succ-ℕ y)) y
-      ( is-injective-succ-ℕ p))
+  is-nonzero-right-factor-mul-ℕ :
+    (x y : ℕ) → is-nonzero-ℕ (x *ℕ y) → is-nonzero-ℕ y
+  is-nonzero-right-factor-mul-ℕ x .zero-ℕ H refl = H (right-zero-law-mul-ℕ x)
+```
 
-is-one-left-is-one-mul-ℕ :
-  (x y : ℕ) → is-one-ℕ (x *ℕ y) → is-one-ℕ x
-is-one-left-is-one-mul-ℕ x y p =
-  is-one-right-is-one-mul-ℕ y x (commutative-mul-ℕ y x ∙ p)
+### If `(x+1)y = x+1`, then `y = 1`
 
-is-one-mul-ℕ :
-  (x y : ℕ) → is-one-ℕ x → is-one-ℕ y → is-one-ℕ (x *ℕ y)
-is-one-mul-ℕ .1 .1 refl refl = refl
+```agda
+abstract
+  is-one-is-right-unit-mul-ℕ :
+    (x y : ℕ) → (succ-ℕ x) *ℕ y ＝ succ-ℕ x → is-one-ℕ y
+  is-one-is-right-unit-mul-ℕ x y p =
+    is-injective-left-mul-succ-ℕ x (p ∙ inv (right-unit-law-mul-ℕ (succ-ℕ x)))
 
-neq-mul-ℕ :
-  (m n : ℕ) → succ-ℕ m ≠ (succ-ℕ m *ℕ (succ-ℕ (succ-ℕ n)))
-neq-mul-ℕ m n p =
-  neq-add-ℕ
-    ( succ-ℕ m)
-    ( ( m *ℕ (succ-ℕ n)) +ℕ n)
-    ( ( p) ∙
-      ( ( right-successor-law-mul-ℕ (succ-ℕ m) (succ-ℕ n)) ∙
-        ( ap ((succ-ℕ m) +ℕ_) (left-successor-law-mul-ℕ m (succ-ℕ n)))))
+  is-one-is-left-unit-mul-ℕ :
+    (x y : ℕ) → x *ℕ (succ-ℕ y) ＝ succ-ℕ y → is-one-ℕ x
+  is-one-is-left-unit-mul-ℕ x y p =
+    is-injective-right-mul-succ-ℕ y (p ∙ inv (left-unit-law-mul-ℕ (succ-ℕ y)))
+
+  is-one-right-is-one-mul-ℕ :
+    (x y : ℕ) → is-one-ℕ (x *ℕ y) → is-one-ℕ y
+  is-one-right-is-one-mul-ℕ zero-ℕ zero-ℕ p = p
+  is-one-right-is-one-mul-ℕ zero-ℕ (succ-ℕ y) ()
+  is-one-right-is-one-mul-ℕ (succ-ℕ x) zero-ℕ p =
+    is-one-right-is-one-mul-ℕ x zero-ℕ p
+  is-one-right-is-one-mul-ℕ (succ-ℕ x) (succ-ℕ y) p =
+    ap
+      ( succ-ℕ)
+      ( is-zero-right-is-zero-add-ℕ (x *ℕ (succ-ℕ y)) y
+        ( is-injective-succ-ℕ p))
+```
+
+### The product of two natural numbers is one if and only if both are one
+
+```agda
+abstract
+  is-one-left-is-one-mul-ℕ :
+    (x y : ℕ) → is-one-ℕ (x *ℕ y) → is-one-ℕ x
+  is-one-left-is-one-mul-ℕ x y p =
+    is-one-right-is-one-mul-ℕ y x (commutative-mul-ℕ y x ∙ p)
+
+  is-one-mul-ℕ :
+    (x y : ℕ) → is-one-ℕ x → is-one-ℕ y → is-one-ℕ (x *ℕ y)
+  is-one-mul-ℕ .1 .1 refl refl = refl
+```
+
+### For all `m` and `n`, `m + 1 ≠ (m+1)(n+2)`
+
+```agda
+abstract
+  neq-mul-ℕ :
+    (m n : ℕ) → succ-ℕ m ≠ (succ-ℕ m *ℕ (succ-ℕ (succ-ℕ n)))
+  neq-mul-ℕ m n p =
+    neq-add-ℕ
+      ( succ-ℕ m)
+      ( ( m *ℕ (succ-ℕ n)) +ℕ n)
+      ( ( p) ∙
+        ( ( right-successor-law-mul-ℕ (succ-ℕ m) (succ-ℕ n)) ∙
+          ( ap ((succ-ℕ m) +ℕ_) (left-successor-law-mul-ℕ m (succ-ℕ n)))))
 ```
 
 ### Either of the factors is zero if and only if the product is zero
 
 ```agda
-is-zero-summand-is-zero-mul-ℕ :
-  (x y : ℕ) → is-zero-ℕ (x *ℕ y) → is-zero-ℕ x + is-zero-ℕ y
-is-zero-summand-is-zero-mul-ℕ 0 y H = inl refl
-is-zero-summand-is-zero-mul-ℕ (succ-ℕ x) 0 H = inr refl
+abstract
+  is-zero-summand-is-zero-mul-ℕ :
+    (x y : ℕ) → is-zero-ℕ (x *ℕ y) → is-zero-ℕ x + is-zero-ℕ y
+  is-zero-summand-is-zero-mul-ℕ 0 y H = inl refl
+  is-zero-summand-is-zero-mul-ℕ (succ-ℕ x) 0 H = inr refl
 
-is-zero-mul-ℕ-is-zero-left-summand :
-  (x y : ℕ) → is-zero-ℕ x → is-zero-ℕ (x *ℕ y)
-is-zero-mul-ℕ-is-zero-left-summand .0 y refl = left-zero-law-mul-ℕ y
+  is-zero-mul-ℕ-is-zero-left-summand :
+    (x y : ℕ) → is-zero-ℕ x → is-zero-ℕ (x *ℕ y)
+  is-zero-mul-ℕ-is-zero-left-summand .0 y refl = left-zero-law-mul-ℕ y
 
-is-zero-mul-ℕ-is-zero-right-summand :
-  (x y : ℕ) → is-zero-ℕ y → is-zero-ℕ (x *ℕ y)
-is-zero-mul-ℕ-is-zero-right-summand x .0 refl = right-zero-law-mul-ℕ x
+  is-zero-mul-ℕ-is-zero-right-summand :
+    (x y : ℕ) → is-zero-ℕ y → is-zero-ℕ (x *ℕ y)
+  is-zero-mul-ℕ-is-zero-right-summand x .0 refl = right-zero-law-mul-ℕ x
 
-is-zero-mul-ℕ-is-zero-summand :
-  (x y : ℕ) → is-zero-ℕ x + is-zero-ℕ y → is-zero-ℕ (x *ℕ y)
-is-zero-mul-ℕ-is-zero-summand x y (inl H) =
-  is-zero-mul-ℕ-is-zero-left-summand x y H
-is-zero-mul-ℕ-is-zero-summand x y (inr H) =
-  is-zero-mul-ℕ-is-zero-right-summand x y H
+  is-zero-mul-ℕ-is-zero-summand :
+    (x y : ℕ) → is-zero-ℕ x + is-zero-ℕ y → is-zero-ℕ (x *ℕ y)
+  is-zero-mul-ℕ-is-zero-summand x y (inl H) =
+    is-zero-mul-ℕ-is-zero-left-summand x y H
+  is-zero-mul-ℕ-is-zero-summand x y (inr H) =
+    is-zero-mul-ℕ-is-zero-right-summand x y H
 ```
 
 ## See also

--- a/src/elementary-number-theory/negative-integers.lagda.md
+++ b/src/elementary-number-theory/negative-integers.lagda.md
@@ -148,24 +148,26 @@ eq-nat-negative-pred-negative-ℤ :
   nat-negative-ℤ (pred-negative-ℤ x) ＝ succ-ℕ (nat-negative-ℤ x)
 eq-nat-negative-pred-negative-ℤ (inl x , H) = refl
 
-is-section-nat-negative-ℤ :
-  (x : negative-ℤ) → negative-int-ℕ (nat-negative-ℤ x) ＝ x
-is-section-nat-negative-ℤ (inl zero-ℕ , H) = refl
-is-section-nat-negative-ℤ (inl (succ-ℕ x) , H) =
-  ap pred-negative-ℤ (is-section-nat-negative-ℤ (inl x , H))
+abstract
+  is-section-nat-negative-ℤ :
+    (x : negative-ℤ) → negative-int-ℕ (nat-negative-ℤ x) ＝ x
+  is-section-nat-negative-ℤ (inl zero-ℕ , H) = refl
+  is-section-nat-negative-ℤ (inl (succ-ℕ x) , H) =
+    ap pred-negative-ℤ (is-section-nat-negative-ℤ (inl x , H))
 
-is-retraction-nat-negative-ℤ :
-  (n : ℕ) → nat-negative-ℤ (negative-int-ℕ n) ＝ n
-is-retraction-nat-negative-ℤ zero-ℕ = refl
-is-retraction-nat-negative-ℤ (succ-ℕ n) =
-  eq-nat-negative-pred-negative-ℤ (negative-int-ℕ n) ∙
-  ap succ-ℕ (is-retraction-nat-negative-ℤ n)
+  is-retraction-nat-negative-ℤ :
+    (n : ℕ) → nat-negative-ℤ (negative-int-ℕ n) ＝ n
+  is-retraction-nat-negative-ℤ zero-ℕ = refl
+  is-retraction-nat-negative-ℤ (succ-ℕ n) =
+    eq-nat-negative-pred-negative-ℤ (negative-int-ℕ n) ∙
+    ap succ-ℕ (is-retraction-nat-negative-ℤ n)
 
-is-equiv-negative-int-ℕ : is-equiv negative-int-ℕ
-pr1 (pr1 is-equiv-negative-int-ℕ) = nat-negative-ℤ
-pr2 (pr1 is-equiv-negative-int-ℕ) = is-section-nat-negative-ℤ
-pr1 (pr2 is-equiv-negative-int-ℕ) = nat-negative-ℤ
-pr2 (pr2 is-equiv-negative-int-ℕ) = is-retraction-nat-negative-ℤ
+  is-equiv-negative-int-ℕ : is-equiv negative-int-ℕ
+  is-equiv-negative-int-ℕ =
+    is-equiv-is-invertible
+      ( nat-negative-ℤ)
+      ( is-section-nat-negative-ℤ)
+      ( is-retraction-nat-negative-ℤ)
 
 equiv-negative-int-ℕ : ℕ ≃ negative-ℤ
 pr1 equiv-negative-int-ℕ = negative-int-ℕ

--- a/src/elementary-number-theory/nonnegative-integers.lagda.md
+++ b/src/elementary-number-theory/nonnegative-integers.lagda.md
@@ -165,27 +165,23 @@ eq-nat-nonnegative-succ-nonnnegative-ℤ :
 eq-nat-nonnegative-succ-nonnnegative-ℤ (inr (inl x) , H) = refl
 eq-nat-nonnegative-succ-nonnnegative-ℤ (inr (inr x) , H) = refl
 
-is-section-nat-nonnegative-ℤ :
-  (x : nonnegative-ℤ) → nonnegative-int-ℕ (nat-nonnegative-ℤ x) ＝ x
-is-section-nat-nonnegative-ℤ ((inr (inl star)) , H) = refl
-is-section-nat-nonnegative-ℤ ((inr (inr x)) , H) = refl
+abstract
+  is-section-nat-nonnegative-ℤ :
+    (x : nonnegative-ℤ) → nonnegative-int-ℕ (nat-nonnegative-ℤ x) ＝ x
+  is-section-nat-nonnegative-ℤ ((inr (inl star)) , H) = refl
+  is-section-nat-nonnegative-ℤ ((inr (inr x)) , H) = refl
 
-is-retraction-nat-nonnegative-ℤ :
-  (n : ℕ) → nat-nonnegative-ℤ (nonnegative-int-ℕ n) ＝ n
-is-retraction-nat-nonnegative-ℤ zero-ℕ = refl
-is-retraction-nat-nonnegative-ℤ (succ-ℕ n) = refl
+  is-retraction-nat-nonnegative-ℤ :
+    (n : ℕ) → nat-nonnegative-ℤ (nonnegative-int-ℕ n) ＝ n
+  is-retraction-nat-nonnegative-ℤ zero-ℕ = refl
+  is-retraction-nat-nonnegative-ℤ (succ-ℕ n) = refl
 
-is-equiv-nat-nonnegative-ℤ : is-equiv nat-nonnegative-ℤ
-pr1 (pr1 is-equiv-nat-nonnegative-ℤ) = nonnegative-int-ℕ
-pr2 (pr1 is-equiv-nat-nonnegative-ℤ) = is-retraction-nat-nonnegative-ℤ
-pr1 (pr2 is-equiv-nat-nonnegative-ℤ) = nonnegative-int-ℕ
-pr2 (pr2 is-equiv-nat-nonnegative-ℤ) = is-section-nat-nonnegative-ℤ
-
-is-equiv-nonnegative-int-ℕ : is-equiv nonnegative-int-ℕ
-pr1 (pr1 is-equiv-nonnegative-int-ℕ) = nat-nonnegative-ℤ
-pr2 (pr1 is-equiv-nonnegative-int-ℕ) = is-section-nat-nonnegative-ℤ
-pr1 (pr2 is-equiv-nonnegative-int-ℕ) = nat-nonnegative-ℤ
-pr2 (pr2 is-equiv-nonnegative-int-ℕ) = is-retraction-nat-nonnegative-ℤ
+  is-equiv-nonnegative-int-ℕ : is-equiv nonnegative-int-ℕ
+  is-equiv-nonnegative-int-ℕ =
+    is-equiv-is-invertible
+      ( nat-nonnegative-ℤ)
+      ( is-section-nat-nonnegative-ℤ)
+      ( is-retraction-nat-nonnegative-ℤ)
 
 equiv-nonnegative-int-ℕ : ℕ ≃ nonnegative-ℤ
 pr1 equiv-nonnegative-int-ℕ = nonnegative-int-ℕ

--- a/src/elementary-number-theory/nonpositive-integers.lagda.md
+++ b/src/elementary-number-theory/nonpositive-integers.lagda.md
@@ -160,25 +160,27 @@ eq-nat-nonpositive-pred-nonpositive-ℤ :
 eq-nat-nonpositive-pred-nonpositive-ℤ (inl x , H) = refl
 eq-nat-nonpositive-pred-nonpositive-ℤ (inr (inl x) , H) = refl
 
-is-section-nat-nonpositive-ℤ :
-  (x : nonpositive-ℤ) → nonpositive-int-ℕ (nat-nonpositive-ℤ x) ＝ x
-is-section-nat-nonpositive-ℤ (inl zero-ℕ , H) = refl
-is-section-nat-nonpositive-ℤ (inl (succ-ℕ x) , H) =
-  ap pred-nonpositive-ℤ (is-section-nat-nonpositive-ℤ (inl x , H))
-is-section-nat-nonpositive-ℤ (inr (inl x) , H) = refl
+abstract
+  is-section-nat-nonpositive-ℤ :
+    (x : nonpositive-ℤ) → nonpositive-int-ℕ (nat-nonpositive-ℤ x) ＝ x
+  is-section-nat-nonpositive-ℤ (inl zero-ℕ , H) = refl
+  is-section-nat-nonpositive-ℤ (inl (succ-ℕ x) , H) =
+    ap pred-nonpositive-ℤ (is-section-nat-nonpositive-ℤ (inl x , H))
+  is-section-nat-nonpositive-ℤ (inr (inl x) , H) = refl
 
-is-retraction-nat-nonpositive-ℤ :
-  (n : ℕ) → nat-nonpositive-ℤ (nonpositive-int-ℕ n) ＝ n
-is-retraction-nat-nonpositive-ℤ zero-ℕ = refl
-is-retraction-nat-nonpositive-ℤ (succ-ℕ n) =
-  eq-nat-nonpositive-pred-nonpositive-ℤ (nonpositive-int-ℕ n) ∙
-  ap succ-ℕ (is-retraction-nat-nonpositive-ℤ n)
+  is-retraction-nat-nonpositive-ℤ :
+    (n : ℕ) → nat-nonpositive-ℤ (nonpositive-int-ℕ n) ＝ n
+  is-retraction-nat-nonpositive-ℤ zero-ℕ = refl
+  is-retraction-nat-nonpositive-ℤ (succ-ℕ n) =
+    eq-nat-nonpositive-pred-nonpositive-ℤ (nonpositive-int-ℕ n) ∙
+    ap succ-ℕ (is-retraction-nat-nonpositive-ℤ n)
 
-is-equiv-nonpositive-int-ℕ : is-equiv nonpositive-int-ℕ
-pr1 (pr1 is-equiv-nonpositive-int-ℕ) = nat-nonpositive-ℤ
-pr2 (pr1 is-equiv-nonpositive-int-ℕ) = is-section-nat-nonpositive-ℤ
-pr1 (pr2 is-equiv-nonpositive-int-ℕ) = nat-nonpositive-ℤ
-pr2 (pr2 is-equiv-nonpositive-int-ℕ) = is-retraction-nat-nonpositive-ℤ
+  is-equiv-nonpositive-int-ℕ : is-equiv nonpositive-int-ℕ
+  is-equiv-nonpositive-int-ℕ =
+    is-equiv-is-invertible
+      ( nat-nonpositive-ℤ)
+      ( is-section-nat-nonpositive-ℤ)
+      ( is-retraction-nat-nonpositive-ℤ)
 
 equiv-nonpositive-int-ℕ : ℕ ≃ nonpositive-ℤ
 pr1 equiv-nonpositive-int-ℕ = nonpositive-int-ℕ

--- a/src/elementary-number-theory/parity-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/parity-natural-numbers.lagda.md
@@ -68,76 +68,82 @@ is-odd-one-ℕ H = Eq-eq-ℕ (is-one-div-one-ℕ 2 H)
 ### A natural number `x` is even if and only if `x + 2` is even
 
 ```agda
-is-even-is-even-succ-succ-ℕ :
-  (n : ℕ) → is-even-ℕ (succ-ℕ (succ-ℕ n)) → is-even-ℕ n
-pr1 (is-even-is-even-succ-succ-ℕ n (succ-ℕ d , p)) = d
-pr2 (is-even-is-even-succ-succ-ℕ n (succ-ℕ d , p)) =
-  is-injective-succ-ℕ (is-injective-succ-ℕ p)
+abstract
+  is-even-is-even-succ-succ-ℕ :
+    (n : ℕ) → is-even-ℕ (succ-ℕ (succ-ℕ n)) → is-even-ℕ n
+  pr1 (is-even-is-even-succ-succ-ℕ n (succ-ℕ d , p)) = d
+  pr2 (is-even-is-even-succ-succ-ℕ n (succ-ℕ d , p)) =
+    is-injective-succ-ℕ (is-injective-succ-ℕ p)
 
-is-even-succ-succ-is-even-ℕ :
-  (n : ℕ) → is-even-ℕ n → is-even-ℕ (succ-ℕ (succ-ℕ n))
-pr1 (is-even-succ-succ-is-even-ℕ n (d , p)) = succ-ℕ d
-pr2 (is-even-succ-succ-is-even-ℕ n (d , p)) = ap (succ-ℕ ∘ succ-ℕ) p
+  is-even-succ-succ-is-even-ℕ :
+    (n : ℕ) → is-even-ℕ n → is-even-ℕ (succ-ℕ (succ-ℕ n))
+  pr1 (is-even-succ-succ-is-even-ℕ n (d , p)) = succ-ℕ d
+  pr2 (is-even-succ-succ-is-even-ℕ n (d , p)) = ap (succ-ℕ ∘ succ-ℕ) p
 ```
 
 ### A natural number `x` is odd if and only if `x + 2` is odd
 
 ```agda
-is-odd-is-odd-succ-succ-ℕ :
-  (n : ℕ) → is-odd-ℕ (succ-ℕ (succ-ℕ n)) → is-odd-ℕ n
-is-odd-is-odd-succ-succ-ℕ n = map-neg (is-even-succ-succ-is-even-ℕ n)
+abstract
+  is-odd-is-odd-succ-succ-ℕ :
+    (n : ℕ) → is-odd-ℕ (succ-ℕ (succ-ℕ n)) → is-odd-ℕ n
+  is-odd-is-odd-succ-succ-ℕ n = map-neg (is-even-succ-succ-is-even-ℕ n)
 
-is-odd-succ-succ-is-odd-ℕ :
-  (n : ℕ) → is-odd-ℕ n → is-odd-ℕ (succ-ℕ (succ-ℕ n))
-is-odd-succ-succ-is-odd-ℕ n = map-neg (is-even-is-even-succ-succ-ℕ n)
+  is-odd-succ-succ-is-odd-ℕ :
+    (n : ℕ) → is-odd-ℕ n → is-odd-ℕ (succ-ℕ (succ-ℕ n))
+  is-odd-succ-succ-is-odd-ℕ n = map-neg (is-even-is-even-succ-succ-ℕ n)
 ```
 
 ### If a natural number `x` is odd, then `x + 1` is even
 
 ```agda
-is-even-succ-is-odd-ℕ :
-  (n : ℕ) → is-odd-ℕ n → is-even-ℕ (succ-ℕ n)
-is-even-succ-is-odd-ℕ zero-ℕ p = ex-falso (p is-even-zero-ℕ)
-is-even-succ-is-odd-ℕ (succ-ℕ zero-ℕ) p = (1 , refl)
-is-even-succ-is-odd-ℕ (succ-ℕ (succ-ℕ n)) p =
-  is-even-succ-succ-is-even-ℕ
-    ( succ-ℕ n)
-    ( is-even-succ-is-odd-ℕ n (is-odd-is-odd-succ-succ-ℕ n p))
+abstract
+  is-even-succ-is-odd-ℕ :
+    (n : ℕ) → is-odd-ℕ n → is-even-ℕ (succ-ℕ n)
+  is-even-succ-is-odd-ℕ zero-ℕ p = ex-falso (p is-even-zero-ℕ)
+  is-even-succ-is-odd-ℕ (succ-ℕ zero-ℕ) p = (1 , refl)
+  is-even-succ-is-odd-ℕ (succ-ℕ (succ-ℕ n)) p =
+    is-even-succ-succ-is-even-ℕ
+      ( succ-ℕ n)
+      ( is-even-succ-is-odd-ℕ n (is-odd-is-odd-succ-succ-ℕ n p))
 ```
 
 ### If a natural number `x` is even, then `x + 1` is odd
 
 ```agda
-is-odd-succ-is-even-ℕ :
-  (n : ℕ) → is-even-ℕ n → is-odd-ℕ (succ-ℕ n)
-is-odd-succ-is-even-ℕ zero-ℕ p = is-odd-one-ℕ
-is-odd-succ-is-even-ℕ (succ-ℕ zero-ℕ) p = ex-falso (is-odd-one-ℕ p)
-is-odd-succ-is-even-ℕ (succ-ℕ (succ-ℕ n)) p =
-  is-odd-succ-succ-is-odd-ℕ
-    ( succ-ℕ n)
-    ( is-odd-succ-is-even-ℕ n (is-even-is-even-succ-succ-ℕ n p))
+abstract
+  is-odd-succ-is-even-ℕ :
+    (n : ℕ) → is-even-ℕ n → is-odd-ℕ (succ-ℕ n)
+  is-odd-succ-is-even-ℕ zero-ℕ p = is-odd-one-ℕ
+  is-odd-succ-is-even-ℕ (succ-ℕ zero-ℕ) p = ex-falso (is-odd-one-ℕ p)
+  is-odd-succ-is-even-ℕ (succ-ℕ (succ-ℕ n)) p =
+    is-odd-succ-succ-is-odd-ℕ
+      ( succ-ℕ n)
+      ( is-odd-succ-is-even-ℕ n (is-even-is-even-succ-succ-ℕ n p))
 ```
 
 ### If a natural number `x + 1` is odd, then `x` is even
 
 ```agda
-is-even-is-odd-succ-ℕ :
-  (n : ℕ) → is-odd-ℕ (succ-ℕ n) → is-even-ℕ n
-is-even-is-odd-succ-ℕ n p =
-  is-even-is-even-succ-succ-ℕ
-    ( n)
-    ( is-even-succ-is-odd-ℕ (succ-ℕ n) p)
+abstract
+  is-even-is-odd-succ-ℕ :
+    (n : ℕ) → is-odd-ℕ (succ-ℕ n) → is-even-ℕ n
+  is-even-is-odd-succ-ℕ n p =
+    is-even-is-even-succ-succ-ℕ
+      ( n)
+      ( is-even-succ-is-odd-ℕ (succ-ℕ n) p)
 ```
 
 ### If a natural number `x + 1` is even, then `x` is odd
 
 ```agda
-is-odd-is-even-succ-ℕ :
-  (n : ℕ) → is-even-ℕ (succ-ℕ n) → is-odd-ℕ n
-is-odd-is-even-succ-ℕ n p =
-  is-odd-is-odd-succ-succ-ℕ
-    ( n)
-    ( is-odd-succ-is-even-ℕ (succ-ℕ n) p)
+abstract
+  is-odd-is-even-succ-ℕ :
+    (n : ℕ) → is-even-ℕ (succ-ℕ n) → is-odd-ℕ n
+  is-odd-is-even-succ-ℕ n p =
+    is-odd-is-odd-succ-succ-ℕ
+      ( n)
+      ( is-odd-succ-is-even-ℕ (succ-ℕ n) p)
 ```
 
 ### A natural number `x` is odd if and only if there is a natural number `y` such that `succ-ℕ (y *ℕ 2) ＝ x`
@@ -146,18 +152,19 @@ is-odd-is-even-succ-ℕ n p =
 has-odd-expansion : ℕ → UU lzero
 has-odd-expansion x = Σ ℕ (λ y → (succ-ℕ (y *ℕ 2)) ＝ x)
 
-is-odd-has-odd-expansion : (n : ℕ) → has-odd-expansion n → is-odd-ℕ n
-is-odd-has-odd-expansion .(succ-ℕ (m *ℕ 2)) (m , refl) =
-  is-odd-succ-is-even-ℕ (m *ℕ 2) (m , refl)
+abstract
+  is-odd-has-odd-expansion : (n : ℕ) → has-odd-expansion n → is-odd-ℕ n
+  is-odd-has-odd-expansion .(succ-ℕ (m *ℕ 2)) (m , refl) =
+    is-odd-succ-is-even-ℕ (m *ℕ 2) (m , refl)
 
-has-odd-expansion-is-odd : (n : ℕ) → is-odd-ℕ n → has-odd-expansion n
-has-odd-expansion-is-odd zero-ℕ p = ex-falso (p is-even-zero-ℕ)
-has-odd-expansion-is-odd (succ-ℕ zero-ℕ) p = 0 , refl
-has-odd-expansion-is-odd (succ-ℕ (succ-ℕ n)) p =
-  ( succ-ℕ (pr1 s)) , ap (succ-ℕ ∘ succ-ℕ) (pr2 s)
-  where
-  s : has-odd-expansion n
-  s = has-odd-expansion-is-odd n (is-odd-is-odd-succ-succ-ℕ n p)
+  has-odd-expansion-is-odd : (n : ℕ) → is-odd-ℕ n → has-odd-expansion n
+  has-odd-expansion-is-odd zero-ℕ p = ex-falso (p is-even-zero-ℕ)
+  has-odd-expansion-is-odd (succ-ℕ zero-ℕ) p = 0 , refl
+  has-odd-expansion-is-odd (succ-ℕ (succ-ℕ n)) p =
+    ( succ-ℕ (pr1 s)) , ap (succ-ℕ ∘ succ-ℕ) (pr2 s)
+    where
+    s : has-odd-expansion n
+    s = has-odd-expansion-is-odd n (is-odd-is-odd-succ-succ-ℕ n p)
 ```
 
 ### If `x` is odd and `y` is even, `x ≠ y`

--- a/src/elementary-number-theory/poset-of-natural-numbers-ordered-by-divisibility.lagda.md
+++ b/src/elementary-number-theory/poset-of-natural-numbers-ordered-by-divisibility.lagda.md
@@ -30,7 +30,8 @@ open import order-theory.preorders
 
 ## Idea
 
-The **poset of natural numbers ordered by divisibility** consists of the
+The **[poset](order-theory.posets.md) of natural numbers ordered by
+divisibility** consists of the
 [natural numbers](elementary-number-theory.natural-numbers.md) and its ordering
 is defined by `m ≤ n := m | n`, i.e., by
 [divisibility](elementary-number-theory.divisibility-natural-numbers.md).

--- a/src/elementary-number-theory/positive-and-negative-integers.lagda.md
+++ b/src/elementary-number-theory/positive-and-negative-integers.lagda.md
@@ -223,35 +223,37 @@ neg-negative-ℤ (x , H) = (neg-ℤ x , is-positive-neg-is-negative-ℤ H)
 #### Nonpositivity is negated positivity
 
 ```agda
-is-not-positive-is-nonpositive-ℤ :
-  {x : ℤ} → is-nonpositive-ℤ x → ¬ (is-positive-ℤ x)
-is-not-positive-is-nonpositive-ℤ {inr (inl x)} _ q = q
-is-not-positive-is-nonpositive-ℤ {inr (inr x)} p _ = p
+abstract
+  is-not-positive-is-nonpositive-ℤ :
+    {x : ℤ} → is-nonpositive-ℤ x → ¬ (is-positive-ℤ x)
+  is-not-positive-is-nonpositive-ℤ {inr (inl x)} _ q = q
+  is-not-positive-is-nonpositive-ℤ {inr (inr x)} p _ = p
 
-is-nonpositive-is-not-positive-ℤ :
-  {x : ℤ} → ¬ (is-positive-ℤ x) → is-nonpositive-ℤ x
-is-nonpositive-is-not-positive-ℤ {x} H =
-  rec-coproduct
-    ( λ K → ex-falso (H K))
-    ( id)
-    ( decide-is-positive-is-nonpositive-ℤ)
+  is-nonpositive-is-not-positive-ℤ :
+    {x : ℤ} → ¬ (is-positive-ℤ x) → is-nonpositive-ℤ x
+  is-nonpositive-is-not-positive-ℤ {x} H =
+    rec-coproduct
+      ( λ K → ex-falso (H K))
+      ( id)
+      ( decide-is-positive-is-nonpositive-ℤ)
 ```
 
 #### Nonnegativity is negated negativity
 
 ```agda
-is-not-negative-is-nonnegative-ℤ :
-  {x : ℤ} → is-nonnegative-ℤ x → ¬ (is-negative-ℤ x)
-is-not-negative-is-nonnegative-ℤ {x} H K =
-  is-not-positive-is-nonpositive-ℤ
-    ( is-nonpositive-neg-is-nonnegative-ℤ H)
-    ( is-positive-neg-is-negative-ℤ K)
+abstract
+  is-not-negative-is-nonnegative-ℤ :
+    {x : ℤ} → is-nonnegative-ℤ x → ¬ (is-negative-ℤ x)
+  is-not-negative-is-nonnegative-ℤ {x} H K =
+    is-not-positive-is-nonpositive-ℤ
+      ( is-nonpositive-neg-is-nonnegative-ℤ H)
+      ( is-positive-neg-is-negative-ℤ K)
 
-is-nonnegative-is-not-negative-ℤ :
-  {x : ℤ} → ¬ (is-negative-ℤ x) → is-nonnegative-ℤ x
-is-nonnegative-is-not-negative-ℤ {x} H =
-  rec-coproduct
-    ( λ K → ex-falso (H K))
-    ( id)
-    ( decide-is-negative-is-nonnegative-ℤ)
+  is-nonnegative-is-not-negative-ℤ :
+    {x : ℤ} → ¬ (is-negative-ℤ x) → is-nonnegative-ℤ x
+  is-nonnegative-is-not-negative-ℤ {x} H =
+    rec-coproduct
+      ( λ K → ex-falso (H K))
+      ( id)
+      ( decide-is-negative-is-nonnegative-ℤ)
 ```

--- a/src/elementary-number-theory/positive-integers.lagda.md
+++ b/src/elementary-number-theory/positive-integers.lagda.md
@@ -66,10 +66,11 @@ is-positive-ℤ (inl x) = empty
 is-positive-ℤ (inr (inl x)) = empty
 is-positive-ℤ (inr (inr x)) = unit
 
-is-prop-is-positive-ℤ : (x : ℤ) → is-prop (is-positive-ℤ x)
-is-prop-is-positive-ℤ (inl x) = is-prop-empty
-is-prop-is-positive-ℤ (inr (inl x)) = is-prop-empty
-is-prop-is-positive-ℤ (inr (inr x)) = is-prop-unit
+abstract
+  is-prop-is-positive-ℤ : (x : ℤ) → is-prop (is-positive-ℤ x)
+  is-prop-is-positive-ℤ (inl x) = is-prop-empty
+  is-prop-is-positive-ℤ (inr (inl x)) = is-prop-empty
+  is-prop-is-positive-ℤ (inr (inr x)) = is-prop-unit
 
 subtype-positive-ℤ : subtype lzero ℤ
 subtype-positive-ℤ x = (is-positive-ℤ x , is-prop-is-positive-ℤ x)
@@ -142,9 +143,10 @@ positive-ℤ-Set = positive-ℤ , is-set-positive-ℤ
 ### The successor of a positive integer is positive
 
 ```agda
-is-positive-succ-is-positive-ℤ :
-  {x : ℤ} → is-positive-ℤ x → is-positive-ℤ (succ-ℤ x)
-is-positive-succ-is-positive-ℤ {inr (inr x)} H = H
+abstract
+  is-positive-succ-is-positive-ℤ :
+    {x : ℤ} → is-positive-ℤ x → is-positive-ℤ (succ-ℤ x)
+  is-positive-succ-is-positive-ℤ {inr (inr x)} H = H
 
 succ-positive-ℤ : positive-ℤ → positive-ℤ
 succ-positive-ℤ (x , H) = (succ-ℤ x , is-positive-succ-is-positive-ℤ H)
@@ -153,10 +155,11 @@ succ-positive-ℤ (x , H) = (succ-ℤ x , is-positive-succ-is-positive-ℤ H)
 ### The integer image of a nonzero natural number is positive
 
 ```agda
-is-positive-int-is-nonzero-ℕ :
-  (x : ℕ) → is-nonzero-ℕ x → is-positive-ℤ (int-ℕ x)
-is-positive-int-is-nonzero-ℕ zero-ℕ H = ex-falso (H refl)
-is-positive-int-is-nonzero-ℕ (succ-ℕ x) H = star
+abstract
+  is-positive-int-is-nonzero-ℕ :
+    (x : ℕ) → is-nonzero-ℕ x → is-positive-ℤ (int-ℕ x)
+  is-positive-int-is-nonzero-ℕ zero-ℕ H = ex-falso (H refl)
+  is-positive-int-is-nonzero-ℕ (succ-ℕ x) H = star
 
 positive-int-ℕ⁺ : ℕ⁺ → positive-ℤ
 positive-int-ℕ⁺ (n , n≠0) = int-ℕ n , is-positive-int-is-nonzero-ℕ n n≠0
@@ -197,24 +200,26 @@ eq-nat-positive-succ-positive-ℤ :
   nat-positive-ℤ (succ-positive-ℤ x) ＝ succ-ℕ (nat-positive-ℤ x)
 eq-nat-positive-succ-positive-ℤ (inr (inr x) , H) = refl
 
-is-section-nat-positive-ℤ :
-  (x : positive-ℤ) → positive-int-ℕ (nat-positive-ℤ x) ＝ x
-is-section-nat-positive-ℤ (inr (inr zero-ℕ) , H) = refl
-is-section-nat-positive-ℤ (inr (inr (succ-ℕ x)) , H) =
-  ap succ-positive-ℤ (is-section-nat-positive-ℤ ( inr (inr x) , H))
+abstract
+  is-section-nat-positive-ℤ :
+    (x : positive-ℤ) → positive-int-ℕ (nat-positive-ℤ x) ＝ x
+  is-section-nat-positive-ℤ (inr (inr zero-ℕ) , H) = refl
+  is-section-nat-positive-ℤ (inr (inr (succ-ℕ x)) , H) =
+    ap succ-positive-ℤ (is-section-nat-positive-ℤ ( inr (inr x) , H))
 
-is-retraction-nat-positive-ℤ :
-  (n : ℕ) → nat-positive-ℤ (positive-int-ℕ n) ＝ n
-is-retraction-nat-positive-ℤ zero-ℕ = refl
-is-retraction-nat-positive-ℤ (succ-ℕ n) =
-  eq-nat-positive-succ-positive-ℤ (positive-int-ℕ n) ∙
-  ap succ-ℕ (is-retraction-nat-positive-ℤ n)
+  is-retraction-nat-positive-ℤ :
+    (n : ℕ) → nat-positive-ℤ (positive-int-ℕ n) ＝ n
+  is-retraction-nat-positive-ℤ zero-ℕ = refl
+  is-retraction-nat-positive-ℤ (succ-ℕ n) =
+    eq-nat-positive-succ-positive-ℤ (positive-int-ℕ n) ∙
+    ap succ-ℕ (is-retraction-nat-positive-ℤ n)
 
-is-equiv-positive-int-ℕ : is-equiv positive-int-ℕ
-pr1 (pr1 is-equiv-positive-int-ℕ) = nat-positive-ℤ
-pr2 (pr1 is-equiv-positive-int-ℕ) = is-section-nat-positive-ℤ
-pr1 (pr2 is-equiv-positive-int-ℕ) = nat-positive-ℤ
-pr2 (pr2 is-equiv-positive-int-ℕ) = is-retraction-nat-positive-ℤ
+  is-equiv-positive-int-ℕ : is-equiv positive-int-ℕ
+  is-equiv-positive-int-ℕ =
+    is-equiv-is-invertible
+      ( nat-positive-ℤ)
+      ( is-section-nat-positive-ℤ)
+      ( is-retraction-nat-positive-ℤ)
 
 equiv-positive-int-ℕ : ℕ ≃ positive-ℤ
 pr1 equiv-positive-int-ℕ = positive-int-ℕ

--- a/src/elementary-number-theory/powers-integers.lagda.md
+++ b/src/elementary-number-theory/powers-integers.lagda.md
@@ -21,8 +21,10 @@ open import foundation.identity-types
 
 ## Idea
 
-The power operation on the integers is the map `n x ↦ xⁿ`, which is defined by
-iteratively multiplying `x` with itself `n` times.
+The
+{{#concept "power operation" WDID=Q33456 WD="exponentiation" Disambiguation="on the integers" Agda=power-ℤ}}
+on the [integers](elementary-number-theory.integers.md) is the map `n x ↦ xⁿ`,
+which is defined by iteratively multiplying `x` with itself `n` times.
 
 ## Definition
 

--- a/src/elementary-number-theory/prime-numbers.lagda.md
+++ b/src/elementary-number-theory/prime-numbers.lagda.md
@@ -90,163 +90,174 @@ has-unique-proper-divisor-ℕ n = is-torsorial (is-proper-divisor-ℕ n)
 ### The number `0` is not a prime
 
 ```agda
-is-nonzero-is-prime-ℕ :
-  (n : ℕ) → is-prime-ℕ n → is-nonzero-ℕ n
-is-nonzero-is-prime-ℕ n H p =
-  is-not-one-two-ℕ
-    ( pr1
-      ( H 2)
-      ( tr (λ k → 2 ≠ k) (inv p) ( is-nonzero-two-ℕ) ,
-        tr (div-ℕ 2) (inv p) (0 , refl)))
+abstract
+  is-nonzero-is-prime-ℕ :
+    (n : ℕ) → is-prime-ℕ n → is-nonzero-ℕ n
+  is-nonzero-is-prime-ℕ n H p =
+    is-not-one-two-ℕ
+      ( pr1
+        ( H 2)
+        ( tr (λ k → 2 ≠ k) (inv p) ( is-nonzero-two-ℕ) ,
+          tr (div-ℕ 2) (inv p) (0 , refl)))
 ```
 
 ### The number `1` is not a prime
 
 ```agda
-is-not-one-is-prime-ℕ : (n : ℕ) → is-prime-ℕ n → is-not-one-ℕ n
-is-not-one-is-prime-ℕ n H p = pr1 (pr2 (H 1) refl) (inv p)
+abstract
+  is-not-one-is-prime-ℕ : (n : ℕ) → is-prime-ℕ n → is-not-one-ℕ n
+  is-not-one-is-prime-ℕ n H p = pr1 (pr2 (H 1) refl) (inv p)
 ```
 
 ### A prime is strictly greater than `1`
 
 ```agda
-le-one-is-prime-ℕ :
-  (n : ℕ) → is-prime-ℕ n → le-ℕ 1 n
-le-one-is-prime-ℕ 0 x = ex-falso (is-nonzero-is-prime-ℕ 0 x refl)
-le-one-is-prime-ℕ 1 x = ex-falso (is-not-one-is-prime-ℕ 1 x refl)
-le-one-is-prime-ℕ (succ-ℕ (succ-ℕ n)) x = star
+abstract
+  le-one-is-prime-ℕ :
+    (n : ℕ) → is-prime-ℕ n → le-ℕ 1 n
+  le-one-is-prime-ℕ 0 x = ex-falso (is-nonzero-is-prime-ℕ 0 x refl)
+  le-one-is-prime-ℕ 1 x = ex-falso (is-not-one-is-prime-ℕ 1 x refl)
+  le-one-is-prime-ℕ (succ-ℕ (succ-ℕ n)) x = star
 ```
 
 ### Being a prime is a proposition
 
 ```agda
-is-prop-is-prime-ℕ :
-  (n : ℕ) → is-prop (is-prime-ℕ n)
-is-prop-is-prime-ℕ n =
-  is-prop-Π
-    ( λ x →
-      is-prop-product
-        ( is-prop-Π (λ p → is-set-ℕ x 1))
-        ( is-prop-Π (λ p → is-prop-is-proper-divisor-ℕ n x)))
+abstract
+  is-prop-is-prime-ℕ :
+    (n : ℕ) → is-prop (is-prime-ℕ n)
+  is-prop-is-prime-ℕ n =
+    is-prop-Π
+      ( λ x →
+        is-prop-product
+          ( is-prop-Π (λ p → is-set-ℕ x 1))
+          ( is-prop-Π (λ p → is-prop-is-proper-divisor-ℕ n x)))
 
 is-prime-ℕ-Prop :
   (n : ℕ) → Prop lzero
 pr1 (is-prime-ℕ-Prop n) = is-prime-ℕ n
 pr2 (is-prime-ℕ-Prop n) = is-prop-is-prime-ℕ n
 
-is-prop-has-unique-proper-divisor-ℕ :
-  (n : ℕ) → is-prop (has-unique-proper-divisor-ℕ n)
-is-prop-has-unique-proper-divisor-ℕ n = is-property-is-contr
+abstract
+  is-prop-has-unique-proper-divisor-ℕ :
+    (n : ℕ) → is-prop (has-unique-proper-divisor-ℕ n)
+  is-prop-has-unique-proper-divisor-ℕ n = is-property-is-contr
 ```
 
 ### The three definitions of primes are equivalent
 
 ```agda
-is-prime-easy-is-prime-ℕ : (n : ℕ) → is-prime-ℕ n → is-prime-easy-ℕ n
-pr1 (is-prime-easy-is-prime-ℕ n H) = is-not-one-is-prime-ℕ n H
-pr2 (is-prime-easy-is-prime-ℕ n H) x = pr1 (H x)
+abstract
+  is-prime-easy-is-prime-ℕ : (n : ℕ) → is-prime-ℕ n → is-prime-easy-ℕ n
+  pr1 (is-prime-easy-is-prime-ℕ n H) = is-not-one-is-prime-ℕ n H
+  pr2 (is-prime-easy-is-prime-ℕ n H) x = forward-implication (H x)
 
-is-prime-is-prime-easy-ℕ : (n : ℕ) → is-prime-easy-ℕ n → is-prime-ℕ n
-pr1 (is-prime-is-prime-easy-ℕ n H x) = pr2 H x
-pr1 (pr2 (is-prime-is-prime-easy-ℕ n H .(succ-ℕ zero-ℕ)) refl) q = pr1 H (inv q)
-pr2 (pr2 (is-prime-is-prime-easy-ℕ n H .(succ-ℕ zero-ℕ)) refl) = div-one-ℕ n
+  is-prime-is-prime-easy-ℕ : (n : ℕ) → is-prime-easy-ℕ n → is-prime-ℕ n
+  pr1 (is-prime-is-prime-easy-ℕ n H x) = pr2 H x
+  pr1 (pr2 (is-prime-is-prime-easy-ℕ n H .(succ-ℕ zero-ℕ)) refl) q =
+    pr1 H (inv q)
+  pr2 (pr2 (is-prime-is-prime-easy-ℕ n H .(succ-ℕ zero-ℕ)) refl) = div-one-ℕ n
 
-has-unique-proper-divisor-is-prime-ℕ :
-  (n : ℕ) → is-prime-ℕ n → has-unique-proper-divisor-ℕ n
-has-unique-proper-divisor-is-prime-ℕ n H =
-  fundamental-theorem-id'
-    ( λ x p → pr2 (H x) (inv p))
-    ( λ x →
-      is-equiv-has-converse-is-prop
-        ( is-set-ℕ 1 x)
-        ( is-prop-is-proper-divisor-ℕ n x)
-        ( λ p → inv (pr1 (H x) p)))
+  has-unique-proper-divisor-is-prime-ℕ :
+    (n : ℕ) → is-prime-ℕ n → has-unique-proper-divisor-ℕ n
+  has-unique-proper-divisor-is-prime-ℕ n H =
+    fundamental-theorem-id'
+      ( λ x p → backward-implication (H x) (inv p))
+      ( λ x →
+        is-equiv-has-converse-is-prop
+          ( is-set-ℕ 1 x)
+          ( is-prop-is-proper-divisor-ℕ n x)
+          ( λ p → inv (forward-implication (H x) p)))
 
-is-prime-has-unique-proper-divisor-ℕ :
-  (n : ℕ) → has-unique-proper-divisor-ℕ n → is-prime-ℕ n
-pr1 (is-prime-has-unique-proper-divisor-ℕ n H x) K =
-  ap pr1
-    ( eq-is-contr H
-      { pair x K}
-      { pair 1 (is-proper-divisor-one-is-proper-divisor-ℕ K)})
-pr2 (is-prime-has-unique-proper-divisor-ℕ n H .1) refl =
-  is-proper-divisor-one-is-proper-divisor-ℕ (pr2 (center H))
+  is-prime-has-unique-proper-divisor-ℕ :
+    (n : ℕ) → has-unique-proper-divisor-ℕ n → is-prime-ℕ n
+  pr1 (is-prime-has-unique-proper-divisor-ℕ n H x) K =
+    ap pr1
+      ( eq-is-contr H
+        { pair x K}
+        { pair 1 (is-proper-divisor-one-is-proper-divisor-ℕ K)})
+  pr2 (is-prime-has-unique-proper-divisor-ℕ n H .1) refl =
+    is-proper-divisor-one-is-proper-divisor-ℕ (pr2 (center H))
 ```
 
 ### Being a prime is decidable
 
 ```agda
-is-decidable-is-prime-easy-ℕ : (n : ℕ) → is-decidable (is-prime-easy-ℕ n)
-is-decidable-is-prime-easy-ℕ zero-ℕ =
-  inr
-    ( λ H →
-      is-not-one-two-ℕ (pr2 H 2 (is-proper-divisor-zero-succ-ℕ 1)))
-is-decidable-is-prime-easy-ℕ (succ-ℕ n) =
-  is-decidable-product
-    ( is-decidable-neg (is-decidable-is-one-ℕ (succ-ℕ n)))
-    ( is-decidable-bounded-Π-ℕ
-      ( is-proper-divisor-ℕ (succ-ℕ n))
-      ( is-one-ℕ)
-      ( is-decidable-is-proper-divisor-ℕ (succ-ℕ n))
-      ( is-decidable-is-one-ℕ)
-      ( succ-ℕ n)
-      ( λ x H → leq-div-succ-ℕ x n (pr2 H)))
+abstract
+  is-decidable-is-prime-easy-ℕ : (n : ℕ) → is-decidable (is-prime-easy-ℕ n)
+  is-decidable-is-prime-easy-ℕ zero-ℕ =
+    inr
+      ( λ H →
+        is-not-one-two-ℕ (pr2 H 2 (is-proper-divisor-zero-succ-ℕ 1)))
+  is-decidable-is-prime-easy-ℕ (succ-ℕ n) =
+    is-decidable-product
+      ( is-decidable-neg (is-decidable-is-one-ℕ (succ-ℕ n)))
+      ( is-decidable-bounded-Π-ℕ
+        ( is-proper-divisor-ℕ (succ-ℕ n))
+        ( is-one-ℕ)
+        ( is-decidable-is-proper-divisor-ℕ (succ-ℕ n))
+        ( is-decidable-is-one-ℕ)
+        ( succ-ℕ n)
+        ( λ x H → leq-div-succ-ℕ x n (pr2 H)))
 
-is-decidable-is-prime-ℕ : (n : ℕ) → is-decidable (is-prime-ℕ n)
-is-decidable-is-prime-ℕ n =
-  is-decidable-iff
-    ( is-prime-is-prime-easy-ℕ n)
-    ( is-prime-easy-is-prime-ℕ n)
-    ( is-decidable-is-prime-easy-ℕ n)
+  is-decidable-is-prime-ℕ : (n : ℕ) → is-decidable (is-prime-ℕ n)
+  is-decidable-is-prime-ℕ n =
+    is-decidable-iff
+      ( is-prime-is-prime-easy-ℕ n)
+      ( is-prime-easy-is-prime-ℕ n)
+      ( is-decidable-is-prime-easy-ℕ n)
 ```
 
 ### The number `2` is a prime
 
 ```agda
-is-one-is-proper-divisor-two-ℕ : is-one-is-proper-divisor-ℕ 2
-is-one-is-proper-divisor-two-ℕ zero-ℕ (pair f (pair k p)) =
-  ex-falso (f (inv (right-zero-law-mul-ℕ k) ∙ p))
-is-one-is-proper-divisor-two-ℕ (succ-ℕ zero-ℕ) (pair f H) = refl
-is-one-is-proper-divisor-two-ℕ (succ-ℕ (succ-ℕ zero-ℕ)) (pair f H) =
-  ex-falso (f refl)
-is-one-is-proper-divisor-two-ℕ (succ-ℕ (succ-ℕ (succ-ℕ x))) (pair f H) =
-  ex-falso (leq-div-succ-ℕ (succ-ℕ (succ-ℕ (succ-ℕ x))) 1 H)
+abstract
+  is-one-is-proper-divisor-two-ℕ : is-one-is-proper-divisor-ℕ 2
+  is-one-is-proper-divisor-two-ℕ zero-ℕ (pair f (pair k p)) =
+    ex-falso (f (inv (right-zero-law-mul-ℕ k) ∙ p))
+  is-one-is-proper-divisor-two-ℕ (succ-ℕ zero-ℕ) (pair f H) = refl
+  is-one-is-proper-divisor-two-ℕ (succ-ℕ (succ-ℕ zero-ℕ)) (pair f H) =
+    ex-falso (f refl)
+  is-one-is-proper-divisor-two-ℕ (succ-ℕ (succ-ℕ (succ-ℕ x))) (pair f H) =
+    ex-falso (leq-div-succ-ℕ (succ-ℕ (succ-ℕ (succ-ℕ x))) 1 H)
 
-is-prime-easy-two-ℕ : is-prime-easy-ℕ 2
-pr1 is-prime-easy-two-ℕ = Eq-eq-ℕ
-pr2 is-prime-easy-two-ℕ = is-one-is-proper-divisor-two-ℕ
+  is-prime-easy-two-ℕ : is-prime-easy-ℕ 2
+  pr1 is-prime-easy-two-ℕ = Eq-eq-ℕ
+  pr2 is-prime-easy-two-ℕ = is-one-is-proper-divisor-two-ℕ
 
-is-prime-two-ℕ : is-prime-ℕ 2
-is-prime-two-ℕ =
-  is-prime-is-prime-easy-ℕ 2 is-prime-easy-two-ℕ
+  is-prime-two-ℕ : is-prime-ℕ 2
+  is-prime-two-ℕ =
+    is-prime-is-prime-easy-ℕ 2 is-prime-easy-two-ℕ
 ```
 
 ### If a prime number `p` divides a nonzero number `x`, then `x/p < x`
 
 ```agda
-le-quotient-div-is-prime-ℕ :
-  (p x : ℕ) → is-nonzero-ℕ x → is-prime-ℕ p →
-  (H : div-ℕ p x) → le-ℕ (quotient-div-ℕ p x H) x
-le-quotient-div-is-prime-ℕ p x N P H =
-  le-quotient-div-ℕ p x N H (is-not-one-is-prime-ℕ p P)
+abstract
+  le-quotient-div-is-prime-ℕ :
+    (p x : ℕ) → is-nonzero-ℕ x → is-prime-ℕ p →
+    (H : div-ℕ p x) → le-ℕ (quotient-div-ℕ p x H) x
+  le-quotient-div-is-prime-ℕ p x N P H =
+    le-quotient-div-ℕ p x N H (is-not-one-is-prime-ℕ p P)
 ```
 
 ### If a prime number `p` divides a number `x + 1`, then `(x + 1)/p ≤ x`
 
 ```agda
-leq-quotient-div-is-prime-ℕ :
-  (p x : ℕ) → is-prime-ℕ p →
-  (H : div-ℕ p (succ-ℕ x)) → leq-ℕ (quotient-div-ℕ p (succ-ℕ x) H) x
-leq-quotient-div-is-prime-ℕ p x P H =
-  leq-le-succ-ℕ
-    ( quotient-div-ℕ p (succ-ℕ x) H)
-    ( x)
-    ( le-quotient-div-is-prime-ℕ p (succ-ℕ x) (is-nonzero-succ-ℕ x) P H)
+abstract
+  leq-quotient-div-is-prime-ℕ :
+    (p x : ℕ) → is-prime-ℕ p →
+    (H : div-ℕ p (succ-ℕ x)) → leq-ℕ (quotient-div-ℕ p (succ-ℕ x) H) x
+  leq-quotient-div-is-prime-ℕ p x P H =
+    leq-le-succ-ℕ
+      ( quotient-div-ℕ p (succ-ℕ x) H)
+      ( x)
+      ( le-quotient-div-is-prime-ℕ p (succ-ℕ x) (is-nonzero-succ-ℕ x) P H)
 ```
 
 ## See also
 
-- The fundamental theorem of arithmetic asserts that every positive natural
-  number can be written uniquely as a product of primes. This theorem is proven
-  in
-  [`fundamental-theorem-of-arithmetic`](elementary-number-theory.fundamental-theorem-of-arithmetic.md).
+- The
+  [fundamental theorem of arithmetic](elementary-number-theory.fundamental-theorem-of-arithmetic.md)
+  asserts that every positive natural number can be written uniquely as a
+  product of primes.

--- a/src/elementary-number-theory/prime-numbers.lagda.md
+++ b/src/elementary-number-theory/prime-numbers.lagda.md
@@ -183,29 +183,28 @@ abstract
 ### Being a prime is decidable
 
 ```agda
-abstract
-  is-decidable-is-prime-easy-ℕ : (n : ℕ) → is-decidable (is-prime-easy-ℕ n)
-  is-decidable-is-prime-easy-ℕ zero-ℕ =
-    inr
-      ( λ H →
-        is-not-one-two-ℕ (pr2 H 2 (is-proper-divisor-zero-succ-ℕ 1)))
-  is-decidable-is-prime-easy-ℕ (succ-ℕ n) =
-    is-decidable-product
-      ( is-decidable-neg (is-decidable-is-one-ℕ (succ-ℕ n)))
-      ( is-decidable-bounded-Π-ℕ
-        ( is-proper-divisor-ℕ (succ-ℕ n))
-        ( is-one-ℕ)
-        ( is-decidable-is-proper-divisor-ℕ (succ-ℕ n))
-        ( is-decidable-is-one-ℕ)
-        ( succ-ℕ n)
-        ( λ x H → leq-div-succ-ℕ x n (pr2 H)))
+is-decidable-is-prime-easy-ℕ : (n : ℕ) → is-decidable (is-prime-easy-ℕ n)
+is-decidable-is-prime-easy-ℕ zero-ℕ =
+  inr
+    ( λ H →
+      is-not-one-two-ℕ (pr2 H 2 (is-proper-divisor-zero-succ-ℕ 1)))
+is-decidable-is-prime-easy-ℕ (succ-ℕ n) =
+  is-decidable-product
+    ( is-decidable-neg (is-decidable-is-one-ℕ (succ-ℕ n)))
+    ( is-decidable-bounded-Π-ℕ
+      ( is-proper-divisor-ℕ (succ-ℕ n))
+      ( is-one-ℕ)
+      ( is-decidable-is-proper-divisor-ℕ (succ-ℕ n))
+      ( is-decidable-is-one-ℕ)
+      ( succ-ℕ n)
+      ( λ x H → leq-div-succ-ℕ x n (pr2 H)))
 
-  is-decidable-is-prime-ℕ : (n : ℕ) → is-decidable (is-prime-ℕ n)
-  is-decidable-is-prime-ℕ n =
-    is-decidable-iff
-      ( is-prime-is-prime-easy-ℕ n)
-      ( is-prime-easy-is-prime-ℕ n)
-      ( is-decidable-is-prime-easy-ℕ n)
+is-decidable-is-prime-ℕ : (n : ℕ) → is-decidable (is-prime-ℕ n)
+is-decidable-is-prime-ℕ n =
+  is-decidable-iff
+    ( is-prime-is-prime-easy-ℕ n)
+    ( is-prime-easy-is-prime-ℕ n)
+    ( is-decidable-is-prime-easy-ℕ n)
 ```
 
 ### The number `2` is a prime

--- a/src/elementary-number-theory/prime-numbers.lagda.md
+++ b/src/elementary-number-theory/prime-numbers.lagda.md
@@ -221,13 +221,13 @@ abstract
   is-one-is-proper-divisor-two-ℕ (succ-ℕ (succ-ℕ (succ-ℕ x))) (pair f H) =
     ex-falso (leq-div-succ-ℕ (succ-ℕ (succ-ℕ (succ-ℕ x))) 1 H)
 
-  is-prime-easy-two-ℕ : is-prime-easy-ℕ 2
-  pr1 is-prime-easy-two-ℕ = Eq-eq-ℕ
-  pr2 is-prime-easy-two-ℕ = is-one-is-proper-divisor-two-ℕ
+is-prime-easy-two-ℕ : is-prime-easy-ℕ 2
+pr1 is-prime-easy-two-ℕ = Eq-eq-ℕ
+pr2 is-prime-easy-two-ℕ = is-one-is-proper-divisor-two-ℕ
 
-  is-prime-two-ℕ : is-prime-ℕ 2
-  is-prime-two-ℕ =
-    is-prime-is-prime-easy-ℕ 2 is-prime-easy-two-ℕ
+is-prime-two-ℕ : is-prime-ℕ 2
+is-prime-two-ℕ =
+  is-prime-is-prime-easy-ℕ 2 is-prime-easy-two-ℕ
 ```
 
 ### If a prime number `p` divides a nonzero number `x`, then `x/p < x`

--- a/src/elementary-number-theory/reduced-integer-fractions.lagda.md
+++ b/src/elementary-number-theory/reduced-integer-fractions.lagda.md
@@ -48,7 +48,7 @@ coprime.
 ```agda
 is-reduced-fraction-ℤ : fraction-ℤ → UU lzero
 is-reduced-fraction-ℤ x =
-  is-relative-prime-ℤ (numerator-fraction-ℤ x) (denominator-fraction-ℤ x)
+  is-relatively-prime-ℤ (numerator-fraction-ℤ x) (denominator-fraction-ℤ x)
 ```
 
 ## Properties and constructions
@@ -59,7 +59,7 @@ is-reduced-fraction-ℤ x =
 is-prop-is-reduced-fraction-ℤ :
   (x : fraction-ℤ) → is-prop (is-reduced-fraction-ℤ x)
 is-prop-is-reduced-fraction-ℤ x =
-  is-prop-is-relative-prime-ℤ
+  is-prop-is-relatively-prime-ℤ
     ( numerator-fraction-ℤ x)
     ( denominator-fraction-ℤ x)
 ```

--- a/src/elementary-number-theory/relatively-prime-integers.lagda.md
+++ b/src/elementary-number-theory/relatively-prime-integers.lagda.md
@@ -21,14 +21,17 @@ open import foundation.universe-levels
 
 ## Idea
 
-Two integers are said to be relatively prime if their greatest common divisor
-is 1.
+Two [integers](elementary-number-theory.integers.md) `x` and `y` are said to be
+{{#concept "relatively prime" Disambiguation="integers" Agda=is-relatively-prime-ℤ}}
+if their
+[greatest common divisor](elementary-number-theory.greatest-common-divisor-integers.md)
+is `1`.
 
 ## Definition
 
 ```agda
-is-relative-prime-ℤ : ℤ → ℤ → UU lzero
-is-relative-prime-ℤ x y = is-one-ℤ (gcd-ℤ x y)
+is-relatively-prime-ℤ : ℤ → ℤ → UU lzero
+is-relatively-prime-ℤ x y = is-one-ℤ (gcd-ℤ x y)
 ```
 
 ## Properties
@@ -36,22 +39,25 @@ is-relative-prime-ℤ x y = is-one-ℤ (gcd-ℤ x y)
 ### Being relatively prime is a proposition
 
 ```agda
-is-prop-is-relative-prime-ℤ : (x y : ℤ) → is-prop (is-relative-prime-ℤ x y)
-is-prop-is-relative-prime-ℤ x y = is-set-ℤ (gcd-ℤ x y) one-ℤ
+abstract
+  is-prop-is-relatively-prime-ℤ :
+    (x y : ℤ) → is-prop (is-relatively-prime-ℤ x y)
+  is-prop-is-relatively-prime-ℤ x y = is-set-ℤ (gcd-ℤ x y) one-ℤ
 ```
 
 ### Two integers are relatively prime if and only if their absolute values are relatively prime natural numbers
 
 ```agda
-is-relatively-prime-abs-is-relatively-prime-ℤ :
-  {a b : ℤ} → is-relative-prime-ℤ a b →
-  is-relatively-prime-ℕ (abs-ℤ a) (abs-ℤ b)
-is-relatively-prime-abs-is-relatively-prime-ℤ {a} {b} H = is-injective-int-ℕ H
+abstract
+  is-relatively-prime-abs-is-relatively-prime-ℤ :
+    {a b : ℤ} → is-relatively-prime-ℤ a b →
+    is-relatively-prime-ℕ (abs-ℤ a) (abs-ℤ b)
+  is-relatively-prime-abs-is-relatively-prime-ℤ {a} {b} H = is-injective-int-ℕ H
 
-is-relatively-prime-is-relatively-prime-abs-ℤ :
-  {a b : ℤ} → is-relatively-prime-ℕ (abs-ℤ a) (abs-ℤ b) →
-  is-relative-prime-ℤ a b
-is-relatively-prime-is-relatively-prime-abs-ℤ {a} {b} H = ap int-ℕ H
+  is-relatively-prime-is-relatively-prime-abs-ℤ :
+    {a b : ℤ} → is-relatively-prime-ℕ (abs-ℤ a) (abs-ℤ b) →
+    is-relatively-prime-ℤ a b
+  is-relatively-prime-is-relatively-prime-abs-ℤ {a} {b} H = ap int-ℕ H
 ```
 
 ### For any two integers `a` and `b` that are not both `0`, the integers `a/gcd(a,b)` and `b/gcd(a,b)` are relatively prime
@@ -60,7 +66,7 @@ is-relatively-prime-is-relatively-prime-abs-ℤ {a} {b} H = ap int-ℕ H
 {-
 relatively-prime-quotient-div-ℤ :
   {a b : ℤ} → (is-nonzero-ℤ a + is-nonzero-ℤ b) →
-  is-relative-prime-ℤ
+  is-relatively-prime-ℤ
     ( quotient-div-ℤ (gcd-ℤ a b) a (div-left-gcd-ℤ a b))
     ( quotient-div-ℤ (gcd-ℤ a b) b (div-right-gcd-ℤ a b))
 relatively-prime-quotient-div-ℤ H =

--- a/src/elementary-number-theory/relatively-prime-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/relatively-prime-natural-numbers.lagda.md
@@ -28,8 +28,12 @@ open import foundation.universe-levels
 
 ## Idea
 
-Two natural numbers `x` and `y` are said to be relatively prime if their
-greatest common divisor is `1`.
+Two [natural numbers](elementary-number-theory.natural-numbers.md) `x` and `y`
+are said to be
+{{#concept "relatively prime" WDID=Q104752 WD="coprime" Disambiguation="natural numbers" Agda=is-relatively-prime-ℕ}}
+if their
+[greatest common divisor](elementary-number-theory.greatest-common-divisor-natural-numbers.md)
+is `1`.
 
 ## Definition
 
@@ -43,8 +47,10 @@ is-relatively-prime-ℕ x y = is-one-ℕ (gcd-ℕ x y)
 ### Being relatively prime is a proposition
 
 ```agda
-is-prop-is-relatively-prime-ℕ : (x y : ℕ) → is-prop (is-relatively-prime-ℕ x y)
-is-prop-is-relatively-prime-ℕ x y = is-set-ℕ (gcd-ℕ x y) 1
+abstract
+  is-prop-is-relatively-prime-ℕ :
+    (x y : ℕ) → is-prop (is-relatively-prime-ℕ x y)
+  is-prop-is-relatively-prime-ℕ x y = is-set-ℕ (gcd-ℕ x y) 1
 
 is-relatively-prime-ℕ-Prop : ℕ → ℕ → Prop lzero
 pr1 (is-relatively-prime-ℕ-Prop x y) = is-relatively-prime-ℕ x y
@@ -76,70 +82,74 @@ pr2 (is-relatively-prime-ℕ-Decidable-Prop x y) =
 ### `a` and `b` are relatively prime if and only if any common divisor is equal to `1`
 
 ```agda
-is-one-is-common-divisor-is-relatively-prime-ℕ :
-  (x y d : ℕ) →
-  is-relatively-prime-ℕ x y → is-common-divisor-ℕ x y d → is-one-ℕ d
-is-one-is-common-divisor-is-relatively-prime-ℕ x y d H K =
-  is-one-div-one-ℕ d
-    ( tr
-      ( div-ℕ d)
-      ( H)
-      ( div-gcd-is-common-divisor-ℕ x y d K))
+abstract
+  is-one-is-common-divisor-is-relatively-prime-ℕ :
+    (x y d : ℕ) →
+    is-relatively-prime-ℕ x y → is-common-divisor-ℕ x y d → is-one-ℕ d
+  is-one-is-common-divisor-is-relatively-prime-ℕ x y d H K =
+    is-one-div-one-ℕ d
+      ( tr
+        ( div-ℕ d)
+        ( H)
+        ( div-gcd-is-common-divisor-ℕ x y d K))
 
-is-relatively-prime-is-one-is-common-divisor-ℕ :
-  (x y : ℕ) →
-  ((d : ℕ) → is-common-divisor-ℕ x y d → is-one-ℕ d) → is-relatively-prime-ℕ x y
-is-relatively-prime-is-one-is-common-divisor-ℕ x y H =
-  H (gcd-ℕ x y) (is-common-divisor-gcd-ℕ x y)
+  is-relatively-prime-is-one-is-common-divisor-ℕ :
+    (x y : ℕ) →
+    ((d : ℕ) → is-common-divisor-ℕ x y d → is-one-ℕ d) →
+    is-relatively-prime-ℕ x y
+  is-relatively-prime-is-one-is-common-divisor-ℕ x y H =
+    H (gcd-ℕ x y) (is-common-divisor-gcd-ℕ x y)
 ```
 
 ### If `a` and `b` are relatively prime, then so are any divisors of `a` and `b`
 
 ```agda
-is-relatively-prime-div-ℕ :
-  (a b c d : ℕ) → div-ℕ c a → div-ℕ d b →
-  is-relatively-prime-ℕ a b → is-relatively-prime-ℕ c d
-is-relatively-prime-div-ℕ a b c d H K L =
-  is-one-is-common-divisor-is-relatively-prime-ℕ a b
-    ( gcd-ℕ c d)
-    ( L)
-    ( transitive-div-ℕ (gcd-ℕ c d) c a H (div-left-factor-gcd-ℕ c d) ,
-      transitive-div-ℕ (gcd-ℕ c d) d b K (div-right-factor-gcd-ℕ c d))
+abstract
+  is-relatively-prime-div-ℕ :
+    (a b c d : ℕ) → div-ℕ c a → div-ℕ d b →
+    is-relatively-prime-ℕ a b → is-relatively-prime-ℕ c d
+  is-relatively-prime-div-ℕ a b c d H K L =
+    is-one-is-common-divisor-is-relatively-prime-ℕ a b
+      ( gcd-ℕ c d)
+      ( L)
+      ( transitive-div-ℕ (gcd-ℕ c d) c a H (div-left-factor-gcd-ℕ c d) ,
+        transitive-div-ℕ (gcd-ℕ c d) d b K (div-right-factor-gcd-ℕ c d))
 ```
 
 ### For any two natural numbers `a` and `b` such that `a + b ≠ 0`, the numbers `a/gcd(a,b)` and `b/gcd(a,b)` are relatively prime
 
 ```agda
-is-relatively-prime-quotient-div-gcd-ℕ :
-  (a b : ℕ) → is-nonzero-ℕ (a +ℕ b) →
-  is-relatively-prime-ℕ
-    ( quotient-div-ℕ (gcd-ℕ a b) a (div-left-factor-gcd-ℕ a b))
-    ( quotient-div-ℕ (gcd-ℕ a b) b (div-right-factor-gcd-ℕ a b))
-is-relatively-prime-quotient-div-gcd-ℕ a b nz =
-  ( uniqueness-is-gcd-ℕ
-    ( quotient-div-ℕ (gcd-ℕ a b) a (div-left-factor-gcd-ℕ a b))
-    ( quotient-div-ℕ (gcd-ℕ a b) b (div-right-factor-gcd-ℕ a b))
-    ( gcd-ℕ
+abstract
+  is-relatively-prime-quotient-div-gcd-ℕ :
+    (a b : ℕ) → is-nonzero-ℕ (a +ℕ b) →
+    is-relatively-prime-ℕ
       ( quotient-div-ℕ (gcd-ℕ a b) a (div-left-factor-gcd-ℕ a b))
-      ( quotient-div-ℕ (gcd-ℕ a b) b (div-right-factor-gcd-ℕ a b)))
-    ( quotient-div-ℕ
+      ( quotient-div-ℕ (gcd-ℕ a b) b (div-right-factor-gcd-ℕ a b))
+  is-relatively-prime-quotient-div-gcd-ℕ a b nz =
+    ( uniqueness-is-gcd-ℕ
+      ( quotient-div-ℕ (gcd-ℕ a b) a (div-left-factor-gcd-ℕ a b))
+      ( quotient-div-ℕ (gcd-ℕ a b) b (div-right-factor-gcd-ℕ a b))
+      ( gcd-ℕ
+        ( quotient-div-ℕ (gcd-ℕ a b) a (div-left-factor-gcd-ℕ a b))
+        ( quotient-div-ℕ (gcd-ℕ a b) b (div-right-factor-gcd-ℕ a b)))
+      ( quotient-div-ℕ
+        ( gcd-ℕ a b)
+        ( gcd-ℕ a b)
+        ( div-gcd-is-common-divisor-ℕ a b
+          ( gcd-ℕ a b)
+          ( is-common-divisor-gcd-ℕ a b)))
+      ( is-gcd-gcd-ℕ
+        ( quotient-div-ℕ (gcd-ℕ a b) a (div-left-factor-gcd-ℕ a b))
+        ( quotient-div-ℕ (gcd-ℕ a b) b (div-right-factor-gcd-ℕ a b)))
+      ( is-gcd-quotient-div-gcd-ℕ
+        ( is-nonzero-gcd-ℕ a b nz)
+        ( is-common-divisor-gcd-ℕ a b))) ∙
+    ( is-idempotent-quotient-div-ℕ
       ( gcd-ℕ a b)
-      ( gcd-ℕ a b)
+      ( is-nonzero-gcd-ℕ a b nz)
       ( div-gcd-is-common-divisor-ℕ a b
         ( gcd-ℕ a b)
         ( is-common-divisor-gcd-ℕ a b)))
-    ( is-gcd-gcd-ℕ
-      ( quotient-div-ℕ (gcd-ℕ a b) a (div-left-factor-gcd-ℕ a b))
-      ( quotient-div-ℕ (gcd-ℕ a b) b (div-right-factor-gcd-ℕ a b)))
-    ( is-gcd-quotient-div-gcd-ℕ
-      ( is-nonzero-gcd-ℕ a b nz)
-      ( is-common-divisor-gcd-ℕ a b))) ∙
-  ( is-idempotent-quotient-div-ℕ
-    ( gcd-ℕ a b)
-    ( is-nonzero-gcd-ℕ a b nz)
-    ( div-gcd-is-common-divisor-ℕ a b
-      ( gcd-ℕ a b)
-      ( is-common-divisor-gcd-ℕ a b)))
 ```
 
 ### If `a` and `b` are prime and distinct, then they are relatively prime
@@ -152,23 +162,24 @@ module _
   (n : a ≠ b)
   where
 
-  is-one-is-common-divisor-is-prime-ℕ :
-    (d : ℕ) → is-common-divisor-ℕ a b d → is-one-ℕ d
-  is-one-is-common-divisor-is-prime-ℕ d c =
-    pr1
-      ( pa d)
-      ( ( λ e →
-          is-not-one-is-prime-ℕ
-            ( a)
-            ( pa)
-            ( pr1 (pb a) (n , (tr (λ x → div-ℕ x b) e (pr2 c))))) ,
-        ( pr1 c))
+  abstract
+    is-one-is-common-divisor-is-prime-ℕ :
+      (d : ℕ) → is-common-divisor-ℕ a b d → is-one-ℕ d
+    is-one-is-common-divisor-is-prime-ℕ d c =
+      pr1
+        ( pa d)
+        ( ( λ e →
+            is-not-one-is-prime-ℕ
+              ( a)
+              ( pa)
+              ( pr1 (pb a) (n , (tr (λ x → div-ℕ x b) e (pr2 c))))) ,
+          ( pr1 c))
 
-  is-relatively-prime-is-prime-ℕ :
-    is-relatively-prime-ℕ a b
-  is-relatively-prime-is-prime-ℕ =
-    is-relatively-prime-is-one-is-common-divisor-ℕ
-      ( a)
-      ( b)
-      ( is-one-is-common-divisor-is-prime-ℕ)
+    is-relatively-prime-is-prime-ℕ :
+      is-relatively-prime-ℕ a b
+    is-relatively-prime-is-prime-ℕ =
+      is-relatively-prime-is-one-is-common-divisor-ℕ
+        ( a)
+        ( b)
+        ( is-one-is-common-divisor-is-prime-ℕ)
 ```

--- a/src/elementary-number-theory/ring-of-integers.lagda.md
+++ b/src/elementary-number-theory/ring-of-integers.lagda.md
@@ -34,6 +34,19 @@ open import ring-theory.trivial-rings
 
 </details>
 
+## Idea
+
+The type of [integers](elementary-number-theory.integers.md) equipped with
+[addition](elementary-number-theory.addition-integers.md) and
+[multiplication](elementary-number-theory.multiplication-integers.md) is a
+[commutative ring](commutative-algebra.commutative-ring.md).
+
+The {{#concept "ring of integers" Agda=ℤ-Ring}} is the **initial**
+[ring](ring-theory.rings.md): for any ring `R`, there's a unique
+[ring homomorphism](ring-theory.homomorphisms-rings.md) from `ℤ` to `R`, i.e.,
+the type of ring homomorphisms `hom-Ring ℤ-Ring R` is
+[contractible](foundation.contractible-types.md).
+
 ## Definition
 
 ```agda
@@ -64,35 +77,46 @@ is-nontrivial-ℤ-Ring H = is-nonzero-one-ℤ (inv H)
 ### The integer multiples in `ℤ-Ring` coincide with multiplication in `ℤ`
 
 ```agda
-is-mul-integer-multiple-ℤ-Ring :
-  (k l : ℤ) → integer-multiple-Ring ℤ-Ring k l ＝ mul-ℤ k l
-is-mul-integer-multiple-ℤ-Ring (inl zero-ℕ) l =
-  ( integer-multiple-neg-one-Ring ℤ-Ring l) ∙
-  ( inv (left-neg-unit-law-mul-ℤ l))
-is-mul-integer-multiple-ℤ-Ring (inl (succ-ℕ k)) l =
-  ( integer-multiple-pred-Ring ℤ-Ring (inl k) l) ∙
-  ( ap
-    ( λ t → right-subtraction-Ring ℤ-Ring t l)
-    ( is-mul-integer-multiple-ℤ-Ring (inl k) l)) ∙
-  ( commutative-add-ℤ (mul-ℤ (inl k) l) (neg-ℤ l)) ∙
-  ( inv (left-predecessor-law-mul-ℤ (inl k) l))
-is-mul-integer-multiple-ℤ-Ring (inr (inl _)) l =
-  ( integer-multiple-zero-Ring ℤ-Ring l) ∙
-  ( inv (left-zero-law-mul-ℤ l))
-is-mul-integer-multiple-ℤ-Ring (inr (inr zero-ℕ)) l =
-  ( integer-multiple-one-Ring ℤ-Ring l) ∙
-  ( inv (left-unit-law-mul-ℤ l))
-is-mul-integer-multiple-ℤ-Ring (inr (inr (succ-ℕ k))) l =
-  ( integer-multiple-succ-Ring ℤ-Ring (inr (inr k)) l) ∙
-  ( ap (add-ℤ' l) (is-mul-integer-multiple-ℤ-Ring (inr (inr k)) l)) ∙
-  ( commutative-add-ℤ _ l) ∙
-  ( inv (left-successor-law-mul-ℤ (inr (inr k)) l))
+abstract
+  integer-multiple-one-ℤ-Ring :
+    (k : ℤ) → integer-multiple-Ring ℤ-Ring k one-ℤ ＝ k
+  integer-multiple-one-ℤ-Ring (inl zero-ℕ) = refl
+  integer-multiple-one-ℤ-Ring (inl (succ-ℕ n)) =
+    ap pred-ℤ (integer-multiple-one-ℤ-Ring (inl n))
+  integer-multiple-one-ℤ-Ring (inr (inl _)) = refl
+  integer-multiple-one-ℤ-Ring (inr (inr zero-ℕ)) = refl
+  integer-multiple-one-ℤ-Ring (inr (inr (succ-ℕ n))) =
+    ap succ-ℤ (integer-multiple-one-ℤ-Ring (inr (inr n)))
 
-is-integer-multiple-ℤ :
-  (k : ℤ) → integer-multiple-Ring ℤ-Ring k one-ℤ ＝ k
-is-integer-multiple-ℤ k =
-  ( is-mul-integer-multiple-ℤ-Ring k one-ℤ) ∙
-  ( right-unit-law-mul-ℤ k)
+  compute-integer-multiple-ℤ-Ring :
+    (k l : ℤ) → integer-multiple-Ring ℤ-Ring k l ＝ mul-ℤ k l
+  compute-integer-multiple-ℤ-Ring (inl zero-ℕ) l =
+    ( integer-multiple-neg-one-Ring ℤ-Ring l) ∙
+    ( inv (left-neg-unit-law-mul-ℤ l))
+  compute-integer-multiple-ℤ-Ring (inl (succ-ℕ k)) l =
+    ( integer-multiple-pred-Ring ℤ-Ring (inl k) l) ∙
+    ( ap
+      ( λ t → right-subtraction-Ring ℤ-Ring t l)
+      ( compute-integer-multiple-ℤ-Ring (inl k) l)) ∙
+    ( commutative-add-ℤ (mul-ℤ (inl k) l) (neg-ℤ l)) ∙
+    ( inv (left-predecessor-law-mul-ℤ (inl k) l))
+  compute-integer-multiple-ℤ-Ring (inr (inl _)) l =
+    ( integer-multiple-zero-Ring ℤ-Ring l) ∙
+    ( inv (left-zero-law-mul-ℤ l))
+  compute-integer-multiple-ℤ-Ring (inr (inr zero-ℕ)) l =
+    ( integer-multiple-one-Ring ℤ-Ring l) ∙
+    ( inv (left-unit-law-mul-ℤ l))
+  compute-integer-multiple-ℤ-Ring (inr (inr (succ-ℕ k))) l =
+    ( integer-multiple-succ-Ring ℤ-Ring (inr (inr k)) l) ∙
+    ( ap (add-ℤ' l) (compute-integer-multiple-ℤ-Ring (inr (inr k)) l)) ∙
+    ( commutative-add-ℤ _ l) ∙
+    ( inv (left-successor-law-mul-ℤ (inr (inr k)) l))
+
+  is-integer-multiple-ℤ :
+    (k : ℤ) → integer-multiple-Ring ℤ-Ring k one-ℤ ＝ k
+  is-integer-multiple-ℤ k =
+    ( compute-integer-multiple-ℤ-Ring k one-ℤ) ∙
+    ( right-unit-law-mul-ℤ k)
 ```
 
 ### The ring of integers is the initial ring
@@ -111,30 +135,31 @@ module _
   map-initial-hom-Ring =
     map-hom-Group ℤ-Group (group-Ring R) hom-group-initial-hom-Ring
 
-  preserves-add-initial-hom-Ring :
-    (k l : ℤ) →
-    map-initial-hom-Ring (add-ℤ k l) ＝
-    add-Ring R (map-initial-hom-Ring k) (map-initial-hom-Ring l)
-  preserves-add-initial-hom-Ring k l =
-    preserves-mul-hom-Group
-      ( ℤ-Group)
-      ( group-Ring R)
-      ( hom-group-initial-hom-Ring)
-      { k}
-      { l}
+  abstract
+    preserves-add-initial-hom-Ring :
+      (k l : ℤ) →
+      map-initial-hom-Ring (add-ℤ k l) ＝
+      add-Ring R (map-initial-hom-Ring k) (map-initial-hom-Ring l)
+    preserves-add-initial-hom-Ring k l =
+      preserves-mul-hom-Group
+        ( ℤ-Group)
+        ( group-Ring R)
+        ( hom-group-initial-hom-Ring)
+        { k}
+        { l}
 
-  preserves-one-initial-hom-Ring : map-initial-hom-Ring one-ℤ ＝ one-Ring R
-  preserves-one-initial-hom-Ring = integer-multiple-one-Ring R (one-Ring R)
+    preserves-one-initial-hom-Ring : map-initial-hom-Ring one-ℤ ＝ one-Ring R
+    preserves-one-initial-hom-Ring = integer-multiple-one-Ring R (one-Ring R)
 
-  preserves-mul-initial-hom-Ring :
-    (k l : ℤ) →
-    map-initial-hom-Ring (mul-ℤ k l) ＝
-    mul-Ring R (map-initial-hom-Ring k) (map-initial-hom-Ring l)
-  preserves-mul-initial-hom-Ring k l =
-    ( ap map-initial-hom-Ring (commutative-mul-ℤ k l)) ∙
-    ( integer-multiple-mul-Ring R l k (one-Ring R)) ∙
-    ( ap (integer-multiple-Ring R l) (inv (right-unit-law-mul-Ring R _))) ∙
-    ( inv (right-integer-multiple-law-mul-Ring R l _ _))
+    preserves-mul-initial-hom-Ring :
+      (k l : ℤ) →
+      map-initial-hom-Ring (mul-ℤ k l) ＝
+      mul-Ring R (map-initial-hom-Ring k) (map-initial-hom-Ring l)
+    preserves-mul-initial-hom-Ring k l =
+      ( ap map-initial-hom-Ring (commutative-mul-ℤ k l)) ∙
+      ( integer-multiple-mul-Ring R l k (one-Ring R)) ∙
+      ( ap (integer-multiple-Ring R l) (inv (right-unit-law-mul-Ring R _))) ∙
+      ( inv (right-integer-multiple-law-mul-Ring R l _ _))
 
   initial-hom-Ring : hom-Ring ℤ-Ring R
   pr1 initial-hom-Ring = hom-group-initial-hom-Ring
@@ -142,27 +167,28 @@ module _
   pr2 (pr2 initial-hom-Ring) = preserves-one-initial-hom-Ring
 ```
 
-#### Any ring homomorphisms from `ℤ` to `R` is equal to the homomorphism `initial-hom-Ring`
+#### Any ring homomorphism from `ℤ` to `R` is equal to the homomorphism `initial-hom-Ring`
 
 ```agda
 module _
   {l : Level} (R : Ring l)
   where
 
-  htpy-initial-hom-Ring :
-    (f : hom-Ring ℤ-Ring R) → htpy-hom-Ring ℤ-Ring R (initial-hom-Ring R) f
-  htpy-initial-hom-Ring f k =
-    ( inv
-      ( ( preserves-integer-multiples-hom-Ring ℤ-Ring R f k one-ℤ) ∙
-        ( ap
-          ( integer-multiple-Ring R k)
-          ( preserves-one-hom-Ring ℤ-Ring R f)))) ∙
-    ( ap (map-hom-Ring ℤ-Ring R f) (is-integer-multiple-ℤ k))
+  abstract
+    htpy-initial-hom-Ring :
+      (f : hom-Ring ℤ-Ring R) → htpy-hom-Ring ℤ-Ring R (initial-hom-Ring R) f
+    htpy-initial-hom-Ring f k =
+      ( inv
+        ( ( preserves-integer-multiples-hom-Ring ℤ-Ring R f k one-ℤ) ∙
+          ( ap
+            ( integer-multiple-Ring R k)
+            ( preserves-one-hom-Ring ℤ-Ring R f)))) ∙
+      ( ap (map-hom-Ring ℤ-Ring R f) (is-integer-multiple-ℤ k))
 
-  contraction-initial-hom-Ring :
-    (f : hom-Ring ℤ-Ring R) → initial-hom-Ring R ＝ f
-  contraction-initial-hom-Ring f =
-    eq-htpy-hom-Ring ℤ-Ring R (initial-hom-Ring R) f (htpy-initial-hom-Ring f)
+    contraction-initial-hom-Ring :
+      (f : hom-Ring ℤ-Ring R) → initial-hom-Ring R ＝ f
+    contraction-initial-hom-Ring f =
+      eq-htpy-hom-Ring ℤ-Ring R (initial-hom-Ring R) f (htpy-initial-hom-Ring f)
 ```
 
 #### The ring of integers is the initial ring
@@ -171,37 +197,6 @@ module _
 is-initial-ℤ-Ring : is-initial-Ring ℤ-Ring
 pr1 (is-initial-ℤ-Ring S) = initial-hom-Ring S
 pr2 (is-initial-ℤ-Ring S) f = contraction-initial-hom-Ring S f
-```
-
-### Integer multiplication in the ring of integers coincides with multiplication of integers
-
-```agda
-integer-multiple-one-ℤ-Ring :
-  (k : ℤ) → integer-multiple-Ring ℤ-Ring k one-ℤ ＝ k
-integer-multiple-one-ℤ-Ring (inl zero-ℕ) = refl
-integer-multiple-one-ℤ-Ring (inl (succ-ℕ n)) =
-  ap pred-ℤ (integer-multiple-one-ℤ-Ring (inl n))
-integer-multiple-one-ℤ-Ring (inr (inl _)) = refl
-integer-multiple-one-ℤ-Ring (inr (inr zero-ℕ)) = refl
-integer-multiple-one-ℤ-Ring (inr (inr (succ-ℕ n))) =
-  ap succ-ℤ (integer-multiple-one-ℤ-Ring (inr (inr n)))
-
-compute-integer-multiple-ℤ-Ring :
-  (k l : ℤ) → integer-multiple-Ring ℤ-Ring k l ＝ mul-ℤ k l
-compute-integer-multiple-ℤ-Ring k l =
-  equational-reasoning
-    integer-multiple-Ring ℤ-Ring k l
-    ＝ integer-multiple-Ring ℤ-Ring k (integer-multiple-Ring ℤ-Ring l one-ℤ)
-      by
-      ap
-        ( integer-multiple-Ring ℤ-Ring k)
-        ( inv (integer-multiple-one-ℤ-Ring l))
-    ＝ integer-multiple-Ring ℤ-Ring (mul-ℤ k l) one-ℤ
-      by
-      inv (integer-multiple-mul-Ring ℤ-Ring k l one-ℤ)
-    ＝ mul-ℤ k l
-      by
-      integer-multiple-one-ℤ-Ring _
 ```
 
 ### The image of `ℤ` in a ring is commutative

--- a/src/elementary-number-theory/semiring-of-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/semiring-of-natural-numbers.lagda.md
@@ -1,7 +1,7 @@
-# The commutative semiring of natural numbers
+# The semiring of natural numbers
 
 ```agda
-module elementary-number-theory.commutative-semiring-of-natural-numbers where
+module elementary-number-theory.semiring-of-natural-numbers where
 ```
 
 <details><summary>Imports</summary>

--- a/src/elementary-number-theory/squares-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/squares-natural-numbers.lagda.md
@@ -68,31 +68,32 @@ square-root-ℕ _ (root , _) = root
 ### Squares of successors
 
 ```agda
-square-succ-ℕ :
-  (n : ℕ) →
-  square-ℕ (succ-ℕ n) ＝ succ-ℕ ((succ-ℕ (succ-ℕ n)) *ℕ n)
-square-succ-ℕ n =
-  ( right-successor-law-mul-ℕ (succ-ℕ n) n) ∙
-  ( commutative-add-ℕ (succ-ℕ n) ((succ-ℕ n) *ℕ n))
+abstract
+  square-succ-ℕ :
+    (n : ℕ) →
+    square-ℕ (succ-ℕ n) ＝ succ-ℕ ((succ-ℕ (succ-ℕ n)) *ℕ n)
+  square-succ-ℕ n =
+    ( right-successor-law-mul-ℕ (succ-ℕ n) n) ∙
+    ( commutative-add-ℕ (succ-ℕ n) ((succ-ℕ n) *ℕ n))
 
-square-succ-succ-ℕ :
-  (n : ℕ) →
-  square-ℕ (succ-ℕ (succ-ℕ n)) ＝ square-ℕ n +ℕ 2 *ℕ n +ℕ 2 *ℕ n +ℕ 4
-square-succ-succ-ℕ n =
-  equational-reasoning
-  square-ℕ (n +ℕ 2)
-  ＝ (n +ℕ 2) *ℕ n +ℕ (n +ℕ 2) *ℕ 2
-    by (left-distributive-mul-add-ℕ (n +ℕ 2) n 2)
-  ＝ square-ℕ n +ℕ 2 *ℕ n +ℕ 2 *ℕ (n +ℕ 2)
-    by
-      ( ap-add-ℕ {(n +ℕ 2) *ℕ n} {(n +ℕ 2) *ℕ 2}
-        ( right-distributive-mul-add-ℕ n 2 n)
-        ( commutative-mul-ℕ (n +ℕ 2) 2))
-  ＝ square-ℕ n +ℕ 2 *ℕ n +ℕ 2 *ℕ n +ℕ 4
-    by
-      ( ap-add-ℕ {square-ℕ n +ℕ 2 *ℕ n} {2 *ℕ (n +ℕ 2)}
-        ( refl)
-        ( left-distributive-mul-add-ℕ 2 n 2))
+  square-succ-succ-ℕ :
+    (n : ℕ) →
+    square-ℕ (succ-ℕ (succ-ℕ n)) ＝ square-ℕ n +ℕ 2 *ℕ n +ℕ 2 *ℕ n +ℕ 4
+  square-succ-succ-ℕ n =
+    equational-reasoning
+    square-ℕ (n +ℕ 2)
+    ＝ (n +ℕ 2) *ℕ n +ℕ (n +ℕ 2) *ℕ 2
+      by (left-distributive-mul-add-ℕ (n +ℕ 2) n 2)
+    ＝ square-ℕ n +ℕ 2 *ℕ n +ℕ 2 *ℕ (n +ℕ 2)
+      by
+        ( ap-add-ℕ {(n +ℕ 2) *ℕ n} {(n +ℕ 2) *ℕ 2}
+          ( right-distributive-mul-add-ℕ n 2 n)
+          ( commutative-mul-ℕ (n +ℕ 2) 2))
+    ＝ square-ℕ n +ℕ 2 *ℕ n +ℕ 2 *ℕ n +ℕ 4
+      by
+        ( ap-add-ℕ {square-ℕ n +ℕ 2 *ℕ n} {2 *ℕ (n +ℕ 2)}
+          ( refl)
+          ( left-distributive-mul-add-ℕ 2 n 2))
 ```
 
 ### `n > √n` for `n > 1`
@@ -101,58 +102,59 @@ The idea is to assume `n = m + 2 ≤ sqrt(m + 2)` for some `m : ℕ` and derive 
 contradiction by squaring both sides of the inequality
 
 ```agda
-greater-than-square-root-ℕ :
-  (n root : ℕ) → ¬ ((n +ℕ 2 ≤-ℕ root) × (n +ℕ 2 ＝ square-ℕ root))
-greater-than-square-root-ℕ n root (pf-leq , pf-eq) =
-  reflects-leq-left-add-ℕ
-    ( square-ℕ root)
-    ( square-ℕ n +ℕ 2 *ℕ n +ℕ n +ℕ 2)
-    ( 0)
-    ( tr
-      ( leq-ℕ (square-ℕ n +ℕ 2 *ℕ n +ℕ n +ℕ 2 +ℕ square-ℕ root))
-      ( inv (left-unit-law-add-ℕ (square-ℕ root)))
-      ( concatenate-eq-leq-ℕ
-        ( square-ℕ root)
-        ( inv
-          ( lemma ∙
-            ( ap-add-ℕ {square-ℕ n +ℕ 2 *ℕ n +ℕ n +ℕ 2} {n +ℕ 2}
-              ( refl)
-              ( pf-eq))))
-        ( preserves-leq-mul-ℕ (n +ℕ 2) root (n +ℕ 2) root pf-leq pf-leq)))
-  where
-  lemma : square-ℕ (n +ℕ 2) ＝ square-ℕ n +ℕ 2 *ℕ n +ℕ n +ℕ 2 +ℕ n +ℕ 2
-  lemma =
-    equational-reasoning
-    square-ℕ (n +ℕ 2)
-    ＝ square-ℕ n +ℕ 2 *ℕ n +ℕ 2 *ℕ n +ℕ 4
-      by (square-succ-succ-ℕ n)
-    ＝ square-ℕ n +ℕ 2 *ℕ n +ℕ (n +ℕ 2 +ℕ n +ℕ 2)
-      by
-        ( ap-add-ℕ {square-ℕ n +ℕ 2 *ℕ n} {2 *ℕ n +ℕ 4}
-          ( refl)
-          ( equational-reasoning
-            2 *ℕ n +ℕ 4
-            ＝ n +ℕ n +ℕ 2 +ℕ 2
-              by
-                ( ap-add-ℕ {2 *ℕ n} {4}
-                  ( left-two-law-mul-ℕ n)
-                  ( refl))
-            ＝ n +ℕ 2 +ℕ 2 +ℕ n
-              by (commutative-add-ℕ n (n +ℕ 2 +ℕ 2))
-            ＝ n +ℕ 2 +ℕ (2 +ℕ n)
-              by (associative-add-ℕ (n +ℕ 2) 2 n)
-            ＝ n +ℕ 2 +ℕ (n +ℕ 2)
-              by
-                ( ap-add-ℕ {n +ℕ 2} {2 +ℕ n}
-                  ( refl)
-                  ( commutative-add-ℕ 2 n))))
-    ＝ square-ℕ n +ℕ 2 *ℕ n +ℕ n +ℕ 2 +ℕ n +ℕ 2
-      by
-        ( inv
-          ( associative-add-ℕ
-            ( square-ℕ n +ℕ 2 *ℕ n)
-            ( n +ℕ 2)
-            ( n +ℕ 2)))
+abstract
+  greater-than-square-root-ℕ :
+    (n root : ℕ) → ¬ ((n +ℕ 2 ≤-ℕ root) × (n +ℕ 2 ＝ square-ℕ root))
+  greater-than-square-root-ℕ n root (pf-leq , pf-eq) =
+    reflects-leq-left-add-ℕ
+      ( square-ℕ root)
+      ( square-ℕ n +ℕ 2 *ℕ n +ℕ n +ℕ 2)
+      ( 0)
+      ( tr
+        ( leq-ℕ (square-ℕ n +ℕ 2 *ℕ n +ℕ n +ℕ 2 +ℕ square-ℕ root))
+        ( inv (left-unit-law-add-ℕ (square-ℕ root)))
+        ( concatenate-eq-leq-ℕ
+          ( square-ℕ root)
+          ( inv
+            ( lemma ∙
+              ( ap-add-ℕ {square-ℕ n +ℕ 2 *ℕ n +ℕ n +ℕ 2} {n +ℕ 2}
+                ( refl)
+                ( pf-eq))))
+          ( preserves-leq-mul-ℕ (n +ℕ 2) root (n +ℕ 2) root pf-leq pf-leq)))
+    where
+    lemma : square-ℕ (n +ℕ 2) ＝ square-ℕ n +ℕ 2 *ℕ n +ℕ n +ℕ 2 +ℕ n +ℕ 2
+    lemma =
+      equational-reasoning
+      square-ℕ (n +ℕ 2)
+      ＝ square-ℕ n +ℕ 2 *ℕ n +ℕ 2 *ℕ n +ℕ 4
+        by (square-succ-succ-ℕ n)
+      ＝ square-ℕ n +ℕ 2 *ℕ n +ℕ (n +ℕ 2 +ℕ n +ℕ 2)
+        by
+          ( ap-add-ℕ {square-ℕ n +ℕ 2 *ℕ n} {2 *ℕ n +ℕ 4}
+            ( refl)
+            ( equational-reasoning
+              2 *ℕ n +ℕ 4
+              ＝ n +ℕ n +ℕ 2 +ℕ 2
+                by
+                  ( ap-add-ℕ {2 *ℕ n} {4}
+                    ( left-two-law-mul-ℕ n)
+                    ( refl))
+              ＝ n +ℕ 2 +ℕ 2 +ℕ n
+                by (commutative-add-ℕ n (n +ℕ 2 +ℕ 2))
+              ＝ n +ℕ 2 +ℕ (2 +ℕ n)
+                by (associative-add-ℕ (n +ℕ 2) 2 n)
+              ＝ n +ℕ 2 +ℕ (n +ℕ 2)
+                by
+                  ( ap-add-ℕ {n +ℕ 2} {2 +ℕ n}
+                    ( refl)
+                    ( commutative-add-ℕ 2 n))))
+      ＝ square-ℕ n +ℕ 2 *ℕ n +ℕ n +ℕ 2 +ℕ n +ℕ 2
+        by
+          ( inv
+            ( associative-add-ℕ
+              ( square-ℕ n +ℕ 2 *ℕ n)
+              ( n +ℕ 2)
+              ( n +ℕ 2)))
 ```
 
 ### Squareness in ℕ is decidable

--- a/src/elementary-number-theory/strict-inequality-integer-fractions.lagda.md
+++ b/src/elementary-number-theory/strict-inequality-integer-fractions.lagda.md
@@ -61,7 +61,7 @@ is [strictly less](elementary-number-theory.strict-inequality-integers.md) than
 ```agda
 le-fraction-ℤ-Prop : fraction-ℤ → fraction-ℤ → Prop lzero
 le-fraction-ℤ-Prop (m , n , p) (m' , n' , p') =
-  le-ℤ-Prop (m *ℤ n') (m' *ℤ n)
+  le-prop-ℤ (m *ℤ n') (m' *ℤ n)
 
 le-fraction-ℤ : fraction-ℤ → fraction-ℤ → UU lzero
 le-fraction-ℤ x y = type-Prop (le-fraction-ℤ-Prop x y)

--- a/src/elementary-number-theory/strict-inequality-integers.lagda.md
+++ b/src/elementary-number-theory/strict-inequality-integers.lagda.md
@@ -57,14 +57,15 @@ on the integers.
 ### Strict inequality on the integers
 
 ```agda
-le-ℤ-Prop : ℤ → ℤ → Prop lzero
-le-ℤ-Prop x y = subtype-positive-ℤ (y -ℤ x)
+le-prop-ℤ : ℤ → ℤ → Prop lzero
+le-prop-ℤ x y = subtype-positive-ℤ (y -ℤ x)
 
 le-ℤ : ℤ → ℤ → UU lzero
-le-ℤ x y = type-Prop (le-ℤ-Prop x y)
+le-ℤ x y = type-Prop (le-prop-ℤ x y)
 
-is-prop-le-ℤ : (x y : ℤ) → is-prop (le-ℤ x y)
-is-prop-le-ℤ x y = is-prop-type-Prop (le-ℤ-Prop x y)
+abstract
+  is-prop-le-ℤ : (x y : ℤ) → is-prop (le-ℤ x y)
+  is-prop-le-ℤ x y = is-prop-type-Prop (le-prop-ℤ x y)
 ```
 
 ## Properties
@@ -72,8 +73,9 @@ is-prop-le-ℤ x y = is-prop-type-Prop (le-ℤ-Prop x y)
 ### Strict inequality on the integers implies inequality
 
 ```agda
-leq-le-ℤ : {x y : ℤ} → le-ℤ x y → leq-ℤ x y
-leq-le-ℤ {x} {y} = is-nonnegative-is-positive-ℤ
+abstract
+  leq-le-ℤ : {x y : ℤ} → le-ℤ x y → leq-ℤ x y
+  leq-le-ℤ {x} {y} = is-nonnegative-is-positive-ℤ
 ```
 
 ### Strict inequality on the integers is decidable
@@ -92,23 +94,25 @@ le-ℤ-Decidable-Prop x y =
 ### Strict inequality on the integers is transitive
 
 ```agda
-transitive-le-ℤ : (k l m : ℤ) → le-ℤ l m → le-ℤ k l → le-ℤ k m
-transitive-le-ℤ k l m H K =
-  is-positive-eq-ℤ
-    ( triangle-diff-ℤ m l k)
-    ( is-positive-add-ℤ H K)
+abstract
+  transitive-le-ℤ : (k l m : ℤ) → le-ℤ l m → le-ℤ k l → le-ℤ k m
+  transitive-le-ℤ k l m H K =
+    is-positive-eq-ℤ
+      ( triangle-diff-ℤ m l k)
+      ( is-positive-add-ℤ H K)
 ```
 
 ### Strict inequality on the integers is asymmetric
 
 ```agda
-asymmetric-le-ℤ : (x y : ℤ) → le-ℤ x y → ¬ (le-ℤ y x)
-asymmetric-le-ℤ x y p =
-  is-not-positive-is-nonpositive-ℤ
-    ( is-nonpositive-eq-ℤ
-      ( distributive-neg-diff-ℤ y x)
-      ( is-nonpositive-neg-is-nonnegative-ℤ
-        ( is-nonnegative-is-positive-ℤ p)))
+abstract
+  asymmetric-le-ℤ : (x y : ℤ) → le-ℤ x y → ¬ (le-ℤ y x)
+  asymmetric-le-ℤ x y p =
+    is-not-positive-is-nonpositive-ℤ
+      ( is-nonpositive-eq-ℤ
+        ( distributive-neg-diff-ℤ y x)
+        ( is-nonpositive-neg-is-nonnegative-ℤ
+          ( is-nonnegative-is-positive-ℤ p)))
 ```
 
 ### Strict inequality on the integers is connected
@@ -128,21 +132,23 @@ connected-le-ℤ x y H =
 ### Any integer is strictly greater than its predecessor
 
 ```agda
-le-pred-ℤ : (x : ℤ) → le-ℤ (pred-ℤ x) x
-le-pred-ℤ x =
-  is-positive-eq-ℤ
-    ( inv (right-predecessor-law-diff-ℤ x x ∙ ap succ-ℤ (is-zero-diff-ℤ' x)))
-    ( is-positive-int-positive-ℤ one-positive-ℤ)
+abstract
+  le-pred-ℤ : (x : ℤ) → le-ℤ (pred-ℤ x) x
+  le-pred-ℤ x =
+    is-positive-eq-ℤ
+      ( inv (right-predecessor-law-diff-ℤ x x ∙ ap succ-ℤ (is-zero-diff-ℤ' x)))
+      ( is-positive-int-positive-ℤ one-positive-ℤ)
 ```
 
 ### Any integer is strictly lesser than its successor
 
 ```agda
-le-succ-ℤ : (x : ℤ) → le-ℤ x (succ-ℤ x)
-le-succ-ℤ x =
-  is-positive-eq-ℤ
-    ( inv (left-successor-law-diff-ℤ x x ∙ ap succ-ℤ (is-zero-diff-ℤ' x)))
-    ( is-positive-int-positive-ℤ one-positive-ℤ)
+abstract
+  le-succ-ℤ : (x : ℤ) → le-ℤ x (succ-ℤ x)
+  le-succ-ℤ x =
+    is-positive-eq-ℤ
+      ( inv (left-successor-law-diff-ℤ x x ∙ ap succ-ℤ (is-zero-diff-ℤ' x)))
+      ( is-positive-int-positive-ℤ one-positive-ℤ)
 ```
 
 ### Strict inequality on the integers is invariant by translation
@@ -162,39 +168,41 @@ module _
 ### Addition on the integers preserves strict inequality
 
 ```agda
-preserves-le-left-add-ℤ :
-  (z x y : ℤ) → le-ℤ x y → le-ℤ (x +ℤ z) (y +ℤ z)
-preserves-le-left-add-ℤ z x y =
-  is-positive-eq-ℤ (inv (right-translation-diff-ℤ y x z))
+abstract
+  preserves-le-left-add-ℤ :
+    (z x y : ℤ) → le-ℤ x y → le-ℤ (x +ℤ z) (y +ℤ z)
+  preserves-le-left-add-ℤ z x y =
+    is-positive-eq-ℤ (inv (right-translation-diff-ℤ y x z))
 
-preserves-le-right-add-ℤ :
-  (z x y : ℤ) → le-ℤ x y → le-ℤ (z +ℤ x) (z +ℤ y)
-preserves-le-right-add-ℤ z x y =
-  is-positive-eq-ℤ (inv (left-translation-diff-ℤ y x z))
+  preserves-le-right-add-ℤ :
+    (z x y : ℤ) → le-ℤ x y → le-ℤ (z +ℤ x) (z +ℤ y)
+  preserves-le-right-add-ℤ z x y =
+    is-positive-eq-ℤ (inv (left-translation-diff-ℤ y x z))
 
-preserves-le-add-ℤ :
-  {a b c d : ℤ} → le-ℤ a b → le-ℤ c d → le-ℤ (a +ℤ c) (b +ℤ d)
-preserves-le-add-ℤ {a} {b} {c} {d} H K =
-  transitive-le-ℤ
-    ( a +ℤ c)
-    ( b +ℤ c)
-    ( b +ℤ d)
-    ( preserves-le-right-add-ℤ b c d K)
-    ( preserves-le-left-add-ℤ c a b H)
+  preserves-le-add-ℤ :
+    {a b c d : ℤ} → le-ℤ a b → le-ℤ c d → le-ℤ (a +ℤ c) (b +ℤ d)
+  preserves-le-add-ℤ {a} {b} {c} {d} H K =
+    transitive-le-ℤ
+      ( a +ℤ c)
+      ( b +ℤ c)
+      ( b +ℤ d)
+      ( preserves-le-right-add-ℤ b c d K)
+      ( preserves-le-left-add-ℤ c a b H)
 ```
 
 ### Addition on the integers reflects strict inequality
 
 ```agda
-reflects-le-left-add-ℤ :
-  (z x y : ℤ) → le-ℤ (x +ℤ z) (y +ℤ z) → le-ℤ x y
-reflects-le-left-add-ℤ z x y =
-  is-positive-eq-ℤ (right-translation-diff-ℤ y x z)
+abstract
+  reflects-le-left-add-ℤ :
+    (z x y : ℤ) → le-ℤ (x +ℤ z) (y +ℤ z) → le-ℤ x y
+  reflects-le-left-add-ℤ z x y =
+    is-positive-eq-ℤ (right-translation-diff-ℤ y x z)
 
-reflects-le-right-add-ℤ :
-  (z x y : ℤ) → le-ℤ (z +ℤ x) (z +ℤ y) → le-ℤ x y
-reflects-le-right-add-ℤ z x y =
-  is-positive-eq-ℤ (left-translation-diff-ℤ y x z)
+  reflects-le-right-add-ℤ :
+    (z x y : ℤ) → le-ℤ (z +ℤ x) (z +ℤ y) → le-ℤ x y
+  reflects-le-right-add-ℤ z x y =
+    is-positive-eq-ℤ (left-translation-diff-ℤ y x z)
 ```
 
 ### An integer `x` is positive if and only if `0 < x`
@@ -273,30 +281,32 @@ module _
 ### The inclusion of natural numbers preserves strict inequality
 
 ```agda
-le-natural-le-ℤ : (m n : ℕ) → le-ℕ m n → le-ℤ (int-ℕ m) (int-ℕ n)
-le-natural-le-ℤ zero-ℕ (succ-ℕ n) star =
-  le-zero-is-positive-ℤ
-    (int-ℕ (succ-ℕ n))
-    (is-positive-int-is-nonzero-ℕ (succ-ℕ n) λ ())
-le-natural-le-ℤ (succ-ℕ m) (succ-ℕ n) m<n =
-  binary-tr
-    ( le-ℤ)
-    ( succ-int-ℕ m)
-    ( succ-int-ℕ n)
-    ( preserves-le-right-add-ℤ
-      ( one-ℤ)
-      ( int-ℕ m)
-      ( int-ℕ n)
-      ( le-natural-le-ℤ m n m<n))
+abstract
+  preserves-le-int-ℕ : (m n : ℕ) → le-ℕ m n → le-ℤ (int-ℕ m) (int-ℕ n)
+  preserves-le-int-ℕ zero-ℕ (succ-ℕ n) star =
+    le-zero-is-positive-ℤ
+      (int-ℕ (succ-ℕ n))
+      (is-positive-int-is-nonzero-ℕ (succ-ℕ n) λ ())
+  preserves-le-int-ℕ (succ-ℕ m) (succ-ℕ n) m<n =
+    binary-tr
+      ( le-ℤ)
+      ( succ-int-ℕ m)
+      ( succ-int-ℕ n)
+      ( preserves-le-right-add-ℤ
+        ( one-ℤ)
+        ( int-ℕ m)
+        ( int-ℕ n)
+        ( preserves-le-int-ℕ m n m<n))
 ```
 
 ### Negation reverses the order of strict inequality of integers
 
 ```agda
-neg-le-ℤ : (x y : ℤ) → le-ℤ x y → le-ℤ (neg-ℤ y) (neg-ℤ x)
-neg-le-ℤ x y =
-  tr
-    ( is-positive-ℤ)
-    ( ap (_+ℤ neg-ℤ x) (inv (neg-neg-ℤ y)) ∙
-      commutative-add-ℤ (neg-ℤ (neg-ℤ y)) (neg-ℤ x))
+abstract
+  neg-le-ℤ : (x y : ℤ) → le-ℤ x y → le-ℤ (neg-ℤ y) (neg-ℤ x)
+  neg-le-ℤ x y =
+    tr
+      ( is-positive-ℤ)
+      ( ( ap (_+ℤ neg-ℤ x) (inv (neg-neg-ℤ y))) ∙
+        ( commutative-add-ℤ (neg-ℤ (neg-ℤ y)) (neg-ℤ x)))
 ```

--- a/src/elementary-number-theory/strict-inequality-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/strict-inequality-natural-numbers.lagda.md
@@ -31,6 +31,7 @@ open import foundation.negation
 open import foundation.propositions
 open import foundation.retractions
 open import foundation.sections
+open import foundation.subtypes
 open import foundation.transport-along-identifications
 open import foundation.unit-type
 open import foundation.universe-levels
@@ -40,21 +41,28 @@ open import order-theory.strictly-preordered-sets
 
 </details>
 
+## Idea
+
+We define the
+{{#concept "standard strict ordering" Disambiguation="natural numbers" Agda=le-ℕ}}
+on the [natural numbers](elementary-number-theory.natural-numbers.md) and prove
+its basic properties.
+
 ## Definition
 
 ### The standard strict inequality on the natural numbers
 
 ```agda
-le-ℕ-Prop : ℕ → ℕ → Prop lzero
-le-ℕ-Prop m zero-ℕ = empty-Prop
-le-ℕ-Prop zero-ℕ (succ-ℕ m) = unit-Prop
-le-ℕ-Prop (succ-ℕ n) (succ-ℕ m) = le-ℕ-Prop n m
+le-prop-ℕ : ℕ → ℕ → Prop lzero
+le-prop-ℕ m zero-ℕ = empty-Prop
+le-prop-ℕ zero-ℕ (succ-ℕ m) = unit-Prop
+le-prop-ℕ (succ-ℕ n) (succ-ℕ m) = le-prop-ℕ n m
 
 le-ℕ : ℕ → ℕ → UU lzero
-le-ℕ n m = type-Prop (le-ℕ-Prop n m)
+le-ℕ n m = type-Prop (le-prop-ℕ n m)
 
 is-prop-le-ℕ : (n : ℕ) → (m : ℕ) → is-prop (le-ℕ n m)
-is-prop-le-ℕ n m = is-prop-type-Prop (le-ℕ-Prop n m)
+is-prop-le-ℕ n m = is-prop-type-Prop (le-prop-ℕ n m)
 
 infix 30 _<-ℕ_
 _<-ℕ_ = le-ℕ
@@ -111,60 +119,66 @@ is-nonzero-le-ℕ m .zero-ℕ () refl
 ### Any nonzero natural number is strictly greater than `0`
 
 ```agda
-le-is-nonzero-ℕ : (n : ℕ) → is-nonzero-ℕ n → le-ℕ zero-ℕ n
-le-is-nonzero-ℕ zero-ℕ H = H refl
-le-is-nonzero-ℕ (succ-ℕ n) H = star
+abstract
+  le-is-nonzero-ℕ : (n : ℕ) → is-nonzero-ℕ n → le-ℕ zero-ℕ n
+  le-is-nonzero-ℕ zero-ℕ H = H refl
+  le-is-nonzero-ℕ (succ-ℕ n) H = star
 ```
 
 ### No natural number is strictly less than zero
 
 ```agda
-contradiction-le-zero-ℕ :
-  (m : ℕ) → (le-ℕ m zero-ℕ) → empty
-contradiction-le-zero-ℕ zero-ℕ ()
-contradiction-le-zero-ℕ (succ-ℕ m) ()
+abstract
+  contradiction-le-zero-ℕ :
+    (m : ℕ) → (le-ℕ m zero-ℕ) → empty
+  contradiction-le-zero-ℕ zero-ℕ ()
+  contradiction-le-zero-ℕ (succ-ℕ m) ()
 ```
 
 ### No successor is strictly less than one
 
 ```agda
-contradiction-le-one-ℕ :
-  (n : ℕ) → le-ℕ (succ-ℕ n) 1 → empty
-contradiction-le-one-ℕ zero-ℕ ()
-contradiction-le-one-ℕ (succ-ℕ n) ()
+abstract
+  contradiction-le-one-ℕ :
+    (n : ℕ) → le-ℕ (succ-ℕ n) 1 → empty
+  contradiction-le-one-ℕ zero-ℕ ()
+  contradiction-le-one-ℕ (succ-ℕ n) ()
 ```
 
-### The strict inequality on the natural numbers is anti-reflexive
+### The strict inequality on the natural numbers is irreflexive
 
 ```agda
-anti-reflexive-le-ℕ : (n : ℕ) → ¬ (n <-ℕ n)
-anti-reflexive-le-ℕ zero-ℕ ()
-anti-reflexive-le-ℕ (succ-ℕ n) = anti-reflexive-le-ℕ n
+abstract
+  irreflexive-le-ℕ : (n : ℕ) → ¬ (n <-ℕ n)
+  irreflexive-le-ℕ zero-ℕ ()
+  irreflexive-le-ℕ (succ-ℕ n) = irreflexive-le-ℕ n
 ```
 
 ### If `x < y` then `x ≠ y`
 
 ```agda
-neq-le-ℕ : {x y : ℕ} → le-ℕ x y → x ≠ y
-neq-le-ℕ {zero-ℕ} {succ-ℕ y} H = is-nonzero-succ-ℕ y ∘ inv
-neq-le-ℕ {succ-ℕ x} {succ-ℕ y} H p = neq-le-ℕ H (is-injective-succ-ℕ p)
+abstract
+  neq-le-ℕ : {x y : ℕ} → le-ℕ x y → x ≠ y
+  neq-le-ℕ {x} H refl = irreflexive-le-ℕ x H
 ```
 
 ### The strict inequality on the natural numbers is antisymmetric
 
 ```agda
-antisymmetric-le-ℕ : (m n : ℕ) → le-ℕ m n → le-ℕ n m → m ＝ n
-antisymmetric-le-ℕ (succ-ℕ m) (succ-ℕ n) p q =
-  ap succ-ℕ (antisymmetric-le-ℕ m n p q)
+abstract
+  antisymmetric-le-ℕ : (m n : ℕ) → le-ℕ m n → le-ℕ n m → m ＝ n
+  antisymmetric-le-ℕ (succ-ℕ m) (succ-ℕ n) p q =
+    ap succ-ℕ (antisymmetric-le-ℕ m n p q)
 ```
 
 ### The strict inequality on the natural numbers is transitive
 
 ```agda
-transitive-le-ℕ : (n m l : ℕ) → (le-ℕ n m) → (le-ℕ m l) → (le-ℕ n l)
-transitive-le-ℕ zero-ℕ (succ-ℕ m) (succ-ℕ l) p q = star
-transitive-le-ℕ (succ-ℕ n) (succ-ℕ m) (succ-ℕ l) p q =
-  transitive-le-ℕ n m l p q
+abstract
+  transitive-le-ℕ : (n m l : ℕ) → (le-ℕ n m) → (le-ℕ m l) → (le-ℕ n l)
+  transitive-le-ℕ zero-ℕ (succ-ℕ m) (succ-ℕ l) p q = star
+  transitive-le-ℕ (succ-ℕ n) (succ-ℕ m) (succ-ℕ l) p q =
+    transitive-le-ℕ n m l p q
 ```
 
 ### The strictly preordered set of natural numbers ordered by strict inequality
@@ -173,23 +187,24 @@ transitive-le-ℕ (succ-ℕ n) (succ-ℕ m) (succ-ℕ l) p q =
 strictly-preordered-set-ℕ : Strictly-Preordered-Set lzero lzero
 pr1 strictly-preordered-set-ℕ = ℕ-Set
 pr2 strictly-preordered-set-ℕ =
-  le-ℕ-Prop , anti-reflexive-le-ℕ , λ n m l I J → transitive-le-ℕ n m l J I
+  le-prop-ℕ , irreflexive-le-ℕ , λ n m l I J → transitive-le-ℕ n m l J I
 ```
 
 ### A sharper variant of transitivity
 
 ```agda
-transitive-le-ℕ' :
-  (k l m : ℕ) → (le-ℕ k l) → (le-ℕ l (succ-ℕ m)) → le-ℕ k m
-transitive-le-ℕ' zero-ℕ zero-ℕ m () s
-transitive-le-ℕ' (succ-ℕ k) zero-ℕ m () s
-transitive-le-ℕ' zero-ℕ (succ-ℕ l) zero-ℕ star s =
-  ex-falso (contradiction-le-one-ℕ l s)
-transitive-le-ℕ' (succ-ℕ k) (succ-ℕ l) zero-ℕ t s =
-  ex-falso (contradiction-le-one-ℕ l s)
-transitive-le-ℕ' zero-ℕ (succ-ℕ l) (succ-ℕ m) star s = star
-transitive-le-ℕ' (succ-ℕ k) (succ-ℕ l) (succ-ℕ m) t s =
-  transitive-le-ℕ' k l m t s
+abstract
+  transitive-le-ℕ' :
+    (k l m : ℕ) → (le-ℕ k l) → (le-ℕ l (succ-ℕ m)) → le-ℕ k m
+  transitive-le-ℕ' zero-ℕ zero-ℕ m () s
+  transitive-le-ℕ' (succ-ℕ k) zero-ℕ m () s
+  transitive-le-ℕ' zero-ℕ (succ-ℕ l) zero-ℕ star s =
+    ex-falso (contradiction-le-one-ℕ l s)
+  transitive-le-ℕ' (succ-ℕ k) (succ-ℕ l) zero-ℕ t s =
+    ex-falso (contradiction-le-one-ℕ l s)
+  transitive-le-ℕ' zero-ℕ (succ-ℕ l) (succ-ℕ m) star s = star
+  transitive-le-ℕ' (succ-ℕ k) (succ-ℕ l) (succ-ℕ m) t s =
+    transitive-le-ℕ' k l m t s
 ```
 
 ### The strict inequality on the natural numbers is linear
@@ -215,125 +230,138 @@ subtraction-le-ℕ (succ-ℕ n) (succ-ℕ m) p =
   P : Σ ℕ (λ l' → (is-nonzero-ℕ l') × (l' +ℕ n ＝ m))
   P = subtraction-le-ℕ n m p
 
-le-subtraction-ℕ : (n m l : ℕ) → is-nonzero-ℕ l → l +ℕ n ＝ m → le-ℕ n m
-le-subtraction-ℕ zero-ℕ m l q p =
-  tr (λ x → le-ℕ zero-ℕ x) p (le-is-nonzero-ℕ l q)
-le-subtraction-ℕ (succ-ℕ n) (succ-ℕ m) l q p =
-  le-subtraction-ℕ n m l q (is-injective-succ-ℕ p)
+abstract
+  le-subtraction-ℕ : (n m l : ℕ) → is-nonzero-ℕ l → l +ℕ n ＝ m → le-ℕ n m
+  le-subtraction-ℕ zero-ℕ m l q p =
+    tr (λ x → le-ℕ zero-ℕ x) p (le-is-nonzero-ℕ l q)
+  le-subtraction-ℕ (succ-ℕ n) (succ-ℕ m) l q p =
+    le-subtraction-ℕ n m l q (is-injective-succ-ℕ p)
 ```
 
 ### Any natural number is strictly less than its successor
 
 ```agda
-succ-le-ℕ : (n : ℕ) → le-ℕ n (succ-ℕ n)
-succ-le-ℕ zero-ℕ = star
-succ-le-ℕ (succ-ℕ n) = succ-le-ℕ n
+abstract
+  succ-le-ℕ : (n : ℕ) → le-ℕ n (succ-ℕ n)
+  succ-le-ℕ zero-ℕ = star
+  succ-le-ℕ (succ-ℕ n) = succ-le-ℕ n
 ```
 
 ### The successor function preserves strict inequality on the right
 
 ```agda
-preserves-le-succ-ℕ :
-  (m n : ℕ) → le-ℕ m n → le-ℕ m (succ-ℕ n)
-preserves-le-succ-ℕ m n H =
-  transitive-le-ℕ m n (succ-ℕ n) H (succ-le-ℕ n)
+abstract
+  preserves-le-succ-ℕ :
+    (m n : ℕ) → le-ℕ m n → le-ℕ m (succ-ℕ n)
+  preserves-le-succ-ℕ m n H =
+    transitive-le-ℕ m n (succ-ℕ n) H (succ-le-ℕ n)
 ```
 
 ### Concatenating strict and nonstrict inequalities
 
 ```agda
-concatenate-leq-le-ℕ :
-  {x y z : ℕ} → x ≤-ℕ y → le-ℕ y z → le-ℕ x z
-concatenate-leq-le-ℕ {zero-ℕ} {zero-ℕ} {succ-ℕ z} H K = star
-concatenate-leq-le-ℕ {zero-ℕ} {succ-ℕ y} {succ-ℕ z} H K = star
-concatenate-leq-le-ℕ {succ-ℕ x} {succ-ℕ y} {succ-ℕ z} H K =
-  concatenate-leq-le-ℕ {x} {y} {z} H K
+abstract
+  concatenate-leq-le-ℕ :
+    {x y z : ℕ} → x ≤-ℕ y → le-ℕ y z → le-ℕ x z
+  concatenate-leq-le-ℕ {zero-ℕ} {zero-ℕ} {succ-ℕ z} H K = star
+  concatenate-leq-le-ℕ {zero-ℕ} {succ-ℕ y} {succ-ℕ z} H K = star
+  concatenate-leq-le-ℕ {succ-ℕ x} {succ-ℕ y} {succ-ℕ z} H K =
+    concatenate-leq-le-ℕ {x} {y} {z} H K
 
-concatenate-le-leq-ℕ :
-  {x y z : ℕ} → le-ℕ x y → y ≤-ℕ z → le-ℕ x z
-concatenate-le-leq-ℕ {zero-ℕ} {succ-ℕ y} {succ-ℕ z} H K = star
-concatenate-le-leq-ℕ {succ-ℕ x} {succ-ℕ y} {succ-ℕ z} H K =
-  concatenate-le-leq-ℕ {x} {y} {z} H K
+  concatenate-le-leq-ℕ :
+    {x y z : ℕ} → le-ℕ x y → y ≤-ℕ z → le-ℕ x z
+  concatenate-le-leq-ℕ {zero-ℕ} {succ-ℕ y} {succ-ℕ z} H K = star
+  concatenate-le-leq-ℕ {succ-ℕ x} {succ-ℕ y} {succ-ℕ z} H K =
+    concatenate-le-leq-ℕ {x} {y} {z} H K
 ```
 
 ### If `m < n` then `n ≰ m`
 
 ```agda
-contradiction-le-ℕ : (m n : ℕ) → le-ℕ m n → ¬ (n ≤-ℕ m)
-contradiction-le-ℕ zero-ℕ (succ-ℕ n) H K = K
-contradiction-le-ℕ (succ-ℕ m) (succ-ℕ n) H = contradiction-le-ℕ m n H
+abstract
+  contradiction-le-ℕ : (m n : ℕ) → le-ℕ m n → ¬ (n ≤-ℕ m)
+  contradiction-le-ℕ zero-ℕ (succ-ℕ n) H K = K
+  contradiction-le-ℕ (succ-ℕ m) (succ-ℕ n) H = contradiction-le-ℕ m n H
 ```
 
 ### If `n ≤ m` then `m ≮ n`
 
 ```agda
-contradiction-le-ℕ' : (m n : ℕ) → n ≤-ℕ m → ¬ (le-ℕ m n)
-contradiction-le-ℕ' m n K H = contradiction-le-ℕ m n H K
+abstract
+  contradiction-le-ℕ' : (m n : ℕ) → n ≤-ℕ m → ¬ (le-ℕ m n)
+  contradiction-le-ℕ' m n K H = contradiction-le-ℕ m n H K
 ```
 
 ### If `m ≮ n` then `n ≤ m`
 
 ```agda
-leq-not-le-ℕ : (m n : ℕ) → ¬ (le-ℕ m n) → n ≤-ℕ m
-leq-not-le-ℕ zero-ℕ zero-ℕ H = star
-leq-not-le-ℕ zero-ℕ (succ-ℕ n) H = ex-falso (H star)
-leq-not-le-ℕ (succ-ℕ m) zero-ℕ H = star
-leq-not-le-ℕ (succ-ℕ m) (succ-ℕ n) H = leq-not-le-ℕ m n H
+abstract
+  leq-not-le-ℕ : (m n : ℕ) → ¬ (le-ℕ m n) → n ≤-ℕ m
+  leq-not-le-ℕ zero-ℕ zero-ℕ H = star
+  leq-not-le-ℕ zero-ℕ (succ-ℕ n) H = ex-falso (H star)
+  leq-not-le-ℕ (succ-ℕ m) zero-ℕ H = star
+  leq-not-le-ℕ (succ-ℕ m) (succ-ℕ n) H = leq-not-le-ℕ m n H
 ```
 
 ### If `n ≰ m` then `m < n`
 
 ```agda
-le-not-leq-ℕ : (m n : ℕ) → ¬ (n ≤-ℕ m) → le-ℕ m n
-le-not-leq-ℕ zero-ℕ zero-ℕ H = ex-falso (H star)
-le-not-leq-ℕ zero-ℕ (succ-ℕ n) H = star
-le-not-leq-ℕ (succ-ℕ m) zero-ℕ H = ex-falso (H star)
-le-not-leq-ℕ (succ-ℕ m) (succ-ℕ n) H = le-not-leq-ℕ m n H
+abstract
+  le-not-leq-ℕ : (m n : ℕ) → ¬ (n ≤-ℕ m) → le-ℕ m n
+  le-not-leq-ℕ zero-ℕ zero-ℕ H = ex-falso (H star)
+  le-not-leq-ℕ zero-ℕ (succ-ℕ n) H = star
+  le-not-leq-ℕ (succ-ℕ m) zero-ℕ H = ex-falso (H star)
+  le-not-leq-ℕ (succ-ℕ m) (succ-ℕ n) H = le-not-leq-ℕ m n H
 ```
 
 ### If `x < y` then `x ≤ y`
 
 ```agda
-leq-le-ℕ :
-  (x y : ℕ) → le-ℕ x y → x ≤-ℕ y
-leq-le-ℕ zero-ℕ (succ-ℕ y) H = star
-leq-le-ℕ (succ-ℕ x) (succ-ℕ y) H = leq-le-ℕ x y H
+abstract
+  leq-le-ℕ :
+    (x y : ℕ) → le-ℕ x y → x ≤-ℕ y
+  leq-le-ℕ zero-ℕ (succ-ℕ y) H = star
+  leq-le-ℕ (succ-ℕ x) (succ-ℕ y) H = leq-le-ℕ x y H
 ```
 
 ### If `x < y + 1` then `x ≤ y`
 
 ```agda
-leq-le-succ-ℕ :
-  (x y : ℕ) → le-ℕ x (succ-ℕ y) → x ≤-ℕ y
-leq-le-succ-ℕ zero-ℕ y H = star
-leq-le-succ-ℕ (succ-ℕ x) (succ-ℕ y) H = leq-le-succ-ℕ x y H
+abstract
+  leq-le-succ-ℕ :
+    (x y : ℕ) → le-ℕ x (succ-ℕ y) → x ≤-ℕ y
+  leq-le-succ-ℕ zero-ℕ y H = star
+  leq-le-succ-ℕ (succ-ℕ x) (succ-ℕ y) H = leq-le-succ-ℕ x y H
 ```
 
 ### If `x < y` then `x + 1 ≤ y`
 
 ```agda
-leq-succ-le-ℕ :
-  (x y : ℕ) → le-ℕ x y → leq-ℕ (succ-ℕ x) y
-leq-succ-le-ℕ zero-ℕ (succ-ℕ y) H = star
-leq-succ-le-ℕ (succ-ℕ x) (succ-ℕ y) H = leq-succ-le-ℕ x y H
+abstract
+  leq-succ-le-ℕ :
+    (x y : ℕ) → le-ℕ x y → leq-ℕ (succ-ℕ x) y
+  leq-succ-le-ℕ zero-ℕ (succ-ℕ y) H = star
+  leq-succ-le-ℕ (succ-ℕ x) (succ-ℕ y) H = leq-succ-le-ℕ x y H
 ```
 
 ### If `x + 1 ≤ y` then `x < y`
 
 ```agda
-le-leq-succ-ℕ :
-  (x y : ℕ) → leq-ℕ (succ-ℕ x) y → le-ℕ x y
-le-leq-succ-ℕ zero-ℕ (succ-ℕ y) H = star
-le-leq-succ-ℕ (succ-ℕ x) (succ-ℕ y) H = le-leq-succ-ℕ x y H
+abstract
+  le-leq-succ-ℕ :
+    (x y : ℕ) → leq-ℕ (succ-ℕ x) y → le-ℕ x y
+  le-leq-succ-ℕ zero-ℕ (succ-ℕ y) H = star
+  le-leq-succ-ℕ (succ-ℕ x) (succ-ℕ y) H = le-leq-succ-ℕ x y H
 ```
 
 ### If `x ≤ y` then `x < y + 1`
 
 ```agda
-le-succ-leq-ℕ :
-  (x y : ℕ) → leq-ℕ x y → le-ℕ x (succ-ℕ y)
-le-succ-leq-ℕ zero-ℕ y H = star
-le-succ-leq-ℕ (succ-ℕ x) (succ-ℕ y) H = le-succ-leq-ℕ x y H
+abstract
+  le-succ-leq-ℕ :
+    (x y : ℕ) → leq-ℕ x y → le-ℕ x (succ-ℕ y)
+  le-succ-leq-ℕ zero-ℕ y H = star
+  le-succ-leq-ℕ (succ-ℕ x) (succ-ℕ y) H = le-succ-leq-ℕ x y H
 ```
 
 ### `x ≤ y` if and only if `(x ＝ y) + (x < y)`
@@ -350,20 +378,20 @@ eq-or-le-leq-ℕ' :
   (x y : ℕ) → leq-ℕ x y → ((y ＝ x) + (le-ℕ x y))
 eq-or-le-leq-ℕ' x y H = map-coproduct inv id (eq-or-le-leq-ℕ x y H)
 
-leq-eq-or-le-ℕ :
-  (x y : ℕ) → ((x ＝ y) + (le-ℕ x y)) → leq-ℕ x y
-leq-eq-or-le-ℕ x .x (inl refl) = refl-leq-ℕ x
-leq-eq-or-le-ℕ x y (inr l) = leq-le-ℕ x y l
+abstract
+  leq-eq-or-le-ℕ :
+    (x y : ℕ) → ((x ＝ y) + (le-ℕ x y)) → leq-ℕ x y
+  leq-eq-or-le-ℕ x .x (inl refl) = refl-leq-ℕ x
+  leq-eq-or-le-ℕ x y (inr l) = leq-le-ℕ x y l
 ```
 
 ### If `x ≤ y` and `x ≠ y` then `x < y`
 
 ```agda
-le-leq-neq-ℕ : {x y : ℕ} → x ≤-ℕ y → x ≠ y → le-ℕ x y
-le-leq-neq-ℕ {zero-ℕ} {zero-ℕ} l f = ex-falso (f refl)
-le-leq-neq-ℕ {zero-ℕ} {succ-ℕ y} l f = star
-le-leq-neq-ℕ {succ-ℕ x} {succ-ℕ y} l f =
-  le-leq-neq-ℕ {x} {y} l (λ p → f (ap succ-ℕ p))
+abstract
+  le-leq-neq-ℕ : {x y : ℕ} → x ≤-ℕ y → x ≠ y → le-ℕ x y
+  le-leq-neq-ℕ {x} {y} x≤y x≠y =
+    rec-coproduct (ex-falso ∘ x≠y) id (eq-or-le-leq-ℕ x y x≤y)
 ```
 
 ### For any two natural numbers `x` and `y`, either `x < y` or `y ≤ x`
@@ -378,8 +406,9 @@ decide-le-leq-ℕ (succ-ℕ x) (succ-ℕ y) = decide-le-leq-ℕ x y
 ### If `1 < x` and `1 < y`, then `1 < xy`
 
 ```agda
-le-one-mul-ℕ : (x y : ℕ) → 1 <-ℕ x → 1 <-ℕ y → 1 <-ℕ (x *ℕ y)
-le-one-mul-ℕ (succ-ℕ (succ-ℕ x)) (succ-ℕ (succ-ℕ y)) star star = star
+abstract
+  le-one-mul-ℕ : (x y : ℕ) → 1 <-ℕ x → 1 <-ℕ y → 1 <-ℕ (x *ℕ y)
+  le-one-mul-ℕ (succ-ℕ (succ-ℕ x)) (succ-ℕ (succ-ℕ y)) star star = star
 ```
 
 ### Strict inequality on the natural numbers is invariant by translation
@@ -398,27 +427,28 @@ eq-translate-left-le-ℕ z x y =
 ### Addition on the natural numbers preserves strict inequality
 
 ```agda
-preserves-le-right-add-ℕ : (z x y : ℕ) → le-ℕ x y → le-ℕ (x +ℕ z) (y +ℕ z)
-preserves-le-right-add-ℕ zero-ℕ x y I = I
-preserves-le-right-add-ℕ (succ-ℕ z) x y I = preserves-le-right-add-ℕ z x y I
+abstract
+  preserves-le-right-add-ℕ : (z x y : ℕ) → le-ℕ x y → le-ℕ (x +ℕ z) (y +ℕ z)
+  preserves-le-right-add-ℕ zero-ℕ x y I = I
+  preserves-le-right-add-ℕ (succ-ℕ z) x y I = preserves-le-right-add-ℕ z x y I
 
-preserves-le-left-add-ℕ : (z x y : ℕ) → le-ℕ x y → le-ℕ (z +ℕ x) (z +ℕ y)
-preserves-le-left-add-ℕ z x y I =
-  binary-tr
-    le-ℕ
-    (commutative-add-ℕ x z)
-    (commutative-add-ℕ y z)
-    (preserves-le-right-add-ℕ z x y I)
+  preserves-le-left-add-ℕ : (z x y : ℕ) → le-ℕ x y → le-ℕ (z +ℕ x) (z +ℕ y)
+  preserves-le-left-add-ℕ z x y I =
+    binary-tr
+      ( le-ℕ)
+      ( commutative-add-ℕ x z)
+      ( commutative-add-ℕ y z)
+      ( preserves-le-right-add-ℕ z x y I)
 
-preserves-le-add-ℕ :
-  {a b c d : ℕ} → le-ℕ a b → le-ℕ c d → le-ℕ (a +ℕ c) (b +ℕ d)
-preserves-le-add-ℕ {a} {b} {c} {d} H K =
-  transitive-le-ℕ
-    (a +ℕ c)
-    (b +ℕ c)
-    (b +ℕ d)
-    (preserves-le-right-add-ℕ c a b H)
-    (preserves-le-left-add-ℕ b c d K)
+  preserves-le-add-ℕ :
+    {a b c d : ℕ} → le-ℕ a b → le-ℕ c d → le-ℕ (a +ℕ c) (b +ℕ d)
+  preserves-le-add-ℕ {a} {b} {c} {d} H K =
+    transitive-le-ℕ
+      ( a +ℕ c)
+      ( b +ℕ c)
+      ( b +ℕ d)
+      ( preserves-le-right-add-ℕ c a b H)
+      ( preserves-le-left-add-ℕ b c d K)
 ```
 
 ### There is an equivalence between natural numbers less than `succ-ℕ n` and natural numbers less than or equal to `n`
@@ -426,10 +456,9 @@ preserves-le-add-ℕ {a} {b} {c} {d} H K =
 ```agda
 equiv-le-succ-ℕ-leq-ℕ :
   (n : ℕ) → Σ ℕ (λ k → le-ℕ k (succ-ℕ n)) ≃ Σ ℕ (λ k → leq-ℕ k n)
-pr1 (equiv-le-succ-ℕ-leq-ℕ n) (k , k<sn) = (k , leq-le-succ-ℕ k n k<sn)
-pr2 (equiv-le-succ-ℕ-leq-ℕ n) =
-  is-equiv-is-invertible
-    ( λ (k , k≤n) → k , le-succ-leq-ℕ k n k≤n)
-    ( λ (k , k≤n) → eq-pair-eq-fiber (eq-type-Prop (leq-ℕ-Prop k n)))
-    ( λ (k , k<sn) → eq-pair-eq-fiber (eq-type-Prop (le-ℕ-Prop k (succ-ℕ n))))
+equiv-le-succ-ℕ-leq-ℕ n =
+  equiv-has-same-elements-type-subtype
+    ( λ k → le-prop-ℕ k (succ-ℕ n))
+    ( λ k → leq-ℕ-Prop k n)
+    ( λ k → (leq-le-succ-ℕ k n , le-succ-leq-ℕ k n))
 ```

--- a/src/elementary-number-theory/strict-inequality-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/strict-inequality-standard-finite-types.lagda.md
@@ -25,22 +25,30 @@ open import univalent-combinatorics.standard-finite-types
 
 </details>
 
+## Idea
+
+Strict inequality on the
+[standard finite types](univalent-combinatorics.standard-finite-types.md) is
+defined inductively with the rule that `inl-Fin k < neg-one-Fin n`, and
+`inl-Fin a < inl-Fin b` if `a < b`.
+
 ## Definitions
 
 ### The strict inequality relation on the standard finite types
 
 ```agda
-le-Fin-Prop : (k : ℕ) → Fin k → Fin k → Prop lzero
-le-Fin-Prop (succ-ℕ k) (inl x) (inl y) = le-Fin-Prop k x y
-le-Fin-Prop (succ-ℕ k) (inl x) (inr star) = unit-Prop
-le-Fin-Prop (succ-ℕ k) (inr star) y = empty-Prop
+le-prop-Fin : (k : ℕ) → Fin k → Fin k → Prop lzero
+le-prop-Fin (succ-ℕ k) (inl x) (inl y) = le-prop-Fin k x y
+le-prop-Fin (succ-ℕ k) (inl x) (inr star) = unit-Prop
+le-prop-Fin (succ-ℕ k) (inr star) y = empty-Prop
 
 le-Fin : (k : ℕ) → Fin k → Fin k → UU lzero
-le-Fin k x y = type-Prop (le-Fin-Prop k x y)
+le-Fin k x y = type-Prop (le-prop-Fin k x y)
 
-is-prop-le-Fin :
-  (k : ℕ) (x y : Fin k) → is-prop (le-Fin k x y)
-is-prop-le-Fin k x y = is-prop-type-Prop (le-Fin-Prop k x y)
+abstract
+  is-prop-le-Fin :
+    (k : ℕ) (x y : Fin k) → is-prop (le-Fin k x y)
+  is-prop-le-Fin k x y = is-prop-type-Prop (le-prop-Fin k x y)
 ```
 
 ### The predicate on maps between standard finite types of preserving strict inequality
@@ -52,14 +60,15 @@ preserves-le-Fin n m f =
   le-Fin n a b →
   le-Fin m (f a) (f b)
 
-is-prop-preserves-le-Fin :
-  (n m : ℕ) (f : Fin n → Fin m) →
-  is-prop (preserves-le-Fin n m f)
-is-prop-preserves-le-Fin n m f =
-  is-prop-Π λ a →
-  is-prop-Π λ b →
-  is-prop-Π λ p →
-  is-prop-le-Fin m (f a) (f b)
+abstract
+  is-prop-preserves-le-Fin :
+    (n m : ℕ) (f : Fin n → Fin m) →
+    is-prop (preserves-le-Fin n m f)
+  is-prop-preserves-le-Fin n m f =
+    is-prop-Π λ a →
+    is-prop-Π λ b →
+    is-prop-Π λ p →
+    is-prop-le-Fin m (f a) (f b)
 ```
 
 ### A map `Fin (succ-ℕ m) → Fin (succ-ℕ n)` preserving strict inequality restricts to a map `Fin m → Fin n`
@@ -89,95 +98,100 @@ restriction-preserves-le-Fin m n f pf x =
 #### The induced map is indeed a restriction
 
 ```agda
-inl-restriction-preserves-le-Fin' :
-  (m n : ℕ) (f : Fin (succ-ℕ m) → Fin (succ-ℕ n)) →
-  (pf : preserves-le-Fin (succ-ℕ m) (succ-ℕ n) f) →
-  (x : Fin m) →
-  (rx : Fin (succ-ℕ n)) →
-  (px : f (inl x) ＝ rx) →
-  inl-Fin n (restriction-preserves-le-Fin' m n f pf x rx px) ＝ f (inl-Fin m x)
-inl-restriction-preserves-le-Fin' (succ-ℕ m) n f pf x (inl a) px = inv px
-inl-restriction-preserves-le-Fin' (succ-ℕ m) n f pf x (inr a) px =
-  ex-falso
-    ( tr (λ - → le-Fin (succ-ℕ n) - (f (inr star))) px
-      ( pf (inl x) (inr star) star))
+abstract
+  inl-restriction-preserves-le-Fin' :
+    (m n : ℕ) (f : Fin (succ-ℕ m) → Fin (succ-ℕ n)) →
+    (pf : preserves-le-Fin (succ-ℕ m) (succ-ℕ n) f) →
+    (x : Fin m) →
+    (rx : Fin (succ-ℕ n)) →
+    (px : f (inl x) ＝ rx) →
+    inl-Fin n (restriction-preserves-le-Fin' m n f pf x rx px) ＝
+    f (inl-Fin m x)
+  inl-restriction-preserves-le-Fin' (succ-ℕ m) n f pf x (inl a) px = inv px
+  inl-restriction-preserves-le-Fin' (succ-ℕ m) n f pf x (inr a) px =
+    ex-falso
+      ( tr (λ - → le-Fin (succ-ℕ n) - (f (inr star))) px
+        ( pf (inl x) (inr star) star))
 
-inl-restriction-preserves-le-Fin :
-  (m n : ℕ) (f : Fin (succ-ℕ m) → Fin (succ-ℕ n)) →
-  (pf : preserves-le-Fin (succ-ℕ m) (succ-ℕ n) f) →
-  (x : Fin m) →
-  inl-Fin n (restriction-preserves-le-Fin m n f pf x) ＝ f (inl-Fin m x)
-inl-restriction-preserves-le-Fin m n f pf x =
-  inl-restriction-preserves-le-Fin' m n f pf x (f (inl x)) refl
+  inl-restriction-preserves-le-Fin :
+    (m n : ℕ) (f : Fin (succ-ℕ m) → Fin (succ-ℕ n)) →
+    (pf : preserves-le-Fin (succ-ℕ m) (succ-ℕ n) f) →
+    (x : Fin m) →
+    inl-Fin n (restriction-preserves-le-Fin m n f pf x) ＝ f (inl-Fin m x)
+  inl-restriction-preserves-le-Fin m n f pf x =
+    inl-restriction-preserves-le-Fin' m n f pf x (f (inl x)) refl
 ```
 
 #### The induced map preserves strict inequality
 
 ```agda
-preserves-le-restriction-preserves-le-Fin' :
-  (m n : ℕ) (f : Fin (succ-ℕ m) → Fin (succ-ℕ n)) →
-  (pf : preserves-le-Fin (succ-ℕ m) (succ-ℕ n) f) →
-  ( a : Fin m)
-  ( b : Fin m) →
-  ( ra : Fin (succ-ℕ n)) →
-  ( pa : f (inl a) ＝ ra) →
-  ( rb : Fin (succ-ℕ n)) →
-  ( pb : f (inl b) ＝ rb) →
-  le-Fin m a b →
-  le-Fin n
-    (restriction-preserves-le-Fin' m n f pf a ra pa)
-    (restriction-preserves-le-Fin' m n f pf b rb pb)
-preserves-le-restriction-preserves-le-Fin'
-  (succ-ℕ m) n f pf a b (inl x) pa (inl y) pb H =
-  tr (le-Fin (succ-ℕ n) (inl x)) pb
-    ( tr (λ - → le-Fin (succ-ℕ n) - (f (inl b))) pa
-    ( pf (inl a) (inl b) H))
-preserves-le-restriction-preserves-le-Fin'
-  (succ-ℕ m) n f pf a b (inl x) pa (inr y) pb H =
-  ex-falso
-    ( tr (λ - → le-Fin (succ-ℕ n) - (f (inr star))) pb
-      ( pf (inl b) (inr star) star))
-preserves-le-restriction-preserves-le-Fin'
-  (succ-ℕ m) n f pf a b (inr x) pa y pb H =
-  ex-falso
-    ( tr (λ - → le-Fin (succ-ℕ n) - (f (inr star))) pa
-      ( pf (inl a) (inr star) star))
+abstract
+  preserves-le-restriction-preserves-le-Fin' :
+    (m n : ℕ) (f : Fin (succ-ℕ m) → Fin (succ-ℕ n)) →
+    (pf : preserves-le-Fin (succ-ℕ m) (succ-ℕ n) f) →
+    ( a : Fin m)
+    ( b : Fin m) →
+    ( ra : Fin (succ-ℕ n)) →
+    ( pa : f (inl a) ＝ ra) →
+    ( rb : Fin (succ-ℕ n)) →
+    ( pb : f (inl b) ＝ rb) →
+    le-Fin m a b →
+    le-Fin n
+      (restriction-preserves-le-Fin' m n f pf a ra pa)
+      (restriction-preserves-le-Fin' m n f pf b rb pb)
+  preserves-le-restriction-preserves-le-Fin'
+    (succ-ℕ m) n f pf a b (inl x) pa (inl y) pb H =
+    tr (le-Fin (succ-ℕ n) (inl x)) pb
+      ( tr (λ - → le-Fin (succ-ℕ n) - (f (inl b))) pa
+      ( pf (inl a) (inl b) H))
+  preserves-le-restriction-preserves-le-Fin'
+    (succ-ℕ m) n f pf a b (inl x) pa (inr y) pb H =
+    ex-falso
+      ( tr (λ - → le-Fin (succ-ℕ n) - (f (inr star))) pb
+        ( pf (inl b) (inr star) star))
+  preserves-le-restriction-preserves-le-Fin'
+    (succ-ℕ m) n f pf a b (inr x) pa y pb H =
+    ex-falso
+      ( tr (λ - → le-Fin (succ-ℕ n) - (f (inr star))) pa
+        ( pf (inl a) (inr star) star))
 
-preserves-le-restriction-preserves-le-Fin :
-  (m n : ℕ) (f : Fin (succ-ℕ m) → Fin (succ-ℕ n)) →
-  (pf : preserves-le-Fin (succ-ℕ m) (succ-ℕ n) f) →
-  preserves-le-Fin m n (restriction-preserves-le-Fin m n f pf)
-preserves-le-restriction-preserves-le-Fin m n f pf a b H =
-  preserves-le-restriction-preserves-le-Fin' m n f pf a b
-    ( f (inl a)) refl (f (inl b)) refl H
+  preserves-le-restriction-preserves-le-Fin :
+    (m n : ℕ) (f : Fin (succ-ℕ m) → Fin (succ-ℕ n)) →
+    (pf : preserves-le-Fin (succ-ℕ m) (succ-ℕ n) f) →
+    preserves-le-Fin m n (restriction-preserves-le-Fin m n f pf)
+  preserves-le-restriction-preserves-le-Fin m n f pf a b H =
+    preserves-le-restriction-preserves-le-Fin' m n f pf a b
+      ( f (inl a)) refl (f (inl b)) refl H
 ```
 
 ### A strict inequality preserving map implies an inequality of cardinalities
 
 ```agda
-leq-preserves-le-Fin :
-  (m n : ℕ) → (f : Fin m → Fin n) →
-  preserves-le-Fin m n f → leq-ℕ m n
-leq-preserves-le-Fin 0 0 f pf = star
-leq-preserves-le-Fin 0 (succ-ℕ n) f pf = star
-leq-preserves-le-Fin (succ-ℕ m) 0 f pf = f (inr star)
-leq-preserves-le-Fin (succ-ℕ 0) (succ-ℕ n) f pf = star
-leq-preserves-le-Fin (succ-ℕ (succ-ℕ m)) (succ-ℕ n) f pf =
-  leq-preserves-le-Fin (succ-ℕ m) n
-    ( restriction-preserves-le-Fin (succ-ℕ m) n f pf)
-    ( preserves-le-restriction-preserves-le-Fin (succ-ℕ m) n f pf)
+abstract
+  leq-preserves-le-Fin :
+    (m n : ℕ) → (f : Fin m → Fin n) →
+    preserves-le-Fin m n f → leq-ℕ m n
+  leq-preserves-le-Fin 0 0 f pf = star
+  leq-preserves-le-Fin 0 (succ-ℕ n) f pf = star
+  leq-preserves-le-Fin (succ-ℕ m) 0 f pf = f (inr star)
+  leq-preserves-le-Fin (succ-ℕ 0) (succ-ℕ n) f pf = star
+  leq-preserves-le-Fin (succ-ℕ (succ-ℕ m)) (succ-ℕ n) f pf =
+    leq-preserves-le-Fin (succ-ℕ m) n
+      ( restriction-preserves-le-Fin (succ-ℕ m) n f pf)
+      ( preserves-le-restriction-preserves-le-Fin (succ-ℕ m) n f pf)
 ```
 
 ### Composition of strict inequality preserving maps
 
 ```agda
-comp-preserves-le-Fin :
-  (m n o : ℕ)
-  (g : Fin n → Fin o)
-  (f : Fin m → Fin n) →
-  preserves-le-Fin m n f →
-  preserves-le-Fin n o g →
-  preserves-le-Fin m o (g ∘ f)
-comp-preserves-le-Fin m n o g f pf pg a b H =
-  pg (f a) (f b) (pf a b H)
+abstract
+  comp-preserves-le-Fin :
+    (m n o : ℕ)
+    (g : Fin n → Fin o)
+    (f : Fin m → Fin n) →
+    preserves-le-Fin m n f →
+    preserves-le-Fin n o g →
+    preserves-le-Fin m o (g ∘ f)
+  comp-preserves-le-Fin m n o g f pf pg a b H =
+    pg (f a) (f b) (pf a b H)
 ```

--- a/src/elementary-number-theory/strong-induction-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/strong-induction-natural-numbers.lagda.md
@@ -27,8 +27,12 @@ open import foundation.universe-levels
 
 ## Idea
 
-The strong induction principle allows one to assume in the inductive step that
-the inductive hypothesis is satisfied at all smaller values.
+The
+{{#concept "strong induction principle" WDID=Q54506667 WD="principle of complete induction" Agda=strong-ind-ℕ}}
+on the [natural numbers](elementary-number-theory.natural-numbers.md) allows one
+to assume in the inductive step that the inductive hypothesis is satisfied at
+all
+[smaller values](elementary-number-theory.strict-inequality-natural-numbers.md).
 
 ## Definition
 

--- a/src/elementary-number-theory/triangular-numbers.lagda.md
+++ b/src/elementary-number-theory/triangular-numbers.lagda.md
@@ -8,10 +8,10 @@ module elementary-number-theory.triangular-numbers where
 
 ```agda
 open import elementary-number-theory.addition-natural-numbers
-open import elementary-number-theory.commutative-semiring-of-natural-numbers
 open import elementary-number-theory.divisibility-natural-numbers
 open import elementary-number-theory.multiplication-natural-numbers
 open import elementary-number-theory.natural-numbers
+open import elementary-number-theory.semiring-of-natural-numbers
 
 open import foundation.action-on-identifications-functions
 open import foundation.dependent-pair-types

--- a/src/elementary-number-theory/unit-fractions-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/unit-fractions-rational-numbers.lagda.md
@@ -151,7 +151,7 @@ opaque
       ( le-ℤ)
       ( left-unit-law-mul-ℤ (int-ℕ m))
       ( left-unit-law-mul-ℤ (int-ℕ n))
-      ( le-natural-le-ℤ m n m<n)
+      ( preserves-le-int-ℕ m n m<n)
 ```
 
 ### For every positive rational number, there is a smaller unit fraction

--- a/src/elementary-number-theory/upper-bounds-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/upper-bounds-natural-numbers.lagda.md
@@ -18,9 +18,13 @@ open import foundation.universe-levels
 
 ## Idea
 
-A type family over the natural numbers has an upper bound `n`, if there is a
-function from `P x` to the type `x ≤ n` for all `x : ℕ`. Similar for strict
-upper bounds.
+A type family over the
+[natural numbers](elementary-number-theory.natural-numbers.md) has an
+{{#concept "upper bound" Disambiguation="of a type family over ℕ" Agda=is-upper-bound-ℕ}}
+`n`, if there is a function from `P x` to the type `x ≤ n` for all `x : ℕ`.
+Analogously, a
+{{#concept "strict upper bound" Disambiguation="of a type family over ℕ" Agda=is-strict-upper-bound-ℕ}}
+is defined by a function from `P x` to the type `x < n` for all `x : ℕ`.
 
 ## Definition
 

--- a/src/elementary-number-theory/well-ordering-principle-natural-numbers.lagda.md
+++ b/src/elementary-number-theory/well-ordering-principle-natural-numbers.lagda.md
@@ -31,9 +31,12 @@ open import foundation.universe-levels
 
 ## Idea
 
-The well-ordering principle of the natural numbers asserts that for every family
-of decidable types over ℕ equipped with a natural number `n` and an element
-`p : P n`, we can find a least natural number `n₀` with an element `p₀ : P n₀`.
+The
+{{#concept "well-ordering principle" Agda=well-ordering-principle-ℕ Disambiguation="of ℕ"}}
+of the [natural numbers](elementary-number-theory.natural-numbers.md) asserts
+that for every family of [decidable types](foundation.decidable-types.md) over ℕ
+equipped with a natural number `n` and an element `p : P n`, we can find a least
+natural number `n₀` with an element `p₀ : P n₀`.
 
 ## Theorem
 
@@ -46,21 +49,22 @@ module _
   {l1 : Level} (P : ℕ → Prop l1)
   where
 
-  all-elements-equal-minimal-element-ℕ :
-    all-elements-equal (minimal-element-ℕ (λ n → type-Prop (P n)))
-  all-elements-equal-minimal-element-ℕ
-    (pair x (pair p l)) (pair y (pair q k)) =
-    eq-type-subtype
-      ( λ n →
-        product-Prop
-          ( pair _ (is-prop-type-Prop (P n)))
-          ( is-lower-bound-ℕ-Prop n))
-      ( antisymmetric-leq-ℕ x y (l y q) (k x p))
+  abstract
+    all-elements-equal-minimal-element-ℕ :
+      all-elements-equal (minimal-element-ℕ (λ n → type-Prop (P n)))
+    all-elements-equal-minimal-element-ℕ
+      (pair x (pair p l)) (pair y (pair q k)) =
+      eq-type-subtype
+        ( λ n →
+          product-Prop
+            ( pair _ (is-prop-type-Prop (P n)))
+            ( is-lower-bound-ℕ-Prop n))
+        ( antisymmetric-leq-ℕ x y (l y q) (k x p))
 
-  is-prop-minimal-element-ℕ :
-    is-prop (minimal-element-ℕ (λ n → type-Prop (P n)))
-  is-prop-minimal-element-ℕ =
-    is-prop-all-elements-equal all-elements-equal-minimal-element-ℕ
+    is-prop-minimal-element-ℕ :
+      is-prop (minimal-element-ℕ (λ n → type-Prop (P n)))
+    is-prop-minimal-element-ℕ =
+      is-prop-all-elements-equal all-elements-equal-minimal-element-ℕ
 
   minimal-element-ℕ-Prop : Prop l1
   pr1 minimal-element-ℕ-Prop = minimal-element-ℕ (λ n → type-Prop (P n))
@@ -114,38 +118,41 @@ number-well-ordering-principle-ℕ P d nP =
 This is independently of the input `(pair n p) : Σ ℕ P`.
 
 ```agda
-is-zero-well-ordering-principle-succ-ℕ :
-  {l : Level} (P : ℕ → UU l) (d : is-decidable-family P)
-  (n : ℕ) (p : P (succ-ℕ n)) (d0 : is-decidable (P zero-ℕ)) →
-  (x : minimal-element-ℕ (λ m → P (succ-ℕ m))) (p0 : P zero-ℕ) →
-  pr1 (well-ordering-principle-succ-ℕ P d n p d0 x) ＝ zero-ℕ
-is-zero-well-ordering-principle-succ-ℕ P d n p (inl p0) x q0 =
-  refl
-is-zero-well-ordering-principle-succ-ℕ P d n p (inr np0) x q0 =
-  ex-falso (np0 q0)
+abstract
+  is-zero-well-ordering-principle-succ-ℕ :
+    {l : Level} (P : ℕ → UU l) (d : is-decidable-family P)
+    (n : ℕ) (p : P (succ-ℕ n)) (d0 : is-decidable (P zero-ℕ)) →
+    (x : minimal-element-ℕ (λ m → P (succ-ℕ m))) (p0 : P zero-ℕ) →
+    pr1 (well-ordering-principle-succ-ℕ P d n p d0 x) ＝ zero-ℕ
+  is-zero-well-ordering-principle-succ-ℕ P d n p (inl p0) x q0 =
+    refl
+  is-zero-well-ordering-principle-succ-ℕ P d n p (inr np0) x q0 =
+    ex-falso (np0 q0)
 
-is-zero-well-ordering-principle-ℕ :
-  {l : Level} (P : ℕ → UU l) (d : is-decidable-family P) →
-  (x : Σ ℕ P) → P zero-ℕ → is-zero-ℕ (number-well-ordering-principle-ℕ P d x)
-is-zero-well-ordering-principle-ℕ P d (pair zero-ℕ p) p0 = refl
-is-zero-well-ordering-principle-ℕ P d (pair (succ-ℕ m) p) =
-  is-zero-well-ordering-principle-succ-ℕ P d m p (d zero-ℕ)
-    ( well-ordering-principle-ℕ
-      ( λ z → P (succ-ℕ z))
-      ( λ x → d (succ-ℕ x))
-      ( pair m p))
+abstract
+  is-zero-well-ordering-principle-ℕ :
+    {l : Level} (P : ℕ → UU l) (d : is-decidable-family P) →
+    (x : Σ ℕ P) → P zero-ℕ → is-zero-ℕ (number-well-ordering-principle-ℕ P d x)
+  is-zero-well-ordering-principle-ℕ P d (pair zero-ℕ p) p0 = refl
+  is-zero-well-ordering-principle-ℕ P d (pair (succ-ℕ m) p) =
+    is-zero-well-ordering-principle-succ-ℕ P d m p (d zero-ℕ)
+      ( well-ordering-principle-ℕ
+        ( λ z → P (succ-ℕ z))
+        ( λ x → d (succ-ℕ x))
+        ( pair m p))
 ```
 
 ### The ε-operator for decidable subtypes of ℕ
 
 ```agda
-ε-operator-decidable-subtype-ℕ :
-  {l1 : Level} (P : ℕ → Prop l1)
-  (d : (x : ℕ) → is-decidable (type-Prop (P x))) →
-  ε-operator-Hilbert (type-subtype P)
-ε-operator-decidable-subtype-ℕ {l1} P d t =
-  tot ( λ x → pr1)
-      ( apply-universal-property-trunc-Prop t
-        ( minimal-element-ℕ-Prop P)
-        ( well-ordering-principle-ℕ (λ x → type-Prop (P x)) d))
+abstract
+  ε-operator-decidable-subtype-ℕ :
+    {l1 : Level} (P : ℕ → Prop l1)
+    (d : (x : ℕ) → is-decidable (type-Prop (P x))) →
+    ε-operator-Hilbert (type-subtype P)
+  ε-operator-decidable-subtype-ℕ {l1} P d t =
+    tot ( λ x → pr1)
+        ( apply-universal-property-trunc-Prop t
+          ( minimal-element-ℕ-Prop P)
+          ( well-ordering-principle-ℕ (λ x → type-Prop (P x)) d))
 ```

--- a/src/elementary-number-theory/well-ordering-principle-standard-finite-types.lagda.md
+++ b/src/elementary-number-theory/well-ordering-principle-standard-finite-types.lagda.md
@@ -48,8 +48,11 @@ open import univalent-combinatorics.standard-finite-types
 
 ## Idea
 
-The standard finite types inherit a well-ordering principle from the natural
-numbers.
+The [standard finite types](univalent-combinatorics.standard-finite-types.md)
+inherit the
+{{#concept "well-ordering principle" Disambiguation="of the standard finite types" Agda=well-ordering-principle-∃-Fin}}
+from the
+[natural numbers](elementary-number-theory.well-ordering-principle-natural-numbers.md).
 
 ## Properties
 

--- a/src/literature/introduction-to-homotopy-type-theory.lagda.md
+++ b/src/literature/introduction-to-homotopy-type-theory.lagda.md
@@ -995,7 +995,7 @@ open import elementary-number-theory.strict-inequality-natural-numbers using
 
 -- (a)
 open import elementary-number-theory.strict-inequality-natural-numbers using
-  ( anti-reflexive-le-ℕ
+  ( irreflexive-le-ℕ
   ; antisymmetric-le-ℕ
   ; transitive-le-ℕ)
 
@@ -1029,7 +1029,7 @@ open import elementary-number-theory.distance-natural-numbers using
 open import elementary-number-theory.distance-natural-numbers using
   ( dist-eq-ℕ
   ; eq-dist-ℕ
-  ; symmetric-dist-ℕ -- dist m n = dist n m
+  ; commutative-dist-ℕ -- dist m n = dist n m
   ; triangle-inequality-dist-ℕ -- dist m n ≤ dist m k + dist k n
   )
 

--- a/src/literature/introduction-to-homotopy-type-theory.lagda.md
+++ b/src/literature/introduction-to-homotopy-type-theory.lagda.md
@@ -971,12 +971,12 @@ _ =
 -- (d)
 open import elementary-number-theory.inequality-natural-numbers using
   ( preserves-leq-left-mul-ℕ
-  ; reflects-order-mul-ℕ)
+  ; reflects-leq-mul-ℕ)
 
 _ : (m n k : ℕ) → (m ≤-ℕ n) ↔ (m *ℕ (succ-ℕ k) ≤-ℕ n *ℕ (succ-ℕ k))
 _ =
   λ m n k →
-    (preserves-leq-left-mul-ℕ (succ-ℕ k) m n , reflects-order-mul-ℕ k m n)
+    (preserves-leq-left-mul-ℕ (succ-ℕ k) m n , reflects-leq-mul-ℕ k m n)
 
 -- (e)
 open import elementary-number-theory.minimum-natural-numbers using

--- a/src/ring-theory/arithmetic-series-semirings.lagda.md
+++ b/src/ring-theory/arithmetic-series-semirings.lagda.md
@@ -7,8 +7,8 @@ module ring-theory.arithmetic-series-semirings where
 <details><summary>Imports</summary>
 
 ```agda
-open import elementary-number-theory.commutative-semiring-of-natural-numbers
 open import elementary-number-theory.natural-numbers
+open import elementary-number-theory.semiring-of-natural-numbers
 open import elementary-number-theory.triangular-numbers
 
 open import foundation.action-on-identifications-binary-functions

--- a/src/univalent-combinatorics/classical-finite-types.lagda.md
+++ b/src/univalent-combinatorics/classical-finite-types.lagda.md
@@ -165,7 +165,7 @@ is-section-classical-standard-Fin-reverse (succ-ℕ n) (zero-ℕ , k<n) = refl
 is-section-classical-standard-Fin-reverse (succ-ℕ n) (succ-ℕ k , k<n) =
   eq-pair-Σ
     ( ap (succ-ℕ ∘ pr1) (is-section-classical-standard-Fin-reverse n (k , k<n)))
-    ( eq-type-Prop (le-ℕ-Prop k n))
+    ( eq-type-Prop (le-prop-ℕ k n))
 
 is-retraction-classical-standard-Fin-reverse :
   (n : ℕ) →

--- a/src/univalent-combinatorics/orientations-complete-undirected-graph.lagda.md
+++ b/src/univalent-combinatorics/orientations-complete-undirected-graph.lagda.md
@@ -353,7 +353,7 @@ module _
               ( cong-add-ℕ k1 k2))))) ∙
       ( ap
         ( mod-two-ℕ)
-        ( ( symmetric-dist-ℕ (k1 +ℕ k2) (2 *ℕ k')) ∙
+        ( ( commutative-dist-ℕ (k1 +ℕ k2) (2 *ℕ k')) ∙
           ( inv
             ( rewrite-left-add-dist-ℕ
               ( k)


### PR DESCRIPTION
Maybe I should've done the natural numbers and the integers separately?  If so, I'll split it...

Changes include:

* more consistent terminology (e.g. irreflexive versus antireflexive, symmetric versus commutative)
* updated naming conventions
* making most proofs of most propositions abstract
* Improved Idea sections: concept links, cross references, fixed missing idea sections entirely
* minor code cleanups, especially the use of `is-equiv-is-invertible`